### PR TITLE
fix(hooks): fire session-idle notification from standalone persistent-mode scripts (#584)

### DIFF
--- a/src/hooks/__tests__/persistent-mode-idle-notification.test.ts
+++ b/src/hooks/__tests__/persistent-mode-idle-notification.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression test for issue #584: session-idle notification never fires
+ *
+ * The Stop hook calls persistent-mode.mjs directly (bypassing bridge.js),
+ * so the idle notification logic in bridge.ts's processPersistentMode() is
+ * never reached. This test verifies that processPersistentMode in bridge.ts
+ * correctly fires session-idle notification when no mode is blocking.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { processHook, resetSkipHooksCache, type HookInput } from '../bridge.js';
+
+// Mock the notifications module so we can verify it gets called
+vi.mock('../../notifications/index.js', () => ({
+  notify: vi.fn().mockResolvedValue(null),
+  getNotificationConfig: vi.fn().mockReturnValue(null),
+  isEventEnabled: vi.fn().mockReturnValue(false),
+  formatNotification: vi.fn(),
+  dispatchNotifications: vi.fn(),
+  formatSessionStart: vi.fn(),
+  formatSessionStop: vi.fn(),
+  formatSessionEnd: vi.fn(),
+  formatSessionIdle: vi.fn(),
+  formatAskUserQuestion: vi.fn(),
+  getCurrentTmuxSession: vi.fn(),
+  getTeamTmuxSessions: vi.fn(),
+  formatTmuxInfo: vi.fn(),
+  getEnabledPlatforms: vi.fn(),
+  sendDiscord: vi.fn(),
+  sendDiscordBot: vi.fn(),
+  sendTelegram: vi.fn(),
+  sendSlack: vi.fn(),
+  sendWebhook: vi.fn(),
+}));
+
+describe('Issue #584 - session-idle notification fires from persistent-mode hook', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.DISABLE_OMC;
+    delete process.env.OMC_SKIP_HOOKS;
+    resetSkipHooksCache();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    resetSkipHooksCache();
+  });
+
+  it('should fire session-idle notification when no mode is blocking', async () => {
+    const { notify } = await import('../../notifications/index.js');
+
+    const input: HookInput = {
+      sessionId: 'test-idle-session',
+      directory: '/tmp/test-idle-584',
+    };
+
+    const result = await processHook('persistent-mode', input);
+
+    expect(result.continue).toBe(true);
+
+    // Wait for async notification dispatch (fire-and-forget)
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(notify).toHaveBeenCalledWith('session-idle', {
+      sessionId: 'test-idle-session',
+      projectPath: expect.any(String),
+    });
+  });
+
+  it('should NOT fire session-idle when user aborted (user_requested=true)', async () => {
+    const { notify } = await import('../../notifications/index.js');
+
+    const input: HookInput = {
+      sessionId: 'test-abort-session',
+      directory: '/tmp/test-abort-584',
+    };
+
+    // Simulate user abort via snake_case field (as Claude Code sends it)
+    const inputWithAbort = {
+      ...input,
+      user_requested: true,
+    } as HookInput;
+
+    const result = await processHook('persistent-mode', inputWithAbort);
+
+    expect(result.continue).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // notify should NOT have been called with session-idle
+    const idleCalls = (notify as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => call[0] === 'session-idle'
+    );
+    expect(idleCalls).toHaveLength(0);
+  });
+
+  it('should NOT fire session-idle when context limit reached', async () => {
+    const { notify } = await import('../../notifications/index.js');
+
+    const input: HookInput = {
+      sessionId: 'test-ctx-session',
+      directory: '/tmp/test-ctx-584',
+    };
+
+    const inputWithCtx = {
+      ...input,
+      stop_reason: 'context_limit',
+    } as HookInput;
+
+    const result = await processHook('persistent-mode', inputWithCtx);
+
+    expect(result.continue).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const idleCalls = (notify as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => call[0] === 'session-idle'
+    );
+    expect(idleCalls).toHaveLength(0);
+  });
+
+  it('should NOT fire session-idle when sessionId is missing', async () => {
+    const { notify } = await import('../../notifications/index.js');
+
+    const input: HookInput = {
+      directory: '/tmp/test-nosession-584',
+    };
+
+    const result = await processHook('persistent-mode', input);
+
+    expect(result.continue).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const idleCalls = (notify as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => call[0] === 'session-idle'
+    );
+    expect(idleCalls).toHaveLength(0);
+  });
+});

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -377,6 +377,31 @@ function isContextLimitStop(data) {
 /**
  * Detect if stop was triggered by user abort (Ctrl+C, cancel button, etc.)
  */
+/**
+ * Send session-idle notification (fire-and-forget, non-blocking).
+ * Called when no persistent mode is blocking and session is truly idle.
+ * Fix: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/584
+ */
+async function sendIdleNotification(sessionId, directory) {
+  if (!sessionId) return;
+
+  try {
+    const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+    if (!pluginRoot) return;
+
+    const notifPath = join(pluginRoot, "dist", "notifications", "index.js");
+    if (!existsSync(notifPath)) return;
+
+    const { notify } = await import(pathToFileURL(notifPath).href);
+    await notify("session-idle", {
+      sessionId,
+      projectPath: directory,
+    });
+  } catch {
+    // Notification module not available, skip silently
+  }
+}
+
 function isUserAbort(data) {
   if (data.user_requested || data.userRequested) return true;
 
@@ -804,7 +829,10 @@ async function main() {
       return;
     }
 
-    // No blocking needed
+    // No blocking needed — Claude is truly idle.
+    // Fire session-idle notification (non-blocking) so user gets notified.
+    // Fix: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/584
+    sendIdleNotification(sessionId, directory).catch(() => {});
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   } catch (error) {
     // On any error, allow stop rather than blocking forever


### PR DESCRIPTION
## Summary

- **Bug**: `session-idle` notifications (added in v4.2.2, #566) never fire because the Stop hook runs `persistent-mode.mjs`/`.cjs` directly, bypassing `bridge.js` where the idle notification logic lived
- **Fix**: Add `sendIdleNotification()` to all three persistent-mode entry points so the notification fires on the "no blocking needed" exit path, matching `bridge.ts` behavior
- **Test**: Add 4 regression tests verifying idle notification fires correctly and is suppressed for user abort, context limit, and missing sessionId

## Changed Files

| File | Change |
|------|--------|
| `scripts/persistent-mode.mjs` | Add `sendIdleNotification()` + call at idle exit |
| `scripts/persistent-mode.cjs` | Add `sendIdleNotification()` + call at idle exit |
| `templates/hooks/persistent-mode.mjs` | Add `sendIdleNotification()` + call at idle exit |
| `src/hooks/__tests__/persistent-mode-idle-notification.test.ts` | 4 regression tests |

## Test plan

- [x] New regression test: idle notification fires when no mode is blocking
- [x] New regression test: idle notification suppressed on user abort
- [x] New regression test: idle notification suppressed on context limit
- [x] New regression test: idle notification suppressed when sessionId missing
- [x] All 200 hook tests pass
- [x] Lint clean
- [x] Build succeeds

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)