### PR TITLE
feat(hud): add transparentBackground option for iTerm2 custom backgrounds

### DIFF
--- a/commands/hud.md
+++ b/commands/hud.md
@@ -205,6 +205,22 @@ When agents are running, the HUD shows detailed information on separate lines:
 - **Yellow**: Warning (context >70%, ralph >7)
 - **Red**: Critical (context >85%, ralph at max)
 
+## Transparent Background
+
+For terminals with custom background images (e.g., iTerm2), you can enable transparent background mode:
+
+```json
+{
+  "elements": {
+    "transparentBackground": true
+  }
+}
+```
+
+This uses ANSI escape code `\x1b[49m` on each line to reset the text background to your terminal's default.
+
+> **Note**: The statusLine container background is controlled by Claude Code's TUI framework. If you still see a black background after enabling this option, this is a Claude Code limitation. Consider requesting transparent statusLine support in the [Claude Code repository](https://github.com/anthropics/claude-code/issues).
+
 ## Configuration Location
 
 HUD config is stored at: `~/.claude/.omc/hud-config.json`
@@ -225,7 +241,8 @@ You can manually edit the config file:
     "contextBar": true,
     "agents": true,
     "backgroundTasks": true,
-    "todos": true
+    "todos": true,
+    "transparentBackground": false
   },
   "thresholds": {
     "contextWarning": 70,

--- a/src/hud/colors.ts
+++ b/src/hud/colors.ts
@@ -19,6 +19,7 @@ const WHITE = '\x1b[37m';
 const BRIGHT_BLUE = '\x1b[94m';
 const BRIGHT_MAGENTA = '\x1b[95m';
 const BRIGHT_CYAN = '\x1b[96m';
+const DEFAULT_BG = '\x1b[49m';
 
 // ============================================================================
 // Color Functions
@@ -170,4 +171,21 @@ export function coloredValue(
 ): string {
   const color = getColor(value, total);
   return `${color}${value}/${total}${RESET}`;
+}
+
+// ============================================================================
+// Background Control
+// ============================================================================
+
+/**
+ * Apply transparent (terminal default) background to each line of text.
+ * This ensures each line starts with \x1b[49m to reset background to terminal default.
+ * Useful for terminals with custom background images (e.g., iTerm2).
+ *
+ * Note: This helps with the text portion but the statusLine container background
+ * is controlled by Claude Code's TUI framework.
+ */
+export function transparentBg(text: string): string {
+  // Apply default background to each line to ensure consistency
+  return text.split('\n').map(line => `${DEFAULT_BG}${line}`).join('\n');
 }

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -5,7 +5,7 @@
  */
 
 import type { HudRenderContext, HudConfig } from './types.js';
-import { bold, dim } from './colors.js';
+import { bold, dim, transparentBg } from './colors.js';
 import { renderRalph } from './elements/ralph.js';
 import { renderAgentsByFormat, renderAgentsMultiLine } from './elements/agents.js';
 import { renderTodosWithCurrent } from './elements/todos.js';
@@ -67,7 +67,12 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
       if (todos) lines.push(todos);
     }
 
-    return lines.join('\n');
+    // Apply transparent background if configured (analytics preset)
+    let analyticsOutput = lines.join('\n');
+    if (enabledElements.transparentBackground) {
+      analyticsOutput = transparentBg(analyticsOutput);
+    }
+    return analyticsOutput;
   }
 
   // [OMC] label
@@ -200,9 +205,17 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   }
 
   // If we have detail lines, output multi-line
+  let output: string;
   if (detailLines.length > 0) {
-    return [headerLine, ...detailLines].join('\n');
+    output = [headerLine, ...detailLines].join('\n');
+  } else {
+    output = headerLine;
   }
 
-  return headerLine;
+  // Apply transparent background if configured
+  if (enabledElements.transparentBackground) {
+    output = transparentBg(output);
+  }
+
+  return output;
 }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -247,6 +247,7 @@ export interface HudElementConfig {
   thinking: boolean;          // Show extended thinking indicator
   sessionHealth: boolean;     // Show session health/duration
   useBars: boolean;           // Show visual progress bars instead of/alongside percentages
+  transparentBackground: boolean;  // Use terminal default background (for custom backgrounds like iTerm2)
 }
 
 export interface HudThresholds {
@@ -287,6 +288,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     thinking: true,
     sessionHealth: true,
     useBars: false,  // Disabled by default for backwards compatibility
+    transparentBackground: false,  // Disabled by default for backwards compatibility
   },
   thresholds: {
     contextWarning: 70,
@@ -315,6 +317,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: false,
     sessionHealth: false,
     useBars: false,
+    transparentBackground: false,
   },
   analytics: {
     omcLabel: false,
@@ -334,6 +337,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: false,
     sessionHealth: false,
     useBars: false,
+    transparentBackground: false,
   },
   focused: {
     omcLabel: true,
@@ -353,6 +357,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     sessionHealth: true,
     useBars: true,
+    transparentBackground: false,
   },
   full: {
     omcLabel: true,
@@ -372,6 +377,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     sessionHealth: true,
     useBars: true,
+    transparentBackground: false,
   },
   opencode: {
     omcLabel: true,
@@ -391,6 +397,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     sessionHealth: true,
     useBars: false,
+    transparentBackground: false,
   },
   dense: {
     omcLabel: true,
@@ -410,5 +417,6 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     sessionHealth: true,
     useBars: true,
+    transparentBackground: false,
   },
 };


### PR DESCRIPTION
## Summary

- Add `transparentBackground` configuration option for the HUD
- Emits ANSI escape code `\x1b[49m` (default background) on each line of output
- Helps iTerm2 users with custom profile backgrounds see their backgrounds through the statusline

## Changes

- **src/hud/colors.ts**: Add `transparentBg()` function
- **src/hud/types.ts**: Add `transparentBackground` boolean config (default: `false`)
- **src/hud/render.ts**: Apply transparent background when enabled
- **commands/hud.md**: Document the feature and its limitations

## Usage

Edit `~/.claude/.omc/hud-config.json`:
```json
{
  "elements": {
    "transparentBackground": true
  }
}
```

## Limitations

> **Note**: The statusLine container background is controlled by Claude Code's TUI framework. If users still see a black background after enabling this option, this is a Claude Code limitation and they should request transparent statusLine support in the [Claude Code repository](https://github.com/anthropics/claude-code/issues).

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 860 tests pass (`npm test`)
- [x] Verified ANSI output includes `\x1b[49m` when enabled
- [ ] Manual test on iTerm2 with custom background (needs user verification)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)