### PR TITLE
fix(hooks): prevent stop hook stdin hang causing session freeze (#385)

### DIFF
--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -18,12 +18,57 @@ import {
 import { join, dirname, resolve, normalize } from "path";
 import { homedir } from "os";
 
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString("utf-8");
+/**
+ * Read stdin with timeout to prevent indefinite hang on Linux.
+ * The blocking `for await (const chunk of process.stdin)` pattern waits
+ * indefinitely for EOF. On Linux, if the parent process doesn't properly
+ * close stdin, this hangs forever. This function uses event-based reading
+ * with a timeout as a safety net.
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/240
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/385
+ */
+function readStdin(timeoutMs = 5000) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        process.stdin.removeAllListeners();
+        process.stdin.destroy();
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    }, timeoutMs);
+
+    process.stdin.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+
+    process.stdin.on("end", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    });
+
+    process.stdin.on("error", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve("");
+      }
+    });
+
+    if (process.stdin.readableEnded) {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    }
+  });
 }
 
 function readJsonFile(path) {
@@ -519,9 +564,75 @@ async function main() {
     console.log(JSON.stringify({ continue: true }));
   } catch (error) {
     // On any error, allow stop rather than blocking forever
-    console.error(`[persistent-mode] Error: ${error.message}`);
-    console.log(JSON.stringify({ continue: true }));
+    // CRITICAL: Use process.stdout.write instead of console.log to avoid
+    // cascading errors if stdout/stderr are broken (issue #319, #385)
+    try {
+      process.stderr.write(
+        `[persistent-mode] Error: ${error?.message || error}\n`,
+      );
+    } catch {
+      // Ignore stderr errors - we just need to return valid JSON
+    }
+    try {
+      process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+    } catch {
+      // If stdout write fails, the hook will timeout and Claude Code will proceed
+      process.exit(0);
+    }
   }
 }
 
-main();
+// Global error handlers to prevent hook from hanging on uncaught errors (issue #319, #385)
+process.on("uncaughtException", (error) => {
+  try {
+    process.stderr.write(
+      `[persistent-mode] Uncaught exception: ${error?.message || error}\n`,
+    );
+  } catch {
+    // Ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  } catch {
+    // If we can't write, just exit
+  }
+  process.exit(0);
+});
+
+process.on("unhandledRejection", (error) => {
+  try {
+    process.stderr.write(
+      `[persistent-mode] Unhandled rejection: ${error?.message || error}\n`,
+    );
+  } catch {
+    // Ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  } catch {
+    // If we can't write, just exit
+  }
+  process.exit(0);
+});
+
+// Safety timeout: if hook doesn't complete in 10 seconds, force exit
+// This prevents infinite hangs from any unforeseen issues (issue #385)
+const safetyTimeout = setTimeout(() => {
+  try {
+    process.stderr.write(
+      "[persistent-mode] Safety timeout reached, forcing exit\n",
+    );
+  } catch {
+    // Ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  } catch {
+    // If we can't write, just exit
+  }
+  process.exit(0);
+}, 10000);
+
+main().finally(() => {
+  clearTimeout(safetyTimeout);
+});

--- a/src/hooks/persistent-mode/__tests__/error-handling.test.ts
+++ b/src/hooks/persistent-mode/__tests__/error-handling.test.ts
@@ -1,41 +1,26 @@
 /**
- * Tests for issue #319: Stop hook error handling
+ * Tests for issue #319, #385: Stop hook error handling
  * Ensures the persistent-mode hook doesn't hang on errors
+ *
+ * Tests all three script variants:
+ * - templates/hooks/persistent-mode.mjs (installed to ~/.claude/hooks/)
+ * - scripts/persistent-mode.mjs (standalone ESM)
+ * - scripts/persistent-mode.cjs (standalone CJS)
+ *
+ * Also tests stop-continuation.mjs for the same stdin hang issue.
  */
 
 import { describe, it, expect } from 'vitest';
 import { spawn } from 'child_process';
 import { join } from 'path';
+import { existsSync } from 'fs';
 
