### PR TITLE
feat(mcp): add prompt_file and output_file to ask_gemini/ask_codex

### DIFF
--- a/bridge/codex-server.cjs
+++ b/bridge/codex-server.cjs
@@ -14187,7 +14187,7 @@ ${(0, import_fs4.readFileSync)(resolvedReal, "utf-8")}`;
   }
 }
 async function handleAskCodex(args) {
-  const { prompt, agent_role, model = CODEX_DEFAULT_MODEL, context_files } = args;
+  const { agent_role, model = CODEX_DEFAULT_MODEL, context_files } = args;
   if (!agent_role || !CODEX_VALID_ROLES.includes(agent_role)) {
     return {
       content: [{
@@ -14196,6 +14196,64 @@ async function handleAskCodex(args) {
       }],
       isError: true
     };
+  }
+  if (args.prompt && args.prompt_file) {
+    return {
+      content: [{ type: "text", text: "Cannot specify both prompt and prompt_file. Use one or the other." }],
+      isError: true
+    };
+  }
+  let resolvedPrompt;
+  if (args.prompt_file) {
+    const resolvedPath = (0, import_path4.resolve)(args.prompt_file);
+    const cwd = process.cwd();
+    const cwdReal = (0, import_fs4.realpathSync)(cwd);
+    const relPath = (0, import_path4.relative)(cwdReal, resolvedPath);
+    if (relPath === "" || relPath === ".." || relPath.startsWith(".." + import_path4.sep)) {
+      return {
+        content: [{ type: "text", text: `prompt_file '${args.prompt_file}' is outside the working directory.` }],
+        isError: true
+      };
+    }
+    try {
+      resolvedPrompt = (0, import_fs4.readFileSync)(resolvedPath, "utf-8");
+    } catch (err) {
+      return {
+        content: [{ type: "text", text: `Failed to read prompt_file '${args.prompt_file}': ${err.message}` }],
+        isError: true
+      };
+    }
+    try {
+      const resolvedReal = (0, import_fs4.realpathSync)(resolvedPath);
+      const relReal = (0, import_path4.relative)(cwdReal, resolvedReal);
+      if (relReal === "" || relReal === ".." || relReal.startsWith(".." + import_path4.sep)) {
+        return {
+          content: [{ type: "text", text: `prompt_file '${args.prompt_file}' resolves to a path outside the working directory.` }],
+          isError: true
+        };
+      }
+    } catch {
+    }
+    if (!resolvedPrompt.trim()) {
+      return {
+        content: [{ type: "text", text: `prompt_file '${args.prompt_file}' is empty.` }],
+        isError: true
+      };
+    }
+  } else if (args.prompt) {
+    resolvedPrompt = args.prompt;
+  } else {
+    return {
+      content: [{ type: "text", text: "Either prompt or prompt_file is required." }],
+      isError: true
+    };
+  }
+  let userPrompt = resolvedPrompt;
+  if (args.output_file) {
+    const outputPath = (0, import_path4.resolve)(args.output_file);
+    userPrompt = `IMPORTANT: Write your complete response to the file: ${outputPath}
+
+${resolvedPrompt}`;
   }
   const detection = detectCodexCli();
   if (!detection.available) {
@@ -14223,13 +14281,13 @@ ${detection.installHint}`
     }
     fileContext = context_files.map((f) => validateAndReadFile(f)).join("\n\n");
   }
-  const fullPrompt = buildPromptWithSystemContext(prompt, fileContext, resolvedSystemPrompt);
+  const fullPrompt = buildPromptWithSystemContext(userPrompt, fileContext, resolvedSystemPrompt);
   const promptResult = persistPrompt({
     provider: "codex",
     agentRole: agent_role,
     model,
     files: context_files,
-    prompt,
+    prompt: resolvedPrompt,
     fullPrompt
   });
   const expectedResponsePath = promptResult ? getExpectedResponsePath("codex", promptResult.slug, promptResult.id) : void 0;
