### PR TITLE
feat: add multi-provider model configuration and start-work execution…

### DIFF
--- a/commands/start-work.md
+++ b/commands/start-work.md
@@ -1,0 +1,105 @@
+---
+description: Execute a plan from .omc/plans/ with boulder state tracking
+aliases: [sw]
+---
+
+# Start Work
+
+[START-WORK ACTIVATED - PLAN EXECUTION MODE]
+
+## User's Plan Selection
+
+{{ARGUMENTS}}
+
+## Overview
+
+Start-work bridges planning to execution. It loads a plan from `.omc/plans/`, creates boulder state for session continuity, and executes tasks sequentially with progress tracking.
+
+## Execution Protocol
+
+### Step 1: Check for Active Boulder
+
+First, check if there's already an active work session:
+
+1. Read `.omc/boulder.json` - if it exists and has an `active_plan`:
+   - Read the plan file at `active_plan` path
+   - Count checkboxes: `- [ ]` (incomplete) vs `- [x]`/`- [X]` (complete)
+   - If incomplete tasks remain → **RESUME** from the first unchecked task
+   - Display: "Resuming plan: {plan_name} - {completed}/{total} tasks done"
+   - Skip to Step 4 (Execute)
+2. Also check `mcp__t__state_read` with `mode: "ralplan"` for any active ralplan state
+
+### Step 2: Find and Select Plan
+
+If no active boulder:
+
+1. Scan `.omc/plans/*.md` using Glob tool
+2. **If `{{ARGUMENTS}}` is provided and non-empty**: Match plan by filename (fuzzy match)
+3. **If exactly 1 plan found**: Auto-select it
+4. **If multiple plans found**: Use `AskUserQuestion` to present choices with progress stats
+5. **If 0 plans found**: Say "No plans found in `.omc/plans/`. Run `/plan` first to create one." and STOP
+
+### Step 3: Initialize Boulder State
+
+Once a plan is selected:
+
+1. Write `.omc/boulder.json`:
+   ```json
+   {
+     "active_plan": ".omc/plans/{name}.md",
+     "started_at": "ISO-timestamp",
+     "session_ids": ["{current-session-id}"],
+     "plan_name": "{name}"
+   }
+   ```
+
+2. Set execution state via `mcp__t__state_write`:
+   - `mode`: "ralplan"
+   - `active`: true
+   - `plan_path`: ".omc/plans/{name}.md"
+   - `current_phase`: "executing"
+   - `task_description`: First line/title of the plan
+   - `started_at`: ISO timestamp
+
+3. Read the full plan content and identify all `- [ ]` tasks
+
+### Step 4: Execute Tasks
+
+For each unchecked `- [ ]` task in the plan:
+
+1. **Announce**: Display which task you're working on
+2. **Execute**: Perform the task using appropriate tools and agents
+3. **Verify**: Confirm the task is actually complete
+4. **Mark complete**: Edit the plan file to change `- [ ]` to `- [x]`
+5. **Save learnings**: Use `mcp__t__notepad_write_working` to record:
+   - What was done
+   - Key decisions made
+   - Any issues encountered
+   - What to do next
+
+### Step 5: Completion
+
+When all tasks are marked `- [x]`:
+
+1. Clear boulder state: Delete `.omc/boulder.json`
+2. Clear ralplan state: `mcp__t__state_clear(mode: "ralplan")`
+3. Display completion summary:
+   - Total tasks completed
+   - Time taken (from boulder started_at)
+   - Key deliverables
+
+## Session Continuity
+
+If the session is interrupted or compacted:
+- The session-start hook will detect the active boulder on next session
+- It will inject context reminding you to resume from where you left off
+- The persistent-mode hook will prevent premature stopping while tasks remain
+- The pre-compact hook will prompt you to save progress before compaction
+
+## CRITICAL RULES
+
+1. **Execute sequentially** - One task at a time, in plan order
+2. **Verify before marking** - Never mark a task `[x]` without verification
+3. **Save progress often** - Use notepad after each task for compaction resilience
+4. **Never skip tasks** - Execute ALL unchecked tasks unless user explicitly says to skip
+5. **Resume on restart** - Always check boulder state first

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -133,6 +133,11 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-precompact.mjs\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/boulder-memory-flush.mjs\"",
+            "timeout": 5
           }
         ]
       }

