### PR TITLE
refactor(state): standardize all mode state files to .omc/state/

### DIFF
--- a/commands/cancel.md
+++ b/commands/cancel.md
@@ -40,14 +40,14 @@ Force clear ALL state files:
 
 ## State Files Checked
 
-- `.omc/autopilot-state.json` → Autopilot
-- `.omc/ralph-state.json` → Ralph
-- `.omc/ultrawork-state.json` → Ultrawork
-- `.omc/ecomode-state.json` → Ecomode
-- `.omc/ultraqa-state.json` → UltraQA
-- `.omc/swarm-state.json` → Swarm
-- `.omc/ultrapilot-state.json` → Ultrapilot
-- `.omc/pipeline-state.json` → Pipeline
+- `.omc/state/autopilot-state.json` → Autopilot
+- `.omc/state/ralph-state.json` → Ralph
+- `.omc/state/ultrawork-state.json` → Ultrawork
+- `.omc/state/ecomode-state.json` → Ecomode
+- `.omc/state/ultraqa-state.json` → UltraQA
+- `.omc/state/swarm-state.json` → Swarm
+- `.omc/state/ultrapilot-state.json` → Ultrapilot
+- `.omc/state/pipeline-state.json` → Pipeline
 
 ## What Gets Preserved
 

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -149,6 +149,24 @@ If autopilot was cancelled or failed, just run `/oh-my-claudecode:autopilot` aga
 3. **Specify constraints** - "using TypeScript", "with PostgreSQL"
 4. **Let it run** - Don't interrupt unless truly needed
 
+## STATE CLEANUP ON COMPLETION
+
+**IMPORTANT: Delete ALL state files on successful completion**
+
+When autopilot reaches the `complete` phase (all validation passed):
+
+```bash
+# Delete autopilot and all sub-mode state files
+rm -f .omc/state/autopilot-state.json
+rm -f .omc/state/ralph-state.json
+rm -f .omc/state/ultrawork-state.json
+rm -f .omc/state/ultraqa-state.json
+rm -f ~/.claude/ralph-state.json
+rm -f ~/.claude/ultrawork-state.json
+```
+
+This ensures clean state for future sessions.
+
 ## Troubleshooting
 
 **Stuck in a phase?**

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -30,16 +30,16 @@ Or say: "stop", "cancel", "abort"
 ## Auto-Detection
 
 The skill checks state files to determine what's active:
-- `.omc/autopilot-state.json` → Autopilot detected
-- `.omc/ralph-state.json` → Ralph detected
-- `.omc/ultrawork-state.json` → Ultrawork detected
-- `.omc/ecomode-state.json` → Ecomode detected
-- `.omc/ultraqa-state.json` → UltraQA detected
-- `.omc/swarm-state.json` → Swarm detected
-- `.omc/ultrapilot-state.json` → Ultrapilot detected
-- `.omc/pipeline-state.json` → Pipeline detected
+- `.omc/state/autopilot-state.json` → Autopilot detected
+- `.omc/state/ralph-state.json` → Ralph detected
+- `.omc/state/ultrawork-state.json` → Ultrawork detected
+- `.omc/state/ecomode-state.json` → Ecomode detected
+- `.omc/state/ultraqa-state.json` → UltraQA detected
+- `.omc/state/swarm-state.json` → Swarm detected
+- `.omc/state/ultrapilot-state.json` → Ultrapilot detected
+- `.omc/state/pipeline-state.json` → Pipeline detected
 - `.omc/state/plan-consensus.json` → Plan Consensus detected
-- `.omc/ralplan-state.json` → Plan Consensus detected (legacy)
+- `.omc/state/ralplan-state.json` → Plan Consensus detected (legacy)
 
 If multiple modes are active, they're cancelled in order of dependency:
 1. Autopilot (includes ralph/ultraqa/ecomode cleanup)
@@ -67,17 +67,17 @@ Or use the `--all` alias:
 ```
 
 This removes all state files:
-- `.omc/autopilot-state.json`
-- `.omc/ralph-state.json`
-- `.omc/ultrawork-state.json`
-- `.omc/ecomode-state.json`
-- `.omc/ultraqa-state.json`
-- `.omc/swarm-state.json`
+- `.omc/state/autopilot-state.json`
+- `.omc/state/ralph-state.json`
+- `.omc/state/ultrawork-state.json`
+- `.omc/state/ecomode-state.json`
+- `.omc/state/ultraqa-state.json`
+- `.omc/state/swarm-state.json`
 - `.omc/state/swarm-tasks.json`
-- `.omc/ultrapilot-state.json`
-- `.omc/pipeline-state.json`
+- `.omc/state/ultrapilot-state.json`
+- `.omc/state/pipeline-state.json`
 - `.omc/state/plan-consensus.json`
-- `.omc/ralplan-state.json`
+- `.omc/state/ralplan-state.json`
 - `~/.claude/ralph-state.json`
 - `~/.claude/ultrawork-state.json`
 - `~/.claude/ecomode-state.json`
@@ -106,24 +106,24 @@ ULTRAWORK_ACTIVE=false
 ECOMODE_ACTIVE=false
 ULTRAQA_ACTIVE=false
 
-if [[ -f .omc/autopilot-state.json ]]; then
-  AUTOPILOT_ACTIVE=$(cat .omc/autopilot-state.json | jq -r '.active // false')
+if [[ -f .omc/state/autopilot-state.json ]]; then
+  AUTOPILOT_ACTIVE=$(cat .omc/state/autopilot-state.json | jq -r '.active // false')
 fi
 
-if [[ -f .omc/ralph-state.json ]]; then
-  RALPH_ACTIVE=$(cat .omc/ralph-state.json | jq -r '.active // false')
+if [[ -f .omc/state/ralph-state.json ]]; then
+  RALPH_ACTIVE=$(cat .omc/state/ralph-state.json | jq -r '.active // false')
 fi
 
-if [[ -f .omc/ultrawork-state.json ]]; then
-  ULTRAWORK_ACTIVE=$(cat .omc/ultrawork-state.json | jq -r '.active // false')
+if [[ -f .omc/state/ultrawork-state.json ]]; then
+  ULTRAWORK_ACTIVE=$(cat .omc/state/ultrawork-state.json | jq -r '.active // false')
 fi
 
-if [[ -f .omc/ecomode-state.json ]]; then
-  ECOMODE_ACTIVE=$(cat .omc/ecomode-state.json | jq -r '.active // false')
+if [[ -f .omc/state/ecomode-state.json ]]; then
+  ECOMODE_ACTIVE=$(cat .omc/state/ecomode-state.json | jq -r '.active // false')
 fi
 
-if [[ -f .omc/ultraqa-state.json ]]; then
-  ULTRAQA_ACTIVE=$(cat .omc/ultraqa-state.json | jq -r '.active // false')
+if [[ -f .omc/state/ultraqa-state.json ]]; then
+  ULTRAQA_ACTIVE=$(cat .omc/state/ultraqa-state.json | jq -r '.active // false')
 fi
 
 PLAN_CONSENSUS_ACTIVE=false
@@ -131,8 +131,8 @@ PLAN_CONSENSUS_ACTIVE=false
 # Check both new and legacy locations
 if [[ -f .omc/state/plan-consensus.json ]]; then
   PLAN_CONSENSUS_ACTIVE=$(cat .omc/state/plan-consensus.json | jq -r '.active // false')
-elif [[ -f .omc/ralplan-state.json ]]; then
-  PLAN_CONSENSUS_ACTIVE=$(cat .omc/ralplan-state.json | jq -r '.active // false')
+elif [[ -f .omc/state/ralplan-state.json ]]; then
+  PLAN_CONSENSUS_ACTIVE=$(cat .omc/state/ralplan-state.json | jq -r '.active // false')
 fi
 ```
 
