### PR TITLE
Fix CLI installation: include templates and add omc command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "3.6.0",
+  "version": "3.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "3.6.0",
+      "version": "3.6.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "bin": {
     "oh-my-claudecode": "dist/cli/index.js",
+    "omc": "dist/cli/index.js",
     "omc-analytics": "dist/cli/analytics.js",
     "omc-cli": "dist/cli/index.js"
   },
@@ -24,6 +25,7 @@
     "hooks",
     "scripts",
     "skills",
+    "templates",
     "docs",
     "plugin.json",
     "README.md",


### PR DESCRIPTION
  ## Summary
  - Add `templates` directory to npm package `files` array - fixes CLI failing with "Hook
  template not found" error
  - Add `omc` as a bin alias alongside `omc-cli` - allows users to run `omc` directly

  ## Problem
  After installing via `npm install -g`, the CLI would fail with:
  FATAL: Hook template not found: .../templates/hooks/keyword-detector.sh

  The `templates/` directory was missing from the npm package because it wasn't listed in
  the `files` array in package.json.

  Additionally, claude told me to run `omc` but only `omc-cli` was available. I added `omc`
  as an option. If you left that out on purpose, feel free to remove that.