--- a/scripts/boulder-memory-flush.mjs
+++ b/scripts/boulder-memory-flush.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/**
+ * Boulder Memory Flush Hook (PreCompact)
+ *
+ * When context is about to be compacted, this hook injects a prompt
+ * telling Claude to save important context to the notepad before
+ * the compaction happens. This preserves critical decisions and
+ * progress across context boundaries.
+ *
+ * Concept ported from openclaw's pre-compaction memory flush.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Import timeout-protected stdin reader (prevents hangs on Linux, see issue #240)
+let readStdin;
+try {
+  const mod = await import(join(__dirname, 'lib', 'stdin.mjs'));
+  readStdin = mod.readStdin;
+} catch {
+  // Fallback: inline timeout-protected readStdin if lib module is missing
+  readStdin = (timeoutMs = 5000) => new Promise((resolve) => {
+    const chunks = [];
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (!settled) { settled = true; process.stdin.removeAllListeners(); process.stdin.destroy(); resolve(Buffer.concat(chunks).toString('utf-8')); }
+    }, timeoutMs);
+    process.stdin.on('data', (chunk) => { chunks.push(chunk); });
+    process.stdin.on('end', () => { if (!settled) { settled = true; clearTimeout(timeout); resolve(Buffer.concat(chunks).toString('utf-8')); } });
+    process.stdin.on('error', () => { if (!settled) { settled = true; clearTimeout(timeout); resolve(''); } });
+    if (process.stdin.readableEnded) { if (!settled) { settled = true; clearTimeout(timeout); resolve(Buffer.concat(chunks).toString('utf-8')); } }
+  });
+}
+
+function readJsonFile(path) {
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  try {
+    const input = await readStdin();
+    let data = {};
+    try { data = JSON.parse(input); } catch {}
+
+    const directory = data.cwd || data.directory || process.cwd();
+
+    // Check for active boulder state
+    const boulderPath = join(directory, '.omc', 'boulder.json');
+    const boulder = readJsonFile(boulderPath);
+
+    // Check for active ralplan state
+    const ralplanPath = join(directory, '.omc', 'state', 'ralplan-state.json');
+    const ralplan = readJsonFile(ralplanPath);
+
+    const hasActiveBoulder = boulder?.active_plan;
+    const hasActiveRalplan = ralplan?.active;
+
+    if (!hasActiveBoulder && !hasActiveRalplan) {
+      // No active work session, passthrough
+      console.log(JSON.stringify({ continue: true }));
+      return;
+    }
+
+    // Build plan progress info
+    let planInfo = '';
+    if (hasActiveBoulder) {
+      const planPath = join(directory, boulder.active_plan);
+      if (existsSync(planPath)) {
+        const content = readFileSync(planPath, 'utf-8');
+        const unchecked = (content.match(/^[-*]\s*\[\s*\]/gm) || []).length;
+        const checked = (content.match(/^[-*]\s*\[[xX]\]/gm) || []).length;
+        planInfo = `\nActive plan: ${boulder.plan_name} (${checked}/${checked + unchecked} tasks done)`;
+      }
+    }
+
+    const flushPrompt = `[PRE-COMPACTION MEMORY FLUSH]
+Context is about to be compacted. BEFORE continuing, save important context:${planInfo}
+
+1. Use mcp__t__notepad_write_working to save:
+   - Key decisions made in this session
+   - Important code patterns or findings discovered
+   - Current task progress and what to do next
+   - Any blockers or unresolved issues
+
+2. If there is a critical discovery that MUST survive compaction,
+   use mcp__t__notepad_write_priority (max 2000 chars, replaces existing).
+
+3. If working on a plan (.omc/plans/*.md), update the plan file to reflect
+   current progress (mark completed tasks with - [x]).
+
+After saving, continue with your work.`;
+
+    console.log(JSON.stringify({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'PreCompact',
+        additionalContext: flushPrompt
+      }
+    }));
+  } catch (error) {
+    // Never block on errors
+    console.error('[boulder-memory-flush] Error:', error.message);
+    console.log(JSON.stringify({ continue: true }));
+  }
+}
+
+main();

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -322,6 +322,39 @@ Continue working in ultrawork mode until all tasks are complete.
 `);
     }
 
+    // Check for boulder state (active plan execution via /start-work)
+    const boulderState = readJsonFile(join(directory, '.omc', 'boulder.json'));
+    if (boulderState?.active_plan) {
+      const planPath = join(directory, boulderState.active_plan);
+      let progressInfo = '';
+      if (existsSync(planPath)) {
+        const content = readFileSync(planPath, 'utf-8');
+        const unchecked = (content.match(/^[-*]\s*\[\s*\]/gm) || []).length;
+        const checked = (content.match(/^[-*]\s*\[[xX]\]/gm) || []).length;
+        const total = checked + unchecked;
+        if (total > 0) {
+          progressInfo = `\nProgress: ${checked}/${total} tasks completed.`;
+        }
+      }
+
+      messages.push(`<session-restore>
+
+[ACTIVE WORK PLAN]
+
+You have an active plan: ${boulderState.active_plan}
+Plan: ${boulderState.plan_name || 'Unknown'}
+Started: ${boulderState.started_at || 'Unknown'}${progressInfo}
+
+Resume from the first unchecked - [ ] task.
+Read the plan file and continue executing.
+After each task: mark - [x] in plan, save learnings to mcp__t__notepad_write_working.
+
+</session-restore>
+
+---
+`);
+    }
+
     // Check for ralph loop state
     // Session-scoped ONLY when session_id exists — no legacy fallback
     let ralphState = null;

--- a/skills/start-work/SKILL.md
+++ b/skills/start-work/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: start-work
+description: Execute a plan from .omc/plans/ with session continuity and boulder state tracking
+---
+
+# Start Work - Plan Execution Skill
+
+You are an execution agent. Your job is to take a plan from `.omc/plans/` and execute it task by task with progress tracking and session continuity.
+
+## Quick Start
+
+1. Check `.omc/boulder.json` for an active work session
+2. If active → resume from last incomplete task
+3. If not active → find plan in `.omc/plans/`, create boulder state, begin execution
+
+## Execution Protocol
+
+### Check Active Boulder
+
+Read `.omc/boulder.json`:
+- If exists with `active_plan` → Resume that plan
+- Count `- [ ]` (incomplete) and `- [x]`/`- [X]` (complete) checkboxes
+- Resume from first unchecked task
+
+### Initialize New Boulder
+
+If no active boulder:
+1. Find plan in `.omc/plans/` (match by name if argument provided)
+2. Create `.omc/boulder.json`:
+   ```json
+   {
+     "active_plan": ".omc/plans/{name}.md",
+     "started_at": "ISO-timestamp",
+     "session_ids": ["{session-id}"],
+     "plan_name": "{name}"
+   }
+   ```
+3. Set state via `mcp__t__state_write(mode: "ralplan", active: true, plan_path: ..., current_phase: "executing")`
+
+### Execute Tasks
+
+For each `- [ ]` task in the plan:
+1. **Announce** which task you're starting
+2. **Execute** the task using appropriate tools and agents
+3. **Verify** the task is actually complete
+4. **Mark complete**: Edit plan file to change `- [ ]` to `- [x]`
+5. **Save learnings**: `mcp__t__notepad_write_working` with progress, decisions, next steps
+
+### Completion
+
+When all tasks are `- [x]`:
+1. Delete `.omc/boulder.json`
+2. `mcp__t__state_clear(mode: "ralplan")`
+3. Report completion summary with time taken and deliverables
+
+## Session Continuity
+
+Boulder state persists across sessions. If interrupted:
+- Session-start hook auto-detects active boulder and injects resume context
+- Persistent-mode hook prevents premature stopping while tasks remain
+- Pre-compact hook prompts saving progress before context compaction
+
+## Rules
+
+- Execute tasks sequentially, in plan order
+- Verify before marking complete
+- Save progress to notepad after each task
+- Never skip tasks without user approval
+- Always check boulder state first on any session start

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -13,6 +13,7 @@ import { join, dirname } from 'path';
 import * as jsonc from 'jsonc-parser';
 import type { PluginConfig } from '../shared/types.js';
 import { getConfigDir } from '../utils/paths.js';
+import { loadModelsConfigFromFile } from '../features/model-config/loader.js';
 
 /**
  * Default configuration
@@ -246,6 +247,16 @@ export function loadConfig(): PluginConfig {
   // Merge environment variables (highest precedence)
   const envConfig = loadEnvConfig();
   config = deepMerge(config, envConfig);
+
+  // Load .claude/models.json for multi-provider model configuration
+  try {
+    const modelsConfig = loadModelsConfigFromFile();
+    if (modelsConfig) {
+      config.modelsConfig = modelsConfig;
+    }
+  } catch (error) {
+    console.warn(`Warning: Failed to load models.json: ${(error as Error).message}`);
+  }
 
   return config;
 }

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -183,6 +183,33 @@ export {
   type PromptAdaptationStrategy,
 } from './model-routing/index.js';
 
+// Model Config - multi-provider model configuration
+export {
+  // Types
+  type ProviderConfig,
+  type AgentModelConfig,
+  type ModelsConfig,
+  type ResolvedModel,
+  // Constants
+  PROVIDER_MCP_MAPPING,
+  CLAUDE_TIERS,
+  // Loader
+  getModelsConfigPath,
+  resolveApiKey,
+  loadModelsConfigFromFile,
+  validateConfig as validateModelsConfig,
+  loadModelsConfig,
+  getAgentModelConfig,
+  getResolvedProviderConfig,
+  clearModelsConfigCache,
+  // Resolver
+  getMcpToolForProvider,
+  resolveModelForAgent,
+  isProviderAvailable,
+  getFallbackModel,
+  resolveModelWithFallback,
+} from './model-config/index.js';
+
 // Notepad Wisdom - plan-scoped wisdom accumulation
 export {
   // Functions

--- a/src/features/model-config/index.ts
+++ b/src/features/model-config/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Model Config Feature
+ *
+ * Multi-provider model configuration via `.claude/models.json`.
+ * Allows assigning specific models from any provider to each agent.
+ *
+ * Usage:
+ * ```typescript
+ * import { resolveModelForAgent, resolveModelWithFallback } from './model-config';
+ *
+ * const resolved = resolveModelWithFallback('architect', 'opus');
+ * if (resolved.type === 'external') {
+ *   // Delegate via MCP tool (ask_codex / ask_gemini)
+ * } else {
+ *   // Use Claude Task tool with resolved.tier
+ * }
+ * ```
+ */
+
+// Types
+export type {
+  ProviderConfig,
+  AgentModelConfig,
+  ModelsConfig,
+  ResolvedModel,
+} from './types.js';
+
+export {
+  PROVIDER_MCP_MAPPING,
+  CLAUDE_TIERS,
+} from './types.js';
+
+// Loader
+export {
+  getModelsConfigPath,
+  resolveApiKey,
+  loadModelsConfigFromFile,
+  validateConfig,
+  loadModelsConfig,
+  getAgentModelConfig,
+  getResolvedProviderConfig,
+  clearModelsConfigCache,
+} from './loader.js';
+
+// Resolver
+export {
+  getMcpToolForProvider,
+  resolveModelForAgent,
+  isProviderAvailable,
+  getFallbackModel,
+  resolveModelWithFallback,
+} from './resolver.js';

