### PR TITLE
fix: prevent SessionStart hook errors on launch (#362)

### DIFF
--- a/scripts/lib/stdin.mjs
+++ b/scripts/lib/stdin.mjs
@@ -1,0 +1,64 @@
+/**
+ * Shared stdin utilities for OMC hook scripts
+ * Provides timeout-protected stdin reading to prevent hangs on Linux
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/240
+ *
+ * Mirrors templates/hooks/lib/stdin.mjs for use by plugin hook scripts.
+ */
+
+/**
+ * Read all stdin with timeout to prevent indefinite hang on Linux.
+ *
+ * The blocking `for await (const chunk of process.stdin)` pattern waits
+ * indefinitely for EOF. On Linux, if the parent process doesn't properly
+ * close stdin, this hangs forever. This function uses event-based reading
+ * with a timeout as a safety net.
+ *
+ * @param {number} timeoutMs - Maximum time to wait for stdin (default: 5000ms)
+ * @returns {Promise<string>} - The stdin content, or empty string on error/timeout
+ */
+export async function readStdin(timeoutMs = 5000) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        process.stdin.removeAllListeners();
+        process.stdin.destroy();
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      }
+    }, timeoutMs);
+
+    process.stdin.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+
+    process.stdin.on('end', () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      }
+    });
+
+    process.stdin.on('error', () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve('');
+      }
+    });
+
+    // If stdin is already ended (e.g. empty pipe), 'end' fires immediately
+    // But if stdin is a TTY or never piped, we need the timeout as safety net
+    if (process.stdin.readableEnded) {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      }
+    }
+  });
+}

--- a/scripts/project-memory-session.mjs
+++ b/scripts/project-memory-session.mjs
@@ -5,17 +5,40 @@
  * Auto-detects project environment and injects context
  */
 
-import { registerProjectMemoryContext } from '../dist/hooks/project-memory/index.js';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 
-/**
- * Read JSON input from stdin
- */
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Import timeout-protected stdin reader (prevents hangs on Linux, see issue #240)
+let readStdin;
+try {
+  const mod = await import(join(__dirname, 'lib', 'stdin.mjs'));
+  readStdin = mod.readStdin;
+} catch {
+  // Fallback: inline timeout-protected readStdin if lib module is missing
+  readStdin = (timeoutMs = 5000) => new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (!settled) { settled = true; process.stdin.removeAllListeners(); process.stdin.destroy(); resolve(Buffer.concat(chunks).toString('utf-8')); }
+    }, timeoutMs);
+    process.stdin.on('data', (chunk) => { chunks.push(chunk); });
+    process.stdin.on('end', () => { if (!settled) { settled = true; clearTimeout(timeout); resolve(Buffer.concat(chunks).toString('utf-8')); } });
+    process.stdin.on('error', () => { if (!settled) { settled = true; clearTimeout(timeout); resolve(''); } });
+    if (process.stdin.readableEnded) { if (!settled) { settled = true; clearTimeout(timeout); resolve(Buffer.concat(chunks).toString('utf-8')); } }
+  });
+}
+
+// Dynamic import of project memory module (prevents crash if dist is missing, see issue #362)
+let registerProjectMemoryContext;
+try {
+  const mod = await import(join(__dirname, '..', 'dist', 'hooks', 'project-memory', 'index.js'));
+  registerProjectMemoryContext = mod.registerProjectMemoryContext;
+} catch {
+  // dist not built or missing - skip project memory detection silently
+  registerProjectMemoryContext = null;
 }
 
 /**
@@ -24,14 +47,17 @@ async function readStdin() {
 async function main() {
   try {
     const input = await readStdin();
-    const data = JSON.parse(input);
+    let data = {};
+    try { data = JSON.parse(input); } catch {}
 
     // Extract directory and session ID
     const directory = data.directory || process.cwd();
     const sessionId = data.sessionId || data.session_id || '';
 
-    // Register project memory context
-    await registerProjectMemoryContext(sessionId, directory);
+    // Register project memory context (skip if module unavailable)
+    if (registerProjectMemoryContext) {
+      await registerProjectMemoryContext(sessionId, directory);
+    }
 
     // Return success (context registered via contextCollector)
     console.log(JSON.stringify({

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -11,8 +11,25 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Dynamic import for the shared stdin module
-const { readStdin } = await import(join(__dirname, 'lib', 'stdin.mjs'));
+// Import timeout-protected stdin reader (prevents hangs on Linux, see issue #240)
+let readStdin;
+try {
+  const mod = await import(join(__dirname, 'lib', 'stdin.mjs'));
+  readStdin = mod.readStdin;
+} catch {
+  // Fallback: inline timeout-protected readStdin if lib module is missing
+  readStdin = (timeoutMs = 5000) => new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (!settled) { settled = true; process.stdin.removeAllListeners(); process.stdin.destroy(); resolve(Buffer.concat(chunks).toString('utf-8')); }
+    }, timeoutMs);
+    process.stdin.on('data', (chunk) => { chunks.push(chunk); });
+    process.stdin.on('end', () => { if (!settled) { settled = true; clearTimeout(timeout); resolve(Buffer.concat(chunks).toString('utf-8')); } });
+    process.stdin.on('error', () => { if (!settled) { settled = true; clearTimeout(timeout); resolve(''); } });
+    if (process.stdin.readableEnded) { if (!settled) { settled = true; clearTimeout(timeout); resolve(Buffer.concat(chunks).toString('utf-8')); } }
+  });
+}
 
 function readJsonFile(path) {
   try {


### PR DESCRIPTION
## Summary

- **Fixed** `scripts/project-memory-session.mjs` crashing before `main()` due to a static import from `../dist/` that fails when dist is missing (partial build). Converted to dynamic import with graceful fallback.
- **Fixed** blocking `for await (process.stdin)` pattern in `scripts/session-start.mjs` and `scripts/project-memory-session.mjs` that hangs on Linux (issue #240). Replaced with timeout-protected stdin reader.
- **Fixed** `templates/hooks/session-start.mjs` crashing if `lib/stdin.mjs` is missing by adding inline fallback.
- **Added** `scripts/lib/stdin.mjs` — shared timeout-protected stdin reader for plugin hook scripts.

Closes #362

## Root Cause Analysis

Three issues combined to cause SessionStart hook errors:

1. `project-memory-session.mjs` (added in PR #331) used a **static ES module import** from `../dist/hooks/project-memory/index.js`. If the dist folder is missing or incompletely built, the module fails to load before `main()` can execute — the `try/catch` in `main()` never fires.

2. Both `scripts/session-start.mjs` and `scripts/project-memory-session.mjs` used the **old blocking `for await (process.stdin)`** pattern. On some Linux systems, this hangs indefinitely (issue #240), causing hook timeouts. The template version had been fixed to use `lib/stdin.mjs` with timeout protection, but the scripts version was never updated.

3. `templates/hooks/session-start.mjs` had a **top-level `await import()`** for `lib/stdin.mjs` with no fallback. If the lib file was missing (e.g., incomplete install), the entire script crashed.

## Test plan

- [x] All 2252 tests pass (`npm run test:run`)
- [x] Build passes (`npm run build`)
- [x] `scripts/session-start.mjs` returns valid JSON with proper stdin
- [x] `scripts/project-memory-session.mjs` returns valid JSON with proper stdin
- [x] `scripts/project-memory-session.mjs` returns valid JSON even with **missing dist/** (graceful fallback)
- [x] `templates/hooks/session-start.mjs` returns valid JSON with proper stdin

🤖 Generated with [Claude Code](https://claude.com/claude-code)