### PR TITLE
fix(setup): backup CLAUDE.md before overwrite (#119)

### DIFF
--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -49,6 +49,14 @@ mkdir -p .claude && echo ".claude directory ready"
 # Extract old version before download
 OLD_VERSION=$(grep -m1 "^# oh-my-claudecode" .claude/CLAUDE.md 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "none")
 
+# Backup existing CLAUDE.md before overwriting (if it exists)
+if [ -f ".claude/CLAUDE.md" ]; then
+  BACKUP_DATE=$(date +%Y-%m-%d)
+  BACKUP_PATH=".claude/CLAUDE.md.backup.${BACKUP_DATE}"
+  cp .claude/CLAUDE.md "$BACKUP_PATH"
+  echo "Backed up existing CLAUDE.md to $BACKUP_PATH"
+fi
+
 # Download fresh CLAUDE.md from GitHub
 curl -fsSL "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md" -o .claude/CLAUDE.md && \
 echo "Downloaded CLAUDE.md to .claude/CLAUDE.md"
@@ -65,6 +73,8 @@ fi
 ```
 
 **Note**: The downloaded CLAUDE.md includes Context Persistence instructions with `<remember>` tags for surviving conversation compaction.
+
+**Note**: If an existing CLAUDE.md is found, it will be backed up to `.claude/CLAUDE.md.backup.YYYY-MM-DD` before downloading the new version.
 
 **MANDATORY**: Always run this command. Do NOT skip. Do NOT use Write tool.
 
@@ -84,6 +94,7 @@ After completing local configuration, report:
 
 **OMC Project Configuration Complete**
 - CLAUDE.md: Updated with latest configuration from GitHub at ./.claude/CLAUDE.md
+- Backup: Previous CLAUDE.md backed up to `.claude/CLAUDE.md.backup.YYYY-MM-DD` (if existed)
 - Scope: **PROJECT** - applies only to this project
 - Hooks: Provided by plugin (no manual installation needed)
 - Agents: 28+ available (base + tiered variants)
@@ -103,6 +114,14 @@ If `--local` flag was used, **STOP HERE**. Do not continue to HUD setup or other
 # Extract old version before download
 OLD_VERSION=$(grep -m1 "^# oh-my-claudecode" ~/.claude/CLAUDE.md 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "none")
 
+# Backup existing CLAUDE.md before overwriting (if it exists)
+if [ -f "$HOME/.claude/CLAUDE.md" ]; then
+  BACKUP_DATE=$(date +%Y-%m-%d)
+  BACKUP_PATH="$HOME/.claude/CLAUDE.md.backup.${BACKUP_DATE}"
+  cp "$HOME/.claude/CLAUDE.md" "$BACKUP_PATH"
+  echo "Backed up existing CLAUDE.md to $BACKUP_PATH"
+fi
+
 # Download fresh CLAUDE.md to global config
 curl -fsSL "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md" -o ~/.claude/CLAUDE.md && \
 echo "Downloaded CLAUDE.md to ~/.claude/CLAUDE.md"
@@ -117,6 +136,8 @@ else
   echo "Updated CLAUDE.md: $OLD_VERSION -> $NEW_VERSION"
 fi
 ```
+
+**Note**: If an existing CLAUDE.md is found, it will be backed up to `~/.claude/CLAUDE.md.backup.YYYY-MM-DD` before downloading the new version.
 
 ### Clean Up Legacy Hooks (if present)
 
@@ -147,6 +168,7 @@ After completing global configuration, report:
 
 **OMC Global Configuration Complete**
 - CLAUDE.md: Updated with latest configuration from GitHub at ~/.claude/CLAUDE.md
+- Backup: Previous CLAUDE.md backed up to `~/.claude/CLAUDE.md.backup.YYYY-MM-DD` (if existed)
 - Scope: **GLOBAL** - applies to all Claude Code sessions
 - Hooks: Provided by plugin (no manual installation needed)
 - Agents: 28+ available (base + tiered variants)
@@ -480,11 +502,13 @@ MODES:
 
   Local Configuration (--local)
     - Downloads fresh CLAUDE.md to ./.claude/
+    - Backs up existing CLAUDE.md to .claude/CLAUDE.md.backup.YYYY-MM-DD
     - Project-specific settings
     - Use this to update project config after OMC upgrades
 
   Global Configuration (--global)
     - Downloads fresh CLAUDE.md to ~/.claude/
+    - Backs up existing CLAUDE.md to ~/.claude/CLAUDE.md.backup.YYYY-MM-DD
     - Applies to all Claude Code sessions
     - Cleans up legacy hooks
     - Use this to update global config after OMC upgrades

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -314,6 +314,14 @@ export function install(options: InstallOptions = {}): InstallResult {
 
       if (!existsSync(homeMdPath)) {
         if (!existsSync(claudeMdPath) || options.force) {
+          // Backup existing CLAUDE.md before overwriting (if it exists and --force)
+          if (existsSync(claudeMdPath) && options.force) {
+            const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+            const backupPath = join(CLAUDE_CONFIG_DIR, `CLAUDE.md.backup.${today}`);
+            const existingContent = readFileSync(claudeMdPath, 'utf-8');
+            writeFileSync(backupPath, existingContent);
+            log(`Backed up existing CLAUDE.md to ${backupPath}`);
+          }
           writeFileSync(claudeMdPath, loadClaudeMdContent());
           log('Created CLAUDE.md');
         } else {


### PR DESCRIPTION
## Summary
- Adds backup functionality before overwriting CLAUDE.md during omc-setup
- Backup file saved with timestamp: `CLAUDE.md.backup.YYYY-MM-DD`
- Works for both local (`.claude/`) and global (`~/.claude/`) configurations

## Changes
- **skills/omc-setup/SKILL.md**: Added backup step to bash scripts for both local and global config
- **src/installer/index.ts**: Added backup logic when `--force` flag is used in npm installer

## Test plan
- [ ] Run `/oh-my-claudecode:omc-setup --local` with existing CLAUDE.md → verify backup created
- [ ] Run `/oh-my-claudecode:omc-setup --global` with existing CLAUDE.md → verify backup created
- [ ] Verify backup file has correct timestamp format (YYYY-MM-DD)
- [ ] Verify original content is preserved in backup

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)