### PR TITLE
fix(hud): address code review feedback for cache toggle feature

### DIFF
--- a/src/__tests__/hud/analytics-display.test.ts
+++ b/src/__tests__/hud/analytics-display.test.ts
@@ -148,6 +148,11 @@ describe('renderAnalyticsLineWithConfig', () => {
       const result = renderAnalyticsLineWithConfig({ ...baseAnalytics, costColor: 'red' }, true, true);
       expect(result).toContain('🔴');
     });
+
+    it('handles empty topAgents gracefully', () => {
+      const result = renderAnalyticsLineWithConfig({ ...baseAnalytics, topAgents: 'none' }, true, true);
+      expect(result).toContain('Top: none');
+    });
   });
 
   describe('showCost=false, showCache=true', () => {

--- a/src/hud/analytics-display.ts
+++ b/src/hud/analytics-display.ts
@@ -101,12 +101,33 @@ function formatTokenCount(tokens: number): string {
 }
 
 /**
+ * Get color indicator emoji for cost color.
+ */
+function getCostColorIndicator(color: 'green' | 'yellow' | 'red'): string {
+  switch (color) {
+    case 'green': return '🟢';
+    case 'yellow': return '🟡';
+    case 'red': return '🔴';
+  }
+}
+
+/**
+ * Get indicator emoji for health status.
+ */
+function getHealthIndicator(health: 'healthy' | 'warning' | 'critical'): string {
+  switch (health) {
+    case 'healthy': return '🟢';
+    case 'warning': return '🟡';
+    case 'critical': return '🔴';
+  }
+}
+
+/**
  * Render analytics as a single-line string for HUD display.
- * @deprecated Use renderSessionHealthAnalytics instead
+ * @deprecated Use renderAnalyticsLineWithConfig() for config-aware rendering
  */
 export function renderAnalyticsLine(analytics: AnalyticsDisplay): string {
-  const costIndicator = analytics.costColor === 'green' ? '🟢' :
-                        analytics.costColor === 'yellow' ? '🟡' : '🔴';
+  const costIndicator = getCostColorIndicator(analytics.costColor);
 
   return `${costIndicator} Cost: ${analytics.sessionCost} | Tokens: ${analytics.sessionTokens} | Cache: ${analytics.cacheEfficiency} | Top: ${analytics.topAgents}`;
 }
@@ -122,8 +143,7 @@ export function renderAnalyticsLineWithConfig(
   const parts: string[] = [];
 
   if (showCost) {
-    const costIndicator = analytics.costColor === 'green' ? '🟢' :
-                          analytics.costColor === 'yellow' ? '🟡' : '🔴';
+    const costIndicator = getCostColorIndicator(analytics.costColor);
     parts.push(`${costIndicator} Cost: ${analytics.sessionCost}`);
   }
 
@@ -165,8 +185,7 @@ export async function getSessionInfo(): Promise<string> {
  * Extract structured analytics data from SessionHealth
  */
 export function getSessionHealthAnalyticsData(sessionHealth: SessionHealth): SessionHealthAnalyticsData {
-  const costIndicator = sessionHealth.health === 'critical' ? '🔴' :
-                        sessionHealth.health === 'warning' ? '🟡' : '🟢';
+  const costIndicator = getHealthIndicator(sessionHealth.health);
 
   const costPrefix = sessionHealth.isEstimated ? '~' : '';
   const cost = `${costPrefix}$${(sessionHealth.sessionCost ?? 0).toFixed(4)}`;


### PR DESCRIPTION
- Extract getCostColorIndicator() and getHealthIndicator() helpers to eliminate duplicated ternary logic at lines 130, 146, 188
- Fix deprecation comment on renderAnalyticsLine() to point to correct successor (renderAnalyticsLineWithConfig, not renderSessionHealthAnalytics)
- Add edge case test for empty topAgents handling