### PR TITLE
fix(ralplan): replace AskUserQuestion with native Plan Mode approval gate

### DIFF
--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -24,9 +24,9 @@ Invokes the plan skill with --consensus mode, which:
 4. Iterates until Critic approves (max 5 iterations)
 5. **Presents approved plan to user for explicit consent before any implementation**
 
-**CRITICAL:** Ralplan NEVER proceeds to implementation (branching, code execution, or file modification) without explicit user approval. After Critic consensus, the user is always asked to Proceed, Adjust, or Discard.
+**CRITICAL:** Ralplan NEVER proceeds to implementation (branching, code execution, or file modification) without explicit user approval. After Critic consensus, the orchestrator enters Claude Code's native Plan Mode (`EnterPlanMode` → `ExitPlanMode`) to present the plan for user approval. Falls back to `AskUserQuestion` (Proceed/Adjust/Discard) if Plan Mode is unavailable.
 
-**State:** After Critic consensus, state transitions to `awaiting_user_approval`. User choices: **Proceed** (execute), **Adjust** (re-plan), or **Discard** (cancel). No response = wait indefinitely.
+**State:** After Critic consensus, state transitions to `awaiting_user_approval`. The orchestrator enters Plan Mode for native approval UX. User choices: **Approve** (execute), **Request changes** (re-plan), or reject. Falls back to AskUserQuestion with Proceed/Adjust/Discard if Plan Mode is unavailable.
 
 ## Implementation
 
@@ -37,6 +37,8 @@ Invoke Skill: plan --consensus {{ARGUMENTS}}
 ```
 
 Pass all arguments to the plan skill. The plan skill handles all consensus logic, state management, and iteration.
+
+**Enforcement:** Ralplan inherits and enforces all hard approval-gate invariants defined in `commands/ralplan.md`. If `/plan --consensus` behavior diverges from the approval gate rules (HARD RULE 1 and HARD RULE 2), the ralplan command-level rules take precedence.
 
 ## External Model Consultation (Preferred)
 


### PR DESCRIPTION
## Summary

- Replace `AskUserQuestion`-based user approval gate in ralplan with Claude Code's native Plan Mode (`EnterPlanMode` → `ExitPlanMode`) for a more integrated approval experience after Critic consensus
- Add safety mitigations for known Plan Mode bugs (#9701 auto-approval, #19623 MCP hang)
- Add deterministic fallback and resume behavior

## Changes

### `commands/ralplan.md`
- **Approval flow**: Replace `AskUserQuestion` with `EnterPlanMode` → write plan summary → `ExitPlanMode`
- **Timeout**: 30s timeout for Plan Mode operations, triggers `AskUserQuestion` fallback on hang
- **Auto-approval defense**: Post-`ExitPlanMode` verification step detects bug #9701 (spurious auto-approval) and falls back to `AskUserQuestion`
- **State machine**: New `awaiting_user_approval_fallback` phase for deterministic resume (Plan Mode vs fallback path)
- **Resume rules**: Session restart checks phase to decide Plan Mode re-entry vs direct `AskUserQuestion`
- **Diagram**: Updated USER GATE → PLAN MODE with annotation
- **Clarification**: `.omc/` file writes explicitly permitted during approval gate (not codebase mutation)

### `skills/ralplan/SKILL.md`
- Updated CRITICAL and State descriptions to reference Plan Mode with fallback
- Added normative enforcement statement: ralplan command-level rules take precedence over `/plan --consensus`

## Review

Reviewed by Codex (gpt-5.3-codex) in code-reviewer role. Initial REJECT addressed all 5 findings:
- HIGH: Timeout/fallback determinism for #19623 → added
- HIGH: Post-ExitPlanMode user-intent verification for #9701 → added
- MEDIUM: Fallback sub-phase for state machine → added
- MEDIUM: Normative enforcement in SKILL.md → added
- LOW: Permitted mutations clarification → added

## Test plan

- [ ] Verify ralplan enters Plan Mode after Critic OKAY
- [ ] Verify ExitPlanMode presents plan to user
- [ ] Verify fallback to AskUserQuestion when Plan Mode hangs
- [ ] Verify resume from `awaiting_user_approval` re-enters Plan Mode
- [ ] Verify resume from `awaiting_user_approval_fallback` uses AskUserQuestion directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)