### PR TITLE
feat(mcp)!: require prompt_file, remove deprecated prompt parameter

### DIFF
--- a/bridge/codex-server.cjs
+++ b/bridge/codex-server.cjs
@@ -14197,54 +14197,56 @@ async function handleAskCodex(args) {
       isError: true
     };
   }
-  if (args.prompt && args.prompt_file) {
+  if ("prompt" in args) {
     return {
-      content: [{ type: "text", text: "Cannot specify both prompt and prompt_file. Use one or the other." }],
+      content: [{ type: "text", text: "The 'prompt' parameter has been removed. Write the prompt to a file (recommended: .omc/prompts/) and pass 'prompt_file' instead." }],
+      isError: true
+    };
+  }
+  if (!args.prompt_file || !args.prompt_file.trim()) {
+    return {
+      content: [{ type: "text", text: "prompt_file is required." }],
       isError: true
     };
   }
   let resolvedPrompt;
-  if (args.prompt_file) {
-    const resolvedPath = (0, import_path4.resolve)(args.prompt_file);
-    const cwd = process.cwd();
-    const cwdReal = (0, import_fs4.realpathSync)(cwd);
-    const relPath = (0, import_path4.relative)(cwdReal, resolvedPath);
-    if (relPath === "" || relPath === ".." || relPath.startsWith(".." + import_path4.sep)) {
-      return {
-        content: [{ type: "text", text: `prompt_file '${args.prompt_file}' is outside the working directory.` }],
-        isError: true
-      };
-    }
-    try {
-      resolvedPrompt = (0, import_fs4.readFileSync)(resolvedPath, "utf-8");
-    } catch (err) {
-      return {
-        content: [{ type: "text", text: `Failed to read prompt_file '${args.prompt_file}': ${err.message}` }],
-        isError: true
-      };
-    }
-    try {
-      const resolvedReal = (0, import_fs4.realpathSync)(resolvedPath);
-      const relReal = (0, import_path4.relative)(cwdReal, resolvedReal);
-      if (relReal === "" || relReal === ".." || relReal.startsWith(".." + import_path4.sep)) {
-        return {
-          content: [{ type: "text", text: `prompt_file '${args.prompt_file}' resolves to a path outside the working directory.` }],
-          isError: true
-        };
-      }
-    } catch {
-    }
-    if (!resolvedPrompt.trim()) {
-      return {
-        content: [{ type: "text", text: `prompt_file '${args.prompt_file}' is empty.` }],
-        isError: true
-      };
-    }
-  } else if (args.prompt) {
-    resolvedPrompt = args.prompt;
-  } else {
+  const resolvedPath = (0, import_path4.resolve)(args.prompt_file);
+  const cwd = process.cwd();
+  const cwdReal = (0, import_fs4.realpathSync)(cwd);
+  const relPath = (0, import_path4.relative)(cwdReal, resolvedPath);
+  if (relPath === "" || relPath === ".." || relPath.startsWith(".." + import_path4.sep)) {
     return {
-      content: [{ type: "text", text: "Either prompt or prompt_file is required." }],
+      content: [{ type: "text", text: `prompt_file '${args.prompt_file}' is outside the working directory.` }],
+      isError: true
+    };
+  }
+  let resolvedReal;
+  try {
+    resolvedReal = (0, import_fs4.realpathSync)(resolvedPath);
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `Failed to resolve prompt_file '${args.prompt_file}': ${err.message}` }],
+      isError: true
+    };
+  }
+  const relReal = (0, import_path4.relative)(cwdReal, resolvedReal);
+  if (relReal === "" || relReal === ".." || relReal.startsWith(".." + import_path4.sep)) {
+    return {
+      content: [{ type: "text", text: `prompt_file '${args.prompt_file}' resolves to a path outside the working directory.` }],
+      isError: true
+    };
+  }
+  try {
+    resolvedPrompt = (0, import_fs4.readFileSync)(resolvedReal, "utf-8");
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `Failed to read prompt_file '${args.prompt_file}': ${err.message}` }],
+      isError: true
+    };
+  }
+  if (!resolvedPrompt.trim()) {
+    return {
+      content: [{ type: "text", text: `prompt_file '${args.prompt_file}' is empty.` }],
       isError: true
     };
   }
