### PR TITLE
feat: framework-agnostic prompts and commands (v3.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.1] - 2026-02-01
+
+### Changed
+
+- **Framework-Agnostic Prompts** - All agent prompts, skill files, and TypeScript source code now use generic, language-neutral commands instead of hardcoded npm/Node.js-specific commands. This makes OMC work seamlessly with any project type (Python, Go, Rust, Java, etc.).
+
+### Files Updated
+
+**Agent Prompts:**
+- `agents/deep-executor.md` - Generic verification evidence placeholders
+- `agents/architect.md` - Generic project manifest and build references
+
+**Skill Files:**
+- `skills/build-fix/SKILL.md` - Generic type check and build command references
+- `skills/ultrawork/SKILL.md` - Generic background task examples
+- `skills/ralph/SKILL.md` - Generic background task examples
+- `skills/ultraqa/SKILL.md` - Generic goal command references
+- `skills/tdd/SKILL.md` - Generic test command references
+- `skills/ultrapilot/SKILL.md` - Generic validation commands
+- `skills/deepinit/SKILL.md` - Generic dependency and test instructions
+
+**Command Files:**
+- `commands/build-fix.md` - Generic type check command
+- `commands/ralph.md` - Generic background task examples
+- `commands/ultrawork.md` - Generic background task examples
+- `commands/ultraqa.md` - Generic goal commands
+
+**TypeScript Source:**
+- `src/hooks/ultraqa/index.ts` - `getGoalCommand()` returns generic comments with examples
+- `src/features/verification/index.ts` - Removed hardcoded npm commands from STANDARD_CHECKS
+- `src/hooks/autopilot/state.ts` - Generic QA phase instructions
+- `src/agents/definitions.ts` - Generic test command reference
+- `src/features/background-tasks.ts` - Generic background task documentation
+- `src/features/task-decomposer/index.ts` - Generic verification commands
+
+---
+
 ## [3.8.17] - 2026-02-01
 
 ### Fixed

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -80,7 +80,7 @@ Before any analysis, gather context via parallel tool calls:
 
 1. **Codebase Structure**: Use Glob to understand project layout
 2. **Related Code**: Use Grep/Read to find relevant implementations
-3. **Dependencies**: Check package.json, imports, etc.
+3. **Dependencies**: Check project manifest (package.json, Cargo.toml, go.mod, pyproject.toml, etc.), imports
 4. **Test Coverage**: Find existing tests for the area
 
 **PARALLEL EXECUTION**: Make multiple tool calls in single message for speed.
