### PR TITLE
fix(hooks): add stdin timeout to prevent freeze on Linux (#240)

### DIFF
--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -388,6 +388,8 @@ export function getHookScripts(): Record<string, string> {
     'persistent-mode.mjs': loadTemplate('persistent-mode.mjs'),
     'session-start.mjs': loadTemplate('session-start.mjs'),
     'pre-tool-use.mjs': loadTemplate('pre-tool-use.mjs'),
-    'post-tool-use.mjs': loadTemplate('post-tool-use.mjs')
+    'post-tool-use.mjs': loadTemplate('post-tool-use.mjs'),
+    // Shared library modules (in lib/ subdirectory)
+    'lib/stdin.mjs': loadTemplate('lib/stdin.mjs')
   };
 }

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -323,6 +323,11 @@ export function install(options: InstallOptions = {}): InstallResult {
 
       for (const [filename, content] of Object.entries(hookScripts)) {
         const filepath = join(HOOKS_DIR, filename);
+        // Create subdirectory if needed (e.g., lib/)
+        const dir = dirname(filepath);
+        if (!existsSync(dir)) {
+          mkdirSync(dir, { recursive: true });
+        }
         if (existsSync(filepath) && !options.force) {
           log(`  Skipping ${filename} (already exists)`);
         } else {

--- a/templates/hooks/lib/stdin.mjs
+++ b/templates/hooks/lib/stdin.mjs
@@ -1,0 +1,62 @@
+/**
+ * Shared stdin utilities for OMC hooks
+ * Provides timeout-protected stdin reading to prevent hangs on Linux
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/240
+ */
+
+/**
+ * Read all stdin with timeout to prevent indefinite hang on Linux.
+ *
+ * The blocking `for await (const chunk of process.stdin)` pattern waits
+ * indefinitely for EOF. On Linux, if the parent process doesn't properly
+ * close stdin, this hangs forever. This function uses event-based reading
+ * with a timeout as a safety net.
+ *
+ * @param {number} timeoutMs - Maximum time to wait for stdin (default: 5000ms)
+ * @returns {Promise<string>} - The stdin content, or empty string on error/timeout
+ */
+export async function readStdin(timeoutMs = 5000) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        process.stdin.removeAllListeners();
+        process.stdin.destroy();
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      }
+    }, timeoutMs);
+
+    process.stdin.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+
+    process.stdin.on('end', () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      }
+    });
+
+    process.stdin.on('error', () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve('');
+      }
+    });
+
+    // If stdin is already ended (e.g. empty pipe), 'end' fires immediately
+    // But if stdin is a TTY or never piped, we need the timeout as safety net
+    if (process.stdin.readableEnded) {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      }
+    }
+  });
+}

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -9,54 +9,15 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
 
-// Read all stdin with timeout to prevent indefinite hang on Linux
-// See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/240
-async function readStdin(timeoutMs = 5000) {
-  return new Promise((resolve) => {
-    const chunks = [];
-    let settled = false;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
-    const timeout = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        process.stdin.removeAllListeners();
-        process.stdin.destroy();
-        resolve(Buffer.concat(chunks).toString('utf-8'));
-      }
-    }, timeoutMs);
-
-    process.stdin.on('data', (chunk) => {
-      chunks.push(chunk);
-    });
-
-    process.stdin.on('end', () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timeout);
-        resolve(Buffer.concat(chunks).toString('utf-8'));
-      }
-    });
-
-    process.stdin.on('error', () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timeout);
-        resolve('');
-      }
-    });
-
-    if (process.stdin.readableEnded) {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timeout);
-        resolve(Buffer.concat(chunks).toString('utf-8'));
-      }
-    }
-  });
-}
+// Dynamic import for the shared stdin module
+const { readStdin } = await import(join(__dirname, 'lib', 'stdin.mjs'));
 
 function readJsonFile(path) {
   try {

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -4,54 +4,15 @@
 // Cross-platform: Windows, macOS, Linux
 
 import { existsSync, readFileSync, readdirSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
 
-// Read all stdin with timeout to prevent indefinite hang on Linux
-// See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/240
-async function readStdin(timeoutMs = 5000) {
-  return new Promise((resolve) => {
-    const chunks = [];
-    let settled = false;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
-    const timeout = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        process.stdin.removeAllListeners();
-        process.stdin.destroy();
-        resolve(Buffer.concat(chunks).toString('utf-8'));
-      }
-    }, timeoutMs);
-
-    process.stdin.on('data', (chunk) => {
-      chunks.push(chunk);
-    });
-
-    process.stdin.on('end', () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timeout);
-        resolve(Buffer.concat(chunks).toString('utf-8'));
-      }
-    });
-
-    process.stdin.on('error', () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timeout);
-        resolve('');
-      }
-    });
-
-    if (process.stdin.readableEnded) {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timeout);
-        resolve(Buffer.concat(chunks).toString('utf-8'));
-      }
-    }
-  });
-}
+// Dynamic import for the shared stdin module
+const { readStdin } = await import(join(__dirname, 'lib', 'stdin.mjs'));
 
 function readJsonFile(path) {
   try {


### PR DESCRIPTION
## Summary

- Fixes critical freeze on Linux where any prompt causes complete CLI hang
- Replaces blocking `for await (const chunk of process.stdin)` with event-based stdin reader with 5-second timeout
- Updates all 5 hook scripts: keyword-detector, session-start, persistent-mode, pre-tool-use, post-tool-use

## Root Cause

All hook scripts used an async iterator pattern to read stdin that waits indefinitely for EOF:

```javascript
// OLD - blocks forever if stdin never closes
async function readStdin() {
  const chunks = [];
  for await (const chunk of process.stdin) {
    chunks.push(chunk);
  }
  return Buffer.concat(chunks).toString('utf-8');
}
```

On Linux, if Claude Code doesn't properly close stdin after writing hook input, the Node.js process hangs forever.

## Solution

Replace with event-based stdin reading that includes a 5-second timeout:

```javascript
// NEW - gracefully times out after 5 seconds
async function readStdin(timeoutMs = 5000) {
  return new Promise((resolve) => {
    const chunks = [];
    let settled = false;

    const timeout = setTimeout(() => {
      if (!settled) {
        settled = true;
        process.stdin.removeAllListeners();
        process.stdin.destroy();
        resolve(Buffer.concat(chunks).toString('utf-8'));
      }
    }, timeoutMs);

    process.stdin.on('data', (chunk) => chunks.push(chunk));
    process.stdin.on('end', () => { /* resolve with data */ });
    process.stdin.on('error', () => { /* resolve empty */ });
  });
}
```

## Test plan

- [x] Build passes (`npm run build`)
- [x] All hooks respond correctly to normal input
- [x] Keyword detection still works (tested with "ulw fix the bug")
- [x] Hooks gracefully recover when stdin never closes (timeout fires at 5s)
- [x] Empty stdin returns `{ continue: true }` (no crash)

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)