### PR TITLE
fix: Windows Gemini MCP fails due to empty string arg dropped by cmd.exe

### DIFF
--- a/bridge/gemini-server.cjs
+++ b/bridge/gemini-server.cjs
@@ -14356,7 +14356,7 @@ function executeGemini(prompt, model, cwd) {
   return new Promise((resolve5, reject) => {
     if (model) validateModelName(model);
     let settled = false;
-    const args = ["-p", "", "--yolo"];
+    const args = ["-p=.", "--yolo"];
     if (model) {
       args.push("--model", model);
     }
@@ -14430,7 +14430,7 @@ function executeGeminiBackground(fullPrompt, modelInput, jobMeta, workingDirecto
     const modelsToTry = modelExplicit ? [effectiveModel] : GEMINI_MODEL_FALLBACKS.includes(effectiveModel) ? GEMINI_MODEL_FALLBACKS.slice(GEMINI_MODEL_FALLBACKS.indexOf(effectiveModel)) : [effectiveModel, ...GEMINI_MODEL_FALLBACKS];
     const trySpawnWithModel = (tryModel, remainingModels) => {
       validateModelName(tryModel);
-      const args = ["-p", "", "--yolo", "--model", tryModel];
+      const args = ["-p=.", "--yolo", "--model", tryModel];
       const child = (0, import_child_process3.spawn)("gemini", args, {
         detached: process.platform !== "win32",
         stdio: ["pipe", "pipe", "pipe"],

--- a/dist/mcp/gemini-core.js
+++ b/dist/mcp/gemini-core.js
@@ -74,7 +74,7 @@ export function executeGemini(prompt, model, cwd) {
         if (model)
             validateModelName(model);
         let settled = false;
-        const args = ['-p', '', '--yolo'];
+        const args = ['-p=.', '--yolo'];
         if (model) {
             args.push('--model', model);
         }
@@ -163,7 +163,7 @@ export function executeGeminiBackground(fullPrompt, modelInput, jobMeta, working
         // Helper to try spawning with a specific model
         const trySpawnWithModel = (tryModel, remainingModels) => {
             validateModelName(tryModel);
-            const args = ['-p', '', '--yolo', '--model', tryModel];
+            const args = ['-p=.', '--yolo', '--model', tryModel];
             const child = spawn('gemini', args, {
                 detached: process.platform !== 'win32',
                 stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/mcp/gemini-core.ts
+++ b/src/mcp/gemini-core.ts
@@ -86,7 +86,7 @@ export function executeGemini(prompt: string, model?: string, cwd?: string): Pro
   return new Promise((resolve, reject) => {
     if (model) validateModelName(model);
     let settled = false;
-    const args = ['-p', '', '--yolo'];
+    const args = ['-p=.', '--yolo'];
     if (model) {
       args.push('--model', model);
     }
@@ -187,7 +187,7 @@ export function executeGeminiBackground(
     // Helper to try spawning with a specific model
     const trySpawnWithModel = (tryModel: string, remainingModels: string[]): { pid: number } | { error: string } => {
       validateModelName(tryModel);
-      const args = ['-p', '', '--yolo', '--model', tryModel];
+      const args = ['-p=.', '--yolo', '--model', tryModel];
       const child = spawn('gemini', args, {
         detached: process.platform !== 'win32',
         stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- On Windows, `cmd.exe` silently drops empty string arguments, so `spawn('gemini', ['-p', '', '--yolo'])` becomes `spawn('gemini', ['-p', '--yolo'])`, causing `--yolo` to be consumed as the `-p` value
- Changed `['-p', '']` to `['-p=.']` in both `executeGemini()` and `executeGeminiBackground()` in `src/mcp/gemini-core.ts`
- The combined `=` form is not split by `cmd.exe` and correctly passes a minimal prompt placeholder

Fixes #482

## Test plan
- [x] All 63 existing gemini-related tests pass (`mcp-fallback-429`, `prompt-file-only`, `validate-and-read-file`, `job-management`)
- [x] Build succeeds with no new errors
- [ ] Manual verification on Windows with Gemini CLI installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>