### PR TITLE
fix(hud): accurate cost display and Sonnet quota tracking (#94, #95)

### DIFF
--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -95,6 +95,13 @@ export interface ThinkingState {
   lastSeen?: Date;
 }
 
+export interface AggregatedTokens {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+}
+
 export interface SessionHealth {
   durationMinutes: number;
   messageCount: number;
@@ -118,6 +125,7 @@ export interface TranscriptData {
   lastActivatedSkill?: SkillInvocation;
   pendingPermission?: PendingPermission;
   thinkingState?: ThinkingState;
+  aggregatedTokens?: AggregatedTokens;
 }
 
 // ============================================================================
@@ -149,14 +157,19 @@ export interface PrdStateForHud {
 // ============================================================================
 
 export interface RateLimits {
-  /** 5-hour rolling window usage percentage (0-100) */
+  /** 5-hour rolling window usage percentage (0-100) - all models combined */
   fiveHourPercent: number;
-  /** Weekly usage percentage (0-100) */
+  /** Weekly usage percentage (0-100) - all models combined */
   weeklyPercent: number;
   /** When the 5-hour limit resets (null if unavailable) */
   fiveHourResetsAt?: Date | null;
   /** When the weekly limit resets (null if unavailable) */
   weeklyResetsAt?: Date | null;
+
+  /** Sonnet-specific weekly usage percentage (0-100), if available or estimated */
+  sonnetWeeklyPercent?: number;
+  /** Sonnet weekly reset time (typically same as overall weekly reset) */
+  sonnetWeeklyResetsAt?: Date | null;
 }
 
 export interface HudRenderContext {


### PR DESCRIPTION
## Summary

- **Issue #94**: Fix inaccurate session cost display by aggregating tokens from all transcript entries (main session + spawned agents)
- **Issue #95**: Add Sonnet-specific weekly quota display alongside combined quota

## Changes

### Issue #94 - Accurate Cost Display
The HUD was displaying ~$0.05 when actual consumption was much higher. Root cause: only main session tokens from `stdin.context_window.current_usage` were tracked, missing spawned agent tokens.

**Fix:**
- Aggregate `message.usage` from all transcript JSONL entries
- Combine stdin baseline with aggregated tokens
- Calculate cost based on true session consumption

### Issue #95 - Sonnet Quota Display
Users requested dual quota indicators to monitor Sonnet-specific limits separately.

**Fix:**
- Extended `RateLimits` type with `sonnetWeeklyPercent` and `sonnetWeeklyResetsAt`
- Parse Sonnet quota from API (future-proof) or estimate as 80% of combined usage
- Compact display formats:
  - Standard: `5h:45% wk:12%/S:45%`
  - Compact: `45%/12%/S:45%`
  - Bar: `5h:[████░]45% wk:[█░]12% S:[███░]45%`

## Test plan

- [ ] Verify HUD displays accurate session cost after spawning agents
- [ ] Confirm Sonnet quota appears in all three render modes
- [ ] Test color thresholds work for both quotas (green/yellow/red)
- [ ] Build passes with no errors

Closes #94, closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)