### PR TITLE
fix(windows): resolve plugin freeze on Claude Code 2.1.27+ (#459)

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -28,6 +28,7 @@
 import { writeFileSync, mkdirSync, existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { readStdin } from './lib/stdin.mjs';
 
 const ULTRATHINK_MESSAGE = `<think-mode>
 
@@ -45,15 +46,6 @@ Use your extended thinking capabilities to provide the most thorough and well-re
 
 ---
 `;
-
-// Read all stdin
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
-}
 
 // Extract prompt from various JSON structures
 function extractPrompt(input) {

--- a/scripts/lib/stdin.mjs
+++ b/scripts/lib/stdin.mjs
@@ -1,13 +1,13 @@
 /**
  * Shared stdin utilities for OMC hook scripts
- * Provides timeout-protected stdin reading to prevent hangs on Linux
+ * Provides timeout-protected stdin reading to prevent hangs on Linux and Windows
  * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/240
  *
  * Mirrors templates/hooks/lib/stdin.mjs for use by plugin hook scripts.
  */
 
 /**
- * Read all stdin with timeout to prevent indefinite hang on Linux.
+ * Read all stdin with timeout to prevent indefinite hang on Linux and Windows (issue #459).
  *
  * The blocking `for await (const chunk of process.stdin)` pattern waits
  * indefinitely for EOF. On Linux, if the parent process doesn't properly

--- a/scripts/permission-handler.mjs
+++ b/scripts/permission-handler.mjs
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
+import { readStdin } from './lib/stdin.mjs';
 
 async function main() {
-  // Read stdin
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
+  // Read stdin (timeout-protected, see issue #240/#459)
+  const input = await readStdin();
 
   try {
     const data = JSON.parse(input);

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -18,12 +18,18 @@ const {
 const { join, dirname, resolve, normalize } = require("path");
 const { homedir } = require("os");
 
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString("utf-8");
+async function readStdin(timeoutMs = 5000) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (!settled) { settled = true; process.stdin.removeAllListeners(); process.stdin.destroy(); resolve(Buffer.concat(chunks).toString("utf-8")); }
+    }, timeoutMs);
+    process.stdin.on("data", (chunk) => { chunks.push(chunk); });
+    process.stdin.on("end", () => { if (!settled) { settled = true; clearTimeout(timeout); resolve(Buffer.concat(chunks).toString("utf-8")); } });
+    process.stdin.on("error", () => { if (!settled) { settled = true; clearTimeout(timeout); resolve(""); } });
+    if (process.stdin.readableEnded) { if (!settled) { settled = true; clearTimeout(timeout); resolve(Buffer.concat(chunks).toString("utf-8")); } }
+  });
 }
 
 function readJsonFile(path) {

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -17,14 +17,7 @@ import {
 } from "fs";
 import { join, dirname, resolve, normalize } from "path";
 import { homedir } from "os";
-
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString("utf-8");
-}
+import { readStdin } from './lib/stdin.mjs';
 
 function readJsonFile(path) {
   try {

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } fr
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
+import { readStdin } from './lib/stdin.mjs';
 
 // Get the directory of this script to resolve the dist module
 const __filename = fileURLToPath(import.meta.url);
@@ -37,15 +38,6 @@ try {
     mkdirSync(stateDir, { recursive: true });
   }
 } catch {}
-
-// Read all stdin
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
-}
 
 // Load session statistics
 function loadStats() {

--- a/scripts/pre-compact.mjs
+++ b/scripts/pre-compact.mjs
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
+import { readStdin } from './lib/stdin.mjs';
 
 async function main() {
-  // Read stdin
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
+  // Read stdin (timeout-protected, see issue #240/#459)
+  const input = await readStdin();
 
   try {
     const data = JSON.parse(input);

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -8,15 +8,7 @@
 
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-
-// Read all stdin
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
-}
+import { readStdin } from './lib/stdin.mjs';
 
 // Simple JSON field extraction
 function extractJsonField(input, field, defaultValue = '') {

--- a/scripts/project-memory-posttool.mjs
+++ b/scripts/project-memory-posttool.mjs
@@ -7,17 +7,7 @@
 
 import { learnFromToolOutput } from '../dist/hooks/project-memory/learner.js';
 import { findProjectRoot } from '../dist/hooks/rules-injector/finder.js';
-
-/**
- * Read JSON input from stdin
- */
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
-}
+import { readStdin } from './lib/stdin.mjs';
 
 /**
  * Main hook execution

--- a/scripts/project-memory-precompact.mjs
+++ b/scripts/project-memory-precompact.mjs
@@ -6,17 +6,7 @@
  */
 
 import { processPreCompact } from '../dist/hooks/project-memory/pre-compact.js';
-
-/**
- * Read JSON input from stdin
- */
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
-}
+import { readStdin } from './lib/stdin.mjs';
 
 /**
  * Main hook execution

--- a/scripts/session-end.mjs
+++ b/scripts/session-end.mjs
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
+import { readStdin } from './lib/stdin.mjs';
 
 async function main() {
-  // Read stdin
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
+  // Read stdin (timeout-protected, see issue #240/#459)
+  const input = await readStdin();
 
   try {
     const data = JSON.parse(input);

--- a/scripts/setup-init.mjs
+++ b/scripts/setup-init.mjs
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
+import { readStdin } from './lib/stdin.mjs';
 
 async function main() {
-  // Read stdin
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
+  // Read stdin (timeout-protected, see issue #240/#459)
+  const input = await readStdin();
 
   try {
     const data = JSON.parse(input);

--- a/scripts/setup-maintenance.mjs
+++ b/scripts/setup-maintenance.mjs
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
+import { readStdin } from './lib/stdin.mjs';
 
 async function main() {
-  // Read stdin
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
+  // Read stdin (timeout-protected, see issue #240/#459)
+  const input = await readStdin();
 
   try {
     const data = JSON.parse(input);

--- a/scripts/skill-injector.mjs
+++ b/scripts/skill-injector.mjs
@@ -13,6 +13,7 @@
 import { existsSync, readdirSync, readFileSync, realpathSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
+import { readStdin } from './lib/stdin.mjs';
 import { createRequire } from 'module';
 
 // Try to load the compiled bridge bundle
@@ -181,15 +182,6 @@ function findMatchingSkillsFallback(prompt, directory, sessionId) {
 // =============================================================================
 // Main Logic (uses bridge if available, fallback otherwise)
 // =============================================================================
-
-// Read all stdin
-async function readStdin() {
-  const chunks = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
-}
 
 // Find matching skills - delegates to bridge or fallback
 function findMatchingSkills(prompt, directory, sessionId) {

--- a/scripts/subagent-tracker.mjs
+++ b/scripts/subagent-tracker.mjs
@@ -1,15 +1,13 @@
 #!/usr/bin/env node
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
+import { readStdin } from './lib/stdin.mjs';
 
 async function main() {
   const action = process.argv[2]; // 'start' or 'stop'
 
-  // Read stdin
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
+  // Read stdin (timeout-protected, see issue #240/#459)
+  const input = await readStdin();
 
   try {
     const data = JSON.parse(input);


### PR DESCRIPTION
## Summary

- Migrate all 13 remaining hook scripts from the blocking `for await (process.stdin)` pattern to the timeout-protected `readStdin()` utility, fixing Claude Code freezing on Windows 11 with CC 2.1.27+
- The timeout-protected reader already existed in `scripts/lib/stdin.mjs` (created for #240) but was only applied to 2 of 15 hook scripts — the other 13 still used the dangerous pattern
- For the CommonJS `persistent-mode.cjs`, inline the timeout-protected implementation since it cannot use ESM imports

## Root Cause

Claude Code 2.1.27+ changed how stdin pipes are handled for hook child processes. On Windows, the pipe isn't properly EOF'd, causing `for await (const chunk of process.stdin)` to block indefinitely. Each hook hangs until its configured timeout (3-5s) kills the process. With multiple hooks per event (UserPromptSubmit, PreToolUse, PostToolUse, etc.), the delays stack up and Claude Code appears frozen.

## Test plan

- [x] Verified zero remaining `for await (process.stdin)` patterns in `scripts/` (only explanatory comment in `lib/stdin.mjs`)
- [x] All 13 ESM scripts now import from shared `./lib/stdin.mjs`
- [x] CJS script has inlined timeout-protected reader
- [x] Full test suite passes (2599 tests, 107 test files)
- [ ] Manual test on Windows 11 with Claude Code 2.1.27+

Fixes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)