### PR TITLE
fix(hud,lsp): fix token formatting threshold and goto_definition null safety

### DIFF
--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -18388,8 +18388,12 @@ function formatRange(range) {
   return start === end ? start : `${start}-${end}`;
 }
 function formatLocation(location) {
-  const path10 = uriToPath(location.uri);
-  const range = formatRange(location.range);
+  const uri = location.uri || location.targetUri;
+  if (!uri) return "Unknown location";
+  const path10 = uriToPath(uri);
+  const locationRange = location.range || location.targetRange || location.targetSelectionRange;
+  if (!locationRange) return path10;
+  const range = formatRange(locationRange);
   return `${path10}:${range}`;
 }
 function formatHover(hover) {

--- a/src/hud/analytics-display.ts
+++ b/src/hud/analytics-display.ts
@@ -95,7 +95,7 @@ export async function getAnalyticsDisplay(): Promise<AnalyticsDisplay> {
  * Format token count with K/M suffix for readability.
  */
 function formatTokenCount(tokens: number): string {
-  if (tokens < 1000) return `${tokens / 1000}k`;
+  if (tokens < 1000) return `${tokens}`;
   if (tokens < 1000000) return `${(tokens / 1000).toFixed(1)}k`;
   return `${(tokens / 1000000).toFixed(2)}M`;
 }

--- a/src/tools/lsp/utils.ts
+++ b/src/tools/lsp/utils.ts
@@ -78,8 +78,12 @@ export function formatRange(range: Range): string {
  * Format a location for display
  */
 export function formatLocation(location: Location): string {
-  const path = uriToPath(location.uri);
-  const range = formatRange(location.range);
+  const uri = location.uri || (location as any).targetUri;
+  if (!uri) return 'Unknown location';
+  const path = uriToPath(uri);
+  const locationRange = location.range || (location as any).targetRange || (location as any).targetSelectionRange;
+  if (!locationRange) return path;
+  const range = formatRange(locationRange);
   return `${path}:${range}`;
 }
 


### PR DESCRIPTION
## Summary

- **HUD analytics**: `formatTokenCount()` returned `"0.999k"` for values < 1000 instead of plain numbers (e.g., `"999"`)
- **LSP goto_definition**: `formatLocation()` crashed with `Cannot read properties of undefined (reading 'startsWith')` when LSP returned `LocationLink` objects

## Changes

### `src/hud/analytics-display.ts`
- Fixed threshold in `formatTokenCount()` to return raw number for < 1000 tokens

### `src/tools/lsp/utils.ts`
- Added fallback chain in `formatLocation()` to handle both `Location` and `LocationLink` LSP response types
- `LocationLink` uses `targetUri`/`targetRange` instead of `uri`/`range`

## Test plan

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] HUD analytics tests pass (32/32, was 31/32 before fix)
- [x] LSP tools still functional (verified with hover, references, symbols)

🤖 Generated with [Claude Code](https://claude.com/claude-code)