### PR TITLE
fix(hooks): handle TaskCreate/TaskUpdate tool name variants

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -241,7 +241,9 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory) 
       }
       break;
 
-    case 'Task': {
+    case 'Task':
+    case 'TaskCreate':
+    case 'TaskUpdate': {
       const agentSummary = getAgentCompletionSummary(directory);
       if (detectWriteFailure(toolOutput)) {
         message = 'Task delegation failed. Verify agent name and parameters.';
@@ -325,7 +327,12 @@ async function main() {
     }
 
     // Process <remember> tags from Task agent output
-    if (toolName === 'Task' || toolName === 'task') {
+    if (
+      toolName === 'Task' ||
+      toolName === 'task' ||
+      toolName === 'TaskCreate' ||
+      toolName === 'TaskUpdate'
+    ) {
       processRememberTags(toolOutput, directory);
     }
 

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -125,7 +125,7 @@ async function main() {
     const todoStatus = getTodoStatus(directory);
 
     let message;
-    if (toolName === 'Task') {
+    if (toolName === 'Task' || toolName === 'TaskCreate' || toolName === 'TaskUpdate') {
       let toolInput = null;
       try {
         toolInput = JSON.parse(input).toolInput;

--- a/templates/hooks/post-tool-use.mjs
+++ b/templates/hooks/post-tool-use.mjs
@@ -111,7 +111,12 @@ async function main() {
     const directory = data.directory || process.cwd();
 
     // Only process Task tool output
-    if (toolName !== 'Task' && toolName !== 'task') {
+    if (
+      toolName !== 'Task' &&
+      toolName !== 'task' &&
+      toolName !== 'TaskCreate' &&
+      toolName !== 'TaskUpdate'
+    ) {
       console.log(JSON.stringify({ continue: true }));
       return;
     }


### PR DESCRIPTION
## Summary
- Claude Code's Feb 2025 update renamed the `Task` tool in hook events to `TaskCreate` and `TaskUpdate`, breaking OMC hooks that only matched `Task`/`task`
- Updated tool name matching in all 3 hook files to recognize the new variants: `Task`, `task`, `TaskCreate`, `TaskUpdate`
- Minimal, surgical fix — only the tool name matching logic was changed

## Files Changed
| File | Change |
|------|--------|
| `scripts/post-tool-verifier.mjs` | Added `TaskCreate`/`TaskUpdate` to switch case and remember-tag processing |
| `scripts/pre-tool-enforcer.mjs` | Extended Task tool name check |
| `templates/hooks/post-tool-use.mjs` | Added new tool names to remember-tag filter |

## Test plan
- [x] Build completes successfully
- [ ] Verify PostToolUse hook no longer errors on `TaskCreate` events
- [ ] Verify PreToolUse hook correctly processes `TaskCreate`/`TaskUpdate` events
- [ ] Verify `<remember>` tag processing works for all Task tool variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)