### PR TITLE
feat(omc-setup): add GitHub star prompt after setup completion

### DIFF
--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -239,6 +239,42 @@ The status bar now shows OMC state. Restart Claude Code to see it.
 Your workflow won't break - it just got easier!
 ```
 
+## Step 8: Ask About Starring Repository
+
+First, check if `gh` CLI is available and authenticated:
+
+```bash
+gh auth status &>/dev/null
+```
+
+### If gh is available and authenticated:
+
+Use the AskUserQuestion tool to prompt the user:
+
+**Question:** "If you're enjoying oh-my-claudecode, would you like to support the project by starring it on GitHub?"
+
+**Options:**
+1. **Yes, star it!** - Star the repository
+2. **No thanks** - Skip without further prompts
+3. **Maybe later** - Skip without further prompts
+
+If user chooses "Yes, star it!":
+
+```bash
+gh api -X PUT /user/starred/Yeachan-Heo/oh-my-claudecode 2>/dev/null && echo "Thanks for starring! ⭐" || true
+```
+
+**Note:** Fail silently if the API call doesn't work - never block setup completion.
+
+### If gh is NOT available or not authenticated:
+
+```bash
+echo ""
+echo "If you enjoy oh-my-claudecode, consider starring the repo:"
+echo "  https://github.com/Yeachan-Heo/oh-my-claudecode"
+echo ""
+```
+
 ## Fallback
 
 If curl fails, tell user to manually download from:


### PR DESCRIPTION
## Summary
- Adds Step 8 to omc-setup that optionally prompts users to star the repository after successful setup
- Uses AskUserQuestion tool for clickable UI with tasteful, non-pushy options ("Yes, star it!", "No thanks", "Maybe later")
- Falls back to showing the repo URL if `gh` CLI is unavailable or not authenticated
- Graceful error handling - never blocks setup completion

Closes #82

## Test plan
- [ ] Run `/omc-setup` and verify the star prompt appears after Step 7
- [ ] Test with `gh` CLI authenticated - verify star API call works
- [ ] Test with `gh` CLI unavailable - verify URL fallback displays
- [ ] Verify declining ("No thanks" / "Maybe later") proceeds without error
- [ ] Verify API failure is handled silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)