### PR TITLE
feat(hooks): add project isolation to state files

### DIFF
--- a/src/hooks/autopilot/state.ts
+++ b/src/hooks/autopilot/state.ts
@@ -186,7 +186,8 @@ export function initAutopilot(
     phase_durations: {},
     total_agents_spawned: 0,
     wisdom_entries: 0,
-    session_id: sessionId
+    session_id: sessionId,
+    project_path: directory
   };
 
   ensureAutopilotDir(directory);

--- a/src/hooks/autopilot/types.ts
+++ b/src/hooks/autopilot/types.ts
@@ -160,6 +160,8 @@ export interface AutopilotState {
 
   /** Session binding */
   session_id?: string;
+  /** Project path for isolation */
+  project_path?: string;
 }
 
 /**

--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -61,6 +61,8 @@ export interface RalphLoopState {
   prompt: string;
   /** Session ID the loop is bound to */
   session_id?: string;
+  /** Project path for isolation */
+  project_path?: string;
   /** Whether PRD mode is active */
   prd_mode?: boolean;
   /** Current story being worked on */
@@ -220,6 +222,7 @@ export function createRalphLoopHook(directory: string): RalphLoopHook {
       started_at: now,
       prompt,
       session_id: sessionId,
+      project_path: directory,
       linked_ultrawork: enableUltrawork
     };
 

--- a/src/hooks/swarm/state.ts
+++ b/src/hooks/swarm/state.ts
@@ -29,6 +29,7 @@ export interface SwarmSummary {
   tasks_claimed: number;
   tasks_done: number;
   active: boolean;
+  project_path?: string;
 }
 
 // Type alias for the Database constructor
@@ -653,7 +654,8 @@ export function writeSwarmSummary(cwd: string): boolean {
       tasks_pending: stats.pendingTasks,
       tasks_claimed: stats.claimedTasks,
       tasks_done: stats.doneTasks,
-      active: state.active
+      active: state.active,
+      project_path: cwd
     };
 
     const stateDir = join(cwd, '.omc', 'state');

--- a/src/hooks/ultrapilot/state.ts
+++ b/src/hooks/ultrapilot/state.ts
@@ -137,7 +137,8 @@ export function initUltrapilot(
     totalWorkersSpawned: 0,
     successfulWorkers: 0,
     failedWorkers: 0,
-    sessionId
+    sessionId,
+    project_path: directory
   };
 
   writeUltrapilotState(directory, state);

--- a/src/hooks/ultrapilot/types.ts
+++ b/src/hooks/ultrapilot/types.ts
@@ -92,6 +92,8 @@ export interface UltrapilotState {
   failedWorkers: number;
   /** Session binding */
   sessionId?: string;
+  /** Project path for isolation */
+  project_path?: string;
 }
 
 /**

--- a/src/hooks/ultraqa/index.ts
+++ b/src/hooks/ultraqa/index.ts
@@ -28,6 +28,8 @@ export interface UltraQAState {
   started_at: string;
   /** Session ID the loop is bound to */
   session_id?: string;
+  /** Project path for isolation */
+  project_path?: string;
 }
 
 export interface UltraQAOptions {
@@ -153,7 +155,8 @@ export function startUltraQA(
     max_cycles: options?.maxCycles ?? DEFAULT_MAX_CYCLES,
     failures: [],
     started_at: new Date().toISOString(),
-    session_id: sessionId
+    session_id: sessionId,
+    project_path: directory
   };
 
   const written = writeUltraQAState(directory, state);

--- a/src/hooks/ultrawork/index.ts
+++ b/src/hooks/ultrawork/index.ts
@@ -18,6 +18,8 @@ export interface UltraworkState {
   original_prompt: string;
   /** Session ID the mode is bound to */
   session_id?: string;
+  /** Project path for isolation */
+  project_path?: string;
   /** Number of times the mode has been reinforced (for metrics) */
   reinforcement_count: number;
   /** Last time the mode was checked/reinforced */
@@ -102,6 +104,7 @@ export function activateUltrawork(
     started_at: new Date().toISOString(),
     original_prompt: prompt,
     session_id: sessionId,
+    project_path: directory || process.cwd(),
     reinforcement_count: 0,
     last_checked_at: new Date().toISOString(),
     linked_to_ralph: linkedToRalph


### PR DESCRIPTION
## Summary

Add `project_path` validation to all persistent mode state files to prevent cross-project state contamination.

### Problem

When using ultrawork/ralph/autopilot in Project A, opening a new terminal in Project B would incorrectly show "mode active" messages from Project A. This happened because the global state fallback (`~/.omc/state/*.json`) had no project awareness.

### Solution

Added `project_path` field to all mode states when saving, and validation when reading to ensure state belongs to the current project.

### Changes

**1. Hook Template - `templates/hooks/persistent-mode.mjs`**

- Added `normalizePath()` - handles trailing slashes and Windows case sensitivity
- Added `isStateForCurrentProject()` - validates project_path matches current directory
- Added validation to all 8 mode checks: ralph, autopilot, ultrapilot, swarm, pipeline, ultraqa, ultrawork, ecomode

**2. TypeScript Sources - Added `project_path` field**

| File | Interface | Function |
|------|-----------|----------|
| `src/hooks/ultrawork/index.ts` | `UltraworkState` | `activateUltrawork()` |
| `src/hooks/ralph/loop.ts` | `RalphLoopState` | `startLoop()` |
| `src/hooks/autopilot/types.ts` | `AutopilotState` | - |
| `src/hooks/autopilot/state.ts` | - | `initAutopilot()` |
| `src/hooks/ultraqa/index.ts` | `UltraQAState` | `startUltraQA()` |
| `src/hooks/ultrapilot/types.ts` | `UltrapilotState` | - |
| `src/hooks/ultrapilot/state.ts` | - | `initUltrapilot()` |
| `src/hooks/swarm/state.ts` | `SwarmSummary` | `writeSwarmSummary()` |

### Backward Compatibility

States without `project_path` (created before this fix) are still accepted for backward compatibility.

### Verification

- ✅ TypeScript build passes
- ✅ All 2142 tests pass
- ✅ ESLint passes (no errors, warnings only)

Fixes #326
Closes #324 (duplicate)