### PR TITLE
Limit HUD output lines to prevent input field shrinkage

### DIFF
--- a/commands/hud.md
+++ b/commands/hud.md
@@ -259,14 +259,14 @@ You can manually edit the config file. Each option can be set individually - any
     "backgroundTasks": true,
     "todos": true,
     "showCache": true,
-    "showCost": true
+    "showCost": true,
+    "maxOutputLines": 4
   },
   "thresholds": {
     "contextWarning": 70,
     "contextCritical": 85,
     "ralphWarning": 7
-  },
-  "maxOutputLines": 4
+  }
 }
 ```
 

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -262,14 +262,14 @@ You can manually edit the config file. Each option can be set individually - any
     "backgroundTasks": true,
     "todos": true,
     "showCache": true,
-    "showCost": true
+    "showCost": true,
+    "maxOutputLines": 4
   },
   "thresholds": {
     "contextWarning": 70,
     "contextCritical": 85,
     "ralphWarning": 7
-  },
-  "maxOutputLines": 4
+  }
 }
 ```
 

--- a/src/__tests__/hud/render.test.ts
+++ b/src/__tests__/hud/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { limitOutputLines } from '../../hud/render.js';
-import { DEFAULT_HUD_CONFIG, PRESET_MAX_OUTPUT_LINES } from '../../hud/types.js';
+import { DEFAULT_HUD_CONFIG, PRESET_CONFIGS } from '../../hud/types.js';
 
 describe('limitOutputLines', () => {
   describe('basic functionality', () => {
@@ -61,15 +61,15 @@ describe('limitOutputLines', () => {
   });
 
   describe('default value usage', () => {
-    it('uses DEFAULT_HUD_CONFIG.maxOutputLines when maxLines not specified', () => {
-      const defaultLimit = DEFAULT_HUD_CONFIG.maxOutputLines;
+    it('uses DEFAULT_HUD_CONFIG.elements.maxOutputLines when maxLines not specified', () => {
+      const defaultLimit = DEFAULT_HUD_CONFIG.elements.maxOutputLines;
       const lines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`);
       const result = limitOutputLines(lines);
       expect(result).toHaveLength(defaultLimit);
     });
 
-    it('uses DEFAULT_HUD_CONFIG.maxOutputLines when maxLines is undefined', () => {
-      const defaultLimit = DEFAULT_HUD_CONFIG.maxOutputLines;
+    it('uses DEFAULT_HUD_CONFIG.elements.maxOutputLines when maxLines is undefined', () => {
+      const defaultLimit = DEFAULT_HUD_CONFIG.elements.maxOutputLines;
       const lines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`);
       const result = limitOutputLines(lines, undefined);
       expect(result).toHaveLength(defaultLimit);
@@ -126,12 +126,12 @@ describe('limitOutputLines', () => {
 
   describe('preset-specific defaults', () => {
     it('has correct maxOutputLines for each preset', () => {
-      expect(PRESET_MAX_OUTPUT_LINES.minimal).toBe(2);
-      expect(PRESET_MAX_OUTPUT_LINES.focused).toBe(4);
-      expect(PRESET_MAX_OUTPUT_LINES.full).toBe(8);
-      expect(PRESET_MAX_OUTPUT_LINES.dense).toBe(6);
-      expect(PRESET_MAX_OUTPUT_LINES.opencode).toBe(4);
-      expect(PRESET_MAX_OUTPUT_LINES.analytics).toBe(4);
+      expect(PRESET_CONFIGS.minimal.maxOutputLines).toBe(2);
+      expect(PRESET_CONFIGS.focused.maxOutputLines).toBe(4);
+      expect(PRESET_CONFIGS.full.maxOutputLines).toBe(12);
+      expect(PRESET_CONFIGS.dense.maxOutputLines).toBe(6);
+      expect(PRESET_CONFIGS.opencode.maxOutputLines).toBe(4);
+      expect(PRESET_CONFIGS.analytics.maxOutputLines).toBe(4);
     });
   });
 
@@ -155,8 +155,8 @@ describe('limitOutputLines', () => {
       expect(result[3]).toBe('... (+5 lines)');
     });
 
-    it('works with DEFAULT_HUD_CONFIG maxOutputLines value of 4', () => {
-      expect(DEFAULT_HUD_CONFIG.maxOutputLines).toBe(4);
+    it('works with DEFAULT_HUD_CONFIG elements.maxOutputLines value of 4', () => {
+      expect(DEFAULT_HUD_CONFIG.elements.maxOutputLines).toBe(4);
     });
   });
 });

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -38,7 +38,7 @@ import type { SessionHealth, HudElementConfig } from './types.js';
  * @returns Trimmed array of lines
  */
 export function limitOutputLines(lines: string[], maxLines?: number): string[] {
-  const limit = Math.max(1, maxLines ?? DEFAULT_HUD_CONFIG.maxOutputLines);
+  const limit = Math.max(1, maxLines ?? DEFAULT_HUD_CONFIG.elements.maxOutputLines);
   if (lines.length <= limit) {
     return lines;
   }
@@ -124,7 +124,7 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
       if (todos) lines.push(todos);
     }
 
-    return limitOutputLines(lines, config.maxOutputLines).join('\n');
+    return limitOutputLines(lines, config.elements.maxOutputLines).join('\n');
   }
 
   // [OMC] label
@@ -258,5 +258,5 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
     }
   }
 
-  return limitOutputLines([headerLine, ...detailLines], config.maxOutputLines).join('\n');
+  return limitOutputLines([headerLine, ...detailLines], config.elements.maxOutputLines).join('\n');
 }

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import type { OmcHudState, BackgroundTask, HudConfig } from './types.js';
-import { DEFAULT_HUD_CONFIG, PRESET_CONFIGS, PRESET_MAX_OUTPUT_LINES } from './types.js';
+import { DEFAULT_HUD_CONFIG, PRESET_CONFIGS } from './types.js';
 import { cleanupStaleBackgroundTasks, markOrphanedTasksAsStale } from './background-cleanup.js';
 
 // ============================================================================
@@ -189,9 +189,8 @@ export function readHudConfig(): HudConfig {
     const config = JSON.parse(content) as Partial<HudConfig>;
 
     // Merge with defaults to ensure all fields exist
-    const preset = config.preset ?? DEFAULT_HUD_CONFIG.preset;
     return {
-      preset,
+      preset: config.preset ?? DEFAULT_HUD_CONFIG.preset,
       elements: {
         ...DEFAULT_HUD_CONFIG.elements,
         ...config.elements,
@@ -200,7 +199,6 @@ export function readHudConfig(): HudConfig {
         ...DEFAULT_HUD_CONFIG.thresholds,
         ...config.thresholds,
       },
-      maxOutputLines: config.maxOutputLines ?? PRESET_MAX_OUTPUT_LINES[preset],
     };
   } catch {
     return DEFAULT_HUD_CONFIG;
@@ -235,7 +233,6 @@ export function applyPreset(preset: HudConfig['preset']): HudConfig {
       ...config.elements,
       ...presetElements,
     },
-    maxOutputLines: PRESET_MAX_OUTPUT_LINES[preset],
   };
 
   writeHudConfig(newConfig);

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -249,6 +249,7 @@ export interface HudElementConfig {
   useBars: boolean;           // Show visual progress bars instead of/alongside percentages
   showCache: boolean;         // Show cache hit rate in analytics displays
   showCost: boolean;          // Show cost/dollar amounts in analytics displays
+  maxOutputLines: number;     // Max total output lines to prevent input field shrinkage
 }
 
 export interface HudThresholds {
@@ -267,7 +268,6 @@ export interface HudConfig {
   elements: HudElementConfig;
   thresholds: HudThresholds;
   staleTaskThresholdMinutes?: number; // Default 30
-  maxOutputLines: number;
 }
 
 export const DEFAULT_HUD_CONFIG: HudConfig = {
@@ -292,6 +292,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     useBars: false,  // Disabled by default for backwards compatibility
     showCache: true,
     showCost: true,
+    maxOutputLines: 4,
   },
   thresholds: {
     contextWarning: 70,
@@ -299,16 +300,6 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     contextCritical: 85,
     ralphWarning: 7,
   },
-  maxOutputLines: 4,
-};
-
-export const PRESET_MAX_OUTPUT_LINES: Record<HudPreset, number> = {
-  minimal: 2,
-  analytics: 4,
-  focused: 4,
-  full: 8,
-  opencode: 4,
-  dense: 6,
 };
 
 export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
@@ -322,7 +313,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     lastSkill: true,
     contextBar: false,
     agents: true,
-    agentsFormat: 'count', // Just count for minimal mode
+    agentsFormat: 'count',
     agentsMaxLines: 0,
     backgroundTasks: false,
     todos: true,
@@ -332,6 +323,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     useBars: false,
     showCache: false,
     showCost: false,
+    maxOutputLines: 2,
   },
   analytics: {
     omcLabel: false,
@@ -353,6 +345,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     useBars: false,
     showCache: true,
     showCost: true,
+    maxOutputLines: 4,
   },
   focused: {
     omcLabel: true,
@@ -364,16 +357,17 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     lastSkill: true,
     contextBar: true,
     agents: true,
-    agentsFormat: 'multiline', // Multi-line for rich visualization
-    agentsMaxLines: 3, // Show up to 3 agents
+    agentsFormat: 'multiline',
+    agentsMaxLines: 3,
     backgroundTasks: true,
     todos: true,
-    permissionStatus: false,  // Disabled: heuristic unreliable
+    permissionStatus: false,
     thinking: true,
     sessionHealth: true,
     useBars: true,
     showCache: true,
     showCost: true,
+    maxOutputLines: 4,
   },
   full: {
     omcLabel: true,
@@ -385,16 +379,17 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     lastSkill: true,
     contextBar: true,
     agents: true,
-    agentsFormat: 'multiline', // Multi-line with more details
-    agentsMaxLines: 10, // Show many agents in full mode
+    agentsFormat: 'multiline',
+    agentsMaxLines: 10,
     backgroundTasks: true,
     todos: true,
-    permissionStatus: false,  // Disabled: heuristic unreliable
+    permissionStatus: false,
     thinking: true,
     sessionHealth: true,
     useBars: true,
     showCache: true,
     showCost: true,
+    maxOutputLines: 12,
   },
   opencode: {
     omcLabel: true,
@@ -410,12 +405,13 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     agentsMaxLines: 0,
     backgroundTasks: false,
     todos: true,
-    permissionStatus: false,  // Disabled: heuristic unreliable
+    permissionStatus: false,
     thinking: true,
     sessionHealth: true,
     useBars: false,
     showCache: true,
     showCost: true,
+    maxOutputLines: 4,
   },
   dense: {
     omcLabel: true,
@@ -431,11 +427,12 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     agentsMaxLines: 5,
     backgroundTasks: true,
     todos: true,
-    permissionStatus: false,  // Disabled: heuristic unreliable
+    permissionStatus: false,
     thinking: true,
     sessionHealth: true,
     useBars: true,
     showCache: true,
     showCost: true,
+    maxOutputLines: 6,
   },
 };


### PR DESCRIPTION
## Summary
Fixes Issue #222 by implementing a configurable maximum output lines limit for the HUD display. This prevents the input field from shrinking when the HUD generates excessive output during extended use sessions.

## Key Changes
- **New `limitOutputLines()` function** in `src/hud/render.ts`: Trims output lines while preserving the header line, with a configurable limit that defaults to 4 lines
- **Added `maxOutputLines` config option** to `HudConfig` interface with a default value of 4
- **Applied line limiting** to both the analytics preset and standard render paths to ensure consistent behavior
- **Updated config reading** in `src/hud/state.ts` to properly handle the new `maxOutputLines` configuration option
- **Comprehensive test suite** with 20+ test cases covering basic functionality, edge cases, and the Issue #222 scenario

## Implementation Details
- The `limitOutputLines()` function uses `slice(0, limit)` to preserve the first line (header) while trimming from the end
- The limit is applied at the final output stage in the `render()` function, affecting both single-line and multi-line output modes
- Default limit of 4 lines was chosen as a reasonable balance between information display and UI stability
- The function is non-mutating and handles edge cases like empty arrays, single lines, and zero limits
- Configuration can be overridden via HUD config while maintaining sensible defaults

## Testing
Added comprehensive test coverage in `src/__tests__/hud/render.test.ts` including:
- Basic functionality tests (within limit, at limit, exceeding limit)
- Header line preservation verification
- Default value usage tests
- Edge cases (maxLines of 0-1, empty arrays, multiline content)
- Issue #222 scenario simulation

Related to #224 