### PR TITLE
fix(hooks): use decision:block instead of continue:true in Stop hook

### DIFF
--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -217,8 +217,8 @@ async function main() {
         writeJsonFile(ralph.path, ralph.state);
 
         console.log(JSON.stringify({
-          continue: true,
-          message: `[RALPH LOOP - ITERATION ${iteration + 1}/${maxIter}] Work is NOT done. Continue. When complete, output: <promise>${ralph.state.completion_promise || 'DONE'}</promise>\n${ralph.state.prompt ? `Task: ${ralph.state.prompt}` : ''}`
+          decision: 'block',
+          reason: `[RALPH LOOP - ITERATION ${iteration + 1}/${maxIter}] Work is NOT done. Continue. When complete, output: <promise>${ralph.state.completion_promise || 'DONE'}</promise>\n${ralph.state.prompt ? `Task: ${ralph.state.prompt}` : ''}`
         }));
         return;
       }
@@ -234,8 +234,8 @@ async function main() {
           writeJsonFile(autopilot.path, autopilot.state);
 
           console.log(JSON.stringify({
-            continue: true,
-            message: `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working.`
+            decision: 'block',
+            reason: `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working.`
           }));
           return;
         }
@@ -253,8 +253,8 @@ async function main() {
           writeJsonFile(ultrapilot.path, ultrapilot.state);
 
           console.log(JSON.stringify({
-            continue: true,
-            message: `[ULTRAPILOT] ${incomplete} workers still running. Continue.`
+            decision: 'block',
+            reason: `[ULTRAPILOT] ${incomplete} workers still running. Continue.`
           }));
           return;
         }
@@ -271,8 +271,8 @@ async function main() {
           writeJsonFile(join(stateDir, 'swarm-summary.json'), swarmSummary);
 
           console.log(JSON.stringify({
-            continue: true,
-            message: `[SWARM ACTIVE] ${pending} tasks remain. Continue working.`
+            decision: 'block',
+            reason: `[SWARM ACTIVE] ${pending} tasks remain. Continue working.`
           }));
           return;
         }
@@ -290,8 +290,8 @@ async function main() {
           writeJsonFile(pipeline.path, pipeline.state);
 
           console.log(JSON.stringify({
-            continue: true,
-            message: `[PIPELINE - Stage ${currentStage + 1}/${totalStages}] Pipeline not complete. Continue.`
+            decision: 'block',
+            reason: `[PIPELINE - Stage ${currentStage + 1}/${totalStages}] Pipeline not complete. Continue.`
           }));
           return;
         }
@@ -307,8 +307,8 @@ async function main() {
         writeJsonFile(ultraqa.path, ultraqa.state);
 
         console.log(JSON.stringify({
-          continue: true,
-          message: `[ULTRAQA - Cycle ${cycle + 1}/${maxCycles}] Tests not all passing. Continue fixing.`
+          decision: 'block',
+          reason: `[ULTRAQA - Cycle ${cycle + 1}/${maxCycles}] Tests not all passing. Continue fixing.`
         }));
         return;
       }
@@ -321,10 +321,8 @@ async function main() {
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 
       if (newCount > maxReinforcements) {
-        console.log(JSON.stringify({
-          continue: true,
-          reason: `[ULTRAWORK ESCAPE] Max reinforcements (${maxReinforcements}) reached. Allowing stop.`
-        }));
+        // Max reinforcements reached - allow stop
+        console.log(JSON.stringify({ continue: true }));
         return;
       }
 
@@ -343,8 +341,8 @@ async function main() {
       }
 
       console.log(JSON.stringify({
-        continue: true,
-        message: reason
+        decision: 'block',
+        reason: reason
       }));
       return;
     }
@@ -355,10 +353,8 @@ async function main() {
       const maxReinforcements = ecomode.state.max_reinforcements || 50;
 
       if (newCount > maxReinforcements) {
-        console.log(JSON.stringify({
-          continue: true,
-          reason: `[ECOMODE ESCAPE] Max reinforcements (${maxReinforcements}) reached. Allowing stop.`
-        }));
+        // Max reinforcements reached - allow stop
+        console.log(JSON.stringify({ continue: true }));
         return;
       }
 
@@ -372,8 +368,8 @@ async function main() {
       }
 
       console.log(JSON.stringify({
-        continue: true,
-        message: reason
+        decision: 'block',
+        reason: reason
       }));
       return;
     }

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -215,8 +215,8 @@ async function main() {
         writeJsonFile(ralph.path, ralph.state);
 
         console.log(JSON.stringify({
-          continue: true,
-          message: `[RALPH LOOP - ITERATION ${iteration + 1}/${maxIter}] Work is NOT done. Continue. When complete, output: <promise>${ralph.state.completion_promise || 'DONE'}</promise>\n${ralph.state.prompt ? `Task: ${ralph.state.prompt}` : ''}`
+          decision: 'block',
+          reason: `[RALPH LOOP - ITERATION ${iteration + 1}/${maxIter}] Work is NOT done. Continue. When complete, output: <promise>${ralph.state.completion_promise || 'DONE'}</promise>\n${ralph.state.prompt ? `Task: ${ralph.state.prompt}` : ''}`
         }));
         return;
       }