@@ -143,19 +143,19 @@ if [[ "$FORCE_MODE" == "true" ]]; then
   echo "FORCE CLEAR: Removing all OMC state files..."
 
   # Remove local state files
-  rm -f .omc/autopilot-state.json
-  rm -f .omc/ralph-state.json
-  rm -f .omc/ultrawork-state.json
-  rm -f .omc/ecomode-state.json
-  rm -f .omc/ultraqa-state.json
-  rm -f .omc/ralph-plan-state.json
-  rm -f .omc/ralph-verification.json
-  rm -f .omc/swarm-state.json
+  rm -f .omc/state/autopilot-state.json
+  rm -f .omc/state/ralph-state.json
+  rm -f .omc/state/ultrawork-state.json
+  rm -f .omc/state/ecomode-state.json
+  rm -f .omc/state/ultraqa-state.json
+  rm -f .omc/state/ralph-plan-state.json
+  rm -f .omc/state/ralph-verification.json
+  rm -f .omc/state/swarm-state.json
   rm -f .omc/state/swarm-tasks.json
-  rm -f .omc/ultrapilot-state.json
-  rm -f .omc/pipeline-state.json
+  rm -f .omc/state/ultrapilot-state.json
+  rm -f .omc/state/pipeline-state.json
   rm -f .omc/state/plan-consensus.json
-  rm -f .omc/ralplan-state.json
+  rm -f .omc/state/ralplan-state.json
 
   # Remove global state files
   rm -f ~/.claude/ralph-state.json
@@ -176,36 +176,36 @@ Call `cancelAutopilot()` from `src/hooks/autopilot/cancel.ts:27-78`:
 ```bash
 # Autopilot handles its own cleanup + ralph + ultraqa
 # Just mark autopilot as inactive (preserves state for resume)
-if [[ -f .omc/autopilot-state.json ]]; then
+if [[ -f .omc/state/autopilot-state.json ]]; then
   # Clean up ralph if active
-  if [[ -f .omc/ralph-state.json ]]; then
-    RALPH_STATE=$(cat .omc/ralph-state.json)
+  if [[ -f .omc/state/ralph-state.json ]]; then
+    RALPH_STATE=$(cat .omc/state/ralph-state.json)
     LINKED_UW=$(echo "$RALPH_STATE" | jq -r '.linked_ultrawork // false')
 
     # Clean linked ultrawork first
-    if [[ "$LINKED_UW" == "true" ]] && [[ -f .omc/ultrawork-state.json ]]; then
-      rm -f .omc/ultrawork-state.json
+    if [[ "$LINKED_UW" == "true" ]] && [[ -f .omc/state/ultrawork-state.json ]]; then
+      rm -f .omc/state/ultrawork-state.json
       rm -f ~/.claude/ultrawork-state.json
       echo "Cleaned up: ultrawork (linked to ralph)"
     fi
 
     # Clean ralph
-    rm -f .omc/ralph-state.json
+    rm -f .omc/state/ralph-state.json
     rm -f ~/.claude/ralph-state.json
-    rm -f .omc/ralph-verification.json
+    rm -f .omc/state/ralph-verification.json
     echo "Cleaned up: ralph"
   fi
 
   # Clean up ultraqa if active
-  if [[ -f .omc/ultraqa-state.json ]]; then
-    rm -f .omc/ultraqa-state.json
+  if [[ -f .omc/state/ultraqa-state.json ]]; then
+    rm -f .omc/state/ultraqa-state.json
     echo "Cleaned up: ultraqa"
   fi
 
   # Mark autopilot inactive but preserve state
-  CURRENT_STATE=$(cat .omc/autopilot-state.json)
+  CURRENT_STATE=$(cat .omc/state/autopilot-state.json)
   CURRENT_PHASE=$(echo "$CURRENT_STATE" | jq -r '.phase // "unknown"')
-  echo "$CURRENT_STATE" | jq '.active = false' > .omc/autopilot-state.json
+  echo "$CURRENT_STATE" | jq '.active = false' > .omc/state/autopilot-state.json
 
   echo "Autopilot cancelled at phase: $CURRENT_PHASE. Progress preserved for resume."
   echo "Run /oh-my-claudecode:autopilot to resume."
@@ -217,29 +217,29 @@ fi
 Call `clearRalphState()` + `clearLinkedUltraworkState()` from `src/hooks/ralph-loop/index.ts:147-182`:
 
 ```bash
-if [[ -f .omc/ralph-state.json ]]; then
+if [[ -f .omc/state/ralph-state.json ]]; then
   # Check if ultrawork is linked
-  RALPH_STATE=$(cat .omc/ralph-state.json)
+  RALPH_STATE=$(cat .omc/state/ralph-state.json)
   LINKED_UW=$(echo "$RALPH_STATE" | jq -r '.linked_ultrawork // false')
 
   # Clean linked ultrawork first
-  if [[ "$LINKED_UW" == "true" ]] && [[ -f .omc/ultrawork-state.json ]]; then
-    UW_STATE=$(cat .omc/ultrawork-state.json)
+  if [[ "$LINKED_UW" == "true" ]] && [[ -f .omc/state/ultrawork-state.json ]]; then
+    UW_STATE=$(cat .omc/state/ultrawork-state.json)
     UW_LINKED=$(echo "$UW_STATE" | jq -r '.linked_to_ralph // false')
 
     # Only clear if it was linked to ralph
     if [[ "$UW_LINKED" == "true" ]]; then
-      rm -f .omc/ultrawork-state.json
+      rm -f .omc/state/ultrawork-state.json
       rm -f ~/.claude/ultrawork-state.json
       echo "Cleaned up: ultrawork (linked to ralph)"
     fi
   fi
 
   # Clean ralph state (both local and global)
-  rm -f .omc/ralph-state.json
+  rm -f .omc/state/ralph-state.json
   rm -f ~/.claude/ralph-state.json
