### PR TITLE
fix: session isolation + Windows path handling

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -91,11 +91,12 @@ function sanitizeForKeywordDetection(text) {
 }
 
 // Create state file for a mode
-function activateState(directory, prompt, stateName) {
+function activateState(directory, prompt, stateName, sessionId) {
   const state = {
     active: true,
     started_at: new Date().toISOString(),
     original_prompt: prompt,
+    session_id: sessionId || undefined,
     reinforcement_count: 0,
     last_checked_at: new Date().toISOString()
   };
@@ -228,6 +229,7 @@ async function main() {
     let data = {};
     try { data = JSON.parse(input); } catch {}
     const directory = data.directory || process.cwd();
+    const sessionId = data.sessionId || data.session_id || '';
 
     const prompt = extractPrompt(input);
     if (!prompt) {
@@ -354,7 +356,7 @@ async function main() {
     // Activate states for modes that need them
     const stateModes = resolved.filter(m => ['ralph', 'autopilot', 'ultrapilot', 'ultrawork', 'ecomode'].includes(m.name));
     for (const mode of stateModes) {
-      activateState(directory, prompt, mode.name);
+      activateState(directory, prompt, mode.name, sessionId);
     }
 
     // Special: Ralph with ultrawork (only if ecomode NOT present)
@@ -362,7 +364,7 @@ async function main() {
     const hasEcomode = resolved.some(m => m.name === 'ecomode');
     const hasUltrawork = resolved.some(m => m.name === 'ultrawork');
     if (hasRalph && !hasEcomode && !hasUltrawork) {
-      activateState(directory, prompt, 'ultrawork');
+      activateState(directory, prompt, 'ultrawork', sessionId);
     }
 
     // Handle ultrathink specially - prepend message instead of skill invocation

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -9,7 +9,7 @@
  */
 
 const { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } = require('fs');
-const { join } = require('path');
+const { join, dirname } = require('path');
 const { homedir } = require('os');
 
 async function readStdin() {
@@ -32,8 +32,8 @@ function readJsonFile(path) {
 function writeJsonFile(path, data) {
   try {
     // Ensure directory exists
-    const dir = path.substring(0, path.lastIndexOf('/'));
-    if (dir && !existsSync(dir)) {
+    const dir = dirname(path);
+    if (dir && dir !== '.' && !existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
     writeFileSync(path, JSON.stringify(data, null, 2));

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -9,7 +9,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { homedir } from 'os';
 
 async function readStdin() {
@@ -32,8 +32,8 @@ function readJsonFile(path) {
 function writeJsonFile(path, data) {
   try {
     // Ensure directory exists
-    const dir = path.substring(0, path.lastIndexOf('/'));
-    if (dir && !existsSync(dir)) {
+    const dir = dirname(path);
+    if (dir && dir !== '.' && !existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
     writeFileSync(path, JSON.stringify(data, null, 2));

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -121,8 +121,8 @@ async function main() {
     }
 
     // Check for ultrawork state - only restore if session matches (issue #311)
-    const ultraworkState = readJsonFile(join(directory, '.omc', 'ultrawork-state.json'))
-      || readJsonFile(join(homedir(), '.claude', 'ultrawork-state.json'));
+    const ultraworkState = readJsonFile(join(directory, '.omc', 'state', 'ultrawork-state.json'))
+      || readJsonFile(join(homedir(), '.omc', 'state', 'ultrawork-state.json'));
 
     if (ultraworkState?.active && (!ultraworkState.session_id || ultraworkState.session_id === sessionId)) {
       messages.push(`<session-restore>

--- a/src/__tests__/delegation-enforcement-levels.test.ts
+++ b/src/__tests__/delegation-enforcement-levels.test.ts
@@ -142,16 +142,16 @@ describe('delegation-enforcement-levels', () => {
       // Local config exists with 'off', global has 'strict'
       mockExistsSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('/tmp/test-project/.omc/config.json')) return true;
-        if (s.includes('/mock/home/.claude/.omc-config.json')) return true;
+        if (/[\\/]tmp[\\/]test-project[\\/]\.omc[\\/]config\.json$/.test(s)) return true;
+        if (/[\\/]mock[\\/]home[\\/]\.claude[\\/]\.omc-config\.json$/.test(s)) return true;
         return false;
       });
       mockReadFileSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('/tmp/test-project/.omc/config.json')) {
+        if (/[\\/]tmp[\\/]test-project[\\/]\.omc[\\/]config\.json$/.test(s)) {
           return JSON.stringify({ delegationEnforcementLevel: 'off' });
         }
-        if (s.includes('/mock/home/.claude/.omc-config.json')) {
+        if (/[\\/]mock[\\/]home[\\/]\.claude[\\/]\.omc-config\.json$/.test(s)) {
           return JSON.stringify({ delegationEnforcementLevel: 'strict' });
         }
         return '';
@@ -166,12 +166,12 @@ describe('delegation-enforcement-levels', () => {
     it('falls back to global config when no local config', () => {
       mockExistsSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('/mock/home/.claude/.omc-config.json')) return true;
+        if (/[\\/]mock[\\/]home[\\/]\.claude[\\/]\.omc-config\.json$/.test(s)) return true;
         return false;
       });
       mockReadFileSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('/mock/home/.claude/.omc-config.json')) {
+        if (/[\\/]mock[\\/]home[\\/]\.claude[\\/]\.omc-config\.json$/.test(s)) {
           return JSON.stringify({ delegationEnforcementLevel: 'strict' });
         }
         return '';
@@ -186,7 +186,7 @@ describe('delegation-enforcement-levels', () => {
     it('falls back to warn on invalid enforcement level in config', () => {
       mockExistsSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('/tmp/test-project/.omc/config.json')) return true;
+        if (/[\\/]tmp[\\/]test-project[\\/]\.omc[\\/]config\.json$/.test(s)) return true;
         return false;
       });
       mockReadFileSync.mockImplementation(() => {
@@ -202,7 +202,7 @@ describe('delegation-enforcement-levels', () => {
     it('falls back to warn on malformed JSON config', () => {
       mockExistsSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('/tmp/test-project/.omc/config.json')) return true;
+        if (/[\\/]tmp[\\/]test-project[\\/]\.omc[\\/]config\.json$/.test(s)) return true;
         return false;
       });
       mockReadFileSync.mockImplementation(() => {
@@ -218,7 +218,7 @@ describe('delegation-enforcement-levels', () => {
     it('supports enforcementLevel key as alternative', () => {
       mockExistsSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('/tmp/test-project/.omc/config.json')) return true;
+        if (/[\\/]tmp[\\/]test-project[\\/]\.omc[\\/]config\.json$/.test(s)) return true;
         return false;
       });
       mockReadFileSync.mockImplementation(() => {
@@ -237,7 +237,7 @@ describe('delegation-enforcement-levels', () => {
     function setEnforcement(level: string) {
       mockExistsSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('.omc/config.json')) return true;
+        if (/[\\/]\.omc[\\/]config\.json$/.test(s)) return true;
         return false;
       });
       mockReadFileSync.mockImplementation(() => {
@@ -493,7 +493,7 @@ describe('delegation-enforcement-levels', () => {
       // before any HUD tracking happens
       mockExistsSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('.omc/config.json')) return true;
+        if (/[\\/]\.omc[\\/]config\.json$/.test(s)) return true;
         return false;
       });
       mockReadFileSync.mockImplementation(() => {
@@ -513,7 +513,7 @@ describe('delegation-enforcement-levels', () => {
     it('blocks propagated from enforcement', async () => {
       mockExistsSync.mockImplementation((p: unknown) => {
         const s = String(p);
-        if (s.includes('.omc/config.json')) return true;
+        if (/[\\/]\.omc[\\/]config\.json$/.test(s)) return true;
         return false;
       });
       mockReadFileSync.mockImplementation(() => {

--- a/src/__tests__/hud-windows.test.ts
+++ b/src/__tests__/hud-windows.test.ts
@@ -66,12 +66,20 @@ describe('HUD Windows Compatibility', () => {
 
     it('pathToFileURL should correctly convert Unix paths', () => {
       const unixPath = '/home/user/test.js';
-      expect(pathToFileURL(unixPath).href).toBe('file:///home/user/test.js');
+      expect(pathToFileURL(unixPath).href).toBe(
+        process.platform === 'win32'
+          ? 'file:///C:/home/user/test.js'
+          : 'file:///home/user/test.js'
+      );
     });
 
     it('pathToFileURL should encode spaces in paths', () => {
       const spacePath = '/path/with spaces/file.js';
-      expect(pathToFileURL(spacePath).href).toBe('file:///path/with%20spaces/file.js');
+      expect(pathToFileURL(spacePath).href).toBe(
+        process.platform === 'win32'
+          ? 'file:///C:/path/with%20spaces/file.js'
+          : 'file:///path/with%20spaces/file.js'
+      );
     });
   });
 

--- a/src/__tests__/hud/state.test.ts
+++ b/src/__tests__/hud/state.test.ts
@@ -34,7 +34,8 @@ describe('readHudConfig', () => {
 
     it('reads from settings.json omcHud key first', () => {
       mockExistsSync.mockImplementation((path) => {
-        return path === '/Users/testuser/.claude/settings.json';
+        const s = String(path);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
       });
       mockReadFileSync.mockReturnValue(JSON.stringify({
         omcHud: {
@@ -53,14 +54,16 @@ describe('readHudConfig', () => {
 
     it('falls back to legacy hud-config.json when settings.json has no omcHud', () => {
       mockExistsSync.mockImplementation((path) => {
-        return path === '/Users/testuser/.claude/settings.json' ||
-               path === '/Users/testuser/.claude/.omc/hud-config.json';
+        const s = String(path);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s) ||
+               /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(s);
       });
       mockReadFileSync.mockImplementation((path) => {
-        if (path === '/Users/testuser/.claude/settings.json') {
+        const s = String(path);
+        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)) {
           return JSON.stringify({ someOtherKey: true });
         }
-        if (path === '/Users/testuser/.claude/.omc/hud-config.json') {
+        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(s)) {
           return JSON.stringify({
             elements: {
               cwd: true,
@@ -78,7 +81,8 @@ describe('readHudConfig', () => {
     it('prefers settings.json over legacy hud-config.json', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockImplementation((path) => {
-        if (path === '/Users/testuser/.claude/settings.json') {
+        const s = String(path);
+        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)) {
           return JSON.stringify({
             omcHud: {
               elements: {
@@ -87,7 +91,7 @@ describe('readHudConfig', () => {
             }
           });
         }
-        if (path === '/Users/testuser/.claude/.omc/hud-config.json') {
+        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(s)) {
           return JSON.stringify({
             elements: {
               gitRepo: false,
@@ -108,7 +112,8 @@ describe('readHudConfig', () => {
   describe('error handling', () => {
     it('returns defaults when settings.json is invalid JSON', () => {
       mockExistsSync.mockImplementation((path) => {
-        return path === '/Users/testuser/.claude/settings.json';
+        const s = String(path);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
       });
       mockReadFileSync.mockReturnValue('invalid json');
 
@@ -120,10 +125,11 @@ describe('readHudConfig', () => {
     it('falls back to legacy when settings.json read fails', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockImplementation((path) => {
-        if (path === '/Users/testuser/.claude/settings.json') {
+        const s = String(path);
+        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)) {
           throw new Error('Read error');
         }
-        if (path === '/Users/testuser/.claude/.omc/hud-config.json') {
+        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(s)) {
           return JSON.stringify({
             elements: { cwd: true }
           });
@@ -140,7 +146,8 @@ describe('readHudConfig', () => {
   describe('merging with defaults', () => {
     it('merges partial config with defaults', () => {
       mockExistsSync.mockImplementation((path) => {
-        return path === '/Users/testuser/.claude/settings.json';
+        const s = String(path);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
       });
       mockReadFileSync.mockReturnValue(JSON.stringify({
         omcHud: {
@@ -162,7 +169,8 @@ describe('readHudConfig', () => {
 
     it('merges thresholds with defaults', () => {
       mockExistsSync.mockImplementation((path) => {
-        return path === '/Users/testuser/.claude/settings.json';
+        const s = String(path);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
       });
       mockReadFileSync.mockReturnValue(JSON.stringify({
         omcHud: {

--- a/src/__tests__/task-continuation.test.ts
+++ b/src/__tests__/task-continuation.test.ts
@@ -325,7 +325,7 @@ describe('Task System Support', () => {
 
     it('should return source: task when only Tasks have incomplete items', async () => {
       vi.mocked(fs.existsSync).mockImplementation((p: any) => {
-        return p.includes('/tasks/');
+        return /[\\/]tasks[\\/]/.test(p);
       });
       vi.mocked(fs.readdirSync).mockReturnValue(['1.json'] as any);
       vi.mocked(fs.readFileSync).mockReturnValue(
@@ -339,7 +339,7 @@ describe('Task System Support', () => {
 
     it('should return source: todo when only legacy todos exist', async () => {
       vi.mocked(fs.existsSync).mockImplementation((p: any) => {
-        return p.includes('/todos/') || p.includes('todos.json');
+        return /[\\/]todos[\\/]/.test(p) || /todos\.json$/.test(p);
       });
       vi.mocked(fs.readdirSync).mockReturnValue(['session123.json'] as any);
       vi.mocked(fs.readFileSync).mockReturnValue(
@@ -354,13 +354,13 @@ describe('Task System Support', () => {
     it('should return source: both when both systems have incomplete items', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readdirSync).mockImplementation((dirPath: any) => {
-        if (dirPath.includes('/tasks/')) {
+        if (/[\\/]tasks[\\/]/.test(dirPath)) {
           return ['1.json'] as any;
         }
         return ['session123.json'] as any;
       });
       vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
-        if (filePath.includes('/tasks/')) {
+        if (/[\\/]tasks[\\/]/.test(filePath)) {
           return JSON.stringify({ id: '1', subject: 'Task', status: 'pending' });
         }
         return JSON.stringify([{ content: 'Todo', status: 'pending' }]);
@@ -374,13 +374,13 @@ describe('Task System Support', () => {
     it('should prioritize tasks over legacy todos', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readdirSync).mockImplementation((dirPath: any) => {
-        if (dirPath.includes('/tasks/')) {
+        if (/[\\/]tasks[\\/]/.test(dirPath)) {
           return ['1.json'] as any;
         }
         return ['session123.json'] as any;
       });
       vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
-        if (filePath.includes('/tasks/')) {
+        if (/[\\/]tasks[\\/]/.test(filePath)) {
           return JSON.stringify({ id: '1', subject: 'Task Subject', status: 'pending' });
         }
         return JSON.stringify([{ content: 'Legacy Todo', status: 'pending' }]);
@@ -652,7 +652,7 @@ describe('Task System Support', () => {
 
     it('should read from project .omc directory', () => {
       vi.mocked(fs.existsSync).mockImplementation((p: any) => {
-        return p.includes('.omc/todos.json');
+        return /[\\/]\.omc[\\/]todos\.json$/.test(p);
       });
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify([{ content: 'Todo', status: 'pending' }])
@@ -706,13 +706,13 @@ describe('Task System Support', () => {
     it('should prefer tasks when both exist and tasks have incomplete items', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readdirSync).mockImplementation((dirPath: any) => {
-        if (dirPath.includes('/tasks/')) {
+        if (/[\\/]tasks[\\/]/.test(dirPath)) {
           return ['1.json'] as any;
         }
         return ['session123.json'] as any;
       });
       vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
-        if (filePath.includes('/tasks/')) {
+        if (/[\\/]tasks[\\/]/.test(filePath)) {
           return JSON.stringify({ id: '1', subject: 'Task', status: 'pending' });
         }
         return JSON.stringify([{ content: 'Todo', status: 'completed' }]);
@@ -731,7 +731,7 @@ describe('Task System Support', () => {
     });
 
     it('should convert tasks to todo format in result', async () => {
-      vi.mocked(fs.existsSync).mockImplementation((p: any) => p.includes('/tasks/'));
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => /[\\/]tasks[\\/]/.test(p));
       vi.mocked(fs.readdirSync).mockReturnValue(['1.json'] as any);
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({ id: 'task-1', subject: 'Task Subject', status: 'pending' })
@@ -872,7 +872,7 @@ describe('Task System Support', () => {
     it('should return valid path for valid session ID', () => {
       const result = getTaskDirectory('valid-session-123');
       expect(result).toContain('valid-session-123');
-      expect(result).toContain('.claude/tasks');
+      expect(result).toContain(path.join('.claude', 'tasks'));
     });
   });
 

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -8,7 +8,7 @@
  */
 
 import { readFileSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname, resolve, relative, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 
 import type {
@@ -53,7 +53,8 @@ export function loadAgentPrompt(agentName: string): string {
     // Security: Verify resolved path is within the agents directory
     const resolvedPath = resolve(agentPath);
     const resolvedAgentsDir = resolve(agentsDir);
-    if (!resolvedPath.startsWith(resolvedAgentsDir + '/') && resolvedPath !== resolvedAgentsDir) {
+    const rel = relative(resolvedAgentsDir, resolvedPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
       throw new Error(`Invalid agent name: path traversal detected`);
     }
 

--- a/src/hooks/persistent-mode/session-isolation.test.ts
+++ b/src/hooks/persistent-mode/session-isolation.test.ts
@@ -70,10 +70,11 @@ describe('Persistent Mode Session Isolation (Issue #311)', () => {
     function runPersistentModeScript(input: Record<string, unknown>): Record<string, unknown> {
       try {
         const result = execSync(
-          `echo '${JSON.stringify(input)}' | node "${scriptPath}"`,
+          `node "${scriptPath}"`,
           {
             encoding: 'utf-8',
             timeout: 5000,
+            input: JSON.stringify(input),
             env: { ...process.env, NODE_ENV: 'test' }
           }
         );

--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -638,7 +638,10 @@ describe('subagent-tracker', () => {
       const updated = readTrackingState(testDir);
       const agent = updated.agents[0];
       expect(agent.file_ownership).toHaveLength(2);
-      expect(agent.file_ownership).toContain('src/hooks/bridge.ts');
+      const normalized = (agent.file_ownership ?? []).map((p) =>
+        String(p).replace(/\\/g, '/').replace(/^\/+/, '')
+      );
+      expect(normalized).toContain('src/hooks/bridge.ts');
     });
 
     it('should detect file conflicts between agents', () => {

--- a/src/hooks/subagent-tracker/__tests__/session-replay.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/session-replay.test.ts
@@ -32,7 +32,7 @@ describe('session-replay', () => {
   describe('getReplayFilePath', () => {
     it('should return correct path for session', () => {
       const path = getReplayFilePath(testDir, 'test-session');
-      expect(path).toContain('.omc/state/agent-replay-test-session.jsonl');
+      expect(path).toContain(join('.omc', 'state', 'agent-replay-test-session.jsonl'));
     });
 
     it('should sanitize session ID', () => {

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -11,13 +11,13 @@
 import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Dynamic import for the shared stdin module
-const { readStdin } = await import(join(__dirname, 'lib', 'stdin.mjs'));
+const { readStdin } = await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href);
 
 function readJsonFile(path) {
   try {
@@ -31,8 +31,8 @@ function readJsonFile(path) {
 function writeJsonFile(path, data) {
   try {
     // Ensure directory exists
-    const dir = path.substring(0, path.lastIndexOf('/'));
-    if (dir && !existsSync(dir)) {
+    const dir = dirname(path);
+    if (dir && dir !== '.' && !existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
     writeFileSync(path, JSON.stringify(data, null, 2));

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -144,8 +144,8 @@ To update, run: claude /install-plugin oh-my-claudecode
     }
 
     // Check for ultrawork state - only restore if session matches (issue #311)
-    const ultraworkState = readJsonFile(join(directory, '.omc', 'ultrawork-state.json'))
-      || readJsonFile(join(homedir(), '.claude', 'ultrawork-state.json'));
+    const ultraworkState = readJsonFile(join(directory, '.omc', 'state', 'ultrawork-state.json'))
+      || readJsonFile(join(homedir(), '.omc', 'state', 'ultrawork-state.json'));
 
     if (ultraworkState?.active && (!ultraworkState.session_id || ultraworkState.session_id === sessionId)) {
       messages.push(`<session-restore>


### PR DESCRIPTION
Fixes Windows + session-isolation regressions related to Issue #311.

- Propagate sessionId into mode state files (session_id) in scripts/keyword-detector.mjs
- Make JSON state writes cross-platform by using dirname() (mjs + cjs)
- Fix Windows ESM dynamic import by using pathToFileURL() in templates
- Make path-based tests cross-platform (regex / path.join) and fix persistent-mode.cjs test stdin on Windows

All validators: 
pm test, 
pm run lint, 
pm run build.