### PR TITLE
feat(skills): add user feedback step in consensus mode (#600)

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -63,15 +63,19 @@ Jumping into code without understanding requirements leads to rework, scope cree
 ### Consensus Mode (`--consensus` / "ralplan")
 
 1. **Planner** creates initial plan
-2. **Architect** reviews for architectural soundness (prefer `ask_codex` with `architect` role)
-3. **Critic** evaluates against quality criteria (prefer `ask_codex` with `critic` role)
-4. If Critic rejects: iterate with feedback (max 5 iterations)
-5. On Critic approval: **MUST** use `AskUserQuestion` to present the plan with these options:
+2. **User feedback**: **MUST** use `AskUserQuestion` to present the draft plan with these options:
+   - **Proceed to review** — send to Architect and Critic for evaluation
+   - **Request changes** — return to step 1 with user feedback incorporated
+   - **Skip review** — go directly to final approval (step 6)
+3. **Architect** reviews for architectural soundness (prefer `ask_codex` with `architect` role)
+4. **Critic** evaluates against quality criteria (prefer `ask_codex` with `critic` role)
+5. If Critic rejects: iterate with feedback (max 5 iterations)
+6. On Critic approval: **MUST** use `AskUserQuestion` to present the plan with these options:
    - **Approve and execute** — proceed to implementation via ralph+ultrawork
    - **Request changes** — return to step 1 with user feedback
    - **Reject** — discard the plan entirely
-6. User chooses via the structured `AskUserQuestion` UI (never ask for approval in plain text)
-7. On user approval: **MUST** invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
+7. User chooses via the structured `AskUserQuestion` UI (never ask for approval in plain text)
+8. On user approval: **MUST** invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
 
 ### Review Mode (`--review`)
 
@@ -100,8 +104,8 @@ Plans are saved to `.omc/plans/`. Drafts go to `.omc/drafts/`.
 - Use `ask_codex` with `agent_role: "analyst"` for requirements analysis
 - Use `ask_codex` with `agent_role: "critic"` for plan review in consensus and review modes
 - If ToolSearch finds no MCP tools or Codex is unavailable, fall back to equivalent Claude agents -- never block on external tools
-- In consensus mode, **MUST** use `AskUserQuestion` for the approval step (step 5) -- never ask for approval in plain text
-- In consensus mode, on user approval **MUST** invoke `Skill("oh-my-claudecode:ralph")` for execution -- never implement directly in the planning agent
+- In consensus mode, **MUST** use `AskUserQuestion` for the user feedback step (step 2) and the final approval step (step 6) -- never ask for approval in plain text
+- In consensus mode, on user approval **MUST** invoke `Skill("oh-my-claudecode:ralph")` for execution (step 8) -- never implement directly in the planning agent
 </Tool_Usage>
 
 <Examples>

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -23,11 +23,12 @@ This skill invokes the Plan skill in consensus mode:
 
 The consensus workflow:
 1. **Planner** creates initial plan
-2. **Architect** reviews for architectural soundness
-3. **Critic** evaluates against quality criteria
-4. If Critic rejects: iterate with feedback (max 5 iterations)
-5. On Critic approval: **MUST** use `AskUserQuestion` to present the plan with approval options
-6. User chooses: Approve, Request changes, or Reject
-7. On approval: **MUST** invoke `Skill("oh-my-claudecode:ralph")` for execution -- never implement directly
+2. **User feedback**: **MUST** use `AskUserQuestion` to present the draft plan before review (Proceed to review / Request changes / Skip review)
+3. **Architect** reviews for architectural soundness
+4. **Critic** evaluates against quality criteria
+5. If Critic rejects: iterate with feedback (max 5 iterations)
+6. On Critic approval: **MUST** use `AskUserQuestion` to present the plan with approval options
+7. User chooses: Approve, Request changes, or Reject
+8. On approval: **MUST** invoke `Skill("oh-my-claudecode:ralph")` for execution -- never implement directly
 
 Follow the Plan skill's full documentation for consensus mode details.


### PR DESCRIPTION
## Summary

- Adds an explicit `AskUserQuestion` step between Planner output and Architect/Critic review in consensus mode (`--consensus` / ralplan)
- Users can now review the draft plan early and choose: **Proceed to review**, **Request changes**, or **Skip review**
- Updates both `skills/plan/SKILL.md` and `skills/ralplan/SKILL.md` flow documentation
- Adds 5 regression tests verifying step ordering (Planner → User feedback → Architect → Critic)

## Test plan

- [x] All 16 consensus-execution-handoff tests pass (11 existing + 5 new)
- [x] Full test suite passes (170 files, 4120 tests, 0 failures)
- [x] Lint clean
- [x] Non-consensus modes (interview, direct, review) unaffected (verified by existing tests)

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)