### PR TITLE
fix(mcp): resolve agent roles in CJS bundles via __dirname fallback

### DIFF
--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -24,13 +24,28 @@ import type {
 // ============================================================
 
 /**
- * Get the package root directory (where agents/ folder lives)
+ * Get the package root directory (where agents/ folder lives).
+ * Handles both ESM (import.meta.url) and CJS bundle (__dirname) contexts.
+ * When esbuild bundles to CJS, import.meta is replaced with {} so we
+ * fall back to __dirname which is natively available in CJS.
  */
 function getPackageDir(): string {
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-  // From src/agents/ go up to package root
-  return join(__dirname, '..', '..');
+  try {
+    if (import.meta?.url) {
+      const __filename = fileURLToPath(import.meta.url);
+      const __dirname = dirname(__filename);
+      // From src/agents/ or dist/agents/ go up to package root
+      return join(__dirname, '..', '..');
+    }
+  } catch {
+    // import.meta.url unavailable — fall through to CJS path
+  }
+  // CJS bundle path: from bridge/ go up 1 level to package root
+  // eslint-disable-next-line no-undef
+  if (typeof __dirname !== 'undefined') {
+    return join(__dirname, '..');
+  }
+  return process.cwd();
 }
 
 /**

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -20,13 +20,27 @@ import { fileURLToPath } from "url";
 
 /**
  * Get the package root directory (where templates/ lives)
- * Works for both development (src/) and production (dist/)
+ * Works for both development (src/), production (dist/), and CJS bundles (bridge/).
+ * When esbuild bundles to CJS, import.meta is replaced with {} so we
+ * fall back to __dirname which is natively available in CJS.
  */
 function getPackageDir(): string {
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-  // From src/installer/ or dist/installer/, go up two levels to package root
-  return join(__dirname, "..", "..");
+  try {
+    if (import.meta?.url) {
+      const __filename = fileURLToPath(import.meta.url);
+      const __dirname = dirname(__filename);
+      // From src/installer/ or dist/installer/, go up two levels to package root
+      return join(__dirname, "..", "..");
+    }
+  } catch {
+    // import.meta.url unavailable — fall through to CJS path
+  }
+  // CJS bundle path: from bridge/ go up 1 level to package root
+  // eslint-disable-next-line no-undef
+  if (typeof __dirname !== "undefined") {
+    return join(__dirname, "..");
+  }
+  return process.cwd();
 }
 
 /**

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -185,14 +185,28 @@ export function isProjectScopedPlugin(): boolean {
 }
 
 /**
- * Get the package root directory
- * From dist/installer/index.js, go up to package root
+ * Get the package root directory.
+ * Works for both ESM (dist/installer/) and CJS bundles (bridge/).
+ * When esbuild bundles to CJS, import.meta is replaced with {} so we
+ * fall back to __dirname which is natively available in CJS.
  */
 function getPackageDir(): string {
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-  // From dist/installer/index.js, go up to package root
-  return join(__dirname, '..', '..');
+  try {
+    if (import.meta?.url) {
+      const __filename = fileURLToPath(import.meta.url);
+      const __dirname = dirname(__filename);
+      // From dist/installer/index.js, go up to package root
+      return join(__dirname, '..', '..');
+    }
+  } catch {
+    // import.meta.url unavailable — fall through to CJS path
+  }
+  // CJS bundle path: from bridge/ go up 1 level to package root
+  // eslint-disable-next-line no-undef
+  if (typeof __dirname !== 'undefined') {
+    return join(__dirname, '..');
+  }
+  return process.cwd();
 }
 
 /**


### PR DESCRIPTION
## Summary
- esbuild replaces `import.meta` with `{}` when bundling to CJS format, causing `fileURLToPath(undefined)` to throw
- This silently set `VALID_AGENT_ROLES` to `[]`, making **all** `agent_role` values fail with "Unknown agent_role"
- Fixed all 4 `getPackageDir()` functions to try `import.meta.url` first (ESM) and fall back to `__dirname` (CJS native) when unavailable
- From `bridge/` dir, going up 1 level correctly reaches the package root where `agents/` lives

## Files Changed
- `src/mcp/prompt-injection.ts` - role discovery for codex/gemini servers
- `src/agents/utils.ts` - agent prompt loading
- `src/installer/hooks.ts` - hook template loading  
- `src/installer/index.ts` - agent definition loading

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] CJS bundle builds successfully (`build-codex-server.mjs`)
- [x] Bundle contains `typeof __dirname` fallback
- [x] 30 agent roles discovered when running from package root
- [ ] Verify `ask_codex` and `ask_gemini` accept agent roles after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)