### PR TITLE
fix: handle claudeAiOauth wrapper in macOS Keychain credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "3.3.0",
+  "version": "3.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "3.3.0",
+      "version": "3.3.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -121,10 +121,14 @@ function readKeychainCredentials(): OAuthCredentials | null {
     if (!result) return null;
 
     const parsed = JSON.parse(result);
-    if (parsed.accessToken) {
+
+    // Handle nested structure (claudeAiOauth wrapper)
+    const creds = parsed.claudeAiOauth || parsed;
+
+    if (creds.accessToken) {
       return {
-        accessToken: parsed.accessToken,
-        expiresAt: parsed.expiresAt,
+        accessToken: creds.accessToken,
+        expiresAt: creds.expiresAt,
       };
     }
   } catch {


### PR DESCRIPTION
## Summary
- Fix HUD rate limit not showing on macOS when Keychain credentials use `claudeAiOauth` wrapper format
- `readKeychainCredentials()` now matches `readFileCredentials()` behavior

## Root Cause
Keychain data structure: `{"claudeAiOauth":{"accessToken":"sk-ant-..."}}`

The code checked `parsed.accessToken` directly, which always failed for wrapped credentials.

## Fix
```typescript
const creds = parsed.claudeAiOauth || parsed;
if (creds.accessToken) { ... }
```

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)