-  rm -f .omc/ralph-plan-state.json
-  rm -f .omc/ralph-verification.json
+  rm -f .omc/state/ralph-plan-state.json
+  rm -f .omc/state/ralph-verification.json
 
   echo "Ralph cancelled. Persistent mode deactivated."
 fi
@@ -250,9 +250,9 @@ fi
 Call `deactivateUltrawork()` from `src/hooks/ultrawork/index.ts:150-173`:
 
 ```bash
-if [[ -f .omc/ultrawork-state.json ]]; then
+if [[ -f .omc/state/ultrawork-state.json ]]; then
   # Check if linked to ralph
-  UW_STATE=$(cat .omc/ultrawork-state.json)
+  UW_STATE=$(cat .omc/state/ultrawork-state.json)
   LINKED=$(echo "$UW_STATE" | jq -r '.linked_to_ralph // false')
 
   if [[ "$LINKED" == "true" ]]; then
@@ -261,7 +261,7 @@ if [[ -f .omc/ultrawork-state.json ]]; then
   fi
 
   # Remove both local and global state
-  rm -f .omc/ultrawork-state.json
+  rm -f .omc/state/ultrawork-state.json
   rm -f ~/.claude/ultrawork-state.json
 
   echo "Ultrawork cancelled. Parallel execution mode deactivated."
@@ -273,8 +273,8 @@ fi
 Call `clearUltraQAState()` from `src/hooks/ultraqa/index.ts:107-120`:
 
 ```bash
-if [[ -f .omc/ultraqa-state.json ]]; then
-  rm -f .omc/ultraqa-state.json
+if [[ -f .omc/state/ultraqa-state.json ]]; then
+  rm -f .omc/state/ultraqa-state.json
   echo "UltraQA cancelled. QA cycling workflow stopped."
 fi
 ```
@@ -285,10 +285,10 @@ fi
 echo "No active OMC modes detected."
 echo ""
 echo "Checked for:"
-echo "  - Autopilot (.omc/autopilot-state.json)"
-echo "  - Ralph (.omc/ralph-state.json)"
-echo "  - Ultrawork (.omc/ultrawork-state.json)"
-echo "  - UltraQA (.omc/ultraqa-state.json)"
+echo "  - Autopilot (.omc/state/autopilot-state.json)"
+echo "  - Ralph (.omc/state/ralph-state.json)"
+echo "  - Ultrawork (.omc/state/ultrawork-state.json)"
+echo "  - UltraQA (.omc/state/ultraqa-state.json)"
 echo ""
 echo "Use --force to clear all state files anyway."
 ```
@@ -313,19 +313,19 @@ if [[ "$FORCE_MODE" == "true" ]]; then
   mkdir -p .omc ~/.claude
 
   # Remove local state files
-  rm -f .omc/autopilot-state.json
-  rm -f .omc/ralph-state.json
-  rm -f .omc/ultrawork-state.json
-  rm -f .omc/ecomode-state.json
-  rm -f .omc/ultraqa-state.json
-  rm -f .omc/ralph-plan-state.json
-  rm -f .omc/ralph-verification.json
-  rm -f .omc/swarm-state.json
+  rm -f .omc/state/autopilot-state.json
+  rm -f .omc/state/ralph-state.json
+  rm -f .omc/state/ultrawork-state.json
+  rm -f .omc/state/ecomode-state.json
+  rm -f .omc/state/ultraqa-state.json
+  rm -f .omc/state/ralph-plan-state.json
+  rm -f .omc/state/ralph-verification.json
+  rm -f .omc/state/swarm-state.json
   rm -f .omc/state/swarm-tasks.json
-  rm -f .omc/ultrapilot-state.json
-  rm -f .omc/pipeline-state.json
+  rm -f .omc/state/ultrapilot-state.json
+  rm -f .omc/state/pipeline-state.json
   rm -f .omc/state/plan-consensus.json
-  rm -f .omc/ralplan-state.json
+  rm -f .omc/state/ralplan-state.json
 
   # Remove global state files
   rm -f ~/.claude/ralph-state.json
@@ -341,8 +341,8 @@ fi
 CANCELLED_ANYTHING=false
 
 # 1. Check Autopilot (highest priority, includes cleanup of ralph/ultraqa)
-if [[ -f .omc/autopilot-state.json ]]; then
-  AUTOPILOT_STATE=$(cat .omc/autopilot-state.json)
+if [[ -f .omc/state/autopilot-state.json ]]; then
+  AUTOPILOT_STATE=$(cat .omc/state/autopilot-state.json)
   AUTOPILOT_ACTIVE=$(echo "$AUTOPILOT_STATE" | jq -r '.active // false')
 
   if [[ "$AUTOPILOT_ACTIVE" == "true" ]]; then
@@ -350,41 +350,41 @@ if [[ -f .omc/autopilot-state.json ]]; then
     CLEANED_UP=()
 
     # Clean up ralph if active
-    if [[ -f .omc/ralph-state.json ]]; then
-      RALPH_STATE=$(cat .omc/ralph-state.json)
+    if [[ -f .omc/state/ralph-state.json ]]; then
+      RALPH_STATE=$(cat .omc/state/ralph-state.json)
       RALPH_ACTIVE=$(echo "$RALPH_STATE" | jq -r '.active // false')
 
       if [[ "$RALPH_ACTIVE" == "true" ]]; then
         LINKED_UW=$(echo "$RALPH_STATE" | jq -r '.linked_ultrawork // false')
 
         # Clean linked ultrawork first
-        if [[ "$LINKED_UW" == "true" ]] && [[ -f .omc/ultrawork-state.json ]]; then
-          rm -f .omc/ultrawork-state.json
+        if [[ "$LINKED_UW" == "true" ]] && [[ -f .omc/state/ultrawork-state.json ]]; then
+          rm -f .omc/state/ultrawork-state.json
           rm -f ~/.claude/ultrawork-state.json
           CLEANED_UP+=("ultrawork")
         fi
 
         # Clean ralph
-        rm -f .omc/ralph-state.json
+        rm -f .omc/state/ralph-state.json
         rm -f ~/.claude/ralph-state.json
-        rm -f .omc/ralph-verification.json
+        rm -f .omc/state/ralph-verification.json
         CLEANED_UP+=("ralph")
       fi
     fi
 
     # Clean up ultraqa if active
-    if [[ -f .omc/ultraqa-state.json ]]; then
-      ULTRAQA_STATE=$(cat .omc/ultraqa-state.json)
+    if [[ -f .omc/state/ultraqa-state.json ]]; then
+      ULTRAQA_STATE=$(cat .omc/state/ultraqa-state.json)
       ULTRAQA_ACTIVE=$(echo "$ULTRAQA_STATE" | jq -r '.active // false')
 
       if [[ "$ULTRAQA_ACTIVE" == "true" ]]; then
-        rm -f .omc/ultraqa-state.json
+        rm -f .omc/state/ultraqa-state.json
         CLEANED_UP+=("ultraqa")
       fi
     fi
 
     # Mark autopilot inactive but preserve state for resume
