### PR TITLE
fix(team): emit status hooks on tmux session ready transition (#572)

### DIFF
--- a/src/team/__tests__/bridge-integration.test.ts
+++ b/src/team/__tests__/bridge-integration.test.ts
@@ -7,6 +7,7 @@ import { readTask, updateTask } from '../task-file-ops.js';
 import { checkShutdownSignal, writeShutdownSignal, appendOutbox } from '../inbox-outbox.js';
 import { writeHeartbeat, readHeartbeat } from '../heartbeat.js';
 import { sanitizeName } from '../tmux-session.js';
+import { logAuditEvent, readAuditLog } from '../audit-log.js';
 
 const TEST_TEAM = 'test-bridge-int';
 const TASKS_DIR = join(homedir(), '.claude', 'tasks', TEST_TEAM);
@@ -213,6 +214,75 @@ describe('Bridge Integration', () => {
         timestamp: new Date().toISOString(),
       };
       expect(msg.type).toBe('ready');
+    });
+
+    it('emits worker_ready audit event when ready outbox message is written', () => {
+      const config = makeConfig();
+
+      // Simulate the bridge ready sequence: heartbeat -> outbox -> audit
+      writeHeartbeat(config.workingDirectory, {
+        workerName: config.workerName,
+        teamName: config.teamName,
+        provider: config.provider,
+        pid: process.pid,
+        lastPollAt: new Date().toISOString(),
+        consecutiveErrors: 0,
+        status: 'ready',
+      });
+
+      appendOutbox(config.teamName, config.workerName, {
+        type: 'ready',
+        message: `Worker ${config.workerName} is ready (${config.provider})`,
+        timestamp: new Date().toISOString(),
+      });
+
+      logAuditEvent(config.workingDirectory, {
+        timestamp: new Date().toISOString(),
+        eventType: 'worker_ready',
+        teamName: config.teamName,
+        workerName: config.workerName,
+      });
+
+      // Verify audit event was logged
+      const events = readAuditLog(config.workingDirectory, config.teamName, {
+        eventType: 'worker_ready',
+      });
+      expect(events.length).toBe(1);
+      expect(events[0].eventType).toBe('worker_ready');
+      expect(events[0].workerName).toBe('worker1');
+    });
+
+    it('writes ready heartbeat status before transitioning to polling', () => {
+      const config = makeConfig();
+
+      // Write ready heartbeat (as the bridge now does on first successful poll)
+      writeHeartbeat(config.workingDirectory, {
+        workerName: config.workerName,
+        teamName: config.teamName,
+        provider: config.provider,
+        pid: process.pid,
+        lastPollAt: new Date().toISOString(),
+        consecutiveErrors: 0,
+        status: 'ready',
+      });
+
+      const hb = readHeartbeat(config.workingDirectory, config.teamName, config.workerName);
+      expect(hb).not.toBeNull();
+      expect(hb?.status).toBe('ready');
+
+      // Then transitions to polling on next cycle
+      writeHeartbeat(config.workingDirectory, {
+        workerName: config.workerName,
+        teamName: config.teamName,
+        provider: config.provider,
+        pid: process.pid,
+        lastPollAt: new Date().toISOString(),
+        consecutiveErrors: 0,
+        status: 'polling',
+      });
+
+      const hb2 = readHeartbeat(config.workingDirectory, config.teamName, config.workerName);
+      expect(hb2?.status).toBe('polling');
     });
   });
 });

