### PR TITLE
fix(hooks): add staleness check and session-end cleanup for mode states

### DIFF
--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -44,6 +44,31 @@ function writeJsonFile(path, data) {
 }
 
 /**
+ * Staleness threshold for mode states (2 hours in milliseconds).
+ * States older than this are treated as inactive to prevent stale state
+ * from causing the stop hook to malfunction in new sessions.
+ */
+const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+/**
+ * Check if a state is stale based on its timestamps.
+ * A state is considered stale if it hasn't been updated recently.
+ * We check both `last_checked_at` and `started_at` - using whichever is more recent.
+ */
+function isStaleState(state) {
+  if (!state) return true;
+
+  const lastChecked = state.last_checked_at ? new Date(state.last_checked_at).getTime() : 0;
+  const startedAt = state.started_at ? new Date(state.started_at).getTime() : 0;
+  const mostRecent = Math.max(lastChecked, startedAt);
+
+  if (mostRecent === 0) return true; // No valid timestamps
+
+  const age = Date.now() - mostRecent;
+  return age > STALE_STATE_THRESHOLD_MS;
+}
+
+/**
  * Read state file from local or global location, tracking the source.
  */
 function readStateFile(stateDir, globalStateDir, filename) {
@@ -122,7 +147,6 @@ function countIncompleteTodos(sessionId, projectDir) {
 function isContextLimitStop(data) {
   const reason = (data.stop_reason || data.stopReason || '').toLowerCase();
 
-  // Known context-limit patterns (both confirmed and defensive)
   const contextPatterns = [
     'context_limit',
     'context_window',
@@ -139,7 +163,6 @@ function isContextLimitStop(data) {
     return true;
   }
 
-  // Also check end_turn_reason (API-level field)
   const endTurnReason = (data.end_turn_reason || data.endTurnReason || '').toLowerCase();
   if (endTurnReason && contextPatterns.some(p => endTurnReason.includes(p))) {
     return true;
@@ -208,12 +231,14 @@ async function main() {
     const totalIncomplete = taskCount + todoCount;
 
     // Priority 1: Ralph Loop (explicit persistence mode)
-    if (ralph.state?.active) {
+    // Skip if state is stale (older than 2 hours) - prevents blocking new sessions
+    if (ralph.state?.active && !isStaleState(ralph.state)) {
       const iteration = ralph.state.iteration || 1;
       const maxIter = ralph.state.max_iterations || 100;
 
       if (iteration < maxIter) {
         ralph.state.iteration = iteration + 1;
+        ralph.state.last_checked_at = new Date().toISOString();
         writeJsonFile(ralph.path, ralph.state);
 
         console.log(JSON.stringify({
@@ -225,12 +250,13 @@ async function main() {
     }
 
     // Priority 2: Autopilot (high-level orchestration)
-    if (autopilot.state?.active) {
+    if (autopilot.state?.active && !isStaleState(autopilot.state)) {
       const phase = autopilot.state.phase || 'unknown';
       if (phase !== 'complete') {
         const newCount = (autopilot.state.reinforcement_count || 0) + 1;
         if (newCount <= 20) {
           autopilot.state.reinforcement_count = newCount;
+          autopilot.state.last_checked_at = new Date().toISOString();
           writeJsonFile(autopilot.path, autopilot.state);
 
           console.log(JSON.stringify({
@@ -243,13 +269,14 @@ async function main() {
     }
 
     // Priority 3: Ultrapilot (parallel autopilot)
-    if (ultrapilot.state?.active) {
+    if (ultrapilot.state?.active && !isStaleState(ultrapilot.state)) {
       const workers = ultrapilot.state.workers || [];
       const incomplete = workers.filter(w => w.status !== 'complete' && w.status !== 'failed').length;
       if (incomplete > 0) {
         const newCount = (ultrapilot.state.reinforcement_count || 0) + 1;
         if (newCount <= 20) {
           ultrapilot.state.reinforcement_count = newCount;
+          ultrapilot.state.last_checked_at = new Date().toISOString();
           writeJsonFile(ultrapilot.path, ultrapilot.state);
 
           console.log(JSON.stringify({
@@ -262,12 +289,13 @@ async function main() {
     }
 
     // Priority 4: Swarm (coordinated agents with SQLite)
-    if (swarmMarker && swarmSummary?.active) {
+    if (swarmMarker && swarmSummary?.active && !isStaleState(swarmSummary)) {
       const pending = (swarmSummary.tasks_pending || 0) + (swarmSummary.tasks_claimed || 0);
       if (pending > 0) {
         const newCount = (swarmSummary.reinforcement_count || 0) + 1;
         if (newCount <= 15) {
           swarmSummary.reinforcement_count = newCount;
+          swarmSummary.last_checked_at = new Date().toISOString();
           writeJsonFile(join(stateDir, 'swarm-summary.json'), swarmSummary);
 
           console.log(JSON.stringify({
@@ -280,13 +308,14 @@ async function main() {
     }
 
     // Priority 5: Pipeline (sequential stages)
-    if (pipeline.state?.active) {
+    if (pipeline.state?.active && !isStaleState(pipeline.state)) {
       const currentStage = pipeline.state.current_stage || 0;
       const totalStages = pipeline.state.stages?.length || 0;
       if (currentStage < totalStages) {
         const newCount = (pipeline.state.reinforcement_count || 0) + 1;
         if (newCount <= 15) {
           pipeline.state.reinforcement_count = newCount;
+          pipeline.state.last_checked_at = new Date().toISOString();
           writeJsonFile(pipeline.path, pipeline.state);
 
           console.log(JSON.stringify({
@@ -299,11 +328,12 @@ async function main() {
     }
 
     // Priority 6: UltraQA (QA cycling)
-    if (ultraqa.state?.active) {
+    if (ultraqa.state?.active && !isStaleState(ultraqa.state)) {
       const cycle = ultraqa.state.cycle || 1;
       const maxCycles = ultraqa.state.max_cycles || 10;
       if (cycle < maxCycles && !ultraqa.state.all_passing) {
         ultraqa.state.cycle = cycle + 1;
+        ultraqa.state.last_checked_at = new Date().toISOString();
         writeJsonFile(ultraqa.path, ultraqa.state);
 
         console.log(JSON.stringify({
@@ -316,7 +346,7 @@ async function main() {
 
     // Priority 7: Ultrawork - ALWAYS continue while active (not just when tasks exist)
     // This prevents false stops from bash errors, transient failures, etc.
-    if (ultrawork.state?.active) {
+    if (ultrawork.state?.active && !isStaleState(ultrawork.state)) {
       const newCount = (ultrawork.state.reinforcement_count || 0) + 1;
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 
@@ -330,7 +360,6 @@ async function main() {
       ultrawork.state.last_checked_at = new Date().toISOString();
       writeJsonFile(ultrawork.path, ultrawork.state);
 
-      // Build continuation message
       let reason = `[ULTRAWORK #${newCount}] Mode active - continue working.`;
       if (totalIncomplete > 0) {
         const itemType = taskCount > 0 ? 'Tasks' : 'todos';
@@ -348,7 +377,7 @@ async function main() {
     }
 
     // Priority 8: Ecomode - ALWAYS continue while active
-    if (ecomode.state?.active) {
+    if (ecomode.state?.active && !isStaleState(ecomode.state)) {
       const newCount = (ecomode.state.reinforcement_count || 0) + 1;
       const maxReinforcements = ecomode.state.max_reinforcements || 50;
 
@@ -359,6 +388,7 @@ async function main() {
       }
 
       ecomode.state.reinforcement_count = newCount;
+      ecomode.state.last_checked_at = new Date().toISOString();
       writeJsonFile(ecomode.path, ecomode.state);
 
       let reason = `[ECOMODE #${newCount}] Mode active - continue working.`;


### PR DESCRIPTION
## Summary

- Fixes stale state causing stop hook to block new sessions indefinitely
- Adds mode state cleanup on session end to prevent state accumulation
- Adds 2-hour staleness threshold to persistent-mode.mjs

## Problem

1. **State files not cleaned up**: When a session ends normally (Ctrl+D, close terminal), mode state files like `ultrawork-state.json` with `active: true` were never cleaned up.

2. **Stale state causes malfunction**: The stop hook (`persistent-mode.mjs`) would read these stale files in new sessions and block stops indefinitely, even though the original session was long gone.

Evidence: Found `ultrawork-state.json` with `started_at: "2026-01-30T09:00"` (>32 hours stale) still marked `active: true`, blocking new sessions.

## Solution

### 1. Staleness Check in Stop Hook
Added `isStaleState()` function with 2-hour threshold:
- Checks `last_checked_at` and `started_at` timestamps
- States older than 2 hours are treated as inactive
- Applied to all 8 modes (ralph, autopilot, ultrapilot, swarm, pipeline, ultraqa, ultrawork, ecomode)

### 2. Session-End Cleanup
Added `cleanupModeStates()` function to session-end hook:
- Removes state files with `active: true` when session ends
- Cleans both local (`.omc/state/`) and global (`~/.claude/`) locations
- Only removes active states (preserves completed/historical states)

## Test plan

- [ ] Start ultrawork mode, verify state file created
- [ ] End session normally (Ctrl+D), verify state file removed
- [ ] Create stale state file (>2 hours old), verify stop hook allows stop
- [ ] Verify active fresh state still blocks stops correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)