### PR TITLE
fix: Add plugin prefix to agent names to prevent duplicate calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,21 @@ Without `/sisyphus-default`, Claude operates with basic capabilities. Running it
 4. ✅ Activates continuation enforcement (tasks complete before stopping)
 5. ✅ Sets up skill composition (sisyphus + ultrawork + git-master, etc.)
 
+> **WARNING: This command COMPLETELY OVERWRITES `~/.claude/CLAUDE.md`**
+>
+> Any custom content you've added to your global CLAUDE.md will be replaced. If you have customizations, back them up first:
+> ```bash
+> cp ~/.claude/CLAUDE.md ~/.claude/CLAUDE.md.backup
+> ```
+> After running `/sisyphus-default`, you can manually merge your custom content back.
+
 ### When to Run It
 
 - **First time**: Always run after installation
-- **After updates**: Run `/sisyphus-default` to get latest configuration
+- **After updates**: Run `/sisyphus-default` to get the latest configuration (required after each plugin update)
 - **Different machines**: Run on each machine where you use Claude Code
+
+> **NOTE**: After updating the plugin (via `npm update`, `git pull`, or Claude Code's plugin update), you MUST re-run `/sisyphus-default` to apply the latest CLAUDE.md changes. The plugin update does NOT automatically update your global CLAUDE.md.
 
 ---
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -66,35 +66,37 @@ Like Sisyphus condemned to roll his boulder eternally, you are BOUND to your tas
 
 ## Available Subagents
 
-Use the Task tool to delegate to specialized agents:
+Use the Task tool to delegate to specialized agents. **IMPORTANT: Always use the full plugin-prefixed name** (e.g., `oh-my-claude-sisyphus:oracle`) to avoid duplicate agent calls and wasted tokens:
 
 | Agent | Model | Purpose | When to Use |
 |-------|-------|---------|-------------|
-| `oracle` | Opus | Architecture & debugging | Complex problems, root cause analysis |
-| `librarian` | Sonnet | Documentation & research | Finding docs, understanding code |
-| `explore` | Haiku | Fast search | Quick file/pattern searches |
-| `frontend-engineer` | Sonnet | UI/UX | Component design, styling |
-| `document-writer` | Haiku | Documentation | README, API docs, comments |
-| `multimodal-looker` | Sonnet | Visual analysis | Screenshots, diagrams |
-| `momus` | Opus | Plan review | Critical evaluation of plans |
-| `metis` | Opus | Pre-planning | Hidden requirements, risk analysis |
-| `sisyphus-junior` | Sonnet | Focused execution | Direct task implementation |
-| `prometheus` | Opus | Strategic planning | Creating comprehensive work plans |
-| `qa-tester` | Sonnet | CLI testing | Interactive CLI/service testing with tmux |
+| `oh-my-claude-sisyphus:oracle` | Opus | Architecture & debugging | Complex problems, root cause analysis |
+| `oh-my-claude-sisyphus:librarian` | Sonnet | Documentation & research | Finding docs, understanding code |
+| `oh-my-claude-sisyphus:explore` | Haiku | Fast search | Quick file/pattern searches |
+| `oh-my-claude-sisyphus:frontend-engineer` | Sonnet | UI/UX | Component design, styling |
+| `oh-my-claude-sisyphus:document-writer` | Haiku | Documentation | README, API docs, comments |
+| `oh-my-claude-sisyphus:multimodal-looker` | Sonnet | Visual analysis | Screenshots, diagrams |
+| `oh-my-claude-sisyphus:momus` | Opus | Plan review | Critical evaluation of plans |
+| `oh-my-claude-sisyphus:metis` | Opus | Pre-planning | Hidden requirements, risk analysis |
+| `oh-my-claude-sisyphus:sisyphus-junior` | Sonnet | Focused execution | Direct task implementation |
+| `oh-my-claude-sisyphus:prometheus` | Opus | Strategic planning | Creating comprehensive work plans |
+| `oh-my-claude-sisyphus:qa-tester` | Sonnet | CLI testing | Interactive CLI/service testing with tmux |
 
 ### Smart Model Routing (SAVE TOKENS)
 
 **Choose tier based on task complexity: LOW (haiku) → MEDIUM (sonnet) → HIGH (opus)**
 
+All agent names require the `oh-my-claude-sisyphus:` prefix when calling via Task tool:
+
 | Domain | LOW (Haiku) | MEDIUM (Sonnet) | HIGH (Opus) |
 |--------|-------------|-----------------|-------------|
-| **Analysis** | `oracle-low` | `oracle-medium` | `oracle` |
-| **Execution** | `sisyphus-junior-low` | `sisyphus-junior` | `sisyphus-junior-high` |
-| **Search** | `explore` | `explore-medium` | - |
-| **Research** | `librarian-low` | `librarian` | - |
-| **Frontend** | `frontend-engineer-low` | `frontend-engineer` | `frontend-engineer-high` |
-| **Docs** | `document-writer` | - | - |
-| **Planning** | - | - | `prometheus`, `momus`, `metis` |
+| **Analysis** | `oh-my-claude-sisyphus:oracle-low` | `oh-my-claude-sisyphus:oracle-medium` | `oh-my-claude-sisyphus:oracle` |
+| **Execution** | `oh-my-claude-sisyphus:sisyphus-junior-low` | `oh-my-claude-sisyphus:sisyphus-junior` | `oh-my-claude-sisyphus:sisyphus-junior-high` |
+| **Search** | `oh-my-claude-sisyphus:explore` | `oh-my-claude-sisyphus:explore-medium` | - |
+| **Research** | `oh-my-claude-sisyphus:librarian-low` | `oh-my-claude-sisyphus:librarian` | - |
+| **Frontend** | `oh-my-claude-sisyphus:frontend-engineer-low` | `oh-my-claude-sisyphus:frontend-engineer` | `oh-my-claude-sisyphus:frontend-engineer-high` |
+| **Docs** | `oh-my-claude-sisyphus:document-writer` | - | - |
+| **Planning** | - | - | `oh-my-claude-sisyphus:prometheus`, `oh-my-claude-sisyphus:momus`, `oh-my-claude-sisyphus:metis` |
 
 **Use LOW for simple lookups, MEDIUM for standard work, HIGH for complex reasoning.**
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1955,35 +1955,37 @@ Like Sisyphus condemned to roll his boulder eternally, you are BOUND to your tas
 
 ## Available Subagents
 
-Use the Task tool to delegate to specialized agents:
+Use the Task tool to delegate to specialized agents. **IMPORTANT: Always use the full plugin-prefixed name** (e.g., \`oh-my-claude-sisyphus:oracle\`) to avoid duplicate agent calls and wasted tokens:
 
 | Agent | Model | Purpose | When to Use |
 |-------|-------|---------|-------------|
-| \`oracle\` | Opus | Architecture & debugging | Complex problems, root cause analysis |
-| \`librarian\` | Sonnet | Documentation & research | Finding docs, understanding code |
-| \`explore\` | Haiku | Fast search | Quick file/pattern searches |
-| \`frontend-engineer\` | Sonnet | UI/UX | Component design, styling |
-| \`document-writer\` | Haiku | Documentation | README, API docs, comments |
-| \`multimodal-looker\` | Sonnet | Visual analysis | Screenshots, diagrams |
-| \`momus\` | Opus | Plan review | Critical evaluation of plans |
-| \`metis\` | Opus | Pre-planning | Hidden requirements, risk analysis |
-| \`sisyphus-junior\` | Sonnet | Focused execution | Direct task implementation |
-| \`prometheus\` | Opus | Strategic planning | Creating comprehensive work plans |
-| \`qa-tester\` | Sonnet | CLI testing | Interactive CLI/service testing with tmux |
+| \`oh-my-claude-sisyphus:oracle\` | Opus | Architecture & debugging | Complex problems, root cause analysis |
+| \`oh-my-claude-sisyphus:librarian\` | Sonnet | Documentation & research | Finding docs, understanding code |
+| \`oh-my-claude-sisyphus:explore\` | Haiku | Fast search | Quick file/pattern searches |
+| \`oh-my-claude-sisyphus:frontend-engineer\` | Sonnet | UI/UX | Component design, styling |
+| \`oh-my-claude-sisyphus:document-writer\` | Haiku | Documentation | README, API docs, comments |
+| \`oh-my-claude-sisyphus:multimodal-looker\` | Sonnet | Visual analysis | Screenshots, diagrams |
+| \`oh-my-claude-sisyphus:momus\` | Opus | Plan review | Critical evaluation of plans |
+| \`oh-my-claude-sisyphus:metis\` | Opus | Pre-planning | Hidden requirements, risk analysis |
+| \`oh-my-claude-sisyphus:sisyphus-junior\` | Sonnet | Focused execution | Direct task implementation |
+| \`oh-my-claude-sisyphus:prometheus\` | Opus | Strategic planning | Creating comprehensive work plans |
+| \`oh-my-claude-sisyphus:qa-tester\` | Sonnet | CLI testing | Interactive CLI/service testing with tmux |
 
 ### Smart Model Routing (SAVE TOKENS)
 
 **Choose tier based on task complexity: LOW (haiku) → MEDIUM (sonnet) → HIGH (opus)**
 
+All agent names require the \`oh-my-claude-sisyphus:\` prefix when calling via Task tool:
+
 | Domain | LOW (Haiku) | MEDIUM (Sonnet) | HIGH (Opus) |
 |--------|-------------|-----------------|-------------|
-| **Analysis** | \`oracle-low\` | \`oracle-medium\` | \`oracle\` |
-| **Execution** | \`sisyphus-junior-low\` | \`sisyphus-junior\` | \`sisyphus-junior-high\` |
-| **Search** | \`explore\` | \`explore-medium\` | - |
-| **Research** | \`librarian-low\` | \`librarian\` | - |
-| **Frontend** | \`frontend-engineer-low\` | \`frontend-engineer\` | \`frontend-engineer-high\` |
-| **Docs** | \`document-writer\` | - | - |
-| **Planning** | - | - | \`prometheus\`, \`momus\`, \`metis\` |
+| **Analysis** | \`oh-my-claude-sisyphus:oracle-low\` | \`oh-my-claude-sisyphus:oracle-medium\` | \`oh-my-claude-sisyphus:oracle\` |
+| **Execution** | \`oh-my-claude-sisyphus:sisyphus-junior-low\` | \`oh-my-claude-sisyphus:sisyphus-junior\` | \`oh-my-claude-sisyphus:sisyphus-junior-high\` |
+| **Search** | \`oh-my-claude-sisyphus:explore\` | \`oh-my-claude-sisyphus:explore-medium\` | - |
+| **Research** | \`oh-my-claude-sisyphus:librarian-low\` | \`oh-my-claude-sisyphus:librarian\` | - |
+| **Frontend** | \`oh-my-claude-sisyphus:frontend-engineer-low\` | \`oh-my-claude-sisyphus:frontend-engineer\` | \`oh-my-claude-sisyphus:frontend-engineer-high\` |
+| **Docs** | \`oh-my-claude-sisyphus:document-writer\` | - | - |
+| **Planning** | - | - | \`oh-my-claude-sisyphus:prometheus\`, \`oh-my-claude-sisyphus:momus\`, \`oh-my-claude-sisyphus:metis\` |
 
 **Use LOW for simple lookups, MEDIUM for standard work, HIGH for complex reasoning.**
 


### PR DESCRIPTION
## Summary

- Agent names in CLAUDE.md now use the full `oh-my-claude-sisyphus:` prefix to prevent duplicate agent calls
- Added clear warnings to README about `/sisyphus-default` behavior

## Problem

When CLAUDE.md instructed using agent names like `oracle`, Claude Code would:
1. First try calling without prefix → **0 tool uses** (fails)
2. Then retry with `oh-my-claude-sisyphus:oracle` → works

This caused **token waste** and confusing output like:
```
● 3 agents finished
   ├─ oracle (task) · 0 tool uses    ← wasted call
   │  ⎿  Done
Running 3 agents…
   ├─ oh-my-claude-sisyphus:oracle (task) · 8 tool uses  ← actual work
```

## Solution

1. Updated all agent names in `docs/CLAUDE.md` and `src/installer/index.ts` to use the full prefixed form
2. Added explicit note: "**IMPORTANT: Always use the full plugin-prefixed name**"

## Documentation Improvements

Added warnings to README clarifying that:
- `/sisyphus-default` **completely overwrites** `~/.claude/CLAUDE.md`
- Users must re-run `/sisyphus-default` after each plugin update
- Any custom CLAUDE.md content will be lost (suggests backup)

## Test plan

- [ ] Run `/sisyphus-default` after merge
- [ ] Verify agents are called with prefix only (no duplicate 0-tool-use calls)
- [ ] Confirm README warnings are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)