### PR TITLE
fix(mcp-setup): use CLI commands instead of direct settings.json writes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "description": "Multi-agent orchestration system for Claude Code",
   "skills": "./skills/"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Fix mcp-setup skill to use `claude mcp add` CLI commands instead of direct `~/.claude/settings.json` manipulation
- Update verification to use `claude mcp list` instead of manual file checks
- Add HTTP transport support for GitHub and custom servers
- Bump version to 3.5.6

## Problem
The mcp-setup skill was instructing users to write MCP servers directly to `~/.claude/settings.json`, but Claude Code reads MCP configs from `~/.claude.json` (stored per-project). This caused configured MCP servers to not appear when running `/mcp`.

## Solution
Use the official `claude mcp add` CLI which handles the correct config location automatically.

## Test plan
- [ ] Run `/mcp-setup` and configure a server
- [ ] Verify `claude mcp list` shows the configured server
- [ ] Verify `/mcp` in Claude Code shows the configured server

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)