### PR TITLE
feat(hud): make budget warning thresholds configurable (#531)

### DIFF
--- a/src/hud/analytics-display.ts
+++ b/src/hud/analytics-display.ts
@@ -208,12 +208,17 @@ export function renderSessionHealthAnalytics(sessionHealth: SessionHealth): stri
 /**
  * Render budget warning if cost exceeds thresholds
  */
-export function renderBudgetWarning(sessionHealth: SessionHealth): string {
+export function renderBudgetWarning(
+  sessionHealth: SessionHealth,
+  thresholds?: { budgetWarning: number; budgetCritical: number },
+): string {
   const cost = sessionHealth.sessionCost ?? 0;
+  const criticalThreshold = thresholds?.budgetCritical ?? 5.0;
+  const warningThreshold = thresholds?.budgetWarning ?? 2.0;
 
-  if (cost > 5.0) {
-    return `⚠️  BUDGET ALERT: Session cost ${cost.toFixed(2)} exceeds $5.00`;
-  } else if (cost > 2.0) {
+  if (cost > criticalThreshold) {
+    return `⚠️  BUDGET ALERT: Session cost ${cost.toFixed(2)} exceeds $${criticalThreshold.toFixed(2)}`;
+  } else if (cost > warningThreshold) {
     return `⚡ Budget notice: Session cost ${cost.toFixed(2)} approaching limit`;
   }
 

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -196,6 +196,7 @@ async function calculateSessionHealth(
   sessionStart: Date | undefined,
   contextPercent: number,
   stdin: StatuslineStdin,
+  thresholds?: { budgetWarning: number; budgetCritical: number },
 ): Promise<SessionHealth | null> {
   // Calculate duration (use 0 if no session start)
   const durationMs = sessionStart ? Date.now() - sessionStart.getTime() : 0;
@@ -261,9 +262,11 @@ async function calculateSessionHealth(
     costPerHour = hours > 0 ? sessionCost / hours : 0;
 
     // Adjust health based on cost (Budget warnings)
-    if (sessionCost > 5.0) {
+    const budgetCritical = thresholds?.budgetCritical ?? 5.0;
+    const budgetWarning = thresholds?.budgetWarning ?? 2.0;
+    if (sessionCost > budgetCritical) {
       health = "critical";
-    } else if (sessionCost > 2.0 && health !== "critical") {
+    } else if (sessionCost > budgetWarning && health !== "critical") {
       health = "warning";
     }
   } catch (error) {
@@ -366,6 +369,7 @@ async function main(): Promise<void> {
         transcriptData.sessionStart,
         getContextPercent(stdin),
         stdin,
+        config.thresholds,
       ),
     };
 

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -127,7 +127,7 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
       // If showBudgetWarning is explicitly set, use it; otherwise default to true (backward compat)
       const showBudgetAnalytics = enabledElements.showBudgetWarning ?? true;
       if (showBudgetAnalytics && enabledElements.showCost) {
-        const budgetWarning = renderBudgetWarning(context.sessionHealth);
+        const budgetWarning = renderBudgetWarning(context.sessionHealth, config.thresholds);
         if (budgetWarning) lines.push(budgetWarning);
       }
     }
@@ -217,7 +217,7 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
     // If showBudgetWarning is explicitly set, use it; otherwise default to true (backward compat)
     const showBudget = enabledElements.showBudgetWarning ?? true;
     if (showBudget && enabledElements.showCost) {
-      const warning = renderBudgetWarning(context.sessionHealth);
+      const warning = renderBudgetWarning(context.sessionHealth, config.thresholds);
       if (warning) detailLines.push(warning);
     }
   }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -290,6 +290,10 @@ export interface HudThresholds {
   contextCritical: number;
   /** Ralph iteration that triggers warning color (default: 7) */
   ralphWarning: number;
+  /** Session cost ($) that triggers budget warning (default: 2.0) */
+  budgetWarning: number;
+  /** Session cost ($) that triggers budget critical alert (default: 5.0) */
+  budgetCritical: number;
 }
 
 export interface HudConfig {
@@ -336,6 +340,8 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     contextCompactSuggestion: 80,
     contextCritical: 85,
     ralphWarning: 7,
+    budgetWarning: 2.0,
+    budgetCritical: 5.0,
   },
   staleTaskThresholdMinutes: 30,
 };


### PR DESCRIPTION
## Summary
- Add `budgetWarning` (default $2.00) and `budgetCritical` (default $5.00) to `HudThresholds` in types.ts
- Update `calculateSessionHealth()` in index.ts to use configurable thresholds instead of hardcoded $2/$5
- Update `renderBudgetWarning()` in analytics-display.ts to accept optional thresholds parameter
- Pass thresholds through from render.ts call sites

Closes #531

🤖 Generated with Claude Code