### PR TITLE
fix: correct relative paths in plugin.json manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,8 +19,5 @@
     "todo-management",
     "productivity"
   ],
-  "commands": "../commands/",
-  "agents": "../agents/",
-  "skills": "../skills/",
-  "hooks": "../hooks/hooks.json"
+  "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Summary
- Fixed invalid manifest in `.claude-plugin/plugin.json` that caused installation to fail

## Root Cause
Claude Code **auto-discovers** `commands/`, `agents/`, and `skills/` directories at the plugin root. Explicitly specifying these paths in the manifest causes validation errors regardless of path format.

The `hooks` field still requires an explicit path since it points to a specific JSON file.

## Changes

| Field | Before | After |
|-------|--------|-------|
| commands | `"../commands/"` | *(removed - auto-discovered)* |
| agents | `"../agents/"` | *(removed - auto-discovered)* |
| skills | `"../skills/"` | *(removed - auto-discovered)* |
| hooks | `"../hooks/hooks.json"` | `"./hooks/hooks.json"` |

## Verified Fix
Tested locally - plugin now installs successfully:
```
✔ Successfully installed plugin: oh-my-claude-sisyphus@oh-my-claude-sisyphus (scope: user)
```

## Test plan
- [x] Install plugin locally after fix
- [ ] Verify all commands, agents, skills, and hooks load correctly

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)