### PR TITLE
feat: Add Windows support with Node.js hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,21 @@
 
 ## Quick Install
 
-### One-liner (recommended)
+### One-liner (macOS/Linux - recommended)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/scripts/install.sh | bash
 ```
 
-### Via npm
+### Via npm (All platforms including Windows)
 
 ```bash
 npm install -g oh-my-claude-sisyphus
 ```
 
-### Manual Install
+> **Windows Users**: This is the only supported installation method. Requires Node.js 18+.
+
+### Manual Install (macOS/Linux)
 
 ```bash
 git clone https://github.com/Yeachan-Heo/oh-my-claude-sisyphus.git
@@ -543,6 +545,18 @@ If you're coming from oh-my-opencode:
 
 - [Claude Code](https://docs.anthropic.com/claude-code) installed
 - Anthropic API key (`ANTHROPIC_API_KEY` environment variable)
+- **Windows**: Node.js 18+ (for npm installation)
+- **macOS/Linux**: Bash shell (default) or Node.js 18+ (optional)
+
+### Platform Support
+
+| Platform | Install Method | Hook Type |
+|----------|---------------|-----------|
+| **Windows** | `npm install -g` | Node.js (.mjs) |
+| **macOS** | curl or npm | Bash (.sh) |
+| **Linux** | curl or npm | Bash (.sh) |
+
+> **Advanced**: Set `SISYPHUS_USE_NODE_HOOKS=1` to use Node.js hooks on macOS/Linux.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start": "node dist/index.js",
     "lint": "eslint src --ext .ts",
     "format": "prettier --write src/**/*.ts",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "postinstall": "node dist/cli/index.js postinstall || true"
   },

--- a/src/hooks/session-recovery/constants.ts
+++ b/src/hooks/session-recovery/constants.ts
@@ -6,7 +6,7 @@
  */
 
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 
 /**
  * Get the data directory for Claude Code storage
@@ -83,4 +83,4 @@ export const ERROR_PATTERNS = {
  * Debug logging configuration
  */
 export const DEBUG = process.env.SESSION_RECOVERY_DEBUG === "1";
-export const DEBUG_LOG_PATH = join(require("os").tmpdir(), "session-recovery-debug.log");
+export const DEBUG_LOG_PATH = join(tmpdir(), "session-recovery-debug.log");


### PR DESCRIPTION
Added the required *node native* functions to install on Windows. This allows installation without requiring on bash support.
The native Node.js hooks should work on UNIX-like systems, too, you can test by setting up the `SISYPHUS_USE_NODE_HOOKS=1` environment variable.
Updated `README.md`

Seems to work fine for me:

```
>npx git+https://github.com/Znuff/oh-my-claude-sisyphus.git install
╔═══════════════════════════════════════════════════════════╗
║         Oh-My-Claude-Sisyphus Installer                   ║
║   Multi-Agent Orchestration for Claude Code               ║
╚═══════════════════════════════════════════════════════════╝

Sisyphus is already installed.
  Version: 1.5.0
  Installed: 2026-01-09T18:15:31.008Z

Use --force to reinstall.
```