### PR TITLE
fix: add ToolSearch discovery for deferred MCP tools

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -101,6 +101,12 @@ Deprecated aliases (backward compatibility): `researcher` -> `dependency-expert`
 <mcp_routing>
 For read-only analysis tasks, prefer MCP tools over spawning Claude agents -- they are faster and cheaper.
 
+**IMPORTANT -- Deferred Tool Discovery:** MCP tools (`ask_codex`, `ask_gemini`, and their job management tools) are deferred and NOT in your tool list at session start. Before your first use of any MCP tool, you MUST call `ToolSearch` to discover it:
+- `ToolSearch("mcp")` -- discovers all MCP tools (preferred, do this once early)
+- `ToolSearch("ask_codex")` -- discovers Codex tools specifically
+- `ToolSearch("ask_gemini")` -- discovers Gemini tools specifically
+If ToolSearch returns no results, the MCP server is not configured -- fall back to the equivalent Claude agent. Never block on unavailable MCP tools.
+
 Available MCP providers:
 - Codex (`mcp__x__ask_codex`): OpenAI gpt-5.3-codex -- code analysis, planning validation, review
 - Gemini (`mcp__g__ask_gemini`): Google gemini-3-pro-preview -- design across many files (1M context)

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -43,9 +43,10 @@ Deep investigation requires a different approach than quick lookups or code chan
 </Steps>
 
 <Tool_Usage>
+- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
 - Use `ask_codex` with `agent_role: "architect"` as the preferred analysis route
 - Pass `context_files` with all relevant source files for grounded analysis
-- Use `Task(subagent_type="oh-my-claudecode:architect", model="opus", ...)` as fallback when Codex is unavailable
+- Use `Task(subagent_type="oh-my-claudecode:architect", model="opus", ...)` as fallback when ToolSearch finds no MCP tools or Codex is unavailable
 - For broad analysis, use `explore` agent first to identify relevant files before routing to architect
 </Tool_Usage>
 

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -68,11 +68,12 @@ Most non-trivial software tasks require coordinated phases: understanding requir
 </Steps>
 
 <Tool_Usage>
+- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
 - Use `ask_codex` with `agent_role: "architect"` for Phase 4 architecture validation
 - Use `ask_codex` with `agent_role: "security-reviewer"` for Phase 4 security review
 - Use `ask_codex` with `agent_role: "code-reviewer"` for Phase 4 quality review
 - Agents form their own analysis first, then consult Codex for cross-validation
-- If Codex is unavailable, proceed without it -- never block on external tools
+- If ToolSearch finds no MCP tools or Codex is unavailable, proceed without it -- never block on external tools
 </Tool_Usage>
 
 <Examples>

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -92,7 +92,9 @@ The code-reviewer agent SHOULD consult Codex for cross-validation.
 - Small, isolated changes
 
 ### Tool Usage
+Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
 Use `mcp__x__ask_codex` with `agent_role: "code-reviewer"`.
+If ToolSearch finds no MCP tools, fall back to the `code-reviewer` Claude agent.
 
 **Note:** Codex calls can take up to 1 hour. Consider the review timeline before consulting.
 

--- a/skills/frontend-ui-ux/SKILL.md
+++ b/skills/frontend-ui-ux/SKILL.md
@@ -16,7 +16,9 @@ Routes to the designer agent or Gemini MCP for frontend work.
 ## Routing
 
 ### Preferred: MCP Direct
+Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
 Use `mcp__g__ask_gemini` with `agent_role: "designer"` for design tasks.
