### PR TITLE
fix: prevent full setup wizard from re-running after updates

### DIFF
--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -7,6 +7,56 @@ description: Setup and configure oh-my-claudecode (the ONLY command you need to 
 
 This is the **only command you need to learn**. After running this, everything else is automatic.
 
+## Pre-Setup Check: Already Configured?
+
+**CRITICAL**: Before doing anything else, check if setup has already been completed. This prevents users from having to re-run the full setup wizard after every update.
+
+```bash
+# Check if setup was already completed
+CONFIG_FILE="$HOME/.claude/.omc-config.json"
+
+if [ -f "$CONFIG_FILE" ]; then
+  SETUP_COMPLETED=$(jq -r '.setupCompleted // empty' "$CONFIG_FILE" 2>/dev/null)
+  SETUP_VERSION=$(jq -r '.setupVersion // empty' "$CONFIG_FILE" 2>/dev/null)
+
+  if [ -n "$SETUP_COMPLETED" ] && [ "$SETUP_COMPLETED" != "null" ]; then
+    echo "OMC setup was already completed on: $SETUP_COMPLETED"
+    [ -n "$SETUP_VERSION" ] && echo "Setup version: $SETUP_VERSION"
+    ALREADY_CONFIGURED="true"
+  fi
+fi
+```
+
+### If Already Configured (and no --force flag)
+
+If `ALREADY_CONFIGURED` is true AND the user did NOT pass `--force`, `--local`, or `--global` flags:
+
+Use AskUserQuestion to prompt:
+
+**Question:** "OMC is already configured. What would you like to do?"
+
+**Options:**
+1. **Update CLAUDE.md only** - Download latest CLAUDE.md without re-running full setup
+2. **Run full setup again** - Go through the complete setup wizard
+3. **Cancel** - Exit without changes
+
+**If user chooses "Update CLAUDE.md only":**
+- Detect if local (.claude/CLAUDE.md) or global (~/.claude/CLAUDE.md) config exists
+- If local exists, run the download/merge script from Step 2A
+- If only global exists, run the download/merge script from Step 2B
+- Skip all other steps
+- Report success and exit
+
+**If user chooses "Run full setup again":**
+- Continue with Step 0 (Resume Detection) below
+
+**If user chooses "Cancel":**
+- Exit without any changes
+
+### Force Flag Override
+
+If user passes `--force` flag, skip this check and proceed directly to setup.
+
 ## Graceful Interrupt Handling
 
 **IMPORTANT**: This setup process saves progress after each step. If interrupted (Ctrl+C or connection loss), the setup can resume from where it left off.
@@ -116,9 +166,10 @@ This skill handles three scenarios:
 ## Mode Detection
 
 Check for flags in the user's invocation:
-- If `--local` flag present → Skip to Local Configuration (Step 2A)
-- If `--global` flag present → Skip to Global Configuration (Step 2B)
-- If no flags → Run Initial Setup wizard (Step 1)
+- If `--local` flag present → Skip Pre-Setup Check, go to Local Configuration (Step 2A)
+- If `--global` flag present → Skip Pre-Setup Check, go to Global Configuration (Step 2B)
+- If `--force` flag present → Skip Pre-Setup Check, run Initial Setup wizard (Step 1)
+- If no flags → Run Pre-Setup Check first, then Initial Setup wizard (Step 1) if needed
 
 ## Step 1: Initial Setup Wizard (Default Behavior)
 
@@ -786,23 +837,52 @@ echo "  https://github.com/Yeachan-Heo/oh-my-claudecode"
 echo ""
 ```
 
-### Clear Setup State on Completion
+### Clear Setup State and Mark Completion
 
-After Step 8 completes (regardless of star choice), clear the setup state:
+After Step 8 completes (regardless of star choice), clear the temporary state and mark setup as completed:
 
 ```bash
-# Setup complete - clear state file
+# Setup complete - clear temporary state file
 rm -f ".omc/state/setup-state.json"
+
+# Mark setup as completed in persistent config (prevents re-running full setup on updates)
+CONFIG_FILE="$HOME/.claude/.omc-config.json"
+mkdir -p "$(dirname "$CONFIG_FILE")"
+
+# Get current OMC version from CLAUDE.md
+OMC_VERSION=""
+if [ -f ".claude/CLAUDE.md" ]; then
+  OMC_VERSION=$(grep -m1 "^# oh-my-claudecode" .claude/CLAUDE.md 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+elif [ -f "$HOME/.claude/CLAUDE.md" ]; then
+  OMC_VERSION=$(grep -m1 "^# oh-my-claudecode" "$HOME/.claude/CLAUDE.md" 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+fi
+
+if [ -f "$CONFIG_FILE" ]; then
+  EXISTING=$(cat "$CONFIG_FILE")
+else
+  EXISTING='{}'
+fi
+
+# Add setupCompleted timestamp and version
+echo "$EXISTING" | jq --arg ts "$(date -Iseconds)" --arg ver "$OMC_VERSION" \
+  '. + {setupCompleted: $ts, setupVersion: $ver}' > "$CONFIG_FILE"
+
 echo "Setup completed successfully!"
+echo "Note: Future updates will only refresh CLAUDE.md, not the full setup wizard."
 ```
 
 ## Keeping Up to Date
 
-After installing oh-my-claudecode updates (via npm or plugin update), run:
-- `/oh-my-claudecode:omc-setup --local` to update project config
-- `/oh-my-claudecode:omc-setup --global` to update global config
+After installing oh-my-claudecode updates (via npm or plugin update):
 
-This ensures you have the newest features and agent configurations.
+**Automatic**: Just run `/oh-my-claudecode:omc-setup` - it will detect you've already configured and offer a quick "Update CLAUDE.md only" option that skips the full wizard.
+
+**Manual options**:
+- `/oh-my-claudecode:omc-setup --local` to update project config only
+- `/oh-my-claudecode:omc-setup --global` to update global config only
+- `/oh-my-claudecode:omc-setup --force` to re-run the full wizard (reconfigure preferences)
+
+This ensures you have the newest features and agent configurations without the token cost of repeating the full setup.
 
 ## Help Text
 
@@ -812,9 +892,10 @@ When user runs `/oh-my-claudecode:omc-setup --help` or just `--help`, display:
 OMC Setup - Configure oh-my-claudecode
 
 USAGE:
-  /oh-my-claudecode:omc-setup           Run initial setup wizard
+  /oh-my-claudecode:omc-setup           Run initial setup wizard (or update if already configured)
   /oh-my-claudecode:omc-setup --local   Configure local project (.claude/CLAUDE.md)
   /oh-my-claudecode:omc-setup --global  Configure global settings (~/.claude/CLAUDE.md)
+  /oh-my-claudecode:omc-setup --force   Force full setup wizard even if already configured
   /oh-my-claudecode:omc-setup --help    Show this help
 
 MODES:
@@ -824,6 +905,7 @@ MODES:
     - Sets up HUD statusline
     - Checks for updates
     - Offers MCP server configuration
+    - If already configured, offers quick update option
 
   Local Configuration (--local)
     - Downloads fresh CLAUDE.md to ./.claude/
@@ -838,10 +920,16 @@ MODES:
     - Cleans up legacy hooks
     - Use this to update global config after OMC upgrades
 
+  Force Full Setup (--force)
+    - Bypasses the "already configured" check
+    - Runs the complete setup wizard from scratch
+    - Use when you want to reconfigure preferences
+
 EXAMPLES:
-  /oh-my-claudecode:omc-setup           # First time setup
+  /oh-my-claudecode:omc-setup           # First time setup (or update CLAUDE.md if configured)
   /oh-my-claudecode:omc-setup --local   # Update this project
   /oh-my-claudecode:omc-setup --global  # Update all projects
+  /oh-my-claudecode:omc-setup --force   # Re-run full setup wizard
 
 For more info: https://github.com/Yeachan-Heo/oh-my-claudecode
 ```


### PR DESCRIPTION
## Summary
- Fixes issue #353: Users were having to go through the full setup wizard every time they updated oh-my-claudecode, which burned through tokens unnecessarily
- Adds persistent setup completion tracking in `~/.claude/.omc-config.json`
- When setup detects it was already completed, offers a quick "Update CLAUDE.md only" option
- Adds `--force` flag to bypass the check when full reconfiguration is needed

## Test plan
- [ ] Fresh install: Run `/oh-my-claudecode:omc-setup` - should go through full wizard and save `setupCompleted` to config
- [ ] After setup: Run `/oh-my-claudecode:omc-setup` again - should detect previous setup and offer quick update option
- [ ] Quick update: Choose "Update CLAUDE.md only" - should only download CLAUDE.md, skip other steps
- [ ] Force flag: Run `/oh-my-claudecode:omc-setup --force` - should bypass check and run full wizard
- [ ] Existing flags: `--local` and `--global` should work as before (skip the pre-setup check)

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)