--- a/src/features/model-config/loader.ts
+++ b/src/features/model-config/loader.ts
@@ -1,0 +1,187 @@
+/**
+ * Model Config Loader
+ *
+ * Loads and validates `.claude/models.json` configuration.
+ * Resolves environment variable references in API keys.
+ * Caches loaded config per session.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import type { ModelsConfig, ProviderConfig, AgentModelConfig } from './types.js';
+import { CLAUDE_TIERS } from './types.js';
+
+/** Cached config instance (session-scoped) */
+let cachedConfig: ModelsConfig | null = null;
+let cachedConfigPath: string | null = null;
+
+/**
+ * Get the path to .claude/models.json in the project root
+ */
+export function getModelsConfigPath(projectRoot?: string): string {
+  const root = projectRoot || process.cwd();
+  return join(root, '.claude', 'models.json');
+}
+
+/**
+ * Resolve an API key value.
+ * If it starts with "$", treat it as an env var reference.
+ * Otherwise return the raw value.
+ */
+export function resolveApiKey(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.startsWith('$')) {
+    const envVar = value.slice(1);
+    return process.env[envVar] || undefined;
+  }
+  return value;
+}
+
+/**
+ * Load and parse .claude/models.json
+ * Returns null if the file doesn't exist.
+ * Throws on parse errors.
+ */
+export function loadModelsConfigFromFile(projectRoot?: string): ModelsConfig | null {
+  const configPath = getModelsConfigPath(projectRoot);
+
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    // Strip comments (// and /* */) for JSONC compatibility
+    const stripped = content
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    return JSON.parse(stripped) as ModelsConfig;
+  } catch (error) {
+    throw new Error(`Failed to parse ${configPath}: ${(error as Error).message}`);
+  }
+}
+
+/**
+ * Validate a loaded models config.
+ * Checks provider references in agent configs, model availability, etc.
+ * Returns an array of warning messages (empty = valid).
+ */
+export function validateConfig(config: ModelsConfig): string[] {
+  const warnings: string[] = [];
+  const providerNames = new Set(Object.keys(config.providers || {}));
+  // "claude" is always a valid provider
+  providerNames.add('claude');
+
+  // Validate agent configs
+  if (config.agents) {
+    for (const [agentName, agentConfig] of Object.entries(config.agents)) {
+      // Check provider reference
+      if (!providerNames.has(agentConfig.provider)) {
+        warnings.push(`Agent "${agentName}" references unknown provider "${agentConfig.provider}"`);
+      }
+
+      // Check model for claude provider
+      if (agentConfig.provider === 'claude' && !CLAUDE_TIERS.includes(agentConfig.model)) {
+        warnings.push(`Agent "${agentName}" uses claude provider but model "${agentConfig.model}" is not a valid tier (${CLAUDE_TIERS.join(', ')})`);
+      }
+
+      // Check model is in provider's model list
+      if (agentConfig.provider !== 'claude' && config.providers?.[agentConfig.provider]) {
+        const provider = config.providers[agentConfig.provider];
+        if (provider.models.length > 0 && !provider.models.includes(agentConfig.model)) {
+          warnings.push(`Agent "${agentName}" uses model "${agentConfig.model}" not listed in provider "${agentConfig.provider}" models`);
+        }
+      }
+
+      // Validate fallback tier
+      if (agentConfig.fallback && !CLAUDE_TIERS.includes(agentConfig.fallback)) {
+        warnings.push(`Agent "${agentName}" has invalid fallback tier "${agentConfig.fallback}"`);
+      }
+    }
+  }
+
+  // Validate defaults
+  if (config.defaults) {
+    if (!providerNames.has(config.defaults.provider)) {
+      warnings.push(`Default config references unknown provider "${config.defaults.provider}"`);
+    }
+  }
+
+  // Validate providers have baseUrl
+  if (config.providers) {
+    for (const [name, provider] of Object.entries(config.providers)) {
+      if (!provider.baseUrl) {
+        warnings.push(`Provider "${name}" is missing baseUrl`);
+      }
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Load models config with caching.
+ * Returns the cached config if the same project root is used.
+ */
+export function loadModelsConfig(projectRoot?: string): ModelsConfig | null {
+  const configPath = getModelsConfigPath(projectRoot);
+
+  if (cachedConfig !== null && cachedConfigPath === configPath) {
+    return cachedConfig;
+  }
+
+  const config = loadModelsConfigFromFile(projectRoot);
+  if (config) {
+    const warnings = validateConfig(config);
+    if (warnings.length > 0) {
+      console.warn('[model-config] Validation warnings:', warnings.join('; '));
+    }
+  }
+
+  cachedConfig = config;
+  cachedConfigPath = configPath;
+  return config;
+}
+
+/**
+ * Get the model config for a specific agent.
+ * Returns the agent-specific config, or defaults, or null.
+ */
+export function getAgentModelConfig(agentName: string, projectRoot?: string): AgentModelConfig | null {
+  const config = loadModelsConfig(projectRoot);
+  if (!config) return null;
+
+  // Check agent-specific config first
+  if (config.agents?.[agentName]) {
+    return config.agents[agentName];
+  }
+
+  // Fall back to defaults
+  if (config.defaults) {
+    return config.defaults;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the full provider config (with API key resolved) for a provider name.
+ */
+export function getResolvedProviderConfig(providerName: string, projectRoot?: string): (ProviderConfig & { resolvedApiKey?: string }) | null {
+  const config = loadModelsConfig(projectRoot);
+  if (!config?.providers?.[providerName]) return null;
+
+  const provider = config.providers[providerName];
+  return {
+    ...provider,
+    resolvedApiKey: resolveApiKey(provider.apiKey),
+  };
+}
+
+/**
+ * Clear the cached config (useful for testing or config reload)
+ */
+export function clearModelsConfigCache(): void {
+  cachedConfig = null;
+  cachedConfigPath = null;
+}

--- a/src/features/model-config/resolver.ts
+++ b/src/features/model-config/resolver.ts
@@ -1,0 +1,138 @@
+/**
+ * Model Resolution Pipeline
+ *
+ * Resolves the model to use for a given agent by checking:
+ * 1. .claude/models.json agent override
+ * 2. .claude/models.json defaults
+ * 3. Fall back to existing static tier from definitions.ts
+ */
+
+import type { ModelType } from '../../shared/types.js';
+import type { ResolvedModel, AgentModelConfig } from './types.js';
+import { CLAUDE_TIERS, PROVIDER_MCP_MAPPING } from './types.js';
+import { getAgentModelConfig, getResolvedProviderConfig } from './loader.js';
+
+/**
+ * Map a Claude tier string to a ModelType
+ */
+function toModelType(tier: string): ModelType | undefined {
+  if (CLAUDE_TIERS.includes(tier)) {
+    return tier as ModelType;
+  }
+  return undefined;
+}
+
+/**
+ * Determine which MCP tool to use for an external provider
+ */
+export function getMcpToolForProvider(provider: string): string | undefined {
+  return PROVIDER_MCP_MAPPING[provider.toLowerCase()];
+}
+
+/**
+ * Resolve model config for a specific agent.
+ *
+ * Resolution order:
+ * 1. .claude/models.json agent-specific config
+ * 2. .claude/models.json defaults
+ * 3. Static tier fallback (passed by caller from definitions.ts)
+ */
+export function resolveModelForAgent(
+  agentName: string,
+  staticTier?: ModelType,
+  projectRoot?: string,
+): ResolvedModel {
+  const agentConfig = getAgentModelConfig(agentName, projectRoot);
+
+  // No models.json config found - use static tier
+  if (!agentConfig) {
+    return {
+      type: 'claude',
+      tier: staticTier || 'sonnet',
+    };
+  }
+
+  return resolveFromAgentConfig(agentConfig, staticTier, projectRoot);
+}
+
+/**
+ * Resolve a ResolvedModel from an AgentModelConfig
+ */
+function resolveFromAgentConfig(
+  agentConfig: AgentModelConfig,
+  staticTier?: ModelType,
+  projectRoot?: string,
+): ResolvedModel {
+  // Claude provider - use native tier
+  if (agentConfig.provider === 'claude') {
+    const tier = toModelType(agentConfig.model);
+    return {
+      type: 'claude',
+      tier: tier || staticTier || 'sonnet',
+    };
+  }
+
+  // External provider - resolve provider details
+  const providerConfig = getResolvedProviderConfig(agentConfig.provider, projectRoot);
+
+  if (!providerConfig) {
+    // Provider not found in config - fall back to Claude tier
+    const fallback = agentConfig.fallback || staticTier || 'sonnet';
+    return {
+      type: 'claude',
+      tier: fallback,
+    };
+  }
+
+  return {
+    type: 'external',
+    provider: agentConfig.provider,
+    model: agentConfig.model,
+    role: agentConfig.role,
+    baseUrl: providerConfig.baseUrl,
+    apiKey: providerConfig.resolvedApiKey,
+    fallbackTier: agentConfig.fallback || staticTier || 'sonnet',
+  };
+}
+
+/**
+ * Check if an external provider is available (has resolved API key or is local)
+ */
+export function isProviderAvailable(resolved: ResolvedModel): boolean {
+  if (resolved.type === 'claude') return true;
+
+  // Local providers (e.g., Ollama) don't need API keys
+  if (resolved.baseUrl?.includes('localhost') || resolved.baseUrl?.includes('127.0.0.1')) {
+    return true;
+  }
+
+  // Remote providers need an API key
+  return !!resolved.apiKey;
+}
+
+/**
+ * Get the fallback ResolvedModel when external provider is unavailable
+ */
+export function getFallbackModel(resolved: ResolvedModel): ResolvedModel {
+  return {
+    type: 'claude',
+    tier: resolved.fallbackTier || 'sonnet',
+  };
+}
+
+/**
+ * Resolve model for agent with automatic fallback if provider unavailable
+ */
+export function resolveModelWithFallback(
+  agentName: string,
+  staticTier?: ModelType,
+  projectRoot?: string,
+): ResolvedModel {
+  const resolved = resolveModelForAgent(agentName, staticTier, projectRoot);
+
+  if (resolved.type === 'external' && !isProviderAvailable(resolved)) {
+    return getFallbackModel(resolved);
+  }
+
+  return resolved;
+}

--- a/src/features/model-config/types.ts
+++ b/src/features/model-config/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Multi-Provider Model Configuration Types
+ *
+ * Types for `.claude/models.json` configuration that allows assigning
+ * specific models from any provider (OpenAI, Gemini, Ollama, etc.)
+ * to each agent.
+ */
+
+import type { ModelType } from '../../shared/types.js';
+
+/**
+ * Provider connection configuration
+ */
+export interface ProviderConfig {
+  /** Base URL for the provider API */
+  baseUrl: string;
+  /** API key - raw string or "$ENV_VAR" reference */
+  apiKey?: string;
+  /** Available model IDs for this provider */
+  models: string[];
+}
+
+/**
+ * Per-agent model assignment
+ */
+export interface AgentModelConfig {
+  /** Provider key from providers map, or "claude" for native Claude */
+  provider: string;
+  /** Model ID (for external providers) or Claude tier name (haiku/sonnet/opus) */
+  model: string;
+  /** Role hint for MCP delegation (e.g., "architect", "designer") */
+  role?: string;
+  /** Claude tier fallback if external provider is unavailable */
+  fallback?: ModelType;
+}
+
+/**
+ * Root configuration from .claude/models.json
+ */
+export interface ModelsConfig {
+  /** Provider definitions with connection details */
+  providers?: Record<string, ProviderConfig>;
+  /** Per-agent model assignments */
+  agents?: Record<string, AgentModelConfig>;
+  /** Default fallback for agents not listed in agents map */
+  defaults?: AgentModelConfig;
+}
+
+/**
+ * Resolved model ready for execution
+ */
+export interface ResolvedModel {
+  /** Whether this is a native Claude model or external provider */
+  type: 'claude' | 'external';
+  /** Claude tier (haiku/sonnet/opus) - set for claude type */
+  tier?: ModelType;
+  /** Provider name - set for external type */
+  provider?: string;
+  /** Model ID - set for external type */
+  model?: string;
+  /** Agent role for MCP delegation */
+  role?: string;
+  /** Resolved base URL for the provider */
+  baseUrl?: string;
+  /** Resolved API key for the provider */
+  apiKey?: string;
+  /** Claude tier to fall back to if external provider fails */
+  fallbackTier?: ModelType;
+}
+
+/**
+ * Known provider-to-MCP-tool mapping
+ */
+export const PROVIDER_MCP_MAPPING: Record<string, string> = {
+  openai: 'codex',
+  codex: 'codex',
+  gemini: 'gemini',
+  google: 'gemini',
+};
+
+/**
+ * Claude tier names for validation
+ */
+export const CLAUDE_TIERS: readonly string[] = ['haiku', 'sonnet', 'opus'] as const;

--- a/src/mcp/codex-server.ts
+++ b/src/mcp/codex-server.ts
@@ -24,9 +24,11 @@ const askCodexTool = tool(
     model: { type: "string", description: `Codex model to use (default: ${CODEX_DEFAULT_MODEL}). Set OMC_CODEX_DEFAULT_MODEL env var to change default.` },
     background: { type: "boolean", description: "Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion." },
     working_directory: { type: "string", description: "Working directory for path resolution and CLI execution. Defaults to process.cwd()." },
+    api_key: { type: "string", description: "Optional API key override. When provided, passed as OPENAI_API_KEY to the Codex CLI process." },
+    base_url: { type: "string", description: "Optional base URL override. When provided, passed as OPENAI_BASE_URL to the Codex CLI process." },
   } as any,
   async (args: any) => {
-    const { prompt_file, output_file, agent_role, model, context_files, background, working_directory } = args as {
+    const { prompt_file, output_file, agent_role, model, context_files, background, working_directory, api_key, base_url } = args as {
       prompt_file: string;
       output_file: string;
       agent_role: string;
@@ -34,8 +36,10 @@ const askCodexTool = tool(
       context_files?: string[];
       background?: boolean;
       working_directory?: string;
+      api_key?: string;
+      base_url?: string;
     };
-    return handleAskCodex({ prompt_file, output_file, agent_role, model, context_files, background, working_directory });
+    return handleAskCodex({ prompt_file, output_file, agent_role, model, context_files, background, working_directory, api_key, base_url });
   }
 );
 

--- a/src/mcp/gemini-core.ts
+++ b/src/mcp/gemini-core.ts
@@ -82,7 +82,7 @@ export function isGeminiRetryableError(stdout: string, stderr: string = ''): { i
 /**
  * Execute Gemini CLI command and return the response
  */
-export function executeGemini(prompt: string, model?: string, cwd?: string): Promise<string> {
+export function executeGemini(prompt: string, model?: string, cwd?: string, options?: { apiKey?: string; baseUrl?: string }): Promise<string> {
   return new Promise((resolve, reject) => {
     if (model) validateModelName(model);
     let settled = false;
@@ -90,9 +90,20 @@ export function executeGemini(prompt: string, model?: string, cwd?: string): Pro
     if (model) {
       args.push('--model', model);
     }
+
+    // Build env overrides for provider-specific credentials
+    const env = options?.apiKey || options?.baseUrl
+      ? {
+          ...process.env,
+          ...(options.apiKey ? { GOOGLE_API_KEY: options.apiKey, GEMINI_API_KEY: options.apiKey } : {}),
+          ...(options.baseUrl ? { GEMINI_BASE_URL: options.baseUrl } : {}),
+        }
+      : undefined;
+
     const child = spawn('gemini', args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(cwd ? { cwd } : {}),
+      ...(env ? { env } : {}),
       // shell: true needed on Windows for .cmd/.bat executables.
       // Safe: args are array-based and model names are regex-validated.
       ...(process.platform === 'win32' ? { shell: true } : {})
@@ -427,6 +438,8 @@ export async function handleAskGemini(args: {
   files?: string[];
   background?: boolean;
   working_directory?: string;
+  api_key?: string;
+  base_url?: string;
 }): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
   const { agent_role, model = GEMINI_DEFAULT_MODEL, files } = args;
 
@@ -686,10 +699,13 @@ ${resolvedPrompt}`;
     resolvedOutputPath = resolve(baseDirReal, args.output_file);
   }
 
+  const providerOptions = args.api_key || args.base_url
+    ? { apiKey: args.api_key, baseUrl: args.base_url }
+    : undefined;
   const errors: string[] = [];
   for (const tryModel of modelsToTry) {
     try {
-      const response = await executeGemini(fullPrompt, tryModel, baseDir);
+      const response = await executeGemini(fullPrompt, tryModel, baseDir, providerOptions);
       const usedFallback = tryModel !== requestedModel;
       const fallbackNote = usedFallback ? `[Fallback: used ${tryModel} instead of ${requestedModel}]\n\n` : '';
 

--- a/src/mcp/gemini-server.ts
+++ b/src/mcp/gemini-server.ts
@@ -29,9 +29,11 @@ const askGeminiTool = tool(
     model: { type: "string", description: `Gemini model to use (default: ${GEMINI_DEFAULT_MODEL}). Set OMC_GEMINI_DEFAULT_MODEL env var to change default. Auto-fallback chain: ${GEMINI_MODEL_FALLBACKS.join(' → ')}.` },
     background: { type: "boolean", description: "Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion." },
     working_directory: { type: "string", description: "Working directory for path resolution and CLI execution. Defaults to process.cwd()." },
+    api_key: { type: "string", description: "Optional API key override. When provided, passed as GOOGLE_API_KEY to the Gemini CLI process." },
+    base_url: { type: "string", description: "Optional base URL override. When provided, passed as GEMINI_BASE_URL to the Gemini CLI process." },
   } as any,
   async (args: any) => {
-    const { prompt_file, output_file, agent_role, model, files, background, working_directory } = args as {
+    const { prompt_file, output_file, agent_role, model, files, background, working_directory, api_key, base_url } = args as {
       prompt_file: string;
       output_file: string;
       agent_role: string;
@@ -39,8 +41,10 @@ const askGeminiTool = tool(
       files?: string[];
       background?: boolean;
       working_directory?: string;
+      api_key?: string;
+      base_url?: string;
     };
-    return handleAskGemini({ prompt_file, output_file, agent_role, model, files, background, working_directory });
+    return handleAskGemini({ prompt_file, output_file, agent_role, model, files, background, working_directory, api_key, base_url });
   }
 );
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,6 +2,8 @@
  * Shared types for Oh-My-Claude-Sisyphus
  */
 
+import type { ModelsConfig } from '../features/model-config/types.js';
+
 export type ModelType = 'sonnet' | 'opus' | 'haiku' | 'inherit';
 
 export interface AgentConfig {
@@ -64,6 +66,9 @@ export interface PluginConfig {
     analyze?: string[];
     ultrathink?: string[];
   };
+
+  // Multi-provider model configuration from .claude/models.json
+  modelsConfig?: ModelsConfig;
 
   // Intelligent model routing configuration
   routing?: {


### PR DESCRIPTION
… system

## Multi-Provider Model Configuration (`src/features/model-config/`)

Add a complete model configuration system that allows routing agents to external LLM providers (OpenAI/Codex, Gemini, Ollama, OpenRouter) via `.claude/models.json`.

### New files:
- `src/features/model-config/types.ts` - Type definitions for ProviderConfig, AgentModelConfig, ModelsConfig, ResolvedModel; constants for PROVIDER_MCP_MAPPING and CLAUDE_TIERS
- `src/features/model-config/loader.ts` - Loads/validates `.claude/models.json`, resolves `$ENV_VAR` references for API keys, implements per-session caching
- `src/features/model-config/resolver.ts` - Resolution pipeline: agent override → defaults → static tier fallback; includes resolveModelForAgent(), isProviderAvailable(), resolveModelWithFallback(), getFallbackModel()
- `src/features/model-config/index.ts` - Barrel exports

### Modified files:
- `src/features/index.ts` - Add model-config exports to features barrel
- `src/config/loader.ts` - Load `.claude/models.json` during config init
- `src/shared/types.ts` - Add `modelsConfig` field to PluginConfig interface
- `src/agents/definitions.ts` - Integrate resolveModelForAgent() into getAgentDefinitions() so every agent's model is resolved through the new system

## Provider Credential Passthrough (MCP Tools)

Enable the model-config system to pass provider-specific API keys and base URLs to external CLI tools.

### Modified files:
- `src/mcp/codex-core.ts` - executeCodex() accepts options with apiKey/baseUrl, passes as OPENAI_API_KEY/OPENAI_BASE_URL env vars to spawned process
- `src/mcp/codex-server.ts` - ask_codex MCP tool schema adds api_key/base_url params
- `src/mcp/gemini-core.ts` - executeGemini() accepts options, sets GOOGLE_API_KEY/GEMINI_API_KEY/GEMINI_BASE_URL env vars
- `src/mcp/gemini-server.ts` - ask_gemini MCP tool schema adds api_key/base_url params

## Start-Work / Boulder State Execution System

Add a complete plan-execution lifecycle: load plans from `.omc/plans/`, track progress with persistent `boulder.json` state, execute tasks sequentially with checkbox tracking, survive context compaction via notepad memory flush, and auto-resume across sessions.

### New files:
- `commands/start-work.md` - /start-work command (alias: sw) for plan execution with boulder state tracking and session continuity
- `skills/start-work/SKILL.md` - Skill metadata for start-work
- `scripts/boulder-memory-flush.mjs` - Pre-compaction hook that saves active boulder/ralplan context to notepad before compaction

### Modified files:
- `hooks/hooks.json` - Add boulder-memory-flush.mjs to pre-compact hook chain
- `scripts/persistent-mode.mjs` - Add "Priority 0: Boulder" check above Ralph Loop; blocks session completion when boulder tasks remain
- `scripts/session-start.mjs` - Add boulder state detection on session start, injects session-restore context with plan progress and resume instructions