@@ -14292,6 +14350,29 @@ ${detection.installHint}`
         response
       });
     }
+    if (args.output_file) {
+      const outputPath = (0, import_path4.resolve)(args.output_file);
+      const cwd = process.cwd();
+      const cwdReal = (0, import_fs4.realpathSync)(cwd);
+      const relOutput = (0, import_path4.relative)(cwdReal, outputPath);
+      if (relOutput === "" || relOutput === ".." || relOutput.startsWith(".." + import_path4.sep)) {
+        console.warn(`[codex-core] output_file '${args.output_file}' is outside the working directory, skipping write.`);
+      } else {
+        try {
+          if (!(0, import_fs4.existsSync)(outputPath)) {
+            const rawPath = `${outputPath}.raw`;
+            const rawDir = (0, import_path4.dirname)(rawPath);
+            const relRawDir = (0, import_path4.relative)(cwdReal, rawDir);
+            if (!(relRawDir === "" || relRawDir === ".." || relRawDir.startsWith(".." + import_path4.sep))) {
+              (0, import_fs4.mkdirSync)(rawDir, { recursive: true });
+              (0, import_fs4.writeFileSync)(rawPath, response, "utf-8");
+            }
+          }
+        } catch (err) {
+          console.warn(`[codex-core] Failed to write output file: ${err.message}`);
+        }
+      }
+    }
     return {
       content: [{
         type: "text",
@@ -14329,12 +14410,14 @@ var askCodexTool = {
         enum: CODEX_VALID_ROLES,
         description: `Required. Agent perspective for Codex: ${CODEX_VALID_ROLES.join(", ")}. Codex is optimized for analytical/planning tasks.`
       },
+      prompt_file: { type: "string", description: "Path to file containing the prompt (alternative to prompt parameter)" },
+      output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written to {output_file}.raw" },
       context_files: { type: "array", items: { type: "string" }, description: "File paths to include as context (contents will be prepended to prompt)" },
       prompt: { type: "string", description: "The prompt to send to Codex" },
       model: { type: "string", description: `Codex model to use (default: ${CODEX_DEFAULT_MODEL}). Set OMC_CODEX_DEFAULT_MODEL env var to change default.` },
       background: { type: "boolean", description: "Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion." }
     },
-    required: ["prompt", "agent_role"]
+    required: ["agent_role"]
   }
 };
 var server = new Server(
@@ -14349,8 +14432,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (name !== "ask_codex") {
     return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };
   }
-  const { prompt, agent_role, model, context_files, background } = args ?? {};
-  return handleAskCodex({ prompt, agent_role, model, context_files, background });
+  const { prompt, prompt_file, output_file, agent_role, model, context_files, background } = args ?? {};
+  return handleAskCodex({ prompt, prompt_file, output_file, agent_role, model, context_files, background });
 });
 async function main() {
   const transport = new StdioServerTransport();

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -255,6 +255,24 @@ When you detect trigger patterns above, you MUST invoke the corresponding skill 
 - For parallel work, delegate to agents via Task tool with `run_in_background: true`
 - Agents calling Codex/Gemini should be spawned in background when orchestrator needs to continue other work
 
+**Tool Parameters (both ask_gemini and ask_codex):**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_role` | string | Yes | Agent perspective (see routing table above) |
+| `prompt_file` | string | No* | Path to file containing prompt (*required if `prompt` not provided) |
+| `output_file` | string | No | Path to write response; fallback: stdout saved to `{output_file}.raw` |
+| `files` / `context_files` | array | No | File paths to include as context |
+| `prompt` | string | No* | Inline prompt (*required if `prompt_file` not provided) |
+| `model` | string | No | Model to use (has defaults and fallback chains) |
+| `background` | boolean | No | Run in background (non-blocking) |
+
+**Notes:**
+- `prompt` and `prompt_file` are mutually exclusive — providing both returns an error
+- When `output_file` is specified, the prompt includes an instruction nudging the CLI to write there
+- If the CLI doesn't write to `output_file`, stdout is captured and written to `{output_file}.raw`
+- `prompt_file` must be within the project working directory (security boundary)
+
 ### OMC State Tools
 
 All state stored at `{worktree}/.omc/state/{mode}-state.json`. Never in `~/.claude/`.