-    echo "$AUTOPILOT_STATE" | jq '.active = false' > .omc/autopilot-state.json
+    echo "$AUTOPILOT_STATE" | jq '.active = false' > .omc/state/autopilot-state.json
 
     echo "Autopilot cancelled at phase: $CURRENT_PHASE."
 
@@ -399,21 +399,21 @@ if [[ -f .omc/autopilot-state.json ]]; then
 fi
 
 # 2. Check Ralph (if not handled by autopilot)
-if [[ -f .omc/ralph-state.json ]]; then
-  RALPH_STATE=$(cat .omc/ralph-state.json)
+if [[ -f .omc/state/ralph-state.json ]]; then
+  RALPH_STATE=$(cat .omc/state/ralph-state.json)
   RALPH_ACTIVE=$(echo "$RALPH_STATE" | jq -r '.active // false')
 
   if [[ "$RALPH_ACTIVE" == "true" ]]; then
     LINKED_UW=$(echo "$RALPH_STATE" | jq -r '.linked_ultrawork // false')
 
     # Clean linked ultrawork first
-    if [[ "$LINKED_UW" == "true" ]] && [[ -f .omc/ultrawork-state.json ]]; then
-      UW_STATE=$(cat .omc/ultrawork-state.json)
+    if [[ "$LINKED_UW" == "true" ]] && [[ -f .omc/state/ultrawork-state.json ]]; then
+      UW_STATE=$(cat .omc/state/ultrawork-state.json)
       UW_LINKED=$(echo "$UW_STATE" | jq -r '.linked_to_ralph // false')
 
       # Only clear if it was linked to ralph
       if [[ "$UW_LINKED" == "true" ]]; then
-        rm -f .omc/ultrawork-state.json
+        rm -f .omc/state/ultrawork-state.json
         rm -f ~/.claude/ultrawork-state.json
         echo "Cleaned up: ultrawork (linked to ralph)"
       fi
@@ -422,22 +422,22 @@ if [[ -f .omc/ralph-state.json ]]; then
     # Clean linked ecomode if present
     LINKED_ECO=$(echo "$RALPH_STATE" | jq -r '.linked_ecomode // false')
 
-    if [[ "$LINKED_ECO" == "true" ]] && [[ -f .omc/ecomode-state.json ]]; then
-      ECO_STATE=$(cat .omc/ecomode-state.json)
+    if [[ "$LINKED_ECO" == "true" ]] && [[ -f .omc/state/ecomode-state.json ]]; then
+      ECO_STATE=$(cat .omc/state/ecomode-state.json)
       ECO_LINKED=$(echo "$ECO_STATE" | jq -r '.linked_to_ralph // false')
 
       if [[ "$ECO_LINKED" == "true" ]]; then
-        rm -f .omc/ecomode-state.json
+        rm -f .omc/state/ecomode-state.json
         rm -f ~/.claude/ecomode-state.json
         echo "Cleaned up: ecomode (linked to ralph)"
       fi
     fi
 
     # Clean ralph state (both local and global)
-    rm -f .omc/ralph-state.json
+    rm -f .omc/state/ralph-state.json
     rm -f ~/.claude/ralph-state.json
-    rm -f .omc/ralph-plan-state.json
-    rm -f .omc/ralph-verification.json
+    rm -f .omc/state/ralph-plan-state.json
+    rm -f .omc/state/ralph-verification.json
 
     echo "Ralph cancelled. Persistent mode deactivated."
     CANCELLED_ANYTHING=true
@@ -446,8 +446,8 @@ if [[ -f .omc/ralph-state.json ]]; then
 fi
 
 # 3. Check Ultrawork (standalone, not linked)
-if [[ -f .omc/ultrawork-state.json ]]; then
-  UW_STATE=$(cat .omc/ultrawork-state.json)
+if [[ -f .omc/state/ultrawork-state.json ]]; then
+  UW_STATE=$(cat .omc/state/ultrawork-state.json)
   UW_ACTIVE=$(echo "$UW_STATE" | jq -r '.active // false')
 
   if [[ "$UW_ACTIVE" == "true" ]]; then
@@ -459,7 +459,7 @@ if [[ -f .omc/ultrawork-state.json ]]; then
     fi
 
     # Remove both local and global state
-    rm -f .omc/ultrawork-state.json
+    rm -f .omc/state/ultrawork-state.json
     rm -f ~/.claude/ultrawork-state.json
 
     echo "Ultrawork cancelled. Parallel execution mode deactivated."
@@ -469,8 +469,8 @@ if [[ -f .omc/ultrawork-state.json ]]; then
 fi
 
 # 4. Check Ecomode (standalone, not linked)
-if [[ -f .omc/ecomode-state.json ]]; then
-  ECO_STATE=$(cat .omc/ecomode-state.json)
+if [[ -f .omc/state/ecomode-state.json ]]; then
+  ECO_STATE=$(cat .omc/state/ecomode-state.json)
   ECO_ACTIVE=$(echo "$ECO_STATE" | jq -r '.active // false')
 
   if [[ "$ECO_ACTIVE" == "true" ]]; then
@@ -482,7 +482,7 @@ if [[ -f .omc/ecomode-state.json ]]; then
     fi
 
     # Remove both local and global state
-    rm -f .omc/ecomode-state.json
+    rm -f .omc/state/ecomode-state.json
     rm -f ~/.claude/ecomode-state.json
 
     echo "Ecomode cancelled. Token-efficient execution mode deactivated."
@@ -492,12 +492,12 @@ if [[ -f .omc/ecomode-state.json ]]; then
 fi
 
 # 5. Check UltraQA (standalone)
-if [[ -f .omc/ultraqa-state.json ]]; then
-  ULTRAQA_STATE=$(cat .omc/ultraqa-state.json)
+if [[ -f .omc/state/ultraqa-state.json ]]; then
+  ULTRAQA_STATE=$(cat .omc/state/ultraqa-state.json)
   ULTRAQA_ACTIVE=$(echo "$ULTRAQA_STATE" | jq -r '.active // false')
 
   if [[ "$ULTRAQA_ACTIVE" == "true" ]]; then
-    rm -f .omc/ultraqa-state.json
+    rm -f .omc/state/ultraqa-state.json
     echo "UltraQA cancelled. QA cycling workflow stopped."
     CANCELLED_ANYTHING=true
     exit 0
@@ -505,12 +505,12 @@ if [[ -f .omc/ultraqa-state.json ]]; then
 fi
 
 # 6. Check Swarm (standalone)
-if [[ -f .omc/swarm-state.json ]]; then
-  SWARM_STATE=$(cat .omc/swarm-state.json)
+if [[ -f .omc/state/swarm-state.json ]]; then
+  SWARM_STATE=$(cat .omc/state/swarm-state.json)
   SWARM_ACTIVE=$(echo "$SWARM_STATE" | jq -r '.active // false')
 
   if [[ "$SWARM_ACTIVE" == "true" ]]; then
