### PR TITLE
fix(hud): persist session start time to prevent tail-parsing duration reset (#528)

### DIFF
--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -29,6 +29,8 @@ export interface OmcHudState {
   backgroundTasks: BackgroundTask[];
   /** Persisted session start time to survive tail-parsing resets */
   sessionStartTimestamp?: string;
+  /** Session ID that owns the persisted sessionStartTimestamp */
+  sessionId?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Persist the real session start timestamp in HUD state (`sessionStartTimestamp` field in `OmcHudState`)
- On first observation of `transcriptData.sessionStart`, write it to HUD state file
- On subsequent renders, use the persisted value instead of the tail-parsed value that resets when transcript exceeds 500KB

Closes #528

🤖 Generated with Claude Code