### PR TITLE
fix(analytics): support Windows-encoded paths in transcript scanner

### DIFF
--- a/src/__tests__/analytics/transcript-scanner.test.ts
+++ b/src/__tests__/analytics/transcript-scanner.test.ts
@@ -2,9 +2,45 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import { mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
-import { homedir, tmpdir } from 'os';
+import { homedir, tmpdir, platform } from 'os';
 import { scanTranscripts, decodeProjectPath } from '../../analytics/transcript-scanner.js';
 import type { Dirent, Stats } from 'fs';
+
+/**
+ * Helper to encode a path the same way Claude Code does.
+ * - Unix: "/home/user/project" → "-home-user-project"
+ * - Windows: "C:\Users\user\project" → "C--Users-user-project"
+ */
+function encodePathForTest(absolutePath: string): string {
+  // Normalize path separators to forward slashes
+  const normalized = absolutePath.replace(/\\/g, '/');
+
+  // Check for Windows drive letter (e.g., "C:/...")
+  const windowsDriveMatch = normalized.match(/^([A-Za-z]):\/(.*)$/);
+  if (windowsDriveMatch) {
+    const driveLetter = windowsDriveMatch[1];
+    const rest = windowsDriveMatch[2];
+    // Encode as "C--Users-user-project"
+    return `${driveLetter}-${rest.replace(/\//g, '-')}`;
+  }
+
+  // Unix path (e.g., "/home/user/project")
+  if (normalized.startsWith('/')) {
+    return `-${normalized.slice(1).replace(/\//g, '-')}`;
+  }
+
+  // Relative path - return as-is
+  return normalized.replace(/\//g, '-');
+}
+
+/**
+ * Helper to get expected decoded path format.
+ * Windows paths are returned with forward slashes for consistency.
+ */
+function expectedDecodedPath(absolutePath: string): string {
+  // Normalize to forward slashes (the decoder always uses forward slashes)
+  return absolutePath.replace(/\\/g, '/');
+}
 
 vi.mock('fs/promises');
 vi.mock('os');
@@ -391,48 +427,52 @@ describe('decodeProjectPath (filesystem-aware)', () => {
   });
 
   it('should decode simple paths without hyphens when path exists', () => {
-    // Create: /tmp/test-xxx/home/user/project
+    // Create: {testDir}/home/user/project
     const projectPath = join(testDir, 'home', 'user', 'project');
     mkdirSync(projectPath, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-home-user-project`;
+    const fullPath = join(testDir, 'home', 'user', 'project');
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
-    expect(result).toBe(`${testDir}/home/user/project`);
+    expect(result).toBe(expectedDecodedPath(fullPath));
   });
 
   it('should decode paths with legitimate hyphens in directory names', () => {
-    // Create: /tmp/test-xxx/home/user/my-project
+    // Create: {testDir}/home/user/my-project
     const projectPath = join(testDir, 'home', 'user', 'my-project');
     mkdirSync(projectPath, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-home-user-my-project`;
+    const fullPath = join(testDir, 'home', 'user', 'my-project');
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
     // Should preserve "my-project" as one directory
-    expect(result).toBe(`${testDir}/home/user/my-project`);
+    expect(result).toBe(expectedDecodedPath(fullPath));
   });
 
   it('should handle multiple hyphens in a single directory name', () => {
-    // Create: /tmp/test-xxx/home/user/my-cool-project
+    // Create: {testDir}/home/user/my-cool-project
     const projectPath = join(testDir, 'home', 'user', 'my-cool-project');
     mkdirSync(projectPath, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-home-user-my-cool-project`;
+    const fullPath = join(testDir, 'home', 'user', 'my-cool-project');
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
-    expect(result).toBe(`${testDir}/home/user/my-cool-project`);
+    expect(result).toBe(expectedDecodedPath(fullPath));
   });
 
   it('should handle hyphens at multiple levels', () => {
-    // Create: /tmp/test-xxx/my-workspace/my-project
+    // Create: {testDir}/my-workspace/my-project
     const projectPath = join(testDir, 'my-workspace', 'my-project');
     mkdirSync(projectPath, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-my-workspace-my-project`;
+    const fullPath = join(testDir, 'my-workspace', 'my-project');
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
-    expect(result).toBe(`${testDir}/my-workspace/my-project`);
+    expect(result).toBe(expectedDecodedPath(fullPath));
   });
 
   it('should fall back to simple decode if no matching filesystem path exists', () => {
@@ -445,49 +485,53 @@ describe('decodeProjectPath (filesystem-aware)', () => {
   });
 
   it('should handle root-level project directories', () => {
-    // Create: /tmp/test-xxx/my-project
+    // Create: {testDir}/my-project
     const projectPath = join(testDir, 'my-project');
     mkdirSync(projectPath, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-my-project`;
+    const fullPath = join(testDir, 'my-project');
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
-    expect(result).toBe(`${testDir}/my-project`);
+    expect(result).toBe(expectedDecodedPath(fullPath));
   });
 
   it('should prefer filesystem-verified paths over simple decode', () => {
-    // Create: /tmp/test-xxx/a/b-c (the correct interpretation)
-    // Don't create /tmp/test-xxx/a/b/c
+    // Create: {testDir}/a/b-c (the correct interpretation)
+    // Don't create {testDir}/a/b/c
     const correctPath = join(testDir, 'a', 'b-c');
     mkdirSync(correctPath, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-a-b-c`;
+    const fullPath = join(testDir, 'a', 'b-c');
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
     // Should choose /a/b-c over /a/b/c
-    expect(result).toBe(`${testDir}/a/b-c`);
+    expect(result).toBe(expectedDecodedPath(fullPath));
   });
 
   it('should handle deeply nested paths with hyphens', () => {
-    // Create: /tmp/test-xxx/home/user/workspace/my-project/sub-folder
+    // Create: {testDir}/home/user/workspace/my-project/sub-folder
     const projectPath = join(testDir, 'home', 'user', 'workspace', 'my-project', 'sub-folder');
     mkdirSync(projectPath, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-home-user-workspace-my-project-sub-folder`;
+    const fullPath = join(testDir, 'home', 'user', 'workspace', 'my-project', 'sub-folder');
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
-    expect(result).toBe(`${testDir}/home/user/workspace/my-project/sub-folder`);
+    expect(result).toBe(expectedDecodedPath(fullPath));
   });
 
   it('should handle paths with consecutive hyphens', () => {
-    // Create: /tmp/test-xxx/my--project (unusual but valid)
+    // Create: {testDir}/my--project (unusual but valid)
     const projectPath = join(testDir, 'my--project');
     mkdirSync(projectPath, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-my--project`;
+    const fullPath = join(testDir, 'my--project');
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
-    expect(result).toBe(`${testDir}/my--project`);
+    expect(result).toBe(expectedDecodedPath(fullPath));
   });
 
   it('should find first matching path when multiple interpretations exist', () => {
@@ -497,11 +541,14 @@ describe('decodeProjectPath (filesystem-aware)', () => {
     mkdirSync(path1, { recursive: true });
     mkdirSync(path2, { recursive: true });
 
-    const encoded = `-${testDir.slice(1)}-a-b-c`;
+    const fullPath = join(testDir, 'a', 'b-c'); // Use one as reference for encoding
+    const encoded = encodePathForTest(fullPath);
     const result = decodeProjectPath(encoded);
 
     // Should match one of the valid paths
-    const isValid = result === `${testDir}/a-b/c` || result === `${testDir}/a/b-c`;
+    const expected1 = expectedDecodedPath(path1);
+    const expected2 = expectedDecodedPath(path2);
+    const isValid = result === expected1 || result === expected2;
     expect(isValid).toBe(true);
   });
 });

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -349,7 +349,8 @@ describe('Installer Constants', () => {
       ];
 
       for (const path of paths) {
-        expect(path).toMatch(/^[/~]/); // Starts with / or ~ (absolute)
+        // Absolute path: starts with / or ~ (Unix) or drive letter like C: (Windows)
+        expect(path).toMatch(/^([/~]|[A-Za-z]:)/);
       }
     });
   });

--- a/src/analytics/transcript-scanner.ts
+++ b/src/analytics/transcript-scanner.ts
@@ -1,7 +1,24 @@
 import { readdir, stat } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, sep } from 'path';
 import { homedir } from 'os';
+
+/**
+ * Check if the encoded path looks like a Windows path (starts with drive letter)
+ * Examples: "C--Users-user-project" or "D--work-project"
+ */
+function isWindowsEncodedPath(dirName: string): boolean {
+  return /^[A-Za-z]-/.test(dirName);
+}
+
+/**
+ * Normalize decoded path to use OS-native separators consistently
+ */
+function normalizePathForOS(decodedPath: string): string {
+  // On Windows, convert forward slashes to backslashes for consistency
+  // But existsSync works with both, so we normalize to forward slashes for cross-platform
+  return decodedPath.replace(/\\/g, '/');
+}
 
 /**
  * Metadata for a discovered transcript file
@@ -41,35 +58,97 @@ const UUID_REGEX = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12
  * Decode project directory name back to original path.
  *
  * The encoding scheme used by Claude Code is lossy - it converts all path
- * separators (/) to dashes (-), but legitimate dashes in directory names
+ * separators (/ or \) to dashes (-), but legitimate dashes in directory names
  * also become dashes, making them indistinguishable.
  *
- * Strategy:
- * 1. Try simple decode (all dashes -> slashes) and check if path exists
- * 2. If not, try to reconstruct by checking filesystem for partial matches
- * 3. Fall back to simple decode if nothing else works
+ * Encoding patterns:
+ *   - Unix: "/home/user/project" → "-home-user-project"
+ *   - Windows: "C:\Users\user\project" → "C--Users-user-project"
  *
- * Example: "-home-bellman-my-project"
- *   - Simple decode: "/home/bellman/my/project" (WRONG if "my-project" is one dir)
- *   - Smart decode: "/home/bellman/my-project" (checks filesystem)
+ * Strategy:
+ * 1. Detect if it's a Windows or Unix encoded path
+ * 2. Try simple decode (all dashes -> slashes) and check if path exists
+ * 3. If not, try to reconstruct by checking filesystem for partial matches
+ * 4. Fall back to simple decode if nothing else works
  *
  * @internal Exported for testing
  */
 export function decodeProjectPath(dirName: string): string {
-  if (!dirName.startsWith('-')) {
-    return dirName;
+  // Handle Windows encoded paths (e.g., "C--Users-user-project")
+  if (isWindowsEncodedPath(dirName)) {
+    return decodeWindowsPath(dirName);
   }
 
-  // Simple decode: replace all dashes with slashes
-  const simplePath = '/' + dirName.slice(1).replace(/-/g, '/');
+  // Handle Unix encoded paths (e.g., "-home-user-project")
+  if (dirName.startsWith('-')) {
+    return decodeUnixPath(dirName);
+  }
+
+  // Not an encoded path, return as-is
+  return dirName;
+}
+
+/**
+ * Split path string preserving consecutive hyphens as single segments.
+ * e.g., "a--b-c" → ["a", "-", "b", "c"] (the "-" represents a hyphen in original name)
+ */
+function splitPreservingConsecutiveHyphens(str: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let i = 0;
+
+  while (i < str.length) {
+    if (str[i] === '-') {
+      if (current) {
+        result.push(current);
+        current = '';
+      }
+      // Check for consecutive hyphens
+      if (i + 1 < str.length && str[i + 1] === '-') {
+        // Consecutive hyphens - this means the original had a hyphen
+        // Push empty string as marker, will be joined with hyphen later
+        result.push('');
+        i++; // Skip the second hyphen
+      }
+      i++;
+    } else {
+      current += str[i];
+      i++;
+    }
+  }
+
+  if (current) {
+    result.push(current);
+  }
+
+  return result;
+}
+
+/**
+ * Decode Windows encoded path (e.g., "C--Users-user-project" → "C:/Users/user/project")
+ */
+function decodeWindowsPath(dirName: string): string {
+  const driveLetter = dirName[0];
+  const rest = dirName.slice(2); // Skip "X-"
+
+  // Simple decode: drive letter + colon + rest with dashes as slashes
+  const simplePath = `${driveLetter}:/${rest.replace(/-/g, '/')}`;
+
+  // Normalize double slashes that might occur from empty segments
+  const normalizedSimple = simplePath.replace(/\/+/g, '/');
 
   // If simple decode exists, we're done
-  if (existsSync(simplePath)) {
-    return simplePath;
+  if (existsSync(normalizedSimple)) {
+    return normalizedSimple;
   }
 
   // Try to reconstruct by checking filesystem for partial matches
-  const segments = dirName.slice(1).split('-');
+  // Use special splitting to handle consecutive hyphens
+  const segments = splitPreservingConsecutiveHyphens(rest);
+  if (segments.length === 0) {
+    return `${driveLetter}:/`;
+  }
+
   const possiblePaths: string[] = [];
 
   // Generate all possible interpretations by trying different hyphen positions
@@ -79,14 +158,89 @@ export function decodeProjectPath(dirName: string): string {
       return;
     }
 
+    const part = parts[index];
+
+    // Empty string means this was a consecutive hyphen - must join with previous
+    if (part === '' && currentPath) {
+      const pathParts = currentPath.split('/');
+      const lastPart = pathParts.pop() || '';
+      const newPath = pathParts.join('/') + '/' + lastPart + '-';
+      generatePaths(parts, index + 1, newPath);
+      return;
+    }
+
     // Try adding next segment as a new directory
-    generatePaths(parts, index + 1, currentPath + '/' + parts[index]);
+    const newDir = currentPath + '/' + part;
+    generatePaths(parts, index + 1, newDir);
 
     // Try combining with previous segment using hyphen (if not first segment)
     if (index > 0 && currentPath) {
       const pathParts = currentPath.split('/');
       const lastPart = pathParts.pop() || '';
-      const newPath = pathParts.join('/') + '/' + lastPart + '-' + parts[index];
+      const newPath = pathParts.join('/') + '/' + lastPart + '-' + part;
+      generatePaths(parts, index + 1, newPath);
+    }
+  }
+
+  generatePaths(segments, 0, `${driveLetter}:`);
+
+  // Find the first path that exists on filesystem
+  for (const path of possiblePaths) {
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+
+  // Fall back to simple decode
+  return normalizedSimple;
+}
+
+/**
+ * Decode Unix encoded path (e.g., "-home-user-project" → "/home/user/project")
+ */
+function decodeUnixPath(dirName: string): string {
+  // Simple decode: replace all dashes with slashes
+  const simplePath = '/' + dirName.slice(1).replace(/-/g, '/');
+
+  // Normalize double slashes
+  const normalizedSimple = simplePath.replace(/\/+/g, '/');
+
+  // If simple decode exists, we're done
+  if (existsSync(normalizedSimple)) {
+    return normalizedSimple;
+  }
+
+  // Try to reconstruct by checking filesystem for partial matches
+  // Use special splitting to handle consecutive hyphens
+  const segments = splitPreservingConsecutiveHyphens(dirName.slice(1));
+  const possiblePaths: string[] = [];
+
+  // Generate all possible interpretations by trying different hyphen positions
+  function generatePaths(parts: string[], index: number, currentPath: string): void {
+    if (index >= parts.length) {
+      possiblePaths.push(currentPath);
+      return;
+    }
+
+    const part = parts[index];
+
+    // Empty string means this was a consecutive hyphen - must join with previous
+    if (part === '' && currentPath) {
+      const pathParts = currentPath.split('/');
+      const lastPart = pathParts.pop() || '';
+      const newPath = pathParts.join('/') + '/' + lastPart + '-';
+      generatePaths(parts, index + 1, newPath);
+      return;
+    }
+
+    // Try adding next segment as a new directory
+    generatePaths(parts, index + 1, currentPath + '/' + part);
+
+    // Try combining with previous segment using hyphen (if not first segment)
+    if (index > 0 && currentPath) {
+      const pathParts = currentPath.split('/');
+      const lastPart = pathParts.pop() || '';
+      const newPath = pathParts.join('/') + '/' + lastPart + '-' + part;
       generatePaths(parts, index + 1, newPath);
     }
   }
@@ -101,7 +255,7 @@ export function decodeProjectPath(dirName: string): string {
   }
 
   // Fall back to simple decode
-  return simplePath;
+  return normalizedSimple;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes `decodeProjectPath()` to correctly handle Windows-encoded paths from Claude Code.

Relates to #115

## Problem

Claude Code encodes project paths differently on Windows vs Unix:

| OS | Original Path | Encoded |
|----|---------------|---------|
| Unix | `/home/user/project` | `-home-user-project` |
| Windows | `C:\Users\user\project` | `C--Users-user-project` |

The existing implementation only handled Unix paths, causing Windows paths to decode incorrectly:
- Input: `C--Users-user-project`
- Expected: `C:/Users/user/project`
- Actual: `C//Users/user/project` (broken)

## Solution

### Detection Logic
```typescript
function isWindowsEncodedPath(dirName: string): boolean {
  return /^[A-Za-z]-/.test(dirName);  // Starts with drive letter
}
```

### Decoding Strategy
1. Detect path type (Windows vs Unix)
2. Try simple decode and check filesystem
3. Handle consecutive hyphens (`my--project` → `my-project`)
4. Fall back to simple decode if no match

## Files Changed

- `src/analytics/transcript-scanner.ts` - Windows path decoding logic
- `src/__tests__/analytics/transcript-scanner.test.ts` - Cross-platform test helpers
- `src/__tests__/installer.test.ts` - Path regex fix for Windows

## Test Results

All 24 transcript-scanner tests pass on both Windows and Unix paths:
```
✓ src/__tests__/analytics/transcript-scanner.test.ts (24 tests)
```

## Backward Compatibility

- Unix paths continue to work unchanged
- Existing encoded paths decode correctly
- No breaking changes to public API

---

🤖 Generated with [Claude Code](https://claude.ai/code)