### PR TITLE
fix(mcp): write output_file directly instead of .raw suffix

### DIFF
--- a/bridge/codex-server.cjs
+++ b/bridge/codex-server.cjs
@@ -14360,12 +14360,11 @@ ${detection.installHint}`
       } else {
         try {
           if (!(0, import_fs4.existsSync)(outputPath)) {
-            const rawPath = `${outputPath}.raw`;
-            const rawDir = (0, import_path4.dirname)(rawPath);
-            const relRawDir = (0, import_path4.relative)(cwdReal, rawDir);
-            if (!(relRawDir === "" || relRawDir === ".." || relRawDir.startsWith(".." + import_path4.sep))) {
-              (0, import_fs4.mkdirSync)(rawDir, { recursive: true });
-              (0, import_fs4.writeFileSync)(rawPath, response, "utf-8");
+            const outDir = (0, import_path4.dirname)(outputPath);
+            const relOutDir = (0, import_path4.relative)(cwdReal, outDir);
+            if (!(relOutDir === "" || relOutDir === ".." || relOutDir.startsWith(".." + import_path4.sep))) {
+              (0, import_fs4.mkdirSync)(outDir, { recursive: true });
+              (0, import_fs4.writeFileSync)(outputPath, response, "utf-8");
             }
           }
         } catch (err) {

--- a/bridge/gemini-server.cjs
+++ b/bridge/gemini-server.cjs
@@ -14362,12 +14362,11 @@ ${detection.installHint}`
         } else {
           try {
             if (!(0, import_fs4.existsSync)(outputPath)) {
-              const rawPath = `${outputPath}.raw`;
-              const rawDir = (0, import_path4.dirname)(rawPath);
-              const relRawDir = (0, import_path4.relative)(cwdReal, rawDir);
-              if (!(relRawDir === "" || relRawDir === ".." || relRawDir.startsWith(".." + import_path4.sep))) {
-                (0, import_fs4.mkdirSync)(rawDir, { recursive: true });
-                (0, import_fs4.writeFileSync)(rawPath, response, "utf-8");
+              const outDir = (0, import_path4.dirname)(outputPath);
+              const relOutDir = (0, import_path4.relative)(cwdReal, outDir);
+              if (!(relOutDir === "" || relOutDir === ".." || relOutDir.startsWith(".." + import_path4.sep))) {
+                (0, import_fs4.mkdirSync)(outDir, { recursive: true });
+                (0, import_fs4.writeFileSync)(outputPath, response, "utf-8");
               }
             }
           } catch (err) {

--- a/src/mcp/codex-core.ts
+++ b/src/mcp/codex-core.ts
@@ -503,7 +503,7 @@ export async function handleAskCodex(args: {
       });
     }
 
-    // Handle output_file: check if CLI wrote it, otherwise write stdout to .raw
+    // Handle output_file: if CLI didn't write it, write stdout there directly
     if (args.output_file) {
       const outputPath = resolve(args.output_file);
 
@@ -516,13 +516,11 @@ export async function handleAskCodex(args: {
       } else {
         try {
           if (!existsSync(outputPath)) {
-            const rawPath = `${outputPath}.raw`;
-            // Only create directories within boundary
-            const rawDir = dirname(rawPath);
-            const relRawDir = relative(cwdReal, rawDir);
-            if (!(relRawDir === '' || relRawDir === '..' || relRawDir.startsWith('..' + sep))) {
-              mkdirSync(rawDir, { recursive: true });
-              writeFileSync(rawPath, response, 'utf-8');
+            const outDir = dirname(outputPath);
+            const relOutDir = relative(cwdReal, outDir);
+            if (!(relOutDir === '' || relOutDir === '..' || relOutDir.startsWith('..' + sep))) {
+              mkdirSync(outDir, { recursive: true });
+              writeFileSync(outputPath, response, 'utf-8');
             }
           }
         } catch (err) {

--- a/src/mcp/gemini-core.ts
+++ b/src/mcp/gemini-core.ts
@@ -512,7 +512,7 @@ export async function handleAskGemini(args: {
         });
       }
 
-      // Handle output_file: check if CLI wrote it, otherwise write stdout to .raw
+      // Handle output_file: if CLI didn't write it, write stdout there directly
       if (args.output_file) {
         const outputPath = resolve(args.output_file);
 
@@ -525,13 +525,11 @@ export async function handleAskGemini(args: {
         } else {
           try {
             if (!existsSync(outputPath)) {
-              const rawPath = `${outputPath}.raw`;
-              // Only create directories within boundary
-              const rawDir = dirname(rawPath);
-              const relRawDir = relative(cwdReal, rawDir);
-              if (!(relRawDir === '' || relRawDir === '..' || relRawDir.startsWith('..' + sep))) {
-                mkdirSync(rawDir, { recursive: true });
-                writeFileSync(rawPath, response, 'utf-8');
+              const outDir = dirname(outputPath);
+              const relOutDir = relative(cwdReal, outDir);
+              if (!(relOutDir === '' || relOutDir === '..' || relOutDir.startsWith('..' + sep))) {
+                mkdirSync(outDir, { recursive: true });
+                writeFileSync(outputPath, response, 'utf-8');
               }
             }
           } catch (err) {


### PR DESCRIPTION
## Summary
- Simplify output_file handling by writing directly to the specified path instead of adding a `.raw` suffix
- Provides consistent behavior for callers — always read from `output_file`, no guessing

## Changes
- If CLI writes the file, it stays as-is
- If CLI doesn't write it, we write stdout to the same path (not `.raw`)
- Caller always reads from `output_file`

## Test plan
- [ ] Test `output_file` with Gemini — verify file created at exact path
- [ ] Test `output_file` with Codex — verify file created at exact path

🤖 Generated with [Claude Code](https://claude.com/claude-code)