--- a/src/mcp/codex-server.ts
+++ b/src/mcp/codex-server.ts
@@ -14,24 +14,27 @@ import { handleAskCodex, CODEX_DEFAULT_MODEL, CODEX_VALID_ROLES } from './codex-
 // Define the ask_codex tool using the SDK tool() helper
 const askCodexTool = tool(
   "ask_codex",
-  "`Send a prompt to OpenAI Codex CLI for analytical/planning tasks. Codex excels at architecture review, planning validation, critical analysis, and code/security review validation. Requires agent_role to specify the perspective (${CODEX_VALID_ROLES.join(', ')}). Requires Codex CLI (npm install -g @openai/codex).`",
+  `Send a prompt to OpenAI Codex CLI for analytical/planning tasks. Codex excels at architecture review, planning validation, critical analysis, and code/security review validation. Requires agent_role to specify the perspective (${CODEX_VALID_ROLES.join(', ')}). Requires Codex CLI (npm install -g @openai/codex).`,
   {
     agent_role: { type: "string", description: `Required. Agent perspective for Codex: ${CODEX_VALID_ROLES.join(', ')}. Codex is optimized for analytical/planning tasks.` },
+    prompt_file: { type: "string", description: "Path to file containing the prompt (alternative to prompt parameter)" },
+    output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written to {output_file}.raw" },
     context_files: { type: "array", items: { type: "string" }, description: "File paths to include as context (contents will be prepended to prompt)" },
     prompt: { type: "string", description: "The prompt to send to Codex" },
     model: { type: "string", description: `Codex model to use (default: ${CODEX_DEFAULT_MODEL}). Set OMC_CODEX_DEFAULT_MODEL env var to change default.` },
     background: { type: "boolean", description: "Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion." },
   } as any,
   async (args: any) => {
-    const { prompt, agent_role, model, context_files, background } = args as {
-      prompt: string;
+    const { prompt, prompt_file, output_file, agent_role, model, context_files, background } = args as {
+      prompt?: string;
+      prompt_file?: string;
+      output_file?: string;
       agent_role: string;
       model?: string;
       context_files?: string[];
       background?: boolean;
     };
-
-    return handleAskCodex({ prompt, agent_role, model, context_files, background });
+    return handleAskCodex({ prompt, prompt_file, output_file, agent_role, model, context_files, background });
   }
 );
 

--- a/src/mcp/codex-standalone-server.ts
+++ b/src/mcp/codex-standalone-server.ts
@@ -28,12 +28,14 @@ const askCodexTool = {
         enum: CODEX_VALID_ROLES,
         description: `Required. Agent perspective for Codex: ${CODEX_VALID_ROLES.join(', ')}. Codex is optimized for analytical/planning tasks.`
       },
+      prompt_file: { type: 'string', description: 'Path to file containing the prompt (alternative to prompt parameter)' },
+      output_file: { type: 'string', description: 'Path to write response. If CLI doesn\'t write here, stdout is written to {output_file}.raw' },
       context_files: { type: 'array', items: { type: 'string' }, description: 'File paths to include as context (contents will be prepended to prompt)' },
       prompt: { type: 'string', description: 'The prompt to send to Codex' },
       model: { type: 'string', description: `Codex model to use (default: ${CODEX_DEFAULT_MODEL}). Set OMC_CODEX_DEFAULT_MODEL env var to change default.` },
       background: { type: 'boolean', description: 'Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion.' },
     },
-    required: ['prompt', 'agent_role'],
+    required: ['agent_role'],
   },
 };
 
@@ -51,14 +53,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (name !== 'ask_codex') {
     return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
   }
