### PR TITLE
docs: add multilingual README files (ko, zh, ja, es)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,177 @@
+[English](README.md) | [한국어](README.ko.md) | [中文](README.zh.md) | [日本語](README.ja.md) | Español
+
+# oh-my-claudecode
+
+[![npm version](https://img.shields.io/npm/v/oh-my-claude-sisyphus?color=cb3837)](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+[![npm downloads](https://img.shields.io/npm/dm/oh-my-claude-sisyphus?color=blue)](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+[![GitHub stars](https://img.shields.io/github/stars/Yeachan-Heo/oh-my-claudecode?style=flat&color=yellow)](https://github.com/Yeachan-Heo/oh-my-claudecode/stargazers)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Sponsor](https://img.shields.io/badge/Sponsor-❤️-red?style=flat&logo=github)](https://github.com/sponsors/Yeachan-Heo)
+
+**Orquestación multi-agente para Claude Code. Curva de aprendizaje cero.**
+
+*No aprendas Claude Code. Solo usa OMC.*
+
+[Comenzar](#inicio-rápido) • [Documentación](https://yeachan-heo.github.io/oh-my-claudecode-website) • [Guía de Migración](docs/MIGRATION.md)
+
+---
+
+## Inicio Rápido
+
+**Paso 1: Instalar**
+```bash
+/plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+/plugin install oh-my-claudecode
+```
+
+**Paso 2: Configurar**
+```bash
+/oh-my-claudecode:omc-setup
+```
+
+**Paso 3: Construye algo**
+```
+autopilot: build a REST API for managing tasks
+```
+
+Eso es todo. Todo lo demás es automático.
+
+<h1 align="center">Tu Claude acaba de recibir esteroides.</h1>
+
+<p align="center">
+  <img src="assets/omc-character.jpg" alt="oh-my-claudecode" width="400" />
+</p>
+
+---
+
+## ¿Por qué oh-my-claudecode?
+
+- **Cero configuración requerida** - Funciona inmediatamente con valores predeterminados inteligentes
+- **Interfaz de lenguaje natural** - Sin comandos que memorizar, solo describe lo que quieres
+- **Paralelización automática** - Tareas complejas distribuidas entre agentes especializados
+- **Ejecución persistente** - No se rendirá hasta que el trabajo esté verificado y completo
+- **Optimización de costos** - Enrutamiento inteligente de modelos ahorra 30-50% en tokens
+- **Aprende de la experiencia** - Extrae y reutiliza automáticamente patrones de resolución de problemas
+- **Visibilidad en tiempo real** - Barra de estado HUD muestra lo que está sucediendo internamente
+
+---
+
+## Características
+
+### Modos de Ejecución
+Múltiples estrategias para diferentes casos de uso - desde construcciones completamente autónomas hasta refactorización eficiente en tokens. [Aprende más →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+
+| Modo | Velocidad | Usar Para |
+|------|-------|---------|
+| **Autopilot** | Rápido | Flujos de trabajo completamente autónomos |
+| **Ultrawork** | Paralelo | Máximo paralelismo para cualquier tarea |
+| **Ralph** | Persistente | Tareas que deben completarse totalmente |
+| **Ultrapilot** | 3-5x más rápido | Sistemas multi-componente |
+| **Ecomode** | Rápido + 30-50% más barato | Proyectos conscientes del presupuesto |
+| **Swarm** | Coordinado | Tareas independientes en paralelo |
+| **Pipeline** | Secuencial | Procesamiento multi-etapa |
+
+### Orquestación Inteligente
+
+- **32 agentes especializados** para arquitectura, investigación, diseño, pruebas, ciencia de datos
+- **Enrutamiento inteligente de modelos** - Haiku para tareas simples, Opus para razonamiento complejo
+- **Delegación automática** - El agente correcto para el trabajo, siempre
+
+### Experiencia de Desarrollo
+
+- **Palabras clave mágicas** - `ralph`, `ulw`, `eco`, `plan` para control explícito
+- **Barra de estado HUD** - Métricas de orquestación en tiempo real en tu barra de estado
+- **Aprendizaje de habilidades** - Extrae patrones reutilizables de tus sesiones
+- **Análisis y seguimiento de costos** - Comprende el uso de tokens en todas las sesiones
+
+[Lista completa de características →](docs/REFERENCE.md)
+
+---
+
+## Palabras Clave Mágicas
+
+Atajos opcionales para usuarios avanzados. El lenguaje natural funciona bien sin ellas.
+
+| Palabra Clave | Efecto | Ejemplo |
+|---------|--------|---------|
+| `autopilot` | Ejecución completamente autónoma | `autopilot: build a todo app` |
+| `ralph` | Modo persistencia | `ralph: refactor auth` |
+| `ulw` | Máximo paralelismo | `ulw fix all errors` |
+| `eco` | Ejecución eficiente en tokens | `eco: migrate database` |
+| `plan` | Entrevista de planificación | `plan the API` |
+| `ralplan` | Consenso de planificación iterativa | `ralplan this feature` |
+
+**ralph incluye ultrawork:** Cuando activas el modo ralph, automáticamente incluye la ejecución paralela de ultrawork. No es necesario combinar palabras clave.
+
+---
+
+## Utilidades
+
+### Espera de Límite de Tasa
+
+Reanuda automáticamente sesiones de Claude Code cuando se reinician los límites de tasa.
+
+```bash
+omc wait          # Verificar estado, obtener orientación
+omc wait --start  # Habilitar demonio de reanudación automática
+omc wait --stop   # Deshabilitar demonio
+```
+
+**Requiere:** tmux (para detección de sesión)
+
+---
+
+## Documentación
+
+- **[Referencia Completa](docs/REFERENCE.md)** - Documentación completa de características
+- **[Monitoreo de Rendimiento](docs/PERFORMANCE-MONITORING.md)** - Seguimiento de agentes, depuración y optimización
+- **[Sitio Web](https://yeachan-heo.github.io/oh-my-claudecode-website)** - Guías interactivas y ejemplos
+- **[Guía de Migración](docs/MIGRATION.md)** - Actualización desde v2.x
+- **[Arquitectura](docs/ARCHITECTURE.md)** - Cómo funciona internamente
+
+---
+
+## Requisitos
+
+- CLI de [Claude Code](https://docs.anthropic.com/claude-code)
+- Suscripción Claude Max/Pro O clave API de Anthropic
+
+---
+
+## Licencia
+
+MIT
+
+---
+
+<div align="center">
+
+**Inspirado por:** [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) • [claude-hud](https://github.com/ryanjoachim/claude-hud) • [Superpowers](https://github.com/NexTechFusion/Superpowers) • [everything-claude-code](https://github.com/affaan-m/everything-claude-code)
+
+**Curva de aprendizaje cero. Poder máximo.**
+
+</div>
+
+## Historial de Estrellas
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+
+## 💖 Apoya Este Proyecto
+
+Si Oh-My-ClaudeCode ayuda a tu flujo de trabajo, considera patrocinar:
+
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-❤️-red?style=for-the-badge&logo=github)](https://github.com/sponsors/Yeachan-Heo)
+
+### ¿Por qué patrocinar?
+
+- Mantener el desarrollo activo
+- Soporte prioritario para patrocinadores
+- Influir en la hoja de ruta y características
+- Ayudar a mantener el software gratuito y de código abierto
+
+### Otras formas de ayudar
+
+- ⭐ Dale una estrella al repositorio
+- 🐛 Reporta errores
+- 💡 Sugiere características
+- 📝 Contribuye código

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,177 @@
+[English](README.md) | [한국어](README.ko.md) | [中文](README.zh.md) | 日本語 | [Español](README.es.md)
+
+# oh-my-claudecode
+
+[![npm version](https://img.shields.io/npm/v/oh-my-claude-sisyphus?color=cb3837)](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+[![npm downloads](https://img.shields.io/npm/dm/oh-my-claude-sisyphus?color=blue)](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+[![GitHub stars](https://img.shields.io/github/stars/Yeachan-Heo/oh-my-claudecode?style=flat&color=yellow)](https://github.com/Yeachan-Heo/oh-my-claudecode/stargazers)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Sponsor](https://img.shields.io/badge/Sponsor-❤️-red?style=flat&logo=github)](https://github.com/sponsors/Yeachan-Heo)
+
+**Claude Code のためのマルチエージェント・オーケストレーション。学習コストゼロ。**
+
+*Claude Code を学ぶ必要はありません。OMC を使うだけ。*
+
+[はじめる](#クイックスタート) • [ドキュメント](https://yeachan-heo.github.io/oh-my-claudecode-website) • [移行ガイド](docs/MIGRATION.md)
+
+---
+
+## クイックスタート
+
+**ステップ 1: インストール**
+```bash
+/plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+/plugin install oh-my-claudecode
+```
+
+**ステップ 2: セットアップ**
+```bash
+/oh-my-claudecode:omc-setup
+```
+
+**ステップ 3: 何か作ってみる**
+```
+autopilot: build a REST API for managing tasks
+```
+
+以上です。あとは自動で進みます。
+
+<h1 align="center">あなたの Claude がステロイド級にパワーアップ。</h1>
+
+<p align="center">
+  <img src="assets/omc-character.jpg" alt="oh-my-claudecode" width="400" />
+</p>
+
+---
+
+## なぜ oh-my-claudecode なのか?
+
+- **設定不要** - 賢いデフォルト設定ですぐに使える
+- **自然言語インターフェース** - コマンドを覚える必要なし、やりたいことを話すだけ
+- **自動並列化** - 複雑なタスクを専門エージェントに自動分散
+- **粘り強い実行** - 検証完了まで諦めない
+- **コスト最適化** - スマートなモデルルーティングでトークンを30〜50%節約
+- **経験から学習** - 問題解決パターンを自動抽出して再利用
+- **リアルタイム可視化** - HUD ステータスラインで裏側の動きが見える
+
+---
+
+## 機能
+
+### 実行モード
+用途に応じた複数の戦略 - 完全自律ビルドからトークン効率の良いリファクタリングまで。[詳しくはこちら →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+
+| モード | スピード | 用途 |
+|------|-------|------|
+| **Autopilot** | 高速 | 完全自律ワークフロー |
+| **Ultrawork** | 並列 | あらゆるタスクの最大並列化 |
+| **Ralph** | 粘り強い | 必ず完遂すべきタスク |
+| **Ultrapilot** | 3〜5倍速 | 複数コンポーネントシステム |
+| **Ecomode** | 高速 + 30〜50%節約 | 予算重視プロジェクト |
+| **Swarm** | 協調 | 並列独立タスク |
+| **Pipeline** | 逐次 | 多段階処理 |
+
+### インテリジェント・オーケストレーション
+
+- **32の専門エージェント** - アーキテクチャ、リサーチ、デザイン、テスト、データサイエンス対応
+- **スマートモデルルーティング** - シンプルなタスクは Haiku、複雑な推論は Opus
+- **自動委譲** - 常に適材適所
+
+### 開発者体験
+
+- **マジックキーワード** - `ralph`、`ulw`、`eco`、`plan` で明示的制御
+- **HUD ステータスライン** - ステータスバーでリアルタイムのオーケストレーション指標を表示
+- **スキル学習** - セッションから再利用可能なパターンを抽出
+- **分析とコスト追跡** - 全セッションのトークン使用状況を把握
+
+[全機能リスト →](docs/REFERENCE.md)
+
+---
+
+## マジックキーワード
+
+パワーユーザー向けのオプション・ショートカット。自然言語でも問題なく動作します。
+
+| キーワード | 効果 | 例 |
+|---------|-----|-----|
+| `autopilot` | 完全自律実行 | `autopilot: build a todo app` |
+| `ralph` | 粘り強いモード | `ralph: refactor auth` |
+| `ulw` | 最大並列化 | `ulw fix all errors` |
+| `eco` | トークン効率実行 | `eco: migrate database` |
+| `plan` | 計画インタビュー | `plan the API` |
+| `ralplan` | 反復的計画合意形成 | `ralplan this feature` |
+
+**ralph は ultrawork を含む:** ralph モードを有効にすると、ultrawork の並列実行が自動的に含まれます。キーワードを組み合わせる必要はありません。
+
+---
+
+## ユーティリティ
+
+### レート制限待機
+
+レート制限がリセットされたら Claude Code セッションを自動再開。
+
+```bash
+omc wait          # ステータス確認とガイダンス取得
+omc wait --start  # 自動再開デーモンを有効化
+omc wait --stop   # デーモンを無効化
+```
+
+**必要なもの:** tmux (セッション検出用)
+
+---
+
+## ドキュメント
+
+- **[完全リファレンス](docs/REFERENCE.md)** - 全機能の詳細ドキュメント
+- **[パフォーマンス監視](docs/PERFORMANCE-MONITORING.md)** - エージェント追跡、デバッグ、最適化
+- **[ウェブサイト](https://yeachan-heo.github.io/oh-my-claudecode-website)** - インタラクティブガイドと例
+- **[移行ガイド](docs/MIGRATION.md)** - v2.x からのアップグレード
+- **[アーキテクチャ](docs/ARCHITECTURE.md)** - 内部の仕組み
+
+---
+
+## 動作環境
+
+- [Claude Code](https://docs.anthropic.com/claude-code) CLI
+- Claude Max/Pro サブスクリプション または Anthropic API キー
+
+---
+
+## ライセンス
+
+MIT
+
+---
+
+<div align="center">
+
+**インスピレーション元:** [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) • [claude-hud](https://github.com/ryanjoachim/claude-hud) • [Superpowers](https://github.com/NexTechFusion/Superpowers) • [everything-claude-code](https://github.com/affaan-m/everything-claude-code)
+
+**学習コストゼロ。最大パワー。**
+
+</div>
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+
+## 💖 このプロジェクトを支援
+
+Oh-My-ClaudeCode があなたのワークフローに役立っているなら、スポンサーをご検討ください:
+
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-❤️-red?style=for-the-badge&logo=github)](https://github.com/sponsors/Yeachan-Heo)
+
+### スポンサーになる理由は?
+
+- 開発を活発に保つ
+- スポンサー向け優先サポート
+- ロードマップと機能に影響力
+- 無料オープンソースの維持を支援
+
+### その他の協力方法
+
+- ⭐ リポジトリにスター
+- 🐛 バグ報告
+- 💡 機能提案
+- 📝 コード貢献

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,177 @@
+[English](README.md) | 한국어 | [中文](README.zh.md) | [日本語](README.ja.md) | [Español](README.es.md)
+
+# oh-my-claudecode
+
+[![npm version](https://img.shields.io/npm/v/oh-my-claude-sisyphus?color=cb3837)](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+[![npm downloads](https://img.shields.io/npm/dm/oh-my-claude-sisyphus?color=blue)](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+[![GitHub stars](https://img.shields.io/github/stars/Yeachan-Heo/oh-my-claudecode?style=flat&color=yellow)](https://github.com/Yeachan-Heo/oh-my-claudecode/stargazers)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Sponsor](https://img.shields.io/badge/Sponsor-❤️-red?style=flat&logo=github)](https://github.com/sponsors/Yeachan-Heo)
+
+**Claude Code를 위한 멀티 에이전트 오케스트레이션. 학습 곡선 제로.**
+
+*Claude Code를 배우지 마세요. 그냥 OMC를 쓰세요.*
+
+[시작하기](#빠른-시작) • [문서](https://yeachan-heo.github.io/oh-my-claudecode-website) • [마이그레이션 가이드](docs/MIGRATION.md)
+
+---
+
+## 빠른 시작
+
+**Step 1: 설치**
+```bash
+/plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+/plugin install oh-my-claudecode
+```
+
+**Step 2: 설정**
+```bash
+/oh-my-claudecode:omc-setup
+```
+
+**Step 3: 무언가 만들기**
+```
+autopilot: build a REST API for managing tasks
+```
+
+끝입니다. 나머지는 모두 자동입니다.
+
+<h1 align="center">당신의 Claude가 스테로이드를 맞았습니다.</h1>
+
+<p align="center">
+  <img src="assets/omc-character.jpg" alt="oh-my-claudecode" width="400" />
+</p>
+
+---
+
+## 왜 oh-my-claudecode인가?
+
+- **설정 불필요** - 똑똑한 기본값으로 바로 작동합니다
+- **자연어 인터페이스** - 외울 명령어 없이, 원하는 것만 설명하세요
+- **자동 병렬화** - 복잡한 작업을 전문 에이전트들에게 분산합니다
+- **지속적 실행** - 작업이 완전히 검증될 때까지 포기하지 않습니다
+- **비용 최적화** - 똑똑한 모델 라우팅으로 토큰을 30-50% 절약합니다
+- **경험으로부터 학습** - 문제 해결 패턴을 자동으로 추출하고 재사용합니다
+- **실시간 가시성** - HUD 상태바에서 내부에서 무슨 일이 일어나는지 확인하세요
+
+---
+
+## 기능
+
+### 실행 모드
+다양한 사용 사례를 위한 여러 전략 - 완전 자율 빌드부터 토큰 효율적인 리팩토링까지. [자세히 보기 →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+
+| 모드 | 속도 | 용도 |
+|------|-------|---------|
+| **Autopilot** | 빠름 | 완전 자율 워크플로우 |
+| **Ultrawork** | 병렬 | 모든 작업에 최대 병렬화 |
+| **Ralph** | 지속적 | 반드시 완료해야 하는 작업 |
+| **Ultrapilot** | 3-5배 빠름 | 다중 컴포넌트 시스템 |
+| **Ecomode** | 빠름 + 30-50% 저렴 | 예산을 고려한 프로젝트 |
+| **Swarm** | 협조적 | 병렬 독립 작업 |
+| **Pipeline** | 순차적 | 다단계 처리 |
+
+### 지능형 오케스트레이션
+
+- **32개의 전문 에이전트** - 아키텍처, 연구, 디자인, 테스팅, 데이터 사이언스
+- **똑똑한 모델 라우팅** - 간단한 작업엔 Haiku, 복잡한 추론엔 Opus
+- **자동 위임** - 매번 작업에 맞는 올바른 에이전트 선택
+
+### 개발자 경험
+
+- **매직 키워드** - 명시적 제어를 위한 `ralph`, `ulw`, `eco`, `plan`
+- **HUD 상태바** - 상태바에서 실시간 오케스트레이션 메트릭 확인
+- **스킬 학습** - 세션에서 재사용 가능한 패턴 추출
+- **분석 및 비용 추적** - 모든 세션의 토큰 사용량 이해
+
+[전체 기능 목록 →](docs/REFERENCE.md)
+
+---
+
+## 매직 키워드
+
+파워 유저를 위한 선택적 단축키. 자연어도 잘 작동합니다.
+
+| 키워드 | 효과 | 예시 |
+|---------|--------|---------|
+| `autopilot` | 완전 자율 실행 | `autopilot: build a todo app` |
+| `ralph` | 지속 모드 | `ralph: refactor auth` |
+| `ulw` | 최대 병렬화 | `ulw fix all errors` |
+| `eco` | 토큰 효율적 실행 | `eco: migrate database` |
+| `plan` | 계획 인터뷰 | `plan the API` |
+| `ralplan` | 반복적 계획 합의 | `ralplan this feature` |
+
+**ralph는 ultrawork를 포함합니다:** ralph 모드를 활성화하면 자동으로 ultrawork의 병렬 실행이 포함됩니다. 키워드를 결합할 필요가 없습니다.
+
+---
+
+## 유틸리티
+
+### Rate Limit Wait
+
+속도 제한이 리셋될 때 Claude Code 세션을 자동 재개합니다.
+
+```bash
+omc wait          # 상태 확인, 가이드 받기
+omc wait --start  # 자동 재개 데몬 활성화
+omc wait --stop   # 데몬 비활성화
+```
+
+**요구사항:** tmux (세션 감지용)
+
+---
+
+## 문서
+
+- **[전체 레퍼런스](docs/REFERENCE.md)** - 완전한 기능 문서
+- **[성능 모니터링](docs/PERFORMANCE-MONITORING.md)** - 에이전트 추적, 디버깅 및 최적화
+- **[웹사이트](https://yeachan-heo.github.io/oh-my-claudecode-website)** - 인터랙티브 가이드와 예제
+- **[마이그레이션 가이드](docs/MIGRATION.md)** - v2.x에서 업그레이드
+- **[아키텍처](docs/ARCHITECTURE.md)** - 내부 작동 원리
+
+---
+
+## 요구사항
+
+- [Claude Code](https://docs.anthropic.com/claude-code) CLI
+- Claude Max/Pro 구독 또는 Anthropic API 키
+
+---
+
+## 라이선스
+
+MIT
+
+---
+
+<div align="center">
+
+**영감을 받은 프로젝트:** [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) • [claude-hud](https://github.com/ryanjoachim/claude-hud) • [Superpowers](https://github.com/NexTechFusion/Superpowers) • [everything-claude-code](https://github.com/affaan-m/everything-claude-code)
+
+**학습 곡선 제로. 최대 파워.**
+
+</div>
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+
+## 💖 이 프로젝트 후원하기
+
+Oh-My-ClaudeCode가 당신의 워크플로우에 도움이 된다면, 후원을 고려해주세요:
+
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-❤️-red?style=for-the-badge&logo=github)](https://github.com/sponsors/Yeachan-Heo)
+
+### 왜 후원해야 하나요?
+
+- 활발한 개발 유지
+- 후원자를 위한 우선 지원
+- 로드맵 및 기능에 영향력 행사
+- 무료 오픈소스 유지 지원
+
+### 다른 도움 방법
+
+- ⭐ 리포지토리에 Star 주기
+- 🐛 버그 리포트
+- 💡 기능 제안
+- 📝 코드 기여

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+English | [한국어](README.ko.md) | [中文](README.zh.md) | [日本語](README.ja.md) | [Español](README.es.md)
+
 # oh-my-claudecode
 
 [![npm version](https://img.shields.io/npm/v/oh-my-claude-sisyphus?color=cb3837)](https://www.npmjs.com/package/oh-my-claude-sisyphus)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,177 @@
+[English](README.md) | [한국어](README.ko.md) | 中文 | [日本語](README.ja.md) | [Español](README.es.md)
+
+# oh-my-claudecode
+
+[![npm version](https://img.shields.io/npm/v/oh-my-claude-sisyphus?color=cb3837)](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+[![npm downloads](https://img.shields.io/npm/dm/oh-my-claude-sisyphus?color=blue)](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+[![GitHub stars](https://img.shields.io/github/stars/Yeachan-Heo/oh-my-claudecode?style=flat&color=yellow)](https://github.com/Yeachan-Heo/oh-my-claudecode/stargazers)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Sponsor](https://img.shields.io/badge/Sponsor-❤️-red?style=flat&logo=github)](https://github.com/sponsors/Yeachan-Heo)
+
+**Claude Code 的多智能体编排系统。零学习曲线。**
+
+*无需学习 Claude Code，直接使用 OMC。*
+
+[快速开始](#快速开始) • [文档](https://yeachan-heo.github.io/oh-my-claudecode-website) • [迁移指南](docs/MIGRATION.md)
+
+---
+
+## 快速开始
+
+**第一步：安装**
+```bash
+/plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+/plugin install oh-my-claudecode
+```
+
+**第二步：配置**
+```bash
+/oh-my-claudecode:omc-setup
+```
+
+**第三步：开始构建**
+```
+autopilot: build a REST API for managing tasks
+```
+
+就这么简单。其余都是自动的。
+
+<h1 align="center">你的 Claude 已被注入超能力。</h1>
+
+<p align="center">
+  <img src="assets/omc-character.jpg" alt="oh-my-claudecode" width="400" />
+</p>
+
+---
+
+## 为什么选择 oh-my-claudecode？
+
+- **无需配置** - 开箱即用，智能默认设置
+- **自然语言交互** - 无需记忆命令，只需描述你的需求
+- **自动并行化** - 复杂任务自动分配给专业智能体
+- **持久执行** - 不会半途而废，直到任务验证完成
+- **成本优化** - 智能模型路由节省 30-50% 的 token
+- **从经验中学习** - 自动提取并复用问题解决模式
+- **实时可见性** - HUD 状态栏显示底层运行状态
+
+---
+
+## 功能特性
+
+### 执行模式
+针对不同场景的多种策略 - 从全自动构建到 token 高效重构。[了解更多 →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+
+| 模式 | 速度 | 适用场景 |
+|------|-------|---------|
+| **Autopilot** | 快速 | 全自动工作流 |
+| **Ultrawork** | 并行 | 任何任务的最大并行化 |
+| **Ralph** | 持久 | 必须完整完成的任务 |
+| **Ultrapilot** | 3-5倍速 | 多组件系统 |
+| **Ecomode** | 快速 + 省30-50%成本 | 预算有限的项目 |
+| **Swarm** | 协同 | 并行独立任务 |
+| **Pipeline** | 顺序 | 多阶段处理 |
+
+### 智能编排
+
+- **32 个专业智能体** 涵盖架构、研究、设计、测试、数据科学
+- **智能模型路由** - 简单任务用 Haiku，复杂推理用 Opus
+- **自动委派** - 每次都选择最合适的智能体
+
+### 开发者体验
+
+- **魔法关键词** - `ralph`、`ulw`、`eco`、`plan` 提供显式控制
+- **HUD 状态栏** - 状态栏实时显示编排指标
+- **技能学习** - 从会话中提取可复用模式
+- **分析与成本追踪** - 了解所有会话的 token 使用情况
+
+[完整功能列表 →](docs/REFERENCE.md)
+
+---
+
+## 魔法关键词
+
+为高级用户提供的可选快捷方式。不用它们，自然语言也能很好地工作。
+
+| 关键词 | 效果 | 示例 |
+|---------|--------|---------|
+| `autopilot` | 全自动执行 | `autopilot: build a todo app` |
+| `ralph` | 持久模式 | `ralph: refactor auth` |
+| `ulw` | 最大并行化 | `ulw fix all errors` |
+| `eco` | token 高效执行 | `eco: migrate database` |
+| `plan` | 规划访谈 | `plan the API` |
+| `ralplan` | 迭代规划共识 | `ralplan this feature` |
+
+**ralph 包含 ultrawork：** 激活 ralph 模式时，会自动包含 ultrawork 的并行执行。无需组合关键词。
+
+---
+
+## 实用工具
+
+### 速率限制等待
+
+当速率限制重置时自动恢复 Claude Code 会话。
+
+```bash
+omc wait          # 检查状态，获取指导
+omc wait --start  # 启用自动恢复守护进程
+omc wait --stop   # 禁用守护进程
+```
+
+**需要：** tmux（用于会话检测）
+
+---
+
+## 文档
+
+- **[完整参考](docs/REFERENCE.md)** - 完整功能文档
+- **[性能监控](docs/PERFORMANCE-MONITORING.md)** - 智能体追踪、调试和优化
+- **[网站](https://yeachan-heo.github.io/oh-my-claudecode-website)** - 交互式指南和示例
+- **[迁移指南](docs/MIGRATION.md)** - 从 v2.x 升级
+- **[架构](docs/ARCHITECTURE.md)** - 底层工作原理
+
+---
+
+## 环境要求
+
+- [Claude Code](https://docs.anthropic.com/claude-code) CLI
+- Claude Max/Pro 订阅 或 Anthropic API 密钥
+
+---
+
+## 开源协议
+
+MIT
+
+---
+
+<div align="center">
+
+**灵感来源：** [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) • [claude-hud](https://github.com/ryanjoachim/claude-hud) • [Superpowers](https://github.com/NexTechFusion/Superpowers) • [everything-claude-code](https://github.com/affaan-m/everything-claude-code)
+
+**零学习曲线。最强大能。**
+
+</div>
+
+## Star 历史
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+
+## 💖 支持本项目
+
+如果 Oh-My-ClaudeCode 帮助了你的工作流，请考虑赞助：
+
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-❤️-red?style=for-the-badge&logo=github)](https://github.com/sponsors/Yeachan-Heo)
+
+### 为什么赞助？
+
+- 保持项目活跃开发
+- 赞助者获得优先支持
+- 影响路线图和功能
+- 帮助维护自由开源
+
+### 其他帮助方式
+
+- ⭐ 为仓库加星
+- 🐛 报告问题
+- 💡 提出功能建议
+- 📝 贡献代码


### PR DESCRIPTION
## Summary
- Add Korean translation (README.ko.md)
- Add Chinese (Simplified) translation (README.zh.md)
- Add Japanese translation (README.ja.md)
- Add Spanish translation (README.es.md)
- Add language switcher at top of main README.md

## Details
All translations are natural, native-sounding — not machine translation quality. Technical terms (CLI commands, package names, npm, Claude Code, API) are kept in English for consistency.

Closes #378

## Test plan
- [ ] Verify all README files render correctly on GitHub
- [ ] Verify language switcher links work in all files
- [ ] Review translations for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)