### PR TITLE
feat: add Codex CLI hooks adapter layer

### DIFF
--- a/src/hooks/codex-adapter/__tests__/adapters.test.ts
+++ b/src/hooks/codex-adapter/__tests__/adapters.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for Claude Code and Codex Adapters
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ClaudeCodeAdapter, getClaudeCodeAdapter } from '../claude-code-adapter.js';
+import {
+  CodexAdapter,
+  getCodexAdapter,
+  parseCodexNotifyStdin,
+  extractCodexTurnContext,
+  wrapWithCodexDegradation,
+} from '../codex-adapter.js';
+import type { CodexNotifyPayload, UnifiedHookInput } from '../types.js';
+
+describe('ClaudeCodeAdapter', () => {
+  let adapter: ClaudeCodeAdapter;
+
+  beforeEach(() => {
+    adapter = new ClaudeCodeAdapter();
+  });
+
+  describe('platform', () => {
+    it('should identify as claude-code', () => {
+      expect(adapter.platform).toBe('claude-code');
+    });
+  });
+
+  describe('capabilities', () => {
+    it('should have full capabilities', () => {
+      expect(adapter.capabilities.canBlock).toBe(true);
+      expect(adapter.capabilities.canModifyInput).toBe(true);
+      expect(adapter.capabilities.hasPreExecutionHooks).toBe(true);
+    });
+  });
+
+  describe('parseInput', () => {
+    it('should parse PreToolUse event', () => {
+      const raw = {
+        sessionId: 'session-1',
+        toolName: 'Write',
+        toolInput: { file_path: '/test.ts' },
+        directory: '/project',
+      };
+
+      const result = adapter.parseInput(raw, 'PreToolUse');
+      expect(result.event).toBe('tool:pre');
+      expect(result.sessionId).toBe('session-1');
+      expect(result.toolName).toBe('Write');
+      expect(result.cwd).toBe('/project');
+      expect(result.platform).toBe('claude-code');
+    });
+
+    it('should parse UserPromptSubmit with prompt field', () => {
+      const raw = {
+        prompt: 'Hello world',
+        sessionId: 'session-1',
+        directory: '/project',
+      };
+
+      const result = adapter.parseInput(raw, 'UserPromptSubmit');
+      expect(result.event).toBe('prompt:submit');
+      expect(result.prompt).toBe('Hello world');
+    });
+
+    it('should parse UserPromptSubmit with message.content', () => {
+      const raw = {
+        message: { content: 'Hello from message' },
+        sessionId: 'session-1',
+        directory: '/project',
+      };
+
+      const result = adapter.parseInput(raw, 'UserPromptSubmit');
+      expect(result.prompt).toBe('Hello from message');
+    });
+
+    it('should parse UserPromptSubmit with parts', () => {
+      const raw = {
+        parts: [
+          { type: 'text', text: 'Part 1' },
+          { type: 'text', text: 'Part 2' },
+        ],
+        sessionId: 'session-1',
+        directory: '/project',
+      };
+
+      const result = adapter.parseInput(raw, 'UserPromptSubmit');
+      expect(result.prompt).toBe('Part 1 Part 2');
+    });
+
+    it('should parse Stop event with stop reason', () => {
+      const raw = {
+        sessionId: 'session-1',
+        stop_reason: 'context_limit',
+        user_requested: false,
+        directory: '/project',
+      };
+
+      const result = adapter.parseInput(raw, 'Stop');
+      expect(result.event).toBe('stop');
+      expect(result.stopReason).toBe('context_limit');
+      expect(result.userRequested).toBe(false);
+    });
+
+    it('should throw for unknown event', () => {
+      expect(() => adapter.parseInput({}, 'FakeEvent')).toThrow('Unknown Claude Code event');
+    });
+  });
+
+  describe('formatOutput', () => {
+    it('should format basic continue output', () => {
+      const output = adapter.formatOutput({ continue: true });
+      expect(output).toEqual({ continue: true });
+    });
+
+    it('should format output with message', () => {
+      const output = adapter.formatOutput({
+        continue: true,
+        message: 'Hello',
+      });
+      expect(output).toEqual({ continue: true, message: 'Hello' });
+    });
+
+    it('should format blocking output', () => {
+      const output = adapter.formatOutput({
+        continue: false,
+        reason: 'Not allowed',
+      });
+      expect(output).toEqual({ continue: false, reason: 'Not allowed' });
+    });
+
+    it('should format output with modified input', () => {
+      const output = adapter.formatOutput({
+        continue: true,
+        modifiedInput: { file_path: '/new.ts' },
+      });
+      expect(output.modifiedInput).toEqual({ file_path: '/new.ts' });
+      expect(output.updatedInput).toEqual({ file_path: '/new.ts' });
+    });
+
+    it('should format output with permission decision', () => {
+      const output = adapter.formatOutput({
+        continue: true,
+        permissionDecision: 'allow',
+      });
+      expect(output.permissionDecision).toBe('allow');
+    });
+  });
+
+  describe('isEventSupported', () => {
+    it('should support all standard events', () => {
+      expect(adapter.isEventSupported('tool:pre')).toBe(true);
+      expect(adapter.isEventSupported('tool:post')).toBe(true);
+      expect(adapter.isEventSupported('session:start')).toBe(true);
+      expect(adapter.isEventSupported('stop')).toBe(true);
+    });
+  });
+
+  describe('mapToPlatformEvent', () => {
+    it('should map unified events to Claude Code events', () => {
+      expect(adapter.mapToPlatformEvent('tool:pre')).toBe('PreToolUse');
+      expect(adapter.mapToPlatformEvent('tool:post')).toBe('PostToolUse');
+      expect(adapter.mapToPlatformEvent('session:start')).toBe('SessionStart');
+    });
+  });
+
+  describe('mapFromPlatformEvent', () => {
+    it('should map Claude Code events to unified events', () => {
+      expect(adapter.mapFromPlatformEvent('PreToolUse')).toBe('tool:pre');
+      expect(adapter.mapFromPlatformEvent('PostToolUse')).toBe('tool:post');
+    });
+  });
+
+  describe('singleton', () => {
+    it('should return same instance', () => {
+      const a = getClaudeCodeAdapter();
+      const b = getClaudeCodeAdapter();
+      expect(a).toBe(b);
+    });
+  });
+});
+
+describe('CodexAdapter', () => {
+  let adapter: CodexAdapter;
+
+  beforeEach(() => {
+    adapter = new CodexAdapter();
+  });
+
+  describe('platform', () => {
+    it('should identify as codex', () => {
+      expect(adapter.platform).toBe('codex');
+    });
+  });
+
+  describe('capabilities', () => {
+    it('should have limited capabilities', () => {
+      expect(adapter.capabilities.canBlock).toBe(false);
+      expect(adapter.capabilities.canModifyInput).toBe(false);
+      expect(adapter.capabilities.hasAgentHooks).toBe(false);
+    });
+  });
+
+  describe('parseInput', () => {
+    it('should parse agent-turn-complete notify payload', () => {
+      const payload: CodexNotifyPayload = {
+        type: 'agent-turn-complete',
+        'turn-id': 'turn-123',
+        'thread-id': 'thread-456',
+        'input-messages': [{ role: 'user', content: 'test' }],
+        'last-assistant-message': 'Done!',
+        cwd: '/project',
+      };
+
+      const result = adapter.parseInput(payload, 'agent-turn-complete');
+      expect(result.event).toBe('turn:complete');
+      expect(result.turnId).toBe('turn-123');
+      expect(result.threadId).toBe('thread-456');
+      expect(result.cwd).toBe('/project');
+      expect(result.platform).toBe('codex');
+    });
+
+    it('should handle future event formats', () => {
+      const raw = {
+        session_id: 'session-1',
+        cwd: '/project',
+        tool_name: 'bash',
+        tool_input: { command: 'ls' },
+      };
+
+      const result = adapter.parseInput(raw, 'tool-before');
+      expect(result.event).toBe('tool:pre');
+      expect(result.toolName).toBe('bash');
+    });
+  });
+
+  describe('formatOutput', () => {
+    it('should format basic output', () => {
+      const output = adapter.formatOutput({ continue: true });
+      expect(output).toEqual({ continue: true });
+    });
+
+    it('should include message in output', () => {
+      const output = adapter.formatOutput({
+        continue: true,
+        message: 'Turn processed',
+      }) as Record<string, unknown>;
+      expect(output.message).toBe('Turn processed');
+    });
+
+    it('should use snake_case for modified_input (Codex convention)', () => {
+      const output = adapter.formatOutput({
+        continue: true,
+        modifiedInput: { command: 'echo test' },
+      }) as Record<string, unknown>;
+      expect(output.modified_input).toEqual({ command: 'echo test' });
+    });
+  });
+
+  describe('isEventSupported', () => {
+    it('should support turn:complete', () => {
+      expect(adapter.isEventSupported('turn:complete')).toBe(true);
+    });
+
+    it('should not support agent hooks', () => {
+      expect(adapter.isEventSupported('agent:start')).toBe(false);
+      expect(adapter.isEventSupported('agent:stop')).toBe(false);
+    });
+  });
+
+  describe('mapToPlatformEvent', () => {
+    it('should map turn:complete to agent-turn-complete', () => {
+      expect(adapter.mapToPlatformEvent('turn:complete')).toBe('agent-turn-complete');
+    });
+
+    it('should return null for unsupported events', () => {
+      expect(adapter.mapToPlatformEvent('prompt:submit')).toBeNull();
+    });
+  });
+
+  describe('canBlock / canModifyInput', () => {
+    it('should report blocking not available', () => {
+      expect(adapter.canBlock()).toBe(false);
+    });
+
+    it('should report input modification not available', () => {
+      expect(adapter.canModifyInput()).toBe(false);
+    });
+  });
+
+  describe('singleton', () => {
+    it('should return same instance', () => {
+      const a = getCodexAdapter();
+      const b = getCodexAdapter();
+      expect(a).toBe(b);
+    });
+  });
+});
+
+describe('Codex helpers', () => {
+  describe('parseCodexNotifyStdin', () => {
+    it('should parse valid JSON', () => {
+      const json = JSON.stringify({
+        type: 'agent-turn-complete',
+        'turn-id': '123',
+        'thread-id': '456',
+        'input-messages': [],
+        'last-assistant-message': 'done',
+        cwd: '/test',
+      });
+      const result = parseCodexNotifyStdin(json);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('agent-turn-complete');
+    });
+
+    it('should return null for invalid JSON', () => {
+      expect(parseCodexNotifyStdin('not json')).toBeNull();
+    });
+  });
+
+  describe('extractCodexTurnContext', () => {
+    it('should extract context from payload', () => {
+      const payload: CodexNotifyPayload = {
+        type: 'agent-turn-complete',
+        'turn-id': 'turn-123',
+        'thread-id': 'thread-456',
+        'input-messages': [1, 2, 3] as unknown[],
+        'last-assistant-message': 'Finished work',
+        cwd: '/project',
+      };
+
+      const ctx = extractCodexTurnContext(payload);
+      expect(ctx.turnId).toBe('turn-123');
+      expect(ctx.threadId).toBe('thread-456');
+      expect(ctx.cwd).toBe('/project');
+      expect(ctx.lastMessage).toBe('Finished work');
+      expect(ctx.messageCount).toBe(3);
+    });
+  });
+
+  describe('wrapWithCodexDegradation', () => {
+    it('should allow non-blocking output through', async () => {
+      const handler = async () => ({
+        continue: true,
+        message: 'OK',
+      });
+
+      const wrapped = wrapWithCodexDegradation(handler);
+      const input: UnifiedHookInput = {
+        event: 'turn:complete',
+        cwd: '/test',
+        platform: 'codex',
+      };
+
+      const result = await wrapped(input);
+      expect(result.continue).toBe(true);
+      expect(result.message).toBe('OK');
+    });
+
+    it('should override blocking on Codex', async () => {
+      const handler = async () => ({
+        continue: false,
+        reason: 'Blocked!',
+      });
+
+      const wrapped = wrapWithCodexDegradation(handler);
+      const input: UnifiedHookInput = {
+        event: 'turn:complete',
+        cwd: '/test',
+        platform: 'codex',
+      };
+
+      const result = await wrapped(input);
+      // Should force continue=true on Codex
+      expect(result.continue).toBe(true);
+    });
+
+    it('should strip modifiedInput on Codex', async () => {
+      const handler = async () => ({
+        continue: true,
+        modifiedInput: { changed: true },
+      });
+
+      const wrapped = wrapWithCodexDegradation(handler);
+      const input: UnifiedHookInput = {
+        event: 'turn:complete',
+        cwd: '/test',
+        platform: 'codex',
+      };
+
+      const result = await wrapped(input);
+      expect(result.modifiedInput).toBeUndefined();
+    });
+
+    it('should allow blocking on non-Codex platform', async () => {
+      const handler = async () => ({
+        continue: false,
+        reason: 'Blocked!',
+      });
+
+      const wrapped = wrapWithCodexDegradation(handler);
+      const input: UnifiedHookInput = {
+        event: 'tool:pre',
+        cwd: '/test',
+        platform: 'claude-code',
+      };
+
+      const result = await wrapped(input);
+      expect(result.continue).toBe(false);
+    });
+  });
+});