-  const { prompt, agent_role, model, context_files, background } = (args ?? {}) as {
-    prompt: string;
+  const { prompt, prompt_file, output_file, agent_role, model, context_files, background } = (args ?? {}) as {
+    prompt?: string;
+    prompt_file?: string;
+    output_file?: string;
     agent_role: string;
     model?: string;
     context_files?: string[];
     background?: boolean;
   };
-  return handleAskCodex({ prompt, agent_role, model, context_files, background });
+  return handleAskCodex({ prompt, prompt_file, output_file, agent_role, model, context_files, background });
 });
 
 async function main() {

--- a/src/mcp/gemini-core.ts
+++ b/src/mcp/gemini-core.ts
@@ -13,8 +13,8 @@
  */
 
 import { spawn } from 'child_process';
-import { readFileSync, realpathSync, statSync } from 'fs';
-import { resolve, relative, sep } from 'path';
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'fs';
+import { dirname, resolve, relative, sep } from 'path';
 import { detectGeminiCli } from './cli-detection.js';
 import { resolveSystemPrompt, buildPromptWithSystemContext } from './prompt-injection.js';
 import { persistPrompt, persistResponse, getExpectedResponsePath } from './prompt-persistence.js';
@@ -288,13 +288,15 @@ export function validateAndReadFile(filePath: string): string {
  * @returns MCP-compatible response with content array
  */
 export async function handleAskGemini(args: {
-  prompt: string;
+  prompt?: string;
+  prompt_file?: string;
+  output_file?: string;
   agent_role: string;
   model?: string;
   files?: string[];
   background?: boolean;
 }): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
-  const { prompt, agent_role, model = GEMINI_DEFAULT_MODEL, files } = args;
+  const { agent_role, model = GEMINI_DEFAULT_MODEL, files } = args;
 
   // Validate agent_role
   if (!agent_role || !(GEMINI_VALID_ROLES as readonly string[]).includes(agent_role)) {
@@ -305,6 +307,71 @@ export async function handleAskGemini(args: {
       }],
       isError: true
     };
+  }
+
+  // Validate mutual exclusion of prompt and prompt_file
+  if (args.prompt && args.prompt_file) {
+    return {
+      content: [{ type: 'text' as const, text: 'Cannot specify both prompt and prompt_file. Use one or the other.' }],
+      isError: true
+    };
+  }
+
+  // Resolve prompt from prompt_file or inline prompt
+  let resolvedPrompt: string;
+  if (args.prompt_file) {
+    const resolvedPath = resolve(args.prompt_file);
+    const cwd = process.cwd();
+    const cwdReal = realpathSync(cwd);
+    const relPath = relative(cwdReal, resolvedPath);
+    if (relPath === '' || relPath === '..' || relPath.startsWith('..' + sep)) {
+      return {
+        content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' is outside the working directory.` }],
+        isError: true
+      };
+    }
+    try {
+      resolvedPrompt = readFileSync(resolvedPath, 'utf-8');
+    } catch (err) {
+      return {
+        content: [{ type: 'text' as const, text: `Failed to read prompt_file '${args.prompt_file}': ${(err as Error).message}` }],
+        isError: true
+      };
+    }
+    // Symlink-safe check
+    try {
+      const resolvedReal = realpathSync(resolvedPath);
+      const relReal = relative(cwdReal, resolvedReal);
+      if (relReal === '' || relReal === '..' || relReal.startsWith('..' + sep)) {
+        return {
+          content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' resolves to a path outside the working directory.` }],
+          isError: true
+        };
+      }
+    } catch {
+      // If realpathSync fails, the file was already read successfully, so continue
+    }
+    // Check for empty prompt
+    if (!resolvedPrompt.trim()) {
+      return {
+        content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' is empty.` }],
+        isError: true
+      };
+    }
+  } else if (args.prompt) {
+    resolvedPrompt = args.prompt;
+  } else {
+    return {
+      content: [{ type: 'text' as const, text: 'Either prompt or prompt_file is required.' }],
+      isError: true
+    };
+  }
+
+  // If output_file specified, nudge the prompt to write there
+  let userPrompt = resolvedPrompt;
+  if (args.output_file) {
+    const outputPath = resolve(args.output_file);
+    userPrompt = `IMPORTANT: Write your complete response to the file: ${outputPath}\n\n${resolvedPrompt}`;
   }
 
   // Check CLI availability
@@ -338,7 +405,7 @@ export async function handleAskGemini(args: {
   }
 
   // Combine: system prompt > file context > user prompt
-  const fullPrompt = buildPromptWithSystemContext(prompt, fileContext, resolvedSystemPrompt);
+  const fullPrompt = buildPromptWithSystemContext(userPrompt, fileContext, resolvedSystemPrompt);
 
   // Persist prompt for audit trail (once, before fallback loop)
   const promptResult = persistPrompt({
@@ -346,7 +413,7 @@ export async function handleAskGemini(args: {
     agentRole: agent_role,
     model,
     files,
-    prompt,
+    prompt: resolvedPrompt,
     fullPrompt,
   });
 
@@ -443,6 +510,34 @@ export async function handleAskGemini(args: {
           usedFallback,
           fallbackModel: usedFallback ? tryModel : undefined,
         });
+      }
+
+      // Handle output_file: check if CLI wrote it, otherwise write stdout to .raw
+      if (args.output_file) {
+        const outputPath = resolve(args.output_file);
+
+        // Security: validate output_file is within working directory
+        const cwd = process.cwd();
+        const cwdReal = realpathSync(cwd);
+        const relOutput = relative(cwdReal, outputPath);
+        if (relOutput === '' || relOutput === '..' || relOutput.startsWith('..' + sep)) {
+          console.warn(`[gemini-core] output_file '${args.output_file}' is outside the working directory, skipping write.`);
+        } else {
+          try {
+            if (!existsSync(outputPath)) {
+              const rawPath = `${outputPath}.raw`;
+              // Only create directories within boundary
+              const rawDir = dirname(rawPath);
+              const relRawDir = relative(cwdReal, rawDir);
+              if (!(relRawDir === '' || relRawDir === '..' || relRawDir.startsWith('..' + sep))) {
+                mkdirSync(rawDir, { recursive: true });
+                writeFileSync(rawPath, response, 'utf-8');
+              }
+            }
+          } catch (err) {
+            console.warn(`[gemini-core] Failed to write output file: ${(err as Error).message}`);
+          }
+        }
       }
 
       return {

--- a/src/mcp/gemini-server.ts
+++ b/src/mcp/gemini-server.ts
@@ -19,24 +19,27 @@ import {
 // Define the ask_gemini tool using the SDK tool() helper
 const askGeminiTool = tool(
   "ask_gemini",
-  "Send a prompt to Google Gemini CLI for design review or implementation validation. Gemini excels at analyzing large codebases with its 1M token context window. Requires agent_role to specify the perspective (designer, writer, or vision). Requires Gemini CLI (npm install -g @google/gemini-cli).",
+  "Send a prompt to Google Gemini CLI for design/implementation tasks. Gemini excels at frontend design review and implementation with its 1M token context window. Requires agent_role (designer, writer, vision). Fallback chain: gemini-3-pro-preview → gemini-3-flash-preview → gemini-2.5-pro → gemini-2.5-flash. Requires Gemini CLI (npm install -g @google/gemini-cli).",
   {
-    agent_role: { type: "string", description: `Required. Agent perspective for Gemini: ${GEMINI_VALID_ROLES.join(', ')}. Gemini is optimized for design review and implementation tasks.` },
-    files: { type: "array", items: { type: "string" }, description: "File paths for Gemini to analyze (leverages 1M token context window)" },
+    agent_role: { type: "string", description: `Required. Agent perspective for Gemini: ${GEMINI_VALID_ROLES.join(', ')}. Gemini is optimized for design/implementation tasks with large context.` },
+    prompt_file: { type: "string", description: "Path to file containing the prompt (alternative to prompt parameter)" },
+    output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written to {output_file}.raw" },
+    files: { type: "array", items: { type: "string" }, description: "File paths to include as context (contents will be prepended to prompt)" },
     prompt: { type: "string", description: "The prompt to send to Gemini" },
-    model: { type: "string", description: `Gemini model to use (default: ${GEMINI_DEFAULT_MODEL}). Automatic fallback chain: ${GEMINI_MODEL_FALLBACKS.join(' → ')}` },
+    model: { type: "string", description: `Gemini model to use (default: ${GEMINI_DEFAULT_MODEL}). Set OMC_GEMINI_DEFAULT_MODEL env var to change default. Auto-fallback chain: ${GEMINI_MODEL_FALLBACKS.join(' → ')}.` },
     background: { type: "boolean", description: "Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion." },
   } as any,
   async (args: any) => {
-    const { prompt, agent_role, model, files, background } = args as {
-      prompt: string;
+    const { prompt, prompt_file, output_file, agent_role, model, files, background } = args as {
+      prompt?: string;
+      prompt_file?: string;
+      output_file?: string;
       agent_role: string;
       model?: string;
       files?: string[];
       background?: boolean;
     };
-
-    return handleAskGemini({ prompt, agent_role, model, files, background });
+    return handleAskGemini({ prompt, prompt_file, output_file, agent_role, model, files, background });
   }
 );
 

--- a/src/mcp/gemini-standalone-server.ts
+++ b/src/mcp/gemini-standalone-server.ts
@@ -29,12 +29,14 @@ const askGeminiTool = {
         enum: GEMINI_VALID_ROLES,
         description: `Required. Agent perspective for Gemini: ${GEMINI_VALID_ROLES.join(', ')}. Gemini is optimized for design/implementation tasks with large context.`
       },
+      prompt_file: { type: 'string', description: 'Path to file containing the prompt (alternative to prompt parameter)' },
+      output_file: { type: 'string', description: 'Path to write response. If CLI doesn\'t write here, stdout is written to {output_file}.raw' },
       files: { type: 'array', items: { type: 'string' }, description: 'File paths to include as context (contents will be prepended to prompt)' },
       prompt: { type: 'string', description: 'The prompt to send to Gemini' },
       model: { type: 'string', description: `Gemini model to use (default: ${GEMINI_DEFAULT_MODEL}). Set OMC_GEMINI_DEFAULT_MODEL env var to change default. Auto-fallback chain: ${GEMINI_MODEL_FALLBACKS.join(' → ')}.` },
       background: { type: 'boolean', description: 'Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion.' },
     },
-    required: ['prompt', 'agent_role'],
+    required: ['agent_role'],
   },
 };
 
@@ -52,14 +54,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (name !== 'ask_gemini') {
     return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
   }
-  const { prompt, agent_role, model, files, background } = (args ?? {}) as {
-    prompt: string;
+  const { prompt, prompt_file, output_file, agent_role, model, files, background } = (args ?? {}) as {
+    prompt?: string;
+    prompt_file?: string;
+    output_file?: string;
     agent_role: string;
     model?: string;
     files?: string[];
     background?: boolean;
   };
-  return handleAskGemini({ prompt, agent_role, model, files, background });
+  return handleAskGemini({ prompt, prompt_file, output_file, agent_role, model, files, background });
 });
 
 async function main() {


### PR DESCRIPTION
## Summary

- Add `prompt_file` parameter to read prompt from file instead of inline text
- Add `output_file` parameter to specify response destination with `.raw` fallback
- Security validation ensures `prompt_file` is within the working directory boundary
- Mutual exclusion: returns error if both `prompt` and `prompt_file` specified
- Schema parameter ordering optimized for live tooling readability: `agent_role`, `prompt_file`, `output_file`, `files`/`context_files`, `prompt`, `model`, `background`
- Updated all 4 server files (SDK and standalone) and docs/CLAUDE.md

## Test plan

- [ ] Call `ask_gemini` with `prompt_file` pointing to a valid file — verify prompt is read from file
- [ ] Call `ask_codex` with `prompt_file` pointing to a valid file — verify prompt is read from file
- [ ] Call with both `prompt` and `prompt_file` — verify mutual exclusion error
- [ ] Call with `output_file` — verify nudge instruction appears in prompt
- [ ] Call with `output_file` when CLI doesn't write the file — verify `.raw` fallback
- [ ] Call with `prompt_file` outside working directory — verify security rejection
- [ ] Call with only `prompt` (no `prompt_file`) — verify backward compatibility
- [ ] Run `npm run build` — verify no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)