### PR TITLE
fix(skills): mandate structured approval and ralph handoff in consensus mode (#595)

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -66,8 +66,12 @@ Jumping into code without understanding requirements leads to rework, scope cree
 2. **Architect** reviews for architectural soundness (prefer `ask_codex` with `architect` role)
 3. **Critic** evaluates against quality criteria (prefer `ask_codex` with `critic` role)
 4. If Critic rejects: iterate with feedback (max 5 iterations)
-5. On Critic approval: enter Plan Mode for explicit user consent
-6. User chooses: Approve (execute), Request changes (re-plan), or Reject (discard)
+5. On Critic approval: **MUST** use `AskUserQuestion` to present the plan with these options:
+   - **Approve and execute** — proceed to implementation via ralph+ultrawork
+   - **Request changes** — return to step 1 with user feedback
+   - **Reject** — discard the plan entirely
+6. User chooses via the structured `AskUserQuestion` UI (never ask for approval in plain text)
+7. On user approval: **MUST** invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
 
 ### Review Mode (`--review`)
 
@@ -96,6 +100,8 @@ Plans are saved to `.omc/plans/`. Drafts go to `.omc/drafts/`.
 - Use `ask_codex` with `agent_role: "analyst"` for requirements analysis
 - Use `ask_codex` with `agent_role: "critic"` for plan review in consensus and review modes
 - If ToolSearch finds no MCP tools or Codex is unavailable, fall back to equivalent Claude agents -- never block on external tools
+- In consensus mode, **MUST** use `AskUserQuestion` for the approval step (step 5) -- never ask for approval in plain text
+- In consensus mode, on user approval **MUST** invoke `Skill("oh-my-claudecode:ralph")` for execution -- never implement directly in the planning agent
 </Tool_Usage>
 
 <Examples>
@@ -152,7 +158,7 @@ Why bad: Decision fatigue. Present one option with trade-offs, get reaction, the
 - Stop interviewing when requirements are clear enough to plan -- do not over-interview
 - In consensus mode, stop after 5 Planner/Architect/Critic iterations and present the best version
 - Consensus mode requires explicit user approval before any implementation begins
-- If the user says "just do it" or "skip planning", transition to execution mode (ralph or executor)
+- If the user says "just do it" or "skip planning", **MUST** invoke `Skill("oh-my-claudecode:ralph")` to transition to execution mode. Do NOT implement directly in the planning agent.
 - Escalate to the user when there are irreconcilable trade-offs that require a business decision
 </Escalation_And_Stop_Conditions>
 

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -26,6 +26,8 @@ The consensus workflow:
 2. **Architect** reviews for architectural soundness
 3. **Critic** evaluates against quality criteria
 4. If Critic rejects: iterate with feedback (max 5 iterations)
-5. On Critic approval: present to user for final consent
+5. On Critic approval: **MUST** use `AskUserQuestion` to present the plan with approval options
+6. User chooses: Approve, Request changes, or Reject
+7. On approval: **MUST** invoke `Skill("oh-my-claudecode:ralph")` for execution -- never implement directly
 
 Follow the Plan skill's full documentation for consensus mode details.

--- a/src/__tests__/consensus-execution-handoff.test.ts
+++ b/src/__tests__/consensus-execution-handoff.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #595: Consensus mode execution handoff regression tests
+ *
+ * Verifies that the plan skill's consensus mode (ralplan) mandates:
+ * 1. Structured AskUserQuestion for approval (not plain text)
+ * 2. Explicit Skill("oh-my-claudecode:ralph") invocation on approval
+ * 3. Prohibition of direct implementation from the planning agent
+ *
+ * Also verifies that non-consensus modes (interview, direct, review) are unaffected.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getBuiltinSkill, clearSkillsCache } from '../features/builtin-skills/skills.js';
+
+/**
+ * Extract a markdown section by heading using regex.
+ * More robust than split-based parsing — tolerates heading format variations.
+ */
+function extractSection(template: string, heading: string): string | undefined {
+  const pattern = new RegExp(`###\\s+${heading}[\\s\\S]*?(?=###|$)`);
+  const match = template.match(pattern);
+  return match?.[0];
+}
+
+/**
+ * Extract content between XML-like tags.
+ */
+function extractTagContent(template: string, tag: string): string | undefined {
+  const pattern = new RegExp(`<${tag}>[\\s\\S]*?</${tag}>`);
+  const match = template.match(pattern);
+  return match?.[0];
+}
+
+describe('Issue #595: Consensus mode execution handoff', () => {
+  beforeEach(() => {
+    clearSkillsCache();
+  });
+
+  describe('plan skill - consensus mode', () => {
+    it('should mandate AskUserQuestion for the approval step', () => {
+      const skill = getBuiltinSkill('plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toContain('AskUserQuestion');
+    });
+
+    it('should mandate Skill invocation for ralph on user approval', () => {
+      const skill = getBuiltinSkill('plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toContain('Skill("oh-my-claudecode:ralph")');
+    });
+
+    it('should use MUST language for execution handoff', () => {
+      const skill = getBuiltinSkill('plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toMatch(/\*\*MUST\*\*.*invoke.*Skill/i);
+    });
+
+    it('should prohibit direct implementation from the planning agent', () => {
+      const skill = getBuiltinSkill('plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toMatch(/Do NOT implement directly/i);
+    });
+
+    it('should not modify interview mode steps', () => {
+      const skill = getBuiltinSkill('plan');
+      expect(skill).toBeDefined();
+
+      const interviewSection = extractSection(skill!.template, 'Interview Mode');
+      expect(interviewSection).toBeDefined();
+      expect(interviewSection).toContain('Classify the request');
+      expect(interviewSection).toContain('Ask one focused question');
+      expect(interviewSection).toContain('Gather codebase facts first');
+    });
+
+    it('should not modify direct mode steps', () => {
+      const skill = getBuiltinSkill('plan');
+      expect(skill).toBeDefined();
+
+      const directSection = extractSection(skill!.template, 'Direct Mode');
+      expect(directSection).toBeDefined();
+      expect(directSection).toContain('Quick Analysis');
+      expect(directSection).toContain('Create plan');
+    });
+
+    it('should not modify review mode steps', () => {
+      const skill = getBuiltinSkill('plan');
+      expect(skill).toBeDefined();
+
+      const reviewSection = extractSection(skill!.template, 'Review Mode');
+      expect(reviewSection).toBeDefined();
+      expect(reviewSection).toContain('Read plan file');
+      expect(reviewSection).toContain('Evaluate via Critic');
+    });
+
+    it('should reference ralph skill invocation in escalation section', () => {
+      const skill = getBuiltinSkill('plan');
+      expect(skill).toBeDefined();
+
+      const escalation = extractTagContent(skill!.template, 'Escalation_And_Stop_Conditions');
+      expect(escalation).toBeDefined();
+      expect(escalation).toContain('Skill("oh-my-claudecode:ralph")');
+      // Old vague language should be gone
+      expect(escalation).not.toContain('transition to execution mode (ralph or executor)');
+    });
+  });
+
+  describe('ralplan skill - consensus alias', () => {
+    it('should reference AskUserQuestion in the approval step', () => {
+      const skill = getBuiltinSkill('ralplan');
+      expect(skill).toBeDefined();
+      expect(skill!.template).toContain('AskUserQuestion');
+    });
+
+    it('should reference ralph skill invocation on approval', () => {
+      const skill = getBuiltinSkill('ralplan');
+      expect(skill).toBeDefined();
+      expect(skill!.template).toContain('Skill("oh-my-claudecode:ralph")');
+    });
+
+    it('should still identify as an alias for /plan --consensus', () => {
+      const skill = getBuiltinSkill('ralplan');
+      expect(skill).toBeDefined();
+      expect(skill!.template).toContain('/oh-my-claudecode:plan --consensus');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #595 — After `ralplan` consensus planning reaches agreement and the user approves, the LLM was editing files directly instead of transitioning to `ralph+ultrawork` multi-agent execution mode.

**Root causes:**
- Consensus step 5 used descriptive language ("enter Plan Mode") instead of mandating `AskUserQuestion`
- No explicit step required invoking `Skill("oh-my-claudecode:ralph")` after user approval
- Escalation section had vague "transition to execution mode (ralph or executor)" without mandatory tool invocation

**Changes:**
- Rewrite consensus steps 5-7 in `skills/plan/SKILL.md` with mandatory `AskUserQuestion` gate and explicit `Skill("oh-my-claudecode:ralph")` invocation
- Add "Do NOT implement directly" prohibition in consensus mode
- Strengthen escalation section to mandatory ralph skill invocation
- Add consensus-mode tool usage directives
- Sync `skills/ralplan/SKILL.md` alias with updated steps
- Add 11 regression tests covering approval mechanism, ralph handoff, MUST language, direct-implementation prohibition, and non-regression of interview/direct/review modes

## Files Changed

| File | Change |
|------|--------|
| `skills/plan/SKILL.md` | Consensus steps 5-7, escalation, tool usage directives |
| `skills/ralplan/SKILL.md` | Alias steps synced with plan skill |
| `src/__tests__/consensus-execution-handoff.test.ts` | 11 regression tests (new) |

## Test plan

- [x] 11 new regression tests pass (`vitest run src/__tests__/consensus-execution-handoff.test.ts`)
- [x] Full test suite passes (169 files, 4112 tests, 0 failures)
- [x] New test file passes eslint with 0 errors
- [x] Existing skill count unchanged (40 skills)
- [x] Non-consensus modes (interview, direct, review) verified unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)