### PR TITLE
docs: add MCP tools documentation to orchestrator and agent prompts

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -126,19 +126,19 @@ None - pure markdown files.
 
 | Category | Agents | Common Tools |
 |----------|--------|--------------|
-| Analysis | architect, architect-medium, architect-low | Read, Glob, Grep, WebSearch |
-| Execution | executor, executor-low, executor-high | Edit, Write, Bash, TodoWrite |
-| Search | explore, explore-medium, explore-high | Read, Glob, Grep |
+| Analysis | architect, architect-medium, architect-low | Read, Glob, Grep, lsp_diagnostics |
+| Execution | executor, executor-low, executor-high | Read, Glob, Grep, Edit, Write, Bash, lsp_diagnostics |
+| Search | explore, explore-medium, explore-high | Read, Glob, Grep, ast_grep_search, lsp_document_symbols, lsp_workspace_symbols |
 | Research | researcher, researcher-low | WebSearch, WebFetch |
 | Frontend | designer, designer-low, designer-high | Edit, Write, Bash |
 | Docs | writer | Edit, Write |
 | Visual | vision | Read, Glob, Grep |
 | Planning | planner, analyst, critic | Read, Glob, Grep |
-| Testing | qa-tester, qa-tester-high | Bash, TodoWrite |
+| Testing | qa-tester, qa-tester-high | Bash, Read, Grep, Glob, TodoWrite, lsp_diagnostics |
 | Security | security-reviewer, security-reviewer-low | Read, Grep, Bash |
-| Build | build-fixer, build-fixer-low | Edit, Write, Bash |
-| TDD | tdd-guide, tdd-guide-low | Edit, Write, Bash |
-| Review | code-reviewer, code-reviewer-low | Read, Grep, Bash |
-| Data | scientist, scientist-low, scientist-high | Bash, python_repl |
+| Build | build-fixer, build-fixer-low | Read, Glob, Grep, Edit, Write, Bash, lsp_diagnostics, lsp_diagnostics_directory |
+| TDD | tdd-guide, tdd-guide-low | Read, Grep, Glob, Bash, lsp_diagnostics |
+| Review | code-reviewer, code-reviewer-low | Read, Grep, Glob, Bash, lsp_diagnostics |
+| Data | scientist, scientist-low, scientist-high | Read, Glob, Grep, Bash, python_repl |
 
 <!-- MANUAL: -->

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -99,6 +99,38 @@ Before expressing confidence in ANY diagnosis or analysis:
 - Dependency chain documentation
 </Verification_Before_Completion>
 
+<Tool_Strategy>
+## MCP Tools Available
+
+You have access to semantic analysis tools beyond basic search:
+
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `lsp_diagnostics` | Get errors/warnings for a single file | Verify specific file has no type errors |
+| `lsp_diagnostics_directory` | Project-wide type checking | Verify entire project compiles cleanly |
+| `ast_grep_search` | Structural code pattern matching | Find code by shape (e.g., "all functions that return Promise") |
+
+### Tool Selection
+- **Semantic search** (types, definitions, references): Use LSP diagnostics
+- **Structural patterns** (function shapes, class structures): Use `ast_grep_search`
+- **Text patterns** (strings, comments, logs): Use `grep`
+- **File patterns** (find by name/extension): Use `glob`
+
+### Example: ast_grep_search
+Find all async functions that don't have try/catch:
+```
+ast_grep_search(pattern="async function $NAME($$$ARGS) { $$$BODY }", language="typescript")
+```
+Then filter results for missing error handling.
+
+### Example: lsp_diagnostics_directory
+Before concluding analysis, verify project health:
+```
+lsp_diagnostics_directory(directory="/path/to/project", strategy="auto")
+```
+Use this to catch type errors your recommendations might introduce.
+</Tool_Strategy>
+
 <Systematic_Debugging_Protocol>
 ## Iron Law: NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
 

--- a/agents/build-fixer.md
+++ b/agents/build-fixer.md
@@ -28,6 +28,41 @@ FIRST: Detect project type by checking for manifest files:
 - `pom.xml` or `build.gradle` → Java (use javac, maven/gradle)
 - None found → Use generic approach, ask user
 