+If ToolSearch finds no MCP tools, use the Claude agent fallback below.
 
 ### Fallback: Claude Agent
 ```

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -88,13 +88,14 @@ Plans are saved to `.omc/plans/`. Drafts go to `.omc/drafts/`.
 </Steps>
 
 <Tool_Usage>
+- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
 - Use `AskUserQuestion` for preference questions (scope, priority, timeline, risk tolerance) -- provides clickable UI
 - Use plain text for questions needing specific values (port numbers, names, follow-up clarifications)
 - Use `explore` agent (Haiku, 30s timeout) to gather codebase facts before asking the user
 - Use `ask_codex` with `agent_role: "planner"` for planning validation on large-scope plans
 - Use `ask_codex` with `agent_role: "analyst"` for requirements analysis
 - Use `ask_codex` with `agent_role: "critic"` for plan review in consensus and review modes
-- If Codex is unavailable, fall back to equivalent Claude agents -- never block on external tools
+- If ToolSearch finds no MCP tools or Codex is unavailable, fall back to equivalent Claude agents -- never block on external tools
 </Tool_Usage>
 
 <Examples>

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -60,9 +60,10 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 </Steps>
 
 <Tool_Usage>
+- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
 - Use `ask_codex` with `agent_role: "architect"` for verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
 - Skip Codex consultation for simple feature additions, well-tested changes, or time-critical verification
-- If Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
+- If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
 </Tool_Usage>
 

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -110,7 +110,9 @@ The security-reviewer agent SHOULD consult Codex for cross-validation.
 - Code with existing security tests
 
 ### Tool Usage
+Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
 Use `mcp__x__ask_codex` with `agent_role: "security-reviewer"`.
+If ToolSearch finds no MCP tools, fall back to the `security-reviewer` Claude agent.
 
 **Note:** Security second opinions are high-value. Consider consulting for CRITICAL/HIGH findings.
 

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -99,6 +99,8 @@ The tdd-guide agent SHOULD consult Codex for test strategy validation.
 - Small, isolated functionality
 
 ### Tool Usage
+Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
 Use `mcp__x__ask_codex` with `agent_role: "tdd-guide"`.
+If ToolSearch finds no MCP tools, fall back to the `test-engineer` Claude agent.
 
 **Remember:** The discipline IS the value. Shortcuts destroy the benefit.

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -434,9 +434,12 @@ The lead runs #1 (Codex analysis), then #2 and #3 in parallel (Codex refactors b
 
 For large ambiguous tasks, run analysis before team creation:
 
-1. Call `ask_codex` (planner role) with task description + codebase context
-2. Use the analysis to produce better task decomposition
-3. Create team and tasks with enriched context
+1. Call `ToolSearch("mcp")` to discover deferred MCP tools (required before first use)
+2. Call `ask_codex` (planner role) with task description + codebase context
+3. Use the analysis to produce better task decomposition
+4. Create team and tasks with enriched context
+
+If ToolSearch finds no MCP tools, skip MCP pre-flight and use Claude agents instead.
 
 This is especially useful when the task scope is unclear and benefits from external reasoning before committing to a specific decomposition.
 

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -197,18 +197,21 @@ function createMcpDelegation(provider, originalPrompt) {
 You MUST delegate this task to the ${provider === 'codex' ? 'Codex' : 'Gemini'} MCP tool.
 
 Steps:
-1. Write a prompt file to \`.omc/prompts/${provider}-{purpose}-{timestamp}.md\` containing clear task instructions derived from the user's request
-2. Determine the appropriate agent_role from: ${config.roles}
-3. Call the \`${config.tool}\` MCP tool with:
+1. Call ToolSearch("mcp") to discover available MCP tools (required -- they are deferred and not in your tool list by default)
+2. Write a prompt file to \`.omc/prompts/${provider}-{purpose}-{timestamp}.md\` containing clear task instructions derived from the user's request
+3. Determine the appropriate agent_role from: ${config.roles}
+4. Call the \`${config.tool}\` MCP tool with:
    - agent_role: <detected or default "${config.defaultRole}">
    - prompt_file: <path you wrote>
    - output_file: <corresponding -summary.md path>
    - context_files: <relevant files from user's request>
 
+If ToolSearch returns no MCP tools, the MCP server is not configured. Fall back to the equivalent Claude agent instead.
+
 User request:
 ${originalPrompt}
 
-IMPORTANT: Do NOT invoke a skill. Delegate to the MCP tool IMMEDIATELY.`;
+IMPORTANT: Do NOT invoke a skill. Discover MCP tools via ToolSearch first, then delegate IMMEDIATELY.`;
 }
 
 /**

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -287,6 +287,20 @@ ${notepadContext}
 `);
     }
 
+    // MCP tool discovery reminder (deferred tools need ToolSearch before use)
+    messages.push(`<session-restore>
+
+[MCP TOOL DISCOVERY REQUIRED]
+
+MCP tools (ask_codex, ask_gemini) are deferred and NOT in your tool list yet.
+Before first use, call ToolSearch("mcp") to discover all available MCP tools.
+If ToolSearch returns no results, MCP servers are not configured -- use Claude agent fallbacks instead.
+
+</session-restore>
+
+---
+`);
+
     if (messages.length > 0) {
       console.log(JSON.stringify({
         continue: true,


### PR DESCRIPTION
## Summary
- MCP tools (`ask_codex`, `ask_gemini`) are deferred and not available in the tool list at session start, causing failures when skills try to use them
- Added `ToolSearch("mcp")` discovery instructions at three layers: CLAUDE.md, session-start hook, keyword-detector hook, and 9 skill files
- All locations include graceful fallback to Claude agents when MCP servers are unavailable

Fixes #483

## Test plan
- [x] All 3017 tests pass (1 pre-existing flaky failure in lock file test, unrelated)
- [ ] Verify session-start hook emits MCP discovery reminder
- [ ] Verify keyword-detector includes ToolSearch step in MCP delegation
- [ ] Verify skills correctly instruct ToolSearch before MCP tool usage
- [ ] Confirm fallback to Claude agents works when MCP tools are not available

🤖 Generated with [Claude Code](https://claude.com/claude-code)