### PR TITLE
feat(lsp): add Dart/Flutter language server support

### DIFF
--- a/src/__tests__/lsp-servers.test.ts
+++ b/src/__tests__/lsp-servers.test.ts
@@ -4,8 +4,8 @@ import { LSP_SERVERS, getServerForFile, getServerForLanguage } from '../tools/ls
 describe('LSP Server Configurations', () => {
   const serverKeys = Object.keys(LSP_SERVERS);
 
-  it('should have 16 configured servers', () => {
-    expect(serverKeys).toHaveLength(16);
+  it('should have 17 configured servers', () => {
+    expect(serverKeys).toHaveLength(17);
   });
 
   it.each(serverKeys)('server "%s" should have valid config', (key) => {
@@ -55,6 +55,7 @@ describe('getServerForFile', () => {
     ['page.heex', 'ElixirLS'],
     ['template.eex', 'ElixirLS'],
     ['Program.cs', 'OmniSharp'],
+    ['main.dart', 'Dart Analysis Server'],
     ['view.erb', 'Ruby Language Server (Solargraph)'],
   ];
 
@@ -104,6 +105,8 @@ describe('getServerForLanguage', () => {
     ['erb', 'Ruby Language Server (Solargraph)'],
     ['c#', 'OmniSharp'],
     ['cs', 'OmniSharp'],
+    ['dart', 'Dart Analysis Server'],
+    ['flutter', 'Dart Analysis Server'],
   ];
 
   it.each(cases)('should resolve language "%s" to "%s"', (lang, expectedName) => {

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -132,6 +132,13 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
     args: ['-lsp'],
     extensions: ['.cs'],
     installHint: 'dotnet tool install -g omnisharp'
+  },
+  dart: {
+    name: 'Dart Analysis Server',
+    command: 'dart',
+    args: ['language-server', '--protocol=lsp'],
+    extensions: ['.dart'],
+    installHint: 'Install Dart SDK from https://dart.dev/get-dart or Flutter SDK from https://flutter.dev'
   }
 };
 
@@ -215,7 +222,9 @@ export function getServerForLanguage(language: string): LspServerConfig | null {
     'eex': 'elixir',
     'csharp': 'csharp',
     'c#': 'csharp',
-    'cs': 'csharp'
+    'cs': 'csharp',
+    'dart': 'dart',
+    'flutter': 'dart'
   };
 
   const serverKey = langMap[language.toLowerCase()];


### PR DESCRIPTION
## Summary
- Add Dart Analysis Server (`dart language-server --protocol=lsp`) as a supported LSP server
- Map `.dart` extension and `dart`/`flutter` language identifiers to the new server
- Update tests to cover the new server config and mappings

## Context
The Dart SDK ships with a built-in language server, so no external tooling is needed beyond having the Dart or Flutter SDK in PATH. This enables all LSP tools (diagnostics, hover, go-to-definition, references, etc.) for Dart and Flutter projects.
