### PR TITLE
feat(cli): improve CLI UX - Phase 1 (#297)

### DIFF
--- a/src/agents/coordinator-deprecated.ts
+++ b/src/agents/coordinator-deprecated.ts
@@ -9,11 +9,15 @@
 
 import type { AgentConfig, AgentPromptMetadata } from './types.js';
 
-// Emit deprecation warning on first import
-console.warn(
-  '[oh-my-claudecode] coordinatorAgent and ORCHESTRATOR_SISYPHUS_PROMPT_METADATA are deprecated ' +
-  'and will be removed in v4.0.0. The coordinator agent was never registered in the runtime agent registry.'
-);
+// Only emit deprecation warning when verbose mode is enabled
+// This prevents noise in normal CLI usage while still informing developers during debugging
+const isVerbose = process.env.VERBOSE === '1' || process.env.DEBUG === '1' || process.argv.includes('--verbose');
+if (isVerbose) {
+  console.warn(
+    '[oh-my-claudecode] coordinatorAgent and ORCHESTRATOR_SISYPHUS_PROMPT_METADATA are deprecated ' +
+    'and will be removed in v4.0.0. The coordinator agent was never registered in the runtime agent registry.'
+  );
+}
 
 /**
  * @deprecated Will be removed in v4.0.0. The coordinator was never a runtime agent.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -184,6 +184,11 @@ program
   .description('Show aggregate statistics (or specific session with --session)')
   .option('--json', 'Output as JSON')
   .option('--session <id>', 'Show stats for specific session (defaults to aggregate)')
+  .addHelpText('after', `
+Examples:
+  $ omc stats                    Show aggregate statistics
+  $ omc stats --session abc123   Show stats for a specific session
+  $ omc stats --json             Output as JSON for scripting`)
   .action(async (options) => {
     await ensureBackfillDone();
     await statsCommand(options);
@@ -194,9 +199,15 @@ program
   .command('cost [period]')
   .description('Generate cost report (period: daily, weekly, monthly)')
   .option('--json', 'Output as JSON')
+  .addHelpText('after', `
+Examples:
+  $ omc cost                     Show monthly cost report
+  $ omc cost daily               Show daily cost breakdown
+  $ omc cost weekly --json       Export weekly costs as JSON`)
   .action(async (period = 'monthly', options) => {
     if (!['daily', 'weekly', 'monthly'].includes(period)) {
-      console.error('Invalid period. Use: daily, weekly, or monthly');
+      console.error(chalk.red(`Invalid period "${period}". Valid options: daily, weekly, monthly`));
+      console.error(chalk.gray('Example: omc cost weekly'));
       process.exit(1);
     }
     await ensureBackfillDone();
@@ -208,7 +219,12 @@ program
   .command('sessions')
   .description('View session history')
   .option('--json', 'Output as JSON')
-  .option('--limit <number>', 'Limit number of sessions', '10')
+  .option('-n, --limit <number>', 'Limit number of sessions', '10')
+  .addHelpText('after', `
+Examples:
+  $ omc sessions                 Show last 10 sessions
+  $ omc sessions --limit 50      Show last 50 sessions
+  $ omc sessions --json          Export session history as JSON`)
   .action(async (options) => {
     await ensureBackfillDone();
     await sessionsCommand({ ...options, limit: parseInt(options.limit) });
@@ -219,7 +235,12 @@ program
   .command('agents')
   .description('Show agent usage breakdown')
   .option('--json', 'Output as JSON')
-  .option('--limit <number>', 'Limit number of agents', '10')
+  .option('-n, --limit <number>', 'Limit number of agents', '10')
+  .addHelpText('after', `
+Examples:
+  $ omc agents                   Show top 10 agents by usage
+  $ omc agents --limit 20        Show top 20 agents
+  $ omc agents --json            Export agent data as JSON`)
   .action(async (options) => {
     await ensureBackfillDone();
     await agentsCommand({ ...options, limit: parseInt(options.limit) });
@@ -230,13 +251,20 @@ program
   .command('export <type> <format> <output>')
   .description('Export data (type: cost, sessions, patterns; format: json, csv)')
   .option('--period <period>', 'Period for cost report (daily, weekly, monthly)', 'monthly')
+  .addHelpText('after', `
+Examples:
+  $ omc export cost json costs.json           Export monthly costs to JSON
+  $ omc export sessions csv sessions.csv      Export sessions to CSV
+  $ omc export cost csv data.csv --period weekly   Export weekly costs`)
   .action((type, format, output, options) => {
     if (!['cost', 'sessions', 'patterns'].includes(type)) {
-      console.error('Invalid type. Use: cost, sessions, or patterns');
+      console.error(chalk.red(`Invalid type "${type}". Valid options: cost, sessions, patterns`));
+      console.error(chalk.gray('Example: omc export cost json output.json'));
       process.exit(1);
     }
     if (!['json', 'csv'].includes(format)) {
-      console.error('Invalid format. Use: json or csv');
+      console.error(chalk.red(`Invalid format "${format}". Valid options: json, csv`));
+      console.error(chalk.gray('Example: omc export sessions csv sessions.csv'));
       process.exit(1);
     }
     exportCommand(type as any, format as any, output, options);
@@ -246,7 +274,11 @@ program
 program
   .command('cleanup')
   .description('Clean up old logs and orphaned background tasks')
-  .option('--retention <days>', 'Retention period in days', '30')
+  .option('-r, --retention <days>', 'Retention period in days', '30')
+  .addHelpText('after', `
+Examples:
+  $ omc cleanup                  Clean up logs older than 30 days
+  $ omc cleanup --retention 7    Clean up logs older than 7 days`)
   .action(options => {
     cleanupCommand({ ...options, retention: parseInt(options.retention) });
   });
@@ -260,8 +292,13 @@ program
   .option('--to <date>', 'End date (ISO format: YYYY-MM-DD)')
   .option('--dry-run', 'Preview without writing data')
   .option('--reset', 'Clear deduplication index and re-process all transcripts')
-  .option('--verbose', 'Show detailed progress')
+  .option('-v, --verbose', 'Show detailed progress')
   .option('--json', 'Output as JSON')
+  .addHelpText('after', `
+Examples:
+  $ omc backfill --reset                       Force full re-sync
+  $ omc backfill --project ~/myproject         Backfill specific project
+  $ omc backfill --from 2024-01-01 --verbose   Backfill from date with progress`)
   .action(async (options) => {
     if (!options.reset && !options.project && !options.from && !options.to) {
       console.log(chalk.yellow('Note: Backfill now runs automatically with every omc command.'));
@@ -279,6 +316,11 @@ program
   .option('--daily', 'Show daily view')
   .option('--stats', 'Show stats view')
   .option('--no-claude', 'Show all providers (not just Claude)')
+  .addHelpText('after', `
+Examples:
+  $ omc tui                      Launch interactive dashboard
+  $ omc tui --light              Use light theme
+  $ omc tui --daily              Start with daily view`)
   .action(async (options) => {
     const available = await isTokscaleCLIAvailable();
 
@@ -302,6 +344,7 @@ program
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(chalk.red(`Failed to launch TUI: ${message}`));
+      console.error(chalk.gray('Try running "omc tui" again, or check if tokscale is properly installed.'));
       process.exit(1);
     }
   });
@@ -314,6 +357,11 @@ program
   .description('Initialize Sisyphus configuration in the current directory')
   .option('-g, --global', 'Initialize global user configuration')
   .option('-f, --force', 'Overwrite existing configuration')
+  .addHelpText('after', `
+Examples:
+  $ omc init                     Initialize in current directory
+  $ omc init --global            Initialize global configuration
+  $ omc init --force             Overwrite existing config`)
   .action(async (options) => {
     console.log(chalk.yellow('⚠️  DEPRECATED: The init command is deprecated.'));
     console.log(chalk.gray('Configuration is now managed automatically. Use /oh-my-claudecode:omc-setup instead.\n'));
@@ -464,6 +512,11 @@ program
   .description('Show current configuration')
   .option('-v, --validate', 'Validate configuration')
   .option('-p, --paths', 'Show configuration file paths')
+  .addHelpText('after', `
+Examples:
+  $ omc config                   Show current configuration
+  $ omc config --validate        Validate configuration files
+  $ omc config --paths           Show config file locations`)
   .action(async (options) => {
     if (options.paths) {
       const paths = getConfigPaths();
@@ -521,6 +574,9 @@ program
 program
   .command('info')
   .description('Show system and agent information')
+  .addHelpText('after', `
+Examples:
+  $ omc info                     Show agents, features, and MCP servers`)
   .action(async () => {
     const session = createSisyphusSession();
 
@@ -565,6 +621,10 @@ program
 program
   .command('test-prompt <prompt>')
   .description('Test how a prompt would be enhanced')
+  .addHelpText('after', `
+Examples:
+  $ omc test-prompt "ultrawork fix bugs"    See how magic keywords are detected
+  $ omc test-prompt "analyze this code"     Test prompt enhancement`)
   .action(async (prompt: string) => {
     const session = createSisyphusSession();
 
@@ -590,6 +650,11 @@ program
   .option('-c, --check', 'Only check for updates, do not install')
   .option('-f, --force', 'Force reinstall even if up to date')
   .option('-q, --quiet', 'Suppress output except for errors')
+  .addHelpText('after', `
+Examples:
+  $ omc update                   Check and install updates
+  $ omc update --check           Only check, don't install
+  $ omc update --force           Force reinstall`)
   .action(async (options) => {
     if (!options.quiet) {
       console.log(chalk.blue('Oh-My-ClaudeCode Update\n'));
@@ -652,6 +717,7 @@ program
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(chalk.red(`Update failed: ${message}`));
+      console.error(chalk.gray('Try again with "omc update --force", or reinstall with "omc install --force".'));
       process.exit(1);
     }
   });
@@ -662,6 +728,9 @@ program
 program
   .command('version')
   .description('Show detailed version information')
+  .addHelpText('after', `
+Examples:
+  $ omc version                  Show version, install method, and commit hash`)
   .action(async () => {
     const installed = getInstalledVersion();
 
@@ -698,6 +767,11 @@ program
   .option('-f, --force', 'Overwrite existing files')
   .option('-q, --quiet', 'Suppress output except for errors')
   .option('--skip-claude-check', 'Skip checking if Claude Code is installed')
+  .addHelpText('after', `
+Examples:
+  $ omc install                  Install to ~/.claude/
+  $ omc install --force          Reinstall, overwriting existing files
+  $ omc install --quiet          Silent install for scripts`)
   .action(async (options) => {
     if (!options.quiet) {
       console.log(chalk.blue('╔═══════════════════════════════════════════════════════════╗'));
@@ -789,6 +863,8 @@ program
       if (result.errors.length > 0) {
         result.errors.forEach(err => console.error(chalk.red(`  - ${err}`)));
       }
+      console.error(chalk.gray('\nTry "omc install --force" to overwrite existing files.'));
+      console.error(chalk.gray('For more diagnostics, run "omc doctor conflicts".'));
       process.exit(1);
     }
   });
@@ -808,6 +884,13 @@ const waitCmd = program
   .option('--json', 'Output as JSON')
   .option('--start', 'Start the auto-resume daemon')
   .option('--stop', 'Stop the auto-resume daemon')
+  .addHelpText('after', `
+Examples:
+  $ omc wait                     Show status and suggestions
+  $ omc wait --start             Start auto-resume daemon
+  $ omc wait --stop              Stop auto-resume daemon
+  $ omc wait status              Show detailed rate limit status
+  $ omc wait detect              Scan for blocked tmux sessions`)
   .action(async (options) => {
     await waitCommand(options);
   });
@@ -826,9 +909,15 @@ waitCmd
   .option('-v, --verbose', 'Enable verbose logging')
   .option('-f, --foreground', 'Run in foreground (blocking)')
   .option('-i, --interval <seconds>', 'Poll interval in seconds', '60')
+  .addHelpText('after', `
+Examples:
+  $ omc wait daemon start            Start background daemon
+  $ omc wait daemon stop             Stop the daemon
+  $ omc wait daemon start -f         Run in foreground`)
   .action(async (action: string, options) => {
     if (action !== 'start' && action !== 'stop') {
-      console.error('Invalid action. Use: start or stop');
+      console.error(chalk.red(`Invalid action "${action}". Valid options: start, stop`));
+      console.error(chalk.gray('Example: omc wait daemon start'));
       process.exit(1);
     }
     await waitDaemonCommand(action as 'start' | 'stop', {
@@ -863,9 +952,15 @@ const teleportCmd = program
   .command('teleport [ref]')
   .description('Create git worktree for isolated development (e.g., omc teleport #123)')
   .option('--worktree', 'Create worktree (default behavior, flag kept for compatibility)')
-  .option('--path <path>', 'Custom worktree path (default: ~/Workspace/omc-worktrees/)')
-  .option('--base <branch>', 'Base branch to create from (default: main)')
+  .option('-p, --path <path>', 'Custom worktree path (default: ~/Workspace/omc-worktrees/)')
+  .option('-b, --base <branch>', 'Base branch to create from (default: main)')
   .option('--json', 'Output as JSON')
+  .addHelpText('after', `
+Examples:
+  $ omc teleport #42             Create worktree for issue/PR #42
+  $ omc teleport add-auth        Create worktree for a feature branch
+  $ omc teleport list            List existing worktrees
+  $ omc teleport remove ./path   Remove a worktree`)
   .action(async (ref: string | undefined, options) => {
     if (!ref) {
       // No ref provided, show help
@@ -908,7 +1003,7 @@ teleportCmd
   .command('remove <path>')
   .alias('rm')
   .description('Remove a worktree')
-  .option('--force', 'Force removal even with uncommitted changes')
+  .option('-f, --force', 'Force removal even with uncommitted changes')
   .option('--json', 'Output as JSON')
   .action(async (path: string, options) => {
     await teleportRemoveCommand(path, options);
@@ -919,12 +1014,19 @@ teleportCmd
  */
 const doctorCmd = program
   .command('doctor')
-  .description('Diagnostic tools for troubleshooting OMC installation');
+  .description('Diagnostic tools for troubleshooting OMC installation')
+  .addHelpText('after', `
+Examples:
+  $ omc doctor conflicts         Check for plugin conflicts`);
 
 doctorCmd
   .command('conflicts')
   .description('Check for plugin coexistence issues and configuration conflicts')
   .option('--json', 'Output as JSON')
+  .addHelpText('after', `
+Examples:
+  $ omc doctor conflicts         Check for configuration issues
+  $ omc doctor conflicts --json  Output results as JSON`)
   .action(async (options) => {
     const exitCode = await doctorConflictsCommand(options);
     process.exit(exitCode);


### PR DESCRIPTION
## Summary
- Suppress `coordinatorAgent` deprecation warning by default (only shown with `--verbose` or `VERBOSE=1`)
- Add usage examples to help text for all 18 CLI commands via `.addHelpText()`
- Improve error messages with chalk formatting, invalid value display, and actionable suggestions
- Standardize option naming with short flags (`-n`, `-r`, `-p`, `-b`, `-f`, `-v`) across commands

## Test plan
- [x] Build passes (`npm run build`)
- [x] Deprecation warning suppressed by default, shown with `VERBOSE=1`
- [x] Help text examples render correctly (verified `stats`, `cost`, `teleport`)
- [x] Existing test suite passes (78/79 pass, 1 pre-existing failure unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)