### PR TITLE
feat(hud): add optional visual progress bars for context and rate limits

### DIFF
--- a/src/hud/elements/index.ts
+++ b/src/hud/elements/index.ts
@@ -11,7 +11,7 @@ export { renderSkills, renderLastSkill } from './skills.js';
 export { renderContext } from './context.js';
 export { renderBackground } from './background.js';
 export { renderPrd } from './prd.js';
-export { renderRateLimits, renderRateLimitsCompact } from './limits.js';
+export { renderRateLimits, renderRateLimitsCompact, renderRateLimitsWithBar } from './limits.js';
 export { renderPermission } from './permission.js';
 export { renderThinking } from './thinking.js';
 export { renderSession } from './session.js';

--- a/src/hud/elements/limits.ts
+++ b/src/hud/elements/limits.ts
@@ -101,3 +101,45 @@ export function renderRateLimitsCompact(limits: RateLimits | null): string | nul
 
   return `${fiveHourColor}${fiveHour}%${RESET}/${weeklyColor}${weekly}%${RESET}`;
 }
+
+/**
+ * Render rate limits with visual progress bars.
+ *
+ * Format: 5h:[████░░░░░░]45%(3h42m) wk:[█░░░░░░░░░]12%(2d5h)
+ */
+export function renderRateLimitsWithBar(
+  limits: RateLimits | null,
+  barWidth: number = 8
+): string | null {
+  if (!limits) return null;
+
+  const fiveHour = Math.min(100, Math.max(0, Math.round(limits.fiveHourPercent)));
+  const weekly = Math.min(100, Math.max(0, Math.round(limits.weeklyPercent)));
+
+  const fiveHourColor = getColor(fiveHour);
+  const weeklyColor = getColor(weekly);
+
+  // Build bars
+  const fiveHourFilled = Math.round((fiveHour / 100) * barWidth);
+  const fiveHourEmpty = barWidth - fiveHourFilled;
+  const fiveHourBar = `${fiveHourColor}${'█'.repeat(fiveHourFilled)}${DIM}${'░'.repeat(fiveHourEmpty)}${RESET}`;
+
+  const weeklyFilled = Math.round((weekly / 100) * barWidth);
+  const weeklyEmpty = barWidth - weeklyFilled;
+  const weeklyBar = `${weeklyColor}${'█'.repeat(weeklyFilled)}${DIM}${'░'.repeat(weeklyEmpty)}${RESET}`;
+
+  // Format reset times
+  const fiveHourReset = formatResetTime(limits.fiveHourResetsAt);
+  const weeklyReset = formatResetTime(limits.weeklyResetsAt);
+
+  // Build parts with bars
+  const fiveHourPart = fiveHourReset
+    ? `5h:[${fiveHourBar}]${fiveHourColor}${fiveHour}%${RESET}${DIM}(${fiveHourReset})${RESET}`
+    : `5h:[${fiveHourBar}]${fiveHourColor}${fiveHour}%${RESET}`;
+
+  const weeklyPart = weeklyReset
+    ? `${DIM}wk:${RESET}[${weeklyBar}]${weeklyColor}${weekly}%${RESET}${DIM}(${weeklyReset})${RESET}`
+    : `${DIM}wk:${RESET}[${weeklyBar}]${weeklyColor}${weekly}%${RESET}`;
+
+  return `${fiveHourPart} ${weeklyPart}`;
+}

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -10,10 +10,10 @@ import { renderRalph } from './elements/ralph.js';
 import { renderAgentsByFormat, renderAgentsMultiLine } from './elements/agents.js';
 import { renderTodosWithCurrent } from './elements/todos.js';
 import { renderSkills, renderLastSkill } from './elements/skills.js';
-import { renderContext } from './elements/context.js';
+import { renderContext, renderContextWithBar } from './elements/context.js';
 import { renderBackground } from './elements/background.js';
 import { renderPrd } from './elements/prd.js';
-import { renderRateLimits } from './elements/limits.js';
+import { renderRateLimits, renderRateLimitsWithBar } from './elements/limits.js';
 import { renderPermission } from './elements/permission.js';
 import { renderThinking } from './elements/thinking.js';
 import { renderSession } from './elements/session.js';
@@ -34,7 +34,9 @@ export function render(context: HudRenderContext, config: HudConfig): string {
 
   // Rate limits (5h and weekly)
   if (enabledElements.rateLimits && context.rateLimits) {
-    const limits = renderRateLimits(context.rateLimits);
+    const limits = enabledElements.useBars
+      ? renderRateLimitsWithBar(context.rateLimits)
+      : renderRateLimits(context.rateLimits);
     if (limits) elements.push(limits);
   }
 
@@ -92,7 +94,9 @@ export function render(context: HudRenderContext, config: HudConfig): string {
 
   // Context window
   if (enabledElements.contextBar) {
-    const ctx = renderContext(context.contextPercent, config.thresholds);
+    const ctx = enabledElements.useBars
+      ? renderContextWithBar(context.contextPercent, config.thresholds)
+      : renderContext(context.contextPercent, config.thresholds);
     if (ctx) elements.push(ctx);
   }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -229,6 +229,7 @@ export interface HudElementConfig {
   permissionStatus: boolean;  // Show pending permission indicator
   thinking: boolean;          // Show extended thinking indicator
   sessionHealth: boolean;     // Show session health/duration
+  useBars: boolean;           // Show visual progress bars instead of/alongside percentages
 }
 
 export interface HudThresholds {
@@ -267,6 +268,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     permissionStatus: false,  // Disabled: heuristic-based, causes false positives
     thinking: true,
     sessionHealth: true,
+    useBars: false,  // Disabled by default for backwards compatibility
   },
   thresholds: {
     contextWarning: 70,
@@ -294,6 +296,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,
     thinking: false,
     sessionHealth: false,
+    useBars: false,
   },
   focused: {
     omcLabel: true,
@@ -312,6 +315,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,  // Disabled: heuristic unreliable
     thinking: true,
     sessionHealth: true,
+    useBars: true,
   },
   full: {
     omcLabel: true,
@@ -330,6 +334,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,  // Disabled: heuristic unreliable
     thinking: true,
     sessionHealth: true,
+    useBars: true,
   },
   opencode: {
     omcLabel: true,
@@ -348,6 +353,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,  // Disabled: heuristic unreliable
     thinking: true,
     sessionHealth: true,
+    useBars: false,
   },
   dense: {
     omcLabel: true,
@@ -366,5 +372,6 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,  // Disabled: heuristic unreliable
     thinking: true,
     sessionHealth: true,
+    useBars: true,
   },
 };


### PR DESCRIPTION
## Summary
- Adds `useBars` config option to `HudElementConfig` for optional visual progress bars
- Creates `renderRateLimitsWithBar()` function rendering rate limits as `5h:[████░░░░░░]45%(3h42m) wk:[█░░░░░░░░░]12%(2d5h)`
- Wires up bar variants in `render.ts` - uses existing `renderContextWithBar()` and new rate limits bar function when enabled
- Bars enabled by default in `focused`, `full`, and `dense` presets; disabled in `minimal` and `opencode` for backwards compatibility

Closes #81

## Test plan
- [ ] Verify TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Test HUD with `useBars: true` - visual bars render correctly for context and rate limits
- [ ] Test HUD with `useBars: false` - original percentage display works as before
- [ ] Verify all preset configs have appropriate `useBars` settings
- [ ] Test edge cases: 0%, 100%, NaN values render correctly
- [ ] Verify bar width adapts correctly for rate limits (8 chars vs 10 for context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)