### PR TITLE
feat(lsp): add language support for PHP, Ruby, Lua, Kotlin, Elixir, C#

### DIFF
--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -17831,6 +17831,48 @@ var LSP_SERVERS = {
     args: ["--stdio"],
     extensions: [".yaml", ".yml"],
     installHint: "npm install -g yaml-language-server"
+  },
+  php: {
+    name: "Intelephense",
+    command: "intelephense",
+    args: ["--stdio"],
+    extensions: [".php", ".phtml"],
+    installHint: "npm install -g intelephense"
+  },
+  ruby: {
+    name: "Solargraph",
+    command: "solargraph",
+    args: ["stdio"],
+    extensions: [".rb", ".rake", ".gemspec"],
+    installHint: "gem install solargraph"
+  },
+  lua: {
+    name: "Lua Language Server",
+    command: "lua-language-server",
+    args: [],
+    extensions: [".lua"],
+    installHint: "Install from https://github.com/LuaLS/lua-language-server or via package manager"
+  },
+  kotlin: {
+    name: "Kotlin Language Server",
+    command: "kotlin-language-server",
+    args: [],
+    extensions: [".kt", ".kts"],
+    installHint: "Install from https://github.com/fwcd/kotlin-language-server"
+  },
+  elixir: {
+    name: "ElixirLS",
+    command: "elixir-ls",
+    args: [],
+    extensions: [".ex", ".exs"],
+    installHint: "Install from https://github.com/elixir-lsp/elixir-ls"
+  },
+  csharp: {
+    name: "OmniSharp",
+    command: "OmniSharp",
+    args: ["-lsp"],
+    extensions: [".cs"],
+    installHint: "Install from https://github.com/OmniSharp/omnisharp-roslyn or via dotnet tool"
   }
 };
 function commandExists(command) {
@@ -18121,7 +18163,18 @@ ${content}`;
       "css": "css",
       "scss": "scss",
       "yaml": "yaml",
-      "yml": "yaml"
+      "yml": "yaml",
+      "php": "php",
+      "phtml": "php",
+      "rb": "ruby",
+      "rake": "ruby",
+      "gemspec": "ruby",
+      "lua": "lua",
+      "kt": "kotlin",
+      "kts": "kotlin",
+      "ex": "elixir",
+      "exs": "elixir",
+      "cs": "csharp"
     };
     return langMap[ext] || ext;
   }

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -423,7 +423,18 @@ export class LspClient {
       'css': 'css',
       'scss': 'scss',
       'yaml': 'yaml',
-      'yml': 'yaml'
+      'yml': 'yaml',
+      'php': 'php',
+      'phtml': 'php',
+      'rb': 'ruby',
+      'rake': 'ruby',
+      'gemspec': 'ruby',
+      'lua': 'lua',
+      'kt': 'kotlin',
+      'kts': 'kotlin',
+      'ex': 'elixir',
+      'exs': 'elixir',
+      'cs': 'csharp'
     };
     return langMap[ext] || ext;
   }

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -90,6 +90,48 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
     args: ['--stdio'],
     extensions: ['.yaml', '.yml'],
     installHint: 'npm install -g yaml-language-server'
+  },
+  php: {
+    name: 'Intelephense',
+    command: 'intelephense',
+    args: ['--stdio'],
+    extensions: ['.php', '.phtml'],
+    installHint: 'npm install -g intelephense'
+  },
+  ruby: {
+    name: 'Solargraph',
+    command: 'solargraph',
+    args: ['stdio'],
+    extensions: ['.rb', '.rake', '.gemspec'],
+    installHint: 'gem install solargraph'
+  },
+  lua: {
+    name: 'Lua Language Server',
+    command: 'lua-language-server',
+    args: [],
+    extensions: ['.lua'],
+    installHint: 'Install from https://github.com/LuaLS/lua-language-server or via package manager'
+  },
+  kotlin: {
+    name: 'Kotlin Language Server',
+    command: 'kotlin-language-server',
+    args: [],
+    extensions: ['.kt', '.kts'],
+    installHint: 'Install from https://github.com/fwcd/kotlin-language-server'
+  },
+  elixir: {
+    name: 'ElixirLS',
+    command: 'elixir-ls',
+    args: [],
+    extensions: ['.ex', '.exs'],
+    installHint: 'Install from https://github.com/elixir-lsp/elixir-ls'
+  },
+  csharp: {
+    name: 'OmniSharp',
+    command: 'OmniSharp',
+    args: ['-lsp'],
+    extensions: ['.cs'],
+    installHint: 'Install from https://github.com/OmniSharp/omnisharp-roslyn or via dotnet tool'
   }
 };
 
@@ -154,7 +196,18 @@ export function getServerForLanguage(language: string): LspServerConfig | null {
     'css': 'css',
     'scss': 'css',
     'less': 'css',
-    'yaml': 'yaml'
+    'yaml': 'yaml',
+    'php': 'php',
+    'ruby': 'ruby',
+    'rb': 'ruby',
+    'lua': 'lua',
+    'kotlin': 'kotlin',
+    'kt': 'kotlin',
+    'elixir': 'elixir',
+    'ex': 'elixir',
+    'csharp': 'csharp',
+    'cs': 'csharp',
+    'c#': 'csharp'
   };
 
   const serverKey = langMap[language.toLowerCase()];


### PR DESCRIPTION
## Summary

Adds LSP server configurations and language ID mappings for 6 new languages:

- **PHP** → Intelephense
- **Ruby** → Solargraph
- **Lua** → lua-language-server
- **Kotlin** → kotlin-language-server
- **Elixir** → ElixirLS
- **C#** → OmniSharp

## Changes

- `src/tools/lsp/servers.ts` - Added LSP_SERVERS entries + langMap entries
- `src/tools/lsp/client.ts` - Added extension-to-languageId mappings

## Verification

- Build: ✅ (tsc clean)
