### PR TITLE
feat(omc-setup): add GitHub star prompt to command

### DIFF
--- a/commands/omc-setup.md
+++ b/commands/omc-setup.md
@@ -227,6 +227,44 @@ CLI ANALYTICS (if installed):
 Your workflow won't break - it just got easier!
 ```
 
+## Step 8: Ask About Starring Repository
+
+First, check if `gh` CLI is available and authenticated:
+
+```bash
+gh auth status &>/dev/null
+```
+
+### If gh is available and authenticated:
+
+Use the AskUserQuestion tool to prompt the user:
+
+**Question:** "If you're enjoying oh-my-claudecode, would you like to support the project by starring it on GitHub?"
+
+**Options:**
+1. **Yes, star it!** - Star the repository
+2. **No thanks** - Skip without further prompts
+3. **Maybe later** - Skip without further prompts
+
+If user chooses "Yes, star it!":
+
+```bash
+gh api -X PUT /user/starred/Yeachan-Heo/oh-my-claudecode 2>/dev/null && echo "Thanks for starring! ⭐" || echo "Could not star - you can star manually at https://github.com/Yeachan-Heo/oh-my-claudecode"
+```
+
+**Note:** Fail gracefully if the API call doesn't work - never block setup completion.
+
+### If gh is NOT available or not authenticated:
+
+Skip the AskUserQuestion and just display:
+
+```bash
+echo ""
+echo "If you enjoy oh-my-claudecode, consider starring the repo:"
+echo "  https://github.com/Yeachan-Heo/oh-my-claudecode"
+echo ""
+```
+
 ## Fallback
 
 If curl fails, tell user to manually download from:


### PR DESCRIPTION
## Summary

Add Step 8 to `commands/omc-setup.md` to ask users if they want to star the repository after setup completion. This syncs the command version with `skills/omc-setup/SKILL.md` which already has this feature.

## Changes

- Check if `gh` CLI is available and authenticated
- If yes, prompt user with AskUserQuestion tool with 3 options:
  - "Yes, star it!" - automatically stars via `gh api`
  - "No thanks" - skip
  - "Maybe later" - skip
- If `gh` not available, display manual link to repository
- Fail gracefully without blocking setup completion

## Implementation

Uses `gh api -X PUT /user/starred/Yeachan-Heo/oh-my-claudecode` to programmatically star the repo when user consents.