### PR TITLE
fix(hud): use correct flat API structure for Sonnet quota (#95)

### DIFF
--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -149,14 +149,19 @@ export interface PrdStateForHud {
 // ============================================================================
 
 export interface RateLimits {
-  /** 5-hour rolling window usage percentage (0-100) */
+  /** 5-hour rolling window usage percentage (0-100) - all models combined */
   fiveHourPercent: number;
-  /** Weekly usage percentage (0-100) */
+  /** Weekly usage percentage (0-100) - all models combined */
   weeklyPercent: number;
   /** When the 5-hour limit resets (null if unavailable) */
   fiveHourResetsAt?: Date | null;
   /** When the weekly limit resets (null if unavailable) */
   weeklyResetsAt?: Date | null;
+
+  /** Sonnet-specific weekly usage percentage (0-100), if available from API */
+  sonnetWeeklyPercent?: number;
+  /** Sonnet weekly reset time */
+  sonnetWeeklyResetsAt?: Date | null;
 }
 
 export interface HudRenderContext {


### PR DESCRIPTION
## Summary

Fixes #95 - Sonnet-specific weekly quota now displays correctly.

The OAuth API (`api.anthropic.com/api/oauth/usage`) returns per-model quotas in a **flat structure** at the top level, not nested under a `models` object:

```typescript
// Actual API response:
{
  five_hour: { utilization: 40 },
  seven_day: { utilization: 77 },
  seven_day_sonnet: { utilization: 2 },  // ← flat, top-level
  seven_day_opus: { utilization: 75 }
}
```

The previous implementation expected `response.models?.sonnet?.seven_day?.utilization`, which never exists, causing the 80% fallback to always trigger.

## Changes

- **`src/hud/usage-api.ts`**:
  - Updated `UsageApiResponse` interface to use flat structure (`seven_day_sonnet`, `seven_day_opus`)
  - Changed parsing to read `response.seven_day_sonnet?.utilization` directly
  - Removed inaccurate 80% fallback estimation

- **`src/hud/types.ts`**:
  - Added `sonnetWeeklyPercent` and `sonnetWeeklyResetsAt` fields to `RateLimits` interface

## Testing

Verified with real OAuth credentials:

```
Weekly (all models): 77%
Sonnet Weekly: 2%        ← actual API value
80% fallback would be: 62%
```

## Reference

Confirmed correct API structure from [clawdbot's implementation](https://github.com/clawdbot/clawdbot/blob/main/src/infra/provider-usage.fetch.claude.ts#L5-L12).