--- a/src/team/activity-log.ts
+++ b/src/team/activity-log.ts
@@ -23,6 +23,7 @@ export interface ActivityEntry {
 const CATEGORY_MAP: Record<AuditEventType, ActivityEntry['category']> = {
   bridge_start: 'lifecycle',
   bridge_shutdown: 'lifecycle',
+  worker_ready: 'lifecycle',
   task_claimed: 'task',
   task_started: 'task',
   task_completed: 'task',
@@ -46,6 +47,7 @@ function describeEvent(event: AuditEvent): string {
   switch (event.eventType) {
     case 'bridge_start': return 'Started bridge daemon';
     case 'bridge_shutdown': return 'Shut down bridge daemon';
+    case 'worker_ready': return 'Worker ready and accepting tasks';
     case 'task_claimed': return `Claimed task ${event.taskId || '(unknown)'}`;
     case 'task_started': return `Started working on task ${event.taskId || '(unknown)'}`;
     case 'task_completed': return `Completed task ${event.taskId || '(unknown)'}`;

--- a/src/team/audit-log.ts
+++ b/src/team/audit-log.ts
@@ -14,6 +14,7 @@ import { appendFileWithMode, ensureDirWithMode, validateResolvedPath } from './f
 export type AuditEventType =
   | 'bridge_start'
   | 'bridge_shutdown'
+  | 'worker_ready'
   | 'task_claimed'
   | 'task_started'
   | 'task_completed'

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -543,11 +543,18 @@ export async function runBridge(config: BridgeConfig): Promise<void> {
       // Emit ready after first successful heartbeat write in poll loop
       if (!readyEmitted) {
         try {
+          // Write ready heartbeat so status-based monitoring detects the transition
+          writeHeartbeat(workingDirectory, buildHeartbeat(config, 'ready', null, 0));
+
           appendOutbox(teamName, workerName, {
             type: 'ready',
             message: `Worker ${workerName} is ready (${provider})`,
             timestamp: new Date().toISOString(),
           });
+
+          // Emit worker_ready audit event for activity-log / hook consumers
+          audit(config, 'worker_ready');
+
           readyEmitted = true;
         } catch (err) {
           audit(config, 'bridge_start', undefined, { warning: 'startup_write_failed', error: String(err) });

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -103,7 +103,7 @@ export interface HeartbeatData {
   lastPollAt: string;       // ISO timestamp of last poll cycle
   currentTaskId?: string;   // task being executed, if any
   consecutiveErrors: number;
-  status: 'polling' | 'executing' | 'shutdown' | 'quarantined';
+  status: 'ready' | 'polling' | 'executing' | 'shutdown' | 'quarantined';
 }
 
 /** Offset cursor for JSONL consumption */

--- a/src/team/unified-team.ts
+++ b/src/team/unified-team.ts
@@ -72,7 +72,7 @@ export function getTeamMembers(
       if (heartbeat) {
         if (heartbeat.status === 'quarantined') status = 'quarantined';
         else if (heartbeat.status === 'executing') status = 'active';
-        else if (heartbeat.status === 'polling') status = 'idle';
+        else if (heartbeat.status === 'ready' || heartbeat.status === 'polling') status = 'idle';
         else status = heartbeat.status as UnifiedTeamMember['status'];
       }
       if (!alive) status = 'dead';


### PR DESCRIPTION
## Summary

Fixes #572 - Status hooks were not emitted when tmux session becomes "ready".

**Root cause:** The bridge daemon wrote a `ready` outbox message on first successful poll, but:
- No `worker_ready` audit event was emitted, so the activity log (hook-driven monitoring surface) never saw the ready transition
- The heartbeat status went directly to `polling`, skipping `ready`, so heartbeat-based monitoring never detected the transition
- The activity log had no mapping for a `worker_ready` event type

**Changes:**
- Add `worker_ready` to `AuditEventType` union and emit it when the bridge becomes ready
- Add `ready` to `HeartbeatData.status` type so heartbeat-based monitoring detects the transition
- Write a `ready` heartbeat before transitioning to `polling` status on the next cycle
- Map `ready` heartbeat status to `idle` in `unified-team.ts` view
- Add `worker_ready` category and description in `activity-log.ts`
- Add 2 regression tests: audit event emission and heartbeat status on ready

## Test plan

- [x] All 365 team tests pass (`npx vitest run src/team/__tests__/`)
- [x] All 19 team-pipeline tests pass
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New test: `emits worker_ready audit event when ready outbox message is written`
- [x] New test: `writes ready heartbeat status before transitioning to polling`

🤖 Generated with [Claude Code](https://claude.com/claude-code)