--- a/src/hooks/codex-adapter/__tests__/codex-config.test.ts
+++ b/src/hooks/codex-adapter/__tests__/codex-config.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for Codex Configuration Reader
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSimpleToml } from '../codex-config.js';
+
+describe('codex-config', () => {
+  describe('parseSimpleToml', () => {
+    it('should parse simple key-value pairs', () => {
+      const toml = `
+key = "value"
+number = 42
+boolean = true
+`;
+      const result = parseSimpleToml(toml);
+      expect(result.key).toBe('value');
+      expect(result.number).toBe(42);
+      expect(result.boolean).toBe(true);
+    });
+
+    it('should parse arrays', () => {
+      const toml = `
+notify = ["command", "arg1", "arg2"]
+numbers = [1, 2, 3]
+`;
+      const result = parseSimpleToml(toml);
+      expect(result.notify).toEqual(['command', 'arg1', 'arg2']);
+      expect(result.numbers).toEqual([1, 2, 3]);
+    });
+
+    it('should parse sections', () => {
+      const toml = `
+[tui]
+status_line = ["omc", "status"]
+status_line_timeout_ms = 500
+`;
+      const result = parseSimpleToml(toml);
+      expect(result.tui).toBeDefined();
+      const tui = result.tui as Record<string, unknown>;
+      expect(tui.status_line).toEqual(['omc', 'status']);
+      expect(tui.status_line_timeout_ms).toBe(500);
+    });
+
+    it('should parse nested sections', () => {
+      const toml = `
+[mcp-servers.my-server]
+command = "/path/to/server"
+args = ["--flag"]
+`;
+      const result = parseSimpleToml(toml);
+      const mcpServers = result['mcp-servers'] as Record<string, unknown>;
+      expect(mcpServers).toBeDefined();
+      const myServer = mcpServers['my-server'] as Record<string, unknown>;
+      expect(myServer.command).toBe('/path/to/server');
+      expect(myServer.args).toEqual(['--flag']);
+    });
+
+    it('should skip comments', () => {
+      const toml = `
+# This is a comment
+key = "value"
+# Another comment
+number = 42
+`;
+      const result = parseSimpleToml(toml);
+      expect(result.key).toBe('value');
+      expect(result.number).toBe(42);
+    });
+
+    it('should skip empty lines', () => {
+      const toml = `
+key = "value"
+
+number = 42
+`;
+      const result = parseSimpleToml(toml);
+      expect(result.key).toBe('value');
+      expect(result.number).toBe(42);
+    });
+
+    it('should handle single-quoted strings', () => {
+      const toml = `
+key = 'single quoted'
+`;
+      const result = parseSimpleToml(toml);
+      expect(result.key).toBe('single quoted');
+    });
+
+    it('should handle false boolean', () => {
+      const toml = `
+enabled = false
+`;
+      const result = parseSimpleToml(toml);
+      expect(result.enabled).toBe(false);
+    });
+
+    it('should handle empty arrays', () => {
+      const toml = `
+empty = []
+`;
+      const result = parseSimpleToml(toml);
+      expect(result.empty).toEqual([]);
+    });
+
+    it('should parse a realistic Codex config', () => {
+      const toml = `
+# Codex CLI configuration
+model = "gpt-4"
+approval_mode = "suggest"
+sandbox_permissions = ["disk_full_read_access", "disk_repo_write_access"]
+
+# Notify hook
+notify = ["omc", "hook", "--platform=codex"]
+
+[tui]
+status_line = ["omc", "status", "--codex"]
+status_line_timeout_ms = 500
+
+[mcp-servers.context7]
+command = "npx"
+args = ["-y", "@context7/mcp-server"]
+`;
+      const result = parseSimpleToml(toml);
+
+      expect(result.model).toBe('gpt-4');
+      expect(result.approval_mode).toBe('suggest');
+      expect(result.sandbox_permissions).toEqual([
+        'disk_full_read_access',
+        'disk_repo_write_access'
+      ]);
+      expect(result.notify).toEqual(['omc', 'hook', '--platform=codex']);
+
+      const tui = result.tui as Record<string, unknown>;
+      expect(tui.status_line).toEqual(['omc', 'status', '--codex']);
+      expect(tui.status_line_timeout_ms).toBe(500);
+
+      const mcpServers = result['mcp-servers'] as Record<string, unknown>;
+      const context7 = mcpServers['context7'] as Record<string, unknown>;
+      expect(context7.command).toBe('npx');
+      expect(context7.args).toEqual(['-y', '@context7/mcp-server']);
+    });
+  });
+});

--- a/src/hooks/codex-adapter/__tests__/dispatcher.test.ts
+++ b/src/hooks/codex-adapter/__tests__/dispatcher.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for Unified Hook Dispatcher
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  registerHook,
+  unregisterHook,
+  getHook,
+  getAllHooks,
+  clearHooks,
+  getAdapter,
+  dispatch,
+  on,
+  onTool,
+  onSession,
+  onTurn,
+} from '../dispatcher.js';
+import { resetPlatformCache } from '../platform-detect.js';
+import type { UnifiedHookInput, UnifiedHookOutput } from '../types.js';
+
+describe('dispatcher', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    clearHooks();
+    resetPlatformCache();
+    process.env.OMC_PLATFORM = 'claude-code';
+  });
+
+  afterEach(() => {
+    clearHooks();
+    process.env = { ...originalEnv };
+    resetPlatformCache();
+  });
+
+  describe('hook registration', () => {
+    it('should register a hook', () => {
+      registerHook({
+        id: 'test-hook',
+        events: ['tool:pre'],
+        handler: async () => ({ continue: true }),
+      });
+
+      expect(getHook('test-hook')).toBeDefined();
+      expect(getHook('test-hook')!.id).toBe('test-hook');
+    });
+
+    it('should unregister a hook', () => {
+      registerHook({
+        id: 'test-hook',
+        events: ['tool:pre'],
+        handler: async () => ({ continue: true }),
+      });
+
+      expect(unregisterHook('test-hook')).toBe(true);
+      expect(getHook('test-hook')).toBeUndefined();
+    });
+
+    it('should return false when unregistering non-existent hook', () => {
+      expect(unregisterHook('non-existent')).toBe(false);
+    });
+
+    it('should list all hooks', () => {
+      registerHook({
+        id: 'hook-1',
+        events: ['tool:pre'],
+        handler: async () => ({ continue: true }),
+      });
+      registerHook({
+        id: 'hook-2',
+        events: ['tool:post'],
+        handler: async () => ({ continue: true }),
+      });
+
+      const hooks = getAllHooks();
+      expect(hooks).toHaveLength(2);
+    });
+
+    it('should clear all hooks', () => {
+      registerHook({
+        id: 'hook-1',
+        events: ['tool:pre'],
+        handler: async () => ({ continue: true }),
+      });
+
+      clearHooks();
+      expect(getAllHooks()).toHaveLength(0);
+    });
+  });
+
+  describe('convenience registration', () => {
+    it('should register with on()', () => {
+      on('test', 'tool:pre', () => ({ continue: true }));
+      expect(getHook('test')).toBeDefined();
+      expect(getHook('test')!.events).toContain('tool:pre');
+    });
+
+    it('should register with on() for multiple events', () => {
+      on('test', ['tool:pre', 'tool:post'], () => ({ continue: true }));
+      expect(getHook('test')!.events).toHaveLength(2);
+    });
+
+    it('should register with onTool()', () => {
+      onTool('test', 'pre', () => ({ continue: true }));
+      expect(getHook('test')!.events).toContain('tool:pre');
+    });
+
+    it('should register with onTool() for post', () => {
+      onTool('test', 'post', () => ({ continue: true }));
+      expect(getHook('test')!.events).toContain('tool:post');
+    });
+
+    it('should register with onSession()', () => {
+      onSession('test', 'start', () => ({ continue: true }));
+      expect(getHook('test')!.events).toContain('session:start');
+    });
+
+    it('should register with onTurn()', () => {
+      onTurn('test', 'complete', () => ({ continue: true }));
+      expect(getHook('test')!.events).toContain('turn:complete');
+    });
+  });
+
+  describe('adapter selection', () => {
+    it('should return Claude Code adapter by default', () => {
+      const adapter = getAdapter();
+      expect(adapter.platform).toBe('claude-code');
+    });
+
+    it('should return Codex adapter when specified', () => {
+      const adapter = getAdapter('codex');
+      expect(adapter.platform).toBe('codex');
+    });
+  });
+
+  describe('dispatch', () => {
+    it('should dispatch to matching hooks', async () => {
+      let called = false;
+      on('test', 'tool:pre', () => {
+        called = true;
+        return { continue: true, message: 'Hook ran!' };
+      });
+
+      const result = await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+
+      expect(called).toBe(true);
+      expect(result.message).toBe('Hook ran!');
+    });
+
+    it('should not dispatch to non-matching hooks', async () => {
+      let called = false;
+      on('test', 'tool:post', () => {
+        called = true;
+        return { continue: true };
+      });
+
+      await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+
+      expect(called).toBe(false);
+    });
+
+    it('should combine messages from multiple hooks', async () => {
+      on('hook-1', 'tool:pre', () => ({
+        continue: true,
+        message: 'Message 1',
+      }));
+      on('hook-2', 'tool:pre', () => ({
+        continue: true,
+        message: 'Message 2',
+      }));
+
+      const result = await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+
+      expect(result.message).toContain('Message 1');
+      expect(result.message).toContain('Message 2');
+    });
+
+    it('should respect priority order', async () => {
+      const order: string[] = [];
+
+      registerHook({
+        id: 'low-priority',
+        events: ['tool:pre'],
+        handler: () => { order.push('low'); return { continue: true }; },
+        priority: 1,
+      });
+      registerHook({
+        id: 'high-priority',
+        events: ['tool:pre'],
+        handler: () => { order.push('high'); return { continue: true }; },
+        priority: 10,
+      });
+
+      await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+
+      expect(order).toEqual(['high', 'low']);
+    });
+
+    it('should stop on blocking output (Claude Code)', async () => {
+      const order: string[] = [];
+
+      registerHook({
+        id: 'blocker',
+        events: ['tool:pre'],
+        handler: () => {
+          order.push('blocker');
+          return { continue: false, reason: 'Blocked!' };
+        },
+        priority: 10,
+      });
+      registerHook({
+        id: 'after-blocker',
+        events: ['tool:pre'],
+        handler: () => {
+          order.push('after');
+          return { continue: true };
+        },
+        priority: 1,
+      });
+
+      const result = await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+
+      expect(result.continue).toBe(false);
+      expect(result.reason).toBe('Blocked!');
+      expect(order).toEqual(['blocker']); // Second hook should not run
+    });
+
+    it('should filter by tool matcher', async () => {
+      let called = false;
+      registerHook({
+        id: 'write-only',
+        events: ['tool:pre'],
+        handler: () => {
+          called = true;
+          return { continue: true };
+        },
+        toolMatcher: /^Write$/,
+      });
+
+      // Should NOT trigger (wrong tool name)
+      await dispatch('PreToolUse', {
+        toolName: 'Read',
+        directory: '/test',
+      }, 'claude-code');
+      expect(called).toBe(false);
+
+      // Should trigger (matching tool name)
+      await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+      expect(called).toBe(true);
+    });
+
+    it('should skip disabled hooks', async () => {
+      let called = false;
+      registerHook({
+        id: 'disabled-hook',
+        events: ['tool:pre'],
+        handler: () => {
+          called = true;
+          return { continue: true };
+        },
+        enabled: false,
+      });
+
+      await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+
+      expect(called).toBe(false);
+    });
+
+    it('should handle handler errors gracefully', async () => {
+      on('error-hook', 'tool:pre', () => {
+        throw new Error('Handler exploded!');
+      });
+
+      // Should not throw
+      const result = await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+
+      expect(result.continue).toBe(true);
+    });
+
+    it('should return continue:true when no hooks match', async () => {
+      const result = await dispatch('PreToolUse', {
+        toolName: 'Write',
+        directory: '/test',
+      }, 'claude-code');
+
+      expect(result.continue).toBe(true);
+    });
+  });
+
+  describe('Codex dispatch', () => {
+    it('should dispatch Codex events', async () => {
+      let receivedInput: UnifiedHookInput | null = null;
+
+      on('codex-hook', 'turn:complete', (input) => {
+        receivedInput = input;
+        return { continue: true, message: 'Turn noted!' };
+      });
+
+      const payload = {
+        type: 'agent-turn-complete',
+        'turn-id': 'turn-123',
+        'thread-id': 'thread-456',
+        'input-messages': [],
+        'last-assistant-message': 'done',
+        cwd: '/project',
+      };
+
+      const result = await dispatch('agent-turn-complete', payload, 'codex');
+
+      expect(receivedInput).not.toBeNull();
+      expect(receivedInput!.event).toBe('turn:complete');
+      expect(receivedInput!.turnId).toBe('turn-123');
+      expect(receivedInput!.platform).toBe('codex');
+      expect(result.message).toBe('Turn noted!');
+    });
+
+    it('should gracefully degrade blocking on Codex', async () => {
+      on('blocker', 'turn:complete', () => ({
+        continue: false,
+        reason: 'Blocked',
+      }));
+
+      const result = await dispatch('agent-turn-complete', {
+        type: 'agent-turn-complete',
+        cwd: '/test',
+        'turn-id': '1',
+        'thread-id': '1',
+        'input-messages': [],
+        'last-assistant-message': '',
+      }, 'codex');
+
+      // Codex can't block, so should be overridden
+      expect(result.continue).toBe(true);
+    });
+
+    it('should warn for unsupported events on Codex', async () => {
+      const result = await dispatch('FakeCodexEvent', {}, 'codex');
+      expect(result.continue).toBe(true);
+    });
+  });
+});

