### PR TITLE
refactor(deepinit): use CLAUDE.md instead of AGENTS.md

### DIFF
--- a/commands/deepinit.md
+++ b/commands/deepinit.md
@@ -1,14 +1,14 @@
 ---
-description: Deep codebase initialization with hierarchical AGENTS.md documentation
+description: Deep codebase initialization with hierarchical CLAUDE.md documentation
 ---
 
 # Deep Init Skill
 
-Creates comprehensive, hierarchical AGENTS.md documentation across the entire codebase.
+Creates comprehensive, hierarchical CLAUDE.md documentation across the entire codebase.
 
 ## Core Concept
 
-AGENTS.md files serve as **AI-readable documentation** that helps agents understand:
+CLAUDE.md files serve as **AI-readable documentation** that helps agents understand:
 - What each directory contains
 - How components relate to each other
 - Special instructions for working in that area
@@ -16,25 +16,25 @@ AGENTS.md files serve as **AI-readable documentation** that helps agents underst
 
 ## Hierarchical Tagging System
 
-Every AGENTS.md (except root) includes a parent reference tag:
+Every CLAUDE.md (except root) includes a parent reference tag:
 
 ```markdown
-<!-- Parent: ../AGENTS.md -->
+<!-- Parent: ../CLAUDE.md -->
 ```
 
 This creates a navigable hierarchy:
 ```
-/AGENTS.md                          ← Root (no parent tag)
-├── src/AGENTS.md                   ← <!-- Parent: ../AGENTS.md -->
-│   ├── src/components/AGENTS.md    ← <!-- Parent: ../AGENTS.md -->
-│   └── src/utils/AGENTS.md         ← <!-- Parent: ../AGENTS.md -->
-└── docs/AGENTS.md                  ← <!-- Parent: ../AGENTS.md -->
+/CLAUDE.md                          ← Root (no parent tag)
+├── src/CLAUDE.md                   ← <!-- Parent: ../CLAUDE.md -->
+│   ├── src/components/CLAUDE.md    ← <!-- Parent: ../CLAUDE.md -->
+│   └── src/utils/CLAUDE.md         ← <!-- Parent: ../CLAUDE.md -->
+└── docs/CLAUDE.md                  ← <!-- Parent: ../CLAUDE.md -->
 ```
 
-## AGENTS.md Template
+## CLAUDE.md Template
 
 ```markdown
-<!-- Parent: {relative_path_to_parent}/AGENTS.md -->
+<!-- Parent: {relative_path_to_parent}/CLAUDE.md -->
 <!-- Generated: {timestamp} | Updated: {timestamp} -->
 
 # {Directory Name}
@@ -54,7 +54,7 @@ This creates a navigable hierarchy:
 
 | Directory | Purpose |
 |-----------|---------|
-| `subdir/` | What it contains (see `subdir/AGENTS.md`) |
+| `subdir/` | What it contains (see `subdir/CLAUDE.md`) |
 
 ## For AI Agents
 
@@ -105,12 +105,12 @@ Level 2: /src/components, /src/utils, /docs/api
 For each directory:
 1. Read all files in the directory
 2. Analyze purpose and relationships
-3. Generate AGENTS.md content
+3. Generate CLAUDE.md content
 4. Write file with proper parent reference
 
 ### Step 4: Compare and Update (if exists)
 
-When AGENTS.md already exists:
+When CLAUDE.md already exists:
 
 1. **Read existing content**
 2. **Identify sections**:
@@ -131,18 +131,18 @@ After generation, run validation checks:
 
 | Check | How to Verify | Corrective Action |
 |-------|--------------|-------------------|
-| Parent references resolve | Read each AGENTS.md, check `<!-- Parent: -->` path exists | Fix path or remove orphan |
-| No orphaned AGENTS.md | Compare AGENTS.md locations to directory structure | Delete orphaned files |
-| Completeness | List all directories, check for AGENTS.md | Generate missing files |
+| Parent references resolve | Read each CLAUDE.md, check `<!-- Parent: -->` path exists | Fix path or remove orphan |
+| No orphaned CLAUDE.md | Compare CLAUDE.md locations to directory structure | Delete orphaned files |
+| Completeness | List all directories, check for CLAUDE.md | Generate missing files |
 | Timestamps current | Check `<!-- Generated: -->` dates | Regenerate outdated files |
 
 Validation script pattern:
 ```bash
-# Find all AGENTS.md files
-find . -name "AGENTS.md" -type f
+# Find all CLAUDE.md files
+find . -name "CLAUDE.md" -type f
 
 # Check parent references
