### PR TITLE
fix(docs): correct npm package references from oh-my-claudecode to oh-my-claude-sisyphus

### DIFF
--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -16,7 +16,7 @@ INSTALLED=$(ls ~/.claude/plugins/cache/omc/oh-my-claudecode/ 2>/dev/null | sort 
 echo "Installed: $INSTALLED"
 
 # Get latest from npm
-LATEST=$(npm view oh-my-claudecode version 2>/dev/null)
+LATEST=$(npm view oh-my-claude-sisyphus version 2>/dev/null)
 echo "Latest: $LATEST"
 ```
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -547,7 +547,7 @@ Background agents can be resumed with full context via `resume-session` tool.
 Version 3.1 is a drop-in upgrade. No migration required!
 
 ```bash
-npm update -g oh-my-claudecode
+npm update -g oh-my-claude-sisyphus
 ```
 
 All existing configurations, plans, and workflows continue working unchanged.
@@ -694,7 +694,7 @@ Users set their default mode preference via `/oh-my-claudecode:omc-setup`.
 Version 3.4.0 is a drop-in upgrade. No migration required!
 
 ```bash
-npm update -g oh-my-claudecode
+npm update -g oh-my-claude-sisyphus
 ```
 
 All existing configurations, plans, and workflows continue working unchanged.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -17,7 +17,7 @@ INSTALLED=$(ls ~/.claude/plugins/cache/omc/oh-my-claudecode/ 2>/dev/null | sort 
 echo "Installed: $INSTALLED"
 
 # Get latest from npm
-LATEST=$(npm view oh-my-claudecode version 2>/dev/null)
+LATEST=$(npm view oh-my-claude-sisyphus version 2>/dev/null)
 echo "Latest: $LATEST"
 ```
 


### PR DESCRIPTION
## Summary

- Fixed incorrect npm package references in documentation
- The actual npm package name is `oh-my-claude-sisyphus` but docs referenced `oh-my-claudecode`
- GitHub repo name and CLI binary name remain unchanged (as intended)

## Files Changed

| File | Change |
|------|--------|
| `commands/doctor.md` | `npm view oh-my-claudecode` → `npm view oh-my-claude-sisyphus` |
| `skills/doctor/SKILL.md` | `npm view oh-my-claudecode` → `npm view oh-my-claude-sisyphus` |
| `docs/MIGRATION.md` | Two `npm update -g oh-my-claudecode` → `npm update -g oh-my-claude-sisyphus` |

## Test plan

- [x] Verified all npm package references now use correct package name `oh-my-claude-sisyphus`
- [x] Verified GitHub URLs still use correct repo name `oh-my-claudecode`
- [x] Verified CLI binary name unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)