### PR TITLE
docs: add notification setup to localized READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -139,6 +139,37 @@ omc wait --stop   # Deshabilitar demonio
 
 ---
 
+## Notificaciones
+
+Puedes recibir notificaciones en tiempo real para eventos del ciclo de vida de la sesión.
+
+Eventos compatibles:
+- `session-start`
+- `session-stop` (cuando un modo persistent entra en estado de espera/bloqueo)
+- `session-end`
+- `ask-user-question`
+
+### Configuración
+Agrega estas variables de entorno en tu perfil de shell (por ejemplo `~/.zshrc`, `~/.bashrc`):
+
+```bash
+# Discord Bot
+export OMC_DISCORD_NOTIFIER_BOT_TOKEN="your_bot_token"
+export OMC_DISCORD_NOTIFIER_CHANNEL="your_channel_id"
+
+# Telegram
+export OMC_TELEGRAM_BOT_TOKEN="your_bot_token"
+export OMC_TELEGRAM_CHAT_ID="your_chat_id"
+
+# Webhooks opcionales
+export OMC_DISCORD_WEBHOOK_URL="your_webhook_url"
+export OMC_SLACK_WEBHOOK_URL="your_webhook_url"
+```
+
+> Nota: las variables deben estar cargadas en el mismo shell donde ejecutas `claude`.
+
+---
+
 ## Documentación
 
 - **[Referencia Completa](docs/REFERENCE.md)** - Documentación completa de características

--- a/README.ja.md
+++ b/README.ja.md
@@ -139,6 +139,37 @@ omc wait --stop   # デーモンを無効化
 
 ---
 
+## 通知 (Notifications)
+
+セッションのライフサイクルイベントに対してリアルタイム通知を受け取れます。
+
+対象イベント:
+- `session-start`
+- `session-stop`（persistent モードが待機/ブロック状態に入ったとき）
+- `session-end`
+- `ask-user-question`
+
+### 設定
+シェルプロファイル（例: `~/.zshrc`, `~/.bashrc`）に環境変数を追加してください:
+
+```bash
+# Discord Bot
+export OMC_DISCORD_NOTIFIER_BOT_TOKEN="your_bot_token"
+export OMC_DISCORD_NOTIFIER_CHANNEL="your_channel_id"
+
+# Telegram
+export OMC_TELEGRAM_BOT_TOKEN="your_bot_token"
+export OMC_TELEGRAM_CHAT_ID="your_chat_id"
+
+# Optional webhooks
+export OMC_DISCORD_WEBHOOK_URL="your_webhook_url"
+export OMC_SLACK_WEBHOOK_URL="your_webhook_url"
+```
+
+> 注意: `claude` を実行する同じシェルで環境変数が読み込まれている必要があります。
+
+---
+
 ## ドキュメント
 
 - **[完全リファレンス](docs/REFERENCE.md)** - 全機能の詳細ドキュメント

--- a/README.ko.md
+++ b/README.ko.md
@@ -139,6 +139,37 @@ omc wait --stop   # 데몬 비활성화
 
 ---
 
+## 알림 (Notifications)
+
+세션 라이프사이클 이벤트에 대해 실시간 알림을 받을 수 있습니다.
+
+지원 이벤트:
+- `session-start`
+- `session-stop` (persistent 모드가 대기/블록 상태로 들어갈 때)
+- `session-end`
+- `ask-user-question`
+
+### 설정
+쉘 프로필(예: `~/.zshrc`, `~/.bashrc`)에 환경 변수를 추가하세요:
+
+```bash
+# Discord Bot
+export OMC_DISCORD_NOTIFIER_BOT_TOKEN="your_bot_token"
+export OMC_DISCORD_NOTIFIER_CHANNEL="your_channel_id"
+
+# Telegram
+export OMC_TELEGRAM_BOT_TOKEN="your_bot_token"
+export OMC_TELEGRAM_CHAT_ID="your_chat_id"
+
+# Optional webhooks
+export OMC_DISCORD_WEBHOOK_URL="your_webhook_url"
+export OMC_SLACK_WEBHOOK_URL="your_webhook_url"
+```
+
+> 참고: `claude`를 실행하는 동일한 쉘에서 환경 변수가 로드되어 있어야 합니다.
+
+---
+
 ## 문서
 
 - **[전체 레퍼런스](docs/REFERENCE.md)** - 완전한 기능 문서

--- a/README.zh.md
+++ b/README.zh.md
@@ -139,6 +139,37 @@ omc wait --stop   # 禁用守护进程
 
 ---
 
+## 通知 (Notifications)
+
+你可以为会话生命周期事件接收实时通知。
+
+支持的事件：
+- `session-start`
+- `session-stop`（当 persistent 模式进入等待/阻塞状态时）
+- `session-end`
+- `ask-user-question`
+
+### 配置
+在 Shell 配置文件（例如 `~/.zshrc`, `~/.bashrc`）中添加以下环境变量：
+
+```bash
+# Discord Bot
+export OMC_DISCORD_NOTIFIER_BOT_TOKEN="your_bot_token"
+export OMC_DISCORD_NOTIFIER_CHANNEL="your_channel_id"
+
+# Telegram
+export OMC_TELEGRAM_BOT_TOKEN="your_bot_token"
+export OMC_TELEGRAM_CHAT_ID="your_chat_id"
+
+# 可选 webhook
+export OMC_DISCORD_WEBHOOK_URL="your_webhook_url"
+export OMC_SLACK_WEBHOOK_URL="your_webhook_url"
+```
+
+> 注意：请确保在运行 `claude` 的同一个 Shell 中已加载这些环境变量。
+
+---
+
 ## 文档
 
 - **[完整参考](docs/REFERENCE.md)** - 完整功能文档


### PR DESCRIPTION
## Summary
- add a new Notifications section to `README.ko.md`, `README.ja.md`, `README.es.md`, and `README.zh.md`
- document lifecycle event behavior (`session-start`, `session-stop`, `session-end`, `ask-user-question`)
- add copy-paste environment variable setup for Discord Bot and Telegram, plus optional webhook vars

## Test plan
- [x] verified markdown renders as plain README sections
- [x] verified examples match implemented env var names in notification config

🤖 Generated with [Claude Code](https://claude.com/claude-code)