@@ -14352,16 +14354,16 @@ ${detection.installHint}`
     }
     if (args.output_file) {
       const outputPath = (0, import_path4.resolve)(args.output_file);
-      const cwd = process.cwd();
-      const cwdReal = (0, import_fs4.realpathSync)(cwd);
-      const relOutput = (0, import_path4.relative)(cwdReal, outputPath);
+      const cwd2 = process.cwd();
+      const cwdReal2 = (0, import_fs4.realpathSync)(cwd2);
+      const relOutput = (0, import_path4.relative)(cwdReal2, outputPath);
       if (relOutput === "" || relOutput === ".." || relOutput.startsWith(".." + import_path4.sep)) {
         console.warn(`[codex-core] output_file '${args.output_file}' is outside the working directory, skipping write.`);
       } else {
         try {
           if (!(0, import_fs4.existsSync)(outputPath)) {
             const outDir = (0, import_path4.dirname)(outputPath);
-            const relOutDir = (0, import_path4.relative)(cwdReal, outDir);
+            const relOutDir = (0, import_path4.relative)(cwdReal2, outDir);
             if (!(relOutDir === "" || relOutDir === ".." || relOutDir.startsWith(".." + import_path4.sep))) {
               (0, import_fs4.mkdirSync)(outDir, { recursive: true });
               (0, import_fs4.writeFileSync)(outputPath, response, "utf-8");
@@ -14409,14 +14411,13 @@ var askCodexTool = {
         enum: CODEX_VALID_ROLES,
         description: `Required. Agent perspective for Codex: ${CODEX_VALID_ROLES.join(", ")}. Codex is optimized for analytical/planning tasks.`
       },
-      prompt_file: { type: "string", description: "Path to file containing the prompt (alternative to prompt parameter)" },
-      output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written to {output_file}.raw" },
+      prompt_file: { type: "string", description: "Path to file containing the prompt" },
+      output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written directly to output_file" },
       context_files: { type: "array", items: { type: "string" }, description: "File paths to include as context (contents will be prepended to prompt)" },
-      prompt: { type: "string", description: "The prompt to send to Codex" },
       model: { type: "string", description: `Codex model to use (default: ${CODEX_DEFAULT_MODEL}). Set OMC_CODEX_DEFAULT_MODEL env var to change default.` },
       background: { type: "boolean", description: "Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion." }
     },
-    required: ["agent_role"]
+    required: ["agent_role", "prompt_file"]
   }
 };
 var server = new Server(
@@ -14431,8 +14432,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (name !== "ask_codex") {
     return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };
   }
-  const { prompt, prompt_file, output_file, agent_role, model, context_files, background } = args ?? {};
-  return handleAskCodex({ prompt, prompt_file, output_file, agent_role, model, context_files, background });
+  const { prompt_file, output_file, agent_role, model, context_files, background } = args ?? {};
+  return handleAskCodex({ prompt_file, output_file, agent_role, model, context_files, background });
 });
 async function main() {
   const transport = new StdioServerTransport();

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -260,17 +260,15 @@ When you detect trigger patterns above, you MUST invoke the corresponding skill 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `agent_role` | string | Yes | Agent perspective (see routing table above) |
-| `prompt_file` | string | No* | Path to file containing prompt (*required if `prompt` not provided) |
-| `output_file` | string | No | Path to write response; fallback: stdout saved to `{output_file}.raw` |
+| `prompt_file` | string | Yes | Required. Path to file containing the prompt. Write prompts under `.omc/prompts/` for audit trail consistency. |
+| `output_file` | string | No | Path to write response; stdout written directly to output_file if CLI doesn't |
 | `files` / `context_files` | array | No | File paths to include as context |
-| `prompt` | string | No* | Inline prompt (*required if `prompt_file` not provided) |
 | `model` | string | No | Model to use (has defaults and fallback chains) |
 | `background` | boolean | No | Run in background (non-blocking) |
 
 **Notes:**
-- `prompt` and `prompt_file` are mutually exclusive — providing both returns an error
+- The `prompt` parameter has been removed. Always write prompts to a file and use `prompt_file`.
 - When `output_file` is specified, the prompt includes an instruction nudging the CLI to write there
-- If the CLI doesn't write to `output_file`, stdout is captured and written to `{output_file}.raw`
 - `prompt_file` must be within the project working directory (security boundary)
 
 ### OMC State Tools

--- a/src/__tests__/prompt-file-only.test.ts
+++ b/src/__tests__/prompt-file-only.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleAskCodex } from '../mcp/codex-core.js';
+import { handleAskGemini } from '../mcp/gemini-core.js';
+
+// Mock CLI detection to return available
+vi.mock('../mcp/cli-detection.js', () => ({
+  detectCodexCli: vi.fn(() => ({ available: true, path: '/usr/bin/codex', version: '1.0.0', installHint: '' })),
+  detectGeminiCli: vi.fn(() => ({ available: true, path: '/usr/bin/gemini', version: '1.0.0', installHint: '' })),
+  resetDetectionCache: vi.fn(),
+}));
+
+// Mock child_process to avoid actual CLI calls
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+describe('prompt_file-only enforcement', () => {
+  describe('handleAskCodex', () => {
+    it('should return error when deprecated prompt parameter is used', async () => {
+      const result = await handleAskCodex({
+        prompt_file: '',
+        agent_role: 'architect',
+        ...({ prompt: 'test prompt' } as any),
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("'prompt' parameter has been removed");
+    });
+
+    it('should return error when prompt_file is empty', async () => {
+      const result = await handleAskCodex({
+        prompt_file: '',
+        agent_role: 'architect',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('prompt_file is required');
+    });
+
+    it('should return error for invalid agent_role', async () => {
+      const result = await handleAskCodex({
+        prompt_file: 'some-file.md',
+        agent_role: 'invalid-role',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid agent_role');
+    });
+  });
+
+  describe('handleAskGemini', () => {
+    it('should return error when deprecated prompt parameter is used', async () => {
+      const result = await handleAskGemini({
+        prompt_file: '',
+        agent_role: 'designer',
+        ...({ prompt: 'test prompt' } as any),
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("'prompt' parameter has been removed");
+    });
+
+    it('should return error when prompt_file is empty', async () => {
+      const result = await handleAskGemini({
+        prompt_file: '',
+        agent_role: 'designer',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('prompt_file is required');
+    });
+
+    it('should return error for invalid agent_role', async () => {
+      const result = await handleAskGemini({
+        prompt_file: 'some-file.md',
+        agent_role: 'invalid-role',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid agent_role');
+    });
+  });
+});

--- a/src/mcp/codex-core.ts
+++ b/src/mcp/codex-core.ts
@@ -300,8 +300,7 @@ export function validateAndReadFile(filePath: string): string {
  * the SDK server and the standalone stdio server.
  */
 export async function handleAskCodex(args: {
-  prompt?: string;
-  prompt_file?: string;
+  prompt_file: string;
   output_file?: string;
   agent_role: string;
   model?: string;
@@ -321,60 +320,64 @@ export async function handleAskCodex(args: {
     };
   }
 
-  // Validate mutual exclusion of prompt and prompt_file
-  if (args.prompt && args.prompt_file) {
+  // Check if deprecated 'prompt' parameter is being used
+  if ('prompt' in (args as Record<string, unknown>)) {
     return {
-      content: [{ type: 'text' as const, text: 'Cannot specify both prompt and prompt_file. Use one or the other.' }],
+      content: [{ type: 'text' as const, text: "The 'prompt' parameter has been removed. Write the prompt to a file (recommended: .omc/prompts/) and pass 'prompt_file' instead." }],
       isError: true
     };
   }
 
-  // Resolve prompt from prompt_file or inline prompt
-  let resolvedPrompt: string;
-  if (args.prompt_file) {
-    const resolvedPath = resolve(args.prompt_file);
-    const cwd = process.cwd();
-    const cwdReal = realpathSync(cwd);
-    const relPath = relative(cwdReal, resolvedPath);
-    if (relPath === '' || relPath === '..' || relPath.startsWith('..' + sep)) {
-      return {
-        content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' is outside the working directory.` }],
-        isError: true
-      };
-    }
-    try {
-      resolvedPrompt = readFileSync(resolvedPath, 'utf-8');
-    } catch (err) {
-      return {
-        content: [{ type: 'text' as const, text: `Failed to read prompt_file '${args.prompt_file}': ${(err as Error).message}` }],
-        isError: true
-      };
-    }
-    // Symlink-safe check: ensure the real path also stays inside the boundary
-    try {
-      const resolvedReal = realpathSync(resolvedPath);
-      const relReal = relative(cwdReal, resolvedReal);
-      if (relReal === '' || relReal === '..' || relReal.startsWith('..' + sep)) {
-        return {
-          content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' resolves to a path outside the working directory.` }],
-          isError: true
-        };
-      }
-    } catch {
-      // If realpathSync fails, the file was already read successfully, so continue
-    }
-    // Check for empty prompt
-    if (!resolvedPrompt.trim()) {
-      return {
-        content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' is empty.` }],
-        isError: true
-      };
-    }
-  } else if (args.prompt) {
-    resolvedPrompt = args.prompt;
-  } else {
+  // Validate prompt_file is provided and not empty
+  if (!args.prompt_file || !args.prompt_file.trim()) {
     return {
-      content: [{ type: 'text' as const, text: 'Either prompt or prompt_file is required.' }],
+      content: [{ type: 'text' as const, text: 'prompt_file is required.' }],
+      isError: true
+    };
+  }
+
+  // Resolve prompt from prompt_file
+  let resolvedPrompt: string;
+  const resolvedPath = resolve(args.prompt_file);
+  const cwd = process.cwd();
+  const cwdReal = realpathSync(cwd);
+  const relPath = relative(cwdReal, resolvedPath);
+  if (relPath === '' || relPath === '..' || relPath.startsWith('..' + sep)) {
+    return {
+      content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' is outside the working directory.` }],
+      isError: true
+    };
+  }
+  // BEFORE reading, resolve symlinks and validate boundary
+  let resolvedReal: string;
+  try {
+    resolvedReal = realpathSync(resolvedPath);
+  } catch (err) {
+    return {
+      content: [{ type: 'text' as const, text: `Failed to resolve prompt_file '${args.prompt_file}': ${(err as Error).message}` }],
+      isError: true
+    };
+  }
+  const relReal = relative(cwdReal, resolvedReal);
+  if (relReal === '' || relReal === '..' || relReal.startsWith('..' + sep)) {
+    return {
+      content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' resolves to a path outside the working directory.` }],
+      isError: true
+    };
+  }
+  // Now safe to read from the validated real path
+  try {
+    resolvedPrompt = readFileSync(resolvedReal, 'utf-8');
+  } catch (err) {
+    return {
+      content: [{ type: 'text' as const, text: `Failed to read prompt_file '${args.prompt_file}': ${(err as Error).message}` }],
+      isError: true
+    };
+  }
+  // Check for empty prompt
+  if (!resolvedPrompt.trim()) {
+    return {
+      content: [{ type: 'text' as const, text: `prompt_file '${args.prompt_file}' is empty.` }],
       isError: true
     };
   }

--- a/src/mcp/codex-server.ts
+++ b/src/mcp/codex-server.ts
@@ -17,24 +17,22 @@ const askCodexTool = tool(
   `Send a prompt to OpenAI Codex CLI for analytical/planning tasks. Codex excels at architecture review, planning validation, critical analysis, and code/security review validation. Requires agent_role to specify the perspective (${CODEX_VALID_ROLES.join(', ')}). Requires Codex CLI (npm install -g @openai/codex).`,
   {
     agent_role: { type: "string", description: `Required. Agent perspective for Codex: ${CODEX_VALID_ROLES.join(', ')}. Codex is optimized for analytical/planning tasks.` },
-    prompt_file: { type: "string", description: "Path to file containing the prompt (alternative to prompt parameter)" },
-    output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written to {output_file}.raw" },
+    prompt_file: { type: "string", description: "Path to file containing the prompt" },
+    output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written directly to output_file" },
     context_files: { type: "array", items: { type: "string" }, description: "File paths to include as context (contents will be prepended to prompt)" },
-    prompt: { type: "string", description: "The prompt to send to Codex" },
     model: { type: "string", description: `Codex model to use (default: ${CODEX_DEFAULT_MODEL}). Set OMC_CODEX_DEFAULT_MODEL env var to change default.` },
     background: { type: "boolean", description: "Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion." },
   } as any,
   async (args: any) => {
-    const { prompt, prompt_file, output_file, agent_role, model, context_files, background } = args as {
-      prompt?: string;
-      prompt_file?: string;
+    const { prompt_file, output_file, agent_role, model, context_files, background } = args as {
+      prompt_file: string;
       output_file?: string;
       agent_role: string;
       model?: string;
       context_files?: string[];
       background?: boolean;
     };
-    return handleAskCodex({ prompt, prompt_file, output_file, agent_role, model, context_files, background });
+    return handleAskCodex({ prompt_file, output_file, agent_role, model, context_files, background });
   }
 );
 

--- a/src/mcp/codex-standalone-server.ts
+++ b/src/mcp/codex-standalone-server.ts
@@ -28,14 +28,13 @@ const askCodexTool = {
         enum: CODEX_VALID_ROLES,
         description: `Required. Agent perspective for Codex: ${CODEX_VALID_ROLES.join(', ')}. Codex is optimized for analytical/planning tasks.`
       },
-      prompt_file: { type: 'string', description: 'Path to file containing the prompt (alternative to prompt parameter)' },
-      output_file: { type: 'string', description: 'Path to write response. If CLI doesn\'t write here, stdout is written to {output_file}.raw' },
+      prompt_file: { type: 'string', description: 'Path to file containing the prompt' },
+      output_file: { type: 'string', description: 'Path to write response. If CLI doesn\'t write here, stdout is written directly to output_file' },
       context_files: { type: 'array', items: { type: 'string' }, description: 'File paths to include as context (contents will be prepended to prompt)' },
-      prompt: { type: 'string', description: 'The prompt to send to Codex' },
       model: { type: 'string', description: `Codex model to use (default: ${CODEX_DEFAULT_MODEL}). Set OMC_CODEX_DEFAULT_MODEL env var to change default.` },
       background: { type: 'boolean', description: 'Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion.' },
     },
-    required: ['agent_role'],
+    required: ['agent_role', 'prompt_file'],
   },
 };
 
