### PR TITLE
fix(hooks): fire AskUserQuestion notification at PreToolUse (#597)

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -343,29 +343,6 @@ async function main() {
       processRememberTags(toolOutput, directory);
     }
 
-    // Send notification when AskUserQuestion is used (user input needed)
-    if (toolName === 'AskUserQuestion') {
-      try {
-        const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
-        if (pluginRoot) {
-          const { notify } = await import(pathToFileURL(join(pluginRoot, 'dist', 'notifications', 'index.js')).href);
-
-          const toolInput = data.tool_input || data.toolInput || {};
-          const questions = toolInput.questions || [];
-          const questionText = questions.map(q => q.question || '').filter(Boolean).join('; ') || 'User input requested';
-
-          // Fire and forget
-          notify('ask-user-question', {
-            sessionId,
-            projectPath: directory,
-            question: questionText,
-          }).catch(() => {});
-        }
-      } catch {
-        // Notification not available, skip
-      }
-    }
-
     // Generate contextual message
     const message = generateMessage(toolName, toolOutput, sessionId, toolCount, directory);
 

--- a/src/hooks/__tests__/askuserquestion-lifecycle.test.ts
+++ b/src/hooks/__tests__/askuserquestion-lifecycle.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression test for issue #597
+ *
+ * AskUserQuestion webhook notifications must fire at PreToolUse (before
+ * the tool blocks waiting for user input), NOT at PostToolUse (after
+ * the user has already answered).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  processHook,
+  resetSkipHooksCache,
+  dispatchAskUserQuestionNotification,
+  _notify,
+  type HookInput,
+} from "../bridge.js";
+
+describe("AskUserQuestion notification lifecycle (issue #597)", () => {
+  const originalEnv = process.env;
+  let dispatchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.DISABLE_OMC;
+    delete process.env.OMC_SKIP_HOOKS;
+    resetSkipHooksCache();
+    // Spy on the object-wrapped helper — avoids ESM module-internal call issue
+    dispatchSpy = vi
+      .spyOn(_notify, "askUserQuestion")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    resetSkipHooksCache();
+    dispatchSpy.mockRestore();
+  });
+
+  const askUserInput: HookInput = {
+    sessionId: "test-session-597",
+    toolName: "AskUserQuestion",
+    toolInput: {
+      questions: [
+        {
+          question: "Which database should we use?",
+          header: "Database",
+          options: [
+            { label: "PostgreSQL", description: "Relational DB" },
+            { label: "MongoDB", description: "Document DB" },
+          ],
+          multiSelect: false,
+        },
+      ],
+    },
+    directory: "/tmp/test-issue-597",
+  };
+
+  // ---- PreToolUse: notification MUST fire ----
+
+  it("pre-tool-use should dispatch ask-user-question notification", async () => {
+    const result = await processHook("pre-tool-use", askUserInput);
+    expect(result.continue).toBe(true);
+
+    expect(dispatchSpy).toHaveBeenCalledOnce();
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      "test-session-597",
+      expect.any(String),
+      askUserInput.toolInput,
+    );
+  });
+
+  // ---- PostToolUse: notification MUST NOT fire ----
+
+  it("post-tool-use should NOT dispatch ask-user-question notification", async () => {
+    const postInput: HookInput = {
+      ...askUserInput,
+      toolOutput: '{"answers":{"0":"PostgreSQL"}}',
+    };
+
+    const result = await processHook("post-tool-use", postInput);
+    expect(result.continue).toBe(true);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  // ---- Edge cases ----
+
+  it("pre-tool-use should skip notification when sessionId is missing", async () => {
+    const noSessionInput: HookInput = {
+      toolName: "AskUserQuestion",
+      toolInput: {
+        questions: [
+          {
+            question: "Pick one?",
+            header: "Choice",
+            options: [
+              { label: "A", description: "Option A" },
+              { label: "B", description: "Option B" },
+            ],
+            multiSelect: false,
+          },
+        ],
+      },
+      directory: "/tmp/test-issue-597",
+    };
+
+    await processHook("pre-tool-use", noSessionInput);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-AskUserQuestion tools should not trigger notification", async () => {
+    const bashInput: HookInput = {
+      sessionId: "test-session-597",
+      toolName: "Bash",
+      toolInput: { command: "echo hello" },
+      directory: "/tmp/test-issue-597",
+    };
+
+    await processHook("pre-tool-use", bashInput);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  // ---- Unit test for the helper itself ----
+
+  it("dispatchAskUserQuestionNotification extracts question text correctly", () => {
+    // Restore the real implementation for this unit test
+    dispatchSpy.mockRestore();
+
+    const toolInput = {
+      questions: [
+        { question: "Which framework?" },
+        { question: "Which bundler?" },
+      ],
+    };
+
+    // Call the real function — the dynamic import will fail silently in test env
+    // We just verify it doesn't throw
+    expect(() =>
+      dispatchAskUserQuestionNotification("sess", "/tmp", toolInput),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Moved AskUserQuestion Discord/Telegram webhook dispatch from `PostToolUse` to `PreToolUse` so users are notified **before** the tool blocks for input, not after the user has already answered
- Patched both shell script layer (`pre-tool-enforcer.mjs` / `post-tool-verifier.mjs`) and TypeScript bridge layer (`bridge.ts`)
- Added 5 regression tests covering lifecycle ordering, edge cases, and the extracted dispatch helper

## Test plan
- [x] New `askuserquestion-lifecycle.test.ts` — 5 tests all green
- [x] Existing `bridge-routing.test.ts` — 59 tests all green (no regressions)
- [x] TypeScript type check — zero errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)