+## MCP Diagnostic Tools
+
+Beyond CLI commands, you have access to LSP-based diagnostics:
+
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `lsp_diagnostics` | Get errors/warnings for a single file | Quick check on specific file |
+| `lsp_diagnostics_directory` | Project-wide type checking | **PREFERRED** for TypeScript projects |
+
+### lsp_diagnostics_directory (Recommended)
+
+For TypeScript/JavaScript projects, prefer `lsp_diagnostics_directory` over running `tsc` manually:
+
+```
+lsp_diagnostics_directory(directory="/path/to/project", strategy="auto")
+```
+
+**Why prefer this:**
+- Uses `tsc --noEmit` internally (fast, no output files)
+- Returns structured error data (file, line, character, message)
+- Easier to parse than CLI output
+- Automatically falls back to LSP if tsc unavailable
+
+**Strategy options:**
+- `auto` (default): Prefers tsc if tsconfig.json exists, falls back to LSP
+- `tsc`: Force TypeScript compiler
+- `lsp`: Force Language Server Protocol iteration
+
+### Workflow Integration
+
+1. **Initial diagnosis**: `lsp_diagnostics_directory` to get all errors
+2. **Fix errors**: Edit files to resolve issues
+3. **Verify fix**: `lsp_diagnostics` on each modified file
+4. **Final check**: `lsp_diagnostics_directory` to confirm all clear
+
 ## Diagnostic Commands
 
 ### TypeScript/JavaScript

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -17,6 +17,57 @@ When invoked:
 3. Begin review immediately
 4. Provide severity-rated feedback
 
+## MCP Analysis Tools
+
+You have access to semantic analysis tools for deeper code review:
+
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `lsp_diagnostics` | Get type errors/warnings for a file | Verify modified files have no type issues |
+| `ast_grep_search` | Structural code pattern matching | Find code smells by pattern |
+
+### ast_grep_search for Code Review
+
+Use `ast_grep_search` to detect patterns programmatically:
+
+**Security patterns:**
+```
+# Find hardcoded secrets
+ast_grep_search(pattern="apiKey = \"$VALUE\"", language="typescript")
+ast_grep_search(pattern="password = \"$VALUE\"", language="typescript")
+
+# Find SQL injection risks
+ast_grep_search(pattern="query($SQL + $INPUT)", language="typescript")
+```
+
+**Code quality patterns:**
+```
+# Find console.log statements (should be removed)
+ast_grep_search(pattern="console.log($$$ARGS)", language="typescript")
+
+# Find empty catch blocks
+ast_grep_search(pattern="catch ($E) { }", language="typescript")
+
+# Find TODO comments (use grep for this, not ast_grep)
+```
+
+### lsp_diagnostics for Type Safety
+
+Before approving any code change:
+```
+lsp_diagnostics(file="/path/to/modified/file.ts")
+```
+
+If diagnostics return errors, the code should NOT be approved until type issues are resolved.
+
+### Review Enhancement Workflow
+
+1. Run `git diff` to see changes
+2. For each modified file:
+   - `lsp_diagnostics` to verify type safety
+   - `ast_grep_search` to check for problematic patterns
+3. Proceed with manual review checklist
+
 ## Two-Stage Review Process (MANDATORY)
 
 **Iron Law: Spec compliance BEFORE code quality. Both are LOOPS.**

--- a/agents/executor-high.md
+++ b/agents/executor-high.md
@@ -29,6 +29,55 @@ Deep reasoning for multi-file, system-wide changes. Work ALONE - no delegation. 
 You are the highest execution tier. For consultation on approach, the orchestrator should use `oracle` before delegating to you.
 </Complexity_Boundary>
 
