### PR TITLE
feat(psm): add multi-provider support with Jira integration

### DIFF
--- a/skills/project-session-manager/SKILL.md
+++ b/skills/project-session-manager/SKILL.md
@@ -49,6 +49,85 @@ Supported formats:
 }
 ```
 
+## Providers
+
+PSM supports multiple issue tracking providers:
+
+| Provider | CLI Required | Reference Formats | Commands |
+|----------|--------------|-------------------|----------|
+| GitHub (default) | `gh` | `owner/repo#123`, `alias#123`, GitHub URLs | review, fix, feature |
+| Jira | `jira` | `PROJ-123` (if PROJ configured), `alias#123` | fix, feature |
+
+### Jira Configuration
+
+To use Jira, add an alias with `jira_project` and `provider: "jira"`:
+
+```json
+{
+  "aliases": {
+    "mywork": {
+      "jira_project": "MYPROJ",
+      "repo": "mycompany/my-project",
+      "local": "~/Workspace/my-project",
+      "default_base": "develop",
+      "provider": "jira"
+    }
+  }
+}
+```
+
+**Important:** The `repo` field is still required for cloning the git repository. Jira tracks issues, but you work in a git repo.
+
+For non-GitHub repos, use `clone_url` instead:
+```json
+{
+  "aliases": {
+    "private": {
+      "jira_project": "PRIV",
+      "clone_url": "git@gitlab.internal:team/repo.git",
+      "local": "~/Workspace/repo",
+      "provider": "jira"
+    }
+  }
+}
+```
+
+### Jira Reference Detection
+
+PSM only recognizes `PROJ-123` format as Jira when `PROJ` is explicitly configured as a `jira_project` in your aliases. This prevents false positives from branch names like `FIX-123`.
+
+### Jira Examples
+
+```bash
+# Fix a Jira issue (MYPROJ must be configured)
+psm fix MYPROJ-123
+
+# Fix using alias (recommended)
+psm fix mywork#123
+
+# Feature development (works same as GitHub)
+psm feature mywork add-webhooks
+
+# Note: 'psm review' is not supported for Jira (no PR concept)
+# Use 'psm fix' for Jira issues
+```
+
+### Jira CLI Setup
+
+Install the Jira CLI:
+```bash
+# macOS
+brew install ankitpokhrel/jira-cli/jira-cli
+
+# Linux
+# See: https://github.com/ankitpokhrel/jira-cli#installation
+
+# Configure (interactive)
+jira init
+```
+
+The Jira CLI handles authentication separately from PSM.
+
 ## Directory Structure
 
 ```
@@ -371,10 +450,14 @@ Parse `{{ARGUMENTS}}` to determine:
 
 ## Requirements
 
-- `git` with worktree support (v2.5+)
-- `gh` CLI (authenticated)
-- `tmux`
-- `jq` for JSON parsing
+Required:
+- `git` - Version control (with worktree support v2.5+)
+- `jq` - JSON parsing
+- `tmux` - Session management (optional, but recommended)
+
+Optional (per provider):
+- `gh` - GitHub CLI (for GitHub workflows)
+- `jira` - Jira CLI (for Jira workflows)
 
 ## Initialization
 

--- a/skills/project-session-manager/lib/config.sh
+++ b/skills/project-session-manager/lib/config.sh
@@ -62,6 +62,53 @@ psm_get_project() {
     echo "${repo}|${local_path}|${default_base}"
 }
 
+# Get provider for a project alias
+# Usage: psm_get_project_provider "mywork"
+# Returns: "github" | "jira" | empty (defaults to github)
+psm_get_project_provider() {
+    local alias="$1"
+    if [[ ! -f "$PSM_PROJECTS" ]]; then
+        echo "github"
+        return
+    fi
+    local provider
+    provider=$(jq -r ".aliases[\"$alias\"].provider // \"github\"" "$PSM_PROJECTS")
+    echo "$provider"
+}
+
+# Get Jira project key for alias
+# Usage: psm_get_project_jira_project "mywork"
+# Returns: "MYPROJ" or empty
+psm_get_project_jira_project() {
+    local alias="$1"
+    if [[ ! -f "$PSM_PROJECTS" ]]; then
+        return
+    fi
+    jq -r ".aliases[\"$alias\"].jira_project // empty" "$PSM_PROJECTS"
+}
+
+# Get explicit clone_url for alias (for non-GitHub repos)
+# Usage: psm_get_project_clone_url "mywork"
+# Returns: URL or empty
+psm_get_project_clone_url() {
+    local alias="$1"
+    if [[ ! -f "$PSM_PROJECTS" ]]; then
+        return
+    fi
+    jq -r ".aliases[\"$alias\"].clone_url // empty" "$PSM_PROJECTS"
+}
+
+# Get repo field for alias
+# Usage: psm_get_project_repo "mywork"
+# Returns: "owner/repo" or empty
+psm_get_project_repo() {
+    local alias="$1"
+    if [[ ! -f "$PSM_PROJECTS" ]]; then
+        return
+    fi
+    jq -r ".aliases[\"$alias\"].repo // empty" "$PSM_PROJECTS"
+}
+
 # Add or update project alias
 psm_set_project() {
     local alias="$1"

--- a/skills/project-session-manager/lib/parse.sh
+++ b/skills/project-session-manager/lib/parse.sh
@@ -46,7 +46,20 @@ psm_parse_ref() {
         return 0
     fi
 
-    # alias#number format (e.g., omc#123)
+    # Jira direct reference (PROJ-123) - config-validated
+    local jira_info
+    if jira_info=$(psm_detect_jira_key "$ref"); then
+        IFS='|' read -r alias project_key issue_number <<< "$jira_info"
+        local project_info
+        project_info=$(psm_get_project "$alias")
+        if [[ $? -eq 0 ]]; then
+            IFS='|' read -r repo local_path base <<< "$project_info"
+            echo "issue|${alias}|${repo}|${issue_number}|${local_path}|${base}|jira|${project_key}-${issue_number}"
+            return 0
+        fi
+    fi
+
+    # alias#number format (e.g., omc#123 or mywork#123)
     if [[ "$ref" =~ ^([a-zA-Z][a-zA-Z0-9_-]*)#([0-9]+)$ ]]; then
         alias="${BASH_REMATCH[1]}"
         number="${BASH_REMATCH[2]}"
@@ -55,11 +68,22 @@ psm_parse_ref() {
         project_info=$(psm_get_project "$alias")
         if [[ $? -eq 0 ]]; then
             IFS='|' read -r repo local_path base <<< "$project_info"
-            # Determine type from context (default to issue, caller specifies)
-            echo "ref|$alias|$repo|$number|$local_path|$base"
+            local provider
+            provider=$(psm_get_project_provider "$alias")
+            local provider_ref=""
+
+            if [[ "$provider" == "jira" ]]; then
+                local jira_proj
+                jira_proj=$(psm_get_project_jira_project "$alias")
+                provider_ref="${jira_proj}-${number}"
+            else
+                provider_ref="${repo}#${number}"
+            fi
+
+            echo "ref|$alias|$repo|$number|$local_path|$base|$provider|$provider_ref"
             return 0
         else
-            echo "error|Unknown project alias: $alias|||"
+            echo "error|Unknown project alias: $alias|||||||"
             return 1
         fi
     fi
@@ -118,4 +142,34 @@ psm_slugify() {
     local title="$1"
     local max_len="${2:-30}"
     echo "$title" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | head -c "$max_len"
+}
+
+# Check if input matches a configured Jira project
+# Usage: psm_detect_jira_key "PROJ-123"
+# Returns: alias|project_key|issue_number OR exits 1
+psm_detect_jira_key() {
+    local input="$1"
+
+    # Must match PROJ-123 pattern (uppercase project, dash, digits)
+    if [[ ! "$input" =~ ^([A-Z][A-Z0-9]*)-([0-9]+)$ ]]; then
+        return 1
+    fi
+
+    local project_prefix="${BASH_REMATCH[1]}"
+    local issue_number="${BASH_REMATCH[2]}"
+
+    # Verify this project prefix exists in config
+    if [[ ! -f "$PSM_PROJECTS" ]]; then
+        return 1
+    fi
+
+    local matching_alias
+    matching_alias=$(jq -r ".aliases | to_entries[] | select(.value.jira_project == \"$project_prefix\") | .key" "$PSM_PROJECTS" | head -1)
+
+    if [[ -n "$matching_alias" ]]; then
+        echo "${matching_alias}|${project_prefix}|${issue_number}"
+        return 0
+    fi
+
+    return 1
 }

--- a/skills/project-session-manager/lib/providers/github.sh
+++ b/skills/project-session-manager/lib/providers/github.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# PSM GitHub Provider
+
+provider_github_available() {
+    command -v gh &> /dev/null
+}
+
+provider_github_detect_ref() {
+    local ref="$1"
+    # Matches github URLs or owner/repo#num patterns
+    [[ "$ref" =~ ^https://github\.com/ ]] || [[ "$ref" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+#[0-9]+$ ]]
+}
+
+provider_github_fetch_pr() {
+    local pr_number="$1"
+    local repo="$2"
+    gh pr view "$pr_number" --repo "$repo" --json number,title,author,headRefName,baseRefName,body,url 2>/dev/null
+}
+
+provider_github_fetch_issue() {
+    local issue_number="$1"
+    local repo="$2"
+    gh issue view "$issue_number" --repo "$repo" --json number,title,body,labels,url 2>/dev/null
+}
+
+provider_github_pr_merged() {
+    local pr_number="$1"
+    local repo="$2"
+    local merged
+    merged=$(gh pr view "$pr_number" --repo "$repo" --json merged 2>/dev/null | jq -r '.merged')
+    [[ "$merged" == "true" ]]
+}
+
+provider_github_issue_closed() {
+    local issue_number="$1"
+    local repo="$2"
+    local closed
+    closed=$(gh issue view "$issue_number" --repo "$repo" --json closed 2>/dev/null | jq -r '.closed')
+    [[ "$closed" == "true" ]]
+}
+
+provider_github_clone_url() {
+    local repo="$1"
+    echo "https://github.com/${repo}.git"
+}

--- a/skills/project-session-manager/lib/providers/interface.sh
+++ b/skills/project-session-manager/lib/providers/interface.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# PSM Provider Interface
+# Each provider implements: _available, _detect_ref, _fetch_issue, _issue_closed,
+#                          _fetch_pr (optional), _pr_merged (optional), _clone_url
+
+# List available providers
+provider_list() {
+    echo "github jira"
+}
+
+# Check if a provider is available (CLI installed)
+# Usage: provider_available "github"
+provider_available() {
+    local provider="$1"
+    "provider_${provider}_available"
+}
+
+# Dispatch to provider function
+# Usage: provider_call "github" "fetch_issue" "123" "owner/repo"
+provider_call() {
+    local provider="$1"
+    local func="$2"
+    shift 2
+    "provider_${provider}_${func}" "$@"
+}
+
+# Detect provider from reference (with config validation)
+# Usage: provider_detect_from_ref "PROJ-123"
+# Returns: provider name or empty
+provider_detect_from_ref() {
+    local ref="$1"
+
+    # Check Jira pattern first (config-validated)
+    if psm_detect_jira_key "$ref" >/dev/null 2>&1; then
+        echo "jira"
+        return 0
+    fi
+
+    # GitHub URL patterns
+    if [[ "$ref" =~ ^https://github\.com/ ]]; then
+        echo "github"
+        return 0
+    fi
+
+    # owner/repo#num pattern -> GitHub
+    if [[ "$ref" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+#[0-9]+$ ]]; then
+        echo "github"
+        return 0
+    fi
+
+    # Default
+    echo "github"
+}

--- a/skills/project-session-manager/lib/providers/jira.sh
+++ b/skills/project-session-manager/lib/providers/jira.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# PSM Jira Provider
+# Uses `jira` CLI (https://github.com/ankitpokhrel/jira-cli)
+
+provider_jira_available() {
+    command -v jira &> /dev/null
+}
+
+provider_jira_detect_ref() {
+    local ref="$1"
+    # Config-validated detection only
+    psm_detect_jira_key "$ref" >/dev/null 2>&1
+}
+
+provider_jira_fetch_issue() {
+    local issue_key="$1"  # e.g., "PROJ-123"
+    # Note: second arg (repo) is ignored for Jira
+    jira issue view "$issue_key" --output json 2>/dev/null
+}
+
+provider_jira_issue_closed() {
+    local issue_key="$1"
+    local status_category
+    status_category=$(jira issue view "$issue_key" --output json 2>/dev/null | jq -r '.fields.status.statusCategory.key')
+    # Jira status categories: "new", "indeterminate", "done"
+    [[ "$status_category" == "done" ]]
+}
+
+# Jira has no PRs - return error
+provider_jira_fetch_pr() {
+    echo '{"error": "Jira does not support pull requests"}' >&2
+    return 1
+}
+
+provider_jira_pr_merged() {
+    return 1  # Always false - Jira has no PRs
+}
+
+provider_jira_clone_url() {
+    local alias="$1"
+    # For Jira, we need to get clone_url from config
+    # First try explicit clone_url, then fall back to repo as GitHub
+    local clone_url
+    clone_url=$(psm_get_project_clone_url "$alias")
+    if [[ -n "$clone_url" ]]; then
+        echo "$clone_url"
+        return 0
+    fi
+
+    local repo
+    repo=$(psm_get_project_repo "$alias")
+    if [[ -n "$repo" ]]; then
+        echo "https://github.com/${repo}.git"
+        return 0
+    fi
+
+    echo "error: No clone_url or repo configured for alias '$alias'" >&2
+    return 1
+}
+
+# Parse Jira reference into components
+# Input: "PROJ-123" or "mywork#123"
+# Output: Extended format for session creation
+provider_jira_parse_ref() {
+    local ref="$1"
+    local jira_info
+
+    # Try direct PROJ-123 pattern
+    if jira_info=$(psm_detect_jira_key "$ref"); then
+        IFS='|' read -r alias project_key issue_number <<< "$jira_info"
+        local project_info
+        project_info=$(psm_get_project "$alias")
+        IFS='|' read -r repo local_path base <<< "$project_info"
+        echo "issue|${alias}|${repo}|${issue_number}|${local_path}|${base}|jira|${project_key}-${issue_number}"
+        return 0
+    fi
+
+    return 1
+}

--- a/skills/project-session-manager/lib/session.sh
+++ b/skills/project-session-manager/lib/session.sh
@@ -2,7 +2,7 @@
 # PSM Session Registry Management
 
 # Add session to registry
-# Usage: psm_add_session <id> <type> <project> <ref> <branch> <base> <tmux> <worktree> <source_repo> <metadata_json>
+# Usage: psm_add_session <id> <type> <project> <ref> <branch> <base> <tmux> <worktree> <source_repo> <metadata_json> [provider] [provider_ref]
 psm_add_session() {
     local id="$1"
     local type="$2"
@@ -14,6 +14,8 @@ psm_add_session() {
     local worktree="$8"
     local source_repo="$9"
     local metadata="${10:-{}}"
+    local provider="${11:-github}"
+    local provider_ref="${12:-}"
 
     local now=$(date -Iseconds)
 
@@ -28,6 +30,8 @@ psm_add_session() {
        --arg worktree "$worktree" \
        --arg source "$source_repo" \
        --arg now "$now" \
+       --arg provider "$provider" \
+       --arg provider_ref "$provider_ref" \
        --argjson meta "$metadata" \
        '.sessions[$id] = {
           "id": $id,
@@ -42,6 +46,8 @@ psm_add_session() {
           "created_at": $now,
           "last_accessed": $now,
           "state": "active",
+          "provider": $provider,
+          "provider_ref": $provider_ref,
           "metadata": $meta
         } | .stats.total_created += 1' \
        "$PSM_SESSIONS" > "$tmp" && mv "$tmp" "$PSM_SESSIONS"

--- a/skills/project-session-manager/psm.sh
+++ b/skills/project-session-manager/psm.sh
@@ -13,6 +13,11 @@ source "$SCRIPT_DIR/lib/worktree.sh"
 source "$SCRIPT_DIR/lib/tmux.sh"
 source "$SCRIPT_DIR/lib/session.sh"
 
+# Source provider files
+source "$SCRIPT_DIR/lib/providers/interface.sh"
+source "$SCRIPT_DIR/lib/providers/github.sh"
+source "$SCRIPT_DIR/lib/providers/jira.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -38,15 +43,14 @@ check_dependencies() {
         missing+=("jq")
     fi
 
-    if ! command -v gh &> /dev/null; then
-        missing+=("gh (GitHub CLI)")
-    fi
+    # Note: gh and jira are checked per-operation, not globally
+    # This allows users without gh to still use Jira, and vice versa
 
     if [[ ${#missing[@]} -gt 0 ]]; then
         log_error "Missing required dependencies: ${missing[*]}"
         log_info "Install with:"
-        log_info "  Ubuntu/Debian: sudo apt install git jq gh"
-        log_info "  macOS: brew install git jq gh"
+        log_info "  Ubuntu/Debian: sudo apt install git jq"
+        log_info "  macOS: brew install git jq"
         exit 1
     fi
 
@@ -106,7 +110,21 @@ cmd_review() {
         return 1
     fi
 
-    IFS='|' read -r type alias repo pr_number local_path base <<< "$parsed"
+    IFS='|' read -r type alias repo pr_number local_path base provider provider_ref <<< "$parsed"
+
+    # Provider guard: Jira doesn't have PRs
+    if [[ "$provider" == "jira" ]]; then
+        log_error "Jira issues cannot be 'reviewed' - Jira has no PR concept."
+        log_info "Use 'psm fix $ref' to work on a Jira issue instead."
+        log_info "Jira integration supports: fix, feature"
+        return 1
+    fi
+
+    # Check GitHub CLI availability
+    if ! provider_github_available; then
+        log_error "GitHub CLI (gh) not found. Install: brew install gh"
+        return 1
+    fi
 
     if [[ -z "$repo" ]]; then
         log_error "Could not determine repository"
@@ -117,7 +135,7 @@ cmd_review() {
 
     # Fetch PR info
     local pr_info
-    pr_info=$(gh pr view "$pr_number" --repo "$repo" --json number,title,author,headRefName,baseRefName,body,url 2>/dev/null) || {
+    pr_info=$(provider_call "github" fetch_pr "$pr_number" "$repo") || {
         log_error "Failed to fetch PR #${pr_number}. Check if the PR exists and you have access."
         return 1
     }
@@ -143,7 +161,9 @@ cmd_review() {
         local_path="${HOME}/Workspace/$(basename "$repo")"
         if [[ ! -d "$local_path" ]]; then
             log_info "Cloning repository to $local_path..."
-            git clone "https://github.com/${repo}.git" "$local_path" || {
+            local clone_url
+            clone_url=$(provider_call "github" clone_url "$repo")
+            git clone "$clone_url" "$local_path" || {
                 log_error "Failed to clone repository"
                 return 1
             }
@@ -209,7 +229,7 @@ EOF
 )
 
     # Add to registry
-    psm_add_session "$session_id" "review" "$alias" "pr-${pr_number}" "$head_branch" "$base_branch" "$session_name" "$worktree_path" "$local_path" "$metadata"
+    psm_add_session "$session_id" "review" "$alias" "pr-${pr_number}" "$head_branch" "$base_branch" "$session_name" "$worktree_path" "$local_path" "$metadata" "github" "${repo}#${pr_number}"
 
     # Output summary
     echo ""
@@ -242,24 +262,45 @@ cmd_fix() {
         return 1
     fi
 
-    IFS='|' read -r type alias repo issue_number local_path base <<< "$parsed"
+    IFS='|' read -r type alias repo issue_number local_path base provider provider_ref <<< "$parsed"
 
-    if [[ -z "$repo" ]]; then
+    # Check provider CLI availability
+    if [[ "$provider" == "jira" ]]; then
+        if ! provider_jira_available; then
+            log_error "Jira CLI not found. Install: brew install ankitpokhrel/jira-cli/jira-cli"
+            return 1
+        fi
+    else
+        if ! provider_github_available; then
+            log_error "GitHub CLI (gh) not found. Install: brew install gh"
+            return 1
+        fi
+    fi
+
+    if [[ -z "$repo" && "$provider" != "jira" ]]; then
         log_error "Could not determine repository"
         return 1
     fi
 
-    log_info "Fetching issue #${issue_number} from ${repo}..."
+    log_info "Fetching issue #${issue_number}..."
 
     # Fetch issue info
     local issue_info
-    issue_info=$(gh issue view "$issue_number" --repo "$repo" --json number,title,body,labels,url 2>/dev/null) || {
-        log_error "Failed to fetch issue #${issue_number}"
-        return 1
-    }
-
-    local issue_title=$(echo "$issue_info" | jq -r '.title')
-    local issue_url=$(echo "$issue_info" | jq -r '.url')
+    if [[ "$provider" == "jira" ]]; then
+        issue_info=$(provider_call "jira" fetch_issue "$provider_ref") || {
+            log_error "Failed to fetch Jira issue ${provider_ref}"
+            return 1
+        }
+        local issue_title=$(echo "$issue_info" | jq -r '.fields.summary')
+        local issue_url=$(echo "$issue_info" | jq -r '.self // empty')
+    else
+        issue_info=$(provider_call "github" fetch_issue "$issue_number" "$repo") || {
+            log_error "Failed to fetch issue #${issue_number}"
+            return 1
+        }
+        local issue_title=$(echo "$issue_info" | jq -r '.title')
+        local issue_url=$(echo "$issue_info" | jq -r '.url')
+    fi
     local slug=$(psm_slugify "$issue_title" 20)
 
     log_info "Issue: #${issue_number} - ${issue_title}"
@@ -271,10 +312,19 @@ cmd_fix() {
 
     # Determine local path
     if [[ -z "$local_path" || ! -d "$local_path" ]]; then
-        local_path="${HOME}/Workspace/$(basename "$repo")"
+        local_path="${HOME}/Workspace/$(basename "${repo:-$alias}")"
         if [[ ! -d "$local_path" ]]; then
             log_info "Cloning repository..."
-            git clone "https://github.com/${repo}.git" "$local_path" || return 1
+            local clone_url
+            if [[ "$provider" == "jira" ]]; then
+                clone_url=$(provider_call "jira" clone_url "$alias") || {
+                    log_error "Failed to get clone URL for '$alias'. Configure 'repo' or 'clone_url' in projects.json"
+                    return 1
+                }
+            else
+                clone_url=$(provider_call "github" clone_url "$repo")
+            fi
+            git clone "$clone_url" "$local_path" || return 1
         fi
     fi
 
@@ -318,7 +368,7 @@ cmd_fix() {
 EOF
 )
 
-    psm_add_session "$session_id" "fix" "$alias" "issue-${issue_number}" "$branch_name" "$base" "$session_name" "$worktree_path" "$local_path" "$metadata"
+    psm_add_session "$session_id" "fix" "$alias" "issue-${issue_number}" "$branch_name" "$base" "$session_name" "$worktree_path" "$local_path" "$metadata" "$provider" "$provider_ref"
 
     echo ""
     log_success "Session ready!"
@@ -473,15 +523,20 @@ cmd_cleanup() {
 
     local cleaned=0
 
-    # Check PR sessions (use process substitution to avoid subshell)
+    # Check PR sessions (GitHub only)
     while IFS='|' read -r id pr_number project; do
         if [[ -z "$id" ]]; then continue; fi
+
+        local session_json=$(psm_get_session "$id")
+        local provider=$(echo "$session_json" | jq -r '.provider // "github"')
+
+        # Only GitHub has PRs
+        if [[ "$provider" != "github" ]]; then continue; fi
 
         local repo=$(psm_get_project "$project" | cut -d'|' -f1)
 
         if [[ -n "$repo" && -n "$pr_number" ]]; then
-            local pr_state=$(gh pr view "$pr_number" --repo "$repo" --json merged 2>/dev/null | jq -r '.merged')
-            if [[ "$pr_state" == "true" ]]; then
+            if provider_github_available && provider_call "github" pr_merged "$pr_number" "$repo"; then
                 log_info "PR #${pr_number} is merged - cleaning up $id"
                 cmd_kill "$id"
                 ((cleaned++))
@@ -489,18 +544,32 @@ cmd_cleanup() {
         fi
     done < <(psm_get_review_sessions)
 
-    # Check issue sessions (use process substitution to avoid subshell)
+    # Check issue sessions (GitHub and Jira)
     while IFS='|' read -r id issue_number project; do
         if [[ -z "$id" ]]; then continue; fi
 
-        local repo=$(psm_get_project "$project" | cut -d'|' -f1)
+        local session_json=$(psm_get_session "$id")
+        local provider=$(echo "$session_json" | jq -r '.provider // "github"')
+        local provider_ref=$(echo "$session_json" | jq -r '.provider_ref // empty')
 
-        if [[ -n "$repo" && -n "$issue_number" ]]; then
-            local issue_state=$(gh issue view "$issue_number" --repo "$repo" --json closed 2>/dev/null | jq -r '.closed')
-            if [[ "$issue_state" == "true" ]]; then
-                log_info "Issue #${issue_number} is closed - cleaning up $id"
-                cmd_kill "$id"
-                ((cleaned++))
+        if [[ "$provider" == "jira" ]]; then
+            # Jira cleanup
+            if provider_jira_available && [[ -n "$provider_ref" ]]; then
+                if provider_call "jira" issue_closed "$provider_ref"; then
+                    log_info "Jira issue ${provider_ref} is done - cleaning up $id"
+                    cmd_kill "$id"
+                    ((cleaned++))
+                fi
+            fi
+        else
+            # GitHub cleanup
+            local repo=$(psm_get_project "$project" | cut -d'|' -f1)
+            if provider_github_available && [[ -n "$repo" && -n "$issue_number" ]]; then
+                if provider_call "github" issue_closed "$issue_number" "$repo"; then
+                    log_info "Issue #${issue_number} is closed - cleaning up $id"
+                    cmd_kill "$id"
+                    ((cleaned++))
+                fi
             fi
         fi
     done < <(psm_get_fix_sessions)


### PR DESCRIPTION
## Summary

Verification of [PR #207](https://github.com/Yeachan-Heo/oh-my-claudecode/pull/207) from upstream.

This PR adds a provider abstraction layer to PSM (Project Session Manager) enabling multiple issue tracker backends. Initially supports GitHub (existing) and Jira (new).

### Key Changes

- **Provider interface** (`lib/providers/interface.sh`): Dispatch, detection, and availability checking
- **GitHub provider** (`lib/providers/github.sh`): Extracted existing GitHub-specific logic
- **Jira provider** (`lib/providers/jira.sh`): New provider using `jira` CLI
- **Config extensions**: `psm_get_project_provider()`, `jira_project`, `clone_url` fields
- **Parse extensions**: `psm_detect_jira_key()` for `PROJ-123` patterns (config-validated)
- **Session extensions**: `provider` and `provider_ref` fields in registry
- **Backward compatible**: Global `gh` CLI dependency removed (checked per-operation)

### Verification Results

- [x] All bash -n syntax checks pass (psm.sh, lib/*.sh, lib/providers/*.sh)
- [x] TypeScript build successful (`npx tsc --noEmit`)
- [x] All 1705 tests pass (`npm test`)

### Code Quality Review

- Config-validated Jira detection prevents false positives from patterns like `FIX-123`
- Dual-reference model ensures Jira aliases have both issue tracker and git repo config
- Clear error messages when Jira CLI unavailable or `psm review` used with Jira
- Provider dispatch through `provider_call()` keeps code modular

## Test plan

- [ ] `psm fix omc#123` works unchanged (backward compatibility)
- [ ] `psm review https://github.com/owner/repo/pull/1` works unchanged
- [ ] `psm fix MYPROJ-123` creates session when MYPROJ is configured as `jira_project`
- [ ] `psm review MYPROJ-123` returns clear error ("Jira has no PR concept")
- [ ] `psm cleanup` handles mixed GitHub/Jira sessions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)