### PR TITLE
Update plugin.json - Resolves Manifest.hooks error in plugin section

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "delegation",
     "todo-management",
     "productivity"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }


### PR DESCRIPTION
Removes the hooks entry as it is redundant as this should only be used for any additional directory entries that are in addition to the standard default directories as the standard default directories are automatically detected and should not be listed in this file in order to avoid a manifest error which the current existing error is a manifest.hooks error in the plugins section for the plugin.