@@ -53,16 +52,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (name !== 'ask_codex') {
     return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
   }
-  const { prompt, prompt_file, output_file, agent_role, model, context_files, background } = (args ?? {}) as {
-    prompt?: string;
-    prompt_file?: string;
+  const { prompt_file, output_file, agent_role, model, context_files, background } = (args ?? {}) as {
+    prompt_file: string;
     output_file?: string;
     agent_role: string;
     model?: string;
     context_files?: string[];
     background?: boolean;
   };
-  return handleAskCodex({ prompt, prompt_file, output_file, agent_role, model, context_files, background });
+  return handleAskCodex({ prompt_file, output_file, agent_role, model, context_files, background });
 });
 
 async function main() {

--- a/src/mcp/gemini-server.ts
+++ b/src/mcp/gemini-server.ts
@@ -22,24 +22,22 @@ const askGeminiTool = tool(
   "Send a prompt to Google Gemini CLI for design/implementation tasks. Gemini excels at frontend design review and implementation with its 1M token context window. Requires agent_role (designer, writer, vision). Fallback chain: gemini-3-pro-preview → gemini-3-flash-preview → gemini-2.5-pro → gemini-2.5-flash. Requires Gemini CLI (npm install -g @google/gemini-cli).",
   {
     agent_role: { type: "string", description: `Required. Agent perspective for Gemini: ${GEMINI_VALID_ROLES.join(', ')}. Gemini is optimized for design/implementation tasks with large context.` },
-    prompt_file: { type: "string", description: "Path to file containing the prompt (alternative to prompt parameter)" },
-    output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written to {output_file}.raw" },
+    prompt_file: { type: "string", description: "Path to file containing the prompt" },
+    output_file: { type: "string", description: "Path to write response. If CLI doesn't write here, stdout is written directly to output_file" },
     files: { type: "array", items: { type: "string" }, description: "File paths to include as context (contents will be prepended to prompt)" },
-    prompt: { type: "string", description: "The prompt to send to Gemini" },
     model: { type: "string", description: `Gemini model to use (default: ${GEMINI_DEFAULT_MODEL}). Set OMC_GEMINI_DEFAULT_MODEL env var to change default. Auto-fallback chain: ${GEMINI_MODEL_FALLBACKS.join(' → ')}.` },
     background: { type: "boolean", description: "Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion." },
   } as any,
   async (args: any) => {
-    const { prompt, prompt_file, output_file, agent_role, model, files, background } = args as {
-      prompt?: string;
-      prompt_file?: string;
+    const { prompt_file, output_file, agent_role, model, files, background } = args as {
+      prompt_file: string;
       output_file?: string;
       agent_role: string;
       model?: string;
       files?: string[];
       background?: boolean;
     };
-    return handleAskGemini({ prompt, prompt_file, output_file, agent_role, model, files, background });
+    return handleAskGemini({ prompt_file, output_file, agent_role, model, files, background });
   }
 );
 

--- a/src/mcp/gemini-standalone-server.ts
+++ b/src/mcp/gemini-standalone-server.ts
@@ -29,14 +29,13 @@ const askGeminiTool = {
         enum: GEMINI_VALID_ROLES,
         description: `Required. Agent perspective for Gemini: ${GEMINI_VALID_ROLES.join(', ')}. Gemini is optimized for design/implementation tasks with large context.`
       },
-      prompt_file: { type: 'string', description: 'Path to file containing the prompt (alternative to prompt parameter)' },
-      output_file: { type: 'string', description: 'Path to write response. If CLI doesn\'t write here, stdout is written to {output_file}.raw' },
+      prompt_file: { type: 'string', description: 'Path to file containing the prompt' },
+      output_file: { type: 'string', description: 'Path to write response. If CLI doesn\'t write here, stdout is written directly to output_file' },
       files: { type: 'array', items: { type: 'string' }, description: 'File paths to include as context (contents will be prepended to prompt)' },
-      prompt: { type: 'string', description: 'The prompt to send to Gemini' },
       model: { type: 'string', description: `Gemini model to use (default: ${GEMINI_DEFAULT_MODEL}). Set OMC_GEMINI_DEFAULT_MODEL env var to change default. Auto-fallback chain: ${GEMINI_MODEL_FALLBACKS.join(' → ')}.` },
       background: { type: 'boolean', description: 'Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion.' },
     },
-    required: ['agent_role'],
+    required: ['agent_role', 'prompt_file'],
   },
 };
 
