### PR TITLE
feat(hooks): adaptive /clear suggestions system

### DIFF
--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -17831,6 +17831,48 @@ var LSP_SERVERS = {
     args: ["--stdio"],
     extensions: [".yaml", ".yml"],
     installHint: "npm install -g yaml-language-server"
+  },
+  php: {
+    name: "PHP Language Server (Intelephense)",
+    command: "intelephense",
+    args: ["--stdio"],
+    extensions: [".php", ".phtml"],
+    installHint: "npm install -g intelephense"
+  },
+  ruby: {
+    name: "Ruby Language Server (Solargraph)",
+    command: "solargraph",
+    args: ["stdio"],
+    extensions: [".rb", ".rake", ".gemspec", ".erb"],
+    installHint: "gem install solargraph"
+  },
+  lua: {
+    name: "Lua Language Server",
+    command: "lua-language-server",
+    args: [],
+    extensions: [".lua"],
+    installHint: "Install from https://github.com/LuaLS/lua-language-server"
+  },
+  kotlin: {
+    name: "Kotlin Language Server",
+    command: "kotlin-language-server",
+    args: [],
+    extensions: [".kt", ".kts"],
+    installHint: "Install from https://github.com/fwcd/kotlin-language-server"
+  },
+  elixir: {
+    name: "ElixirLS",
+    command: "elixir-ls",
+    args: [],
+    extensions: [".ex", ".exs", ".heex", ".eex"],
+    installHint: "Install from https://github.com/elixir-lsp/elixir-ls"
+  },
+  csharp: {
+    name: "OmniSharp",
+    command: "omnisharp",
+    args: ["-lsp"],
+    extensions: [".cs"],
+    installHint: "dotnet tool install -g omnisharp"
   }
 };
 function commandExists(command) {
@@ -18121,7 +18163,21 @@ ${content}`;
       "css": "css",
       "scss": "scss",
       "yaml": "yaml",
-      "yml": "yaml"
+      "yml": "yaml",
+      "php": "php",
+      "phtml": "php",
+      "rb": "ruby",
+      "rake": "ruby",
+      "gemspec": "ruby",
+      "erb": "ruby",
+      "lua": "lua",
+      "kt": "kotlin",
+      "kts": "kotlin",
+      "ex": "elixir",
+      "exs": "elixir",
+      "heex": "elixir",
+      "eex": "elixir",
+      "cs": "csharp"
     };
     return langMap[ext] || ext;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "3.7.15",
+  "version": "3.7.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "3.7.15",
+      "version": "3.7.16",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/src/hooks/clear-suggestions/constants.ts
+++ b/src/hooks/clear-suggestions/constants.ts
@@ -1,0 +1,120 @@
+/**
+ * Clear Suggestions Constants
+ *
+ * Messages, thresholds, and configuration defaults for the
+ * adaptive /clear suggestions system.
+ */
+
+/**
+ * Cooldown period between clear suggestions (5 minutes)
+ */
+export const CLEAR_SUGGESTION_COOLDOWN_MS = 5 * 60 * 1000;
+
+/**
+ * Maximum suggestions per session
+ */
+export const MAX_CLEAR_SUGGESTIONS = 2;
+
+/**
+ * Context usage threshold to trigger context+artifacts suggestion (50%)
+ */
+export const CONTEXT_THRESHOLD = 0.50;
+
+/**
+ * Consecutive failure count for degradation signal
+ */
+export const FAILURE_THRESHOLD = 3;
+
+/**
+ * Failure window - only count failures within this window (10 minutes)
+ */
+export const FAILURE_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * Message for workflow completion trigger
+ */
+export const WORKFLOW_COMPLETE_MESSAGE = (modeName: string, artifacts: string): string =>
+  `SESSION RESET SUGGESTION
+
+The **${modeName}** workflow has completed successfully. Starting fresh with /clear would give you:
+- A clean context window for your next task
+- Faster, more reliable responses
+- No stale context from the completed workflow
+
+${artifacts}
+Type **/clear** to start fresh, or continue working in this session.
+`;
+
+/**
+ * Message for architect verification trigger
+ */
+export const ARCHITECT_VERIFIED_MESSAGE = (artifacts: string): string =>
+  `SESSION RESET SUGGESTION
+
+Architect verification has **passed** - your work is approved. This is an ideal moment to reset:
+- The verification cycle consumed significant context
+- Your completed work is saved in project files
+- A fresh session will be more responsive for the next task
+
+${artifacts}
+Type **/clear** to start fresh, or continue working in this session.
+`;
+
+/**
+ * Message for planning complete trigger
+ */
+export const PLANNING_COMPLETE_MESSAGE = (artifacts: string): string =>
+  `SESSION RESET SUGGESTION
+
+Planning is **complete** and your plan has been saved to disk. Consider resetting:
+- The planning interview used substantial context
+- Your plan files are preserved and will be auto-loaded
+- Execution will be more reliable in a fresh session
+
+${artifacts}
+Type **/clear** to start fresh, or continue working in this session.
+`;
+
+/**
+ * Message for context+artifacts trigger
+ */
+export const CONTEXT_ARTIFACTS_MESSAGE = (usagePct: number, artifacts: string): string =>
+  `SESSION RESET SUGGESTION
+
+Context usage is at **${usagePct}%** but your progress is safely preserved in project files. Consider resetting:
+- High context usage can cause degraded performance
+- /clear reloads your CLAUDE.md and project context automatically
+- Your artifacts will be available in the new session
+
+${artifacts}
+Type **/clear** to start fresh, or use **/compact** if you want to continue this session.
+`;
+
+/**
+ * Message for degradation signals trigger
+ */
+export const DEGRADATION_SIGNALS_MESSAGE = (failureCount: number, artifacts: string): string =>
+  `SESSION RESET SUGGESTION
+
+Detected **${failureCount} consecutive failures** which may indicate context degradation. A fresh start could help:
+- Accumulated context can cause tool call failures
+- /clear gives you a clean slate while preserving all files
+- Your work is saved on disk and will not be lost
+
+${artifacts}
+Type **/clear** to start fresh, or continue troubleshooting in this session.
+`;
+
+/**
+ * Format preserved artifacts into a readable list
+ */
+export function formatPreservedArtifacts(
+  artifacts: Array<{ type: string; description: string }>
+): string {
+  if (artifacts.length === 0) {
+    return '';
+  }
+
+  const lines = artifacts.map(a => `  - ${a.description}`);
+  return `**Preserved artifacts** (available after /clear):\n${lines.join('\n')}\n`;
+}

--- a/src/hooks/clear-suggestions/index.ts
+++ b/src/hooks/clear-suggestions/index.ts
@@ -1,0 +1,388 @@
+/**
+ * Clear Suggestions Hook
+ *
+ * Adaptive /clear suggestions system that intelligently recommends session
+ * resets when it would improve reliability and performance.
+ *
+ * Features:
+ * - 5 semantic triggers for context-aware suggestions
+ * - 5-minute cooldown between suggestions
+ * - Maximum 2 suggestions per session
+ * - Non-intrusive messaging explaining WHY clearing helps
+ * - Lists preserved artifacts (plans, notes, decisions)
+ *
+ * Complements (doesn't replace) existing /compact suggestions.
+ */
+
+import type {
+  ClearSuggestionTrigger,
+  ClearSuggestionState,
+  ClearSuggestionConfig,
+  ClearSuggestionResult,
+  ClearSuggestionInput,
+  PreservedArtifact,
+} from './types.js';
+
+import {
+  CLEAR_SUGGESTION_COOLDOWN_MS,
+  MAX_CLEAR_SUGGESTIONS,
+  WORKFLOW_COMPLETE_MESSAGE,
+  ARCHITECT_VERIFIED_MESSAGE,
+  PLANNING_COMPLETE_MESSAGE,
+  CONTEXT_ARTIFACTS_MESSAGE,
+  DEGRADATION_SIGNALS_MESSAGE,
+  formatPreservedArtifacts,
+} from './constants.js';
+
+import {
+  detectWorkflowComplete,
+  detectArchitectVerified,
+  detectPlanningComplete,
+  detectContextWithArtifacts,
+  detectDegradationSignals,
+  isToolFailure,
+  discoverPreservedArtifacts,
+  checkModeJustCompleted,
+  checkArchitectJustVerified,
+} from './triggers.js';
+
+import type { ExecutionMode } from '../mode-registry/types.js';
+
+/**
+ * In-memory session state tracking
+ */
+const sessionStates = new Map<string, ClearSuggestionState>();
+
+/**
+ * Get or create session state
+ */
+function getSessionState(sessionId: string): ClearSuggestionState {
+  let state = sessionStates.get(sessionId);
+  if (!state) {
+    state = {
+      sessionId,
+      lastSuggestionTime: 0,
+      suggestionCount: 0,
+      consecutiveFailures: 0,
+      failureTimestamps: [],
+    };
+    sessionStates.set(sessionId, state);
+  }
+  return state;
+}
+
+/**
+ * Update session state
+ */
+function updateSessionState(sessionId: string, updates: Partial<ClearSuggestionState>): void {
+  const state = getSessionState(sessionId);
+  Object.assign(state, updates);
+}
+
+/**
+ * Record a suggestion was shown
+ */
+function recordSuggestion(sessionId: string): void {
+  const state = getSessionState(sessionId);
+  state.lastSuggestionTime = Date.now();
+  state.suggestionCount++;
+  // Clear one-time flags
+  state.workflowJustCompleted = undefined;
+  state.architectJustVerified = undefined;
+  state.planningJustCompleted = undefined;
+}
+
+/**
+ * Record a tool failure
+ */
+function recordFailure(sessionId: string): void {
+  const state = getSessionState(sessionId);
+  state.consecutiveFailures++;
+  state.failureTimestamps.push(Date.now());
+  // Keep only recent timestamps (last 10)
+  if (state.failureTimestamps.length > 10) {
+    state.failureTimestamps = state.failureTimestamps.slice(-10);
+  }
+}
+
+/**
+ * Reset failure count (called on successful tool execution)
+ */
+function resetFailures(sessionId: string): void {
+  const state = getSessionState(sessionId);
+  state.consecutiveFailures = 0;
+}
+
+/**
+ * Check if cooldown has elapsed
+ */
+function isCooldownElapsed(sessionId: string, config?: ClearSuggestionConfig): boolean {
+  const state = getSessionState(sessionId);
+  const cooldownMs = config?.cooldownMs ?? CLEAR_SUGGESTION_COOLDOWN_MS;
+  const elapsed = Date.now() - state.lastSuggestionTime;
+  return elapsed >= cooldownMs;
+}
+
+/**
+ * Check if max suggestions reached
+ */
+function isMaxSuggestionsReached(sessionId: string, config?: ClearSuggestionConfig): boolean {
+  const state = getSessionState(sessionId);
+  const maxSuggestions = config?.maxSuggestions ?? MAX_CLEAR_SUGGESTIONS;
+  return state.suggestionCount >= maxSuggestions;
+}
+
+/**
+ * Generate message for a trigger
+ */
+function generateMessage(
+  trigger: ClearSuggestionTrigger,
+  artifacts: PreservedArtifact[],
+  state: ClearSuggestionState,
+  contextUsageRatio?: number
+): string {
+  const artifactsText = formatPreservedArtifacts(
+    artifacts.map(a => ({ type: a.type, description: a.description }))
+  );
+
+  switch (trigger) {
+    case 'workflow_complete': {
+      const modeName = state.workflowJustCompleted || 'workflow';
+      const modeDisplayNames: Record<string, string> = {
+        ralph: 'Ralph',
+        autopilot: 'Autopilot',
+        ultrawork: 'Ultrawork',
+        ultraqa: 'UltraQA',
+        ultrapilot: 'Ultrapilot',
+        swarm: 'Swarm',
+        pipeline: 'Pipeline',
+        ecomode: 'Ecomode',
+      };
+      const displayName = modeDisplayNames[modeName] || modeName;
+      return WORKFLOW_COMPLETE_MESSAGE(displayName, artifactsText);
+    }
+    case 'architect_verified':
+      return ARCHITECT_VERIFIED_MESSAGE(artifactsText);
+    case 'planning_complete':
+      return PLANNING_COMPLETE_MESSAGE(artifactsText);
+    case 'context_artifacts': {
+      const usagePct = Math.round((contextUsageRatio ?? 0.5) * 100);
+      return CONTEXT_ARTIFACTS_MESSAGE(usagePct, artifactsText);
+    }
+    case 'degradation_signals': {
+      const failureCount = state.consecutiveFailures;
+      return DEGRADATION_SIGNALS_MESSAGE(failureCount, artifactsText);
+    }
+    default:
+      return '';
+  }
+}
+
+/**
+ * Main check function - evaluates all triggers and returns suggestion if appropriate
+ */
+export function checkClearSuggestion(
+  input: ClearSuggestionInput,
+  config?: ClearSuggestionConfig
+): ClearSuggestionResult {
+  const { sessionId, directory, toolName, toolOutput, contextUsageRatio } = input;
+
+  // Check if disabled
+  if (config?.enabled === false) {
+    return { shouldSuggest: false, skipReason: 'disabled' };
+  }
+
+  // Check max suggestions
+  if (isMaxSuggestionsReached(sessionId, config)) {
+    return { shouldSuggest: false, skipReason: 'max_suggestions_reached' };
+  }
+
+  // Check cooldown
+  if (!isCooldownElapsed(sessionId, config)) {
+    return { shouldSuggest: false, skipReason: 'cooldown_active' };
+  }
+
+  // Get session state
+  const state = getSessionState(sessionId);
+
+  // Track tool failures/successes
+  if (toolName && toolOutput) {
+    if (isToolFailure(toolName, toolOutput)) {
+      recordFailure(sessionId);
+    } else {
+      resetFailures(sessionId);
+    }
+  }
+
+  // Check for mode completions
+  const completedModes: ExecutionMode[] = ['ralph', 'autopilot', 'ultrawork', 'ultraqa'];
+  for (const mode of completedModes) {
+    if (checkModeJustCompleted(directory, mode)) {
+      updateSessionState(sessionId, { workflowJustCompleted: mode as ExecutionMode });
+      break;
+    }
+  }
+
+  // Check for architect verification
+  if (checkArchitectJustVerified(directory)) {
+    updateSessionState(sessionId, { architectJustVerified: true });
+  }
+
+  // Discover preserved artifacts
+  const artifacts = discoverPreservedArtifacts(directory);
+
+  // Evaluate triggers in priority order
+  // Priority: workflow_complete > architect_verified > planning_complete > context_artifacts > degradation_signals
+
+  let trigger: ClearSuggestionTrigger | null = null;
+
+  // 1. Workflow complete (highest priority - clear win)
+  trigger = detectWorkflowComplete(state);
+  if (trigger) {
+    const message = generateMessage(trigger, artifacts, state, contextUsageRatio);
+    recordSuggestion(sessionId);
+    return { shouldSuggest: true, trigger, message, preservedArtifacts: artifacts };
+  }
+
+  // 2. Architect verified
+  trigger = detectArchitectVerified(state);
+  if (trigger) {
+    const message = generateMessage(trigger, artifacts, state, contextUsageRatio);
+    recordSuggestion(sessionId);
+    return { shouldSuggest: true, trigger, message, preservedArtifacts: artifacts };
+  }
+
+  // 3. Planning complete
+  trigger = detectPlanningComplete(state);
+  if (trigger) {
+    const message = generateMessage(trigger, artifacts, state, contextUsageRatio);
+    recordSuggestion(sessionId);
+    return { shouldSuggest: true, trigger, message, preservedArtifacts: artifacts };
+  }
+
+  // 4. Context >50% with artifacts
+  trigger = detectContextWithArtifacts(contextUsageRatio, artifacts, config);
+  if (trigger) {
+    const message = generateMessage(trigger, artifacts, state, contextUsageRatio);
+    recordSuggestion(sessionId);
+    return { shouldSuggest: true, trigger, message, preservedArtifacts: artifacts };
+  }
+
+  // 5. Degradation signals (lowest priority - only if nothing else triggered)
+  trigger = detectDegradationSignals(state, config);
+  if (trigger) {
+    const message = generateMessage(trigger, artifacts, state, contextUsageRatio);
+    recordSuggestion(sessionId);
+    return { shouldSuggest: true, trigger, message, preservedArtifacts: artifacts };
+  }
+
+  return { shouldSuggest: false, skipReason: 'no_triggers_fired' };
+}
+
+/**
+ * Mark planning as just completed (called by plan/ralplan skills)
+ */
+export function markPlanningComplete(sessionId: string): void {
+  updateSessionState(sessionId, { planningJustCompleted: true });
+}
+
+/**
+ * Reset session state (called on /clear)
+ */
+export function resetClearSuggestionState(sessionId: string): void {
+  sessionStates.delete(sessionId);
+}
+
+/**
+ * Get current session stats (for debugging)
+ */
+export function getClearSuggestionStats(sessionId: string): ClearSuggestionState | null {
+  return sessionStates.get(sessionId) ?? null;
+}
+
+/**
+ * Clean up stale sessions (older than 30 minutes)
+ */
+export function cleanupStaleSessions(): void {
+  const now = Date.now();
+  const maxAge = 30 * 60 * 1000; // 30 minutes
+
+  for (const [sessionId, state] of sessionStates) {
+    if (state.lastSuggestionTime > 0 && now - state.lastSuggestionTime > maxAge) {
+      sessionStates.delete(sessionId);
+    }
+  }
+}
+
+/**
+ * Create a clear suggestion hook instance
+ */
+export function createClearSuggestionHook(config?: ClearSuggestionConfig) {
+  return {
+    /**
+     * PostToolUse - Check if we should suggest /clear
+     */
+    postToolUse: (input: {
+      tool_name: string;
+      session_id: string;
+      directory: string;
+      tool_response?: string;
+      context_usage_ratio?: number;
+    }): string | null => {
+      const result = checkClearSuggestion(
+        {
+          sessionId: input.session_id,
+          directory: input.directory,
+          toolName: input.tool_name,
+          toolOutput: input.tool_response,
+          contextUsageRatio: input.context_usage_ratio,
+        },
+        config
+      );
+
+      if (result.shouldSuggest && result.message) {
+        return result.message;
+      }
+
+      return null;
+    },
+
+    /**
+     * Stop event - Reset failure tracking
+     */
+    stop: (input: { session_id: string }): void => {
+      resetFailures(input.session_id);
+    },
+  };
+}
+
+// Re-export types
+export type {
+  ClearSuggestionTrigger,
+  ClearSuggestionState,
+  ClearSuggestionConfig,
+  ClearSuggestionResult,
+  ClearSuggestionInput,
+  PreservedArtifact,
+} from './types.js';
+
+// Re-export constants
+export {
+  CLEAR_SUGGESTION_COOLDOWN_MS,
+  MAX_CLEAR_SUGGESTIONS,
+  CONTEXT_THRESHOLD,
+  FAILURE_THRESHOLD,
+} from './constants.js';
+
+// Re-export trigger functions for testing
+export {
+  detectWorkflowComplete,
+  detectArchitectVerified,
+  detectPlanningComplete,
+  detectContextWithArtifacts,
+  detectDegradationSignals,
+  isToolFailure,
+  discoverPreservedArtifacts,
+  checkModeJustCompleted,
+  checkArchitectJustVerified,
+} from './triggers.js';

--- a/src/hooks/clear-suggestions/triggers.ts
+++ b/src/hooks/clear-suggestions/triggers.ts
@@ -1,0 +1,273 @@
+/**
+ * Clear Suggestions Trigger Detection
+ *
+ * Implements the 5 semantic triggers that determine when to suggest /clear:
+ * 1. Workflow complete - ralph/autopilot/ultrawork finished
+ * 2. Architect verified - architect approval passed
+ * 3. Planning complete - ralplan/plan skill completed
+ * 4. Context >50% + artifacts - high context but plan files exist
+ * 5. Degradation signals - 3+ consecutive failures
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import type { ClearSuggestionTrigger, ClearSuggestionState, ClearSuggestionConfig, PreservedArtifact } from './types.js';
+import { CONTEXT_THRESHOLD, FAILURE_THRESHOLD, FAILURE_WINDOW_MS } from './constants.js';
+
+/**
+ * Detect if a workflow (ralph/autopilot/ultrawork) just completed.
+ *
+ * Checks state files for modes that transitioned from active to inactive
+ * within the current hook call.
+ */
+export function detectWorkflowComplete(
+  state: ClearSuggestionState
+): ClearSuggestionTrigger | null {
+  if (state.workflowJustCompleted) {
+    return 'workflow_complete';
+  }
+  return null;
+}
+
+/**
+ * Detect if architect verification just passed.
+ *
+ * Reads ralph verification state to see if architect approved.
+ */
+export function detectArchitectVerified(
+  state: ClearSuggestionState
+): ClearSuggestionTrigger | null {
+  if (state.architectJustVerified) {
+    return 'architect_verified';
+  }
+  return null;
+}
+
+/**
+ * Detect if planning just completed.
+ *
+ * Checks if a plan skill or ralplan skill just finished.
+ */
+export function detectPlanningComplete(
+  state: ClearSuggestionState
+): ClearSuggestionTrigger | null {
+  if (state.planningJustCompleted) {
+    return 'planning_complete';
+  }
+  return null;
+}
+
+/**
+ * Detect if context is above threshold and artifacts exist to reload.
+ *
+ * This trigger fires when context is high but the user has saved artifacts
+ * (plans, PRDs, notes) that would automatically reload after /clear.
+ */
+export function detectContextWithArtifacts(
+  contextUsageRatio: number | undefined,
+  artifacts: PreservedArtifact[],
+  config?: ClearSuggestionConfig
+): ClearSuggestionTrigger | null {
+  const threshold = config?.contextThreshold ?? CONTEXT_THRESHOLD;
+
+  if (contextUsageRatio === undefined || contextUsageRatio < threshold) {
+    return null;
+  }
+
+  // Only suggest if there are artifacts to reload
+  if (artifacts.length === 0) {
+    return null;
+  }
+
+  return 'context_artifacts';
+}
+
+/**
+ * Detect degradation signals from consecutive failures.
+ *
+ * Tracks recent tool failures and triggers when the threshold is exceeded.
+ */
+export function detectDegradationSignals(
+  state: ClearSuggestionState,
+  config?: ClearSuggestionConfig
+): ClearSuggestionTrigger | null {
+  const threshold = config?.failureThreshold ?? FAILURE_THRESHOLD;
+  const now = Date.now();
+
+  // Filter to recent failures only
+  const recentFailures = state.failureTimestamps.filter(
+    ts => now - ts < FAILURE_WINDOW_MS
+  );
+
+  if (recentFailures.length >= threshold) {
+    return 'degradation_signals';
+  }
+
+  return null;
+}
+
+/**
+ * Check if a tool output indicates a failure
+ */
+export function isToolFailure(toolName: string, toolOutput: string): boolean {
+  if (!toolOutput) return false;
+
+  const output = toolOutput.toLowerCase();
+
+  // Bash failures
+  if (toolName === 'Bash' || toolName === 'bash') {
+    const failurePatterns = [
+      /error:/i,
+      /failed/i,
+      /exit code: [1-9]/i,
+      /exit status [1-9]/i,
+      /fatal:/i,
+      /command not found/i,
+    ];
+    return failurePatterns.some(p => p.test(toolOutput));
+  }
+
+  // Edit failures
+  if (toolName === 'Edit' || toolName === 'edit') {
+    const editFailures = [
+      'old_string not found',
+      'not unique',
+      'no match',
+      'failed to edit',
+    ];
+    return editFailures.some(f => output.includes(f));
+  }
+
+  // Task failures
+  if (toolName === 'Task' || toolName === 'task') {
+    const taskFailures = [
+      'error',
+      'failed',
+      'timeout',
+      'agent error',
+    ];
+    return taskFailures.some(f => output.includes(f));
+  }
+
+  return false;
+}
+
+/**
+ * Discover preserved artifacts in the project directory.
+ *
+ * Scans for plans, PRDs, specs, progress files, notepads, and wisdom files
+ * that would survive a /clear and be available in the new session.
+ */
+export function discoverPreservedArtifacts(directory: string): PreservedArtifact[] {
+  const artifacts: PreservedArtifact[] = [];
+
+  const candidates: Array<{
+    type: PreservedArtifact['type'];
+    relativePath: string;
+    description: string;
+  }> = [
+    // Plans
+    { type: 'plan', relativePath: '.omc/plans', description: 'Implementation plans (.omc/plans/)' },
+    // PRD
+    { type: 'prd', relativePath: '.omc/prd.json', description: 'Product Requirements Document (.omc/prd.json)' },
+    { type: 'prd', relativePath: 'prd.json', description: 'Product Requirements Document (prd.json)' },
+    // Spec
+    { type: 'spec', relativePath: '.omc/autopilot/spec.md', description: 'Autopilot specification (.omc/autopilot/spec.md)' },
+    // Progress
+    { type: 'progress', relativePath: '.omc/progress.txt', description: 'Progress log (.omc/progress.txt)' },
+    { type: 'progress', relativePath: 'progress.txt', description: 'Progress log (progress.txt)' },
+    // Notepad
+    { type: 'notepad', relativePath: '.omc/notepad.md', description: 'Notepad memory (.omc/notepad.md)' },
+    // Wisdom files
+    { type: 'learning', relativePath: '.omc/notepads', description: 'Wisdom entries (.omc/notepads/)' },
+    // AGENTS.md
+    { type: 'decision', relativePath: 'AGENTS.md', description: 'Agent documentation (AGENTS.md)' },
+    // CLAUDE.md
+    { type: 'decision', relativePath: '.claude/CLAUDE.md', description: 'Project instructions (.claude/CLAUDE.md)' },
+  ];
+
+  for (const candidate of candidates) {
+    const fullPath = join(directory, candidate.relativePath);
+    if (existsSync(fullPath)) {
+      artifacts.push({
+        type: candidate.type,
+        path: fullPath,
+        description: candidate.description,
+      });
+    }
+  }
+
+  return artifacts;
+}
+
+/**
+ * Check if a mode just completed by comparing current state with previous state.
+ *
+ * Reads mode state files to detect transitions from active to inactive.
+ */
+export function checkModeJustCompleted(
+  directory: string,
+  modeName: string
+): boolean {
+  const stateDir = join(directory, '.omc', 'state');
+
+  // Map mode names to their state files
+  const stateFiles: Record<string, string> = {
+    ralph: 'ralph-state.json',
+    autopilot: 'autopilot-state.json',
+    ultrawork: 'ultrawork-state.json',
+    ultraqa: 'ultraqa-state.json',
+  };
+
+  const stateFile = stateFiles[modeName];
+  if (!stateFile) return false;
+
+  const filePath = join(stateDir, stateFile);
+  if (!existsSync(filePath)) return false;
+
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const state = JSON.parse(content);
+
+    // Check for completed state: active=false with a completed_at timestamp
+    if (state.active === false && state.completed_at) {
+      // Only trigger if completed recently (within last 30 seconds)
+      const completedAt = new Date(state.completed_at).getTime();
+      const age = Date.now() - completedAt;
+      return age < 30_000;
+    }
+
+    // For autopilot, check phase === 'complete'
+    if (state.phase === 'complete' && state.active === false) {
+      return true;
+    }
+  } catch {
+    // State file unreadable
+  }
+
+  return false;
+}
+
+/**
+ * Check if architect verification just passed
+ */
+export function checkArchitectJustVerified(directory: string): boolean {
+  const verificationFile = join(directory, '.omc', 'state', 'ralph-verification.json');
+
+  if (!existsSync(verificationFile)) return false;
+
+  try {
+    const content = readFileSync(verificationFile, 'utf-8');
+    const state = JSON.parse(content);
+
+    if (state.status === 'approved' && state.completed_at) {
+      const completedAt = new Date(state.completed_at).getTime();
+      const age = Date.now() - completedAt;
+      return age < 30_000;
+    }
+  } catch {
+    // Verification file unreadable
+  }
+
+  return false;
+}

--- a/src/hooks/clear-suggestions/types.ts
+++ b/src/hooks/clear-suggestions/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Clear Suggestions Types
+ *
+ * Type definitions for the adaptive /clear suggestions system that
+ * intelligently recommends session resets when it would improve
+ * reliability and performance.
+ */
+
+import type { ExecutionMode } from '../mode-registry/types.js';
+
+/**
+ * Trigger types for clear suggestions
+ */
+export type ClearSuggestionTrigger =
+  | 'workflow_complete'     // After ralph/autopilot/ultrawork finishes
+  | 'architect_verified'    // After architect approval passes
+  | 'planning_complete'     // After ralplan/plan skill completes
+  | 'context_artifacts'     // High context but plan files exist to reload
+  | 'degradation_signals';  // 3+ consecutive failures detected
+
+/**
+ * State tracking for clear suggestions within a session
+ */
+export interface ClearSuggestionState {
+  /** Session ID being tracked */
+  sessionId: string;
+  /** Timestamp of last suggestion shown */
+  lastSuggestionTime: number;
+  /** Number of suggestions shown this session */
+  suggestionCount: number;
+  /** Recent failure count for degradation detection */
+  consecutiveFailures: number;
+  /** Timestamps of recent failures */
+  failureTimestamps: number[];
+  /** Whether a workflow just completed */
+  workflowJustCompleted?: ExecutionMode;
+  /** Whether architect just verified */
+  architectJustVerified?: boolean;
+  /** Whether planning just completed */
+  planningJustCompleted?: boolean;
+}
+
+/**
+ * Configuration for clear suggestions
+ */
+export interface ClearSuggestionConfig {
+  /** Enable clear suggestions (default: true) */
+  enabled?: boolean;
+  /** Cooldown period in ms between suggestions (default: 300000 = 5 minutes) */
+  cooldownMs?: number;
+  /** Maximum suggestions per session (default: 2) */
+  maxSuggestions?: number;
+  /** Context usage threshold (default: 0.50 = 50%) */
+  contextThreshold?: number;
+  /** Consecutive failures threshold for degradation (default: 3) */
+  failureThreshold?: number;
+  /** Custom message template */
+  customMessage?: string;
+}
+
+/**
+ * Artifact that would be preserved after clear
+ */
+export interface PreservedArtifact {
+  /** Type of artifact */
+  type: 'plan' | 'prd' | 'spec' | 'progress' | 'notepad' | 'decision' | 'learning' | 'issue';
+  /** Path to the artifact file */
+  path: string;
+  /** Human-readable description */
+  description: string;
+}
+
+/**
+ * Result from checking clear suggestion triggers
+ */
+export interface ClearSuggestionResult {
+  /** Whether to show a suggestion */
+  shouldSuggest: boolean;
+  /** Which trigger fired (if any) */
+  trigger?: ClearSuggestionTrigger;
+  /** The suggestion message to show */
+  message?: string;
+  /** List of artifacts that would be preserved */
+  preservedArtifacts?: PreservedArtifact[];
+  /** Reason for not suggesting (for debugging) */
+  skipReason?: string;
+}
+
+/**
+ * Input for clear suggestion hook
+ */
+export interface ClearSuggestionInput {
+  /** Session ID */
+  sessionId: string;
+  /** Working directory */
+  directory: string;
+  /** Tool name that just executed */
+  toolName?: string;
+  /** Tool output (for failure detection) */
+  toolOutput?: string;
+  /** Estimated context usage ratio (0-1) */
+  contextUsageRatio?: number;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -799,3 +799,32 @@ export {
   type SessionMetrics,
   type HookOutput as SessionEndHookOutput
 } from './session-end/index.js';
+
+export {
+  // Clear Suggestions
+  createClearSuggestionHook,
+  checkClearSuggestion,
+  markPlanningComplete,
+  resetClearSuggestionState,
+  getClearSuggestionStats,
+  cleanupStaleSessions,
+  discoverPreservedArtifacts,
+  isToolFailure,
+  checkModeJustCompleted,
+  checkArchitectJustVerified,
+  detectWorkflowComplete,
+  detectArchitectVerified,
+  detectPlanningComplete,
+  detectContextWithArtifacts,
+  detectDegradationSignals,
+  CLEAR_SUGGESTION_COOLDOWN_MS,
+  MAX_CLEAR_SUGGESTIONS,
+  CONTEXT_THRESHOLD as CLEAR_CONTEXT_THRESHOLD,
+  FAILURE_THRESHOLD as CLEAR_FAILURE_THRESHOLD,
+  type ClearSuggestionTrigger,
+  type ClearSuggestionState,
+  type ClearSuggestionConfig,
+  type ClearSuggestionResult,
+  type ClearSuggestionInput,
+  type PreservedArtifact
+} from './clear-suggestions/index.js';


### PR DESCRIPTION
## Summary

Implements an adaptive `/clear` suggestions system that intelligently recommends session resets when it would improve reliability and performance.

Based on Boris Cherny's (Claude Code founder) recommendation: clearing sessions after major milestones produces more reliable execution than accumulating context noise.

### 5 Semantic Triggers

| Trigger | When |
|---------|------|
| **Workflow complete** | After ralph/autopilot/ultrawork finishes |
| **Architect verified** | After architect approval passes |
| **Planning complete** | After ralplan/plan skill completes |
| **Context >50% + artifacts** | High context but plan files exist to reload |
| **Degradation signals** | 3+ consecutive failures detected |

### Key Features

- Complements (doesn't replace) existing `/compact` suggestions
- 5-minute cooldown between suggestions
- Max 2 suggestions per session
- Non-intrusive messaging explaining WHY clearing helps
- Lists preserved artifacts (plans, notes, decisions)

### Files to Create

- `src/hooks/clear-suggestions/index.ts` - Main hook module
- `src/hooks/clear-suggestions/types.ts` - Type definitions
- `src/hooks/clear-suggestions/constants.ts` - Messages and thresholds
- `src/hooks/clear-suggestions/triggers.ts` - Trigger detection functions

### Files to Modify

- `scripts/post-tool-verifier.mjs` - Integration point
- `src/hooks/index.ts` - Export new module

## Test plan

- [ ] Workflow completion trigger fires after ralph/autopilot done
- [ ] Architect approval trigger fires after verification
- [ ] Planning completion trigger fires after ralplan completes
- [ ] Context + artifacts trigger fires at 50%+ with plans present
- [ ] Cooldown prevents rapid suggestions (wait <5 min, no repeat)
- [ ] Max suggestions limit works (hit 2, no more appear)
- [ ] Ralplan completion specifically triggers /clear suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)