### PR TITLE
fix(docs): correct execution modes docs link

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -59,7 +59,7 @@ Eso es todo. Todo lo demás es automático.
 ## Características
 
 ### Modos de Ejecución
-Múltiples estrategias para diferentes casos de uso - desde construcciones completamente autónomas hasta refactorización eficiente en tokens. [Aprende más →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+Múltiples estrategias para diferentes casos de uso - desde construcciones completamente autónomas hasta refactorización eficiente en tokens. [Aprende más →](https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#execution-modes)
 
 | Modo | Velocidad | Usar Para |
 |------|-------|---------|

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,7 +59,7 @@ autopilot: build a REST API for managing tasks
 ## 機能
 
 ### 実行モード
-用途に応じた複数の戦略 - 完全自律ビルドからトークン効率の良いリファクタリングまで。[詳しくはこちら →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+用途に応じた複数の戦略 - 完全自律ビルドからトークン効率の良いリファクタリングまで。[詳しくはこちら →](https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#execution-modes)
 
 | モード | スピード | 用途 |
 |------|-------|------|

--- a/README.ko.md
+++ b/README.ko.md
@@ -59,7 +59,7 @@ autopilot: build a REST API for managing tasks
 ## 기능
 
 ### 실행 모드
-다양한 사용 사례를 위한 여러 전략 - 완전 자율 빌드부터 토큰 효율적인 리팩토링까지. [자세히 보기 →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+다양한 사용 사례를 위한 여러 전략 - 완전 자율 빌드부터 토큰 효율적인 리팩토링까지. [자세히 보기 →](https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#execution-modes)
 
 | 모드 | 속도 | 용도 |
 |------|-------|---------|

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ That's it. Everything else is automatic.
 ## Features
 
 ### Execution Modes
-Multiple strategies for different use cases - from fully autonomous builds to token-efficient refactoring. [Learn more →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+Multiple strategies for different use cases - from fully autonomous builds to token-efficient refactoring. [Learn more →](https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#execution-modes)
 
 | Mode | Speed | Use For |
 |------|-------|---------|

--- a/README.zh.md
+++ b/README.zh.md
@@ -59,7 +59,7 @@ autopilot: build a REST API for managing tasks
 ## 功能特性
 
 ### 执行模式
-针对不同场景的多种策略 - 从全自动构建到 token 高效重构。[了解更多 →](https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes)
+针对不同场景的多种策略 - 从全自动构建到 token 高效重构。[了解更多 →](https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#execution-modes)
 
 | 模式 | 速度 | 适用场景 |
 |------|-------|---------|


### PR DESCRIPTION
## Summary
Fix incorrect docs links for the "Execution Modes" section across translated READMEs.

## Changes
- Update the links:
  - From: `https://yeachan-heo.github.io/oh-my-claudecode-website/execution-modes`
  - To: `https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#execution-modes`

## Files changed
- README.md
- README.ko.md
- README.ja.md
- README.es.md
- README.zh.md

## Verification
- Checked that all READMEs point to the same valid docs anchor for execution modes.