### PR TITLE
fix: register setup wizard config fields in TypeScript

### DIFF
--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -151,6 +151,9 @@ export function checkConfigIssues(): ConflictReport['configIssues'] {
       'taskToolConfig',
       'defaultExecutionMode',
       'bashHistory',
+      'ecomode',
+      'setupCompleted',
+      'setupVersion',
     ]);
 
     for (const field of Object.keys(config)) {

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -53,6 +53,10 @@ export interface SisyphusConfig {
     /** Whether ecomode is enabled (default: true). Set to false to disable ecomode completely. */
     enabled?: boolean;
   };
+  /** Whether initial setup has been completed (ISO timestamp) */
+  setupCompleted?: string;
+  /** Version of setup wizard that was completed */
+  setupVersion?: string;
 }
 
 /**
@@ -75,6 +79,8 @@ export function getSisyphusConfig(): SisyphusConfig {
       taskToolConfig: config.taskToolConfig,
       defaultExecutionMode: config.defaultExecutionMode,
       ecomode: config.ecomode,
+      setupCompleted: config.setupCompleted,
+      setupVersion: config.setupVersion,
     };
   } catch {
     // If config file is invalid, default to disabled for security


### PR DESCRIPTION
## Summary
- Add `setupCompleted` and `setupVersion` fields to `SisyphusConfig` interface in `src/features/auto-update.ts`
- Include these fields in `getSisyphusConfig()` return value
- Add `setupCompleted`, `setupVersion`, and `ecomode` to `knownFields` in `src/cli/commands/doctor-conflicts.ts`

## Test plan
- [x] Verify TypeScript compiles without errors
- [x] Run `npm test` - 2251 tests pass (1 pre-existing test failure unrelated to these changes)
- [ ] Verify doctor command no longer reports unknown fields for `setupCompleted`, `setupVersion`, `ecomode`

Fixes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)