### PR TITLE
docs: clarify npm package name vs project brand name

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -36,6 +36,8 @@ autopilot: build a REST API for managing tasks
 
 Eso es todo. Todo lo demás es automático.
 
+> **Nota: Nombre del paquete** — El proyecto usa la marca **oh-my-claudecode** (repositorio, plugin, comandos), pero el paquete npm se publica como [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus). Si instalas las herramientas CLI via npm/bun, usa `npm install -g oh-my-claude-sisyphus`.
+
 ### Actualizar
 
 ```bash

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,6 +36,8 @@ autopilot: build a REST API for managing tasks
 
 以上です。あとは自動で進みます。
 
+> **注意: パッケージ名について** — プロジェクトのブランド名は **oh-my-claudecode**（リポジトリ、プラグイン、コマンド）ですが、npmパッケージは [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus) として公開されています。npm/bunでCLIツールをインストールする場合は `npm install -g oh-my-claude-sisyphus` を使用してください。
+
 ### アップデート
 
 ```bash

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,6 +36,8 @@ autopilot: build a REST API for managing tasks
 
 끝입니다. 나머지는 모두 자동입니다.
 
+> **참고: 패키지 이름** — 프로젝트 브랜드명은 **oh-my-claudecode** (저장소, 플러그인, 명령어)이지만, npm 패키지는 [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus)로 배포됩니다. npm/bun으로 CLI 도구를 설치할 때는 `npm install -g oh-my-claude-sisyphus`를 사용하세요.
+
 ### 업데이트
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ autopilot: build a REST API for managing tasks
 
 That's it. Everything else is automatic.
 
+> **Note: Package naming** — The project is branded as **oh-my-claudecode** (repo, plugin, commands), but the npm package is published as [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus). If you install the CLI tools via npm/bun, use `npm install -g oh-my-claude-sisyphus`.
+
 ### Updating
 
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -36,6 +36,8 @@ autopilot: build a REST API for managing tasks
 
 就这么简单。其余都是自动的。
 
+> **注意：包命名** — 项目品牌名为 **oh-my-claudecode**（仓库、插件、命令），但 npm 包以 [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus) 发布。通过 npm/bun 安装 CLI 工具时，请使用 `npm install -g oh-my-claude-sisyphus`。
+
 ### 更新
 
 ```bash

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -323,7 +323,7 @@ Examples:
     }
     // Generate config content
     const configContent = `// Oh-My-ClaudeCode Configuration
-// See: https://github.com/your-repo/oh-my-claudecode for documentation
+// See: https://github.com/Yeachan-Heo/oh-my-claudecode for documentation
 {
   "$schema": "./sisyphus-schema.json",
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -117,20 +117,18 @@ Your old commands still work! But now you don't need them.
 
 **After 3.0:** Just work naturally - Claude auto-activates the right behaviors. One-time setup: just say "setup omc"
 
-### Package Rename
+### Project Rebrand
 
-The package has been renamed to better reflect its purpose and improve discoverability.
+The project was rebranded to better reflect its purpose and improve discoverability.
 
-- **Old**: `oh-my-claude-sisyphus`
-- **New**: `oh-my-claudecode`
+- **Project/brand name**: `oh-my-claudecode` (GitHub repo, plugin name, commands)
+- **npm package name**: `oh-my-claude-sisyphus` (unchanged)
 
-#### NPM Commands
+> **Why the difference?** The npm package name `oh-my-claude-sisyphus` was kept for backward compatibility with existing installations. The project, GitHub repository, plugin, and all commands use `oh-my-claudecode`.
+
+#### NPM Install Command (unchanged)
 
 ```bash
-# Old
-npm install -g oh-my-claude-sisyphus
-
-# New
 npm install -g oh-my-claude-sisyphus
 ```
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -4,7 +4,7 @@ Command-line interface for Oh-My-ClaudeCode analytics, token tracking, cost repo
 
 ## Installation
 
-After installing oh-my-claudecode:
+Install via npm (note: the npm package name is `oh-my-claude-sisyphus`):
 
 ```bash
 npm install -g oh-my-claude-sisyphus

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -386,7 +386,7 @@ Examples:
 
     // Generate config content
     const configContent = `// Oh-My-ClaudeCode Configuration
-// See: https://github.com/your-repo/oh-my-claudecode for documentation
+// See: https://github.com/Yeachan-Heo/oh-my-claudecode for documentation
 {
   "$schema": "./sisyphus-schema.json",
 


### PR DESCRIPTION
## Summary

Fixes #491 - NPM package name confusion.

- Added a **"Package naming" note** to all README variants (en, ko, ja, zh, es) explaining that the npm package is `oh-my-claude-sisyphus` while the project brand is `oh-my-claudecode`
- Fixed the misleading **"Package Rename" section** in `docs/MIGRATION.md` — renamed to "Project Rebrand" with clear explanation of why the npm name was kept
- Fixed a **placeholder GitHub URL** (`your-repo`) in `src/cli/index.ts`
- Added **npm name context** to `src/cli/README.md` install section

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 3031 tests pass (`npm run test:run` — 130 files, 0 failures)
- [x] Verified compiled dist contains the URL fix
- [x] No changes to runtime behavior — documentation only (plus one comment URL fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)