### PR TITLE
fix: address 13 bugs from stress test report (#301)

### DIFF
--- a/commands/hud.md
+++ b/commands/hud.md
@@ -82,13 +82,19 @@ import { pathToFileURL } from "node:url";
 
 // Semantic version comparison: returns negative if a < b, positive if a > b, 0 if equal
 function semverCompare(a, b) {
-  const pa = a.replace(/^v/, "").split(".").map(Number);
-  const pb = b.replace(/^v/, "").split(".").map(Number);
+  // Use parseInt to handle pre-release suffixes (e.g. "0-beta" -> 0)
+  const pa = a.replace(/^v/, "").split(".").map(s => parseInt(s, 10) || 0);
+  const pb = b.replace(/^v/, "").split(".").map(s => parseInt(s, 10) || 0);
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
     const na = pa[i] || 0;
     const nb = pb[i] || 0;
     if (na !== nb) return na - nb;
   }
+  // If numeric parts equal, non-pre-release > pre-release
+  const aHasPre = /-/.test(a);
+  const bHasPre = /-/.test(b);
+  if (aHasPre && !bHasPre) return -1;
+  if (!aHasPre && bHasPre) return 1;
   return 0;
 }
 

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -105,14 +105,14 @@ function activateState(directory, prompt, stateName) {
   if (!existsSync(localDir)) {
     try { mkdirSync(localDir, { recursive: true }); } catch {}
   }
-  try { writeFileSync(join(localDir, `${stateName}-state.json`), JSON.stringify(state, null, 2)); } catch {}
+  try { writeFileSync(join(localDir, `${stateName}-state.json`), JSON.stringify(state, null, 2), { mode: 0o600 }); } catch {}
 
   // Write to global .omc/state directory
   const globalDir = join(homedir(), '.omc', 'state');
   if (!existsSync(globalDir)) {
     try { mkdirSync(globalDir, { recursive: true }); } catch {}
   }
-  try { writeFileSync(join(globalDir, `${stateName}-state.json`), JSON.stringify(state, null, 2)); } catch {}
+  try { writeFileSync(join(globalDir, `${stateName}-state.json`), JSON.stringify(state, null, 2), { mode: 0o600 }); } catch {}
 }
 
 /**

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -75,6 +75,8 @@ Or use the `--all` alias:
 This removes all state files:
 - `.omc/state/autopilot-state.json`
 - `.omc/state/ralph-state.json`
+- `.omc/state/ralph-plan-state.json`
+- `.omc/state/ralph-verification.json`
 - `.omc/state/ultrawork-state.json`
 - `.omc/state/ecomode-state.json`
 - `.omc/state/ultraqa-state.json`
@@ -82,10 +84,19 @@ This removes all state files:
 - `.omc/state/swarm.db-wal`
 - `.omc/state/swarm.db-shm`
 - `.omc/state/swarm-active.marker`
+- `.omc/state/swarm-tasks.db`
 - `.omc/state/ultrapilot-state.json`
+- `.omc/state/ultrapilot-ownership.json`
 - `.omc/state/pipeline-state.json`
 - `.omc/state/plan-consensus.json`
 - `.omc/state/ralplan-state.json`
+- `.omc/state/boulder.json`
+- `.omc/state/hud-state.json`
+- `.omc/state/subagent-tracking.json`
+- `.omc/state/subagent-tracker.lock`
+- `.omc/state/rate-limit-daemon.pid`
+- `.omc/state/rate-limit-daemon.log`
+- `.omc/state/checkpoints/` (directory)
 
 ## Implementation Steps
 
@@ -150,19 +161,34 @@ if [[ "$FORCE_MODE" == "true" ]]; then
   # Remove local state files
   rm -f .omc/state/autopilot-state.json
   rm -f .omc/state/ralph-state.json
+  rm -f .omc/state/ralph-plan-state.json
+  rm -f .omc/state/ralph-verification.json
   rm -f .omc/state/ultrawork-state.json
   rm -f .omc/state/ecomode-state.json
   rm -f .omc/state/ultraqa-state.json
-  rm -f .omc/state/ralph-plan-state.json
-  rm -f .omc/state/ralph-verification.json
   rm -f .omc/state/swarm.db
   rm -f .omc/state/swarm.db-wal
   rm -f .omc/state/swarm.db-shm
   rm -f .omc/state/swarm-active.marker
+  rm -f .omc/state/swarm-tasks.db
   rm -f .omc/state/ultrapilot-state.json
+  rm -f .omc/state/ultrapilot-ownership.json
   rm -f .omc/state/pipeline-state.json
   rm -f .omc/state/plan-consensus.json
   rm -f .omc/state/ralplan-state.json
+  rm -f .omc/state/boulder.json
+  rm -f .omc/state/hud-state.json
+  rm -f .omc/state/subagent-tracking.json
+  rm -f .omc/state/subagent-tracker.lock
+  rm -f .omc/state/rate-limit-daemon.pid
+  rm -f .omc/state/rate-limit-daemon.log
+  rm -rf .omc/state/checkpoints/
+
+  # Stop rate-limit daemon if running
+  if [[ -f .omc/state/rate-limit-daemon.pid ]]; then
+    kill "$(cat .omc/state/rate-limit-daemon.pid)" 2>/dev/null || true
+    rm -f .omc/state/rate-limit-daemon.pid
+  fi
 
   echo "All OMC modes cleared. You are free to start fresh."
   exit 0
@@ -309,22 +335,36 @@ if [[ "$FORCE_MODE" == "true" ]]; then
 
   mkdir -p .omc/state
 
+  # Stop rate-limit daemon if running
+  if [[ -f .omc/state/rate-limit-daemon.pid ]]; then
+    kill "$(cat .omc/state/rate-limit-daemon.pid)" 2>/dev/null || true
+    rm -f .omc/state/rate-limit-daemon.pid
+  fi
+
   # Remove local state files
   rm -f .omc/state/autopilot-state.json
   rm -f .omc/state/ralph-state.json
+  rm -f .omc/state/ralph-plan-state.json
+  rm -f .omc/state/ralph-verification.json
   rm -f .omc/state/ultrawork-state.json
   rm -f .omc/state/ecomode-state.json
   rm -f .omc/state/ultraqa-state.json
-  rm -f .omc/state/ralph-plan-state.json
-  rm -f .omc/state/ralph-verification.json
   rm -f .omc/state/swarm.db
   rm -f .omc/state/swarm.db-wal
   rm -f .omc/state/swarm.db-shm
   rm -f .omc/state/swarm-active.marker
+  rm -f .omc/state/swarm-tasks.db
   rm -f .omc/state/ultrapilot-state.json
+  rm -f .omc/state/ultrapilot-ownership.json
   rm -f .omc/state/pipeline-state.json
   rm -f .omc/state/plan-consensus.json
   rm -f .omc/state/ralplan-state.json
+  rm -f .omc/state/boulder.json
+  rm -f .omc/state/hud-state.json
+  rm -f .omc/state/subagent-tracking.json
+  rm -f .omc/state/subagent-tracker.lock
+  rm -f .omc/state/rate-limit-daemon.log
+  rm -rf .omc/state/checkpoints/
 
   echo ""
   echo "All OMC modes cleared. You are free to start fresh."

--- a/skills/ecomode/SKILL.md
+++ b/skills/ecomode/SKILL.md
@@ -39,8 +39,8 @@ Ecomode is a modifier that combines with execution modes:
 
 | Decision | Rule |
 |----------|------|
-| DEFAULT | Use LOW tier (Haiku) for all tasks |
-| UPGRADE | Use MEDIUM (Sonnet) only when task complexity warrants |
+| DEFAULT | Start with LOW tier (Haiku) for most tasks |
+| UPGRADE | Escalate to MEDIUM (Sonnet) when LOW tier fails or task requires multi-file reasoning |
 | AVOID | HIGH tier (Opus) - only for planning/critique if essential |
 
 ## Agent Selection in Ecomode

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -85,13 +85,19 @@ import { pathToFileURL } from "node:url";
 
 // Semantic version comparison: returns negative if a < b, positive if a > b, 0 if equal
 function semverCompare(a, b) {
-  const pa = a.replace(/^v/, "").split(".").map(Number);
-  const pb = b.replace(/^v/, "").split(".").map(Number);
+  // Use parseInt to handle pre-release suffixes (e.g. "0-beta" -> 0)
+  const pa = a.replace(/^v/, "").split(".").map(s => parseInt(s, 10) || 0);
+  const pb = b.replace(/^v/, "").split(".").map(s => parseInt(s, 10) || 0);
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
     const na = pa[i] || 0;
     const nb = pb[i] || 0;
     if (na !== nb) return na - nb;
   }
+  // If numeric parts equal, non-pre-release > pre-release
+  const aHasPre = /-/.test(a);
+  const bHasPre = /-/.test(b);
+  if (aHasPre && !bHasPre) return -1;
+  if (!aHasPre && bHasPre) return 1;
   return 0;
 }
 

--- a/src/__tests__/analytics/token-tracker.test.ts
+++ b/src/__tests__/analytics/token-tracker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { TokenTracker, resetTokenTracker } from '../../analytics/token-tracker.js';
+import { resetTokenTracker } from '../../analytics/token-tracker.js';
 
 describe('TokenTracker.getTopAgents', () => {
   beforeEach(() => {
@@ -8,13 +8,13 @@ describe('TokenTracker.getTopAgents', () => {
   });
 
   it('returns empty array when no usage recorded', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
     const result = await tracker.getTopAgents(5);
     expect(result).toEqual([]);
   });
 
   it('returns agents sorted by cost descending', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
 
     // Record usage for multiple agents
     await tracker.recordTokenUsage({
@@ -44,7 +44,7 @@ describe('TokenTracker.getTopAgents', () => {
   });
 
   it('respects the limit parameter', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
 
     // Record usage for 5 agents
     for (let i = 0; i < 5; i++) {
@@ -63,7 +63,7 @@ describe('TokenTracker.getTopAgents', () => {
   });
 
   it('aggregates multiple usages for same agent', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
 
     // Record multiple usages for same agent
     await tracker.recordTokenUsage({
@@ -92,7 +92,7 @@ describe('TokenTracker.getTopAgents', () => {
   });
 
   it('uses "(main session)" for entries without agentName', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
 
     await tracker.recordTokenUsage({
       modelName: 'claude-sonnet-4.5',
@@ -108,7 +108,7 @@ describe('TokenTracker.getTopAgents', () => {
   });
 
   it('handles mixed agents with and without names', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
 
     // Main session usage
     await tracker.recordTokenUsage({
@@ -136,7 +136,7 @@ describe('TokenTracker.getTopAgents', () => {
   });
 
   it('calculates cost correctly across different models', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
 
     // Haiku (cheaper)
     await tracker.recordTokenUsage({
@@ -168,7 +168,7 @@ describe('TokenTracker.getTopAgents', () => {
   });
 
   it('includes cache tokens in cost calculation', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
 
     // Usage with cache
     await tracker.recordTokenUsage({
@@ -202,7 +202,7 @@ describe('TokenTracker.getTopAgents', () => {
   });
 
   it('returns agents in stable order when costs are equal', async () => {
-    const tracker = new TokenTracker('test-session');
+    const tracker = resetTokenTracker('test-session');
 
     // Record identical usage for multiple agents
     for (let i = 0; i < 3; i++) {

--- a/src/analytics/cost-estimator.ts
+++ b/src/analytics/cost-estimator.ts
@@ -130,7 +130,7 @@ function getPricingForModel(modelName: string): ModelPricing {
   return PRICING['claude-sonnet-4.5'];
 }
 
-function normalizeModelName(modelName: string): string {
+export function normalizeModelName(modelName: string): string {
   // Handle various model name formats
   const lower = modelName.toLowerCase();
 

--- a/src/hooks/autopilot/validation.ts
+++ b/src/hooks/autopilot/validation.ts
@@ -20,6 +20,9 @@ import type {
   ValidationVerdict
 } from './types.js';
 
+/** Number of architects required for validation consensus */
+export const REQUIRED_ARCHITECTS = 3;
+
 export interface ValidationCoordinatorResult {
   success: boolean;
   allApproved: boolean;
@@ -60,8 +63,8 @@ export function recordValidationVerdict(
     state.validation.architects_spawned++;
   }
 
-  // Check if all verdicts are in (3 architects)
-  if (state.validation.verdicts.length >= 3) {
+  // Check if all verdicts are in
+  if (state.validation.verdicts.length >= REQUIRED_ARCHITECTS) {
     state.validation.all_approved = state.validation.verdicts.every(
       v => v.verdict === 'APPROVED'
     );
@@ -87,7 +90,7 @@ export function getValidationStatus(directory: string): ValidationCoordinatorRes
   }
 
   return {
-    success: state.validation.verdicts.length >= 3,
+    success: state.validation.verdicts.length >= REQUIRED_ARCHITECTS,
     allApproved: state.validation.all_approved,
     verdicts: state.validation.verdicts,
     round: state.validation.validation_rounds,

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -666,13 +666,13 @@ export async function processHook(
         }
         const stopInput = input as SubagentStopInput;
         const result = processSubagentStop(stopInput);
-        // Record to session replay
+        // Record to session replay (default to true when SDK doesn't provide success)
         recordAgentStop(
           stopInput.cwd,
           stopInput.session_id,
           stopInput.agent_id,
           stopInput.agent_type,
-          stopInput.success
+          stopInput.success !== false
         );
         return result;
       }

--- a/src/hooks/learner/auto-invoke.ts
+++ b/src/hooks/learner/auto-invoke.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { atomicWriteJson } from '../../lib/atomic-write.js';
 
 export interface InvocationConfig {
   enabled: boolean;
@@ -202,20 +203,17 @@ export function getInvocationStats(state: AutoInvokeState): {
  */
 export function saveInvocationHistory(state: AutoInvokeState): void {
   const historyDir = path.join(os.homedir(), '.omc', 'analytics', 'invocations');
+  const historyFile = path.join(historyDir, `${state.sessionId}.json`);
 
-  try {
-    fs.mkdirSync(historyDir, { recursive: true });
-
-    const historyFile = path.join(historyDir, `${state.sessionId}.json`);
-    fs.writeFileSync(historyFile, JSON.stringify({
-      sessionId: state.sessionId,
-      config: state.config,
-      invocations: state.invocations,
-      stats: getInvocationStats(state),
-    }, null, 2));
-  } catch (error) {
+  // Use atomic write to prevent corruption from concurrent sessions (Bug #11 fix)
+  atomicWriteJson(historyFile, {
+    sessionId: state.sessionId,
+    config: state.config,
+    invocations: state.invocations,
+    stats: getInvocationStats(state),
+  }).catch(error => {
     console.error('[auto-invoke] Failed to save invocation history:', error);
-  }
+  });
 }
 
 /**

--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -116,7 +116,8 @@ export function readRalphState(directory: string): RalphLoopState | null {
   try {
     const content = readFileSync(stateFile, 'utf-8');
     return JSON.parse(content);
-  } catch {
+  } catch (error) {
+    console.error('[ralph] Failed to read state file:', error);
     return null;
   }
 }
@@ -128,7 +129,7 @@ export function writeRalphState(directory: string, state: RalphLoopState): boole
   try {
     ensureStateDir(directory);
     const stateFile = getStateFilePath(directory);
-    writeFileSync(stateFile, JSON.stringify(state, null, 2));
+    writeFileSync(stateFile, JSON.stringify(state, null, 2), { mode: 0o600 });
     return true;
   } catch {
     return false;

--- a/src/hooks/ultrawork/session-isolation.test.ts
+++ b/src/hooks/ultrawork/session-isolation.test.ts
@@ -108,11 +108,12 @@ describe('Ultrawork Session Isolation (Issue #269)', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when both state and caller have undefined session_id', () => {
+    it('should return false when both state and caller have undefined session_id (Bug #5 fix)', () => {
       activateUltrawork('Test task', undefined, tempDir);
 
+      // Both undefined should NOT match - prevents cross-session contamination
       const result = shouldReinforceUltrawork(undefined, tempDir);
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
     it('should return false when ultrawork is not active', () => {
@@ -212,12 +213,13 @@ describe('Ultrawork Session Isolation (Issue #269)', () => {
   });
 
   describe('Edge cases', () => {
-    it('should handle empty string session IDs as distinct from undefined', () => {
+    it('should reject empty string and undefined session IDs for isolation safety', () => {
       const emptySession = '';
       activateUltrawork('Task with empty session', emptySession, tempDir);
 
-      // Empty string should be treated as a valid session ID
-      expect(shouldReinforceUltrawork(emptySession, tempDir)).toBe(true);
+      // Empty string and undefined should both be rejected to prevent
+      // cross-session contamination (Bug #5 fix)
+      expect(shouldReinforceUltrawork(emptySession, tempDir)).toBe(false);
       expect(shouldReinforceUltrawork(undefined, tempDir)).toBe(false);
     });
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -7,6 +7,7 @@
  */
 
 import { join } from 'path';
+import { existsSync, unlinkSync, rmSync } from 'fs';
 import { homedir } from 'os';
 
 /**
@@ -57,4 +58,35 @@ export function getConfigDir(): string {
     return process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
   }
   return process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+}
+
+/**
+ * Safely delete a file, ignoring ENOENT errors.
+ * Prevents crashes when cleaning up files that may not exist (Bug #13 fix).
+ */
+export function safeUnlinkSync(filePath: string): boolean {
+  try {
+    if (existsSync(filePath)) {
+      unlinkSync(filePath);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Safely remove a directory recursively, ignoring errors.
+ */
+export function safeRmSync(dirPath: string): boolean {
+  try {
+    if (existsSync(dirPath)) {
+      rmSync(dirPath, { recursive: true, force: true });
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #301 - addresses 13 of the 15 bugs identified in the v3.9.5 stress test report.

### Critical (4 bugs)
- **Bug #1**: SubagentStop hook read non-existent `success` field from SDK, causing all agents to be marked as "failed". Now defaults to `completed` when field is undefined.
- **Bug #4**: Session token stats lost across `TokenTracker` instances. Constructor now restores existing session stats from global state.
- **Bug #5**: Ultrawork session isolation bypassed when both session IDs were `undefined` (`undefined === undefined` evaluated to `true`). Now rejects all falsy session IDs.

### High (6 bugs)
- **Bug #6**: Cancel skill `--force` missed 12+ state files (boulder, hud-state, subagent-tracking, checkpoints, ownership, etc). Added comprehensive cleanup list.
- **Bug #7**: HUD `semverCompare()` returned `NaN` on pre-release versions like `3.9.5-beta`. Fixed to use `parseInt` and handle pre-release ordering.
- **Bug #8**: Silent JSON parse failures in critical state readers. Added error logging to ralph and ultrawork state readers.
- **Bug #9**: Stale task detection never fired when `onStaleSession` callback was not configured. Now auto-cleans tasks after 2x staleness threshold.
- **Bug #10**: Hardcoded `3`-architect assumption in autopilot validation. Extracted to `REQUIRED_ARCHITECTS` constant.

### Medium (5 bugs)
- **Bug #11**: Auto-invoke history used non-atomic `writeFileSync`. Now uses `atomicWriteJson` to prevent corruption from concurrent sessions.
- **Bug #12**: Ecomode docs contradicted implementation - said "all tasks" use Haiku while defining escalation paths. Clarified wording.
- **Bug #13**: Added `safeUnlinkSync`/`safeRmSync` utilities to prevent `ENOENT` crashes during cleanup.
- **Bug #14**: State files containing user prompts written with `0644` permissions. Now writes with `0600` (owner-only).
- **Bug #15**: Model names recorded inconsistently. Now normalizes at recording time via exported `normalizeModelName()`.

### Not addressed
- **Bug #2** (ConcurrencyManager race): Analysis shows the semaphore implementation is correct for single-threaded Node.js.
- **Bug #3** (Ralph state wrong structure): Code inspection shows `writeRalphState` correctly writes `RalphLoopState`. Could not reproduce.

### Files changed (17)
- `src/hooks/subagent-tracker/index.ts` - Bug #1 fix
- `src/hooks/bridge.ts` - Bug #1 fix (call site)
- `src/analytics/token-tracker.ts` - Bug #4, #15 fixes
- `src/hooks/ultrawork/index.ts` - Bug #5, #8, #14 fixes
- `skills/cancel/SKILL.md` - Bug #6 fix
- `skills/hud/SKILL.md`, `commands/hud.md` - Bug #7 fix
- `src/features/background-agent/manager.ts` - Bug #9 fix
- `src/hooks/autopilot/validation.ts` - Bug #10 fix
- `src/hooks/learner/auto-invoke.ts` - Bug #11 fix
- `skills/ecomode/SKILL.md` - Bug #12 fix
- `src/utils/paths.ts` - Bug #13 fix (new utilities)
- `src/hooks/ralph/loop.ts` - Bug #8, #14 fixes
- `scripts/keyword-detector.mjs` - Bug #14 fix
- `src/analytics/cost-estimator.ts` - Bug #15 fix (export normalizer)
- Tests updated for new behaviors

## Test plan
- [x] `npx tsc --noEmit` passes (zero type errors)
- [x] `npx vitest run` passes (2111 tests pass, 1 pre-existing failure unrelated to changes)
- [x] Session isolation tests updated to verify Bug #5 fix
- [x] Token tracker tests updated for constructor restoration behavior
- [ ] Manual test: activate/cancel ultrawork, verify state cleanup
- [ ] Manual test: verify HUD loads correctly with pre-release version directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)