-grep -r "<!-- Parent:" --include="AGENTS.md" .
+grep -r "<!-- Parent:" --include="CLAUDE.md" .
 ```
 
 ## Smart Delegation
@@ -160,14 +160,14 @@ When encountering empty or near-empty directories:
 
 | Condition | Action |
 |-----------|--------|
-| No files, no subdirectories | **Skip** - do not create AGENTS.md |
-| No files, has subdirectories | Create minimal AGENTS.md with subdirectory listing only |
-| Has only generated files (*.min.js, *.map) | Skip or minimal AGENTS.md |
-| Has only config files | Create AGENTS.md describing configuration purpose |
+| No files, no subdirectories | **Skip** - do not create CLAUDE.md |
+| No files, has subdirectories | Create minimal CLAUDE.md with subdirectory listing only |
+| Has only generated files (*.min.js, *.map) | Skip or minimal CLAUDE.md |
+| Has only config files | Create CLAUDE.md describing configuration purpose |
 
-Example minimal AGENTS.md for directory-only containers:
+Example minimal CLAUDE.md for directory-only containers:
 ```markdown
-<!-- Parent: ../AGENTS.md -->
+<!-- Parent: ../CLAUDE.md -->
 # {Directory Name}
 
 ## Purpose
@@ -176,7 +176,7 @@ Container directory for organizing related modules.
 ## Subdirectories
 | Directory | Purpose |
 |-----------|---------|
-| `subdir/` | Description (see `subdir/AGENTS.md`) |
+| `subdir/` | Description (see `subdir/CLAUDE.md`) |
 ```
 
 ## Parallelization Rules
@@ -202,7 +202,7 @@ Container directory for organizing related modules.
 
 ## Example Output
 
-### Root AGENTS.md
+### Root CLAUDE.md
 ```markdown
 <!-- Generated: 2024-01-15 | Updated: 2024-01-15 -->
 
@@ -221,9 +221,9 @@ A web application for managing user tasks with real-time collaboration features.
 ## Subdirectories
 | Directory | Purpose |
 |-----------|---------|
-| `src/` | Application source code (see `src/AGENTS.md`) |
-| `docs/` | Documentation (see `docs/AGENTS.md`) |
-| `tests/` | Test suites (see `tests/AGENTS.md`) |
+| `src/` | Application source code (see `src/CLAUDE.md`) |
+| `docs/` | Documentation (see `docs/CLAUDE.md`) |
+| `tests/` | Test suites (see `tests/CLAUDE.md`) |
 
 ## For AI Agents
 
@@ -250,9 +250,9 @@ A web application for managing user tasks with real-time collaboration features.
 <!-- MANUAL: Custom project notes can be added below -->
 ```
 
-### Nested AGENTS.md
+### Nested CLAUDE.md
 ```markdown
-<!-- Parent: ../AGENTS.md -->
+<!-- Parent: ../CLAUDE.md -->
 <!-- Generated: 2024-01-15 | Updated: 2024-01-15 -->
 
 # components
@@ -270,8 +270,8 @@ Reusable React components organized by feature and complexity.
 ## Subdirectories
 | Directory | Purpose |
 |-----------|---------|
-| `forms/` | Form-related components (see `forms/AGENTS.md`) |
-| `layout/` | Layout components (see `layout/AGENTS.md`) |
+| `forms/` | Form-related components (see `forms/CLAUDE.md`) |
+| `layout/` | Layout components (see `layout/CLAUDE.md`) |
 
 ## For AI Agents
 
@@ -303,7 +303,7 @@ Reusable React components organized by feature and complexity.
 
 ## Triggering Update Mode
 
-When running on an existing codebase with AGENTS.md files:
+When running on an existing codebase with CLAUDE.md files:
 
 1. Detect existing files first
 2. Read and parse existing content


### PR DESCRIPTION
## Background

I was poking around the Claude Code docs and realized that `AGENTS.md` isn't actually an official thing. The standard filename for directory-level documentation is `CLAUDE.md`.

From the docs:
- `CLAUDE.md` files are automatically loaded when Claude Code works in a directory
- The official structure uses `.claude/rules/*.md` for modular rules
- `.claude/agents/*.md` is for custom agent definitions (not `AGENTS.md` in every folder)

## What this PR does

Simple find-and-replace in `commands/deepinit.md`:

```
AGENTS.md → CLAUDE.md
```

All 37 occurrences updated. The skill now generates files that actually get picked up by Claude Code automatically.

## Why it matters

Before: deepinit creates `src/AGENTS.md` → Claude Code ignores it
After: deepinit creates `src/CLAUDE.md` → Claude Code loads it when working in `src/`

No breaking changes since deepinit regenerates documentation anyway.