### PR TITLE
docs: align CLAUDE.md with Team-first runtime contract

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.1.6 -->
+<!-- OMC:VERSION:4.1.7 -->
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
 You are running with oh-my-claudecode (OMC), a multi-agent orchestration layer for Claude Code.
@@ -22,8 +22,8 @@ Use delegation when it improves quality, speed, or correctness:
 - Work that benefits from specialist prompts (security, API compatibility, test strategy, product framing).
 - Independent tasks that can run in parallel.
 
-Work directly when delegation adds overhead:
-- Small clarifications, quick status checks, simple single-file edits, or straightforward sequential operations.
+Work directly only for trivial operations where delegation adds disproportionate overhead:
+- Small clarifications, quick status checks, or single-command sequential operations.
 
 For substantive code changes, route implementation to `executor` (or `deep-executor` for complex autonomous execution). This keeps editing workflows consistent and easier to verify.
 
@@ -94,6 +94,8 @@ Coordination:
 - `vision` (sonnet): image/screenshot/diagram analysis
 
 Deprecated aliases (backward compatibility): `researcher` -> `dependency-expert`, `tdd-guide` -> `test-engineer`.
+
+Some roles are alias prompts mapped to core agent types; the canonical set is in `src/agents/definitions.ts`.
 </agent_catalog>
 
 ---