-    rm -f .omc/swarm-state.json
+    rm -f .omc/state/swarm-state.json
     rm -f .omc/state/swarm-tasks.json
     echo "Swarm cancelled. Coordinated agents stopped."
     CANCELLED_ANYTHING=true
@@ -519,12 +519,12 @@ if [[ -f .omc/swarm-state.json ]]; then
 fi
 
 # 7. Check Ultrapilot (standalone)
-if [[ -f .omc/ultrapilot-state.json ]]; then
-  ULTRAPILOT_STATE=$(cat .omc/ultrapilot-state.json)
+if [[ -f .omc/state/ultrapilot-state.json ]]; then
+  ULTRAPILOT_STATE=$(cat .omc/state/ultrapilot-state.json)
   ULTRAPILOT_ACTIVE=$(echo "$ULTRAPILOT_STATE" | jq -r '.active // false')
 
   if [[ "$ULTRAPILOT_ACTIVE" == "true" ]]; then
-    rm -f .omc/ultrapilot-state.json
+    rm -f .omc/state/ultrapilot-state.json
     echo "Ultrapilot cancelled. Parallel autopilot workers stopped."
     CANCELLED_ANYTHING=true
     exit 0
@@ -532,12 +532,12 @@ if [[ -f .omc/ultrapilot-state.json ]]; then
 fi
 
 # 8. Check Pipeline (standalone)
-if [[ -f .omc/pipeline-state.json ]]; then
-  PIPELINE_STATE=$(cat .omc/pipeline-state.json)
+if [[ -f .omc/state/pipeline-state.json ]]; then
+  PIPELINE_STATE=$(cat .omc/state/pipeline-state.json)
   PIPELINE_ACTIVE=$(echo "$PIPELINE_STATE" | jq -r '.active // false')
 
   if [[ "$PIPELINE_ACTIVE" == "true" ]]; then
-    rm -f .omc/pipeline-state.json
+    rm -f .omc/state/pipeline-state.json
     echo "Pipeline cancelled. Sequential agent chain stopped."
     CANCELLED_ANYTHING=true
     exit 0
@@ -550,7 +550,7 @@ if [[ "$PLAN_CONSENSUS_ACTIVE" == "true" ]]; then
 
   # Clear state files
   rm -f .omc/state/plan-consensus.json
-  rm -f .omc/ralplan-state.json
+  rm -f .omc/state/ralplan-state.json
 
   echo "Plan Consensus cancelled. Planning session ended."
   echo "Note: Plan file preserved at path specified in state."
@@ -563,14 +563,14 @@ if [[ "$CANCELLED_ANYTHING" == "false" ]]; then
   echo "No active OMC modes detected."
   echo ""
   echo "Checked for:"
-  echo "  - Autopilot (.omc/autopilot-state.json)"
-  echo "  - Ralph (.omc/ralph-state.json)"
-  echo "  - Ultrawork (.omc/ultrawork-state.json)"
-  echo "  - Ecomode (.omc/ecomode-state.json)"
-  echo "  - UltraQA (.omc/ultraqa-state.json)"
-  echo "  - Swarm (.omc/swarm-state.json)"
-  echo "  - Ultrapilot (.omc/ultrapilot-state.json)"
-  echo "  - Pipeline (.omc/pipeline-state.json)"
+  echo "  - Autopilot (.omc/state/autopilot-state.json)"
+  echo "  - Ralph (.omc/state/ralph-state.json)"
+  echo "  - Ultrawork (.omc/state/ultrawork-state.json)"
+  echo "  - Ecomode (.omc/state/ecomode-state.json)"
+  echo "  - UltraQA (.omc/state/ultraqa-state.json)"
+  echo "  - Swarm (.omc/state/swarm-state.json)"
+  echo "  - Ultrapilot (.omc/state/ultrapilot-state.json)"
+  echo "  - Pipeline (.omc/state/pipeline-state.json)"
   echo "  - Plan Consensus (.omc/state/plan-consensus.json)"
   echo ""
   echo "Use --force to clear all state files anyway."

--- a/skills/ecomode/SKILL.md
+++ b/skills/ecomode/SKILL.md
@@ -126,3 +126,17 @@ Before stopping, verify:
 3. **Prefer executor-low** for simple changes - only upgrade if it fails
 4. **Avoid opus agents** unless the task genuinely requires deep reasoning
 5. **Use writer (haiku)** for all documentation tasks
+
+## STATE CLEANUP ON COMPLETION
+
+**IMPORTANT: Delete state files on completion - do NOT just set `active: false`**
+
+When ecomode completes (all verification passes):
+
+```bash
+# Delete ecomode state files
+rm -f .omc/state/ecomode-state.json
+rm -f ~/.claude/ecomode-state.json
+```
+
+This ensures clean state for future sessions. Stale state files with `active: false` should not be left behind.

--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -397,6 +397,19 @@ The pipeline orchestrator:
 7. **Persists state** - Updates state file after each stage
 8. **Enforces verification** - Runs checks before completion
 
+## STATE CLEANUP ON COMPLETION
+
+**IMPORTANT: Delete state files on completion - do NOT just set `active: false`**
+
+When pipeline completes (all stages done or cancelled):
+
+```bash
+# Delete pipeline state file
+rm -f .omc/state/pipeline-state.json
+```
+
+This ensures clean state for future sessions. Stale state files with `active: false` should not be left behind.
+
 ## Skill Invocation
 
 This skill activates when:

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -188,12 +188,33 @@ DO NOT output the completion promise without Architect verification.
 - NO Premature Stopping - ALL TODOs must be complete
 - NO TEST DELETION - fix code, not tests
 
+## STATE CLEANUP ON COMPLETION
+
+**IMPORTANT: Delete state files on successful completion - do NOT just set `active: false`**
+
+When outputting the completion promise after Architect verification:
+
+```bash
+# Delete ralph state file (and linked ultrawork if applicable)
+rm -f .omc/state/ralph-state.json
+rm -f .omc/state/ralph-verification.json
+rm -f ~/.claude/ralph-state.json
+
+# If ultrawork was linked, delete it too
+rm -f .omc/state/ultrawork-state.json
+rm -f ~/.claude/ultrawork-state.json
+```
+
+This ensures clean state for future sessions. Stale state files with `active: false` should not be left behind.
+
 ## INSTRUCTIONS
 
 - Review your progress so far
 - Continue from where you left off
 - Use parallel execution and background tasks
-- When FULLY complete AND Architect verified, output: <promise>{{PROMISE}}</promise>
+- When FULLY complete AND Architect verified:
+  1. Clean up state files (delete ralph-state.json, ultrawork-state.json)
+  2. Output: <promise>{{PROMISE}}</promise>
 - Do not stop until the task is truly done
 
 Original task:

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -332,6 +332,19 @@ Spawns 2 writers, each documenting different modules.
 - **Progress Visibility:** Live stats on claimed/done/pending
 - **Scalable:** Works for 10s to 100s of subtasks
 
