### PR TITLE
feat(orchestrator): add worktree isolation enforcement

### DIFF
--- a/src/hooks/omc-orchestrator/audit.ts
+++ b/src/hooks/omc-orchestrator/audit.ts
@@ -14,7 +14,7 @@ export interface AuditEntry {
   tool: string;
   filePath: string;
   decision: 'allowed' | 'warned' | 'blocked';
-  reason: 'allowed_path' | 'source_file' | 'other';
+  reason: 'allowed_path' | 'source_file' | 'worktree_isolation' | 'other';
   enforcementLevel?: 'off' | 'warn' | 'strict';
   sessionId?: string;
 }

--- a/src/hooks/omc-orchestrator/constants.ts
+++ b/src/hooks/omc-orchestrator/constants.ts
@@ -50,6 +50,51 @@ export const WARNED_EXTENSIONS = [
 /** Tools that perform file modifications */
 export const WRITE_EDIT_TOOLS = ['Write', 'Edit', 'write', 'edit'];
 
+/** Warning when attempting to modify files in a sibling worktree */
+export const WORKTREE_ISOLATION_WARNING = `
+
+---
+
+[CRITICAL SYSTEM DIRECTIVE - WORKTREE ISOLATION VIOLATION]
+
+**STOP. YOU ARE VIOLATING WORKTREE ISOLATION.**
+
+You are attempting to modify a file in a **different git worktree**.
+
+**Current worktree:** $CURRENT_WORKTREE
+**Target path:** $TARGET_PATH
+**Target worktree:** $TARGET_WORKTREE
+
+---
+
+**THIS IS FORBIDDEN.**
+
+Each terminal/session operates on its own worktree independently:
+- Terminal 1: /project (main) - DO NOT touch from Terminal 2
+- Terminal 2: /project-feature (worktree) - DO NOT touch from Terminal 1
+
+**WHY THIS MATTERS:**
+- User runs multiple Claude Code instances in parallel
+- Each instance works on a separate feature branch
+- Cross-worktree modifications cause merge conflicts and lost work
+
+**CORRECT APPROACH:**
+1. Only modify files within your current worktree ($CURRENT_WORKTREE)
+2. For other worktree work, the user will use a separate terminal
+3. If you need to reference another worktree, provide information only - NO modifications
+
+**ALLOWED:**
+- Reading files from any worktree (for reference)
+- Providing information about what should be done
+- Creating new worktrees (\`git worktree add\`)
+
+**FORBIDDEN:**
+- Writing/editing files in sibling worktrees
+- Running build/test commands in sibling worktrees
+
+---
+`;
+
 /** Reminder when orchestrator performs direct file work */
 export const DIRECT_WORK_REMINDER = `
 


### PR DESCRIPTION
## Summary

- Prevents orchestrator from modifying files in sibling git worktrees, enabling safe parallel development across multiple terminals
- Detects all worktrees via `git worktree list --porcelain` with 60s cache
- Blocks Write/Edit/Bash operations targeting sibling worktrees before delegation checks
- Injects worktree context at session start so the model is aware of isolation boundaries

## Problem

When running multiple Claude Code instances in parallel (each on its own worktree), the orchestrator has no awareness of worktree boundaries. This leads to:
- Accidental cross-worktree file modifications
- Merge conflicts and lost work between parallel sessions
- No enforcement mechanism to keep each terminal's work isolated

Fixes #280

## Test plan

- [ ] Verify `getWorktrees()` correctly parses `git worktree list --porcelain` output
- [ ] Verify `getSiblingWorktree()` detects files in sibling worktrees
- [ ] Verify Write/Edit to sibling worktree is blocked with warning message
- [ ] Verify session-start injects worktree context when multiple worktrees exist
- [ ] Verify single-worktree repos are unaffected (no false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)