@@ -188,7 +188,7 @@ FAIL_IF: [conditions indicating the fix didn't work]
 1. Fix the race condition in src/server.ts:142
 2. **Verify with qa-tester**:
    VERIFY: Server handles concurrent connections
-   SETUP: npm run build
+   SETUP: Build the project
    COMMANDS:
    1. Start server → expect "Listening on port 3000"
    2. Send 10 concurrent requests → expect all return 200

--- a/agents/deep-executor.md
+++ b/agents/deep-executor.md
@@ -142,8 +142,8 @@ When task is 100% complete, output:
 - `/absolute/path/to/file2.ts` - [what changed]
 
 ### Verification Evidence
-- Build: `npm run build` -> SUCCESS
-- Tests: `npm test` -> 42 passed, 0 failed
+- Build: [project build command] -> SUCCESS
+- Tests: [project test command] -> 42 passed, 0 failed
 - Diagnostics: 0 errors, 0 warnings
 
 ### Definition of Done

--- a/commands/build-fix.md
+++ b/commands/build-fix.md
@@ -19,7 +19,7 @@ Resolve build and TypeScript errors quickly with minimal code changes. Get the b
 
 ## Workflow
 
-1. Run `npx tsc --noEmit` to collect all errors
+1. Run the project's type check command (e.g., `tsc --noEmit`, `mypy`, `cargo check`) to collect all errors
 2. Categorize errors by type
 3. Fix errors one at a time with minimal changes
 4. Verify fix doesn't introduce new errors
@@ -28,8 +28,8 @@ Resolve build and TypeScript errors quickly with minimal code changes. Get the b
 ## Stop Conditions
 
 The agent stops when:
-- `npx tsc --noEmit` exits with code 0
-- `npm run build` completes successfully
+- The type check command exits with code 0
+- The project's build command completes successfully
 - No new errors are introduced
 
 ## Minimal Diff Strategy

--- a/commands/ralph.md
+++ b/commands/ralph.md
@@ -70,9 +70,9 @@ Task(subagent_type="oh-my-claudecode:architect", model="opus", prompt="...")
 ### Background Execution Rules
 
 **Run in Background** (set `run_in_background: true`):
-- Package installation: npm install, pip install, cargo build
-- Build processes: npm run build, make, tsc
-- Test suites: npm test, pytest, cargo test
+- Package installation (npm install, pip install, cargo build, etc.)
+- Build processes (project build command, make, etc.)
+- Test suites (project test command, etc.)
 - Docker operations: docker build, docker pull
 
 **Run Blocking** (foreground):

--- a/commands/ultraqa.md
+++ b/commands/ultraqa.md
@@ -31,10 +31,10 @@ If no structured goal provided, interpret the argument as a custom goal.
 ### Cycle N (Max 5)
 
 1. **RUN QA**: Execute verification based on goal type
-   - `--tests`: Run `npm test` or equivalent
-   - `--build`: Run `npm run build` or equivalent
-   - `--lint`: Run `npm run lint` or equivalent
-   - `--typecheck`: Run `npm run typecheck` or `tsc --noEmit`
+   - `--tests`: Run the project's test command
+   - `--build`: Run the project's build command
+   - `--lint`: Run the project's lint command
+   - `--typecheck`: Run the project's type check command
    - `--custom`: Run appropriate command and check for pattern
    - `--interactive`: Use qa-tester for interactive CLI/service testing:
      ```

--- a/commands/ultrawork.md
+++ b/commands/ultrawork.md
@@ -84,9 +84,9 @@ Task(subagent_type="explore-medium", model="sonnet", prompt="Find all authentica
 ## Background Execution Rules
 
 **Run in Background** (set `run_in_background: true`):
-- Package installation: npm install, pip install, cargo build
-- Build processes: npm run build, make, tsc
-- Test suites: npm test, pytest, cargo test
+- Package installation (npm install, pip install, cargo build, etc.)
+- Build processes (project build command, make, etc.)
+- Test suites (project test command, etc.)
 - Docker operations: docker build, docker pull
 
 **Run Blocking** (foreground):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/build-fix/SKILL.md
+++ b/skills/build-fix/SKILL.md
@@ -5,14 +5,14 @@ description: Fix build and TypeScript errors with minimal changes
 
 # Build Fix Skill
 
-Fix build and TypeScript errors quickly with minimal code changes. Get the build green without refactoring.
+Fix build and compilation errors quickly with minimal code changes. Get the build green without refactoring.
 
 ## When to Use
 
 This skill activates when:
 - User says "fix the build", "build is broken"
 - TypeScript compilation fails
-- `npm run build` or `tsc` reports errors
+- the build command or type checker reports errors
 - User requests "minimal fixes" for errors
 
 ## What It Does
@@ -20,8 +20,8 @@ This skill activates when:
 Delegates to the `build-fixer` agent (Sonnet model) to:
 
 1. **Collect Errors**
-   - Run `npx tsc --noEmit` to get all TypeScript errors
-   - Or run `npm run build` to get build failures
+   - Run the project's type check command (e.g., `tsc --noEmit`, `mypy`, `cargo check`, `go vet`)
+   - Or run the project's build command to get build failures
    - Categorize errors by type and severity
 
 2. **Fix Strategically**
@@ -38,7 +38,7 @@ Delegates to the `build-fixer` agent (Sonnet model) to:
    - ONLY what's needed to make build pass
 
 4. **Verify**
-   - Run `npx tsc --noEmit` after each fix
+   - Run the project's type check command after each fix
    - Ensure no new errors introduced
    - Stop when build passes
 
@@ -69,8 +69,8 @@ Output: Build error resolution report with:
 ## Stop Conditions
 
 The build-fixer agent stops when:
-- `npx tsc --noEmit` exits with code 0
-- `npm run build` completes successfully
+- Type check command exits with code 0
+- Build command completes successfully
 - No new errors introduced
 
 ## Output Format
@@ -90,7 +90,7 @@ Fixes Applied:
 ...
 
 Final Build Status: ✓ PASSING
-Verification: npx tsc --noEmit (exit code 0)
+Verification: [type check command] (exit code 0)
 ```
 
 ## Best Practices

--- a/skills/deepinit/SKILL.md
+++ b/skills/deepinit/SKILL.md
@@ -229,12 +229,12 @@ A web application for managing user tasks with real-time collaboration features.
 ## For AI Agents
 
 ### Working In This Directory
-- Always run `npm install` after modifying package.json
+- Always install dependencies after modifying the project manifest
 - Use TypeScript strict mode
 - Follow ESLint rules
 
 ### Testing Requirements
-- Run `npm test` before committing
+- Run tests before committing
 - Ensure >80% coverage
 
 ### Common Patterns

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -109,9 +109,9 @@ Task(subagent_type="oh-my-claudecode:architect", model="opus", prompt="...")
 ### Background Execution Rules
 
 **Run in Background** (set `run_in_background: true`):
-- Package installation: npm install, pip install, cargo build
-- Build processes: npm run build, make, tsc
-- Test suites: npm test, pytest, cargo test
+- Package installation (npm install, pip install, cargo build, etc.)
+- Build processes (project build command, make, etc.)
+- Test suites (project test command, etc.)
 - Docker operations: docker build, docker pull
 
 **Run Blocking** (foreground):

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -47,12 +47,12 @@ Write code before test? DELETE IT. Start over. No exceptions.
 
 Before each implementation:
 ```bash
-npm test  # Should have ONE new failure
+# Run the project's test command - should have ONE new failure
 ```
 
 After implementation:
 ```bash
-npm test  # New test should pass, all others still pass
+# Run the project's test command - new test should pass, all others still pass
 ```
 
 ## Output Format

--- a/skills/ultrapilot/SKILL.md
+++ b/skills/ultrapilot/SKILL.md
@@ -284,9 +284,9 @@ Deliver: Code changes + list of boundary dependencies`,
 **Goal:** Verify integrated system works
 
 **Checks (parallel):**
-1. **Build** - `npm run build` or equivalent
-2. **Lint** - `npm run lint`
-3. **Type check** - `tsc --noEmit`
+1. **Build** - Run the project's build command
+2. **Lint** - Run the project's lint command
+3. **Type check** - Run the project's type check command
 4. **Unit tests** - All tests pass
 5. **Integration tests** - Cross-component tests
 

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -32,10 +32,10 @@ If no structured goal provided, interpret the argument as a custom goal.
 ### Cycle N (Max 5)
 
 1. **RUN QA**: Execute verification based on goal type
-   - `--tests`: Run `npm test` or equivalent
-   - `--build`: Run `npm run build` or equivalent
-   - `--lint`: Run `npm run lint` or equivalent
-   - `--typecheck`: Run `npm run typecheck` or `tsc --noEmit`
+   - `--tests`: Run the project's test command
+   - `--build`: Run the project's build command
+   - `--lint`: Run the project's lint command
+   - `--typecheck`: Run the project's type check command
    - `--custom`: Run appropriate command and check for pattern
    - `--interactive`: Use qa-tester for interactive CLI/service testing:
      ```

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -45,9 +45,9 @@ Task(subagent_type="oh-my-claudecode:architect", model="opus", prompt="...")
 ## Background Execution Rules
 
 **Run in Background** (set `run_in_background: true`):
-- Package installation: npm install, pip install, cargo build
-- Build processes: npm run build, make, tsc
-- Test suites: npm test, pytest, cargo test
+- Package installation (npm install, pip install, cargo build, etc.)
+- Build processes (project build command, make, etc.)
+- Test suites (project test command, etc.)
 
 **Run Blocking** (foreground):
 - Quick status checks: git status, ls, pwd
@@ -86,7 +86,7 @@ Use `ralph` instead when you want:
 When ultrawork is invoked directly (not via ralph), apply lightweight verification before claiming completion:
 
 ### Quick Verification Checklist
-- [ ] **BUILD:** `tsc --noEmit` or equivalent passes
+- [ ] **BUILD:** Project type check/build command passes
 - [ ] **TESTS:** Run affected tests, all pass
 - [ ] **ERRORS:** No new errors introduced
 

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -439,7 +439,7 @@ This is the recommended workflow for any bug that requires running actual servic
 ### Verification Guidance (Gated for Token Efficiency)
 
 **Verification priority order:**
-1. **Existing tests** (npm test, pytest, etc.) - PREFERRED, cheapest
+1. **Existing tests** (run the project's test command) - PREFERRED, cheapest
 2. **Direct commands** (curl, simple CLI) - cheap
 3. **QA-Tester** (tmux sessions) - expensive, use sparingly
 

--- a/src/features/background-tasks.ts
+++ b/src/features/background-tasks.ts
@@ -313,9 +313,9 @@ For long-running operations, use the \`run_in_background\` parameter to avoid bl
 ### When to Use Background Execution
 
 **Run in Background** (set \`run_in_background: true\`):
-- Package installation: \`npm install\`, \`pip install\`, \`cargo build\`
-- Build processes: \`npm run build\`, \`make\`, \`tsc\`
-- Test suites: \`npm test\`, \`pytest\`, \`cargo test\`
+- Package installation (\`npm install\`, \`pip install\`, \`cargo build\`, etc.)
+- Build processes (project build command, \`make\`, etc.)
+- Test suites (project test command, etc.)
 - Docker operations: \`docker build\`, \`docker pull\`
 - Git operations on large repos: \`git clone\`, \`git fetch\`
 - Database migrations: \`prisma migrate\`, \`typeorm migration:run\`
@@ -330,7 +330,7 @@ For long-running operations, use the \`run_in_background\` parameter to avoid bl
 
 1. **Start in background:**
    \`\`\`
-   Bash(command: "npm run build", run_in_background: true)
+   Bash(command: "project build command", run_in_background: true)
    \`\`\`
 
 2. **Continue with other work** while the task runs

--- a/src/features/task-decomposer/index.ts
+++ b/src/features/task-decomposer/index.ts
@@ -751,9 +751,9 @@ function generateVerificationSteps(
 ): string[] {
   const steps: string[] = [];
 
-  steps.push('Run TypeScript compiler: tsc --noEmit');
-  steps.push('Run linter: eslint');
-  steps.push('Run tests: npm test');
+  steps.push('Run the project type check command');
+  steps.push('Run the project lint command');
+  steps.push('Run the project test command');
 
   if (component.role === 'frontend' || component.role === 'ui') {
     steps.push('Visual inspection of UI components');

--- a/src/features/verification/index.ts
+++ b/src/features/verification/index.ts
@@ -31,7 +31,7 @@ export const STANDARD_CHECKS = {
     description: 'Code compiles without errors',
     evidenceType: 'build_success' as VerificationEvidenceType,
     required: true,
-    command: 'npm run build',
+    command: undefined,
     completed: false
   },
   TEST: {
@@ -40,7 +40,7 @@ export const STANDARD_CHECKS = {
     description: 'All tests pass without errors',
     evidenceType: 'test_pass' as VerificationEvidenceType,
     required: true,
-    command: 'npm test',
+    command: undefined,
     completed: false
   },
   LINT: {
@@ -49,7 +49,7 @@ export const STANDARD_CHECKS = {
     description: 'No linting errors',
     evidenceType: 'lint_clean' as VerificationEvidenceType,
     required: true,
-    command: 'npm run lint',
+    command: undefined,
     completed: false
   },
   FUNCTIONALITY: {

--- a/src/hooks/autopilot/state.ts
+++ b/src/hooks/autopilot/state.ts
@@ -519,9 +519,9 @@ The transition handler has:
 3. Started UltraQA in 'tests' mode
 
 You are now in QA phase. Run the QA cycle:
-1. Build: npm run build (or equivalent)
-2. Lint: npm run lint (or equivalent)
-3. Test: npm test (or equivalent)
+1. Build: Run the project's build command
+2. Lint: Run the project's lint command
+3. Test: Run the project's test command
 
 Fix any failures and repeat until all pass.
 

--- a/src/hooks/ultraqa/index.ts
+++ b/src/hooks/ultraqa/index.ts
@@ -277,13 +277,13 @@ function normalizeFailure(failure: string): string {
 export function getGoalCommand(goalType: UltraQAGoalType): string {
   switch (goalType) {
     case 'tests':
-      return 'npm test';
+      return '# Run the project test command (e.g., npm test, pytest, go test ./..., cargo test)';
     case 'build':
-      return 'npm run build';
+      return '# Run the project build command (e.g., npm run build, go build ./..., cargo build)';
     case 'lint':
-      return 'npm run lint';
+      return '# Run the project lint command (e.g., npm run lint, ruff check ., golangci-lint run)';
     case 'typecheck':
-      return 'npm run typecheck || tsc --noEmit';
+      return '# Run the project type check command (e.g., tsc --noEmit, mypy ., cargo check)';
     case 'custom':
       return '# Custom command based on goal pattern';
   }


### PR DESCRIPTION
## Summary

- Replace all hardcoded npm/Node.js-specific commands in agent prompts, skill files, command docs, and TypeScript source with generic, language-neutral references
- OMC now works seamlessly with any project type (Python, Go, Rust, Java, etc.)
- Bump version to 3.9.1

## Changed Files (22)

**Agent Prompts (2):** `deep-executor.md`, `architect.md`  
**Skill Files (7):** `build-fix`, `ultrawork`, `ralph`, `ultraqa`, `tdd`, `ultrapilot`, `deepinit`  
**Command Docs (4):** `build-fix.md`, `ralph.md`, `ultrawork.md`, `ultraqa.md`  
**TypeScript Source (6):** `ultraqa/index.ts`, `verification/index.ts`, `autopilot/state.ts`, `definitions.ts`, `background-tasks.ts`, `task-decomposer/index.ts`  
**Meta (3):** `package.json`, `package-lock.json`, `CHANGELOG.md`

## Key Changes

- `getGoalCommand()` in ultraqa no longer returns hardcoded `npm test` etc. — returns generic comments with multi-ecosystem examples
- `STANDARD_CHECKS` in verification module no longer hardcodes `npm run build`/`npm test`/`npm run lint` as default commands
- All skill/agent/command prompts use "project's test/build/lint command" instead of npm-specific commands
- Files that already listed commands per-language (tdd-guide.md, build-fixer.md, autopilot/prompts.ts) were left unchanged

## Test plan

- [x] All 1951 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)