-const HOOK_PATH = join(__dirname, '../../../../templates/hooks/persistent-mode.mjs');
-const TIMEOUT_MS = 3000;
-
-describe('persistent-mode hook error handling (issue #319)', () => {
-  it('should return continue:true on empty valid input without hanging', async () => {
-    const result = await runHook('{}');
-    expect(result.output).toContain('continue');
-    expect(result.timedOut).toBe(false);
-    expect(result.exitCode).toBe(0);
-  });
-
-  it('should return continue:true on broken stdin without hanging', async () => {
-    const result = await runHook('', true); // Empty stdin, close immediately
-    expect(result.output).toContain('continue');
-    expect(result.timedOut).toBe(false);
-  });
-
-  it('should return continue:true on invalid JSON without hanging', async () => {
-    const result = await runHook('invalid json{{{');
-    expect(result.output).toContain('continue');
-    expect(result.timedOut).toBe(false);
-  });
-
-  it('should complete within timeout even on errors', async () => {
-    const result = await runHook('{"malformed": }');
-    expect(result.timedOut).toBe(false);
-    expect(result.duration).toBeLessThan(TIMEOUT_MS);
-  });
-});
+const PROJECT_ROOT = join(__dirname, '..', '..', '..', '..');
+const TEMPLATE_HOOK_PATH = join(PROJECT_ROOT, 'templates/hooks/persistent-mode.mjs');
+const SCRIPTS_MJS_PATH = join(PROJECT_ROOT, 'scripts/persistent-mode.mjs');
+const SCRIPTS_CJS_PATH = join(PROJECT_ROOT, 'scripts/persistent-mode.cjs');
+const STOP_CONTINUATION_PATH = join(PROJECT_ROOT, 'templates/hooks/stop-continuation.mjs');
+const TIMEOUT_MS = 6000;
 
 interface HookResult {
   output: string;
@@ -45,10 +30,10 @@ interface HookResult {
   duration: number;
 }
 
-function runHook(input: string, closeImmediately = false): Promise<HookResult> {
+function runHook(hookPath: string, input: string, closeImmediately = false): Promise<HookResult> {
   return new Promise((resolve) => {
     const startTime = Date.now();
-    const proc = spawn('node', [HOOK_PATH]);
+    const proc = spawn('node', [hookPath]);
 
     let stdout = '';
     let stderr = '';
@@ -88,3 +73,119 @@ function runHook(input: string, closeImmediately = false): Promise<HookResult> {
     }
   });
 }
+
+describe('persistent-mode hook error handling (issue #319, #385)', () => {
+  // Template version (templates/hooks/persistent-mode.mjs)
+  describe('templates/hooks/persistent-mode.mjs', () => {
+    it('should return continue:true on empty valid input without hanging', async () => {
+      const result = await runHook(TEMPLATE_HOOK_PATH, '{}');
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should return continue:true on broken stdin without hanging', async () => {
+      const result = await runHook(TEMPLATE_HOOK_PATH, '', true);
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should return continue:true on invalid JSON without hanging', async () => {
+      const result = await runHook(TEMPLATE_HOOK_PATH, 'invalid json{{{');
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should complete within timeout even on errors', async () => {
+      const result = await runHook(TEMPLATE_HOOK_PATH, '{"malformed": }');
+      expect(result.timedOut).toBe(false);
+      expect(result.duration).toBeLessThan(TIMEOUT_MS);
+    });
+  });
+
+  // Scripts ESM version (scripts/persistent-mode.mjs)
+  describe('scripts/persistent-mode.mjs (issue #385 fix)', () => {
+    it('should exist', () => {
+      expect(existsSync(SCRIPTS_MJS_PATH)).toBe(true);
+    });
+
+    it('should return continue:true on empty valid input without hanging', async () => {
+      const result = await runHook(SCRIPTS_MJS_PATH, '{}');
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should return continue:true on broken stdin without hanging', async () => {
+      const result = await runHook(SCRIPTS_MJS_PATH, '', true);
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should return continue:true on invalid JSON without hanging', async () => {
+      const result = await runHook(SCRIPTS_MJS_PATH, 'invalid json{{{');
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should complete within timeout', async () => {
+      const result = await runHook(SCRIPTS_MJS_PATH, '{}');
+      expect(result.timedOut).toBe(false);
+      expect(result.duration).toBeLessThan(TIMEOUT_MS);
+    });
+  });
+
+  // Scripts CJS version (scripts/persistent-mode.cjs)
+  describe('scripts/persistent-mode.cjs (issue #385 fix)', () => {
+    it('should exist', () => {
+      expect(existsSync(SCRIPTS_CJS_PATH)).toBe(true);
+    });
+
+    it('should return continue:true on empty valid input without hanging', async () => {
+      const result = await runHook(SCRIPTS_CJS_PATH, '{}');
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should return continue:true on broken stdin without hanging', async () => {
+      const result = await runHook(SCRIPTS_CJS_PATH, '', true);
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should return continue:true on invalid JSON without hanging', async () => {
+      const result = await runHook(SCRIPTS_CJS_PATH, 'invalid json{{{');
+      expect(result.output).toContain('continue');
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should complete within timeout', async () => {
+      const result = await runHook(SCRIPTS_CJS_PATH, '{}');
+      expect(result.timedOut).toBe(false);
+      expect(result.duration).toBeLessThan(TIMEOUT_MS);
+    });
+  });
+});
+
+describe('stop-continuation hook (issue #385)', () => {
+  it('should exist', () => {
+    expect(existsSync(STOP_CONTINUATION_PATH)).toBe(true);
+  });
+
+  it('should return continue:true on empty stdin without hanging', async () => {
+    const result = await runHook(STOP_CONTINUATION_PATH, '', true);
+    expect(result.output).toContain('continue');
+    expect(result.timedOut).toBe(false);
+  });
+
+  it('should return continue:true on valid input without hanging', async () => {
+    const result = await runHook(STOP_CONTINUATION_PATH, '{}');
+    expect(result.output).toContain('continue');
+    expect(result.timedOut).toBe(false);
+  });
+
+  it('should complete within timeout', async () => {
+    const result = await runHook(STOP_CONTINUATION_PATH, '{}');
+    expect(result.timedOut).toBe(false);
+    expect(result.duration).toBeLessThan(TIMEOUT_MS);
+  });
+});

--- a/templates/hooks/stop-continuation.mjs
+++ b/templates/hooks/stop-continuation.mjs
@@ -1,15 +1,82 @@
 #!/usr/bin/env node
-// OMC Stop Continuation Hook (Simplified)
-// Always allows stop - soft enforcement via message injection only.
+/**
+ * OMC Stop Continuation Hook (Simplified)
+ * Always allows stop - soft enforcement via message injection only.
+ *
+ * Uses timeout-protected stdin reading to prevent hangs on Linux.
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/240
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/385
+ */
 
-// Consume stdin (required for hook protocol)
-async function main() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  // Always allow stop
-  console.log(JSON.stringify({ continue: true }));
+/**
+ * Read stdin with timeout to prevent indefinite hang.
+ */
+function readStdin(timeoutMs = 5000) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        process.stdin.removeAllListeners();
+        process.stdin.destroy();
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    }, timeoutMs);
+
+    process.stdin.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+
+    process.stdin.on("end", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    });
+
+    process.stdin.on("error", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve("");
+      }
+    });
+
+    if (process.stdin.readableEnded) {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(Buffer.concat(chunks).toString("utf-8"));
+      }
+    }
+  });
 }
 
