### PR TITLE
fix(ultrawork): add concurrent session detection and warning (#386)

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -220,11 +220,16 @@ function processKeywordDetector(input: HookInput): HookOutput {
         break;
       }
 
-      case "ultrawork":
-        // Activate persistent ultrawork state
-        activateUltrawork(promptText, sessionId, directory);
-        messages.push(ULTRAWORK_MESSAGE);
+      case "ultrawork": {
+        // Activate persistent ultrawork state with concurrent session detection
+        const result = activateUltrawork(promptText, sessionId, directory);
+        if (result.warning) {
+          messages.push(`⚠️ ${result.warning}\n\n---\n\n${ULTRAWORK_MESSAGE}`);
+        } else {
+          messages.push(ULTRAWORK_MESSAGE);
+        }
         break;
+      }
 
       case "ultrathink":
         messages.push(ULTRATHINK_MESSAGE);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -435,7 +435,9 @@ export {
   shouldReinforceUltrawork,
   getUltraworkPersistenceMessage,
   createUltraworkStateHook,
-  type UltraworkState
+  checkExistingSession,
+  type UltraworkState,
+  type UltraworkActivationResult
 } from './ultrawork/index.js';
 
 export {

--- a/src/hooks/ultrawork/index.ts
+++ b/src/hooks/ultrawork/index.ts
@@ -28,6 +28,17 @@ export interface UltraworkState {
   linked_to_ralph?: boolean;
 }
 
+export interface UltraworkActivationResult {
+  /** Whether activation succeeded */
+  success: boolean;
+  /** Warning message if another session was already active */
+  warning?: string;
+  /** The session_id of the previously active session (if any) */
+  previousSessionId?: string;
+  /** When the previous session was started */
+  previousStartedAt?: string;
+}
+
 const _DEFAULT_STATE: UltraworkState = {
   active: false,
   started_at: '',
@@ -91,6 +102,42 @@ export function writeUltraworkState(state: UltraworkState, directory?: string): 
 }
 
 /**
+ * Check if another ultrawork session is already active in this project.
+ * Returns info about the existing session if found, null otherwise.
+ */
+export function checkExistingSession(
+  sessionId?: string,
+  directory?: string
+): { sessionId?: string; startedAt: string; prompt: string } | null {
+  const state = readUltraworkState(directory);
+
+  if (!state || !state.active) {
+    return null;
+  }
+
+  // If the same session is re-activating, that's fine (no warning needed)
+  if (state.session_id && sessionId && state.session_id === sessionId) {
+    return null;
+  }
+
+  // Check staleness - if the existing state is stale (>2 hours), don't warn
+  const lastChecked = state.last_checked_at ? new Date(state.last_checked_at).getTime() : 0;
+  const startedAt = state.started_at ? new Date(state.started_at).getTime() : 0;
+  const mostRecent = Math.max(lastChecked, startedAt);
+  const STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+  if (mostRecent > 0 && (Date.now() - mostRecent) > STALE_THRESHOLD_MS) {
+    return null; // Stale state, safe to overwrite
+  }
+
+  return {
+    sessionId: state.session_id,
+    startedAt: state.started_at,
+    prompt: state.original_prompt
+  };
+}
+
+/**
  * Activate ultrawork mode
  */
 export function activateUltrawork(
@@ -98,7 +145,10 @@ export function activateUltrawork(
   sessionId?: string,
   directory?: string,
   linkedToRalph?: boolean
-): boolean {
+): UltraworkActivationResult {
+  // Check for existing active session before overwriting
+  const existing = checkExistingSession(sessionId, directory);
+
   const state: UltraworkState = {
     active: true,
     started_at: new Date().toISOString(),
@@ -110,7 +160,33 @@ export function activateUltrawork(
     linked_to_ralph: linkedToRalph
   };
 
-  return writeUltraworkState(state, directory);
+  const written = writeUltraworkState(state, directory);
+
+  if (!written) {
+    return { success: false };
+  }
+
+  if (existing) {
+    const warning = `WARNING: Another ultrawork session was already active in this project.\n` +
+      `  Previous session: ${existing.sessionId || 'unknown'}\n` +
+      `  Started at: ${existing.startedAt}\n` +
+      `  Task: ${existing.prompt}\n\n` +
+      `The previous session's state has been overwritten by this session.\n` +
+      `Running multiple ultrawork sessions in the same project may cause:\n` +
+      `  - File modification conflicts\n` +
+      `  - Unexpected task execution\n` +
+      `  - State confusion\n\n` +
+      `Consider using /ultrapilot for multi-session parallel work with file ownership partitioning.`;
+
+    return {
+      success: true,
+      warning,
+      previousSessionId: existing.sessionId,
+      previousStartedAt: existing.startedAt
+    };
+  }
+
+  return { success: true };
 }
 
 /**

--- a/src/hooks/ultrawork/session-isolation.test.ts
+++ b/src/hooks/ultrawork/session-isolation.test.ts
@@ -7,7 +7,8 @@ import {
   readUltraworkState,
   shouldReinforceUltrawork,
   deactivateUltrawork,
-  incrementReinforcement
+  incrementReinforcement,
+  checkExistingSession
 } from './index.js';
 
 describe('Ultrawork Session Isolation (Issue #269)', () => {
@@ -27,7 +28,7 @@ describe('Ultrawork Session Isolation (Issue #269)', () => {
       const prompt = 'Fix all errors';
 
       const result = activateUltrawork(prompt, sessionId, tempDir);
-      expect(result).toBe(true);
+      expect(result.success).toBe(true);
 
       const state = readUltraworkState(tempDir);
       expect(state).not.toBeNull();
@@ -40,7 +41,7 @@ describe('Ultrawork Session Isolation (Issue #269)', () => {
       const prompt = 'Fix all errors';
 
       const result = activateUltrawork(prompt, undefined, tempDir);
-      expect(result).toBe(true);
+      expect(result.success).toBe(true);
 
       const state = readUltraworkState(tempDir);
       expect(state).not.toBeNull();
@@ -313,6 +314,132 @@ describe('Ultrawork Session Isolation (Issue #269)', () => {
       // Timestamps are ISO strings, compare as dates
       expect(new Date(updatedState?.last_checked_at || 0).getTime())
         .toBeGreaterThanOrEqual(new Date(initialTimestamp || 0).getTime());
+    });
+  });
+
+  describe('Concurrent session detection (Issue #386)', () => {
+    it('should return warning when activating while another session is active', () => {
+      const sessionA = 'session-alpha';
+      const sessionB = 'session-beta';
+
+      // Session A activates first
+      const resultA = activateUltrawork('Task A', sessionA, tempDir);
+      expect(resultA.success).toBe(true);
+      expect(resultA.warning).toBeUndefined();
+
+      // Session B activates while A is still active
+      const resultB = activateUltrawork('Task B', sessionB, tempDir);
+      expect(resultB.success).toBe(true);
+      expect(resultB.warning).toBeDefined();
+      expect(resultB.warning).toContain('Another ultrawork session was already active');
+      expect(resultB.warning).toContain('session-alpha');
+      expect(resultB.warning).toContain('Task A');
+      expect(resultB.previousSessionId).toBe(sessionA);
+    });
+
+    it('should NOT warn when same session re-activates', () => {
+      const sessionId = 'session-same';
+
+      // First activation
+      const result1 = activateUltrawork('Task 1', sessionId, tempDir);
+      expect(result1.success).toBe(true);
+      expect(result1.warning).toBeUndefined();
+
+      // Same session re-activates (e.g., user runs /ultrawork again)
+      const result2 = activateUltrawork('Task 2', sessionId, tempDir);
+      expect(result2.success).toBe(true);
+      expect(result2.warning).toBeUndefined();
+    });
+
+    it('should NOT warn when previous session state is stale (>2 hours)', async () => {
+      const sessionA = 'session-old';
+      const sessionB = 'session-new';
+
+      // Session A activates
+      activateUltrawork('Old task', sessionA, tempDir);
+
+      // Manually make the state stale by backdating timestamps
+      const state = readUltraworkState(tempDir);
+      if (state) {
+        const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+        state.started_at = threeHoursAgo;
+        state.last_checked_at = threeHoursAgo;
+        // Write directly to bypass activation logic
+        const { writeFileSync } = await import('fs');
+        const { join } = await import('path');
+        const stateFile = join(tempDir, '.omc', 'state', 'ultrawork-state.json');
+        writeFileSync(stateFile, JSON.stringify(state, null, 2));
+      }
+
+      // Session B activates - should NOT warn because A is stale
+      const resultB = activateUltrawork('New task', sessionB, tempDir);
+      expect(resultB.success).toBe(true);
+      expect(resultB.warning).toBeUndefined();
+    });
+
+    it('should NOT warn on first activation (clean state)', () => {
+      const result = activateUltrawork('First task', 'session-first', tempDir);
+      expect(result.success).toBe(true);
+      expect(result.warning).toBeUndefined();
+    });
+
+    it('should NOT warn after previous session deactivated', () => {
+      const sessionA = 'session-done';
+      const sessionB = 'session-next';
+
+      // Session A activates and then deactivates
+      activateUltrawork('Task A', sessionA, tempDir);
+      deactivateUltrawork(tempDir);
+
+      // Session B activates - no warning since A is gone
+      const resultB = activateUltrawork('Task B', sessionB, tempDir);
+      expect(resultB.success).toBe(true);
+      expect(resultB.warning).toBeUndefined();
+    });
+
+    it('should suggest /ultrapilot in the warning message', () => {
+      const sessionA = 'session-1';
+      const sessionB = 'session-2';
+
+      activateUltrawork('Task', sessionA, tempDir);
+      const result = activateUltrawork('Task', sessionB, tempDir);
+
+      expect(result.warning).toContain('/ultrapilot');
+      expect(result.warning).toContain('file ownership partitioning');
+    });
+  });
+
+  describe('checkExistingSession', () => {
+    it('should return null when no state exists', () => {
+      const result = checkExistingSession('any-session', tempDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when state is not active', () => {
+      activateUltrawork('Task', 'session-1', tempDir);
+      deactivateUltrawork(tempDir);
+
+      const result = checkExistingSession('session-2', tempDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for same session', () => {
+      const sessionId = 'same-session';
+      activateUltrawork('Task', sessionId, tempDir);
+
+      const result = checkExistingSession(sessionId, tempDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return existing session info for different session', () => {
+      const sessionA = 'session-existing';
+      activateUltrawork('Existing task', sessionA, tempDir);
+
+      const result = checkExistingSession('session-new', tempDir);
+      expect(result).not.toBeNull();
+      expect(result?.sessionId).toBe(sessionA);
+      expect(result?.prompt).toBe('Existing task');
+      expect(result?.startedAt).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Problem
Issue #386: Multi-session ultrawork causes cross-session contamination and state overwrites.

When running `/ultrawork` in multiple Claude Code sessions within the same project directory, sessions can interfere with each other, leading to:
1. Cross-session state contamination
2. State overwrites
3. Unexpected task execution

## Root Cause
- Swarm state SQLite uses single row (id=1) - all sessions share it
- State files are per-project, not per-session
- No runtime warning when another session is active

## Solution
Added runtime detection and warning:
- Check if another ultrawork session is already active
- Warn user about potential conflicts
- Suggest using `/ultrapilot` for multi-session work

## Testing
✅ All tests pass
✅ Warning triggers when concurrent session detected
✅ Session isolation tests added

Fixes #386

---

**Note:** This is a re-submission to `dev` branch. Original PR #389 was accidentally merged to `main` and has been reverted via PR #392.