### PR TITLE
fix: correct typos found by typos-cli

### DIFF
--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -788,7 +788,7 @@ export const orchestratorSisyphusAgent: AgentConfig = {
 - Adapting to codebase maturity (disciplined vs chaotic)
 - Delegating specialized work to the right subagents
 - Parallel execution for maximum throughput
-- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITELY.
+- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITLY.
 
 **Operating Mode**: You NEVER work alone when specialists are available. Frontend work → delegate. Deep research → parallel background agents. Complex architecture → consult Oracle.
 

--- a/src/agents/orchestrator-sisyphus.ts
+++ b/src/agents/orchestrator-sisyphus.ts
@@ -49,7 +49,7 @@ export const orchestratorSisyphusAgent: AgentConfig = {
 - Adapting to codebase maturity (disciplined vs chaotic)
 - Delegating specialized work to the right subagents
 - Parallel execution for maximum throughput
-- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITELY.
+- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITLY.
 
 **Operating Mode**: You NEVER work alone when specialists are available. Frontend work → delegate. Deep research → parallel background agents. Complex architecture → consult Oracle.
 

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -26,7 +26,7 @@ Named by [YeonGyu Kim](https://github.com/code-yeongyu).
 - Adapting to codebase maturity (disciplined vs chaotic)
 - Delegating specialized work to the right subagents
 - Parallel execution for maximum throughput
-- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITELY.
+- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITLY.
   - KEEP IN MIND: YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION]), BUT IF NOT USER REQUESTED YOU TO WORK, NEVER START WORK.
 
 **Operating Mode**: You NEVER work alone when specialists are available. Frontend work → delegate. Deep research → parallel background agents (async subagents). Complex architecture → consult Oracle.
@@ -1338,7 +1338,7 @@ Named by [YeonGyu Kim](https://github.com/code-yeongyu).
 - Adapting to codebase maturity (disciplined vs chaotic)
 - Delegating specialized work to the right subagents
 - Parallel execution for maximum throughput
-- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITELY.
+- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITLY.
   - KEEP IN MIND: YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION]), BUT IF NOT USER REQUESTED YOU TO WORK, NEVER START WORK.
 
 **Operating Mode**: You NEVER work alone when specialists are available. Frontend work → delegate. Deep research → parallel background agents (async subagents). Complex architecture → consult Oracle.

--- a/src/hooks/preemptive-compaction/index.ts
+++ b/src/hooks/preemptive-compaction/index.ts
@@ -230,8 +230,8 @@ export function createPreemptiveCompactionHook(
 
       // Only check after tools that produce large outputs
       const toolLower = input.tool_name.toLowerCase();
-      const largOutputTools = ['read', 'grep', 'glob', 'bash', 'webfetch'];
-      if (!largOutputTools.includes(toolLower)) {
+      const largeOutputTools = ['read', 'grep', 'glob', 'bash', 'webfetch'];
+      if (!largeOutputTools.includes(toolLower)) {
         return null;
       }
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -775,7 +775,7 @@ You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMy
 - Adapting to codebase maturity (disciplined vs chaotic)
 - Delegating specialized work to the right subagents
 - Parallel execution for maximum throughput
-- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITELY.
+- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITLY.
 
 **Operating Mode**: You NEVER work alone when specialists are available. Frontend work → delegate. Deep research → parallel background agents. Complex architecture → consult Oracle.
 
@@ -1529,7 +1529,7 @@ Named by [YeonGyu Kim](https://github.com/code-yeongyu).
 - Adapting to codebase maturity (disciplined vs chaotic)
 - Delegating specialized work to the right subagents
 - Parallel execution for maximum throughput
-- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITELY.
+- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITLY.
   - KEEP IN MIND: YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION]), BUT IF NOT USER REQUESTED YOU TO WORK, NEVER START WORK.
 
 **Operating Mode**: You NEVER work alone when specialists are available. Frontend work → delegate. Deep research → parallel background agents (async subagents). Complex architecture → consult Oracle.
@@ -2833,7 +2833,7 @@ Named by [YeonGyu Kim](https://github.com/code-yeongyu).
 - Adapting to codebase maturity (disciplined vs chaotic)
 - Delegating specialized work to the right subagents
 - Parallel execution for maximum throughput
-- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITELY.
+- Follows user instructions. NEVER START IMPLEMENTING, UNLESS USER WANTS YOU TO IMPLEMENT SOMETHING EXPLICITLY.
   - KEEP IN MIND: YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION]), BUT IF NOT USER REQUESTED YOU TO WORK, NEVER START WORK.
 
 **Operating Mode**: You NEVER work alone when specialists are available. Frontend work → delegate. Deep research → parallel background agents (async subagents). Complex architecture → consult Oracle.

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,6 @@
+# Typos configuration
+# https://github.com/crate-ci/typos
+
+[default.extend-words]
+# Claude API uses "preceeding" in error messages - must match exactly
+preceeding = "preceeding"


### PR DESCRIPTION
## Summary
Fix typos identified by [typos-cli](https://github.com/crate-ci/typos).

## Typos Fixed
| Typo | Correction | Occurrences |
|------|------------|-------------|
| `EXPLICITELY` | `EXPLICITLY` | 6 |
| `largOutputTools` | `largeOutputTools` | 2 |

## Configuration
Added `typos.toml` to ignore `preceeding` - this matches Claude's API error messages and must remain as-is.

## Files Changed
- `src/installer/index.ts`
- `src/agents/definitions.ts`
- `src/agents/orchestrator-sisyphus.ts`
- `src/features/builtin-skills/skills.ts`
- `src/hooks/preemptive-compaction/index.ts`
- `typos.toml` (new)

## Verification
- `npx tsc --noEmit` passes
- `npx tsc` builds successfully
- `typos` returns clean