### PR TITLE
fix: sisyphus-default now uses curl to download fresh CLAUDE.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Claude Code native multi-agent orchestration - intelligent model routing, 19 agents, 11 commands, 231 tests",
   "author": {
     "name": "Yeachan Heo",

--- a/commands/sisyphus-default.md
+++ b/commands/sisyphus-default.md
@@ -4,19 +4,27 @@ description: Set Sisyphus as your default operating mode
 
 $ARGUMENTS
 
-## Task: Configure Sisyphus
+## Task: Configure Sisyphus Default Mode
 
-### Step 1: Fetch and Write CLAUDE.md
+**CRITICAL**: This skill ALWAYS downloads fresh CLAUDE.md from GitHub. DO NOT use the Write tool - use bash curl exclusively.
 
-1. Use WebFetch to get the latest CLAUDE.md:
+### Step 1: Download Fresh CLAUDE.md (MANDATORY)
+
+Execute this bash command to erase and download fresh CLAUDE.md:
+
+```bash
+# Remove existing CLAUDE.md and download fresh from GitHub
+rm -f ~/.claude/CLAUDE.md && \
+curl -fsSL "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md" -o ~/.claude/CLAUDE.md && \
+echo "✅ CLAUDE.md downloaded successfully" || \
+echo "❌ Failed to download CLAUDE.md"
 ```
-WebFetch(url: "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md", prompt: "Return the complete raw markdown content exactly as-is")
-```
 
-2. Use the Write tool to write the fetched content to `~/.claude/CLAUDE.md` (ALWAYS overwrite)
+**MANDATORY**: Always run this command. Do NOT skip. Do NOT use Write tool.
 
-**FALLBACK** if WebFetch fails:
-Tell user to visit https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md and copy the content manually.
+**FALLBACK** if curl fails:
+Tell user to manually download from:
+https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md
 
 ### Step 2: Clean Up Legacy Hooks (if present)
 
@@ -50,9 +58,15 @@ If plugin is not enabled, instruct user:
 After completing all steps, report:
 
 ✅ **Sisyphus Configuration Complete**
-- CLAUDE.md: Updated with latest configuration
+- CLAUDE.md: Updated with latest configuration from GitHub
 - Hooks: Provided by plugin (no manual installation needed)
 - Agents: 19+ available (base + tiered variants)
 - Model routing: Haiku/Sonnet/Opus based on task complexity
 
 **Note**: Hooks are now managed by the plugin system automatically. No manual hook installation required.
+
+---
+
+## 🔄 Keeping Up to Date
+
+After installing oh-my-claude-sisyphus updates (via npm or plugin update), run `/sisyphus-default` again to get the latest CLAUDE.md configuration. This ensures you have the newest features and agent configurations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -706,28 +706,53 @@ cat > "$CLAUDE_CONFIG_DIR/commands/sisyphus-default.md" << 'CMD_EOF'
 description: Set Sisyphus as your default operating mode
 ---
 
-I'll configure Sisyphus as your default operating mode by updating your CLAUDE.md.
-
 $ARGUMENTS
 
-## Enabling Sisyphus Default Mode
+## Task: Configure Sisyphus Default Mode
 
-This will update your global CLAUDE.md to include the Sisyphus orchestration system, making multi-agent coordination your default behavior for all sessions.
+**CRITICAL**: This skill ALWAYS downloads fresh CLAUDE.md from GitHub. DO NOT use the Write tool - use bash curl exclusively.
 
-### What This Enables
-1. Automatic access to 11 specialized subagents
-2. Multi-agent delegation capabilities via the Task tool
-3. Continuation enforcement - tasks complete before stopping
-4. Magic keyword support (ultrawork, search, analyze)
+### Step 1: Download Fresh CLAUDE.md (MANDATORY)
 
-### To Revert
-Remove or edit ~/.claude/CLAUDE.md
+Execute this bash command to erase and download fresh CLAUDE.md:
+
+```bash
+# Remove existing CLAUDE.md and download fresh from GitHub
+rm -f ~/.claude/CLAUDE.md && \
+curl -fsSL "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md" -o ~/.claude/CLAUDE.md && \
+echo "✅ CLAUDE.md downloaded successfully" || \
+echo "❌ Failed to download CLAUDE.md"
+```
+
+**MANDATORY**: Always run this command. Do NOT skip. Do NOT use Write tool.
+
+**FALLBACK** if curl fails:
+Tell user to manually download from:
+https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md
+
+### Step 2: Verify Plugin Installation
+
+Verify the plugin is enabled:
+
+```bash
+grep -q "oh-my-claude-sisyphus" ~/.claude/settings.json && echo "Plugin enabled" || echo "Plugin NOT enabled"
+```
+
+### Step 3: Confirm Success
+
+After completing all steps, report:
+
+✅ **Sisyphus Configuration Complete**
+- CLAUDE.md: Updated with latest configuration from GitHub
+- Hooks: Provided by plugin (no manual installation needed)
+- Agents: 19+ available (base + tiered variants)
+- Model routing: Haiku/Sonnet/Opus based on task complexity
 
 ---
 
-**Sisyphus is now your default mode.** All future sessions will use multi-agent orchestration automatically.
+## 🔄 Keeping Up to Date
 
-Use `/sisyphus <task>` to explicitly invoke orchestration mode, or just include "ultrawork" in your prompts.
+After installing oh-my-claude-sisyphus updates (via npm or plugin update), run `/sisyphus-default` again to get the latest CLAUDE.md configuration.
 CMD_EOF
 
 # Plan command (Prometheus planning system)
@@ -1724,6 +1749,10 @@ echo -e "${YELLOW}Updating:${NC}"
 echo "  /update                       # Check for and install updates"
 echo "  # Or run this install script again:"
 echo "  curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/scripts/install.sh | bash"
+echo ""
+echo -e "${YELLOW}After Updates:${NC}"
+echo "  Run '/sisyphus-default' to download the latest CLAUDE.md configuration."
+echo "  This ensures you get the newest features and agent behaviors."
 echo ""
 echo -e "${BLUE}Quick Start:${NC}"
 echo "  1. Run 'claude' to start Claude Code"

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -274,7 +274,7 @@ describe('Installer Constants', () => {
 
     it('should match package.json version', () => {
       // This is a runtime check - VERSION should match the package.json
-      expect(VERSION).toBe('2.4.0');
+      expect(VERSION).toBe('2.4.1');
     });
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -520,6 +520,10 @@ program
         console.log('    frontend-engineer-high - Design systems (Opus)');
         console.log('    frontend-engineer-low  - Simple styling (Haiku)');
         console.log('');
+        console.log(chalk.yellow('After Updates:'));
+        console.log('  Run \'/sisyphus-default\' to download the latest CLAUDE.md configuration.');
+        console.log('  This ensures you get the newest features and agent behaviors.');
+        console.log('');
         console.log(chalk.blue('Quick Start:'));
         console.log('  1. Run \'claude\' to start Claude Code');
         console.log('  2. Type \'/sisyphus-default\' to enable Sisyphus permanently');
@@ -551,6 +555,7 @@ program
     if (result.success) {
       console.log(chalk.green('✓ Oh-My-Claude-Sisyphus installed successfully!'));
       console.log(chalk.gray('  Run "oh-my-claude-sisyphus info" to see available agents.'));
+      console.log(chalk.yellow('  Run "/sisyphus-default" in Claude Code to get the latest CLAUDE.md.'));
     } else {
       // Don't fail the npm install, just warn
       console.warn(chalk.yellow('⚠ Could not complete Sisyphus setup:'), result.message);

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -39,7 +39,7 @@ export const SETTINGS_FILE = join(CLAUDE_CONFIG_DIR, 'settings.json');
 export const VERSION_FILE = join(CLAUDE_CONFIG_DIR, '.sisyphus-version.json');
 
 /** Current version */
-export const VERSION = '2.4.0';
+export const VERSION = '2.4.1';
 
 /** Installation result */
 export interface InstallResult {
@@ -1623,28 +1623,53 @@ If you have incomplete tasks and attempt to stop, the system will remind you:
 description: Set Sisyphus as your default operating mode
 ---
 
-I'll configure Sisyphus as your default operating mode by updating your CLAUDE.md.
-
 $ARGUMENTS
 
-## Enabling Sisyphus Default Mode
+## Task: Configure Sisyphus Default Mode
 
-This will update your global CLAUDE.md to include the Sisyphus orchestration system, making multi-agent coordination your default behavior for all sessions.
+**CRITICAL**: This skill ALWAYS downloads fresh CLAUDE.md from GitHub. DO NOT use the Write tool - use bash curl exclusively.
 
-### What This Enables
-1. Automatic access to 11 specialized subagents
-2. Multi-agent delegation capabilities via the Task tool
-3. Continuation enforcement - tasks complete before stopping
-4. Magic keyword support (ultrawork, search, analyze)
+### Step 1: Download Fresh CLAUDE.md (MANDATORY)
 
-### To Revert
-Remove or edit ~/.claude/CLAUDE.md
+Execute this bash command to erase and download fresh CLAUDE.md:
+
+\`\`\`bash
+# Remove existing CLAUDE.md and download fresh from GitHub
+rm -f ~/.claude/CLAUDE.md && \\
+curl -fsSL "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md" -o ~/.claude/CLAUDE.md && \\
+echo "✅ CLAUDE.md downloaded successfully" || \\
+echo "❌ Failed to download CLAUDE.md"
+\`\`\`
+
+**MANDATORY**: Always run this command. Do NOT skip. Do NOT use Write tool.
+
+**FALLBACK** if curl fails:
+Tell user to manually download from:
+https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md
+
+### Step 2: Verify Plugin Installation
+
+Verify the plugin is enabled:
+
+\`\`\`bash
+grep -q "oh-my-claude-sisyphus" ~/.claude/settings.json && echo "Plugin enabled" || echo "Plugin NOT enabled"
+\`\`\`
+
+### Step 3: Confirm Success
+
+After completing all steps, report:
+
+✅ **Sisyphus Configuration Complete**
+- CLAUDE.md: Updated with latest configuration from GitHub
+- Hooks: Provided by plugin (no manual installation needed)
+- Agents: 19+ available (base + tiered variants)
+- Model routing: Haiku/Sonnet/Opus based on task complexity
 
 ---
 
-**Sisyphus is now your default mode.** All future sessions will use multi-agent orchestration automatically.
+## 🔄 Keeping Up to Date
 
-Use \`/sisyphus <task>\` to explicitly invoke orchestration mode, or just include "ultrawork" in your prompts.`,
+After installing oh-my-claude-sisyphus updates (via npm or plugin update), run \`/sisyphus-default\` again to get the latest CLAUDE.md configuration.`,
 
   'plan.md': `---
 description: Start a planning session with Prometheus


### PR DESCRIPTION
## Summary

- `/sisyphus-default` now uses bash `curl` instead of WebFetch + Write tool
- Always erases existing CLAUDE.md and downloads fresh from GitHub
- Added "After Updates" notice to all install outputs prompting users to rerun `/sisyphus-default`

## The Problem

Previously, `/sisyphus-default` used WebFetch to fetch CLAUDE.md content and Write tool to save it. This was unreliable because:
- WebFetch can be blocked or rate-limited
- Using Write tool instead of bash is less systematic
- Users weren't notified to rerun `/sisyphus-default` after package updates

## The Solution

The skill now executes this bash command:
```bash
rm -f ~/.claude/CLAUDE.md && \
curl -fsSL "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claude-sisyphus/main/docs/CLAUDE.md" -o ~/.claude/CLAUDE.md
```

This ensures:
1. Old CLAUDE.md is always deleted first
2. Fresh content is downloaded directly from GitHub
3. No reliance on WebFetch tool

## User Alert Mechanism

Added "After Updates" notice to:
- `scripts/install.sh` final output
- `oh-my-claude-sisyphus install` CLI output  
- `npm postinstall` output

This prompts users to run `/sisyphus-default` after updates to get the latest configuration.

## Test plan

- [x] All 231 tests pass
- [ ] Manual test: run `/sisyphus-default` in Claude Code and verify CLAUDE.md is downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)