### PR TITLE
docs(hud): add showCache and showCost to config example

### DIFF
--- a/commands/hud.md
+++ b/commands/hud.md
@@ -257,7 +257,9 @@ You can manually edit the config file:
     "contextBar": true,
     "agents": true,
     "backgroundTasks": true,
-    "todos": true
+    "todos": true,
+    "showCache": true,
+    "showCost": true
   },
   "thresholds": {
     "contextWarning": 70,

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -260,7 +260,9 @@ You can manually edit the config file:
     "contextBar": true,
     "agents": true,
     "backgroundTasks": true,
-    "todos": true
+    "todos": true,
+    "showCache": true,
+    "showCost": true
   },
   "thresholds": {
     "contextWarning": 70,


### PR DESCRIPTION
## Summary
- Add `showCache` and `showCost` to the Manual Configuration JSON example in HUD skill docs
- Follows PR #133 which added these config options to the HUD

## Changes
Minimal update to documentation only - just adds the two new options to the existing config example so users can discover them.

## Test plan
- [ ] Verify JSON example is valid
- [ ] Verify options match what was added in PR #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)