### PR TITLE
fix(hud): add COMPRESS? and CRITICAL suffixes to context bar mode (#532)

### DIFF
--- a/src/hud/elements/context.ts
+++ b/src/hud/elements/context.ts
@@ -55,8 +55,14 @@ export function renderContextWithBar(
   const empty = barWidth - filled;
 
   let color: string;
+  let suffix = '';
+
   if (safePercent >= thresholds.contextCritical) {
     color = RED;
+    suffix = ' CRITICAL';
+  } else if (safePercent >= thresholds.contextCompactSuggestion) {
+    color = YELLOW;
+    suffix = ' COMPRESS?';
   } else if (safePercent >= thresholds.contextWarning) {
     color = YELLOW;
   } else {
@@ -64,5 +70,5 @@ export function renderContextWithBar(
   }
 
   const bar = `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
-  return `ctx:[${bar}]${color}${safePercent}%${RESET}`;
+  return `ctx:[${bar}]${color}${safePercent}%${suffix}${RESET}`;
 }


### PR DESCRIPTION
## Summary
- Add `suffix` variable and threshold checks for CRITICAL and COMPRESS? text in `renderContextWithBar()`
- Add missing `contextCompactSuggestion` threshold branch that was present in `renderContext()` but absent in bar mode
- Append suffix after percentage in bar output string

Closes #532

🤖 Generated with Claude Code