### PR TITLE
fix(tui): add missing 'tui' subcommand when launching tokscale

### DIFF
--- a/src/cli/analytics.ts
+++ b/src/cli/analytics.ts
@@ -89,10 +89,8 @@ program
 program
   .command('tui')
   .description('Launch tokscale interactive TUI for token visualization')
-  .option('--light', 'Use light theme')
   .option('--models', 'Show models view')
-  .option('--daily', 'Show daily view')
-  .option('--stats', 'Show stats view')
+  .option('--daily', 'Show daily/monthly view')
   .option('--no-claude', 'Show all providers (not just Claude)')
   .action(async (options) => {
     const available = await isTokscaleCLIAvailable();
@@ -105,12 +103,10 @@ program
 
     const view = options.models ? 'models'
                : options.daily ? 'daily'
-               : options.stats ? 'stats'
                : 'overview';
 
     try {
       await launchTokscaleTUI({
-        light: options.light,
         view,
         claude: options.claude
       });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -269,10 +269,8 @@ program
 program
   .command('tui')
   .description('Launch tokscale interactive TUI for token visualization')
-  .option('--light', 'Use light theme')
   .option('--models', 'Show models view')
-  .option('--daily', 'Show daily view')
-  .option('--stats', 'Show stats view')
+  .option('--daily', 'Show daily/monthly view')
   .option('--no-claude', 'Show all providers (not just Claude)')
   .action(async (options) => {
     const available = await isTokscaleCLIAvailable();
@@ -285,12 +283,10 @@ program
 
     const view = options.models ? 'models'
                : options.daily ? 'daily'
-               : options.stats ? 'stats'
                : 'overview';
 
     try {
       await launchTokscaleTUI({
-        light: options.light,
         view,
         claude: options.claude
       });


### PR DESCRIPTION
## Summary

- Fix `omc tui` command failing with "error: too many arguments"
- The tokscale launcher was passing `--claude` as a top-level argument instead of to the `tui` subcommand

**Before:** `bunx tokscale@latest --claude` (fails)
**After:** `bunx tokscale@latest tui --claude` (works)

## Changes

- Add missing `tui` subcommand in `launchTokscaleTUI()`
- Remove unsupported `--light` option (tokscale's `--light` means CLI output, not theme)
- Remove unsupported `--stats` option (not available in tokscale)
- Map `--daily` view to tokscale's `monthly` command (closest equivalent)

## Test plan

- [x] Build passes (`bun run build`)
- [x] `omc tui --help` shows updated options
- [x] `bunx tokscale@latest tui --claude` launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)