--- a/src/hooks/codex-adapter/__tests__/event-map.test.ts
+++ b/src/hooks/codex-adapter/__tests__/event-map.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for Event Mapping Module
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  fromClaudeCodeEvent,
+  toClaudeCodeEvent,
+  fromCodexEvent,
+  toCodexEvent,
+  getClaudeCodeEvents,
+  getCodexEvents,
+  getUnsupportedCodexEvents,
+  isCrossPlatformEvent,
+  getCrossPlatformEvents,
+} from '../event-map.js';
+import type { UnifiedHookEvent } from '../types.js';
+
+describe('event-map', () => {
+  describe('Claude Code event mapping', () => {
+    describe('fromClaudeCodeEvent', () => {
+      it('should map PreToolUse to tool:pre', () => {
+        expect(fromClaudeCodeEvent('PreToolUse')).toBe('tool:pre');
+      });
+
+      it('should map PostToolUse to tool:post', () => {
+        expect(fromClaudeCodeEvent('PostToolUse')).toBe('tool:post');
+      });
+
+      it('should map PostToolUseFailure to tool:error', () => {
+        expect(fromClaudeCodeEvent('PostToolUseFailure')).toBe('tool:error');
+      });
+
+      it('should map UserPromptSubmit to prompt:submit', () => {
+        expect(fromClaudeCodeEvent('UserPromptSubmit')).toBe('prompt:submit');
+      });
+
+      it('should map SessionStart to session:start', () => {
+        expect(fromClaudeCodeEvent('SessionStart')).toBe('session:start');
+      });
+
+      it('should map SessionEnd to session:end', () => {
+        expect(fromClaudeCodeEvent('SessionEnd')).toBe('session:end');
+      });
+
+      it('should map SubagentStart to agent:start', () => {
+        expect(fromClaudeCodeEvent('SubagentStart')).toBe('agent:start');
+      });
+
+      it('should map SubagentStop to agent:stop', () => {
+        expect(fromClaudeCodeEvent('SubagentStop')).toBe('agent:stop');
+      });
+
+      it('should map Stop to stop', () => {
+        expect(fromClaudeCodeEvent('Stop')).toBe('stop');
+      });
+
+      it('should map PreCompact to context:pre-compact', () => {
+        expect(fromClaudeCodeEvent('PreCompact')).toBe('context:pre-compact');
+      });
+
+      it('should return null for unknown event', () => {
+        expect(fromClaudeCodeEvent('UnknownEvent')).toBeNull();
+      });
+    });
+
+    describe('toClaudeCodeEvent', () => {
+      it('should map tool:pre to PreToolUse', () => {
+        expect(toClaudeCodeEvent('tool:pre')).toBe('PreToolUse');
+      });
+
+      it('should map tool:post to PostToolUse', () => {
+        expect(toClaudeCodeEvent('tool:post')).toBe('PostToolUse');
+      });
+
+      it('should map session:start to SessionStart', () => {
+        expect(toClaudeCodeEvent('session:start')).toBe('SessionStart');
+      });
+
+      it('should return null for events without Claude Code equivalent', () => {
+        expect(toClaudeCodeEvent('turn:start')).toBeNull();
+        expect(toClaudeCodeEvent('turn:complete')).toBeNull();
+      });
+    });
+  });
+
+  describe('Codex event mapping', () => {
+    describe('fromCodexEvent', () => {
+      it('should map agent-turn-complete to turn:complete', () => {
+        expect(fromCodexEvent('agent-turn-complete')).toBe('turn:complete');
+      });
+
+      it('should map agent-turn-start to turn:start', () => {
+        expect(fromCodexEvent('agent-turn-start')).toBe('turn:start');
+      });
+
+      it('should map tool-before to tool:pre', () => {
+        expect(fromCodexEvent('tool-before')).toBe('tool:pre');
+      });
+
+      it('should map tool-after to tool:post', () => {
+        expect(fromCodexEvent('tool-after')).toBe('tool:post');
+      });
+
+      it('should map session-start to session:start', () => {
+        expect(fromCodexEvent('session-start')).toBe('session:start');
+      });
+
+      it('should map session-end to session:end', () => {
+        expect(fromCodexEvent('session-end')).toBe('session:end');
+      });
+
+      it('should return null for unknown event', () => {
+        expect(fromCodexEvent('unknown-event')).toBeNull();
+      });
+    });
+
+    describe('toCodexEvent', () => {
+      it('should map turn:complete to agent-turn-complete', () => {
+        expect(toCodexEvent('turn:complete')).toBe('agent-turn-complete');
+      });
+
+      it('should map turn:start to agent-turn-start', () => {
+        expect(toCodexEvent('turn:start')).toBe('agent-turn-start');
+      });
+
+      it('should map tool:pre to tool-before', () => {
+        expect(toCodexEvent('tool:pre')).toBe('tool-before');
+      });
+
+      it('should return null for events without Codex equivalent', () => {
+        expect(toCodexEvent('prompt:submit')).toBeNull();
+        expect(toCodexEvent('permission:request')).toBeNull();
+        expect(toCodexEvent('agent:start')).toBeNull();
+        expect(toCodexEvent('agent:stop')).toBeNull();
+      });
+    });
+  });
+
+  describe('batch mapping', () => {
+    describe('getClaudeCodeEvents', () => {
+      it('should map multiple unified events to Claude Code events', () => {
+        const unified: UnifiedHookEvent[] = ['tool:pre', 'tool:post', 'session:start'];
+        const result = getClaudeCodeEvents(unified);
+        expect(result).toContain('PreToolUse');
+        expect(result).toContain('PostToolUse');
+        expect(result).toContain('SessionStart');
+      });
+
+      it('should skip events without Claude Code equivalent', () => {
+        const unified: UnifiedHookEvent[] = ['tool:pre', 'turn:complete'];
+        const result = getClaudeCodeEvents(unified);
+        expect(result).toHaveLength(1);
+        expect(result).toContain('PreToolUse');
+      });
+    });
+
+    describe('getCodexEvents', () => {
+      it('should map multiple unified events to Codex events', () => {
+        const unified: UnifiedHookEvent[] = ['turn:complete', 'tool:pre', 'session:start'];
+        const result = getCodexEvents(unified);
+        expect(result).toContain('agent-turn-complete');
+        expect(result).toContain('tool-before');
+        expect(result).toContain('session-start');
+      });
+
+      it('should skip events without Codex equivalent', () => {
+        const unified: UnifiedHookEvent[] = ['turn:complete', 'prompt:submit', 'agent:start'];
+        const result = getCodexEvents(unified);
+        expect(result).toHaveLength(1);
+        expect(result).toContain('agent-turn-complete');
+      });
+    });
+  });
+
+  describe('unsupported events', () => {
+    describe('getUnsupportedCodexEvents', () => {
+      it('should return events not supported on Codex', () => {
+        const requested: UnifiedHookEvent[] = ['turn:complete', 'prompt:submit', 'agent:start', 'stop'];
+        const unsupported = getUnsupportedCodexEvents(requested);
+        expect(unsupported).toContain('prompt:submit');
+        expect(unsupported).toContain('agent:start');
+        expect(unsupported).toContain('stop');
+        expect(unsupported).not.toContain('turn:complete');
+      });
+
+      it('should return empty array when all events are supported', () => {
+        const requested: UnifiedHookEvent[] = ['turn:complete', 'session:start', 'tool:pre'];
+        const unsupported = getUnsupportedCodexEvents(requested);
+        expect(unsupported).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('cross-platform events', () => {
+    describe('isCrossPlatformEvent', () => {
+      it('should return true for events available on both platforms', () => {
+        expect(isCrossPlatformEvent('session:start')).toBe(true);
+        expect(isCrossPlatformEvent('session:end')).toBe(true);
+        expect(isCrossPlatformEvent('tool:pre')).toBe(true);
+        expect(isCrossPlatformEvent('tool:post')).toBe(true);
+      });
+
+      it('should return false for Claude Code-only events', () => {
+        expect(isCrossPlatformEvent('prompt:submit')).toBe(false);
+        expect(isCrossPlatformEvent('permission:request')).toBe(false);
+        expect(isCrossPlatformEvent('agent:start')).toBe(false);
+      });
+
+      it('should return false for Codex-only events', () => {
+        // turn:start and turn:complete don't have Claude Code equivalents
+        expect(isCrossPlatformEvent('turn:complete')).toBe(false);
+        expect(isCrossPlatformEvent('turn:start')).toBe(false);
+      });
+    });
+
+    describe('getCrossPlatformEvents', () => {
+      it('should return all cross-platform events', () => {
+        const events = getCrossPlatformEvents();
+        expect(events).toContain('session:start');
+        expect(events).toContain('session:end');
+        expect(events).toContain('tool:pre');
+        expect(events).toContain('tool:post');
+      });
+    });
+  });
+});

--- a/src/hooks/codex-adapter/__tests__/platform-detect.test.ts
+++ b/src/hooks/codex-adapter/__tests__/platform-detect.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for Platform Detection Module
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  detectPlatform,
+  isCodex,
+  isClaudeCode,
+  getPlatformCapabilities,
+  resetPlatformCache,
+} from '../platform-detect.js';
+
+describe('platform-detect', () => {
+  // Store original env vars
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Reset cache before each test
+    resetPlatformCache();
+    // Clear relevant env vars
+    delete process.env.OMC_PLATFORM;
+    delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CLAUDE_CODE_VERSION;
+    delete process.env.CODEX_CLI;
+    delete process.env.CODEX_SESSION_ID;
+    delete process.env.CODEX_SANDBOX_NETWORK;
+  });
+
+  afterEach(() => {
+    // Restore original env
+    process.env = { ...originalEnv };
+    resetPlatformCache();
+  });
+
+  describe('detectPlatform', () => {
+    it('should return claude-code by default', () => {
+      const platform = detectPlatform();
+      expect(platform).toBe('claude-code');
+    });
+
+    it('should respect OMC_PLATFORM=claude-code override', () => {
+      process.env.OMC_PLATFORM = 'claude-code';
+      expect(detectPlatform()).toBe('claude-code');
+    });
+
+    it('should respect OMC_PLATFORM=codex override', () => {
+      process.env.OMC_PLATFORM = 'codex';
+      expect(detectPlatform()).toBe('codex');
+    });
+
+    it('should detect Claude Code via CLAUDE_CODE env var', () => {
+      process.env.CLAUDE_CODE = '1';
+      expect(detectPlatform()).toBe('claude-code');
+    });
+
+    it('should detect Claude Code via CLAUDE_PROJECT_DIR env var', () => {
+      process.env.CLAUDE_PROJECT_DIR = '/some/path';
+      expect(detectPlatform()).toBe('claude-code');
+    });
+
+    it('should detect Codex via CODEX_CLI env var', () => {
+      process.env.CODEX_CLI = '1';
+      expect(detectPlatform()).toBe('codex');
+    });
+
+    it('should detect Codex via CODEX_SESSION_ID env var', () => {
+      process.env.CODEX_SESSION_ID = 'abc123';
+      expect(detectPlatform()).toBe('codex');
+    });
+
+    it('should cache the detection result', () => {
+      const first = detectPlatform();
+      process.env.OMC_PLATFORM = 'codex'; // Try to change
+      const second = detectPlatform();
+      expect(first).toBe(second);
+    });
+
+    it('should reset cache with resetPlatformCache', () => {
+      detectPlatform(); // Cache result
+      process.env.OMC_PLATFORM = 'codex';
+      resetPlatformCache();
+      expect(detectPlatform()).toBe('codex');
+    });
+  });
+
+  describe('isCodex', () => {
+    it('should return true when platform is codex', () => {
+      process.env.OMC_PLATFORM = 'codex';
+      expect(isCodex()).toBe(true);
+    });
+
+    it('should return false when platform is claude-code', () => {
+      process.env.OMC_PLATFORM = 'claude-code';
+      expect(isCodex()).toBe(false);
+    });
+  });
+
+  describe('isClaudeCode', () => {
+    it('should return true when platform is claude-code', () => {
+      process.env.OMC_PLATFORM = 'claude-code';
+      expect(isClaudeCode()).toBe(true);
+    });
+
+    it('should return false when platform is codex', () => {
+      process.env.OMC_PLATFORM = 'codex';
+      expect(isClaudeCode()).toBe(false);
+    });
+  });
+
+  describe('getPlatformCapabilities', () => {
+    describe('claude-code capabilities', () => {
+      beforeEach(() => {
+        process.env.OMC_PLATFORM = 'claude-code';
+      });
+
+      it('should have full capabilities', () => {
+        const caps = getPlatformCapabilities();
+        expect(caps.platform).toBe('claude-code');
+        expect(caps.canBlock).toBe(true);
+        expect(caps.canModifyInput).toBe(true);
+        expect(caps.hasPreExecutionHooks).toBe(true);
+        expect(caps.hasPostExecutionHooks).toBe(true);
+        expect(caps.hasToolLevelHooks).toBe(true);
+        expect(caps.hasSessionHooks).toBe(true);
+        expect(caps.hasAgentHooks).toBe(true);
+      });
+
+      it('should support all standard events', () => {
+        const caps = getPlatformCapabilities();
+        expect(caps.supportedEvents).toContain('session:start');
+        expect(caps.supportedEvents).toContain('session:end');
+        expect(caps.supportedEvents).toContain('tool:pre');
+        expect(caps.supportedEvents).toContain('tool:post');
+        expect(caps.supportedEvents).toContain('prompt:submit');
+        expect(caps.supportedEvents).toContain('agent:start');
+        expect(caps.supportedEvents).toContain('agent:stop');
+      });
+    });
+
+    describe('codex capabilities', () => {
+      beforeEach(() => {
+        process.env.OMC_PLATFORM = 'codex';
+      });
+
+      it('should have limited capabilities', () => {
+        const caps = getPlatformCapabilities();
+        expect(caps.platform).toBe('codex');
+        expect(caps.canBlock).toBe(false);
+        expect(caps.canModifyInput).toBe(false);
+        expect(caps.hasPreExecutionHooks).toBe(false);
+        expect(caps.hasPostExecutionHooks).toBe(true);
+        expect(caps.hasAgentHooks).toBe(false);
+      });
+
+      it('should only support turn:complete event currently', () => {
+        const caps = getPlatformCapabilities();
+        expect(caps.supportedEvents).toContain('turn:complete');
+        // These are NOT supported on current Codex
+        expect(caps.supportedEvents).not.toContain('tool:pre');
+        expect(caps.supportedEvents).not.toContain('agent:start');
+      });
+    });
+
+    it('should accept platform parameter override', () => {
+      process.env.OMC_PLATFORM = 'claude-code';
+      const codexCaps = getPlatformCapabilities('codex');
+      expect(codexCaps.platform).toBe('codex');
+    });
+  });
+});

--- a/src/hooks/codex-adapter/claude-code-adapter.ts
+++ b/src/hooks/codex-adapter/claude-code-adapter.ts
@@ -1,0 +1,206 @@
+/**
+ * Claude Code Platform Adapter
+ *
+ * Full-featured adapter for Claude Code's native hook system.
+ * Provides complete bidirectional mapping and all hook capabilities.
+ */
+
+import type {
+  PlatformAdapter,
+  Platform,
+  PlatformCapabilities,
+  UnifiedHookEvent,
+  UnifiedHookInput,
+  UnifiedHookOutput,
+  ClaudeCodeHookInput,
+  ClaudeCodeHookOutput,
+  ClaudeCodeHookEvent,
+  CodexHooksConfig,
+} from './types.js';
+import { getPlatformCapabilities } from './platform-detect.js';
+import { fromClaudeCodeEvent, toClaudeCodeEvent } from './event-map.js';
+
+// ============================================================================
+// CLAUDE CODE ADAPTER IMPLEMENTATION
+// ============================================================================
+
+/**
+ * Claude Code Platform Adapter
+ *
+ * Provides full hook capabilities:
+ * - 12+ event types
+ * - Blocking/approval flows
+ * - Input modification
+ * - Tool-level granularity
+ * - Session lifecycle
+ * - Agent control
+ */
+export class ClaudeCodeAdapter implements PlatformAdapter {
+  readonly platform: Platform = 'claude-code';
+  private _capabilities: PlatformCapabilities | null = null;
+
+  get capabilities(): PlatformCapabilities {
+    if (!this._capabilities) {
+      this._capabilities = getPlatformCapabilities('claude-code');
+    }
+    return this._capabilities;
+  }
+
+  /**
+   * Parse Claude Code hook input to unified format
+   */
+  parseInput(rawInput: unknown, event: string): UnifiedHookInput {
+    const input = rawInput as ClaudeCodeHookInput;
+    const unifiedEvent = fromClaudeCodeEvent(event);
+
+    if (!unifiedEvent) {
+      throw new Error(`Unknown Claude Code event: ${event}`);
+    }
+
+    // Extract prompt text from various formats
+    let prompt: string | undefined;
+    if (input.prompt) {
+      prompt = input.prompt;
+    } else if (input.message?.content) {
+      prompt = input.message.content;
+    } else if (input.parts) {
+      prompt = input.parts
+        .filter(p => p.type === 'text' && p.text)
+        .map(p => p.text)
+        .join(' ');
+    }
+
+    return {
+      event: unifiedEvent,
+      sessionId: input.sessionId,
+      cwd: input.directory ?? process.cwd(),
+      prompt,
+      toolName: input.toolName,
+      toolInput: input.toolInput,
+      toolOutput: input.toolOutput,
+      stopReason: input.stop_reason ?? input.stopReason,
+      userRequested: input.user_requested ?? input.userRequested,
+      rawPayload: input,
+      platform: this.platform,
+    };
+  }
+
+  /**
+   * Convert unified output to Claude Code format
+   */
+  formatOutput(output: UnifiedHookOutput): ClaudeCodeHookOutput {
+    const result: ClaudeCodeHookOutput = {
+      continue: output.continue,
+    };
+
+    if (output.message) {
+      result.message = output.message;
+    }
+
+    if (output.reason) {
+      result.reason = output.reason;
+    }
+
+    if (output.modifiedInput !== undefined) {
+      result.modifiedInput = output.modifiedInput;
+      result.updatedInput = output.modifiedInput;
+    }
+
+    if (output.permissionDecision) {
+      result.permissionDecision = output.permissionDecision;
+    }
+
+    return result;
+  }
+
+  /**
+   * Check if an event is supported
+   */
+  isEventSupported(event: UnifiedHookEvent): boolean {
+    return this.capabilities.supportedEvents.includes(event);
+  }
+
+  /**
+   * Map unified event to Claude Code event
+   */
+  mapToPlatformEvent(event: UnifiedHookEvent): string | null {
+    return toClaudeCodeEvent(event);
+  }
+
+  /**
+   * Map Claude Code event to unified event
+   */
+  mapFromPlatformEvent(platformEvent: string): UnifiedHookEvent | null {
+    return fromClaudeCodeEvent(platformEvent);
+  }
+
+  /**
+   * Read Claude Code configuration (for compatibility info)
+   * Returns null as Claude Code doesn't use hooks.json format
+   */
+  async readConfig(_cwd: string): Promise<CodexHooksConfig | null> {
+    // Claude Code uses settings.json, not hooks.json
+    // Return null - caller should use Claude Code's native config
+    return null;
+  }
+}
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+/**
+ * Get all Claude Code events supported by the adapter
+ */
+export function getSupportedClaudeCodeEvents(): ClaudeCodeHookEvent[] {
+  return [
+    'PreToolUse',
+    'PostToolUse',
+    'PostToolUseFailure',
+    'UserPromptSubmit',
+    'PermissionRequest',
+    'SessionStart',
+    'SessionEnd',
+    'Stop',
+    'SubagentStart',
+    'SubagentStop',
+    'Notification',
+    'PreCompact',
+  ];
+}
+
+/**
+ * Create a Claude Code hook configuration entry
+ */
+export function createClaudeCodeHookConfig(
+  event: ClaudeCodeHookEvent,
+  command: string[],
+  options?: {
+    matcher?: string;
+    timeout?: number;
+  }
+): {
+  type: 'command';
+  command: string[];
+  matcher?: string;
+  timeout?: number;
+} {
+  return {
+    type: 'command',
+    command,
+    matcher: options?.matcher,
+    timeout: options?.timeout ?? 5000,
+  };
+}
+
+/**
+ * Singleton instance
+ */
+let _instance: ClaudeCodeAdapter | null = null;
+
+export function getClaudeCodeAdapter(): ClaudeCodeAdapter {
+  if (!_instance) {
+    _instance = new ClaudeCodeAdapter();
+  }
+  return _instance;
+}

--- a/src/hooks/codex-adapter/codex-adapter.ts
+++ b/src/hooks/codex-adapter/codex-adapter.ts
@@ -1,0 +1,276 @@
+/**
+ * Codex CLI Platform Adapter
+ *
+ * Limited adapter for Codex CLI's hook system (current and future).
+ *
+ * Current capabilities (Codex as of Jan 2026):
+ * - Single event: agent-turn-complete via notify
+ * - Post-execution only
+ * - No blocking, no input modification
+ *
+ * Future capabilities (PR #9691):
+ * - Multiple events
+ * - Pre/post execution
+ * - Potentially blocking
+ */
+
+import type {
+  PlatformAdapter,
+  Platform,
+  PlatformCapabilities,
+  UnifiedHookEvent,
+  UnifiedHookInput,
+  UnifiedHookOutput,
+  CodexNotifyPayload,
+  CodexHooksConfig,
+} from './types.js';
+import { getPlatformCapabilities } from './platform-detect.js';
+import { fromCodexEvent, toCodexEvent } from './event-map.js';
+import { readCodexHooksConfig } from './codex-config.js';
+
+// ============================================================================
+// CODEX ADAPTER IMPLEMENTATION
+// ============================================================================
+
+/**
+ * Codex CLI Platform Adapter
+ *
+ * Current limitations:
+ * - Only turn:complete event
+ * - Cannot block operations
+ * - Cannot modify inputs
+ * - No tool-level hooks
+ * - No session/agent hooks
+ */
+export class CodexAdapter implements PlatformAdapter {
+  readonly platform: Platform = 'codex';
+  private _capabilities: PlatformCapabilities | null = null;
+
+  get capabilities(): PlatformCapabilities {
+    if (!this._capabilities) {
+      this._capabilities = getPlatformCapabilities('codex');
+    }
+    return this._capabilities;
+  }
+
+  /**
+   * Parse Codex hook input to unified format
+   *
+   * Currently only handles agent-turn-complete from notify
+   */
+  parseInput(rawInput: unknown, event: string): UnifiedHookInput {
+    const unifiedEvent = fromCodexEvent(event);
+
+    // Handle the current notify payload format
+    if (event === 'agent-turn-complete') {
+      const payload = rawInput as CodexNotifyPayload;
+
+      return {
+        event: unifiedEvent ?? 'turn:complete',
+        cwd: payload.cwd ?? process.cwd(),
+        turnId: payload['turn-id'],
+        threadId: payload['thread-id'],
+        // Extract last message as potential prompt context
+        prompt: payload['last-assistant-message'],
+        rawPayload: payload,
+        platform: this.platform,
+      };
+    }
+
+    // Handle future event formats (PR #9691)
+    const input = rawInput as Record<string, unknown>;
+
+    return {
+      event: unifiedEvent ?? 'turn:complete',
+      sessionId: input.session_id as string | undefined,
+      cwd: (input.cwd as string) ?? process.cwd(),
+      prompt: input.prompt as string | undefined,
+      toolName: input.tool_name as string | undefined,
+      toolInput: input.tool_input,
+      toolOutput: input.tool_output,
+      turnId: input.turn_id as string | undefined,
+      threadId: input.thread_id as string | undefined,
+      rawPayload: input,
+      platform: this.platform,
+    };
+  }
+
+  /**
+   * Convert unified output to Codex format
+   *
+   * Note: Codex notify is fire-and-forget, output is ignored.
+   * Future hooks may support output.
+   */
+  formatOutput(output: UnifiedHookOutput): Record<string, unknown> {
+    // Current Codex notify doesn't use output
+    // Format for future PR #9691 compatibility
+    const result: Record<string, unknown> = {
+      continue: output.continue,
+    };
+
+    if (output.message) {
+      result.message = output.message;
+    }
+
+    if (output.reason) {
+      result.reason = output.reason;
+    }
+
+    // Note: Codex doesn't support input modification yet
+    // Include for forward compatibility
+    if (output.modifiedInput !== undefined) {
+      result.modified_input = output.modifiedInput;
+    }
+
+    return result;
+  }
+
+  /**
+   * Check if an event is supported on Codex
+   */
+  isEventSupported(event: UnifiedHookEvent): boolean {
+    return this.capabilities.supportedEvents.includes(event);
+  }
+
+  /**
+   * Map unified event to Codex event
+   */
+  mapToPlatformEvent(event: UnifiedHookEvent): string | null {
+    return toCodexEvent(event);
+  }
+
+  /**
+   * Map Codex event to unified event
+   */
+  mapFromPlatformEvent(platformEvent: string): UnifiedHookEvent | null {
+    return fromCodexEvent(platformEvent);
+  }
+
+  /**
+   * Read Codex hooks configuration
+   */
+  async readConfig(cwd: string): Promise<CodexHooksConfig | null> {
+    return readCodexHooksConfig(cwd);
+  }
+
+  /**
+   * Get a warning message for unsupported features
+   */
+  getUnsupportedFeatureWarning(feature: string): string {
+    return `[Codex Adapter] Feature "${feature}" is not supported on Codex CLI. ` +
+      `This feature requires Claude Code or a future Codex version with PR #9691.`;
+  }
+
+  /**
+   * Check if blocking is available (it's not on current Codex)
+   */
+  canBlock(): boolean {
+    return this.capabilities.canBlock;
+  }
+
+  /**
+   * Check if input modification is available (it's not on current Codex)
+   */
+  canModifyInput(): boolean {
+    return this.capabilities.canModifyInput;
+  }
+}
+
+// ============================================================================
+// CODEX-SPECIFIC HELPERS
+// ============================================================================
+
+/**
+ * Parse stdin from Codex notify command
+ */
+export function parseCodexNotifyStdin(stdin: string): CodexNotifyPayload | null {
+  try {
+    return JSON.parse(stdin) as CodexNotifyPayload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a response for Codex notify (currently ignored, but format for future)
+ */
+export function createCodexNotifyResponse(
+  success: boolean,
+  message?: string
+): string {
+  return JSON.stringify({
+    success,
+    message,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/**
+ * Extract useful context from a Codex turn payload
+ */
+export function extractCodexTurnContext(payload: CodexNotifyPayload): {
+  turnId: string;
+  threadId: string;
+  cwd: string;
+  lastMessage: string;
+  messageCount: number;
+} {
+  return {
+    turnId: payload['turn-id'] ?? '',
+    threadId: payload['thread-id'] ?? '',
+    cwd: payload.cwd ?? '',
+    lastMessage: payload['last-assistant-message'] ?? '',
+    messageCount: payload['input-messages']?.length ?? 0,
+  };
+}
+
+/**
+ * Singleton instance
+ */
+let _instance: CodexAdapter | null = null;
+
+export function getCodexAdapter(): CodexAdapter {
+  if (!_instance) {
+    _instance = new CodexAdapter();
+  }
+  return _instance;
+}
+
+// ============================================================================
+// GRACEFUL DEGRADATION HELPERS
+// ============================================================================
+
+/**
+ * Wrap a hook handler with Codex-specific graceful degradation
+ *
+ * If a hook tries to use unsupported features (blocking, input modification),
+ * this wrapper will log a warning and allow the operation to continue.
+ */
+export function wrapWithCodexDegradation(
+  handler: (input: UnifiedHookInput) => Promise<UnifiedHookOutput>
+): (input: UnifiedHookInput) => Promise<UnifiedHookOutput> {
+  return async (input: UnifiedHookInput) => {
+    const output = await handler(input);
+
+    // Warn if handler tried to block on Codex
+    if (!output.continue && input.platform === 'codex') {
+      console.warn(
+        '[Codex Adapter] Hook attempted to block operation, but blocking is not ' +
+        'supported on Codex CLI. Operation will continue. Reason:',
+        output.reason
+      );
+      return { ...output, continue: true };
+    }
+
+    // Warn if handler tried to modify input on Codex
+    if (output.modifiedInput !== undefined && input.platform === 'codex') {
+      console.warn(
+        '[Codex Adapter] Hook attempted to modify input, but input modification ' +
+        'is not supported on Codex CLI. Original input will be used.'
+      );
+      return { ...output, modifiedInput: undefined };
+    }
+
+    return output;
+  };
+}

--- a/src/hooks/codex-adapter/codex-config.ts
+++ b/src/hooks/codex-adapter/codex-config.ts
@@ -1,0 +1,428 @@
+/**
+ * Codex Configuration Reader
+ *
+ * Reads and parses Codex CLI configuration files:
+ * - ~/.codex/config.toml (notify configuration)
+ * - .codex/hooks.json (hooks configuration - PR #9691)
+ * - ~/.codex/hooks.json (global hooks configuration)
+ */
+
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import type {
+  CodexHooksConfig,
+  CodexHookDefinition,
+  CodexNotifyConfig,
+  CodexStatusLineConfig,
+} from './types.js';
+
+// ============================================================================
+// PATH HELPERS
+// ============================================================================
+
+/**
+ * Expand ~ to home directory
+ */
+function expandPath(path: string): string {
+  if (path.startsWith('~')) {
+    return join(homedir(), path.slice(1));
+  }
+  return path;
+}
+
+/**
+ * Get the global Codex config directory
+ */
+export function getCodexConfigDir(): string {
+  return join(homedir(), '.codex');
+}
+
+/**
+ * Get the project Codex config directory
+ */
+export function getProjectCodexDir(cwd: string): string {
+  return join(cwd, '.codex');
+}
+
+// ============================================================================
+// CONFIG.TOML PARSING (MINIMAL TOML PARSER)
+// ============================================================================
+
+/**
+ * Parse a simple TOML file (supports basic key-value pairs and arrays)
+ *
+ * Note: This is a minimal parser for Codex config.toml.
+ * For full TOML support, consider using a library like 'toml' or '@iarna/toml'.
+ */
+export function parseSimpleToml(content: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let currentSection = '';
+
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    // Section header: [section] or [section.subsection]
+    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      currentSection = sectionMatch[1];
+      continue;
+    }
+
+    // Key-value pair: key = value
+    const kvMatch = trimmed.match(/^([^=]+)\s*=\s*(.+)$/);
+    if (kvMatch) {
+      const key = kvMatch[1].trim();
+      const rawValue = kvMatch[2].trim();
+      const value = parseTomlValue(rawValue);
+
+      if (currentSection) {
+        // Nested section
+        setNestedValue(result, currentSection, key, value);
+      } else {
+        result[key] = value;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Parse a TOML value (string, number, boolean, array)
+ */
+function parseTomlValue(raw: string): unknown {
+  // String (quoted)
+  if ((raw.startsWith('"') && raw.endsWith('"')) ||
+      (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+
+  // Array
+  if (raw.startsWith('[') && raw.endsWith(']')) {
+    const inner = raw.slice(1, -1).trim();
+    if (!inner) return [];
+
+    // Simple array parsing (doesn't handle nested arrays)
+    const items: unknown[] = [];
+    let current = '';
+    let inString = false;
+    let stringChar = '';
+
+    for (const char of inner) {
+      if (!inString && (char === '"' || char === "'")) {
+        inString = true;
+        stringChar = char;
+        current += char;
+      } else if (inString && char === stringChar) {
+        inString = false;
+        current += char;
+      } else if (!inString && char === ',') {
+        items.push(parseTomlValue(current.trim()));
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+
+    if (current.trim()) {
+      items.push(parseTomlValue(current.trim()));
+    }
+
+    return items;
+  }
+
+  // Boolean
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+
+  // Number
+  const num = Number(raw);
+  if (!isNaN(num)) return num;
+
+  // Fallback: return as string
+  return raw;
+}
+
+/**
+ * Set a nested value in an object
+ */
+function setNestedValue(
+  obj: Record<string, unknown>,
+  section: string,
+  key: string,
+  value: unknown
+): void {
+  const parts = section.split('.');
+  let current: Record<string, unknown> = obj;
+
+  for (const part of parts) {
+    if (!(part in current) || typeof current[part] !== 'object') {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+
+  current[key] = value;
+}
+
+// ============================================================================
+// CODEX CONFIG READERS
+// ============================================================================
+
+/**
+ * Read Codex config.toml
+ */
+export function readCodexConfigToml(): Record<string, unknown> | null {
+  const configPath = join(getCodexConfigDir(), 'config.toml');
+
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    return parseSimpleToml(content);
+  } catch (error) {
+    console.warn('[codex-config] Failed to parse config.toml:', error);
+    return null;
+  }
+}
+
+/**
+ * Read notify configuration from config.toml
+ */
+export function readNotifyConfig(): CodexNotifyConfig | null {
+  const config = readCodexConfigToml();
+  if (!config) return null;
+
+  const notify = config.notify as string[] | undefined;
+  const notifyEvents = config.notify_events as string[] | undefined;
+
+  if (!notify && !notifyEvents) {
+    return null;
+  }
+
+  return {
+    notify,
+    notify_events: notifyEvents,
+  };
+}
+
+/**
+ * Read status line configuration from config.toml
+ */
+export function readStatusLineConfig(): CodexStatusLineConfig | null {
+  const config = readCodexConfigToml();
+  if (!config) return null;
+
+  const tui = config.tui as Record<string, unknown> | undefined;
+  if (!tui) return null;
+
+  const statusLine = tui.status_line as string[] | undefined;
+  const timeout = tui.status_line_timeout_ms as number | undefined;
+
+  if (!statusLine) return null;
+
+  return {
+    status_line: statusLine,
+    status_line_timeout_ms: timeout,
+  };
+}
+
+/**
+ * Read hooks.json configuration
+ */
+export function readHooksJson(cwd: string): CodexHooksConfig | null {
+  // Check project-level hooks first
+  const projectPath = join(getProjectCodexDir(cwd), 'hooks.json');
+  if (existsSync(projectPath)) {
+    try {
+      const content = readFileSync(projectPath, 'utf-8');
+      return JSON.parse(content) as CodexHooksConfig;
+    } catch (error) {
+      console.warn('[codex-config] Failed to parse project hooks.json:', error);
+    }
+  }
+
+  // Fall back to global hooks
+  const globalPath = join(getCodexConfigDir(), 'hooks.json');
+  if (existsSync(globalPath)) {
+    try {
+      const content = readFileSync(globalPath, 'utf-8');
+      return JSON.parse(content) as CodexHooksConfig;
+    } catch (error) {
+      console.warn('[codex-config] Failed to parse global hooks.json:', error);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Read combined Codex hooks configuration
+ * Merges notify config with hooks.json
+ */
+export function readCodexHooksConfig(cwd: string): CodexHooksConfig {
+  const hooksJson = readHooksJson(cwd);
+  const notifyConfig = readNotifyConfig();
+
+  // Start with hooks.json if present
+  const config: CodexHooksConfig = hooksJson ?? {
+    version: 1,
+    hooks: [],
+  };
+
+  // If we have notify config but no hooks, create a hook for it
+  if (notifyConfig?.notify && (!config.hooks || config.hooks.length === 0)) {
+    config.hooks = [{
+      event: 'agent-turn-complete',
+      command: notifyConfig.notify,
+      enabled: true,
+    }];
+  }
+
+  return config;
+}
+
+// ============================================================================
+// CODEX CONFIG WRITERS
+// ============================================================================
+
+/**
+ * Ensure the Codex config directory exists
+ */
+export function ensureCodexConfigDir(): void {
+  const dir = getCodexConfigDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+/**
+ * Ensure the project Codex directory exists
+ */
+export function ensureProjectCodexDir(cwd: string): void {
+  const dir = getProjectCodexDir(cwd);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+/**
+ * Write hooks.json configuration
+ */
+export function writeHooksJson(
+  cwd: string,
+  config: CodexHooksConfig,
+  global: boolean = false
+): void {
+  const targetDir = global ? getCodexConfigDir() : getProjectCodexDir(cwd);
+
+  if (global) {
+    ensureCodexConfigDir();
+  } else {
+    ensureProjectCodexDir(cwd);
+  }
+
+  const targetPath = join(targetDir, 'hooks.json');
+  writeFileSync(targetPath, JSON.stringify(config, null, 2));
+}
+
+/**
+ * Add a hook definition to the configuration
+ */
+export function addHookToConfig(
+  cwd: string,
+  hook: CodexHookDefinition,
+  global: boolean = false
+): CodexHooksConfig {
+  const config = readCodexHooksConfig(cwd);
+
+  if (!config.hooks) {
+    config.hooks = [];
+  }
+
+  // Check for duplicate
+  const existing = config.hooks.find(
+    h => h.event === hook.event && JSON.stringify(h.command) === JSON.stringify(hook.command)
+  );
+
+  if (!existing) {
+    config.hooks.push(hook);
+    writeHooksJson(cwd, config, global);
+  }
+
+  return config;
+}
+
+/**
+ * Remove a hook definition from the configuration
+ */
+export function removeHookFromConfig(
+  cwd: string,
+  event: string,
+  commandPrefix?: string,
+  global: boolean = false
+): CodexHooksConfig {
+  const config = readCodexHooksConfig(cwd);
+
+  if (!config.hooks) {
+    return config;
+  }
+
+  config.hooks = config.hooks.filter(h => {
+    if (h.event !== event) return true;
+    if (commandPrefix && h.command[0]?.includes(commandPrefix)) return false;
+    if (!commandPrefix) return false;
+    return true;
+  });
+
+  writeHooksJson(cwd, config, global);
+  return config;
+}
+
+// ============================================================================
+// OMC DISPATCHER CONFIG
+// ============================================================================
+
+/**
+ * Get the OMC dispatcher command for Codex notify hook
+ */
+export function getOmcDispatcherCommand(): string[] {
+  // Use the installed omc CLI
+  return ['omc', 'hook', '--platform=codex'];
+}
+
+/**
+ * Check if OMC dispatcher is configured in Codex
+ */
+export function isOmcDispatcherConfigured(cwd: string): boolean {
+  const config = readCodexHooksConfig(cwd);
+  const omcCommand = getOmcDispatcherCommand();
+
+  return config.hooks?.some(hook =>
+    hook.command[0] === omcCommand[0] || hook.command[0]?.includes('omc')
+  ) ?? false;
+}
+
+/**
+ * Configure OMC as the Codex dispatcher
+ */
+export function configureOmcDispatcher(cwd: string, global: boolean = true): void {
+  const hook: CodexHookDefinition = {
+    event: 'agent-turn-complete',
+    command: getOmcDispatcherCommand(),
+    enabled: true,
+    timeout: 5000,
+  };
+
+  addHookToConfig(cwd, hook, global);
+}

--- a/src/hooks/codex-adapter/dispatcher.ts
+++ b/src/hooks/codex-adapter/dispatcher.ts
@@ -1,0 +1,366 @@
+/**
+ * Unified Hook Dispatcher
+ *
+ * Central dispatcher that routes hook events to registered handlers,
+ * working across both Claude Code and Codex CLI platforms.
+ *
+ * Features:
+ * - Platform-agnostic hook registration
+ * - Automatic event mapping
+ * - Graceful degradation for unsupported features
+ * - Priority-based handler execution
+ * - Tool name filtering via matchers
+ */
+
+import type {
+  Platform,
+  PlatformAdapter,
+  UnifiedHookEvent,
+  UnifiedHookInput,
+  UnifiedHookOutput,
+  HookRegistration,
+} from './types.js';
+import { detectPlatform, getPlatformCapabilities } from './platform-detect.js';
+import { getClaudeCodeAdapter } from './claude-code-adapter.js';
+import { getCodexAdapter, wrapWithCodexDegradation } from './codex-adapter.js';
+import { getUnsupportedCodexEvents } from './event-map.js';
+
+// ============================================================================
+// HOOK REGISTRY
+// ============================================================================
+
+/** Registered hooks */
+const _hooks: Map<string, HookRegistration> = new Map();
+
+/** Hook execution order cache (invalidated on registration changes) */
+let _sortedHooks: HookRegistration[] | null = null;
+
+/**
+ * Register a hook handler
+ */
+export function registerHook(registration: HookRegistration): void {
+  _hooks.set(registration.id, registration);
+  _sortedHooks = null; // Invalidate cache
+
+  // Log warnings for unsupported events on Codex
+  if (detectPlatform() === 'codex') {
+    const unsupported = getUnsupportedCodexEvents(registration.events);
+    if (unsupported.length > 0) {
+      console.warn(
+        `[Dispatcher] Hook "${registration.id}" registered for events not supported on Codex:`,
+        unsupported.join(', ')
+      );
+    }
+  }
+}
+
+/**
+ * Unregister a hook handler
+ */
+export function unregisterHook(id: string): boolean {
+  const removed = _hooks.delete(id);
+  if (removed) {
+    _sortedHooks = null;
+  }
+  return removed;
+}
+
+/**
+ * Get a registered hook by ID
+ */
+export function getHook(id: string): HookRegistration | undefined {
+  return _hooks.get(id);
+}
+
+/**
+ * Get all registered hooks
+ */
+export function getAllHooks(): HookRegistration[] {
+  return Array.from(_hooks.values());
+}
+
+/**
+ * Clear all registered hooks
+ */
+export function clearHooks(): void {
+  _hooks.clear();
+  _sortedHooks = null;
+}
+
+/**
+ * Get hooks sorted by priority (higher priority first)
+ */
+function getSortedHooks(): HookRegistration[] {
+  if (_sortedHooks === null) {
+    _sortedHooks = Array.from(_hooks.values())
+      .filter(h => h.enabled !== false)
+      .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  }
+  return _sortedHooks;
+}
+
+// ============================================================================
+// ADAPTER MANAGEMENT
+// ============================================================================
+
+/**
+ * Get the appropriate adapter for the current platform
+ */
+export function getAdapter(platform?: Platform): PlatformAdapter {
+  const p = platform ?? detectPlatform();
+
+  switch (p) {
+    case 'claude-code':
+      return getClaudeCodeAdapter();
+    case 'codex':
+      return getCodexAdapter();
+    default:
+      // Default to Claude Code adapter
+      return getClaudeCodeAdapter();
+  }
+}
+
+// ============================================================================
+// DISPATCHER
+// ============================================================================
+
+/**
+ * Dispatch a hook event to all registered handlers
+ *
+ * @param platformEvent - Platform-specific event name
+ * @param rawInput - Raw platform-specific input
+ * @param platform - Platform override (auto-detected if not specified)
+ * @returns Combined output from all handlers
+ */
+export async function dispatch(
+  platformEvent: string,
+  rawInput: unknown,
+  platform?: Platform
+): Promise<UnifiedHookOutput> {
+  const p = platform ?? detectPlatform();
+  const adapter = getAdapter(p);
+  const capabilities = adapter.capabilities;
+
+  // Parse input to unified format
+  let input: UnifiedHookInput;
+  try {
+    input = adapter.parseInput(rawInput, platformEvent);
+  } catch (error) {
+    console.error('[Dispatcher] Failed to parse input:', error);
+    return { continue: true };
+  }
+
+  // Check if event is supported on this platform
+  if (!adapter.isEventSupported(input.event)) {
+    console.warn(
+      `[Dispatcher] Event "${input.event}" is not supported on ${p}. Skipping.`
+    );
+    return { continue: true };
+  }
+
+  // Find matching hooks
+  const hooks = getSortedHooks().filter(hook => {
+    // Check event match
+    if (!hook.events.includes(input.event)) {
+      return false;
+    }
+
+    // Check tool matcher (for tool events)
+    if (hook.toolMatcher && input.toolName) {
+      if (!hook.toolMatcher.test(input.toolName)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  if (hooks.length === 0) {
+    return { continue: true };
+  }
+
+  // Execute hooks in priority order
+  let combinedOutput: UnifiedHookOutput = { continue: true };
+  const messages: string[] = [];
+
+  for (const hook of hooks) {
+    try {
+      // Wrap handler with degradation for Codex
+      const asyncHandler = async (i: UnifiedHookInput) => hook.handler(i);
+      const handler = p === 'codex'
+        ? wrapWithCodexDegradation(asyncHandler)
+        : asyncHandler;
+
+      const output = await handler(input);
+
+      // Aggregate messages
+      if (output.message) {
+        messages.push(output.message);
+      }
+      if (output.additionalContext) {
+        messages.push(output.additionalContext);
+      }
+
+      // If any hook blocks, respect it (unless Codex can't block)
+      if (!output.continue) {
+        if (capabilities.canBlock) {
+          combinedOutput = {
+            ...combinedOutput,
+            continue: false,
+            reason: output.reason,
+          };
+          break; // Stop processing on block
+        } else {
+          console.warn(
+            `[Dispatcher] Hook "${hook.id}" tried to block, but platform "${p}" ` +
+            `doesn't support blocking. Continuing.`
+          );
+        }
+      }
+
+      // Capture input modifications (only if supported)
+      if (output.modifiedInput !== undefined && capabilities.canModifyInput) {
+        combinedOutput.modifiedInput = output.modifiedInput;
+        // Update input for next handler
+        input = { ...input, toolInput: output.modifiedInput };
+      }
+
+      // Capture permission decision
+      if (output.permissionDecision) {
+        combinedOutput.permissionDecision = output.permissionDecision;
+      }
+    } catch (error) {
+      console.error(`[Dispatcher] Hook "${hook.id}" failed:`, error);
+      // Continue to next hook on error
+    }
+  }
+
+  // Combine messages
+  if (messages.length > 0) {
+    combinedOutput.message = messages.join('\n\n---\n\n');
+  }
+
+  return combinedOutput;
+}
+
+/**
+ * Dispatch and format output for the platform
+ */
+export async function dispatchAndFormat(
+  platformEvent: string,
+  rawInput: unknown,
+  platform?: Platform
+): Promise<unknown> {
+  const p = platform ?? detectPlatform();
+  const adapter = getAdapter(p);
+
+  const output = await dispatch(platformEvent, rawInput, p);
+  return adapter.formatOutput(output);
+}
+
+// ============================================================================
+// CONVENIENCE FUNCTIONS
+// ============================================================================
+
+/**
+ * Register a simple hook for specific events
+ */
+export function on(
+  id: string,
+  events: UnifiedHookEvent | UnifiedHookEvent[],
+  handler: (input: UnifiedHookInput) => Promise<UnifiedHookOutput> | UnifiedHookOutput,
+  options?: {
+    toolMatcher?: RegExp;
+    priority?: number;
+  }
+): void {
+  registerHook({
+    id,
+    events: Array.isArray(events) ? events : [events],
+    handler,
+    toolMatcher: options?.toolMatcher,
+    priority: options?.priority,
+  });
+}
+
+/**
+ * Register a hook for tool events only
+ */
+export function onTool(
+  id: string,
+  phase: 'pre' | 'post' | 'error',
+  handler: (input: UnifiedHookInput) => Promise<UnifiedHookOutput> | UnifiedHookOutput,
+  toolMatcher?: RegExp
+): void {
+  const eventMap: Record<string, UnifiedHookEvent> = {
+    pre: 'tool:pre',
+    post: 'tool:post',
+    error: 'tool:error',
+  };
+
+  on(id, eventMap[phase], handler, { toolMatcher });
+}
+
+/**
+ * Register a hook for session lifecycle
+ */
+export function onSession(
+  id: string,
+  phase: 'start' | 'end',
+  handler: (input: UnifiedHookInput) => Promise<UnifiedHookOutput> | UnifiedHookOutput
+): void {
+  const eventMap: Record<string, UnifiedHookEvent> = {
+    start: 'session:start',
+    end: 'session:end',
+  };
+
+  on(id, eventMap[phase], handler);
+}
+
+/**
+ * Register a hook for turn events (Codex-compatible)
+ */
+export function onTurn(
+  id: string,
+  phase: 'start' | 'complete',
+  handler: (input: UnifiedHookInput) => Promise<UnifiedHookOutput> | UnifiedHookOutput
+): void {
+  const eventMap: Record<string, UnifiedHookEvent> = {
+    start: 'turn:start',
+    complete: 'turn:complete',
+  };
+
+  on(id, eventMap[phase], handler);
+}
+
+// ============================================================================
+// CLI ENTRY POINT
+// ============================================================================
+
+/**
+ * Process a hook from CLI stdin
+ *
+ * Usage: omc hook --platform=codex < payload.json
+ */
+export async function processCliHook(
+  platformEvent: string,
+  platform: Platform
+): Promise<void> {
+  // Read stdin
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  const inputStr = Buffer.concat(chunks).toString('utf-8');
+
+  let rawInput: unknown;
+  try {
+    rawInput = JSON.parse(inputStr);
+  } catch {
+    rawInput = {};
+  }
+
+  // Dispatch and output
+  const output = await dispatchAndFormat(platformEvent, rawInput, platform);
+  console.log(JSON.stringify(output));
+}

--- a/src/hooks/codex-adapter/event-map.ts
+++ b/src/hooks/codex-adapter/event-map.ts
@@ -1,0 +1,175 @@
+/**
+ * Event Mapping Layer
+ *
+ * Maps between unified hook events, Claude Code events, and Codex events.
+ * Handles the asymmetry between platforms (12+ Claude Code events vs 1 Codex event).
+ */
+
+import type {
+  UnifiedHookEvent,
+  ClaudeCodeHookEvent,
+  CodexHookEvent,
+} from './types.js';
+
+// ============================================================================
+// CLAUDE CODE <-> UNIFIED MAPPING
+// ============================================================================
+
+/**
+ * Map Claude Code native event -> unified event
+ */
+const CLAUDE_CODE_TO_UNIFIED: Record<ClaudeCodeHookEvent, UnifiedHookEvent> = {
+  SessionStart: 'session:start',
+  SessionEnd: 'session:end',
+  UserPromptSubmit: 'prompt:submit',
+  PreToolUse: 'tool:pre',
+  PostToolUse: 'tool:post',
+  PostToolUseFailure: 'tool:error',
+  PermissionRequest: 'permission:request',
+  SubagentStart: 'agent:start',
+  SubagentStop: 'agent:stop',
+  Stop: 'stop',
+  PreCompact: 'context:pre-compact',
+  Notification: 'notification',
+};
+
+/**
+ * Map unified event -> Claude Code native event
+ */
+const UNIFIED_TO_CLAUDE_CODE: Partial<Record<UnifiedHookEvent, ClaudeCodeHookEvent>> = {
+  'session:start': 'SessionStart',
+  'session:end': 'SessionEnd',
+  'prompt:submit': 'UserPromptSubmit',
+  'tool:pre': 'PreToolUse',
+  'tool:post': 'PostToolUse',
+  'tool:error': 'PostToolUseFailure',
+  'permission:request': 'PermissionRequest',
+  'agent:start': 'SubagentStart',
+  'agent:stop': 'SubagentStop',
+  'stop': 'Stop',
+  'context:pre-compact': 'PreCompact',
+  'notification': 'Notification',
+  // Note: 'turn:start' and 'turn:complete' have no direct Claude Code equivalent
+};
+
+// ============================================================================
+// CODEX <-> UNIFIED MAPPING
+// ============================================================================
+
+/**
+ * Map Codex native event -> unified event
+ */
+const CODEX_TO_UNIFIED: Record<CodexHookEvent, UnifiedHookEvent> = {
+  'agent-turn-complete': 'turn:complete',
+  'agent-turn-start': 'turn:start',
+  'tool-before': 'tool:pre',
+  'tool-after': 'tool:post',
+  'session-start': 'session:start',
+  'session-end': 'session:end',
+};
+
+/**
+ * Map unified event -> Codex native event
+ */
+const UNIFIED_TO_CODEX: Partial<Record<UnifiedHookEvent, CodexHookEvent>> = {
+  'turn:complete': 'agent-turn-complete',
+  'turn:start': 'agent-turn-start',
+  'tool:pre': 'tool-before',
+  'tool:post': 'tool-after',
+  'session:start': 'session-start',
+  'session:end': 'session-end',
+  // No Codex equivalent for: prompt:submit, tool:error, permission:request,
+  // agent:start, agent:stop, stop, context:pre-compact, notification
+};
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+/**
+ * Convert a Claude Code event to a unified event
+ */
+export function fromClaudeCodeEvent(event: string): UnifiedHookEvent | null {
+  return CLAUDE_CODE_TO_UNIFIED[event as ClaudeCodeHookEvent] ?? null;
+}
+
+/**
+ * Convert a unified event to a Claude Code event
+ */
+export function toClaudeCodeEvent(event: UnifiedHookEvent): ClaudeCodeHookEvent | null {
+  return UNIFIED_TO_CLAUDE_CODE[event] ?? null;
+}
+
+/**
+ * Convert a Codex event to a unified event
+ */
+export function fromCodexEvent(event: string): UnifiedHookEvent | null {
+  return CODEX_TO_UNIFIED[event as CodexHookEvent] ?? null;
+}
+
+/**
+ * Convert a unified event to a Codex event
+ */
+export function toCodexEvent(event: UnifiedHookEvent): CodexHookEvent | null {
+  return UNIFIED_TO_CODEX[event] ?? null;
+}
+
+/**
+ * Get all Claude Code events that map to a set of unified events
+ */
+export function getClaudeCodeEvents(unifiedEvents: UnifiedHookEvent[]): ClaudeCodeHookEvent[] {
+  const result: ClaudeCodeHookEvent[] = [];
+  for (const event of unifiedEvents) {
+    const mapped = toClaudeCodeEvent(event);
+    if (mapped) {
+      result.push(mapped);
+    }
+  }
+  return result;
+}
+
+/**
+ * Get all Codex events that map to a set of unified events
+ */
+export function getCodexEvents(unifiedEvents: UnifiedHookEvent[]): CodexHookEvent[] {
+  const result: CodexHookEvent[] = [];
+  for (const event of unifiedEvents) {
+    const mapped = toCodexEvent(event);
+    if (mapped) {
+      result.push(mapped);
+    }
+  }
+  return result;
+}
+
+/**
+ * Get unified events that are NOT supported on Codex
+ * Useful for warning users about unsupported features
+ */
+export function getUnsupportedCodexEvents(
+  requestedEvents: UnifiedHookEvent[]
+): UnifiedHookEvent[] {
+  return requestedEvents.filter(event => !UNIFIED_TO_CODEX[event]);
+}
+
+/**
+ * Check if a unified event is available on both platforms
+ */
+export function isCrossPlatformEvent(event: UnifiedHookEvent): boolean {
+  return UNIFIED_TO_CLAUDE_CODE[event] !== undefined
+    && UNIFIED_TO_CODEX[event] !== undefined;
+}
+
+/**
+ * Get all cross-platform events (available on both platforms)
+ */
+export function getCrossPlatformEvents(): UnifiedHookEvent[] {
+  const allEvents: UnifiedHookEvent[] = [
+    'session:start', 'session:end', 'prompt:submit',
+    'tool:pre', 'tool:post', 'tool:error',
+    'permission:request', 'agent:start', 'agent:stop',
+    'turn:start', 'turn:complete',
+    'context:pre-compact', 'notification', 'stop',
+  ];
+  return allEvents.filter(isCrossPlatformEvent);
+}

--- a/src/hooks/codex-adapter/index.ts
+++ b/src/hooks/codex-adapter/index.ts
@@ -1,0 +1,202 @@
+/**
+ * Codex Hooks Adapter Module
+ *
+ * Provides a unified hooks interface that works across both
+ * Claude Code and Codex CLI platforms.
+ *
+ * ## Features
+ *
+ * - **Platform Detection**: Automatically detects Claude Code vs Codex CLI
+ * - **Event Mapping**: Maps unified events to platform-specific events
+ * - **Graceful Degradation**: Falls back gracefully when features unavailable
+ * - **Config Reading**: Reads both Claude Code and Codex configuration formats
+ * - **Unified Dispatcher**: Single dispatch interface for all hooks
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import {
+ *   detectPlatform,
+ *   getPlatformCapabilities,
+ *   on,
+ *   dispatch,
+ * } from './codex-adapter';
+ *
+ * // Check platform
+ * const platform = detectPlatform();
+ * const caps = getPlatformCapabilities();
+ *
+ * // Register a hook
+ * on('my-hook', 'turn:complete', async (input) => {
+ *   console.log('Turn completed:', input.turnId);
+ *   return { continue: true, message: 'Processed!' };
+ * });
+ *
+ * // Dispatch an event
+ * const output = await dispatch('agent-turn-complete', payload);
+ * ```
+ *
+ * ## Platform Compatibility
+ *
+ * | Feature | Claude Code | Codex CLI (Current) | Codex CLI (Future) |
+ * |---------|-------------|---------------------|-------------------|
+ * | Events | 12+ | 1 | 6+ |
+ * | Blocking | Yes | No | Maybe |
+ * | Input Mod | Yes | No | Maybe |
+ * | Pre-exec | Yes | No | Yes |
+ * | Post-exec | Yes | Yes | Yes |
+ *
+ * @module codex-adapter
+ */
+
+// ============================================================================
+// TYPE EXPORTS
+// ============================================================================
+
+export type {
+  // Platform types
+  Platform,
+  PlatformCapabilities,
+
+  // Event types
+  UnifiedHookEvent,
+  ClaudeCodeHookEvent,
+  CodexHookEvent,
+
+  // Input/Output types
+  UnifiedHookInput,
+  UnifiedHookOutput,
+  ClaudeCodeHookInput,
+  ClaudeCodeHookOutput,
+  CodexNotifyPayload,
+
+  // Config types
+  CodexHooksConfig,
+  CodexHookDefinition,
+  CodexNotifyConfig,
+  CodexStatusLineConfig,
+
+  // Registration types
+  HookRegistration,
+  UnifiedHookHandler,
+  PlatformAdapter,
+} from './types.js';
+
+// ============================================================================
+// PLATFORM DETECTION
+// ============================================================================
+
+export {
+  detectPlatform,
+  isCodex,
+  isClaudeCode,
+  getPlatformCapabilities,
+  formatCapabilities,
+  resetPlatformCache,
+} from './platform-detect.js';
+
+// ============================================================================
+// EVENT MAPPING
+// ============================================================================
+
+export {
+  fromClaudeCodeEvent,
+  toClaudeCodeEvent,
+  fromCodexEvent,
+  toCodexEvent,
+  getClaudeCodeEvents,
+  getCodexEvents,
+  getUnsupportedCodexEvents,
+  isCrossPlatformEvent,
+  getCrossPlatformEvents,
+} from './event-map.js';
+
+// ============================================================================
+// CODEX CONFIG
+// ============================================================================
+
+export {
+  // Path helpers
+  getCodexConfigDir,
+  getProjectCodexDir,
+
+  // TOML parsing
+  parseSimpleToml,
+
+  // Config readers
+  readCodexConfigToml,
+  readNotifyConfig,
+  readStatusLineConfig,
+  readHooksJson,
+  readCodexHooksConfig,
+
+  // Config writers
+  ensureCodexConfigDir,
+  ensureProjectCodexDir,
+  writeHooksJson,
+  addHookToConfig,
+  removeHookFromConfig,
+
+  // OMC dispatcher
+  getOmcDispatcherCommand,
+  isOmcDispatcherConfigured,
+  configureOmcDispatcher,
+} from './codex-config.js';
+
+// ============================================================================
+// ADAPTERS
+// ============================================================================
+
+export {
+  ClaudeCodeAdapter,
+  getClaudeCodeAdapter,
+  getSupportedClaudeCodeEvents,
+  createClaudeCodeHookConfig,
+} from './claude-code-adapter.js';
+
+export {
+  CodexAdapter,
+  getCodexAdapter,
+  parseCodexNotifyStdin,
+  createCodexNotifyResponse,
+  extractCodexTurnContext,
+  wrapWithCodexDegradation,
+} from './codex-adapter.js';
+
+// ============================================================================
+// DISPATCHER
+// ============================================================================
+
+export {
+  // Registry
+  registerHook,
+  unregisterHook,
+  getHook,
+  getAllHooks,
+  clearHooks,
+
+  // Adapter management
+  getAdapter,
+
+  // Dispatch
+  dispatch,
+  dispatchAndFormat,
+
+  // Convenience functions
+  on,
+  onTool,
+  onSession,
+  onTurn,
+
+  // CLI
+  processCliHook,
+} from './dispatcher.js';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+export {
+  CODEX_CONFIG_PATHS,
+  CLAUDE_CODE_CONFIG_PATHS,
+} from './types.js';

--- a/src/hooks/codex-adapter/platform-detect.ts
+++ b/src/hooks/codex-adapter/platform-detect.ts
@@ -1,0 +1,283 @@
+/**
+ * Platform Detection Module
+ *
+ * Detects whether OMC is running under Claude Code or Codex CLI.
+ * Uses environment variables, process info, and config file presence.
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { Platform, PlatformCapabilities, UnifiedHookEvent } from './types.js';
+
+// ============================================================================
+// DETECTION HEURISTICS
+// ============================================================================
+
+/**
+ * Environment variables that indicate Claude Code
+ */
+const CLAUDE_CODE_ENV_VARS = [
+  'CLAUDE_CODE',
+  'CLAUDE_PROJECT_DIR',
+  'CLAUDE_PLUGIN_ROOT',
+  'CLAUDE_CODE_VERSION',
+] as const;
+
+/**
+ * Environment variables that indicate Codex CLI
+ */
+const CODEX_ENV_VARS = [
+  'CODEX_CLI',
+  'CODEX_SESSION_ID',
+  'CODEX_SANDBOX_NETWORK',
+  'OPENAI_API_KEY',      // Codex requires OpenAI key
+] as const;
+
+/**
+ * Config file paths that indicate Claude Code
+ */
+const CLAUDE_CODE_CONFIG_FILES = [
+  () => join(homedir(), '.claude', 'settings.json'),
+  () => join(homedir(), '.claude', 'CLAUDE.md'),
+] as const;
+
+/**
+ * Config file paths that indicate Codex CLI
+ */
+const CODEX_CONFIG_FILES = [
+  () => join(homedir(), '.codex', 'config.toml'),
+  () => join(homedir(), '.codex', 'hooks.json'),
+] as const;
+
+// ============================================================================
+// PLATFORM DETECTION
+// ============================================================================
+
+/** Cached detection result */
+let _cachedPlatform: Platform | null = null;
+let _cachedCapabilities: PlatformCapabilities | null = null;
+
+/**
+ * Detect the current CLI platform
+ *
+ * Detection priority:
+ * 1. Explicit environment variable (OMC_PLATFORM)
+ * 2. Claude Code env vars
+ * 3. Codex env vars
+ * 4. Config file presence
+ * 5. Fallback to 'claude-code' (most common)
+ */
+export function detectPlatform(): Platform {
+  if (_cachedPlatform !== null) {
+    return _cachedPlatform;
+  }
+
+  // 1. Explicit override
+  const explicitPlatform = process.env.OMC_PLATFORM;
+  if (explicitPlatform === 'claude-code' || explicitPlatform === 'codex') {
+    _cachedPlatform = explicitPlatform;
+    return _cachedPlatform;
+  }
+
+  // 2. Claude Code env vars (strong signal)
+  const hasClaudeCodeEnv = CLAUDE_CODE_ENV_VARS.some(v => process.env[v] !== undefined);
+  if (hasClaudeCodeEnv) {
+    _cachedPlatform = 'claude-code';
+    return _cachedPlatform;
+  }
+
+  // 3. Codex env vars (strong signal)
+  const hasCodexEnv = CODEX_ENV_VARS.some(v => {
+    // OPENAI_API_KEY alone isn't enough - check for Codex-specific vars first
+    if (v === 'OPENAI_API_KEY') return false;
+    return process.env[v] !== undefined;
+  });
+  if (hasCodexEnv) {
+    _cachedPlatform = 'codex';
+    return _cachedPlatform;
+  }
+
+  // 4. Config file presence
+  const hasClaudeCodeConfig = CLAUDE_CODE_CONFIG_FILES.some(getPath => {
+    try { return existsSync(getPath()); } catch { return false; }
+  });
+  const hasCodexConfig = CODEX_CONFIG_FILES.some(getPath => {
+    try { return existsSync(getPath()); } catch { return false; }
+  });
+
+  if (hasCodexConfig && !hasClaudeCodeConfig) {
+    _cachedPlatform = 'codex';
+    return _cachedPlatform;
+  }
+
+  // 5. Default to claude-code (OMC's primary platform)
+  _cachedPlatform = 'claude-code';
+  return _cachedPlatform;
+}
+
+/**
+ * Check if running under Codex CLI
+ */
+export function isCodex(): boolean {
+  return detectPlatform() === 'codex';
+}
+
+/**
+ * Check if running under Claude Code
+ */
+export function isClaudeCode(): boolean {
+  return detectPlatform() === 'claude-code';
+}
+
+/**
+ * Reset cached detection (for testing)
+ */
+export function resetPlatformCache(): void {
+  _cachedPlatform = null;
+  _cachedCapabilities = null;
+}
+
+// ============================================================================
+// PLATFORM CAPABILITIES
+// ============================================================================
+
+/**
+ * Claude Code supported events (all events available)
+ */
+const CLAUDE_CODE_EVENTS: UnifiedHookEvent[] = [
+  'session:start',
+  'session:end',
+  'prompt:submit',
+  'tool:pre',
+  'tool:post',
+  'tool:error',
+  'permission:request',
+  'agent:start',
+  'agent:stop',
+  'turn:complete',
+  'context:pre-compact',
+  'notification',
+  'stop',
+];
+
+/**
+ * Codex CLI supported events (current - only turn:complete via notify)
+ */
+const CODEX_CURRENT_EVENTS: UnifiedHookEvent[] = [
+  'turn:complete',
+];
+
+/**
+ * Codex CLI events expected after PR #9691
+ */
+const CODEX_FUTURE_EVENTS: UnifiedHookEvent[] = [
+  'turn:start',
+  'turn:complete',
+  'tool:pre',
+  'tool:post',
+  'session:start',
+  'session:end',
+];
+
+/**
+ * Get capabilities for the detected platform
+ */
+export function getPlatformCapabilities(platform?: Platform): PlatformCapabilities {
+  const p = platform ?? detectPlatform();
+
+  if (_cachedCapabilities !== null && _cachedCapabilities.platform === p) {
+    return _cachedCapabilities;
+  }
+
+  let capabilities: PlatformCapabilities;
+
+  switch (p) {
+    case 'claude-code':
+      capabilities = {
+        platform: 'claude-code',
+        supportedEvents: CLAUDE_CODE_EVENTS,
+        canBlock: true,
+        canModifyInput: true,
+        hasPreExecutionHooks: true,
+        hasPostExecutionHooks: true,
+        hasToolLevelHooks: true,
+        hasSessionHooks: true,
+        hasAgentHooks: true,
+      };
+      break;
+
+    case 'codex': {
+      // Check if PR #9691 hooks are available by checking for hooks config
+      const hasAdvancedHooks = checkCodexAdvancedHooks();
+      capabilities = {
+        platform: 'codex',
+        supportedEvents: hasAdvancedHooks ? CODEX_FUTURE_EVENTS : CODEX_CURRENT_EVENTS,
+        canBlock: hasAdvancedHooks,
+        canModifyInput: false,  // Codex doesn't support input modification yet
+        hasPreExecutionHooks: hasAdvancedHooks,
+        hasPostExecutionHooks: true,  // notify gives post-execution
+        hasToolLevelHooks: hasAdvancedHooks,
+        hasSessionHooks: hasAdvancedHooks,
+        hasAgentHooks: false,
+      };
+      break;
+    }
+
+    default:
+      capabilities = {
+        platform: 'unknown',
+        supportedEvents: [],
+        canBlock: false,
+        canModifyInput: false,
+        hasPreExecutionHooks: false,
+        hasPostExecutionHooks: false,
+        hasToolLevelHooks: false,
+        hasSessionHooks: false,
+        hasAgentHooks: false,
+      };
+  }
+
+  _cachedCapabilities = capabilities;
+  return capabilities;
+}
+
+/**
+ * Check if Codex has advanced hooks (PR #9691 shipped)
+ *
+ * Detects by looking for hooks configuration in config.toml
+ * or the presence of hooks.json.
+ */
+function checkCodexAdvancedHooks(): boolean {
+  try {
+    const hooksJsonPath = join(homedir(), '.codex', 'hooks.json');
+    if (existsSync(hooksJsonPath)) {
+      return true;
+    }
+  } catch {
+    // Ignore
+  }
+
+  // Check for [hooks] section in config.toml
+  // Future: parse TOML when PR #9691 ships
+  return false;
+}
+
+/**
+ * Get a human-readable summary of platform capabilities
+ */
+export function formatCapabilities(capabilities: PlatformCapabilities): string {
+  const lines: string[] = [
+    `Platform: ${capabilities.platform}`,
+    `Events: ${capabilities.supportedEvents.length} supported`,
+    `Blocking: ${capabilities.canBlock ? 'Yes' : 'No'}`,
+    `Input Modification: ${capabilities.canModifyInput ? 'Yes' : 'No'}`,
+    `Pre-execution: ${capabilities.hasPreExecutionHooks ? 'Yes' : 'No'}`,
+    `Post-execution: ${capabilities.hasPostExecutionHooks ? 'Yes' : 'No'}`,
+    `Tool-level: ${capabilities.hasToolLevelHooks ? 'Yes' : 'No'}`,
+    `Session hooks: ${capabilities.hasSessionHooks ? 'Yes' : 'No'}`,
+    `Agent hooks: ${capabilities.hasAgentHooks ? 'Yes' : 'No'}`,
+  ];
+
+  return lines.join('\n');
+}

--- a/src/hooks/codex-adapter/types.ts
+++ b/src/hooks/codex-adapter/types.ts
@@ -1,0 +1,407 @@
+/**
+ * Codex Hooks Adapter - Type Definitions
+ *
+ * Defines types for the unified hooks interface that supports both
+ * Claude Code and Codex CLI platforms.
+ *
+ * Key concepts:
+ * - Platform: 'claude-code' or 'codex' (runtime detection)
+ * - HookEvent: Unified event type that maps to both platforms
+ * - Capabilities: Feature detection for graceful degradation
+ */
+
+// ============================================================================
+// PLATFORM DETECTION
+// ============================================================================
+
+/**
+ * Supported CLI platforms
+ */
+export type Platform = 'claude-code' | 'codex' | 'unknown';
+
+/**
+ * Platform capabilities - what features are available
+ */
+export interface PlatformCapabilities {
+  /** Platform identifier */
+  platform: Platform;
+
+  /** Platform version (if detectable) */
+  version?: string;
+
+  /** Supported hook events */
+  supportedEvents: UnifiedHookEvent[];
+
+  /** Can hooks block/prevent operations? */
+  canBlock: boolean;
+
+  /** Can hooks modify tool inputs? */
+  canModifyInput: boolean;
+
+  /** Are pre-execution hooks available? */
+  hasPreExecutionHooks: boolean;
+
+  /** Are post-execution hooks available? */
+  hasPostExecutionHooks: boolean;
+
+  /** Is there tool-level granularity? */
+  hasToolLevelHooks: boolean;
+
+  /** Session lifecycle hooks available? */
+  hasSessionHooks: boolean;
+
+  /** Agent/subagent control hooks available? */
+  hasAgentHooks: boolean;
+}
+
+// ============================================================================
+// UNIFIED HOOK EVENTS
+// ============================================================================
+
+/**
+ * Unified hook event types that work across both platforms
+ *
+ * Maps to:
+ * - Claude Code: 12+ native events
+ * - Codex CLI: 1 event (agent-turn-complete) + future PR #9691 events
+ */
+export type UnifiedHookEvent =
+  // Session lifecycle
+  | 'session:start'
+  | 'session:end'
+
+  // User input
+  | 'prompt:submit'          // Before user prompt is processed
+
+  // Tool execution (Claude Code native, Codex future)
+  | 'tool:pre'               // Before tool execution
+  | 'tool:post'              // After successful tool execution
+  | 'tool:error'             // After failed tool execution
+
+  // Permission/approval
+  | 'permission:request'     // When permission is needed
+
+  // Agent control
+  | 'agent:start'            // Subagent spawned
+  | 'agent:stop'             // Subagent terminated
+
+  // Turn lifecycle (Codex primary event)
+  | 'turn:start'             // Agent turn begins (Codex future)
+  | 'turn:complete'          // Agent turn completes (Codex: agent-turn-complete)
+
+  // Context management
+  | 'context:pre-compact'    // Before context compaction
+
+  // Notifications
+  | 'notification'           // General notifications
+  | 'stop';                  // Agent stop requested
+
+// ============================================================================
+// CLAUDE CODE EVENT MAPPING
+// ============================================================================
+
+/**
+ * Claude Code native hook events
+ */
+export type ClaudeCodeHookEvent =
+  | 'PreToolUse'
+  | 'PostToolUse'
+  | 'PostToolUseFailure'
+  | 'UserPromptSubmit'
+  | 'PermissionRequest'
+  | 'SessionStart'
+  | 'SessionEnd'
+  | 'Stop'
+  | 'SubagentStart'
+  | 'SubagentStop'
+  | 'Notification'
+  | 'PreCompact';
+
+/**
+ * Claude Code hook input (from stdin)
+ */
+export interface ClaudeCodeHookInput {
+  sessionId?: string;
+  prompt?: string;
+  message?: { content?: string };
+  parts?: Array<{ type: string; text?: string }>;
+  toolName?: string;
+  toolInput?: unknown;
+  toolOutput?: unknown;
+  directory?: string;
+  stop_reason?: string;
+  stopReason?: string;
+  user_requested?: boolean;
+  userRequested?: boolean;
+}
+
+/**
+ * Claude Code hook output (to stdout)
+ */
+export interface ClaudeCodeHookOutput {
+  continue: boolean;
+  message?: string;
+  reason?: string;
+  modifiedInput?: unknown;
+  permissionDecision?: 'allow' | 'deny' | 'ask';
+  updatedInput?: unknown;
+}
+
+// ============================================================================
+// CODEX EVENT MAPPING
+// ============================================================================
+
+/**
+ * Codex CLI native hook events (current + PR #9691)
+ */
+export type CodexHookEvent =
+  | 'agent-turn-complete'     // Current: only supported event
+  | 'agent-turn-start'        // Future: PR #9691
+  | 'tool-before'             // Future: PR #9691
+  | 'tool-after'              // Future: PR #9691
+  | 'session-start'           // Future: PR #9691
+  | 'session-end';            // Future: PR #9691
+
+/**
+ * Codex notify payload (current implementation)
+ */
+export interface CodexNotifyPayload {
+  type: 'agent-turn-complete';
+  'turn-id': string;
+  'thread-id': string;
+  'input-messages': unknown[];
+  'last-assistant-message': string;
+  cwd: string;
+}
+
+/**
+ * Codex hooks.json configuration format (PR #9691 proposed)
+ */
+export interface CodexHooksConfig {
+  version?: number;
+  hooks?: CodexHookDefinition[];
+  /** Compatibility mode with Claude Code event names */
+  claude_code_compat?: {
+    enabled: boolean;
+    unsupported_events?: string[];
+  };
+}
+
+/**
+ * Codex hook definition in hooks.json
+ */
+export interface CodexHookDefinition {
+  /** Event type to listen for */
+  event: CodexHookEvent | string;
+  /** Command to execute */
+  command: string[];
+  /** Whether the hook is enabled */
+  enabled?: boolean;
+  /** Timeout in milliseconds */
+  timeout?: number;
+  /** Regex matcher for filtering (e.g., tool names) */
+  matcher?: string;
+}
+
+/**
+ * Codex config.toml notify configuration
+ */
+export interface CodexNotifyConfig {
+  /** Notify command array */
+  notify?: string[];
+  /** Notify events (future) */
+  notify_events?: string[];
+}
+
+/**
+ * Codex status line configuration (PR #10170)
+ */
+export interface CodexStatusLineConfig {
+  status_line?: string[];
+  status_line_timeout_ms?: number;
+}
+
+// ============================================================================
+// UNIFIED HOOK INTERFACE
+// ============================================================================
+
+/**
+ * Unified hook input that normalizes both platforms
+ */
+export interface UnifiedHookInput {
+  /** Event type */
+  event: UnifiedHookEvent;
+
+  /** Session identifier */
+  sessionId?: string;
+
+  /** Working directory */
+  cwd: string;
+
+  /** User prompt text (for prompt events) */
+  prompt?: string;
+
+  /** Tool name (for tool events) */
+  toolName?: string;
+
+  /** Tool input (for tool events) */
+  toolInput?: unknown;
+
+  /** Tool output (for post-tool events) */
+  toolOutput?: unknown;
+
+  /** Tool error (for error events) */
+  toolError?: unknown;
+
+  /** Turn ID (Codex) */
+  turnId?: string;
+
+  /** Thread ID (Codex) */
+  threadId?: string;
+
+  /** Agent ID (for agent events) */
+  agentId?: string;
+
+  /** Agent type (for agent events) */
+  agentType?: string;
+
+  /** Stop reason (for stop events) */
+  stopReason?: string;
+
+  /** Whether stop was user-requested */
+  userRequested?: boolean;
+
+  /** Raw platform-specific payload */
+  rawPayload?: unknown;
+
+  /** Source platform */
+  platform: Platform;
+}
+
+/**
+ * Unified hook output
+ */
+export interface UnifiedHookOutput {
+  /** Whether to continue with the operation */
+  continue: boolean;
+
+  /** Message to inject into context */
+  message?: string;
+
+  /** Reason for blocking (when continue=false) */
+  reason?: string;
+
+  /** Modified tool input (for pre-tool hooks) */
+  modifiedInput?: unknown;
+
+  /** Permission decision (for permission events) */
+  permissionDecision?: 'allow' | 'deny' | 'ask';
+
+  /** Additional context to inject */
+  additionalContext?: string;
+}
+
+/**
+ * Hook handler function signature
+ */
+export type UnifiedHookHandler = (
+  input: UnifiedHookInput
+) => Promise<UnifiedHookOutput> | UnifiedHookOutput;
+
+/**
+ * Hook registration
+ */
+export interface HookRegistration {
+  /** Unique identifier */
+  id: string;
+
+  /** Events to listen for */
+  events: UnifiedHookEvent[];
+
+  /** Handler function */
+  handler: UnifiedHookHandler;
+
+  /** Optional matcher for tool names */
+  toolMatcher?: RegExp;
+
+  /** Priority (higher = runs first) */
+  priority?: number;
+
+  /** Whether hook is enabled */
+  enabled?: boolean;
+}
+
+// ============================================================================
+// ADAPTER INTERFACE
+// ============================================================================
+
+/**
+ * Platform adapter interface
+ *
+ * Implementations:
+ * - ClaudeCodeAdapter: Full-featured, direct integration
+ * - CodexAdapter: Limited features, works with notify + future hooks
+ */
+export interface PlatformAdapter {
+  /** Platform identifier */
+  readonly platform: Platform;
+
+  /** Platform capabilities */
+  readonly capabilities: PlatformCapabilities;
+
+  /**
+   * Parse platform-specific input to unified format
+   */
+  parseInput(rawInput: unknown, event: string): UnifiedHookInput;
+
+  /**
+   * Convert unified output to platform-specific format
+   */
+  formatOutput(output: UnifiedHookOutput): unknown;
+
+  /**
+   * Check if an event is supported on this platform
+   */
+  isEventSupported(event: UnifiedHookEvent): boolean;
+
+  /**
+   * Map unified event to platform-specific event name
+   */
+  mapToPlatformEvent(event: UnifiedHookEvent): string | null;
+
+  /**
+   * Map platform-specific event to unified event
+   */
+  mapFromPlatformEvent(platformEvent: string): UnifiedHookEvent | null;
+
+  /**
+   * Read platform configuration
+   */
+  readConfig(cwd: string): Promise<CodexHooksConfig | null>;
+}
+
+// ============================================================================
+// CONFIG FILE PATHS
+// ============================================================================
+
+/**
+ * Known Codex configuration file paths
+ */
+export const CODEX_CONFIG_PATHS = {
+  /** Global config.toml */
+  globalConfig: '~/.codex/config.toml',
+  /** Project hooks.json */
+  projectHooks: '.codex/hooks.json',
+  /** Global hooks.json (future) */
+  globalHooks: '~/.codex/hooks.json',
+} as const;
+
+/**
+ * Known Claude Code configuration file paths
+ */
+export const CLAUDE_CODE_CONFIG_PATHS = {
+  /** Global settings.json */
+  globalSettings: '~/.claude/settings.json',
+  /** Project settings.json */
+  projectSettings: '.claude/settings.json',
+} as const;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -811,3 +811,93 @@ export {
   type HookOutput as SessionEndHookOutput
 } from './session-end/index.js';
 
+// Codex Adapter (Unified Hooks Interface)
+export {
+  // Platform Detection
+  detectPlatform,
+  isCodex,
+  isClaudeCode,
+  getPlatformCapabilities,
+  formatCapabilities,
+  resetPlatformCache,
+
+  // Event Mapping
+  fromClaudeCodeEvent,
+  toClaudeCodeEvent,
+  fromCodexEvent,
+  toCodexEvent,
+  getClaudeCodeEvents,
+  getCodexEvents,
+  getUnsupportedCodexEvents,
+  isCrossPlatformEvent,
+  getCrossPlatformEvents,
+
+  // Codex Config
+  getCodexConfigDir,
+  getProjectCodexDir,
+  parseSimpleToml,
+  readCodexConfigToml,
+  readNotifyConfig,
+  readStatusLineConfig,
+  readHooksJson,
+  readCodexHooksConfig,
+  ensureCodexConfigDir,
+  ensureProjectCodexDir,
+  writeHooksJson,
+  addHookToConfig,
+  removeHookFromConfig,
+  getOmcDispatcherCommand,
+  isOmcDispatcherConfigured,
+  configureOmcDispatcher,
+
+  // Adapters
+  ClaudeCodeAdapter,
+  getClaudeCodeAdapter,
+  getSupportedClaudeCodeEvents,
+  createClaudeCodeHookConfig,
+  CodexAdapter,
+  getCodexAdapter,
+  parseCodexNotifyStdin,
+  createCodexNotifyResponse,
+  extractCodexTurnContext,
+  wrapWithCodexDegradation,
+
+  // Dispatcher
+  registerHook,
+  unregisterHook,
+  getHook,
+  getAllHooks,
+  clearHooks,
+  getAdapter,
+  dispatch,
+  dispatchAndFormat,
+  on,
+  onTool,
+  onSession,
+  onTurn,
+  processCliHook,
+
+  // Types
+  type Platform,
+  type PlatformCapabilities,
+  type UnifiedHookEvent,
+  type ClaudeCodeHookEvent,
+  type CodexHookEvent,
+  type UnifiedHookInput,
+  type UnifiedHookOutput,
+  type ClaudeCodeHookInput,
+  type ClaudeCodeHookOutput,
+  type CodexNotifyPayload,
+  type CodexHooksConfig,
+  type CodexHookDefinition,
+  type CodexNotifyConfig,
+  type CodexStatusLineConfig,
+  type HookRegistration,
+  type UnifiedHookHandler,
+  type PlatformAdapter,
+
+  // Constants
+  CODEX_CONFIG_PATHS,
+  CLAUDE_CODE_CONFIG_PATHS,
+} from './codex-adapter/index.js';
+


### PR DESCRIPTION
## Summary

- Add unified hooks interface supporting both Claude Code and Codex CLI platforms
- Implement platform detection to auto-detect Claude Code vs Codex CLI
- Create event mapping layer to translate between platform-specific and unified events
- Build Codex config reader for config.toml and hooks.json formats
- Design graceful degradation for unsupported Codex features (blocking, input modification)

## Architecture

```
codex-adapter/
├── types.ts           # Unified type definitions
├── platform-detect.ts # Auto-detect Claude Code vs Codex
├── event-map.ts       # Bidirectional event mapping
├── codex-config.ts    # Read Codex config.toml/hooks.json
├── claude-code-adapter.ts  # Full-featured Claude Code adapter
├── codex-adapter.ts   # Limited Codex adapter with degradation
├── dispatcher.ts      # Unified hook dispatcher
├── index.ts           # Module exports
└── __tests__/         # 127 comprehensive tests
```

## Platform Capabilities

| Feature | Claude Code | Codex (Current) | Codex (Future) |
|---------|-------------|-----------------|----------------|
| Events | 12+ | 1 (notify) | 6+ (PR #9691) |
| Blocking | ✅ | ❌ | Maybe |
| Input Mod | ✅ | ❌ | Maybe |
| Pre-exec | ✅ | ❌ | ✅ |
| Post-exec | ✅ | ✅ | ✅ |

## Key Features

1. **Platform Detection**: Detects platform via env vars (`CLAUDE_CODE`, `CODEX_CLI`) or config file presence
2. **Event Mapping**: Maps unified events (`tool:pre`, `turn:complete`) to platform events (`PreToolUse`, `agent-turn-complete`)
3. **Graceful Degradation**: Hooks that try to block on Codex get logged and continue
4. **Forward Compatible**: Designed to support Codex PR #9691 when it ships

## Test plan

- [x] Run `npm run build` - passes
- [x] Run `npx vitest run src/hooks/codex-adapter/__tests__/` - 127 tests pass
- [ ] Manual testing with Codex CLI (when available)

## References

- Research doc: `~/Workspace/omc-worktrees/research/codex-hooks/CODEX_HOOKS_RESEARCH.md`
- Codex PR #9691: Official hooks implementation (pending)
- Codex PR #10170: Custom status line pattern (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)