### PR TITLE
fix(ralplan): add human-in-the-loop approval gate before implementation (#448)

### DIFF
--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -22,6 +22,9 @@ Invokes the plan skill with --consensus mode, which:
 2. Consults Architect for architectural questions
 3. Reviews with Critic agent
 4. Iterates until Critic approves (max 5 iterations)
+5. **Presents approved plan to user for explicit consent before any implementation**
+
+**CRITICAL:** Ralplan NEVER proceeds to implementation (branching, code execution, or file modification) without explicit user approval. After Critic consensus, the user is always asked to Proceed, Adjust, or Discard.
 
 ## Implementation
 


### PR DESCRIPTION
## Summary

- Adds a mandatory **User Approval Gate** phase between Critic consensus and implementation in the ralplan workflow
- After Critic approves (OKAY), the orchestrator now **stops and asks the user** to Proceed, Adjust, or Discard via `AskUserQuestion` before any codebase mutation
- Adds explicit HARD RULES and FORBIDDEN lists preventing branch creation, executor spawning, or code modification without user consent

## Problem

Since v3.8, ralplan autonomously proceeded to branch creation (`git checkout -b`) and code execution (spawning executor agents) immediately after Critic approval, bypassing the user entirely. This caused unintended codebase mutations and uncontrolled token consumption.

## Changes

**`commands/ralplan.md`** (primary fix):
- Updated flow diagram with USER GATE step showing Proceed/Adjust/Discard paths
- Added `awaiting_user_approval` phase to state machine
- Rewrote verdict handling to transition to user gate instead of executing
- Added new "User Approval Gate" section with 6 HARD RULES
- Updated Skill Workflow with steps 9-12 (present, log, wait, complete)
- Added explicit FORBIDDEN list of actions without user consent

**`skills/ralplan/SKILL.md`** (supporting):
- Added step 5 documenting user consent requirement
- Added CRITICAL note about never proceeding without approval

## Test plan

- [ ] Run `/ralplan` with a task, verify it stops after Critic OKAY and presents AskUserQuestion
- [ ] Verify choosing "Proceed" allows execution
- [ ] Verify choosing "Adjust" returns to Planner
- [ ] Verify choosing "Discard" cancels without execution
- [ ] Verify no git branches are created before user approval

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)