### PR TITLE
fix(hooks): sanitize original_prompt in stop hook to prevent AskUser re-injection

### DIFF
--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -28,6 +28,25 @@ function readJsonFile(path) {
   }
 }
 
+/**
+ * Sanitize a prompt string for safe re-injection in stop hook reasons.
+ * Strips injected context tags, collapses whitespace, and truncates to prevent
+ * the model from re-interpreting AskUser patterns or other instruction-like text.
+ */
+function sanitizePromptForReason(text) {
+  if (!text || typeof text !== 'string') return '';
+  return text
+    .replace(/<session-restore>[\s\S]*?<\/session-restore>/g, '')
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '')
+    .replace(/<notepad-context>[\s\S]*?<\/notepad-context>/g, '')
+    .replace(/<ultrawork-persistence>[\s\S]*?<\/ultrawork-persistence>/g, '')
+    .replace(/^\s*HOOKS.*$/gm, '')
+    .replace(/\[MAGIC KEYWORD:[\s\S]*?IMMEDIATELY\./g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 160);
+}
+
 function writeJsonFile(path, data) {
   try {
     // Ensure directory exists
@@ -95,15 +114,17 @@ function countIncompleteTodos(sessionId, projectDir) {
     } catch { /* skip */ }
   }
 
-  // Project-local todos only
+  // Project-local todos only (first valid path wins — avoid double-counting)
   for (const path of [
     join(projectDir, '.omc', 'todos.json'),
     join(projectDir, '.claude', 'todos.json')
   ]) {
     try {
       const data = readJsonFile(path);
+      if (!data) continue;
       const todos = Array.isArray(data) ? data : (Array.isArray(data?.todos) ? data.todos : []);
       count += todos.filter(t => t.status !== 'completed' && t.status !== 'cancelled').length;
+      break;
     } catch { /* skip */ }
   }
 
@@ -215,7 +236,7 @@ async function main() {
 
         console.log(JSON.stringify({
           decision: 'block',
-          reason: `[RALPH LOOP - ITERATION ${iteration + 1}/${maxIter}] Work is NOT done. Continue. When complete, output: <promise>${ralph.state.completion_promise || 'DONE'}</promise>\n${ralph.state.prompt ? `Task: ${ralph.state.prompt}` : ''}`
+          reason: `[RALPH LOOP - ITERATION ${iteration + 1}/${maxIter}] Work is NOT done. Continue. When complete, output: <promise>${ralph.state.completion_promise || 'DONE'}</promise>\n${ralph.state.prompt ? `Task: ${sanitizePromptForReason(ralph.state.prompt)}` : ''}`
         }));
         return;
       }
@@ -333,7 +354,7 @@ async function main() {
         reason = `[ULTRAWORK #${newCount}] ${totalIncomplete} incomplete ${itemType}. Continue working.`;
       }
       if (ultrawork.state.original_prompt) {
-        reason += `\nTask: ${ultrawork.state.original_prompt}`;
+        reason += `\nTask: ${sanitizePromptForReason(ultrawork.state.original_prompt)}`;
       }
 
       console.log(JSON.stringify({


### PR DESCRIPTION
## Summary

- **Bug**: The stop hook (`persistent-mode.mjs`) re-injects `original_prompt` / `ralph.state.prompt` verbatim into the block reason. When the stored prompt contains AskUser-inducing text (question formats, option lists, injected context tags like `<session-restore>`, `[MAGIC KEYWORD:...]`), the model re-interprets it as a new instruction and fires AskUser on every stop reinforcement cycle — creating an infinite AskUser loop.
- **Fix**: Add `sanitizePromptForReason()` that strips injected context tags, collapses whitespace, and truncates to 160 chars. Applied to both ultrawork `original_prompt` and ralph `prompt` injection points.
- **Bonus**: Fix `countIncompleteTodos` to `break` after the first valid path, preventing double-counting across `.omc/` and `.claude/` directories (which inflates `totalIncomplete` and prolongs stop blocking unnecessarily).

## Changes

| File | Change |
|------|--------|
| `scripts/persistent-mode.mjs` | Add `sanitizePromptForReason()`, apply to ralph/ultrawork prompt injection, fix todo double-count |
| `templates/hooks/persistent-mode.mjs` | Same changes (template version) |

## Root Cause Analysis

```
1. User inputs "ulw: <task>"
2. keyword-detector stores full prompt as original_prompt in ultrawork-state.json
3. Model works, then attempts to Stop
4. persistent-mode.mjs blocks Stop, appends `\nTask: ${original_prompt}` unfiltered to reason
5. Model reads reason → finds AskUser-inducing text → fires AskUser
6. Repeat steps 3-5 up to 50 times (max reinforcements)
```

The `sanitizePromptForReason()` function strips:
- `<session-restore>`, `<system-reminder>`, `<notepad-context>`, `<ultrawork-persistence>` tags
- `[MAGIC KEYWORD:...IMMEDIATELY.]` blocks
- `HOOKS...` lines
- Collapses whitespace, truncates to 160 chars

## Test plan

- [ ] Activate ultrawork with a complex prompt containing AskUser-like patterns
- [ ] Verify Stop hook reason contains sanitized/truncated prompt (max 160 chars)
- [ ] Verify no automatic AskUser is triggered after Stop reinforcement
- [ ] Verify ralph loop prompt is also sanitized in Stop reason
- [ ] Verify todo count doesn't double-count when both `.omc/todos.json` and `.claude/todos.json` exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)