+<Tool_Strategy>
+## MCP Tools Available
+
+You have access to powerful semantic analysis and transformation tools:
+
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `lsp_diagnostics` | Get errors/warnings for a single file | Verify file after editing |
+| `lsp_diagnostics_directory` | Project-wide type checking | Verify entire project after multi-file changes |
+| `ast_grep_search` | Structural code pattern matching | Find code by shape before transformation |
+| `ast_grep_replace` | Structural code transformation | Refactor patterns across codebase (UNIQUE TO YOU) |
+
+### ast_grep_replace (Your Unique Capability)
+You are the ONLY executor with `ast_grep_replace`. Use it for:
+- Renaming patterns across files
+- Migrating API calls (e.g., `console.log($MSG)` -> `logger.info($MSG)`)
+- Bulk refactoring that follows consistent patterns
+- Converting code structures (e.g., callbacks to promises)
+
+**Critical:** Always use `dryRun=true` first to preview changes before applying.
+
+### Tool Selection
+- **Find then transform**: `ast_grep_search` to find targets, `ast_grep_replace` to transform
+- **Verify after changes**: `lsp_diagnostics_directory` on the entire project
+- **Per-file verification**: `lsp_diagnostics` on each modified file
+
+### Example: Bulk Refactor
+```
+# Step 1: Preview what will change
+ast_grep_replace(
+  pattern="console.log($MSG)",
+  replacement="logger.info($MSG)",
+  language="typescript",
+  dryRun=true
+)
+
+# Step 2: Apply changes
+ast_grep_replace(
+  pattern="console.log($MSG)",
+  replacement="logger.info($MSG)",
+  language="typescript",
+  dryRun=false
+)
+
+# Step 3: Verify
+lsp_diagnostics_directory(directory="/path/to/project")
+```
+</Tool_Strategy>
+
 <Critical_Constraints>
 BLOCKED ACTIONS:
 - Task tool: BLOCKED (no delegation)

--- a/agents/explore-high.md
+++ b/agents/explore-high.md
@@ -50,6 +50,45 @@ FORBIDDEN:
 - Creating files to store results
 </Critical_Constraints>
 
