### PR TITLE
fix(hooks): PreCompact hook returns invalid hookEventName

### DIFF
--- a/src/hooks/pre-compact/index.ts
+++ b/src/hooks/pre-compact/index.ts
@@ -45,10 +45,8 @@ export interface CompactCheckpoint {
 
 export interface HookOutput {
   continue: boolean;
-  hookSpecificOutput: {
-    hookEventName: 'PreCompact';
-    additionalContext: string;
-  };
+  /** System message for context injection (Claude Code compatible) */
+  systemMessage?: string;
 }
 
 // ============================================================================
@@ -324,12 +322,11 @@ export async function processPreCompact(input: PreCompactInput): Promise<HookOut
   // Format summary for context injection
   const summary = formatCompactSummary(checkpoint);
 
+  // Note: hookSpecificOutput only supports PreToolUse, UserPromptSubmit, PostToolUse
+  // Use systemMessage for custom hook events like PreCompact
   return {
     continue: true,
-    hookSpecificOutput: {
-      hookEventName: 'PreCompact',
-      additionalContext: summary
-    }
+    systemMessage: summary
   };
 }
 


### PR DESCRIPTION
## What's happening

The PreCompact hook throws a validation error because it returns `hookEventName: 'PreCompact'` in `hookSpecificOutput`. Claude Code's schema only accepts three values here:

- `PreToolUse`
- `UserPromptSubmit`
- `PostToolUse`

So when compaction runs, you get this scary-looking error:

```
PreCompact [...] failed: Hook JSON output validation failed:
  - : Invalid input
```

The hook still works (checkpoint is saved, `continue: true` passes through), but the error message is confusing and makes it look like something broke.

## The fix

Just use `systemMessage` instead. It's the proper way to inject context for custom hook events:

```diff
-  return {
-    continue: true,
-    hookSpecificOutput: {
-      hookEventName: 'PreCompact',
-      additionalContext: summary
-    }
-  };
+  return {
+    continue: true,
+    systemMessage: summary
+  };
```

## Testing

- `npm run build` passes
- Manual compaction no longer shows the validation error