### PR TITLE
fix(omc-setup): use cross-platform date conversion for state age check

### DIFF
--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -21,9 +21,37 @@ Before starting any step, check for existing state:
 ```bash
 # Check for existing setup state
 STATE_FILE=".omc/state/setup-state.json"
+
+# Cross-platform ISO date to epoch conversion
+iso_to_epoch() {
+  local iso_date="$1"
+  local epoch=""
+  # Try GNU date first (Linux)
+  epoch=$(date -d "$iso_date" +%s 2>/dev/null)
+  if [ $? -eq 0 ] && [ -n "$epoch" ]; then
+    echo "$epoch"
+    return 0
+  fi
+  # Try BSD/macOS date
+  local clean_date=$(echo "$iso_date" | sed 's/[+-][0-9][0-9]:[0-9][0-9]$//' | sed 's/Z$//' | sed 's/T/ /')
+  epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$clean_date" +%s 2>/dev/null)
+  if [ $? -eq 0 ] && [ -n "$epoch" ]; then
+    echo "$epoch"
+    return 0
+  fi
+  echo "0"
+}
+
 if [ -f "$STATE_FILE" ]; then
   # Check if state is stale (older than 24 hours)
-  STATE_AGE=$(($(date +%s) - $(date -d "$(jq -r .timestamp "$STATE_FILE" 2>/dev/null || echo "1970-01-01")" +%s 2>/dev/null || echo 0)))
+  TIMESTAMP_RAW=$(jq -r '.timestamp // empty' "$STATE_FILE" 2>/dev/null)
+  if [ -n "$TIMESTAMP_RAW" ]; then
+    TIMESTAMP_EPOCH=$(iso_to_epoch "$TIMESTAMP_RAW")
+    NOW_EPOCH=$(date +%s)
+    STATE_AGE=$((NOW_EPOCH - TIMESTAMP_EPOCH))
+  else
+    STATE_AGE=999999  # Force fresh start if no timestamp
+  fi
   if [ "$STATE_AGE" -gt 86400 ]; then
     echo "Previous setup state is more than 24 hours old. Starting fresh."
     rm -f "$STATE_FILE"


### PR DESCRIPTION
## Summary

- Replace GNU-specific `date -d` command with a cross-platform `iso_to_epoch()` function
- Function works on both Linux (GNU date) and macOS/BSD systems
- Handles ISO timestamps with timezone offsets (+00:00) and Z suffix
- Returns 0 for invalid/empty input to force fresh start

## Problem

The existing code uses `date -d` which is GNU-specific and fails on macOS/BSD:
```bash
STATE_AGE=$(($(date +%s) - $(date -d "$(jq -r .timestamp "$STATE_FILE")" +%s)))
```

This breaks the 24-hour stale expiration check on macOS.

## Solution

Added an `iso_to_epoch()` function that:
1. Tries GNU date first (`date -d`)
2. Falls back to BSD date format (`date -j -f`)
3. Handles timezone stripping for BSD compatibility

## Files Changed

- `commands/omc-setup.md`
- `skills/omc-setup/SKILL.md`

## Test Plan

- [x] Tested on macOS (BSD date) - function correctly converts ISO dates
- [x] Verified edge cases: empty input, invalid input, timezone offset, Z suffix

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)