### PR TITLE
feat(config): add ecomode.enabled option to disable ecomode completely

### DIFF
--- a/commands/ecomode.md
+++ b/commands/ecomode.md
@@ -53,6 +53,20 @@ Run `/oh-my-claudecode:omc-setup` to set ecomode as your default parallel execut
 
 When set as default, saying "fast" or "parallel" will activate ecomode instead of ultrawork.
 
+## Disabling Ecomode
+
+To completely disable ecomode (prevents all ecomode keyword detection and activation), add to `~/.claude/.omc-config.json`:
+
+```json
+{
+  "ecomode": {
+    "enabled": false
+  }
+}
+```
+
+When disabled, ecomode keywords ("eco", "ecomode", "efficient", "save-tokens", "budget") will be ignored and will not trigger ecomode activation.
+
 ## Cancellation
 
 - `/oh-my-claudecode:cancel` - Cancel active mode

--- a/skills/ecomode/SKILL.md
+++ b/skills/ecomode/SKILL.md
@@ -89,6 +89,19 @@ Long-running commands (install, build, test) run in background. Maximum 5 concur
 4. **Use writer (haiku)** for all documentation tasks
 5. **Avoid opus agents** unless the task genuinely requires deep reasoning
 
+## Disabling Ecomode
+
+Ecomode can be completely disabled via config. When disabled, all ecomode keywords are ignored.
+
+Set in `~/.claude/.omc-config.json`:
+```json
+{
+  "ecomode": {
+    "enabled": false
+  }
+}
+```
+
 ## State Management
 
 Ecomode state is tracked in `.omc/state/ecomode-state.json`.

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -552,6 +552,15 @@ echo "Default execution mode set to: USER_CHOICE"
 
 **Note**: This preference ONLY affects generic keywords ("fast", "parallel"). Explicit keywords ("ulw", "eco") always override this preference.
 
+### Optional: Disable Ecomode Entirely
+
+If the user wants to disable ecomode completely (so ecomode keywords are ignored), add to the config:
+
+```bash
+echo "$EXISTING" | jq '. + {ecomode: {enabled: false}}' > "$CONFIG_FILE"
+echo "Ecomode disabled completely"
+```
+
 ## Step 3.8: Install CLI Analytics Tools (Optional)
 
 The OMC CLI provides standalone token analytics commands (`omc stats`, `omc agents`, `omc tui`).

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -48,6 +48,11 @@ export interface SisyphusConfig {
   };
   /** Preferred execution mode for parallel work (set by omc-setup Step 3.7) */
   defaultExecutionMode?: 'ultrawork' | 'ecomode';
+  /** Ecomode-specific configuration */
+  ecomode?: {
+    /** Whether ecomode is enabled (default: true). Set to false to disable ecomode completely. */
+    enabled?: boolean;
+  };
 }
 
 /**
@@ -69,6 +74,7 @@ export function getSisyphusConfig(): SisyphusConfig {
       taskTool: config.taskTool,
       taskToolConfig: config.taskToolConfig,
       defaultExecutionMode: config.defaultExecutionMode,
+      ecomode: config.ecomode,
     };
   } catch {
     // If config file is invalid, default to disabled for security
@@ -81,6 +87,16 @@ export function getSisyphusConfig(): SisyphusConfig {
  */
 export function isSilentAutoUpdateEnabled(): boolean {
   return getSisyphusConfig().silentAutoUpdate;
+}
+
+/**
+ * Check if ecomode is enabled
+ * Returns true by default if not explicitly disabled
+ */
+export function isEcomodeEnabled(): boolean {
+  const config = getSisyphusConfig();
+  // Default to true if not configured
+  return config.ecomode?.enabled !== false;
 }
 
 /**

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -7,6 +7,8 @@
  * Ported from oh-my-opencode's keyword-detector hook.
  */
 
+import { isEcomodeEnabled } from '../../features/auto-update.js';
+
 export type KeywordType =
   | 'cancel'      // Priority 1
   | 'ralph'       // Priority 2
@@ -143,6 +145,11 @@ export function detectKeywordsWithType(
 
   // Check each keyword type
   for (const type of KEYWORD_PRIORITY) {
+    // Skip ecomode detection if disabled in config
+    if (type === 'ecomode' && !isEcomodeEnabled()) {
+      continue;
+    }
+
     const pattern = KEYWORD_PATTERNS[type];
     const match = cleanedText.match(pattern);
 
@@ -180,8 +187,8 @@ export function getAllKeywords(text: string): KeywordType[] {
   // Exclusive: cancel suppresses everything
   if (types.includes('cancel')) return ['cancel'];
 
-  // Mutual exclusion: ecomode beats ultrawork
-  if (types.includes('ecomode') && types.includes('ultrawork')) {
+  // Mutual exclusion: ecomode beats ultrawork (only if ecomode is enabled)
+  if (types.includes('ecomode') && types.includes('ultrawork') && isEcomodeEnabled()) {
     types = types.filter(t => t !== 'ultrawork');
   }
 


### PR DESCRIPTION
Fixes #292

Add `ecomode.enabled` config option to completely disable ecomode.

When set to `false`, ecomode is skipped entirely.