### PR TITLE
fix(update): use release tag URL instead of main branch for install script

### DIFF
--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -314,12 +314,17 @@ export async function performUpdate(options?: {
     const release = await fetchLatestRelease();
     const newVersion = release.tag_name.replace(/^v/, '');
 
-    // Download the install script
-    const installScriptUrl = `${GITHUB_RAW_URL}/main/scripts/install.sh`;
+    // Download the install script from the release tag (not main branch)
+    const releaseTag = release.tag_name; // e.g., "v3.9.8"
+    const installScriptUrl = `${GITHUB_RAW_URL}/${releaseTag}/scripts/install.sh`;
     const response = await fetch(installScriptUrl);
 
     if (!response.ok) {
-      throw new Error(`Failed to download install script: ${response.status}`);
+      // Fallback: suggest /plugin install as the canonical method
+      throw new Error(
+        `Failed to download install script from ${releaseTag}: ${response.status}\n` +
+        'Please update using: /plugin install oh-my-claudecode'
+      );
     }
 
     const scriptContent = await response.text();
@@ -432,7 +437,7 @@ export function formatUpdateNotification(checkResult: UpdateCheckResult): string
     `  Latest version:  ${checkResult.latestVersion}`,
     '',
     '  To update, run: /update',
-    '  Or run: curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/scripts/install.sh | bash',
+    '  Or reinstall via: /plugin install oh-my-claudecode',
     ''
   ];
 


### PR DESCRIPTION
## Summary
Fixes the update command failing with 404 error when trying to download the install script.

## Changes
- Changed install script download URL from `main` branch to release tag (e.g., `v3.9.8/scripts/install.sh`)
- Updated fallback error message to recommend `/plugin install oh-my-claudecode`
- Updated `formatUpdateNotification()` to suggest `/plugin install` instead of `curl | bash`

## Root Cause
The update command was downloading the install script from:
```
https://raw.githubusercontent.com/.../main/scripts/install.sh
```

This fails with 404 because the `main` branch may not have the install script (or it's been moved/renamed).

## Fix
Now downloads from the release tag:
```
https://raw.githubusercontent.com/.../v3.9.8/scripts/install.sh
```

And if that fails, the error message directs users to use:
```
/plugin install oh-my-claudecode
```

Closes #335