### PR TITLE
fix(hud): implement staleTaskThresholdMinutes config option

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -277,8 +277,13 @@ async function main(): Promise<void> {
 
     const cwd = stdin.cwd || process.cwd();
 
+    // Read configuration (before transcript parsing so we can use staleTaskThresholdMinutes)
+    const config = readHudConfig();
+
     // Parse transcript for agents and todos
-    const transcriptData = await parseTranscript(stdin.transcript_path);
+    const transcriptData = await parseTranscript(stdin.transcript_path, {
+      staleTaskThresholdMinutes: config.staleTaskThresholdMinutes,
+    });
 
     // Record token usage (auto-tracking)
     await recordTokenUsage(stdin, transcriptData);
@@ -292,9 +297,6 @@ async function main(): Promise<void> {
     // Read HUD state for background tasks
     const hudState = readHudState(cwd);
     const backgroundTasks = hudState?.backgroundTasks || [];
-
-    // Read configuration
-    const config = readHudConfig();
 
     // Fetch rate limits from OAuth API (if available)
     const rateLimits = config.elements.rateLimits !== false

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -199,6 +199,7 @@ export function readHudConfig(): HudConfig {
         ...DEFAULT_HUD_CONFIG.thresholds,
         ...config.thresholds,
       },
+      staleTaskThresholdMinutes: config.staleTaskThresholdMinutes ?? DEFAULT_HUD_CONFIG.staleTaskThresholdMinutes,
     };
   } catch {
     return DEFAULT_HUD_CONFIG;

--- a/src/hud/transcript.ts
+++ b/src/hud/transcript.ts
@@ -58,8 +58,13 @@ const THINKING_RECENCY_MS = 30_000; // 30 seconds
  *
  * For large files (>500KB), only parses the tail portion for performance.
  */
+export interface ParseTranscriptOptions {
+  staleTaskThresholdMinutes?: number;
+}
+
 export async function parseTranscript(
-  transcriptPath: string | undefined
+  transcriptPath: string | undefined,
+  options?: ParseTranscriptOptions
 ): Promise<TranscriptData> {
   // IMPORTANT: Clear module-level state at the start of each parse
   // to prevent stale data from previous HUD invocations
@@ -119,8 +124,9 @@ export async function parseTranscript(
     // Return partial results on error
   }
 
-  // Filter out stale agents (running for more than 30 minutes are likely abandoned)
-  const STALE_AGENT_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+  // Filter out stale agents (running for more than threshold minutes are likely abandoned)
+  const staleMinutes = options?.staleTaskThresholdMinutes ?? 30;
+  const STALE_AGENT_THRESHOLD_MS = staleMinutes * 60 * 1000;
   const now = Date.now();
 
   for (const agent of agentMap.values()) {

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -266,7 +266,7 @@ export interface HudConfig {
   preset: HudPreset;
   elements: HudElementConfig;
   thresholds: HudThresholds;
-  staleTaskThresholdMinutes?: number; // Default 30
+  staleTaskThresholdMinutes: number; // Default 30
 }
 
 export const DEFAULT_HUD_CONFIG: HudConfig = {
@@ -298,6 +298,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     contextCritical: 85,
     ralphWarning: 7,
   },
+  staleTaskThresholdMinutes: 30,
 };
 
 export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {


### PR DESCRIPTION
## Summary

- Makes `staleTaskThresholdMinutes` a required field in `HudConfig` with default value `30`
- Passes the config value to `parseTranscript` instead of using a hardcoded `30 * 60 * 1000`
- Moves `readHudConfig()` call before `parseTranscript()` in HUD main so the value is available

## Files Changed

- `src/hud/types.ts` - Made field required, added default to `DEFAULT_HUD_CONFIG`
- `src/hud/state.ts` - Included field in config merge
- `src/hud/transcript.ts` - Added `ParseTranscriptOptions`, use config value for stale threshold
- `src/hud/index.ts` - Read config earlier, pass `staleTaskThresholdMinutes` to `parseTranscript`

## Test plan

- [x] `npm run build` passes
- [x] All 114 HUD tests pass (`npm test -- hud`)

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)