### PR TITLE
fix(hud): CJK-aware string truncation for double-width characters

### DIFF
--- a/src/hud/elements/agents.ts
+++ b/src/hud/elements/agents.ts
@@ -9,6 +9,7 @@
 
 import type { ActiveAgent, AgentsFormat } from '../types.js';
 import { cyan, dim, RESET, getModelTierColor, getDurationColor } from '../colors.js';
+import { truncateToWidth } from '../../utils/string-width.js';
 
 const CYAN = '\x1b[36m';
 
@@ -248,11 +249,12 @@ export function renderAgentsDetailed(agents: ActiveAgent[]): string | null {
 
 /**
  * Truncate description to fit in statusline.
+ * CJK-aware: accounts for double-width characters.
  */
-function truncateDescription(desc: string | undefined, maxLen: number = 20): string {
+function truncateDescription(desc: string | undefined, maxWidth: number = 20): string {
   if (!desc) return '...';
-  if (desc.length <= maxLen) return desc;
-  return desc.slice(0, maxLen - 3) + '...';
+  // Use CJK-aware truncation (maxWidth is visual columns, not character count)
+  return truncateToWidth(desc, maxWidth);
 }
 
 /**
@@ -427,7 +429,8 @@ export function renderAgentsMultiLine(
     const durationColor = getDurationColor(durationMs);
 
     const desc = a.description || '...';
-    const truncatedDesc = desc.length > 45 ? desc.slice(0, 42) + '...' : desc;
+    // Use CJK-aware truncation (45 visual columns)
+    const truncatedDesc = truncateToWidth(desc, 45);
 
     detailLines.push(
       `${dim(prefix)} ${color}${code}${RESET} ${dim(shortName)}${durationColor}${duration}${RESET}  ${truncatedDesc}`

--- a/src/hud/elements/background.ts
+++ b/src/hud/elements/background.ts
@@ -6,6 +6,7 @@
 
 import type { BackgroundTask } from '../types.js';
 import { RESET } from '../colors.js';
+import { truncateToWidth } from '../../utils/string-width.js';
 
 const CYAN = '\x1b[36m';
 const GREEN = '\x1b[32m';
@@ -69,8 +70,8 @@ export function renderBackgroundDetailed(tasks: BackgroundTask[]): string | null
       const parts = t.agentType.split(':');
       return parts[parts.length - 1];
     }
-    // Otherwise use truncated description
-    return t.description.slice(0, 8);
+    // Otherwise use truncated description (CJK-aware)
+    return truncateToWidth(t.description, 8, '');
   });
 
   const suffix = running.length > 3 ? ',+' + (running.length - 3) : '';

--- a/src/hud/elements/model.ts
+++ b/src/hud/elements/model.ts
@@ -5,6 +5,7 @@
  */
 
 import { dim, cyan } from '../colors.js';
+import { truncateToWidth } from '../../utils/string-width.js';
 
 /**
  * Format model name for display.
@@ -19,8 +20,8 @@ export function formatModelName(modelId: string | null | undefined): string | nu
   if (id.includes('sonnet')) return 'Sonnet';
   if (id.includes('haiku')) return 'Haiku';
 
-  // Return original if not recognized (truncate if too long)
-  return modelId.length > 20 ? modelId.substring(0, 17) + '...' : modelId;
+  // Return original if not recognized (CJK-aware truncation)
+  return truncateToWidth(modelId, 20);
 }
 
 /**

--- a/src/hud/elements/skills.ts
+++ b/src/hud/elements/skills.ts
@@ -6,15 +6,17 @@
 
 import type { UltraworkStateForHud, RalphStateForHud, SkillInvocation } from '../types.js';
 import { RESET, cyan } from '../colors.js';
+import { truncateToWidth } from '../../utils/string-width.js';
 
 const MAGENTA = '\x1b[35m';
 const BRIGHT_MAGENTA = '\x1b[95m';
 
 /**
- * Truncate string to max length with ellipsis.
+ * Truncate string to max visual width with ellipsis.
+ * CJK-aware: accounts for double-width characters.
  */
-function truncate(str: string, max: number): string {
-  return str.length > max ? str.slice(0, max) + '...' : str;
+function truncate(str: string, maxWidth: number): string {
+  return truncateToWidth(str, maxWidth);
 }
 
 /**

--- a/src/hud/elements/todos.ts
+++ b/src/hud/elements/todos.ts
@@ -6,6 +6,7 @@
 
 import type { TodoItem } from "../types.js";
 import { RESET } from "../colors.js";
+import { truncateToWidth } from "../../utils/string-width.js";
 
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -71,8 +72,8 @@ export function renderTodosWithCurrent(todos: TodoItem[]): string | null {
 
   if (inProgress) {
     const activeText = inProgress.activeForm || inProgress.content || "...";
-    const truncated =
-      activeText.length > 30 ? activeText.slice(0, 27) + "..." : activeText;
+    // Use CJK-aware truncation (30 visual columns)
+    const truncated = truncateToWidth(activeText, 30);
     result += ` ${DIM}(working: ${truncated})${RESET}`;
   }
 

--- a/src/utils/__tests__/string-width.test.ts
+++ b/src/utils/__tests__/string-width.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for CJK-aware string width utilities.
+ * Related: Issue #344 - Korean IME input visibility
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  isCJKCharacter,
+  isZeroWidth,
+  getCharWidth,
+  stringWidth,
+  stripAnsi,
+  truncateToWidth,
+  padToWidth,
+  sliceByWidth,
+} from "../string-width.js";
+
+describe("isCJKCharacter", () => {
+  it("detects Korean Hangul syllables", () => {
+    expect(isCJKCharacter("안".codePointAt(0)!)).toBe(true);
+    expect(isCJKCharacter("녕".codePointAt(0)!)).toBe(true);
+    expect(isCJKCharacter("하".codePointAt(0)!)).toBe(true);
+  });
+
+  it("detects CJK Unified Ideographs (Chinese)", () => {
+    expect(isCJKCharacter("中".codePointAt(0)!)).toBe(true);
+    expect(isCJKCharacter("文".codePointAt(0)!)).toBe(true);
+  });
+
+  it("detects Japanese Hiragana and Katakana", () => {
+    expect(isCJKCharacter("あ".codePointAt(0)!)).toBe(true);
+    expect(isCJKCharacter("カ".codePointAt(0)!)).toBe(true);
+  });
+
+  it("detects full-width ASCII", () => {
+    expect(isCJKCharacter("Ａ".codePointAt(0)!)).toBe(true);
+    expect(isCJKCharacter("１".codePointAt(0)!)).toBe(true);
+  });
+
+  it("returns false for ASCII characters", () => {
+    expect(isCJKCharacter("A".codePointAt(0)!)).toBe(false);
+    expect(isCJKCharacter("1".codePointAt(0)!)).toBe(false);
+    expect(isCJKCharacter(" ".codePointAt(0)!)).toBe(false);
+  });
+});
+
+describe("isZeroWidth", () => {
+  it("detects zero-width space", () => {
+    expect(isZeroWidth(0x200b)).toBe(true);
+  });
+
+  it("detects zero-width joiner", () => {
+    expect(isZeroWidth(0x200d)).toBe(true);
+  });
+
+  it("detects combining diacritical marks", () => {
+    expect(isZeroWidth(0x0300)).toBe(true); // Combining Grave Accent
+    expect(isZeroWidth(0x0301)).toBe(true); // Combining Acute Accent
+  });
+
+  it("returns false for regular characters", () => {
+    expect(isZeroWidth("a".codePointAt(0)!)).toBe(false);
+    expect(isZeroWidth("가".codePointAt(0)!)).toBe(false);
+  });
+});
+
+describe("getCharWidth", () => {
+  it("returns 2 for CJK characters", () => {
+    expect(getCharWidth("한")).toBe(2);
+    expect(getCharWidth("中")).toBe(2);
+  });
+
+  it("returns 1 for ASCII characters", () => {
+    expect(getCharWidth("A")).toBe(1);
+    expect(getCharWidth("z")).toBe(1);
+  });
+
+  it("returns 0 for empty string", () => {
+    expect(getCharWidth("")).toBe(0);
+  });
+});
+
+describe("stringWidth", () => {
+  it("calculates width of ASCII string", () => {
+    expect(stringWidth("hello")).toBe(5);
+  });
+
+  it("calculates width of Korean string", () => {
+    // Each Korean character is double-width
+    expect(stringWidth("안녕하세요")).toBe(10);
+  });
+
+  it("calculates width of mixed ASCII and CJK", () => {
+    // "hi" = 2, "안녕" = 4
+    expect(stringWidth("hi안녕")).toBe(6);
+  });
+
+  it("strips ANSI codes before calculating", () => {
+    expect(stringWidth("\x1b[31mhello\x1b[0m")).toBe(5);
+    expect(stringWidth("\x1b[1m안녕\x1b[0m")).toBe(4);
+  });
+
+  it("returns 0 for empty string", () => {
+    expect(stringWidth("")).toBe(0);
+  });
+
+  it("returns 0 for null/undefined", () => {
+    expect(stringWidth("")).toBe(0);
+  });
+
+  it("calculates width of Japanese text", () => {
+    // Each character is double-width
+    expect(stringWidth("こんにちは")).toBe(10);
+  });
+
+  it("calculates width of Chinese text", () => {
+    expect(stringWidth("你好世界")).toBe(8);
+  });
+});
+
+describe("stripAnsi", () => {
+  it("strips SGR sequences", () => {
+    expect(stripAnsi("\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("strips bold sequences", () => {
+    expect(stripAnsi("\x1b[1mbold\x1b[0m")).toBe("bold");
+  });
+
+  it("strips multiple sequences", () => {
+    expect(stripAnsi("\x1b[1m\x1b[31mboldred\x1b[0m")).toBe("boldred");
+  });
+
+  it("returns unchanged string without ANSI", () => {
+    expect(stripAnsi("hello")).toBe("hello");
+  });
+});
+
+describe("truncateToWidth", () => {
+  it("returns string unchanged if within width", () => {
+    expect(truncateToWidth("hello", 10)).toBe("hello");
+  });
+
+  it("truncates ASCII string with ellipsis", () => {
+    expect(truncateToWidth("hello world", 8)).toBe("hello...");
+  });
+
+  it("truncates Korean string correctly", () => {
+    // "안녕하세요" = 10 columns
+    // With maxWidth=6, suffix "..." = 3 cols, target = 3 cols = 1 Korean char (2) + overflow
+    const result = truncateToWidth("안녕하세요", 7);
+    // "안녕" = 4 cols, "..." = 3 cols = total 7
+    expect(result).toBe("안녕...");
+  });
+
+  it("truncates mixed CJK/ASCII correctly", () => {
+    // "hi안녕하세요" = 2 + 10 = 12 columns
+    const result = truncateToWidth("hi안녕하세요", 9);
+    // "hi안녕" = 6 cols, "..." = 3 cols = total 9
+    expect(result).toBe("hi안녕...");
+  });
+
+  it("handles maxWidth of 0", () => {
+    expect(truncateToWidth("hello", 0)).toBe("");
+  });
+
+  it("handles empty string", () => {
+    expect(truncateToWidth("", 10)).toBe("");
+  });
+
+  it("handles string exactly at width", () => {
+    expect(truncateToWidth("hello", 5)).toBe("hello");
+  });
+
+  it("uses custom suffix", () => {
+    expect(truncateToWidth("hello world", 8, "…")).toBe("hello w…");
+  });
+
+  it("does not break CJK characters", () => {
+    // "안녕" = 4 columns. With maxWidth=5, "..." = 3, target = 2 = 1 Korean char
+    const result = truncateToWidth("안녕하세요", 5);
+    expect(result).toBe("안...");
+  });
+});
+
+describe("padToWidth", () => {
+  it("pads ASCII string to width", () => {
+    expect(padToWidth("hi", 5)).toBe("hi   ");
+  });
+
+  it("pads CJK string correctly", () => {
+    // "안녕" = 4 columns, pad to 6 = 2 spaces
+    expect(padToWidth("안녕", 6)).toBe("안녕  ");
+  });
+
+  it("does not pad if already at width", () => {
+    expect(padToWidth("hello", 5)).toBe("hello");
+  });
+
+  it("does not pad if exceeding width", () => {
+    expect(padToWidth("hello world", 5)).toBe("hello world");
+  });
+});
+
+describe("sliceByWidth", () => {
+  it("slices ASCII string by width", () => {
+    expect(sliceByWidth("hello", 0, 3)).toBe("hel");
+  });
+
+  it("slices CJK string by width", () => {
+    // "안녕하" = 6 columns, slice 0-4 = "안녕"
+    expect(sliceByWidth("안녕하", 0, 4)).toBe("안녕");
+  });
+
+  it("does not split CJK character", () => {
+    // "안녕" = 4 columns. Slicing to width 3 should only include "안" (2 cols)
+    expect(sliceByWidth("안녕", 0, 3)).toBe("안");
+  });
+
+  it("handles empty string", () => {
+    expect(sliceByWidth("", 0, 5)).toBe("");
+  });
+});

--- a/src/utils/string-width.ts
+++ b/src/utils/string-width.ts
@@ -1,0 +1,253 @@
+/**
+ * CJK-aware String Width Utilities
+ *
+ * Provides functions for calculating visual width of strings containing
+ * CJK (Chinese, Japanese, Korean) characters, which are typically displayed
+ * as double-width in terminal emulators.
+ *
+ * This is a lightweight implementation without external dependencies.
+ * For full Unicode support, consider using the 'string-width' npm package.
+ *
+ * Related: Issue #344 - Korean IME input visibility
+ */
+
+/**
+ * Check if a character code point is a CJK (double-width) character.
+ *
+ * This covers the main CJK Unicode ranges:
+ * - CJK Unified Ideographs
+ * - Hangul Syllables
+ * - Hiragana and Katakana
+ * - Full-width ASCII and punctuation
+ * - CJK Compatibility Ideographs
+ */
+export function isCJKCharacter(codePoint: number): boolean {
+  return (
+    // CJK Unified Ideographs (Chinese characters)
+    (codePoint >= 0x4e00 && codePoint <= 0x9fff) ||
+    // CJK Unified Ideographs Extension A
+    (codePoint >= 0x3400 && codePoint <= 0x4dbf) ||
+    // CJK Unified Ideographs Extension B-F (rare characters)
+    (codePoint >= 0x20000 && codePoint <= 0x2ebef) ||
+    // CJK Compatibility Ideographs
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    // Hangul Syllables (Korean)
+    (codePoint >= 0xac00 && codePoint <= 0xd7af) ||
+    // Hangul Jamo (Korean components)
+    (codePoint >= 0x1100 && codePoint <= 0x11ff) ||
+    // Hangul Compatibility Jamo
+    (codePoint >= 0x3130 && codePoint <= 0x318f) ||
+    // Hangul Jamo Extended-A
+    (codePoint >= 0xa960 && codePoint <= 0xa97f) ||
+    // Hangul Jamo Extended-B
+    (codePoint >= 0xd7b0 && codePoint <= 0xd7ff) ||
+    // Hiragana (Japanese)
+    (codePoint >= 0x3040 && codePoint <= 0x309f) ||
+    // Katakana (Japanese)
+    (codePoint >= 0x30a0 && codePoint <= 0x30ff) ||
+    // Katakana Phonetic Extensions
+    (codePoint >= 0x31f0 && codePoint <= 0x31ff) ||
+    // Full-width ASCII variants
+    (codePoint >= 0xff01 && codePoint <= 0xff60) ||
+    // Full-width punctuation and symbols
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    // CJK Symbols and Punctuation
+    (codePoint >= 0x3000 && codePoint <= 0x303f) ||
+    // Enclosed CJK Letters and Months
+    (codePoint >= 0x3200 && codePoint <= 0x32ff) ||
+    // CJK Compatibility
+    (codePoint >= 0x3300 && codePoint <= 0x33ff) ||
+    // CJK Compatibility Forms
+    (codePoint >= 0xfe30 && codePoint <= 0xfe4f)
+  );
+}
+
+/**
+ * Check if a character is a zero-width character.
+ * These characters don't contribute to visual width.
+ */
+export function isZeroWidth(codePoint: number): boolean {
+  return (
+    // Zero-width characters
+    codePoint === 0x200b || // Zero Width Space
+    codePoint === 0x200c || // Zero Width Non-Joiner
+    codePoint === 0x200d || // Zero Width Joiner
+    codePoint === 0xfeff || // Byte Order Mark / Zero Width No-Break Space
+    // Combining diacritical marks (they modify previous character)
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    // Combining Diacritical Marks Extended
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    // Combining Diacritical Marks Supplement
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    // Combining Diacritical Marks for Symbols
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    // Combining Half Marks
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f)
+  );
+}
+
+/**
+ * Get the visual width of a single character.
+ * - CJK characters: 2 (double-width)
+ * - Zero-width characters: 0
+ * - Regular ASCII and most others: 1
+ */
+export function getCharWidth(char: string): number {
+  const codePoint = char.codePointAt(0);
+  if (codePoint === undefined) return 0;
+
+  if (isZeroWidth(codePoint)) return 0;
+  if (isCJKCharacter(codePoint)) return 2;
+  return 1;
+}
+
+/**
+ * Calculate the visual width of a string in terminal columns.
+ * Accounts for CJK double-width characters.
+ *
+ * Note: This strips ANSI escape codes before calculating width.
+ *
+ * @param str - The string to measure
+ * @returns Visual width in terminal columns
+ */
+export function stringWidth(str: string): number {
+  if (!str) return 0;
+
+  // Strip ANSI escape codes
+  const stripped = stripAnsi(str);
+
+  let width = 0;
+  for (const char of stripped) {
+    width += getCharWidth(char);
+  }
+  return width;
+}
+
+/**
+ * Strip ANSI escape codes from a string.
+ */
+export function stripAnsi(str: string): string {
+  // ANSI escape code pattern: ESC [ ... m (SGR sequences)
+  // Also handles other common sequences
+  return str.replace(
+    // eslint-disable-next-line no-control-regex
+    /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07/g,
+    ""
+  );
+}
+
+/**
+ * Truncate a string to fit within a maximum visual width.
+ * CJK-aware: accounts for double-width characters.
+ *
+ * @param str - The string to truncate
+ * @param maxWidth - Maximum visual width in terminal columns
+ * @param suffix - Suffix to append if truncated (default: "...")
+ * @returns Truncated string that fits within maxWidth
+ */
+export function truncateToWidth(
+  str: string,
+  maxWidth: number,
+  suffix: string = "..."
+): string {
+  if (!str || maxWidth <= 0) return "";
+
+  const strWidth = stringWidth(str);
+  if (strWidth <= maxWidth) return str;
+
+  const suffixWidth = stringWidth(suffix);
+  const targetWidth = maxWidth - suffixWidth;
+
+  if (targetWidth <= 0) {
+    // Can't even fit the suffix, return truncated suffix
+    return truncateToWidthNoSuffix(suffix, maxWidth);
+  }
+
+  return truncateToWidthNoSuffix(str, targetWidth) + suffix;
+}
+
+/**
+ * Truncate a string to fit within a maximum visual width without adding suffix.
+ * Used internally and when you don't want ellipsis.
+ */
+function truncateToWidthNoSuffix(str: string, maxWidth: number): string {
+  let width = 0;
+  let result = "";
+
+  for (const char of str) {
+    const charWidth = getCharWidth(char);
+    if (width + charWidth > maxWidth) break;
+    result += char;
+    width += charWidth;
+  }
+
+  return result;
+}
+
+/**
+ * Pad a string to a minimum visual width (right-pad with spaces).
+ * CJK-aware: accounts for double-width characters.
+ *
+ * @param str - The string to pad
+ * @param minWidth - Minimum visual width
+ * @param padChar - Character to pad with (default: space)
+ * @returns Padded string
+ */
+export function padToWidth(
+  str: string,
+  minWidth: number,
+  padChar: string = " "
+): string {
+  const currentWidth = stringWidth(str);
+  if (currentWidth >= minWidth) return str;
+
+  const padWidth = minWidth - currentWidth;
+  return str + padChar.repeat(padWidth);
+}
+
+/**
+ * Slice a string by visual width instead of character count.
+ * CJK-aware: accounts for double-width characters.
+ *
+ * @param str - The string to slice
+ * @param startWidth - Start position in visual columns (0-based)
+ * @param endWidth - End position in visual columns (exclusive)
+ * @returns Sliced string
+ */
+export function sliceByWidth(
+  str: string,
+  startWidth: number,
+  endWidth?: number
+): string {
+  if (!str) return "";
+
+  let currentWidth = 0;
+  let result = "";
+  let started = false;
+
+  for (const char of str) {
+    const charWidth = getCharWidth(char);
+
+    // Check if we've reached the start position
+    if (!started && currentWidth + charWidth > startWidth) {
+      started = true;
+    }
+
+    // Check if we've reached the end position
+    if (endWidth !== undefined && currentWidth >= endWidth) {
+      break;
+    }
+
+    if (started) {
+      // Check if adding this character would exceed endWidth
+      if (endWidth !== undefined && currentWidth + charWidth > endWidth) {
+        break;
+      }
+      result += char;
+    }
+
+    currentWidth += charWidth;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Fixes #344 - Korean (CJK) IME input invisible in Claude Code input field.

- Adds `src/utils/string-width.ts` - a lightweight, zero-dependency CJK-aware string width utility that correctly handles double-width characters (Korean, Japanese, Chinese, full-width ASCII)
- Updates all HUD string truncation sites (agents, todos, skills, background, model) to use visual-width-aware truncation instead of naive `.slice()`/`.length`
- Includes 41 tests covering all utility functions with Korean, Japanese, Chinese, and mixed text

**Root cause analysis**: The core IME composition visibility issue is in Claude Code itself (Anthropic's CLI), not in OMC. However, OMC's HUD was using `.slice(0, N)` and `.length` for truncation, which counts UTF-16 code units rather than terminal display columns. Since CJK characters are double-width in terminals, this caused misaligned HUD output that could compound the display problem for CJK users.

### Changes

| File | Change |
|------|--------|
| `src/utils/string-width.ts` | New CJK-aware width calculation, truncation, padding, slicing utilities |
| `src/utils/__tests__/string-width.test.ts` | 41 tests covering Korean, Japanese, Chinese, mixed text, ANSI stripping |
| `src/hud/elements/agents.ts` | Use `truncateToWidth()` for agent descriptions |
| `src/hud/elements/todos.ts` | Use `truncateToWidth()` for todo text |
| `src/hud/elements/skills.ts` | Use `truncateToWidth()` for skill args |
| `src/hud/elements/background.ts` | Use `truncateToWidth()` for task descriptions |
| `src/hud/elements/model.ts` | Use `truncateToWidth()` for model names |

## Test plan

- [x] All 41 new string-width tests pass
- [x] Full test suite passes (2188 tests, 0 failures)
- [x] Build succeeds
- [ ] Manual verification: HUD renders correctly with Korean text in agent descriptions and todo items

🤖 Generated with [Claude Code](https://claude.com/claude-code)