### PR TITLE
fix: include templates folder in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "hooks",
     "scripts",
     "skills",
+    "templates",
     "docs",
     "plugin.json",
     "README.md",


### PR DESCRIPTION
The templates/hooks directory was missing from the npm package files list, causing "FATAL: Hook template not found" errors on Windows installation.