### PR TITLE
fix: Handle non-interactive stdin when piped via curl

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,10 +25,17 @@ if ! command -v claude &> /dev/null; then
     echo -e "${YELLOW}Warning: 'claude' command not found. Please install Claude Code first:${NC}"
     echo "  curl -fsSL https://claude.ai/install.sh | bash"
     echo ""
-    read -p "Continue anyway? (y/N) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 1
+    # Check if running interactively (stdin is a terminal)
+    if [ -t 0 ]; then
+        read -p "Continue anyway? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    else
+        # Non-interactive mode (piped from curl) - continue with installation
+        echo -e "${YELLOW}Non-interactive mode detected. Continuing installation...${NC}"
+        echo -e "${YELLOW}You can install Claude Code later with: curl -fsSL https://claude.ai/install.sh | bash${NC}"
     fi
 else
     echo -e "${GREEN}✓ Claude Code found${NC}"
@@ -1048,15 +1055,21 @@ echo ""
 echo -e "${YELLOW}Security Note:${NC} Silent updates download and execute code from GitHub."
 echo "  You can always manually update using /update command instead."
 echo ""
-read -p "Enable silent auto-updates? (y/N) " -n 1 -r
-echo
 
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-    ENABLE_SILENT_UPDATE="true"
-    echo -e "${GREEN}✓ Silent auto-updates enabled${NC}"
+if [ -t 0 ]; then
+    read -p "Enable silent auto-updates? (y/N) " -n 1 -r
+    echo
+
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        ENABLE_SILENT_UPDATE="true"
+        echo -e "${GREEN}✓ Silent auto-updates enabled${NC}"
+    else
+        ENABLE_SILENT_UPDATE="false"
+        echo -e "${GREEN}✓ Silent auto-updates disabled (use /update to update manually)${NC}"
+    fi
 else
     ENABLE_SILENT_UPDATE="false"
-    echo -e "${GREEN}✓ Silent auto-updates disabled (use /update to update manually)${NC}"
+    echo -e "${GREEN}✓ Silent auto-updates disabled (non-interactive mode, use /update to update manually)${NC}"
 fi
 
 # Save configuration


### PR DESCRIPTION
## Summary

- Fix installation failure when running `curl -fsSL ... | bash`
- Detect non-interactive mode using `[ -t 0 ]` check
- Continue installation without prompting when stdin is piped

## Problem

When users install via the recommended one-liner:
```bash
curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/scripts/install.sh | bash
```

The script fails with:
```
curl: (56) Failure writing output to destination, passed 420 returned 0
```

This happens because:
1. `read -p` tries to read from stdin (which is the curl pipe, not a terminal)
2. The script exits or behaves unexpectedly
3. bash closes stdin, causing curl to fail writing remaining data

## Solution

Check if stdin is a terminal using `[ -t 0 ]`:
- **Interactive mode** (terminal): Prompt user as before
- **Non-interactive mode** (piped): Continue installation without prompting, default silent auto-updates to disabled for security

## Testing

Verified bash syntax: `bash -n scripts/install.sh` passes