### PR TITLE
fix: add session isolation to ultrawork persistent mode (#311)

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -338,7 +338,10 @@ async function main() {
 
     // Priority 7: Ultrawork - ALWAYS continue while active (not just when tasks exist)
     // This prevents false stops from bash errors, transient failures, etc.
-    if (ultrawork.state?.active && !isStaleState(ultrawork.state)) {
+    // Session isolation: only block if state belongs to this session (issue #311)
+    // If state has session_id, it must match. If no session_id (legacy), allow.
+    if (ultrawork.state?.active && !isStaleState(ultrawork.state) &&
+        (!ultrawork.state.session_id || ultrawork.state.session_id === sessionId)) {
       const newCount = (ultrawork.state.reinforcement_count || 0) + 1;
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -338,7 +338,10 @@ async function main() {
 
     // Priority 7: Ultrawork - ALWAYS continue while active (not just when tasks exist)
     // This prevents false stops from bash errors, transient failures, etc.
-    if (ultrawork.state?.active && !isStaleState(ultrawork.state)) {
+    // Session isolation: only block if state belongs to this session (issue #311)
+    // If state has session_id, it must match. If no session_id (legacy), allow.
+    if (ultrawork.state?.active && !isStaleState(ultrawork.state) &&
+        (!ultrawork.state.session_id || ultrawork.state.session_id === sessionId)) {
       const newCount = (ultrawork.state.reinforcement_count || 0) + 1;
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -109,6 +109,7 @@ async function main() {
     try { data = JSON.parse(input); } catch {}
 
     const directory = data.directory || process.cwd();
+    const sessionId = data.sessionId || data.session_id || '';
     const messages = [];
 
     // Check HUD installation (one-time setup guidance)
@@ -119,11 +120,11 @@ async function main() {
 </system-reminder>`);
     }
 
-    // Check for ultrawork state
+    // Check for ultrawork state - only restore if session matches (issue #311)
     const ultraworkState = readJsonFile(join(directory, '.omc', 'ultrawork-state.json'))
       || readJsonFile(join(homedir(), '.claude', 'ultrawork-state.json'));
 
-    if (ultraworkState?.active) {
+    if (ultraworkState?.active && (!ultraworkState.session_id || ultraworkState.session_id === sessionId)) {
       messages.push(`<session-restore>
 
 [ULTRAWORK MODE RESTORED]

--- a/src/hooks/persistent-mode/session-isolation.test.ts
+++ b/src/hooks/persistent-mode/session-isolation.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import { checkPersistentModes } from './index.js';
+import { activateUltrawork, deactivateUltrawork } from '../ultrawork/index.js';
+
+describe('Persistent Mode Session Isolation (Issue #311)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'persistent-mode-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('checkPersistentModes session isolation', () => {
+    it('should block stop when session_id matches active ultrawork', async () => {
+      const sessionId = 'session-owner';
+      activateUltrawork('Fix the bug', sessionId, tempDir);
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(true);
+      expect(result.mode).toBe('ultrawork');
+    });
+
+    it('should NOT block stop when session_id does not match', async () => {
+      const ownerSession = 'session-owner';
+      const otherSession = 'session-intruder';
+      activateUltrawork('Fix the bug', ownerSession, tempDir);
+
+      const result = await checkPersistentModes(otherSession, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('none');
+    });
+
+    it('should NOT block when no ultrawork state exists', async () => {
+      const result = await checkPersistentModes('any-session', tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('none');
+    });
+
+    it('should NOT block after ultrawork is deactivated', async () => {
+      const sessionId = 'session-done';
+      activateUltrawork('Task complete', sessionId, tempDir);
+      deactivateUltrawork(tempDir);
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+    });
+
+    it('should NOT block when session_id is undefined and state has session_id', async () => {
+      activateUltrawork('Task', 'session-with-id', tempDir);
+
+      const result = await checkPersistentModes(undefined, tempDir);
+      expect(result.shouldBlock).toBe(false);
+    });
+  });
+
+  describe('persistent-mode.cjs script session isolation', () => {
+    const scriptPath = join(
+      process.cwd(),
+      'scripts',
+      'persistent-mode.cjs'
+    );
+
+    function runPersistentModeScript(input: Record<string, unknown>): Record<string, unknown> {
+      try {
+        const result = execSync(
+          `echo '${JSON.stringify(input)}' | node "${scriptPath}"`,
+          {
+            encoding: 'utf-8',
+            timeout: 5000,
+            env: { ...process.env, NODE_ENV: 'test' }
+          }
+        );
+        // The script may output multiple lines (stderr + stdout)
+        // Parse the last line which should be the JSON output
+        const lines = result.trim().split('\n');
+        const lastLine = lines[lines.length - 1];
+        return JSON.parse(lastLine);
+      } catch (error: unknown) {
+        const execError = error as { stdout?: string; stderr?: string };
+        // execSync throws on non-zero exit, but script should always exit 0
+        if (execError.stdout) {
+          const lines = execError.stdout.trim().split('\n');
+          const lastLine = lines[lines.length - 1];
+          return JSON.parse(lastLine);
+        }
+        throw error;
+      }
+    }
+
+    function createUltraworkState(dir: string, sessionId: string, prompt: string): void {
+      const stateDir = join(dir, '.omc', 'state');
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(
+        join(stateDir, 'ultrawork-state.json'),
+        JSON.stringify({
+          active: true,
+          started_at: new Date().toISOString(),
+          original_prompt: prompt,
+          session_id: sessionId,
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString()
+        }, null, 2)
+      );
+    }
+
+    it('should block when sessionId matches ultrawork state', () => {
+      const sessionId = 'test-session-match';
+      createUltraworkState(tempDir, sessionId, 'Test task');
+
+      const output = runPersistentModeScript({
+        directory: tempDir,
+        sessionId: sessionId
+      });
+
+      expect(output.decision).toBe('block');
+      expect(output.reason).toContain('ULTRAWORK');
+    });
+
+    it('should NOT block when sessionId does not match ultrawork state', () => {
+      createUltraworkState(tempDir, 'session-A', 'Task for A');
+
+      const output = runPersistentModeScript({
+        directory: tempDir,
+        sessionId: 'session-B'
+      });
+
+      // Should allow stop (continue: true) because session doesn't match
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+    });
+
+    it('should block for legacy state without session_id (backward compat)', () => {
+      const stateDir = join(tempDir, '.omc', 'state');
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(
+        join(stateDir, 'ultrawork-state.json'),
+        JSON.stringify({
+          active: true,
+          started_at: new Date().toISOString(),
+          original_prompt: 'Legacy task',
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString()
+          // Note: no session_id field
+        }, null, 2)
+      );
+
+      const output = runPersistentModeScript({
+        directory: tempDir,
+        sessionId: 'any-session'
+      });
+
+      // Legacy state (no session_id) should still block for backward compat
+      expect(output.decision).toBe('block');
+      expect(output.reason).toContain('ULTRAWORK');
+    });
+  });
+});

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -89,11 +89,12 @@ function sanitizeForKeywordDetection(text) {
 }
 
 // Create state file for a mode
-function activateState(directory, prompt, stateName) {
+function activateState(directory, prompt, stateName, sessionId) {
   const state = {
     active: true,
     started_at: new Date().toISOString(),
     original_prompt: prompt,
+    session_id: sessionId || undefined,
     reinforcement_count: 0,
     last_checked_at: new Date().toISOString()
   };
@@ -350,9 +351,10 @@ async function main() {
     }
 
     // Activate states for modes that need them
+    const sessionId = data.sessionId || data.session_id || '';
     const stateModes = resolved.filter(m => ['ralph', 'autopilot', 'ultrapilot', 'ultrawork', 'ecomode'].includes(m.name));
     for (const mode of stateModes) {
-      activateState(directory, prompt, mode.name);
+      activateState(directory, prompt, mode.name, sessionId);
     }
 
     // Special: Ralph with ultrawork (only if ecomode NOT present)
@@ -360,7 +362,7 @@ async function main() {
     const hasEcomode = resolved.some(m => m.name === 'ecomode');
     const hasUltrawork = resolved.some(m => m.name === 'ultrawork');
     if (hasRalph && !hasEcomode && !hasUltrawork) {
-      activateState(directory, prompt, 'ultrawork');
+      activateState(directory, prompt, 'ultrawork', sessionId);
     }
 
     // Handle ultrathink specially - prepend message instead of skill invocation

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -345,7 +345,10 @@ async function main() {
 
     // Priority 7: Ultrawork - ALWAYS continue while active (not just when tasks exist)
     // This prevents false stops from bash errors, transient failures, etc.
-    if (ultrawork.state?.active && !isStaleState(ultrawork.state)) {
+    // Session isolation: only block if state belongs to this session (issue #311)
+    // If state has session_id, it must match. If no session_id (legacy), allow.
+    if (ultrawork.state?.active && !isStaleState(ultrawork.state) &&
+        (!ultrawork.state.session_id || ultrawork.state.session_id === sessionId)) {
       const newCount = (ultrawork.state.reinforcement_count || 0) + 1;
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -116,6 +116,7 @@ async function main() {
     try { data = JSON.parse(input); } catch {}
 
     const directory = data.directory || process.cwd();
+    const sessionId = data.sessionId || data.session_id || '';
     const messages = [];
 
     // Check for updates (non-blocking)
@@ -142,11 +143,11 @@ To update, run: claude /install-plugin oh-my-claudecode
 `);
     }
 
-    // Check for ultrawork state
+    // Check for ultrawork state - only restore if session matches (issue #311)
     const ultraworkState = readJsonFile(join(directory, '.omc', 'ultrawork-state.json'))
       || readJsonFile(join(homedir(), '.claude', 'ultrawork-state.json'));
 
-    if (ultraworkState?.active) {
+    if (ultraworkState?.active && (!ultraworkState.session_id || ultraworkState.session_id === sessionId)) {
       messages.push(`<session-restore>
 
 [ULTRAWORK MODE RESTORED]


### PR DESCRIPTION
## Summary
- **Root cause**: Ultrawork's persistent session hooks (persistent-mode, session-start, keyword-detector) did not check `session_id` before blocking stops or restoring state, causing the original task to re-execute when a new session inherited stale ultrawork state
- **Fix**: Added `session_id` to state files created by keyword-detector, and added session isolation checks in persistent-mode (stop hooks) and session-start (restore hooks)
- **Backward compat**: Legacy state files without `session_id` are still allowed (no breaking change)

## Changes
| File | Change |
|------|--------|
| `templates/hooks/keyword-detector.mjs` | Store `session_id` in state files on activation |
| `scripts/session-start.mjs` | Only restore ultrawork if `session_id` matches |
| `templates/hooks/session-start.mjs` | Only restore ultrawork if `session_id` matches |
| `scripts/persistent-mode.cjs` | Only block stops for matching `session_id` |
| `scripts/persistent-mode.mjs` | Only block stops for matching `session_id` |
| `templates/hooks/persistent-mode.mjs` | Only block stops for matching `session_id` |
| `src/hooks/persistent-mode/session-isolation.test.ts` | New: 8 tests for session isolation |

## Test plan
- [x] All 2132 existing tests pass (0 failures)
- [x] 8 new session isolation tests pass (TypeScript module + CJS script integration)
- [x] Verified backward compat: legacy state without `session_id` still blocks (no regression)
- [ ] Manual: activate ultrawork, end session, start new session — original task should NOT re-execute

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)