+## STATE CLEANUP ON COMPLETION
+
+**IMPORTANT: Delete state files on completion - do NOT just set `active: false`**
+
+When all tasks are done:
+
+```bash
+# Delete swarm state files
+rm -f .omc/state/swarm-state.json
+rm -f .omc/state/swarm-tasks.json
+rm -f .omc/state/swarm-claims.json
+```
+
 ## Implementation Notes
 
 The orchestrator (main skill handler) is responsible for:

--- a/skills/ultrapilot/SKILL.md
+++ b/skills/ultrapilot/SKILL.md
@@ -547,6 +547,18 @@ Then run:
 /oh-my-claudecode:ultrapilot --custom-decomposition
 ```
 
+## STATE CLEANUP ON COMPLETION
+
+**IMPORTANT: Delete state files on completion - do NOT just set `active: false`**
+
+When all workers complete successfully:
+
+```bash
+# Delete ultrapilot state files
+rm -f .omc/state/ultrapilot-state.json
+rm -f .omc/state/ultrapilot-ownership.json
+```
+
 ## Future Enhancements
 
 **Planned for v4.1:**

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -117,6 +117,19 @@ User can cancel with `/oh-my-claudecode:cancel` which clears the state file.
 4. **CLEAR OUTPUT** - User should always know current cycle and status
 5. **CLEAN UP** - Clear state file on completion or cancellation
 
+## STATE CLEANUP ON COMPLETION
+
+**IMPORTANT: Delete state files on completion - do NOT just set `active: false`**
+
+When goal is met OR max cycles reached OR exiting early:
+
+```bash
+# Delete ultraqa state file
+rm -f .omc/state/ultraqa-state.json
+```
+
+This ensures clean state for future sessions. Stale state files with `active: false` should not be left behind.
+
 ---
 
 Begin ULTRAQA cycling now. Parse the goal and start cycle 1.

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -90,3 +90,17 @@ Before stopping, verify:
 - [ ] ERRORS: Zero unaddressed errors
 
 **If ANY checkbox is unchecked, CONTINUE WORKING.**
+
+## STATE CLEANUP ON COMPLETION
+
+**IMPORTANT: Delete state files on completion - do NOT just set `active: false`**
+
+When all verification passes and work is complete:
+
+```bash
+# Delete ultrawork state files
+rm -f .omc/state/ultrawork-state.json
+rm -f ~/.claude/ultrawork-state.json
+```
+
+This ensures clean state for future sessions. Stale state files with `active: false` should not be left behind.

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -919,6 +919,7 @@ describe('Mutual Exclusion - UltraQA and Ralph', () => {
     testDir = join(tmpdir(), `omc-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(testDir, { recursive: true });
     mkdirSync(join(testDir, '.omc'), { recursive: true });