@@ -232,8 +232,8 @@ async function main() {
           writeJsonFile(autopilot.path, autopilot.state);
 
           console.log(JSON.stringify({
-            continue: true,
-            message: `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working.`
+            decision: 'block',
+            reason: `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working.`
           }));
           return;
         }
@@ -251,8 +251,8 @@ async function main() {
           writeJsonFile(ultrapilot.path, ultrapilot.state);
 
           console.log(JSON.stringify({
-            continue: true,
-            message: `[ULTRAPILOT] ${incomplete} workers still running. Continue.`
+            decision: 'block',
+            reason: `[ULTRAPILOT] ${incomplete} workers still running. Continue.`
           }));
           return;
         }
@@ -269,8 +269,8 @@ async function main() {
           writeJsonFile(join(stateDir, 'swarm-summary.json'), swarmSummary);
 
           console.log(JSON.stringify({
-            continue: true,
-            message: `[SWARM ACTIVE] ${pending} tasks remain. Continue working.`
+            decision: 'block',
+            reason: `[SWARM ACTIVE] ${pending} tasks remain. Continue working.`
           }));
           return;
         }
@@ -288,8 +288,8 @@ async function main() {
           writeJsonFile(pipeline.path, pipeline.state);
 
           console.log(JSON.stringify({
-            continue: true,
-            message: `[PIPELINE - Stage ${currentStage + 1}/${totalStages}] Pipeline not complete. Continue.`
+            decision: 'block',
+            reason: `[PIPELINE - Stage ${currentStage + 1}/${totalStages}] Pipeline not complete. Continue.`
           }));
           return;
         }
@@ -305,8 +305,8 @@ async function main() {
         writeJsonFile(ultraqa.path, ultraqa.state);
 
         console.log(JSON.stringify({
-          continue: true,
-          message: `[ULTRAQA - Cycle ${cycle + 1}/${maxCycles}] Tests not all passing. Continue fixing.`
+          decision: 'block',
+          reason: `[ULTRAQA - Cycle ${cycle + 1}/${maxCycles}] Tests not all passing. Continue fixing.`
         }));
         return;
       }
@@ -319,10 +319,8 @@ async function main() {
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 
       if (newCount > maxReinforcements) {
-        console.log(JSON.stringify({
-          continue: true,
-          reason: `[ULTRAWORK ESCAPE] Max reinforcements (${maxReinforcements}) reached. Allowing stop.`
-        }));
+        // Max reinforcements reached - allow stop
+        console.log(JSON.stringify({ continue: true }));
         return;
       }
 
@@ -340,8 +338,8 @@ async function main() {
       }
 
       console.log(JSON.stringify({
-        continue: true,
-        message: reason
+        decision: 'block',
+        reason: reason
       }));
       return;
     }
@@ -352,10 +350,8 @@ async function main() {
       const maxReinforcements = ecomode.state.max_reinforcements || 50;
 
       if (newCount > maxReinforcements) {
-        console.log(JSON.stringify({
-          continue: true,
-          reason: `[ECOMODE ESCAPE] Max reinforcements (${maxReinforcements}) reached. Allowing stop.`
-        }));
+        // Max reinforcements reached - allow stop
+        console.log(JSON.stringify({ continue: true }));
         return;
       }
 
@@ -369,8 +365,8 @@ async function main() {
       }
 
       console.log(JSON.stringify({
-        continue: true,
-        message: reason
+        decision: 'block',
+        reason: reason
       }));
       return;
     }


### PR DESCRIPTION
## Summary
- Fixed the persistent-mode Stop hook which was using `{ continue: true }` instead of `{ decision: "block" }`
- The old approach was a no-op - it always allowed stops instead of blocking them
- Changed all 8 mode handlers (ralph, autopilot, ultrapilot, swarm, pipeline, ultraqa, ultrawork, ecomode) to properly block stops

## Test plan
- [x] All 1791 existing tests pass
- [ ] Manual test: activate ultrawork mode and verify Claude doesn't stop prematurely
- [ ] Manual test: verify context-limit and user-abort stops are still allowed

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)