### PR TITLE
feat(hud): Add type-coded agent visualization with model tier colors

### DIFF
--- a/src/__tests__/hud-agents.test.ts
+++ b/src/__tests__/hud-agents.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Sisyphus HUD - Agents Element Tests
+ *
+ * Tests for agent visualization with different formats.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  renderAgents,
+  renderAgentsCoded,
+  renderAgentsCodedWithDuration,
+  renderAgentsDetailed,
+  renderAgentsByFormat,
+} from '../hud/elements/agents.js';
+import type { ActiveAgent } from '../hud/types.js';
+
+// ANSI color codes for verification
+const RESET = '\x1b[0m';
+const CYAN = '\x1b[36m';
+const MAGENTA = '\x1b[35m';
+const YELLOW = '\x1b[33m';
+const GREEN = '\x1b[32m';
+
+// Helper to create mock agents
+function createAgent(
+  type: string,
+  model?: string,
+  startTime?: Date
+): ActiveAgent {
+  return {
+    id: `agent-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type,
+    model,
+    status: 'running',
+    startTime: startTime || new Date(),
+  };
+}
+
+describe('Agents Element', () => {
+  describe('renderAgents (count format)', () => {
+    it('should return null for empty array', () => {
+      expect(renderAgents([])).toBeNull();
+    });
+
+    it('should return null when no agents are running', () => {
+      const agents: ActiveAgent[] = [
+        { ...createAgent('oracle'), status: 'completed' },
+      ];
+      expect(renderAgents(agents)).toBeNull();
+    });
+
+    it('should show count of running agents', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oracle'),
+        createAgent('explore'),
+      ];
+      const result = renderAgents(agents);
+      expect(result).toBe(`agents:${CYAN}2${RESET}`);
+    });
+  });
+
+  describe('renderAgentsCoded (codes format)', () => {
+    it('should return null for empty array', () => {
+      expect(renderAgentsCoded([])).toBeNull();
+    });
+
+    it('should show single-character codes for known agents', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:oracle', 'opus'),
+      ];
+      const result = renderAgentsCoded(agents);
+      // Oracle with opus should be uppercase O in magenta
+      expect(result).toContain('agents:');
+      expect(result).toContain('O');
+    });
+
+    it('should use lowercase for sonnet/haiku tiers', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:explore', 'haiku'),
+      ];
+      const result = renderAgentsCoded(agents);
+      expect(result).toContain('e');
+    });
+
+    it('should handle multiple agents', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:oracle', 'opus'),
+        createAgent('oh-my-claude-sisyphus:explore', 'haiku'),
+        createAgent('oh-my-claude-sisyphus:sisyphus-junior', 'sonnet'),
+      ];
+      const result = renderAgentsCoded(agents);
+      expect(result).toBeDefined();
+      // Should contain codes for all three
+      expect(result!.replace(/\x1b\[[0-9;]*m/g, '')).toBe('agents:Oes');
+    });
+
+    it('should handle agents without model info', () => {
+      const agents: ActiveAgent[] = [createAgent('oh-my-claude-sisyphus:oracle')];
+      const result = renderAgentsCoded(agents);
+      expect(result).toContain('O');
+    });
+
+    it('should use first letter for unknown agent types', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:unknown-agent', 'sonnet'),
+      ];
+      const result = renderAgentsCoded(agents);
+      expect(result!.replace(/\x1b\[[0-9;]*m/g, '')).toBe('agents:u');
+    });
+  });
+
+  describe('renderAgentsCodedWithDuration (codes-duration format)', () => {
+    it('should return null for empty array', () => {
+      expect(renderAgentsCodedWithDuration([])).toBeNull();
+    });
+
+    it('should not show duration for very recent agents', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:oracle', 'opus', new Date()),
+      ];
+      const result = renderAgentsCodedWithDuration(agents);
+      // No duration suffix for <10s
+      expect(result!.replace(/\x1b\[[0-9;]*m/g, '')).toBe('agents:O');
+    });
+
+    it('should show seconds for agents running 10-59s', () => {
+      const agents: ActiveAgent[] = [
+        createAgent(
+          'oh-my-claude-sisyphus:oracle',
+          'opus',
+          new Date(Date.now() - 30000)
+        ), // 30 seconds ago
+      ];
+      const result = renderAgentsCodedWithDuration(agents);
+      const stripped = result!.replace(/\x1b\[[0-9;]*m/g, '');
+      expect(stripped).toMatch(/agents:O\(30s\)/);
+    });
+
+    it('should show minutes for agents running 1-9 min', () => {
+      const agents: ActiveAgent[] = [
+        createAgent(
+          'oh-my-claude-sisyphus:oracle',
+          'opus',
+          new Date(Date.now() - 180000)
+        ), // 3 minutes ago
+      ];
+      const result = renderAgentsCodedWithDuration(agents);
+      const stripped = result!.replace(/\x1b\[[0-9;]*m/g, '');
+      expect(stripped).toMatch(/agents:O\(3m\)/);
+    });
+
+    it('should show alert for agents running 10+ min', () => {
+      const agents: ActiveAgent[] = [
+        createAgent(
+          'oh-my-claude-sisyphus:oracle',
+          'opus',
+          new Date(Date.now() - 600000)
+        ), // 10 minutes ago
+      ];
+      const result = renderAgentsCodedWithDuration(agents);
+      const stripped = result!.replace(/\x1b\[[0-9;]*m/g, '');
+      expect(stripped).toMatch(/agents:O!/);
+    });
+  });
+
+  describe('renderAgentsDetailed (detailed format)', () => {
+    it('should return null for empty array', () => {
+      expect(renderAgentsDetailed([])).toBeNull();
+    });
+
+    it('should show full agent names', () => {
+      const agents: ActiveAgent[] = [createAgent('oh-my-claude-sisyphus:oracle')];
+      const result = renderAgentsDetailed(agents);
+      expect(result).toContain('oracle');
+    });
+
+    it('should abbreviate common long names', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:sisyphus-junior', 'sonnet'),
+      ];
+      const result = renderAgentsDetailed(agents);
+      expect(result).toContain('sj');
+    });
+
+    it('should include duration for long-running agents', () => {
+      const agents: ActiveAgent[] = [
+        createAgent(
+          'oh-my-claude-sisyphus:oracle',
+          'opus',
+          new Date(Date.now() - 120000)
+        ), // 2 minutes
+      ];
+      const result = renderAgentsDetailed(agents);
+      expect(result).toContain('(2m)');
+    });
+  });
+
+  describe('renderAgentsByFormat (format router)', () => {
+    const agents: ActiveAgent[] = [
+      createAgent('oh-my-claude-sisyphus:oracle', 'opus'),
+      createAgent('oh-my-claude-sisyphus:explore', 'haiku'),
+    ];
+
+    it('should route to count format', () => {
+      const result = renderAgentsByFormat(agents, 'count');
+      expect(result).toBe(`agents:${CYAN}2${RESET}`);
+    });
+
+    it('should route to codes format', () => {
+      const result = renderAgentsByFormat(agents, 'codes');
+      expect(result).toContain('agents:');
+      expect(result!.replace(/\x1b\[[0-9;]*m/g, '')).toBe('agents:Oe');
+    });
+
+    it('should route to codes-duration format', () => {
+      const result = renderAgentsByFormat(agents, 'codes-duration');
+      expect(result).toContain('agents:');
+    });
+
+    it('should route to detailed format', () => {
+      const result = renderAgentsByFormat(agents, 'detailed');
+      expect(result).toContain('oracle');
+    });
+
+    it('should default to count for unknown format', () => {
+      const result = renderAgentsByFormat(agents, 'unknown' as any);
+      expect(result).toBe(`agents:${CYAN}2${RESET}`);
+    });
+  });
+
+  describe('Agent type codes', () => {
+    const testCases = [
+      { type: 'oracle', model: 'opus', expected: 'O' },
+      { type: 'oracle-low', model: 'haiku', expected: 'o' },
+      { type: 'oracle-medium', model: 'sonnet', expected: 'o' },
+      { type: 'explore', model: 'haiku', expected: 'e' },
+      { type: 'explore-medium', model: 'sonnet', expected: 'e' },
+      { type: 'sisyphus-junior', model: 'sonnet', expected: 's' },
+      { type: 'sisyphus-junior-low', model: 'haiku', expected: 's' },
+      { type: 'sisyphus-junior-high', model: 'opus', expected: 'S' },
+      { type: 'frontend-engineer', model: 'sonnet', expected: 'f' },
+      { type: 'frontend-engineer-high', model: 'opus', expected: 'F' },
+      { type: 'librarian', model: 'sonnet', expected: 'l' },
+      { type: 'document-writer', model: 'haiku', expected: 'd' },
+      { type: 'prometheus', model: 'opus', expected: 'P' },
+      { type: 'momus', model: 'opus', expected: 'M' },
+      { type: 'metis', model: 'opus', expected: 'T' },
+      { type: 'qa-tester', model: 'sonnet', expected: 'q' },
+      { type: 'multimodal-looker', model: 'sonnet', expected: 'v' },
+    ];
+
+    testCases.forEach(({ type, model, expected }) => {
+      it(`should render ${type} (${model}) as '${expected}'`, () => {
+        const agents: ActiveAgent[] = [
+          createAgent(`oh-my-claude-sisyphus:${type}`, model),
+        ];
+        const result = renderAgentsCoded(agents);
+        const stripped = result!.replace(/\x1b\[[0-9;]*m/g, '');
+        expect(stripped).toBe(`agents:${expected}`);
+      });
+    });
+  });
+
+  describe('Model tier color coding', () => {
+    it('should use magenta for opus tier', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:oracle', 'opus'),
+      ];
+      const result = renderAgentsCoded(agents);
+      expect(result).toContain(MAGENTA);
+    });
+
+    it('should use yellow for sonnet tier', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:sisyphus-junior', 'sonnet'),
+      ];
+      const result = renderAgentsCoded(agents);
+      expect(result).toContain(YELLOW);
+    });
+
+    it('should use green for haiku tier', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:explore', 'haiku'),
+      ];
+      const result = renderAgentsCoded(agents);
+      expect(result).toContain(GREEN);
+    });
+
+    it('should use cyan for unknown model', () => {
+      const agents: ActiveAgent[] = [
+        createAgent('oh-my-claude-sisyphus:oracle'),
+      ];
+      const result = renderAgentsCoded(agents);
+      expect(result).toContain(CYAN);
+    });
+  });
+});

--- a/src/hud/colors.ts
+++ b/src/hud/colors.ts
@@ -109,6 +109,38 @@ export function getTodoColor(completed: number, total: number): string {
 }
 
 // ============================================================================
+// Model Tier Colors (for agent visualization)
+// ============================================================================
+
+/**
+ * Get color for model tier.
+ * - Opus: Magenta (high-powered)
+ * - Sonnet: Yellow (standard)
+ * - Haiku: Green (lightweight)
+ */
+export function getModelTierColor(model: string | undefined): string {
+  if (!model) return CYAN; // Default/unknown
+  const tier = model.toLowerCase();
+  if (tier.includes('opus')) return MAGENTA;
+  if (tier.includes('sonnet')) return YELLOW;
+  if (tier.includes('haiku')) return GREEN;
+  return CYAN; // Unknown model
+}
+
+/**
+ * Get color for agent duration (warning/alert).
+ * - <2min: normal (green)
+ * - 2-5min: warning (yellow)
+ * - >5min: alert (red)
+ */
+export function getDurationColor(durationMs: number): string {
+  const minutes = durationMs / 60000;
+  if (minutes >= 5) return RED;
+  if (minutes >= 2) return YELLOW;
+  return GREEN;
+}
+
+// ============================================================================
 // Progress Bars
 // ============================================================================
 

--- a/src/hud/elements/agents.ts
+++ b/src/hud/elements/agents.ts
@@ -1,13 +1,98 @@
 /**
  * Sisyphus HUD - Agents Element
  *
- * Renders active agent count display.
+ * Renders active agent count display with multiple format options:
+ * - count: agents:2
+ * - codes: agents:Oes (type-coded with model tier casing)
+ * - detailed: agents:[oracle(2m),explore,sj]
  */
 
-import type { ActiveAgent } from '../types.js';
-import { cyan, dim, RESET } from '../colors.js';
+import type { ActiveAgent, AgentsFormat } from '../types.js';
+import { cyan, dim, RESET, getModelTierColor, getDurationColor } from '../colors.js';
 
 const CYAN = '\x1b[36m';
+
+// ============================================================================
+// Agent Type Codes
+// ============================================================================
+
+/**
+ * Single-character codes for each agent type.
+ * Case indicates model tier: Uppercase = Opus, lowercase = Sonnet/Haiku
+ */
+const AGENT_TYPE_CODES: Record<string, string> = {
+  oracle: 'O',
+  'oracle-low': 'o',
+  'oracle-medium': 'o',
+  explore: 'E',
+  'explore-medium': 'e',
+  'sisyphus-junior': 'S',
+  'sisyphus-junior-low': 's',
+  'sisyphus-junior-high': 'S',
+  'frontend-engineer': 'F',
+  'frontend-engineer-low': 'f',
+  'frontend-engineer-high': 'F',
+  librarian: 'L',
+  'librarian-low': 'l',
+  'document-writer': 'd', // Always haiku
+  prometheus: 'P', // Always opus
+  momus: 'M', // Always opus
+  metis: 'T', // Me**t**is (M taken)
+  'qa-tester': 'q', // Always sonnet
+  'multimodal-looker': 'v', // **V**isual (always sonnet)
+};
+
+/**
+ * Get single-character code for an agent type.
+ */
+function getAgentCode(agentType: string, model?: string): string {
+  // Extract the short name from full type (e.g., "oh-my-claude-sisyphus:oracle" -> "oracle")
+  const parts = agentType.split(':');
+  const shortName = parts[parts.length - 1] || agentType;
+
+  // Look up the code
+  let code = AGENT_TYPE_CODES[shortName];
+
+  if (!code) {
+    // Unknown agent - use first letter
+    code = shortName.charAt(0).toUpperCase();
+  }
+
+  // Determine case based on model tier if code is single letter
+  if (model) {
+    const tier = model.toLowerCase();
+    if (tier.includes('opus')) {
+      code = code.toUpperCase();
+    } else {
+      code = code.toLowerCase();
+    }
+  }
+
+  return code;
+}
+
+/**
+ * Format duration for display.
+ * <10s: no suffix, 10s-59s: (Xs), 1m-9m: (Xm), >=10m: !
+ */
+function formatDuration(durationMs: number): string {
+  const seconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+
+  if (seconds < 10) {
+    return ''; // No suffix for very short durations
+  } else if (seconds < 60) {
+    return `(${seconds}s)`;
+  } else if (minutes < 10) {
+    return `(${minutes}m)`;
+  } else {
+    return '!'; // Alert for very long durations
+  }
+}
+
+// ============================================================================
+// Render Functions
+// ============================================================================
 
 /**
  * Render active agent count.
@@ -26,9 +111,73 @@ export function renderAgents(agents: ActiveAgent[]): string | null {
 }
 
 /**
+ * Render agents with single-character type codes.
+ * Uppercase = Opus tier, lowercase = Sonnet/Haiku.
+ * Color-coded by model tier.
+ *
+ * Format: agents:Oes
+ */
+export function renderAgentsCoded(agents: ActiveAgent[]): string | null {
+  const running = agents.filter((a) => a.status === 'running');
+
+  if (running.length === 0) {
+    return null;
+  }
+
+  // Build coded string with colors
+  const codes = running.map((a) => {
+    const code = getAgentCode(a.type, a.model);
+    const color = getModelTierColor(a.model);
+    return `${color}${code}${RESET}`;
+  });
+
+  return `agents:${codes.join('')}`;
+}
+
+/**
+ * Render agents with codes and duration indicators.
+ * Shows how long each agent has been running.
+ *
+ * Format: agents:O(2m)es
+ */
+export function renderAgentsCodedWithDuration(agents: ActiveAgent[]): string | null {
+  const running = agents.filter((a) => a.status === 'running');
+
+  if (running.length === 0) {
+    return null;
+  }
+
+  const now = Date.now();
+
+  // Build coded string with colors and durations
+  const codes = running.map((a) => {
+    const code = getAgentCode(a.type, a.model);
+    const durationMs = now - a.startTime.getTime();
+    const duration = formatDuration(durationMs);
+
+    // Color the code by model tier
+    const modelColor = getModelTierColor(a.model);
+
+    if (duration === '!') {
+      // Alert case - show exclamation in duration color
+      const durationColor = getDurationColor(durationMs);
+      return `${modelColor}${code}${durationColor}!${RESET}`;
+    } else if (duration) {
+      // Normal duration - dim the time portion
+      return `${modelColor}${code}${dim(duration)}${RESET}`;
+    } else {
+      // No duration suffix
+      return `${modelColor}${code}${RESET}`;
+    }
+  });
+
+  return `agents:${codes.join('')}`;
+}
+
+/**
  * Render detailed agent list (for full mode).
  *
- * Format: agents:[explore,oracle]
+ * Format: agents:[oracle(2m),explore,sj]
  */
 export function renderAgentsDetailed(agents: ActiveAgent[]): string | null {
   const running = agents.filter((a) => a.status === 'running');
@@ -37,12 +186,51 @@ export function renderAgentsDetailed(agents: ActiveAgent[]): string | null {
     return null;
   }
 
-  // Extract short agent type names
+  const now = Date.now();
+
+  // Extract short agent type names with duration
   const names = running.map((a) => {
     // Extract last part of agent type (e.g., "oh-my-claude-sisyphus:explore" -> "explore")
     const parts = a.type.split(':');
-    return parts[parts.length - 1] || a.type;
+    let name = parts[parts.length - 1] || a.type;
+
+    // Abbreviate common names
+    if (name === 'sisyphus-junior') name = 'sj';
+    if (name === 'sisyphus-junior-low') name = 'sj-l';
+    if (name === 'sisyphus-junior-high') name = 'sj-h';
+    if (name === 'frontend-engineer') name = 'fe';
+    if (name === 'frontend-engineer-low') name = 'fe-l';
+    if (name === 'frontend-engineer-high') name = 'fe-h';
+    if (name === 'document-writer') name = 'doc';
+    if (name === 'multimodal-looker') name = 'visual';
+
+    // Add duration if significant
+    const durationMs = now - a.startTime.getTime();
+    const duration = formatDuration(durationMs);
+
+    return duration ? `${name}${duration}` : name;
   });
 
   return `agents:[${CYAN}${names.join(',')}${RESET}]`;
+}
+
+/**
+ * Render agents based on format configuration.
+ */
+export function renderAgentsByFormat(
+  agents: ActiveAgent[],
+  format: AgentsFormat
+): string | null {
+  switch (format) {
+    case 'count':
+      return renderAgents(agents);
+    case 'codes':
+      return renderAgentsCoded(agents);
+    case 'codes-duration':
+      return renderAgentsCodedWithDuration(agents);
+    case 'detailed':
+      return renderAgentsDetailed(agents);
+    default:
+      return renderAgents(agents);
+  }
 }

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -7,7 +7,7 @@
 import type { HudRenderContext, HudConfig } from './types.js';
 import { bold, dim } from './colors.js';
 import { renderRalph } from './elements/ralph.js';
-import { renderAgents } from './elements/agents.js';
+import { renderAgentsByFormat } from './elements/agents.js';
 import { renderTodos } from './elements/todos.js';
 import { renderSkills } from './elements/skills.js';
 import { renderContext } from './elements/context.js';
@@ -52,7 +52,10 @@ export function render(context: HudRenderContext, config: HudConfig): string {
 
   // Active agents
   if (enabledElements.agents) {
-    const agents = renderAgents(context.activeAgents);
+    const agents = renderAgentsByFormat(
+      context.activeAgents,
+      enabledElements.agentsFormat || 'codes'
+    );
     if (agents) elements.push(agents);
   }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -139,6 +139,15 @@ export interface HudRenderContext {
 
 export type HudPreset = 'minimal' | 'focused' | 'full';
 
+/**
+ * Agent display format options:
+ * - count: agents:2
+ * - codes: agents:Oes (type-coded with model tier casing)
+ * - codes-duration: agents:O(2m)es (codes with duration)
+ * - detailed: agents:[oracle(2m),explore,sj]
+ */
+export type AgentsFormat = 'count' | 'codes' | 'codes-duration' | 'detailed';
+
 export interface HudElementConfig {
   sisyphusLabel: boolean;
   ralph: boolean;
@@ -146,6 +155,7 @@ export interface HudElementConfig {
   activeSkills: boolean;
   contextBar: boolean;
   agents: boolean;
+  agentsFormat: AgentsFormat;
   backgroundTasks: boolean;
   todos: boolean;
 }
@@ -174,6 +184,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     activeSkills: true,
     contextBar: true,
     agents: true,
+    agentsFormat: 'codes',
     backgroundTasks: true,
     todos: true,
   },
@@ -192,6 +203,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     activeSkills: true,
     contextBar: false,
     agents: false,
+    agentsFormat: 'count',
     backgroundTasks: false,
     todos: true,
   },
@@ -202,6 +214,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     activeSkills: true,
     contextBar: true,
     agents: true,
+    agentsFormat: 'codes',
     backgroundTasks: true,
     todos: true,
   },
@@ -212,6 +225,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     activeSkills: true,
     contextBar: true,
     agents: true,
+    agentsFormat: 'codes-duration',
     backgroundTasks: true,
     todos: true,
   },


### PR DESCRIPTION
## Summary
- Enhanced HUD agent display with multiple visualization formats for better parallel agent visibility
- Added single-character type codes for agents (O=oracle, E=explore, S=sisyphus-junior, etc.)
- Model tier indication via case (Uppercase=Opus, lowercase=Sonnet/Haiku)
- Color-coded by model tier (Magenta=Opus, Yellow=Sonnet, Green=Haiku)
- Duration indicators for long-running agents (<10s: none, 10-59s: (Xs), 1-9m: (Xm), ≥10m: !)

## Formats
| Format | Example | Preset |
|--------|---------|--------|
| count | `agents:2` | minimal |
| codes | `agents:Oes` | focused (default) |
| codes-duration | `agents:O(2m)es` | full |
| detailed | `agents:[oracle(2m),explore,sj]` | config |

## Changes
- `src/hud/elements/agents.ts` - New render functions and agent code mapping
- `src/hud/colors.ts` - Model tier and duration color functions
- `src/hud/types.ts` - AgentsFormat type and config updates
- `src/hud/render.ts` - Wire up format routing
- `src/__tests__/hud-agents.test.ts` - 44 new tests

## Test plan
- [x] All 402 tests pass (44 new + 358 existing)
- [x] Manual testing verified all formats work correctly
- [x] Oracle verification confirmed production-ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)