### PR TITLE
fix(hooks): use OMC package version instead of project package.json (#516)

### DIFF
--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -196,7 +196,7 @@ async function main() {
 
     // Check for updates (non-blocking)
     // Read version from OMC's own package.json, not the project's (fixes #516)
-    let currentVersion = '3.8.4'; // fallback
+    let currentVersion = null;
     for (let i = 1; i <= 4; i++) {
       const candidate = join(__dirname, ...Array(i).fill('..'), 'package.json');
       const pkg = readJsonFile(candidate);
@@ -206,7 +206,7 @@ async function main() {
       }
     }
 
-    const updateInfo = await checkForUpdates(currentVersion);
+    const updateInfo = currentVersion ? await checkForUpdates(currentVersion) : null;
     if (updateInfo) {
       messages.push(`<session-restore>
 


### PR DESCRIPTION
## Summary
- Session-start hook was reading `package.json` from the project directory (cwd) to determine OMC version for update checks
- This caused wrong version drift reports when the project had its own `package.json` with a different version
- Now walks up from the hook script's own `__dirname` to find OMC's `package.json` by matching `pkg.name === 'oh-my-claude-sisyphus'`

Closes #516

🤖 Generated with Claude Code