### PR TITLE
fix: preserve HUD multi-line output in sanitizeOutput (#369)

### DIFF
--- a/src/__tests__/hud/sanitize.test.ts
+++ b/src/__tests__/hud/sanitize.test.ts
@@ -111,9 +111,9 @@ describe('sanitizeOutput', () => {
     expect(sanitizeOutput(input)).toBe('\x1b[32m####------\x1b[0m 40%');
   });
 
-  it('should collapse multi-line output to single line', () => {
+  it('should PRESERVE multi-line output with newlines', () => {
     const input = 'Line 1\nLine 2\nLine 3';
-    expect(sanitizeOutput(input)).toBe('Line 1 | Line 2 | Line 3');
+    expect(sanitizeOutput(input)).toBe('Line 1\nLine 2\nLine 3');
   });
 
   it('should handle complex HUD output preserving colors', () => {
@@ -121,27 +121,27 @@ describe('sanitizeOutput', () => {
     expect(sanitizeOutput(input)).toBe('\x1b[1m[OMC]\x1b[0m | \x1b[32m####------\x1b[0m 40% | agents:3');
   });
 
-  it('should filter empty lines', () => {
+  it('should preserve lines and trim trailing whitespace', () => {
     const input = 'Line 1\n\n\nLine 2\n\n';
-    expect(sanitizeOutput(input)).toBe('Line 1 | Line 2');
+    expect(sanitizeOutput(input)).toBe('Line 1\n\n\nLine 2');
   });
 
-  it('should collapse excessive whitespace', () => {
+  it('should preserve whitespace within lines', () => {
     const input = 'Text    with   extra    spaces';
-    expect(sanitizeOutput(input)).toBe('Text with extra spaces');
+    expect(sanitizeOutput(input)).toBe('Text    with   extra    spaces');
   });
 
-  it('should handle real HUD multi-line output with colors preserved', () => {
+  it('should handle real HUD multi-line output with colors and newlines preserved', () => {
     const input = `\x1b[1m[OMC]\x1b[0m | \x1b[2m5h:\x1b[0m\x1b[32m12%\x1b[0m | Ctx: \x1b[32m████░░░░░░\x1b[0m 40%
 \x1b[2m└─\x1b[0m \x1b[35mO\x1b[0m:architect (2m) analyzing code
 \x1b[2m└─\x1b[0m \x1b[33ms\x1b[0m:executor (1m) writing tests`;
 
     const result = sanitizeOutput(input);
 
-    // Should be single line with ASCII blocks but colors preserved
+    // Should preserve multi-line structure with ASCII blocks and colors
     expect(result).not.toContain('█');
     expect(result).not.toContain('░');
-    expect(result).not.toContain('\n');
+    expect(result).toContain('\n'); // PRESERVE newlines for tree structure
     expect(result).toContain('[OMC]');
     expect(result).toContain('architect');
     // Colors SHOULD be present (SGR sequences ending with 'm')


### PR DESCRIPTION
## Summary
The sanitizeOutput() function was collapsing multi-line HUD output to a single pipe-separated line, breaking the tree structure display.

**Before (broken):**
```
[OMC] | session:2m | 🟢 | ctx:31% | agents:4 | ├─ x exec Create Gemini MCP server | ├─ x exec 12s Create Codex MCP server | ... (+2 lines)
```

**After (fixed):**
```
[OMC] | session:2m | 🟢 | ctx:31% | agents:4 |
├─ x exec Create Gemini MCP server
├─ x exec 12s Create Codex MCP server
... (+2 lines)
```

## Changes
- Remove multi-line collapse logic from sanitizeOutput()
- Preserve newlines for proper HUD tree structure display
- Update tests to expect preserved newlines

## Files changed
- src/hud/sanitize.ts — preserve newlines instead of collapsing
- src/__tests__/hud/sanitize.test.ts — updated test expectations

Closes #369