### PR TITLE
feat(hud): add showCache and showCost config toggles for analytics di…

### DIFF
--- a/src/__tests__/hud/analytics-display.test.ts
+++ b/src/__tests__/hud/analytics-display.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { renderSessionHealthAnalytics } from '../../hud/analytics-display.js';
+import {
+  renderSessionHealthAnalytics,
+  renderAnalyticsLineWithConfig,
+  getSessionHealthAnalyticsData,
+  type AnalyticsDisplay,
+} from '../../hud/analytics-display.js';
 import type { SessionHealth } from '../../hud/types.js';
 
 describe('renderSessionHealthAnalytics', () => {
@@ -108,5 +113,164 @@ describe('renderSessionHealthAnalytics', () => {
       totalTokens: 2500000,
     });
     expect(result).toContain('2.50M');
+  });
+});
+
+describe('renderAnalyticsLineWithConfig', () => {
+  const baseAnalytics: AnalyticsDisplay = {
+    sessionCost: '$1.2345',
+    sessionTokens: '50.0k',
+    topAgents: 'executor:$0.80 architect:$0.30',
+    cacheEfficiency: '45.6%',
+    costColor: 'green',
+  };
+
+  describe('showCost=true, showCache=true (default)', () => {
+    it('renders all elements', () => {
+      const result = renderAnalyticsLineWithConfig(baseAnalytics, true, true);
+      expect(result).toContain('Cost: $1.2345');
+      expect(result).toContain('Tokens: 50.0k');
+      expect(result).toContain('Cache: 45.6%');
+      expect(result).toContain('Top: executor:$0.80 architect:$0.30');
+    });
+
+    it('shows green indicator for green costColor', () => {
+      const result = renderAnalyticsLineWithConfig({ ...baseAnalytics, costColor: 'green' }, true, true);
+      expect(result).toContain('🟢');
+    });
+
+    it('shows yellow indicator for yellow costColor', () => {
+      const result = renderAnalyticsLineWithConfig({ ...baseAnalytics, costColor: 'yellow' }, true, true);
+      expect(result).toContain('🟡');
+    });
+
+    it('shows red indicator for red costColor', () => {
+      const result = renderAnalyticsLineWithConfig({ ...baseAnalytics, costColor: 'red' }, true, true);
+      expect(result).toContain('🔴');
+    });
+  });
+
+  describe('showCost=false, showCache=true', () => {
+    it('hides cost but shows cache', () => {
+      const result = renderAnalyticsLineWithConfig(baseAnalytics, false, true);
+      expect(result).not.toContain('Cost:');
+      expect(result).toContain('Tokens: 50.0k');
+      expect(result).toContain('Cache: 45.6%');
+      expect(result).toContain('Top:');
+    });
+  });
+
+  describe('showCost=true, showCache=false', () => {
+    it('shows cost but hides cache', () => {
+      const result = renderAnalyticsLineWithConfig(baseAnalytics, true, false);
+      expect(result).toContain('Cost: $1.2345');
+      expect(result).toContain('Tokens: 50.0k');
+      expect(result).not.toContain('Cache:');
+      expect(result).toContain('Top:');
+    });
+  });
+
+  describe('showCost=false, showCache=false (minimal)', () => {
+    it('shows only tokens and top agents', () => {
+      const result = renderAnalyticsLineWithConfig(baseAnalytics, false, false);
+      expect(result).not.toContain('Cost:');
+      expect(result).not.toContain('Cache:');
+      expect(result).toContain('Tokens: 50.0k');
+      expect(result).toContain('Top:');
+    });
+
+    it('formats with pipe separators', () => {
+      const result = renderAnalyticsLineWithConfig(baseAnalytics, false, false);
+      const parts = result.split(' | ');
+      expect(parts).toHaveLength(2);
+    });
+  });
+});
+
+describe('getSessionHealthAnalyticsData', () => {
+  const baseHealth: SessionHealth = {
+    durationMinutes: 5,
+    messageCount: 0,
+    health: 'healthy',
+    sessionCost: 0,
+    totalTokens: 0,
+    cacheHitRate: 0,
+    costPerHour: 0,
+    isEstimated: false,
+  };
+
+  describe('cost indicator', () => {
+    it('returns green for healthy', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, health: 'healthy' });
+      expect(data.costIndicator).toBe('🟢');
+    });
+
+    it('returns yellow for warning', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, health: 'warning' });
+      expect(data.costIndicator).toBe('🟡');
+    });
+
+    it('returns red for critical', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, health: 'critical' });
+      expect(data.costIndicator).toBe('🔴');
+    });
+  });
+
+  describe('cost formatting', () => {
+    it('formats with 4 decimal places', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, sessionCost: 1.2345 });
+      expect(data.cost).toBe('$1.2345');
+    });
+
+    it('adds estimated prefix when isEstimated', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, sessionCost: 0.5, isEstimated: true });
+      expect(data.cost).toBe('~$0.5000');
+    });
+
+    it('handles undefined as 0', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, sessionCost: undefined });
+      expect(data.cost).toBe('$0.0000');
+    });
+  });
+
+  describe('token formatting', () => {
+    it('formats small counts without suffix', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, totalTokens: 999 });
+      expect(data.tokens).toBe('999');
+    });
+
+    it('formats thousands with k suffix', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, totalTokens: 50000 });
+      expect(data.tokens).toBe('50.0k');
+    });
+
+    it('formats millions with M suffix', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, totalTokens: 2500000 });
+      expect(data.tokens).toBe('2.50M');
+    });
+  });
+
+  describe('cache formatting', () => {
+    it('formats with 1 decimal and percent', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, cacheHitRate: 45.67 });
+      expect(data.cache).toBe('45.7%');
+    });
+
+    it('handles undefined as 0', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, cacheHitRate: undefined });
+      expect(data.cache).toBe('0.0%');
+    });
+  });
+
+  describe('cost per hour', () => {
+    it('formats with dollar and /h suffix', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, costPerHour: 2.5 });
+      expect(data.costHour).toBe('$2.50/h');
+    });
+
+    it('returns empty when undefined', () => {
+      const data = getSessionHealthAnalyticsData({ ...baseHealth, costPerHour: undefined });
+      expect(data.costHour).toBe('');
+    });
   });
 });

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -247,6 +247,8 @@ export interface HudElementConfig {
   thinking: boolean;          // Show extended thinking indicator
   sessionHealth: boolean;     // Show session health/duration
   useBars: boolean;           // Show visual progress bars instead of/alongside percentages
+  showCache: boolean;         // Show cache hit rate in analytics displays
+  showCost: boolean;          // Show cost/dollar amounts in analytics displays
 }
 
 export interface HudThresholds {
@@ -287,6 +289,8 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     thinking: true,
     sessionHealth: true,
     useBars: false,  // Disabled by default for backwards compatibility
+    showCache: true,
+    showCost: true,
   },
   thresholds: {
     contextWarning: 70,
@@ -315,6 +319,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: false,
     sessionHealth: false,
     useBars: false,
+    showCache: false,
+    showCost: false,
   },
   analytics: {
     omcLabel: false,
@@ -334,6 +340,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: false,
     sessionHealth: false,
     useBars: false,
+    showCache: true,
+    showCost: true,
   },
   focused: {
     omcLabel: true,
@@ -353,6 +361,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     sessionHealth: true,
     useBars: true,
+    showCache: true,
+    showCost: true,
   },
   full: {
     omcLabel: true,
@@ -372,6 +382,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     sessionHealth: true,
     useBars: true,
+    showCache: true,
+    showCost: true,
   },
   opencode: {
     omcLabel: true,
@@ -391,6 +403,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     sessionHealth: true,
     useBars: false,
+    showCache: true,
+    showCost: true,
   },
   dense: {
     omcLabel: true,
@@ -410,5 +424,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     sessionHealth: true,
     useBars: true,
+    showCache: true,
+    showCost: true,
   },
 };


### PR DESCRIPTION
…splay

- Add showCache and showCost options to HudElementConfig
- Update all HUD presets with new config options
- Create getSessionHealthAnalyticsData() for structured data extraction
- Create renderAnalyticsLineWithConfig() respecting config flags
- Fix color indicators to use emoji circles (🟢🟡🔴) consistently
- Remove unused import in render.ts
- Add comprehensive tests for new config-aware functions