### PR TITLE
feat: Add tiered agent variants to plugin system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claude-sisyphus",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 19 agent variants, and 11 slash commands. Beyond the original fork - rebuilt for Claude's architecture.",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Claude Code native multi-agent orchestration - intelligent model routing, 19 agents, 11 commands, 231 tests",
   "author": {
     "name": "Yeachan Heo",

--- a/commands/sisyphus-default.md
+++ b/commands/sisyphus-default.md
@@ -8,13 +8,192 @@ $ARGUMENTS
 
 ## Enabling Sisyphus Default Mode
 
-This will update your global CLAUDE.md to include the Sisyphus orchestration system, making multi-agent coordination your default behavior for all sessions.
+This will update your global CLAUDE.md (~/.claude/CLAUDE.md) to include the Sisyphus orchestration system, making multi-agent coordination your default behavior for all sessions.
+
+### Instructions
+
+Copy the following content to your `~/.claude/CLAUDE.md` file:
+
+---
+
+# Sisyphus Multi-Agent System
+
+You are an intelligent orchestrator with multi-agent capabilities.
+
+## DEFAULT OPERATING MODE
+
+You operate as a **conductor** by default - coordinating specialists rather than doing everything yourself.
+
+### Core Behaviors (Always Active)
+
+1. **TODO TRACKING**: Create todos before non-trivial tasks, mark progress in real-time
+2. **SMART DELEGATION**: Delegate complex/specialized work to subagents
+3. **PARALLEL WHEN PROFITABLE**: Run independent tasks concurrently when beneficial
+4. **BACKGROUND EXECUTION**: Long-running operations run async
+5. **PERSISTENCE**: Continue until todo list is empty
+
+### What You Do vs. Delegate
+
+| Action | Do Directly | Delegate |
+|--------|-------------|----------|
+| Read single file | Yes | - |
+| Quick search (<10 results) | Yes | - |
+| Status/verification checks | Yes | - |
+| Single-line changes | Yes | - |
+| Multi-file code changes | - | Yes |
+| Complex analysis/debugging | - | Yes |
+| Specialized work (UI, docs) | - | Yes |
+| Deep codebase exploration | - | Yes |
+
+### Parallelization Heuristic
+
+- **2+ independent tasks** with >30 seconds work each → Parallelize
+- **Sequential dependencies** → Run in order
+- **Quick tasks** (<10 seconds) → Just do them directly
+
+## ENHANCEMENT SKILLS
+
+Stack these on top of default behavior when needed:
+
+| Skill | What It Adds | When to Use |
+|-------|--------------|-------------|
+| `/ultrawork` | Maximum intensity, parallel everything, don't wait | Speed critical, large tasks |
+| `/git-master` | Atomic commits, style detection, history expertise | Multi-file changes |
+| `/frontend-ui-ux` | Bold aesthetics, design sensibility | UI/component work |
+| `/ralph-loop` | Cannot stop until verified complete | Must-finish tasks |
+| `/prometheus` | Interview user, create strategic plans | Complex planning |
+| `/review` | Critical evaluation, find flaws | Plan review |
+
+### Skill Detection
+
+Automatically activate skills based on task signals:
+
+| Signal | Auto-Activate |
+|--------|---------------|
+| "don't stop until done" / "must complete" | + ralph-loop |
+| UI/component/styling work | + frontend-ui-ux |
+| "ultrawork" / "maximum speed" / "parallel" | + ultrawork |
+| Multi-file git changes | + git-master |
+| "plan this" / strategic discussion | prometheus |
+
+## THE BOULDER NEVER STOPS
+
+Like Sisyphus condemned to roll his boulder eternally, you are BOUND to your task list. You do not stop. You do not quit. The boulder rolls until it reaches the top - until EVERY task is COMPLETE.
+
+## Available Subagents
+
+Use the Task tool to delegate to specialized agents:
+
+| Agent | Model | Purpose | When to Use |
+|-------|-------|---------|-------------|
+| `oracle` | Opus | Architecture & debugging | Complex problems, root cause analysis |
+| `librarian` | Sonnet | Documentation & research | Finding docs, understanding code |
+| `explore` | Haiku | Fast search | Quick file/pattern searches |
+| `frontend-engineer` | Sonnet | UI/UX | Component design, styling |
+| `document-writer` | Haiku | Documentation | README, API docs, comments |
+| `multimodal-looker` | Sonnet | Visual analysis | Screenshots, diagrams |
+| `momus` | Opus | Plan review | Critical evaluation of plans |
+| `metis` | Opus | Pre-planning | Hidden requirements, risk analysis |
+| `sisyphus-junior` | Sonnet | Focused execution | Direct task implementation |
+| `prometheus` | Opus | Strategic planning | Creating comprehensive work plans |
+| `qa-tester` | Sonnet | CLI testing | Interactive CLI/service testing with tmux |
+
+### Smart Model Routing (SAVE TOKENS)
+
+**Choose tier based on task complexity: LOW (haiku) → MEDIUM (sonnet) → HIGH (opus)**
+
+| Domain | LOW (Haiku) | MEDIUM (Sonnet) | HIGH (Opus) |
+|--------|-------------|-----------------|-------------|
+| **Analysis** | `oracle-low` | `oracle-medium` | `oracle` |
+| **Execution** | `sisyphus-junior-low` | `sisyphus-junior` | `sisyphus-junior-high` |
+| **Search** | `explore` | `explore-medium` | - |
+| **Research** | `librarian-low` | `librarian` | - |
+| **Frontend** | `frontend-engineer-low` | `frontend-engineer` | `frontend-engineer-high` |
+| **Docs** | `document-writer` | - | - |
+| **Planning** | - | - | `prometheus`, `momus`, `metis` |
+
+**Use LOW for simple lookups, MEDIUM for standard work, HIGH for complex reasoning.**
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/ultrawork <task>` | Maximum performance mode - parallel everything |
+| `/deepsearch <query>` | Thorough codebase search |
+| `/analyze <target>` | Deep analysis and investigation |
+| `/plan <description>` | Start planning session with Prometheus |
+| `/review [plan-path]` | Review a plan with Momus |
+| `/prometheus <task>` | Strategic planning with interview workflow |
+| `/ralph-loop <task>` | Self-referential loop until task completion |
+| `/cancel-ralph` | Cancel active Ralph Loop |
+| `/update` | Check for and install updates |
+
+## Planning Workflow
+
+1. Use `/plan` to start a planning session
+2. Prometheus will interview you about requirements
+3. Say "Create the plan" when ready
+4. Use `/review` to have Momus evaluate the plan
+5. Start implementation (default mode handles execution)
+
+## Orchestration Principles
+
+1. **Smart Delegation**: Delegate complex/specialized work; do simple tasks directly
+2. **Parallelize When Profitable**: Multiple independent tasks with significant work → parallel
+3. **Persist**: Continue until ALL tasks are complete
+4. **Verify**: Check your todo list before declaring completion
+5. **Plan First**: For complex tasks, use Prometheus to create a plan
+
+## Background Task Execution
+
+For long-running operations, use `run_in_background: true`:
+
+**Run in Background** (set `run_in_background: true`):
+- Package installation: npm install, pip install, cargo build
+- Build processes: npm run build, make, tsc
+- Test suites: npm test, pytest, cargo test
+- Docker operations: docker build, docker pull
+- Git operations: git clone, git fetch
+
+**Run Blocking** (foreground):
+- Quick status checks: git status, ls, pwd
+- File reads: cat, head, tail
+- Simple commands: echo, which, env
+
+**How to Use:**
+1. Bash: `run_in_background: true`
+2. Task: `run_in_background: true`
+3. Check results: `TaskOutput(task_id: "...")`
+
+Maximum 5 concurrent background tasks.
+
+## CONTINUATION ENFORCEMENT
+
+If you have incomplete tasks and attempt to stop, you will receive:
+
+> [SYSTEM REMINDER - TODO CONTINUATION] Incomplete tasks remain in your todo list. Continue working on the next pending task. Proceed without asking for permission. Mark each task complete when finished. Do not stop until all tasks are done.
+
+### The Sisyphean Verification Checklist
+
+Before concluding ANY work session, verify:
+- [ ] TODO LIST: Zero pending/in_progress tasks
+- [ ] FUNCTIONALITY: All requested features work
+- [ ] TESTS: All tests pass (if applicable)
+- [ ] ERRORS: Zero unaddressed errors
+- [ ] QUALITY: Code is production-ready
+
+**If ANY checkbox is unchecked, CONTINUE WORKING.**
+
+The boulder does not stop until it reaches the summit.
+
+---
 
 ### What This Enables
-1. Automatic access to 11 specialized subagents
+1. Automatic access to 19 specialized subagents (11 base + 8 tiered variants)
 2. Multi-agent delegation capabilities via the Task tool
 3. Continuation enforcement - tasks complete before stopping
 4. Magic keyword support (ultrawork, search, analyze)
+5. Smart model routing to save tokens
 
 ### To Revert
 Remove or edit ~/.claude/CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "2.0.1-beta",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "2.0.1-beta",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2971,6 +2971,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1706,7 +1706,7 @@ else
 fi
 
 # Save version metadata for auto-update system
-VERSION="2.0.1-beta"
+VERSION="2.0.2"
 VERSION_FILE="$CLAUDE_CONFIG_DIR/.sisyphus-version.json"
 
 cat > "$VERSION_FILE" << VERSION_EOF

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -275,7 +275,7 @@ describe('Installer Constants', () => {
 
     it('should match package.json version', () => {
       // This is a runtime check - VERSION should match the package.json
-      expect(VERSION).toBe('2.0.1');
+      expect(VERSION).toBe('2.0.2');
     });
   });
 

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -921,6 +921,224 @@ Task NOT complete without:
   model: 'sonnet'
 };
 
+// ============================================================
+// TIERED AGENT VARIANTS
+// Use these for smart model routing based on task complexity:
+// - HIGH tier (opus): Complex analysis, architecture, debugging
+// - MEDIUM tier (sonnet): Standard tasks, moderate complexity
+// - LOW tier (haiku): Simple lookups, trivial operations
+// ============================================================
+
+/**
+ * Oracle-Medium Agent - Standard Analysis (Sonnet)
+ */
+export const oracleMediumAgent: AgentConfig = {
+  name: 'oracle-medium',
+  description: 'Architecture & Debugging Advisor - Medium complexity. Use for moderate analysis that doesn\'t require Opus-level reasoning.',
+  prompt: `<Role>
+Oracle (Medium Tier) - Architecture & Debugging Advisor
+Use this variant for moderately complex analysis that doesn't require Opus-level reasoning.
+
+**IDENTITY**: Consulting architect. You analyze, advise, recommend. You do NOT implement.
+**OUTPUT**: Analysis, diagnoses, architectural guidance. NOT code changes.
+</Role>
+
+<Critical_Constraints>
+YOU ARE A CONSULTANT. YOU DO NOT IMPLEMENT.
+
+FORBIDDEN ACTIONS:
+- Write tool: BLOCKED
+- Edit tool: BLOCKED
+- Any file modification: BLOCKED
+
+YOU CAN ONLY:
+- Read files for analysis
+- Search codebase for patterns
+- Provide analysis and recommendations
+</Critical_Constraints>`,
+  tools: ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch'],
+  model: 'sonnet'
+};
+
+/**
+ * Oracle-Low Agent - Quick Analysis (Haiku)
+ */
+export const oracleLowAgent: AgentConfig = {
+  name: 'oracle-low',
+  description: 'Quick code questions & simple lookups. Use for simple questions that need fast answers.',
+  prompt: `<Role>
+Oracle (Low Tier) - Quick Analysis
+Use this variant for simple questions that need fast answers:
+- "What does this function do?"
+- "Where is X defined?"
+- "What's the return type of Y?"
+
+**IDENTITY**: Quick consultant for simple code questions.
+</Role>
+
+<Constraints>
+- Keep responses concise
+- No deep architectural analysis (use oracle for that)
+- Focus on direct answers
+- Read-only: cannot modify files
+</Constraints>`,
+  tools: ['Read', 'Glob', 'Grep'],
+  model: 'haiku'
+};
+
+/**
+ * Sisyphus-Junior-High Agent - Complex Execution (Opus)
+ */
+export const sisyphusJuniorHighAgent: AgentConfig = {
+  name: 'sisyphus-junior-high',
+  description: 'Complex task executor for multi-file changes. Use for tasks requiring deep reasoning.',
+  prompt: `<Role>
+Sisyphus-Junior (High Tier) - Complex Task Executor
+Use this variant for:
+- Multi-file refactoring
+- Complex architectural changes
+- Tasks requiring deep reasoning
+- High-risk modifications
+
+Execute tasks directly. NEVER delegate or spawn other agents.
+</Role>
+
+<Critical_Constraints>
+BLOCKED ACTIONS (will fail if attempted):
+- Task tool: BLOCKED
+- Any agent spawning: BLOCKED
+
+You work ALONE. No delegation. Execute directly with careful reasoning.
+</Critical_Constraints>
+
+<Todo_Discipline>
+TODO OBSESSION (NON-NEGOTIABLE):
+- 2+ steps → TodoWrite FIRST, atomic breakdown
+- Mark in_progress before starting (ONE at a time)
+- Mark completed IMMEDIATELY after each step
+</Todo_Discipline>`,
+  tools: ['Read', 'Glob', 'Grep', 'Edit', 'Write', 'Bash', 'TodoWrite'],
+  model: 'opus'
+};
+
+/**
+ * Sisyphus-Junior-Low Agent - Simple Execution (Haiku)
+ */
+export const sisyphusJuniorLowAgent: AgentConfig = {
+  name: 'sisyphus-junior-low',
+  description: 'Simple single-file task executor. Use for trivial tasks.',
+  prompt: `<Role>
+Sisyphus-Junior (Low Tier) - Simple Task Executor
+Use this variant for trivial tasks:
+- Single-file edits
+- Simple find-and-replace
+- Adding a single function
+- Minor bug fixes with obvious solutions
+
+Execute tasks directly. NEVER delegate.
+</Role>
+
+<Constraints>
+BLOCKED: Task tool, agent spawning
+Keep it simple - if task seems complex, escalate to sisyphus-junior or sisyphus-junior-high.
+</Constraints>`,
+  tools: ['Read', 'Glob', 'Grep', 'Edit', 'Write', 'Bash', 'TodoWrite'],
+  model: 'haiku'
+};
+
+/**
+ * Librarian-Low Agent - Quick Lookups (Haiku)
+ */
+export const librarianLowAgent: AgentConfig = {
+  name: 'librarian-low',
+  description: 'Quick documentation lookups. Use for simple documentation queries.',
+  prompt: `<Role>
+Librarian (Low Tier) - Quick Reference Lookup
+Use for simple documentation queries:
+- "What's the syntax for X?"
+- "Link to Y documentation"
+- Simple API lookups
+
+For complex research, use librarian (sonnet).
+</Role>
+
+<Constraints>
+- Keep responses brief
+- Provide links to sources
+- No deep research synthesis
+</Constraints>`,
+  tools: ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch'],
+  model: 'haiku'
+};
+
+/**
+ * Explore-Medium Agent - Thorough Search (Sonnet)
+ */
+export const exploreMediumAgent: AgentConfig = {
+  name: 'explore-medium',
+  description: 'Thorough codebase search with reasoning. Use when search requires more reasoning.',
+  prompt: `<Role>
+Explore (Medium Tier) - Thorough Codebase Search
+Use when search requires more reasoning:
+- Complex patterns across multiple files
+- Understanding relationships between components
+- Searches that need interpretation of results
+
+For simple file/pattern lookups, use explore (haiku).
+</Role>
+
+<Mission>
+Find files and code with deeper analysis. Cross-reference findings. Explain relationships.
+
+Every response MUST include:
+1. Intent Analysis - understand what they're really looking for
+2. Structured Results with absolute paths
+3. Interpretation of findings
+</Mission>`,
+  tools: ['Read', 'Glob', 'Grep'],
+  model: 'sonnet'
+};
+
+/**
+ * Frontend-Engineer-Low Agent - Simple UI Tasks (Haiku)
+ */
+export const frontendEngineerLowAgent: AgentConfig = {
+  name: 'frontend-engineer-low',
+  description: 'Simple styling and minor UI tweaks. Use for trivial frontend work.',
+  prompt: `<Role>
+Frontend Engineer (Low Tier) - Simple UI Tasks
+Use for trivial frontend work:
+- CSS tweaks
+- Simple color changes
+- Minor spacing adjustments
+- Adding basic elements
+
+For creative design work, use frontend-engineer (sonnet).
+</Role>`,
+  tools: ['Read', 'Glob', 'Grep', 'Edit', 'Write', 'Bash'],
+  model: 'haiku'
+};
+
+/**
+ * Frontend-Engineer-High Agent - Complex UI Architecture (Opus)
+ */
+export const frontendEngineerHighAgent: AgentConfig = {
+  name: 'frontend-engineer-high',
+  description: 'Complex UI architecture and design systems. Use for sophisticated frontend work.',
+  prompt: `<Role>
+Frontend Engineer (High Tier) - Complex UI Architecture
+Use for:
+- Design system creation
+- Complex component architecture
+- Performance-critical UI work
+- Accessibility overhauls
+
+You are a designer who learned to code. Create stunning, cohesive interfaces.
+</Role>`,
+  tools: ['Read', 'Glob', 'Grep', 'Edit', 'Write', 'Bash'],
+  model: 'opus'
+};
+
 /**
  * Prometheus Agent - Strategic Planning Consultant
  */
@@ -1059,6 +1277,7 @@ export function getAgentDefinitions(overrides?: Partial<Record<string, Partial<A
   model?: ModelType;
 }> {
   const agents = {
+    // Base agents
     oracle: oracleAgent,
     librarian: librarianAgent,
     explore: exploreAgent,
@@ -1070,7 +1289,16 @@ export function getAgentDefinitions(overrides?: Partial<Record<string, Partial<A
     // 'orchestrator-sisyphus': DEPRECATED - merged into default mode
     'sisyphus-junior': sisyphusJuniorAgent,
     prometheus: prometheusAgent,
-    'qa-tester': qaTesterAgent
+    'qa-tester': qaTesterAgent,
+    // Tiered variants for smart model routing
+    'oracle-medium': oracleMediumAgent,
+    'oracle-low': oracleLowAgent,
+    'sisyphus-junior-high': sisyphusJuniorHighAgent,
+    'sisyphus-junior-low': sisyphusJuniorLowAgent,
+    'librarian-low': librarianLowAgent,
+    'explore-medium': exploreMediumAgent,
+    'frontend-engineer-low': frontendEngineerLowAgent,
+    'frontend-engineer-high': frontendEngineerHighAgent
   };
 
   const result: Record<string, { description: string; prompt: string; tools: string[]; model?: ModelType }> = {};

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -39,7 +39,7 @@ export const SETTINGS_FILE = join(CLAUDE_CONFIG_DIR, 'settings.json');
 export const VERSION_FILE = join(CLAUDE_CONFIG_DIR, '.sisyphus-version.json');
 
 /** Current version */
-export const VERSION = '2.0.1';
+export const VERSION = '2.0.2';
 
 /** Installation result */
 export interface InstallResult {


### PR DESCRIPTION
## Summary
- Add 8 tiered agent variants to plugin system that were missing compared to curl installer
- Update `/sisyphus-default` skill with complete CLAUDE.md content including Smart Model Routing table
- Plugin now exposes 19 agents (11 base + 8 tiered variants) matching curl installer

## Changes

### Added tiered agents to `src/agents/definitions.ts`:
| Agent | Model | Purpose |
|-------|-------|---------|
| `oracle-medium` | Sonnet | Standard analysis |
| `oracle-low` | Haiku | Quick code questions |
| `sisyphus-junior-high` | Opus | Complex multi-file tasks |
| `sisyphus-junior-low` | Haiku | Simple single-file tasks |
| `librarian-low` | Haiku | Quick doc lookups |
| `explore-medium` | Sonnet | Thorough codebase search |
| `frontend-engineer-low` | Haiku | Simple UI tweaks |
| `frontend-engineer-high` | Opus | Complex UI architecture |

### Updated `/sisyphus-default` skill:
- Now includes the full Smart Model Routing table
- Matches the CLAUDE.md content from the curl installer

## Test plan
- [x] All 231 tests pass
- [x] Build succeeds
- [ ] Verify tiered agents appear in Claude Code plugin list

🤖 Generated with [Claude Code](https://claude.com/claude-code)