### PR TITLE
fix(hud): Windows compatibility fixes for HUD setup (#138)

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -48,7 +48,7 @@ function countIncompleteTodos(todosDir) {
 
 // Check if HUD is properly installed
 function checkHudInstallation() {
-  const hudScript = join(homedir(), '.claude', 'hud', 'sisyphus-hud.mjs');
+  const hudScript = join(homedir(), '.claude', 'hud', 'omc-hud.mjs');
   const settingsFile = join(homedir(), '.claude', 'settings.json');
 
   // Check if HUD script exists

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -81,6 +81,19 @@ Then, use the Write tool to create `~/.claude/hud/omc-hud.mjs` with this exact c
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Semantic version comparison: returns negative if a < b, positive if a > b, 0 if equal
+function semverCompare(a, b) {
+  const pa = a.replace(/^v/, "").split(".").map(Number);
+  const pb = b.replace(/^v/, "").split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
 
 async function main() {
   const home = homedir();
@@ -92,11 +105,11 @@ async function main() {
     try {
       const versions = readdirSync(pluginCacheBase);
       if (versions.length > 0) {
-        const latestVersion = versions.sort().reverse()[0];
+        const latestVersion = versions.sort(semverCompare).reverse()[0];
         pluginCacheDir = join(pluginCacheBase, latestVersion);
         const pluginPath = join(pluginCacheDir, "dist/hud/index.js");
         if (existsSync(pluginPath)) {
-          await import(pluginPath);
+          await import(pathToFileURL(pluginPath).href);
           return;
         }
       }
@@ -114,7 +127,7 @@ async function main() {
   for (const devPath of devPaths) {
     if (existsSync(devPath)) {
       try {
-        await import(devPath);
+        await import(pathToFileURL(devPath).href);
         return;
       } catch { /* continue */ }
     }
@@ -138,12 +151,31 @@ chmod +x ~/.claude/hud/omc-hud.mjs
 
 **Step 4:** Update settings.json to use the HUD:
 
-Read `~/.claude/settings.json`, then update/add the `statusLine` field:
+Read `~/.claude/settings.json`, then update/add the `statusLine` field.
+
+**IMPORTANT:** The command must use an absolute path, not `~`, because Windows does not expand `~` in shell commands.
+
+First, determine the correct path:
+```bash
+node -e "const p=require('path').join(require('os').homedir(),'.claude','hud','omc-hud.mjs');console.log(JSON.stringify(p))"
+```
+
+Then set the `statusLine` field using the resolved path. On Unix it will look like:
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "node ~/.claude/hud/omc-hud.mjs"
+    "command": "node /home/username/.claude/hud/omc-hud.mjs"
+  }
+}
+```
+
+On Windows it will look like:
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node C:\\Users\\username\\.claude\\hud\\omc-hud.mjs"
   }
 }
 ```


### PR DESCRIPTION
## Summary

Fixes 4 Windows-related HUD bugs reported by @sjh0728-somansa in #138:

- **session-start.mjs**: Fixed wrong filename check (`sisyphus-hud.mjs` → `omc-hud.mjs`)
- **settings.json path**: Setup instructions now use absolute path instead of `~` (Windows doesn't expand tilde)
- **Dynamic import()**: Added `pathToFileURL()` conversion — Windows requires `file://` scheme for ESM `import()`
- **Version sorting**: Replaced lexicographic `versions.sort()` with `semverCompare()` so version `10` correctly sorts after `9`

## Test plan

- [x] All 1331 existing tests pass
- [ ] Verify `semverCompare` sorts versions `[1, 2, 9, 10, 11]` correctly (tested locally, `11` selected as latest)
- [ ] Verify HUD setup works on Unix (no behavioral change for existing users)
- [ ] Verify HUD setup works on Windows (new `pathToFileURL` + absolute path)
- [ ] Verify `session-start.mjs` correctly detects HUD installation with new filename

## Files changed

| File | Change |
|------|--------|
| `scripts/session-start.mjs` | Fix filename: `sisyphus-hud.mjs` → `omc-hud.mjs` |
| `commands/hud.md` | Add `pathToFileURL`, `semverCompare`, absolute path instructions |
| `skills/hud/SKILL.md` | Same fixes as `hud.md` (kept in sync) |

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)