### PR TITLE
fix: rename invalid 'Setup' hook event to 'SessionStart' (#320)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -28,9 +28,7 @@
             "timeout": 5
           }
         ]
-      }
-    ],
-    "Setup": [
+      },
       {
         "matcher": "init",
         "hooks": [


### PR DESCRIPTION
## Fix

Renames the invalid `Setup` hook event type to `SessionStart` in hooks.json.

`Setup` is not a valid Claude Code hook event type, causing plugin load failures as reported in #320.

The Setup hooks (init and maintenance) are now properly placed under `SessionStart`.

Fixes #320