-main();
+async function main() {
+  try {
+    // Consume stdin (required for hook protocol)
+    await readStdin();
+    // Always allow stop
+    process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  } catch {
+    // On any error, still allow stop
+    process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  }
+}
+
+// Safety timeout: if hook doesn't complete in 10 seconds, force exit
+const safetyTimeout = setTimeout(() => {
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  } catch {
+    // Ignore
+  }
+  process.exit(0);
+}, 10000);
+
+main().finally(() => {
+  clearTimeout(safetyTimeout);
+});


### PR DESCRIPTION
## Summary

Fixes #385: Stop hook causes session to freeze.

The root cause was the use of `for await (const chunk of process.stdin)` pattern which blocks indefinitely on Linux when the parent process doesn't properly close stdin. This pattern was identified and fixed in issue #240 for other hooks but the `scripts/` directory variants and `stop-continuation.mjs` were never updated.

**Changes:**
- `scripts/persistent-mode.cjs`: Replace `for await` with inline timeout-protected `readStdin` (5s timeout), add 10s safety timeout, add uncaught exception/rejection handlers
- `scripts/persistent-mode.mjs`: Same fixes as CJS variant
- `templates/hooks/stop-continuation.mjs`: Replace `for await` with timeout-protected stdin reading and safety timeout
- Updated tests to cover all three script variants and stop-continuation hook

## Test plan

- [x] All 18 new tests pass for the stop hook variants
- [x] Full test suite passes (2273 tests, 0 failures)
- [x] Build succeeds
- [ ] Manual testing: Install plugin and verify sessions end properly without freezing

🤖 Generated with [Claude Code](https://claude.ai/code)