### PR TITLE
feat(hud): add model name element (#211)

### DIFF
--- a/src/__tests__/hud/defaults.test.ts
+++ b/src/__tests__/hud/defaults.test.ts
@@ -15,6 +15,10 @@ describe('HUD Default Configuration', () => {
       expect(DEFAULT_HUD_CONFIG.elements.gitBranch).toBe(false);
     });
 
+    it('should have model disabled by default for backward compatibility', () => {
+      expect(DEFAULT_HUD_CONFIG.elements.model).toBe(false);
+    });
+
     it('should use text format for thinking indicator by default', () => {
       expect(DEFAULT_HUD_CONFIG.elements.thinkingFormat).toBe('text');
     });
@@ -34,6 +38,10 @@ describe('HUD Default Configuration', () => {
 
       it(`${preset} preset should have gitBranch disabled`, () => {
         expect(PRESET_CONFIGS[preset].gitBranch).toBe(false);
+      });
+
+      it(`${preset} preset should have model disabled`, () => {
+        expect(PRESET_CONFIGS[preset].model).toBe(false);
       });
     });
   });

--- a/src/__tests__/hud/model.test.ts
+++ b/src/__tests__/hud/model.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { formatModelName, renderModel } from '../../hud/elements/model.js';
+
+describe('model element', () => {
+  describe('formatModelName', () => {
+    it('returns Opus for opus model IDs', () => {
+      expect(formatModelName('claude-opus-4-5-20251101')).toBe('Opus');
+      expect(formatModelName('claude-3-opus-20240229')).toBe('Opus');
+    });
+
+    it('returns Sonnet for sonnet model IDs', () => {
+      expect(formatModelName('claude-sonnet-4-20250514')).toBe('Sonnet');
+      expect(formatModelName('claude-3-5-sonnet-20241022')).toBe('Sonnet');
+    });
+
+    it('returns Haiku for haiku model IDs', () => {
+      expect(formatModelName('claude-3-haiku-20240307')).toBe('Haiku');
+    });
+
+    it('returns null for null/undefined', () => {
+      expect(formatModelName(null)).toBeNull();
+      expect(formatModelName(undefined)).toBeNull();
+    });
+
+    it('truncates long unrecognized model names', () => {
+      const longName = 'some-very-long-model-name-that-exceeds-limit';
+      expect(formatModelName(longName)?.length).toBeLessThanOrEqual(20);
+    });
+  });
+
+  describe('renderModel', () => {
+    it('renders formatted model name', () => {
+      const result = renderModel('claude-opus-4-5-20251101');
+      expect(result).toContain('model:');
+      expect(result).toContain('Opus');
+    });
+
+    it('returns null for null input', () => {
+      expect(renderModel(null)).toBeNull();
+    });
+  });
+});

--- a/src/hud/elements/index.ts
+++ b/src/hud/elements/index.ts
@@ -18,3 +18,4 @@ export { renderSession } from './session.js';
 export { renderAutopilot, renderAutopilotCompact, type AutopilotStateForHud } from './autopilot.js';
 export { renderCwd } from './cwd.js';
 export { renderGitRepo, renderGitBranch, getGitRepoName, getGitBranch } from './git.js';
+export { renderModel, formatModelName } from './model.js';

--- a/src/hud/elements/model.ts
+++ b/src/hud/elements/model.ts
@@ -1,0 +1,33 @@
+/**
+ * OMC HUD - Model Element
+ *
+ * Renders the current model name.
+ */
+
+import { dim, cyan } from '../colors.js';
+
+/**
+ * Format model name for display.
+ * Converts model IDs to friendly names.
+ */
+export function formatModelName(modelId: string | null | undefined): string | null {
+  if (!modelId) return null;
+
+  const id = modelId.toLowerCase();
+
+  if (id.includes('opus')) return 'Opus';
+  if (id.includes('sonnet')) return 'Sonnet';
+  if (id.includes('haiku')) return 'Haiku';
+
+  // Return original if not recognized (truncate if too long)
+  return modelId.length > 20 ? modelId.substring(0, 17) + '...' : modelId;
+}
+
+/**
+ * Render model element.
+ */
+export function renderModel(modelId: string | null | undefined): string | null {
+  const name = formatModelName(modelId);
+  if (!name) return null;
+  return `${dim('model:')}${cyan(name)}`;
+}

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -21,6 +21,7 @@ import { renderSession } from './elements/session.js';
 import { renderAutopilot } from './elements/autopilot.js';
 import { renderCwd } from './elements/cwd.js';
 import { renderGitRepo, renderGitBranch } from './elements/git.js';
+import { renderModel } from './elements/model.js';
 import {
   getAnalyticsDisplay,
   renderAnalyticsLineWithConfig,
@@ -148,6 +149,12 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   if (enabledElements.gitBranch) {
     const gitBranchElement = renderGitBranch(context.cwd);
     if (gitBranchElement) gitElements.push(gitBranchElement);
+  }
+
+  // Model name
+  if (enabledElements.model && context.modelName) {
+    const modelElement = renderModel(context.modelName);
+    if (modelElement) gitElements.push(modelElement);
   }
 
   // [OMC] label

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -251,6 +251,7 @@ export interface HudElementConfig {
   cwdFormat: CwdFormat;      // Path display format
   gitRepo: boolean;          // Show git repository name
   gitBranch: boolean;        // Show git branch
+  model: boolean;            // Show current model name
   omcLabel: boolean;
   rateLimits: boolean;  // Show 5h and weekly rate limits
   ralph: boolean;
@@ -299,6 +300,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     cwdFormat: 'relative',
     gitRepo: false,           // Disabled by default for backward compatibility
     gitBranch: false,         // Disabled by default for backward compatibility
+    model: false,             // Disabled by default for backward compatibility
     omcLabel: true,
     rateLimits: true,  // Show rate limits by default
     ralph: true,
@@ -336,6 +338,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'folder',
     gitRepo: false,
     gitBranch: false,
+    model: false,
     omcLabel: true,
     rateLimits: true,
     ralph: true,
@@ -363,6 +366,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'folder',
     gitRepo: false,
     gitBranch: false,
+    model: false,
     omcLabel: false,
     rateLimits: false,
     ralph: false,
@@ -390,6 +394,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'relative',
     gitRepo: false,
     gitBranch: false,
+    model: false,
     omcLabel: true,
     rateLimits: true,
     ralph: true,
@@ -417,6 +422,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'relative',
     gitRepo: false,
     gitBranch: false,
+    model: false,
     omcLabel: true,
     rateLimits: true,
     ralph: true,
@@ -444,6 +450,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'relative',
     gitRepo: false,
     gitBranch: false,
+    model: false,
     omcLabel: true,
     rateLimits: false,
     ralph: true,
@@ -471,6 +478,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'relative',
     gitRepo: false,
     gitBranch: false,
+    model: false,
     omcLabel: true,
     rateLimits: true,
     ralph: true,


### PR DESCRIPTION
## Summary
- Add `model` HUD element showing current model name (Opus/Sonnet/Haiku)
- Disabled by default for backward compatibility
- Full test coverage

## Configuration

Enable in `~/.claude/settings.json`:
```json
{
  "omcHud": {
    "elements": {
      "model": true
    }
  }
}
```

## Test plan
- [ ] Verify model name displays correctly for Opus/Sonnet/Haiku
- [ ] Verify element is disabled by default
- [ ] All tests pass

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)