@@ -54,16 +53,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (name !== 'ask_gemini') {
     return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
   }
-  const { prompt, prompt_file, output_file, agent_role, model, files, background } = (args ?? {}) as {
-    prompt?: string;
-    prompt_file?: string;
+  const { prompt_file, output_file, agent_role, model, files, background } = (args ?? {}) as {
+    prompt_file: string;
     output_file?: string;
     agent_role: string;
     model?: string;
     files?: string[];
     background?: boolean;
   };
-  return handleAskGemini({ prompt, prompt_file, output_file, agent_role, model, files, background });
+  return handleAskGemini({ prompt_file, output_file, agent_role, model, files, background });
 });
 
 async function main() {


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: Remove `prompt` parameter from `ask_codex` and `ask_gemini` MCP tools
- Agents must now write prompts to files (recommended: `.omc/prompts/`) and pass `prompt_file`
- Hard error returned when deprecated `prompt` parameter is used

## Changes

| File | Change |
|------|--------|
| `codex-core.ts` / `gemini-core.ts` | Remove `prompt` from signature, make `prompt_file` required, add deprecation error |
| `*-server.ts` / `*-standalone-server.ts` | Remove `prompt` from schemas, add `prompt_file` to required |
| `docs/CLAUDE.md` | Update parameter table |
| `prompt-file-only.test.ts` | **NEW** - 6 unit tests for error paths |

## Error Messages

When `prompt` is used:
```
The 'prompt' parameter has been removed. Write the prompt to a file (recommended: .omc/prompts/) and pass 'prompt_file' instead.
```

When `prompt_file` is missing:
```
prompt_file is required.
```

## Test plan

- [x] `npm run build` passes
- [x] 6 new unit tests pass
- [x] Full test suite: 2422 passed (1 pre-existing failure in analytics-display.test.ts unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)