### PR TITLE
fix(session-end): remove hookSpecificOutput to fix JSON validation error

### DIFF
--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -23,14 +23,6 @@ export interface SessionMetrics {
 
 export interface HookOutput {
   continue: boolean;
-  hookSpecificOutput?: {
-    hookEventName: string;
-    metrics?: SessionMetrics;
-    cleanup_summary?: {
-      files_removed: number;
-      state_cleared: boolean;
-    };
-  };
 }
 
 /**
@@ -243,22 +235,16 @@ export function exportSessionSummary(directory: string, metrics: SessionMetrics)
  * Process session end
  */
 export function processSessionEnd(input: SessionEndInput): HookOutput {
+  // Record and export session metrics to disk
   const metrics = recordSessionMetrics(input.cwd, input);
-  const filesRemoved = cleanupTransientState(input.cwd);
-
   exportSessionSummary(input.cwd, metrics);
 
-  return {
-    continue: true,
-    hookSpecificOutput: {
-      hookEventName: 'SessionEnd',
-      metrics,
-      cleanup_summary: {
-        files_removed: filesRemoved,
-        state_cleared: true,
-      },
-    },
-  };
+  // Clean up transient state files
+  cleanupTransientState(input.cwd);
+
+  // Return simple response - metrics are persisted to .omc/sessions/
+  // Note: hookSpecificOutput is NOT supported for SessionEnd events in Claude Code's hook schema
+  return { continue: true };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove `hookSpecificOutput` from `processSessionEnd()` return value
- Simplify `HookOutput` interface to only include `continue: boolean`
- Session metrics are still persisted to `.omc/sessions/` via `exportSessionSummary()`

## Problem
The `session-end.mjs` hook was returning `hookSpecificOutput` for `SessionEnd` events, but Claude Code's hook JSON schema does not support `hookSpecificOutput` for `SessionEnd` events (only `PreToolUse`, `PostToolUse`, and `UserPromptSubmit`).

This caused:
```
SessionEnd hook [node "${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs"] failed:
Hook JSON output validation failed: - : Invalid input
```

## Solution
Follow the same pattern as `session-start.mjs` which correctly returns only `{ continue: true }` without `hookSpecificOutput`.

## Test plan
- [x] TypeScript build passes
- [x] All existing tests pass
- [ ] Manual verification: session end hook completes without validation errors

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)