### PR TITLE
feat: version drift detection and auto-cleanup on session start

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,4 +1,5 @@
 <!-- OMC:START -->
+<!-- OMC:VERSION:4.0.0 -->
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
 You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**

--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -63,9 +63,14 @@ async function main() {
     try {
       const versions = readdirSync(pluginCacheBase);
       if (versions.length > 0) {
-        const latestVersion = versions.sort(semverCompare).reverse()[0];
-        const pluginPath = join(pluginCacheBase, latestVersion, "dist/hud/index.js");
-        if (existsSync(pluginPath)) {
+        // Filter to only versions with built dist/hud/index.js
+        const builtVersions = versions.filter(v => {
+          const hudPath = join(pluginCacheBase, v, "dist/hud/index.js");
+          return existsSync(hudPath);
+        });
+        if (builtVersions.length > 0) {
+          const latestBuilt = builtVersions.sort(semverCompare).reverse()[0];
+          const pluginPath = join(pluginCacheBase, latestBuilt, "dist/hud/index.js");
           await import(pluginPath);
           return;
         }

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -6,7 +6,7 @@
  * Cross-platform: Windows, macOS, Linux
  */
 
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
@@ -42,6 +42,156 @@ function readJsonFile(path) {
   } catch {
     return null;
   }
+}
+
+// Semantic version comparison (for cache cleanup sorting)
+function semverCompare(a, b) {
+  const pa = a.replace(/^v/, '').split('.').map(s => parseInt(s, 10) || 0);
+  const pb = b.replace(/^v/, '').split('.').map(s => parseInt(s, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
+
+// Extract OMC version from CLAUDE.md content
+function extractOmcVersion(content) {
+  const match = content.match(/<!-- OMC:VERSION:(\d+\.\d+\.\d+[^\s]*?) -->/);
+  return match ? match[1] : null;
+}
+
+// Get plugin version from CLAUDE_PLUGIN_ROOT
+function getPluginVersion() {
+  try {
+    const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+    if (!pluginRoot) return null;
+    const pkg = readJsonFile(join(pluginRoot, 'package.json'));
+    return pkg?.version || null;
+  } catch { return null; }
+}
+
+// Get npm global package version
+function getNpmVersion() {
+  try {
+    const versionFile = join(homedir(), '.claude', '.omc-version.json');
+    const data = readJsonFile(versionFile);
+    return data?.version || null;
+  } catch { return null; }
+}
+
+// Get CLAUDE.md version
+function getClaudeMdVersion() {
+  try {
+    const claudeMdPath = join(homedir(), '.claude', 'CLAUDE.md');
+    if (!existsSync(claudeMdPath)) return null;  // File doesn't exist
+    const content = readFileSync(claudeMdPath, 'utf-8');
+    const version = extractOmcVersion(content);
+    return version || 'unknown';  // File exists but no marker = 'unknown'
+  } catch { return null; }
+}
+
+// Detect version drift between components
+function detectVersionDrift() {
+  const pluginVersion = getPluginVersion();
+  const npmVersion = getNpmVersion();
+  const claudeMdVersion = getClaudeMdVersion();
+
+  // Need at least plugin version to detect drift
+  if (!pluginVersion) return null;
+
+  const drift = [];
+
+  if (npmVersion && npmVersion !== pluginVersion) {
+    drift.push({ component: 'npm package (omc CLI)', current: npmVersion, expected: pluginVersion });
+  }
+
+  if (claudeMdVersion === 'unknown') {
+    drift.push({
+      component: 'CLAUDE.md instructions',
+      current: 'unknown (needs migration)',
+      expected: pluginVersion
+    });
+  } else if (claudeMdVersion && claudeMdVersion !== pluginVersion) {
+    drift.push({
+      component: 'CLAUDE.md instructions',
+      current: claudeMdVersion,
+      expected: pluginVersion
+    });
+  }
+
+  if (drift.length === 0) return null;
+
+  return { pluginVersion, npmVersion, claudeMdVersion, drift };
+}
+
+// Check if we should notify (once per unique drift combination)
+function shouldNotifyDrift(driftInfo) {
+  const stateFile = join(homedir(), '.claude', '.omc', 'update-state.json');
+  const driftKey = `plugin:${driftInfo.pluginVersion}-npm:${driftInfo.npmVersion}-claude:${driftInfo.claudeMdVersion}`;
+
+  try {
+    if (existsSync(stateFile)) {
+      const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+      if (state.lastNotifiedDrift === driftKey) return false;
+    }
+  } catch {}
+
+  // Save new drift state
+  try {
+    const dir = join(homedir(), '.claude', '.omc');
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(stateFile, JSON.stringify({
+      lastNotifiedDrift: driftKey,
+      lastNotifiedAt: new Date().toISOString()
+    }));
+  } catch {}
+
+  return true;
+}
+
+// Check npm registry for available update (with 24h cache)
+async function checkNpmUpdate(currentVersion) {
+  const cacheFile = join(homedir(), '.claude', '.omc', 'update-check.json');
+  const CACHE_DURATION = 24 * 60 * 60 * 1000;
+  const now = Date.now();
+
+  // Check cache
+  try {
+    if (existsSync(cacheFile)) {
+      const cached = JSON.parse(readFileSync(cacheFile, 'utf-8'));
+      if (cached.timestamp && (now - cached.timestamp) < CACHE_DURATION) {
+        return (cached.updateAvailable && semverCompare(cached.latestVersion, currentVersion) > 0)
+          ? { currentVersion, latestVersion: cached.latestVersion }
+          : null;
+      }
+    }
+  } catch {}
+
+  // Fetch from npm registry with 2s timeout
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 2000);
+    const response = await fetch('https://registry.npmjs.org/oh-my-claude-sisyphus/latest', {
+      signal: controller.signal
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    const latestVersion = data.version;
+    const updateAvailable = semverCompare(latestVersion, currentVersion) > 0;
+
+    // Update cache
+    try {
+      const dir = join(homedir(), '.claude', '.omc');
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      writeFileSync(cacheFile, JSON.stringify({ timestamp: now, latestVersion, currentVersion, updateAvailable }));
+    } catch {}
+
+    return updateAvailable ? { currentVersion, latestVersion } : null;
+  } catch { return null; }
 }
 
 // Check if HUD is properly installed (with retry for race conditions)
@@ -109,6 +259,29 @@ async function main() {
     const directory = data.directory || process.cwd();
     const sessionId = data.sessionId || data.session_id || '';
     const messages = [];
+
+    // Check for version drift between components
+    const driftInfo = detectVersionDrift();
+    if (driftInfo && shouldNotifyDrift(driftInfo)) {
+      let driftMsg = `[OMC VERSION DRIFT DETECTED]\n\nPlugin version: ${driftInfo.pluginVersion}\n`;
+      for (const d of driftInfo.drift) {
+        driftMsg += `${d.component}: ${d.current} (expected ${d.expected})\n`;
+      }
+      driftMsg += `\nRun 'omc update' to sync all components.`;
+
+      messages.push(`<session-restore>\n\n${driftMsg}\n\n</session-restore>\n\n---\n`);
+    }
+
+    // Check npm registry for available update (with 24h cache)
+    try {
+      const pluginVersion = getPluginVersion();
+      if (pluginVersion) {
+        const updateInfo = await checkNpmUpdate(pluginVersion);
+        if (updateInfo) {
+          messages.push(`<session-restore>\n\n[OMC UPDATE AVAILABLE]\n\nA new version of oh-my-claudecode is available: v${updateInfo.latestVersion} (current: v${updateInfo.currentVersion})\n\nTo update, run: omc update\n(This syncs plugin, npm package, and CLAUDE.md together)\n\n</session-restore>\n\n---\n`);
+        }
+      }
+    } catch {}
 
     // Check HUD installation (one-time setup guidance)
     const hudCheck = await checkHudInstallation();
@@ -211,6 +384,23 @@ ${cleanContent}
         // Silently ignore notepad read errors
       }
     }
+
+    // Cleanup old plugin cache versions (keep latest 2)
+    try {
+      const cacheBase = join(homedir(), '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+      if (existsSync(cacheBase)) {
+        const versions = readdirSync(cacheBase)
+          .filter(v => /^\d+\.\d+\.\d+/.test(v))
+          .sort(semverCompare)
+          .reverse();
+        const toRemove = versions.slice(2);
+        for (const version of toRemove) {
+          try {
+            rmSync(join(cacheBase, version), { recursive: true, force: true });
+          } catch {}
+        }
+      }
+    } catch {}
 
     if (messages.length > 0) {
       console.log(JSON.stringify({

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -210,7 +210,8 @@ async function main() {
 
 A new version of oh-my-claudecode is available: v${updateInfo.latestVersion} (current: ${updateInfo.currentVersion})
 
-To update, run: claude /install-plugin oh-my-claudecode
+To update, run: omc update
+(This syncs plugin, npm package, and CLAUDE.md together)
 
 </session-restore>
 


### PR DESCRIPTION
## Summary

- Add version drift detection between plugin root, npm package, and CLAUDE.md on session start
- Notify user to run `omc update` when components are out of sync (once per unique drift combination)
- Add npm registry update check with 24h cache and 2s timeout to plugin session-start hook
- Clean up old plugin cache versions automatically (keep latest 2)
- Fix HUD wrapper bug: filter for built versions before selecting latest
- Add `<!-- OMC:VERSION:X.Y.Z -->` marker to CLAUDE.md for version tracking
- Update `mergeClaudeMd()` to inject version marker dynamically
- Fix legacy hook update notification to recommend `omc update` instead of `/plugin install`

## Problem

oh-my-claudecode has THREE components that must stay in sync:

| Component | Location | Updated By |
|-----------|----------|------------|
| Plugin root | `~/.claude/plugins/cache/omc/oh-my-claudecode/{ver}/` | `/plugin install` |
| npm package | Global npm (`oh-my-claude-sisyphus`) | `npm install -g` |
| CLAUDE.md | `~/.claude/CLAUDE.md` | `omc install` |

When a user runs `/plugin install`, only the plugin root is updated. The npm package (providing `omc` CLI) and CLAUDE.md instructions remain at old versions, causing feature mismatches and confusion.

Secondary problem: old plugin cache versions accumulate indefinitely (10+ versions observed).

## Test plan

- [x] Syntax check all modified `.mjs` files (`node --check`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 2416 existing tests pass (1 pre-existing failure unrelated)
- [x] Architect verification: PASS
- [ ] Manual: Start session with plugin version != npm version, verify drift notification appears
- [ ] Manual: Verify drift notification only shows once per unique combination
- [ ] Manual: Verify old plugin cache versions are cleaned up after session start
- [ ] Manual: Verify HUD loads from latest BUILT version, not just latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)