### PR TITLE
fix(hooks): add completion promise checking to Ultrawork and Ecomode

### DIFF
--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -331,10 +331,11 @@ async function main() {
       writeJsonFile(ultrawork.path, ultrawork.state);
 
       // Build continuation message
-      let reason = `[ULTRAWORK #${newCount}] Mode active - continue working.`;
+      const promise = ultrawork.state.completion_promise || 'DONE';
+      let reason = `[ULTRAWORK #${newCount}] Mode active - continue working. When complete, output: <promise>${promise}</promise>`;
       if (totalIncomplete > 0) {
         const itemType = taskCount > 0 ? 'Tasks' : 'todos';
-        reason = `[ULTRAWORK #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working.`;
+        reason = `[ULTRAWORK #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working. When complete, output: <promise>${promise}</promise>`;
       }
       if (ultrawork.state.original_prompt) {
         reason += `\nTask: ${ultrawork.state.original_prompt}`;
@@ -361,10 +362,14 @@ async function main() {
       ecomode.state.reinforcement_count = newCount;
       writeJsonFile(ecomode.path, ecomode.state);
 
-      let reason = `[ECOMODE #${newCount}] Mode active - continue working.`;
+      const promise = ecomode.state.completion_promise || 'DONE';
+      let reason = `[ECOMODE #${newCount}] Mode active - continue working. When complete, output: <promise>${promise}</promise>`;
       if (totalIncomplete > 0) {
         const itemType = taskCount > 0 ? 'Tasks' : 'todos';
-        reason = `[ECOMODE #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working.`;
+        reason = `[ECOMODE #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working. When complete, output: <promise>${promise}</promise>`;
+      }
+      if (ecomode.state.original_prompt) {
+        reason += `\nTask: ${ecomode.state.original_prompt}`;
       }
 
       console.log(JSON.stringify({

--- a/src/hooks/ultrawork/index.ts
+++ b/src/hooks/ultrawork/index.ts
@@ -25,6 +25,8 @@ export interface UltraworkState {
   last_checked_at: string;
   /** Whether this ultrawork session is linked to a ralph-loop session */
   linked_to_ralph?: boolean;
+  /** Completion promise string - when outputted, signals task completion */
+  completion_promise?: string;
 }
 
 const _DEFAULT_STATE: UltraworkState = {
@@ -138,7 +140,8 @@ export function activateUltrawork(
     session_id: sessionId,
     reinforcement_count: 0,
     last_checked_at: new Date().toISOString(),
-    linked_to_ralph: linkedToRalph
+    linked_to_ralph: linkedToRalph,
+    completion_promise: 'DONE'
   };
 
   return writeUltraworkState(state, directory);

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -328,10 +328,11 @@ async function main() {
       ultrawork.state.last_checked_at = new Date().toISOString();
       writeJsonFile(ultrawork.path, ultrawork.state);
 
-      let reason = `[ULTRAWORK #${newCount}] Mode active - continue working.`;
+      const promise = ultrawork.state.completion_promise || 'DONE';
+      let reason = `[ULTRAWORK #${newCount}] Mode active - continue working. When complete, output: <promise>${promise}</promise>`;
       if (totalIncomplete > 0) {
         const itemType = taskCount > 0 ? 'Tasks' : 'todos';
-        reason = `[ULTRAWORK #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working.`;
+        reason = `[ULTRAWORK #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working. When complete, output: <promise>${promise}</promise>`;
       }
       if (ultrawork.state.original_prompt) {
         reason += `\nTask: ${ultrawork.state.original_prompt}`;
@@ -358,10 +359,14 @@ async function main() {
       ecomode.state.reinforcement_count = newCount;
       writeJsonFile(ecomode.path, ecomode.state);
 
-      let reason = `[ECOMODE #${newCount}] Mode active - continue working.`;
+      const promise = ecomode.state.completion_promise || 'DONE';
+      let reason = `[ECOMODE #${newCount}] Mode active - continue working. When complete, output: <promise>${promise}</promise>`;
       if (totalIncomplete > 0) {
         const itemType = taskCount > 0 ? 'Tasks' : 'todos';
-        reason = `[ECOMODE #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working.`;
+        reason = `[ECOMODE #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working. When complete, output: <promise>${promise}</promise>`;
+      }
+      if (ecomode.state.original_prompt) {
+        reason += `\nTask: ${ecomode.state.original_prompt}`;
       }
 
       console.log(JSON.stringify({


### PR DESCRIPTION
## Summary

- Add `completion_promise` support to Ultrawork and Ecomode persistent-mode hooks, matching Ralph's existing behavior
- Agents in Ultrawork/Ecomode can now output `<promise>DONE</promise>` to signal task completion and exit cleanly instead of blocking until `max_reinforcements` (default 50)
- Add `completion_promise?: string` field to `UltraworkState` interface with default `'DONE'`

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Activate Ultrawork mode and confirm block message includes `When complete, output: <promise>DONE</promise>`
- [ ] Activate Ecomode and confirm block message includes the same promise instruction
- [ ] Verify existing Ralph promise behavior is unchanged
- [ ] Verify backward compatibility with state files that lack `completion_promise` field (falls back to `'DONE'`)

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)