+    mkdirSync(join(testDir, '.omc', 'state'), { recursive: true });
   });
 
   afterEach(() => {
@@ -936,19 +937,19 @@ describe('Mutual Exclusion - UltraQA and Ralph', () => {
     });
 
     it('should return true when ultraqa is active', () => {
-      const stateFile = join(testDir, '.omc', 'ultraqa-state.json');
+      const stateFile = join(testDir, '.omc', 'state', 'ultraqa-state.json');
       writeFileSync(stateFile, JSON.stringify({ active: true }));
       expect(isUltraQAActive(testDir)).toBe(true);
     });
 
     it('should return false when ultraqa is not active', () => {
-      const stateFile = join(testDir, '.omc', 'ultraqa-state.json');
+      const stateFile = join(testDir, '.omc', 'state', 'ultraqa-state.json');
       writeFileSync(stateFile, JSON.stringify({ active: false }));
       expect(isUltraQAActive(testDir)).toBe(false);
     });
 
     it('should return false for invalid JSON', () => {
-      const stateFile = join(testDir, '.omc', 'ultraqa-state.json');
+      const stateFile = join(testDir, '.omc', 'state', 'ultraqa-state.json');
       writeFileSync(stateFile, 'invalid json');
       expect(isUltraQAActive(testDir)).toBe(false);
     });
@@ -960,13 +961,13 @@ describe('Mutual Exclusion - UltraQA and Ralph', () => {
     });
 
     it('should return true when ralph is active', () => {
-      const stateFile = join(testDir, '.omc', 'ralph-state.json');
+      const stateFile = join(testDir, '.omc', 'state', 'ralph-state.json');
       writeFileSync(stateFile, JSON.stringify({ active: true }));
       expect(isRalphLoopActive(testDir)).toBe(true);
     });
 
     it('should return false when ralph is not active', () => {
-      const stateFile = join(testDir, '.omc', 'ralph-state.json');
+      const stateFile = join(testDir, '.omc', 'state', 'ralph-state.json');
       writeFileSync(stateFile, JSON.stringify({ active: false }));
       expect(isRalphLoopActive(testDir)).toBe(false);
     });
@@ -975,7 +976,7 @@ describe('Mutual Exclusion - UltraQA and Ralph', () => {
   describe('UltraQA mutual exclusion', () => {
     it('should fail to start UltraQA when Ralph is active', () => {
       // Activate Ralph first
-      const ralphStateFile = join(testDir, '.omc', 'ralph-state.json');
+      const ralphStateFile = join(testDir, '.omc', 'state', 'ralph-state.json');
       writeFileSync(ralphStateFile, JSON.stringify({ active: true }));
 
       // Try to start UltraQA
@@ -996,7 +997,7 @@ describe('Mutual Exclusion - UltraQA and Ralph', () => {
     });
 
     it('should succeed starting UltraQA when ralph state exists but inactive', () => {
-      const ralphStateFile = join(testDir, '.omc', 'ralph-state.json');
+      const ralphStateFile = join(testDir, '.omc', 'state', 'ralph-state.json');
       writeFileSync(ralphStateFile, JSON.stringify({ active: false }));
 
       const result = startUltraQA(testDir, 'tests', 'test-session');
@@ -1011,7 +1012,7 @@ describe('Mutual Exclusion - UltraQA and Ralph', () => {
   describe('Ralph mutual exclusion', () => {
     it('should fail to start Ralph when UltraQA is active', () => {
       // Activate UltraQA first
-      const ultraqaStateFile = join(testDir, '.omc', 'ultraqa-state.json');
+      const ultraqaStateFile = join(testDir, '.omc', 'state', 'ultraqa-state.json');
       writeFileSync(ultraqaStateFile, JSON.stringify({ active: true }));
 
       // Try to start Ralph
@@ -1032,7 +1033,7 @@ describe('Mutual Exclusion - UltraQA and Ralph', () => {
     });
 
     it('should succeed starting Ralph when ultraqa state exists but inactive', () => {
-      const ultraqaStateFile = join(testDir, '.omc', 'ultraqa-state.json');
+      const ultraqaStateFile = join(testDir, '.omc', 'state', 'ultraqa-state.json');
       writeFileSync(ultraqaStateFile, JSON.stringify({ active: false }));
 
       const hook = createRalphLoopHook(testDir);

--- a/src/hooks/autopilot/__tests__/cancel.test.ts
+++ b/src/hooks/autopilot/__tests__/cancel.test.ts
@@ -38,6 +38,8 @@ describe('AutopilotCancel', () => {
 
   beforeEach(() => {
     testDir = mkdtempSync(join(tmpdir(), 'autopilot-cancel-test-'));
+    const fs = require('fs');
+    fs.mkdirSync(join(testDir, '.omc', 'state'), { recursive: true });
     vi.clearAllMocks();
   });
 
@@ -57,7 +59,7 @@ describe('AutopilotCancel', () => {
     it('should return failure when state exists but is not active', () => {
       const state = initAutopilot(testDir, 'test idea');
       state.active = false;
-      const stateFile = join(testDir, '.omc', 'autopilot-state.json');
+      const stateFile = join(testDir, '.omc', 'state', 'autopilot-state.json');
       const fs = require('fs');
       fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
 

--- a/src/hooks/autopilot/state.ts
+++ b/src/hooks/autopilot/state.ts
@@ -34,16 +34,16 @@ const SPEC_DIR = 'autopilot';
  */
 function getStateFilePath(directory: string): string {
   const omcDir = join(directory, '.omc');
-  return join(omcDir, STATE_FILE);
+  return join(omcDir, 'state', STATE_FILE);
 }
 
 /**
- * Ensure the .omc directory exists
+ * Ensure the .omc/state directory exists
  */
-function ensureOmcDir(directory: string): void {
-  const omcDir = join(directory, '.omc');
-  if (!existsSync(omcDir)) {
-    mkdirSync(omcDir, { recursive: true });
+function ensureStateDir(directory: string): void {
+  const stateDir = join(directory, '.omc', 'state');
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true });
   }
 }
 
@@ -51,7 +51,7 @@ function ensureOmcDir(directory: string): void {
  * Ensure the autopilot directory exists
  */
 export function ensureAutopilotDir(directory: string): string {
-  ensureOmcDir(directory);
+  ensureStateDir(directory);
   const autopilotDir = join(directory, '.omc', SPEC_DIR);
   if (!existsSync(autopilotDir)) {
     mkdirSync(autopilotDir, { recursive: true });
@@ -82,7 +82,7 @@ export function readAutopilotState(directory: string): AutopilotState | null {
  */
 export function writeAutopilotState(directory: string, state: AutopilotState): boolean {
   try {
-    ensureOmcDir(directory);
+    ensureStateDir(directory);
     const stateFile = getStateFilePath(directory);
     writeFileSync(stateFile, JSON.stringify(state, null, 2));
     return true;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -664,3 +664,19 @@ export {
   type IntegrationResult,
   type FileOwnership
 } from './ultrapilot/index.js';
+
+export {
+  // Mode Registry (Centralized State Management)
+  MODE_CONFIGS,
+  getStateDir,
+  ensureStateDir as ensureModeStateDir,
+  getStateFilePath as getModeStateFilePath,
+  getMarkerFilePath as getModeMarkerFilePath,
+  getGlobalStateFilePath,
+  clearModeState,
+  hasModeState,
+  getActiveModes,
+  clearAllModeStates,
+  type ExecutionMode,
+  type ModeConfig
+} from './mode-registry/index.js';

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -1,0 +1,204 @@
+/**
+ * Mode Registry
+ *
+ * Centralized configuration and utilities for OMC execution mode state files.
+ * All modes store state in `.omc/state/` subdirectory for consistency.
+ */
+
+import { existsSync, unlinkSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Supported execution modes
+ */
+export type ExecutionMode =
+  | 'autopilot'
+  | 'ralph'
+  | 'ultrawork'
+  | 'ultraqa'
+  | 'ultrapilot'
+  | 'swarm'
+  | 'pipeline'
+  | 'ecomode';
+
+/**
+ * Mode configuration
+ */
+export interface ModeConfig {
+  /** State file name (relative to .omc/state/) */
+  stateFile: string;
+  /** Optional marker file for additional state */
+  markerFile?: string;
+  /** Whether this mode has a global state file in ~/.claude/ */
+  hasGlobalState?: boolean;
+}
+
+/**
+ * Configuration for all execution modes
+ * All state files are stored in `.omc/state/` subdirectory
+ */
+export const MODE_CONFIGS: Record<ExecutionMode, ModeConfig> = {
+  autopilot: {
+    stateFile: 'autopilot-state.json'
+  },
+  ralph: {
+    stateFile: 'ralph-state.json',
+    markerFile: 'ralph-verification.json',
+    hasGlobalState: true
+  },
+  ultrawork: {
+    stateFile: 'ultrawork-state.json',
+    hasGlobalState: true
+  },
+  ultraqa: {
+    stateFile: 'ultraqa-state.json'
+  },
+  ultrapilot: {
+    stateFile: 'ultrapilot-state.json',
+    markerFile: 'ultrapilot-ownership.json'
+  },
+  swarm: {
+    stateFile: 'swarm-state.json',
+    markerFile: 'swarm-tasks.json'
+  },
+  pipeline: {
+    stateFile: 'pipeline-state.json'
+  },
+  ecomode: {
+    stateFile: 'ecomode-state.json',
+    hasGlobalState: true
+  }
+};
+
+/**
+ * Get the state directory path
+ */
+export function getStateDir(cwd: string): string {
+  return join(cwd, '.omc', 'state');
+}
+
+/**
+ * Ensure the state directory exists
+ */
+export function ensureStateDir(cwd: string): void {
+  const stateDir = getStateDir(cwd);
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true });
+  }
+}
+
+/**
+ * Get the state file path for a mode
+ */
+export function getStateFilePath(cwd: string, mode: ExecutionMode): string {
+  const config = MODE_CONFIGS[mode];
+  return join(getStateDir(cwd), config.stateFile);
+}
+
+/**
+ * Get the marker file path for a mode (if applicable)
+ */
+export function getMarkerFilePath(cwd: string, mode: ExecutionMode): string | null {
+  const config = MODE_CONFIGS[mode];
+  if (!config.markerFile) {
+    return null;
+  }
+  return join(getStateDir(cwd), config.markerFile);
+}
+
+/**
+ * Get the global state file path (in ~/.claude/) for modes that support it
+ */
+export function getGlobalStateFilePath(mode: ExecutionMode): string | null {
+  const config = MODE_CONFIGS[mode];
+  if (!config.hasGlobalState) {
+    return null;
+  }
+  const homeDir = process.env.HOME || process.env.USERPROFILE || '';
+  return join(homeDir, '.claude', config.stateFile);
+}
+
+/**
+ * Clear all state files for a mode
+ *
+ * Deletes:
+ * - Local state file (.omc/state/{mode}-state.json)
+ * - Local marker file if applicable
+ * - Global state file if applicable (~/.claude/{mode}-state.json)
+ *
+ * @returns true if all files were deleted successfully (or didn't exist)
+ */
+export function clearModeState(mode: ExecutionMode, cwd: string): boolean {
+  const config = MODE_CONFIGS[mode];
+  let success = true;
+
+  // Delete local state file
+  const stateFile = getStateFilePath(cwd, mode);
+  if (existsSync(stateFile)) {
+    try {
+      unlinkSync(stateFile);
+    } catch {
+      success = false;
+    }
+  }
+
+  // Delete marker file if applicable
+  const markerFile = getMarkerFilePath(cwd, mode);
+  if (markerFile && existsSync(markerFile)) {
+    try {
+      unlinkSync(markerFile);
+    } catch {
+      success = false;
+    }
+  }
+
+  // Delete global state file if applicable
+  const globalFile = getGlobalStateFilePath(mode);
+  if (globalFile && existsSync(globalFile)) {
+    try {
+      unlinkSync(globalFile);
+    } catch {
+      success = false;
+    }
+  }
+
+  return success;
+}
+
+/**
+ * Check if a mode has active state (file exists)
+ */
+export function hasModeState(cwd: string, mode: ExecutionMode): boolean {
+  const stateFile = getStateFilePath(cwd, mode);
+  return existsSync(stateFile);
+}
+
+/**
+ * Get all modes that currently have state files
+ */
+export function getActiveModes(cwd: string): ExecutionMode[] {
+  const modes: ExecutionMode[] = [];
+
+  for (const mode of Object.keys(MODE_CONFIGS) as ExecutionMode[]) {
+    if (hasModeState(cwd, mode)) {
+      modes.push(mode);
+    }
+  }
+
+  return modes;
+}
+
+/**
+ * Clear all mode states (force clear)
+ */
+export function clearAllModeStates(cwd: string): boolean {
+  let success = true;
+
+  for (const mode of Object.keys(MODE_CONFIGS) as ExecutionMode[]) {
+    if (!clearModeState(mode, cwd)) {
+      success = false;
+    }
+  }
+
+  return success;
+}

--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -36,7 +36,7 @@ import {
 // Forward declaration to avoid circular import - check ultraqa state file directly
 export function isUltraQAActive(directory: string): boolean {
   const omcDir = join(directory, '.omc');
-  const stateFile = join(omcDir, 'ultraqa-state.json');
+  const stateFile = join(omcDir, 'state', 'ultraqa-state.json');
   if (!existsSync(stateFile)) {
     return false;
   }
@@ -96,16 +96,16 @@ const DEFAULT_COMPLETION_PROMISE = 'TASK_COMPLETE';
  */
 function getStateFilePath(directory: string): string {
   const omcDir = join(directory, '.omc');
-  return join(omcDir, 'ralph-state.json');
+  return join(omcDir, 'state', 'ralph-state.json');
 }
 
 /**
  * Ensure the .omc directory exists
  */
 function ensureStateDir(directory: string): void {
-  const omcDir = join(directory, '.omc');
-  if (!existsSync(omcDir)) {
-    mkdirSync(omcDir, { recursive: true });
+  const stateDir = join(directory, '.omc', 'state');
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true });
   }
 }
 
@@ -172,7 +172,7 @@ export function clearLinkedUltraworkState(directory: string): boolean {
   }
 
   const omcDir = join(directory, '.omc');
-  const stateFile = join(omcDir, 'ultrawork-state.json');
+  const stateFile = join(omcDir, 'state', 'ultrawork-state.json');
   try {
     unlinkSync(stateFile);
     return true;

--- a/src/hooks/ultraqa/index.ts
+++ b/src/hooks/ultraqa/index.ts
@@ -56,16 +56,16 @@ const SAME_FAILURE_THRESHOLD = 3;
  */
 function getStateFilePath(directory: string): string {
   const omcDir = join(directory, '.omc');
-  return join(omcDir, 'ultraqa-state.json');
+  return join(omcDir, 'state', 'ultraqa-state.json');
 }
 
 /**
- * Ensure the .omc directory exists
+ * Ensure the .omc/state directory exists
  */
 function ensureStateDir(directory: string): void {
-  const omcDir = join(directory, '.omc');
-  if (!existsSync(omcDir)) {
-    mkdirSync(omcDir, { recursive: true });
+  const stateDir = join(directory, '.omc', 'state');
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true });
   }
 }
 

--- a/src/hooks/ultrawork/index.ts
+++ b/src/hooks/ultrawork/index.ts
@@ -41,7 +41,7 @@ const _DEFAULT_STATE: UltraworkState = {
 function getStateFilePath(directory?: string): string {
   const baseDir = directory || process.cwd();
   const omcDir = join(baseDir, '.omc');
-  return join(omcDir, 'ultrawork-state.json');
+  return join(omcDir, 'state', 'ultrawork-state.json');
 }
 
 /**
@@ -52,11 +52,11 @@ function getGlobalStateFilePath(): string {
 }
 
 /**
- * Ensure the .omc directory exists
+ * Ensure the .omc/state directory exists
  */
 function ensureStateDir(directory?: string): void {
   const baseDir = directory || process.cwd();
-  const omcDir = join(baseDir, '.omc');
+  const omcDir = join(baseDir, '.omc', 'state');
   if (!existsSync(omcDir)) {
     mkdirSync(omcDir, { recursive: true });
   }


### PR DESCRIPTION
## Summary

- Consolidates all execution mode state files into `.omc/state/` subdirectory for consistent organization
- Adds new `mode-registry` module with centralized state management utilities
- Updates all skill files with explicit cleanup instructions to delete state files on completion (not just set `active: false`)
- Fixes path mismatches between mode-registry and cancel skill

## Changes

### State File Path Standardization
All modes now use `.omc/state/` subdirectory:
- `autopilot-state.json`
- `ralph-state.json`
- `ultrawork-state.json`
- `ultraqa-state.json`
- `ultrapilot-state.json` (already correct)
- `swarm-state.json`
- `pipeline-state.json`
- `ecomode-state.json`

### New Mode Registry Module
`src/hooks/mode-registry/index.ts` provides:
- `MODE_CONFIGS` - centralized configuration for all modes
- `getStateFilePath()`, `getMarkerFilePath()` - path helpers
- `clearModeState()` - proper state cleanup
- `getActiveModes()`, `clearAllModeStates()` - utilities

### Cleanup Instructions Added
All skill files now include explicit "STATE CLEANUP ON COMPLETION" sections instructing to delete state files rather than just setting `active: false`.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` - all 860 tests pass
- [x] Grep verification confirms no old paths remain in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)