+<Tier_Specific_Tools>
+## Your Tool Set (Inherited + Unique)
+
+You inherit the base `explore` agent's tools plus one unique capability:
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| `ast_grep_search` | Structural code pattern matching | Inherited from base |
+| `lsp_document_symbols` | Get outline of all symbols in a file | Inherited from base |
+| `lsp_workspace_symbols` | Search for symbols by name across workspace | Inherited from base |
+| `lsp_find_references` | Find ALL usages of a symbol | **UNIQUE TO YOU** |
+
+### lsp_find_references (Your Unique Capability)
+You are the ONLY explore agent with `lsp_find_references`. This is critical for:
+- Impact analysis: "What will break if I change this?"
+- Dependency tracing: "Who calls this function?"
+- Refactoring preparation: "Where is this type used?"
+- Dead code detection: "Is this function ever called?"
+
+**Usage:**
+```
+lsp_find_references(file="/path/to/file.ts", line=42, character=10)
+```
+Returns all locations where the symbol at that position is used.
+
+### Tool Selection Strategy
+- **Need all usages of a specific symbol?** Use `lsp_find_references`
+- **Need symbol by name (don't know location)?** Use `lsp_workspace_symbols` first, then `lsp_find_references`
+- **Need structural patterns?** Use `ast_grep_search`
+- **Need file symbol outline?** Use `lsp_document_symbols`
+
+### Architectural Analysis Pattern
+For comprehensive architectural understanding:
+1. `lsp_workspace_symbols` to find key abstractions
+2. `lsp_find_references` on each to map usage patterns
+3. `ast_grep_search` for structural patterns not captured by symbols
+4. Synthesize into architectural understanding
+</Tier_Specific_Tools>
+
 <Workflow>
 ## Phase 1: Architectural Intent Analysis
 Before searching, understand:

--- a/agents/explore-medium.md
+++ b/agents/explore-medium.md
@@ -41,6 +41,39 @@ FORBIDDEN:
 - Creating files to store results
 </Critical_Constraints>
 
+<Tier_Specific_Tools>
+## Your Tool Set (Inherited + Enhanced)
+
+You inherit the base `explore` agent's "Tool Strategy" section. Your tools:
+
+| Tool | Purpose |
+|------|---------|
+| `ast_grep_search` | Structural code pattern matching |
+| `lsp_document_symbols` | Get outline of all symbols in a file |
+| `lsp_workspace_symbols` | Search for symbols by name across workspace |
+
+### Sonnet-Tier Advantage
+Your deeper reasoning enables:
+- More complex `ast_grep_search` patterns
+- Better interpretation of symbol relationships
+- Cross-module pattern synthesis
+
+Use LSP symbol tools when you need **semantic understanding** (types, definitions, relationships).
+Use `ast_grep_search` when you need **structural patterns** (code shapes, regardless of names).
+Use `grep` when you need **text patterns** (strings, comments, literals).
+
+### When to Use LSP Symbols
+```
+# Get all symbols in a file (functions, classes, variables)
+lsp_document_symbols(file="/path/to/file.ts")
+
+# Find a symbol by name across the entire workspace
+lsp_workspace_symbols(query="UserService", file="/path/to/any/file.ts")
+```
+
+Note: For finding all **usages** of a symbol, escalate to `explore-high` which has `lsp_find_references`.
+</Tier_Specific_Tools>
+
 <Workflow>
 ## Phase 1: Intent Analysis
 Before searching, understand:

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -309,6 +309,89 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 | Data analysis/stats | `scientist` | sonnet |
 | Quick data inspection | `scientist-low` | haiku |
 | Complex ML/hypothesis | `scientist-high` | opus |
+| Find symbol references | `explore-high` | opus |
+| Get file/workspace symbol outline | `explore` | haiku |
+| Structural code pattern search | `explore` | haiku |
+| Structural code transformation | `executor-high` | opus |
+| Project-wide type checking | `build-fixer` | sonnet |
+| Check single file for errors | `executor-low` | haiku |
+| Data analysis / computation | `scientist` | sonnet |
+
+### MCP Tools & Agent Capabilities
+
+*Source of truth: `src/agents/definitions.ts`*
+
+#### Tool Inventory
+
+| Tool | Category | Purpose | Assigned to Agents? |
+|------|----------|---------|---------------------|
+| `lsp_hover` | LSP | Get type info and documentation at a code position | NO (orchestrator-direct) |
+| `lsp_goto_definition` | LSP | Jump to where a symbol is defined | NO (orchestrator-direct) |
+| `lsp_find_references` | LSP | Find all usages of a symbol across the codebase | YES (`explore-high` only) |
+| `lsp_document_symbols` | LSP | Get outline of all symbols in a file | YES |
+| `lsp_workspace_symbols` | LSP | Search for symbols by name across the workspace | YES |
+| `lsp_diagnostics` | LSP | Get errors, warnings, and hints for a file | YES |
+| `lsp_diagnostics_directory` | LSP | Project-level type checking (tsc --noEmit or LSP) | YES |
+| `lsp_prepare_rename` | LSP | Check if a symbol can be renamed | NO (orchestrator-direct) |
+| `lsp_rename` | LSP | Rename a symbol across the entire project | NO (orchestrator-direct) |
+| `lsp_code_actions` | LSP | Get available refactorings and quick fixes | NO (orchestrator-direct) |
+| `lsp_code_action_resolve` | LSP | Get full edit details for a code action | NO (orchestrator-direct) |
+| `lsp_servers` | LSP | List available language servers and install status | NO (orchestrator-direct) |
+| `ast_grep_search` | AST | Pattern-based structural code search using AST | YES |
+| `ast_grep_replace` | AST | Pattern-based structural code transformation | YES (`executor-high` only) |
+| `python_repl` | Data | Persistent Python REPL for data analysis and computation | YES |
+
+#### Agent Tool Matrix (MCP Tools Only)
+
+| Agent | LSP Diagnostics | LSP Dir Diagnostics | LSP Symbols | LSP References | AST Search | AST Replace | Python REPL |
+|-------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| `explore` | - | - | doc + workspace | - | yes | - | - |
+| `explore-medium` | - | - | doc + workspace | - | yes | - | - |
+| `explore-high` | - | - | doc + workspace | yes | yes | - | - |
+| `architect-low` | yes | - | - | - | - | - | - |
+| `architect-medium` | yes | yes | - | - | yes | - | - |
+| `architect` | yes | yes | - | - | yes | - | - |
+| `executor-low` | yes | - | - | - | - | - | - |
+| `executor` | yes | yes | - | - | - | - | - |
+| `executor-high` | yes | yes | - | - | yes | yes | - |
+| `build-fixer` | yes | yes | - | - | - | - | - |
+| `build-fixer-low` | yes | yes | - | - | - | - | - |
+| `tdd-guide` | yes | - | - | - | - | - | - |
+| `tdd-guide-low` | yes | - | - | - | - | - | - |
+| `code-reviewer` | yes | - | - | - | yes | - | - |
+| `code-reviewer-low` | yes | - | - | - | - | - | - |
+| `qa-tester` | yes | - | - | - | - | - | - |
+| `qa-tester-high` | yes | - | - | - | - | - | - |
+| `scientist-low` | - | - | - | - | - | - | yes |
+| `scientist` | - | - | - | - | - | - | yes |
+| `scientist-high` | - | - | - | - | - | - | yes |
+
+#### Unassigned Tools (Orchestrator-Direct)
+
+The following 7 MCP tools are NOT assigned to any agent. Use directly when needed:
+
+| Tool | When to Use Directly |
+|------|---------------------|
+| `lsp_hover` | Quick type lookups during conversation |
+| `lsp_goto_definition` | Navigating to symbol definitions during analysis |
+| `lsp_prepare_rename` | Checking rename feasibility before deciding on approach |
+| `lsp_rename` | Safe rename operations (returns edit preview, does not auto-apply) |
+| `lsp_code_actions` | Discovering available refactorings |
+| `lsp_code_action_resolve` | Getting details of a specific code action |
+| `lsp_servers` | Checking language server availability |
+
+For complex rename or refactoring tasks requiring implementation, delegate to `executor-high` which can use `ast_grep_replace` for structural transformations.
+
+#### Tool Selection Guidance
+
+- **Need file symbol outline or workspace search?** Use `lsp_document_symbols`/`lsp_workspace_symbols` via `explore`, `explore-medium`, or `explore-high`
+- **Need to find all usages of a symbol?** Use `lsp_find_references` via `explore-high` (only agent with it)
+- **Need structural code patterns?** (e.g., "find all functions matching X shape") Use `ast_grep_search` via `explore` family, `architect`/`architect-medium`, or `code-reviewer`
+- **Need to transform code structurally?** Use `ast_grep_replace` via `executor-high` (only agent with it)
+- **Need project-wide type checking?** Use `lsp_diagnostics_directory` via `architect`/`architect-medium`, `executor`/`executor-high`, or `build-fixer` family
+- **Need single-file error checking?** Use `lsp_diagnostics` via many agents (see matrix)
+- **Need data analysis / computation?** Use `python_repl` via `scientist` agents (all tiers)
+- **Need quick type info or definition lookup?** Use `lsp_hover`/`lsp_goto_definition` directly (orchestrator-direct tools)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add comprehensive MCP tools documentation so the orchestrator knows which agents have which tools and when to use them
- Document all 15 MCP tools (12 LSP + 2 AST + 1 python_repl) with agent assignments
- Update 6 priority agent prompts with Tool Strategy sections

## Changes

**docs/CLAUDE.md:**
- New "MCP Tools & Agent Capabilities" section in Part 3
- Tool Inventory table listing all 15 MCP tools
- Agent Tool Matrix showing which agents have which MCP tools
- Unassigned Tools section (7 orchestrator-direct tools)
- Tool Selection Guidance for delegation decisions
- Extended Agent Selection Guide with 7 tool-driven entries

**agents/AGENTS.md:**
- Updated Common Tools column with MCP tools per category

**Agent prompts updated with Tool Strategy sections:**
- `architect.md`: lsp_diagnostics, lsp_diagnostics_directory, ast_grep_search
- `executor-high.md`: above + ast_grep_replace (unique capability)
- `explore-medium.md`: ast_grep_search, lsp_document_symbols, lsp_workspace_symbols
- `explore-high.md`: above + lsp_find_references (unique capability)
- `build-fixer.md`: lsp_diagnostics, lsp_diagnostics_directory
- `code-reviewer.md`: lsp_diagnostics, ast_grep_search

## Test plan

- [ ] Verify docs/CLAUDE.md renders correctly
- [ ] Verify agent prompts load without errors
- [ ] Cross-check tool assignments against src/agents/definitions.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)