### PR TITLE
fix: Handle non-interactive stdin in uninstall script

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -27,8 +27,20 @@ echo "  - Hooks (keyword-detector, silent-auto-update, stop-continuation)"
 echo "  - Version and state files"
 echo "  - Hook configurations from settings.json"
 echo ""
-read -p "Continue? (y/N) " -n 1 -r
-echo
+if [ -t 0 ]; then
+    read -p "Continue? (y/N) " -n 1 -r
+    echo
+else
+    # Try reading from terminal if script is piped
+    if [ -c /dev/tty ]; then
+        echo -n "Continue? (y/N) " >&2
+        read -n 1 -r < /dev/tty
+        echo
+    else
+        echo "Non-interactive mode detected or terminal not available. Uninstallation cancelled."
+        exit 1
+    fi
+fi
 
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Cancelled."


### PR DESCRIPTION
Add TTY detection to support curl-piped execution. Falls back to /dev/tty for user prompt when stdin is piped. Exits gracefully if neither interactive mode is available.

Close #16 