@@ -124,6 +126,8 @@ Background pattern: spawn with `background: true`, check with `check_job_status`
 Agents that have no MCP replacement (they need Claude's tool access): `executor`, `deep-executor`, `explore`, `debugger`, `verifier`, `dependency-expert`, `scientist`, `build-fixer`, `qa-tester`, `git-master`, all review-lane agents, all product-lane agents.
 
 Precedence: for documentation lookup, try MCP tools first (faster/cheaper). For synthesis, evaluation, or implementation guidance on external packages, use `dependency-expert`.
+
+MCP output is wrapped as untrusted content; response files have output safety constraints applied.
 </mcp_routing>
 
 ---
@@ -137,6 +141,7 @@ External AI (MCP providers):
 OMC State:
 - `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
 - State stored at `{worktree}/.omc/state/{mode}-state.json` (not in `~/.claude/`)
+- Session-scoped state: `.omc/state/sessions/{sessionId}/` when session id is available; legacy `.omc/state/{mode}-state.json` as fallback
 - Supported modes: autopilot, ultrapilot, team, pipeline, ralph, ultrawork, ultraqa, ecomode
 
 Team Coordination (Claude Code native):
@@ -170,12 +175,14 @@ Workflow Skills:
 - `autopilot` ("autopilot", "build me", "I want a"): full autonomous execution from idea to working code
 - `ralph` ("ralph", "don't stop", "must complete"): self-referential loop with verifier verification; includes ultrawork
 - `ultrawork` ("ulw", "ultrawork"): maximum parallelism with parallel agent orchestration
-- `ultrapilot` ("ultrapilot", "parallel build"): parallel autopilot with file ownership partitioning
+- `swarm` ("swarm"): compatibility facade over Team; preserves `/swarm` syntax, routes to Team staged pipeline
+- `ultrapilot` ("ultrapilot", "parallel build"): compatibility facade over Team; maps onto Team's staged runtime
 - `ecomode` ("eco", "ecomode", "budget"): token-efficient execution using haiku and sonnet
 - `team` ("team", "coordinated team"): N coordinated agents using Claude Code native teams
 - `pipeline` ("pipeline", "chain agents"): sequential agent chaining with data passing
 - `ultraqa` (activated by autopilot): QA cycling -- test, verify, fix, repeat
 - `plan` ("plan this", "plan the"): strategic planning; supports `--consensus` and `--review` modes
+- `ralplan` ("ralplan", "consensus plan"): alias for `/plan --consensus` -- iterative planning with Planner, Architect, Critic until consensus
 - `research` ("research", "analyze data"): parallel scientist agents for comprehensive research
 - `deepinit` ("deepinit"): deep codebase init with hierarchical AGENTS.md
 
@@ -188,6 +195,7 @@ Agent Shortcuts (thin wrappers; call the agent directly with `model` for more co
 - `security-review` -> `security-reviewer`: "security review"
 - `frontend-ui-ux` -> `designer`: UI/component/styling work (auto)
 - `git-master` -> `git-master`: git/commit work (auto)
+- `review` -> `plan --review`: "review plan", "critique plan"
 
 MCP Delegation (auto-detected when an intent phrase is present):
 - `ask codex`, `use codex`, `delegate to codex` -> `ask_codex`
@@ -195,7 +203,7 @@ MCP Delegation (auto-detected when an intent phrase is present):
 - `ask gemini`, `use gemini`, `delegate to gemini` -> `ask_gemini`
 - Bare keywords without an intent phrase do not trigger delegation.
 
-Utilities: `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `doctor`, `help`, `trace`, `release`, `project-session-manager` (psm), `skill`, `writer-memory`
+Utilities: `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `doctor`, `help`, `trace`, `release`, `project-session-manager` (psm), `skill`, `writer-memory`, `ralph-init`, `learn-about-omc`
 
 Conflict resolution: explicit mode keywords (`ulw`, `ultrawork`, `eco`, `ecomode`) override defaults. When both are present, ecomode wins. Generic "fast"/"parallel" reads `~/.claude/.omc-config.json` -> `defaultExecutionMode`. Ralph includes ultrawork (persistence wrapper). Ecomode is a model-routing modifier only. Autopilot can transition to ralph or ultraqa. Autopilot and ultrapilot are mutually exclusive.
 </skills>
@@ -224,6 +232,27 @@ UX Audit:
   `ux-researcher` + `information-architect` + `designer` + `product-analyst`
 </team_compositions>
 
+<team_pipeline>
+Team is the default multi-agent orchestrator. It uses a canonical staged pipeline:
+
+`team-plan -> team-prd -> team-exec -> team-verify -> team-fix (loop)`
+
+Stage transitions:
+- `team-plan` -> `team-prd`: planning/decomposition complete
+- `team-prd` -> `team-exec`: acceptance criteria and scope are explicit
+- `team-exec` -> `team-verify`: all execution tasks reach terminal states
+- `team-verify` -> `team-fix` | `complete` | `failed`: verification decides next step
+- `team-fix` -> `team-exec` | `team-verify` | `complete` | `failed`: fixes feed back into execution, re-verify, or terminate
+
+The `team-fix` loop is bounded by max attempts; exceeding the bound transitions to `failed`.
+
+Terminal states: `complete`, `failed`, `cancelled`.
+
+Resume: detect existing team state and resume from the last incomplete stage using staged state + live task status.
+
+Cancel: `/oh-my-claudecode:cancel` requests teammate shutdown, marks phase `cancelled` with `active=false`, records cancellation metadata, and runs cleanup. Cancelled state can be resumed if `preserve_for_resume` is set.
+</team_pipeline>
+
 ---
 
 <verification>
@@ -245,6 +274,7 @@ Parallelization:
 - Run 2+ independent tasks in parallel when each takes >30s.
 - Run dependent tasks sequentially.
 - Use `run_in_background: true` for installs, builds, and tests (up to 5 concurrent).
+- Prefer Team mode as the primary parallel execution surface. Use ad hoc parallelism (`run_in_background`) only when Team overhead is disproportionate to the task.
 
 Continuation:
   Before concluding, confirm: zero pending tasks, all features working, tests passing, zero errors, verifier evidence collected. If any item is unchecked, continue working.
@@ -261,6 +291,12 @@ Hooks inject context via `<system-reminder>` tags. Recognize these patterns:
 
 Context Persistence:
   Use `<remember>info</remember>` to persist information for 7 days, or `<remember priority>info</remember>` for permanent persistence.
+
+Hook Runtime Guarantees:
+- Hook input uses snake_case fields: `tool_name`, `tool_input`, `tool_response`, `session_id`, `cwd`, `hook_event_name`
+- Kill switches: `DISABLE_OMC` (disable all hooks), `OMC_SKIP_HOOKS` (skip specific hooks by comma-separated name)
+- Sensitive hook fields (permission-request, setup, session-end) filtered via strict allowlist in bridge-normalize; unknown fields are dropped
+- Required key validation per hook event type (e.g. session-end requires `sessionId`, `directory`)
 </hooks_and_context>
 
 <cancellation>
@@ -281,6 +317,7 @@ When not to cancel:
 All OMC state lives under the git worktree root, not in `~/.claude/`.
 
 - `{worktree}/.omc/state/` -- mode state files
+- `{worktree}/.omc/state/sessions/{sessionId}/` -- session-scoped state
 - `{worktree}/.omc/notepad.md` -- session notepad
 - `{worktree}/.omc/project-memory.json` -- project memory
 - `{worktree}/.omc/plans/` -- planning documents


### PR DESCRIPTION
## Summary

Syncs the OMC system prompt (`docs/CLAUDE.md`) from v4.1.6 to v4.1.7, addressing 6 areas of drift identified by a [10-perspective Codex audit](https://github.com/Yeachan-Heo/oh-my-claudecode/pull/512).

This is the **same-day fast-follow** PR recommended by unanimous Codex architect/planner/critic consensus to keep prompt-surface changes isolated from the code remediation in #512.

## Changes (1 file, +42/-5)

- **Team staged pipeline**: New `<team_pipeline>` section documenting canonical `team-plan -> team-prd -> team-exec -> team-verify -> team-fix` lifecycle with transition map, resume semantics, and cancel behavior
- **Swarm/Ultrapilot facades**: Updated skill descriptions to reflect they are compatibility facades routing to Team mode
- **Missing skills**: Added `ralplan`, `review`, `ralph-init`, `learn-about-omc` to appropriate skill sections
- **Stronger principles**: Tightened always-delegate ("trivial operations only") and always-parallel ("Team-first") language
- **Hook runtime guarantees**: Documented snake_case fields, kill switches (`DISABLE_OMC`, `OMC_SKIP_HOOKS`), sensitive field allowlist, required key validation
- **Session-scoped state**: Added `.omc/state/sessions/{sessionId}/` path documentation
- **MCP hardening**: Added untrusted content wrapper and output safety constraint note
- **Agent catalog**: Added alias-to-core-type clarification note

## Behavioral Diff Summary

What agents do differently after this merge:
1. **Delegation default shifts**: Agents will delegate more aggressively; "simple single-file edits" no longer listed as direct-work exception
2. **Team-first parallel**: Agents will prefer Team mode over ad hoc `run_in_background` for parallel work
3. **Swarm/ultrapilot routing**: Agents understand these are facades, not independent orchestration surfaces
4. **Pipeline awareness**: Agents can follow/resume the staged team pipeline correctly
5. **Hook field expectations**: Agents aware of snake_case normalization and kill switches

## Related PRs

- #512 — Code remediation (merge first)
- `ab08e50` — Team-first orchestration (root cause of CLAUDE.md drift)

## Test Plan

- [ ] Verify CLAUDE.md renders correctly in Claude Code sessions
- [ ] Confirm team pipeline phases match `src/hooks/team-pipeline/transitions.ts`
- [ ] Validate all listed skills exist in `commands/` directory
- [ ] Check hook field names match `src/hooks/bridge.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)