### PR TITLE
fix: rename doctor/help skills, tighten ecomode keywords (#632, #638, #292)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claudecode",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
-      "version": "4.2.8",
+      "version": "4.2.9",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"
@@ -27,5 +27,5 @@
       ]
     }
   ],
-  "version": "4.2.8"
+  "version": "4.2.9"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
     "name": "oh-my-claudecode contributors"

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -35,7 +35,7 @@ tests/                   # Test files
 ## When Responding to Issues
 
 ### Installation Issues
-- Recommend running `/oh-my-claudecode:doctor` to diagnose problems
+- Recommend running `/oh-my-claudecode:omc-doctor` to diagnose problems
 - Check if user installed via correct method: `/plugin marketplace add Yeachan-Heo/oh-my-claudecode`
 - Common issues: outdated Claude Code version, missing dependencies
 

--- a/README.es.md
+++ b/README.es.md
@@ -51,7 +51,7 @@ Eso es todo. Todo lo demás es automático.
 Si experimentas problemas despues de actualizar, limpia la cache antigua del plugin:
 
 ```bash
-/oh-my-claudecode:doctor
+/oh-my-claudecode:omc-doctor
 ```
 
 <h1 align="center">Tu Claude acaba de recibir esteroides.</h1>

--- a/README.ja.md
+++ b/README.ja.md
@@ -51,7 +51,7 @@ autopilot: build a REST API for managing tasks
 更新後に問題が発生した場合は、古いプラグインキャッシュをクリアしてください：
 
 ```bash
-/oh-my-claudecode:doctor
+/oh-my-claudecode:omc-doctor
 ```
 
 <h1 align="center">あなたの Claude がステロイド級にパワーアップ。</h1>

--- a/README.ko.md
+++ b/README.ko.md
@@ -51,7 +51,7 @@ autopilot: build a REST API for managing tasks
 업데이트 후 문제가 발생하면, 이전 플러그인 캐시를 정리하세요:
 
 ```bash
-/oh-my-claudecode:doctor
+/oh-my-claudecode:omc-doctor
 ```
 
 <h1 align="center">당신의 Claude가 스테로이드를 맞았습니다.</h1>

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Enable Claude Code native teams in `~/.claude/settings.json`:
 If you experience issues after updating, clear the old plugin cache:
 
 ```bash
-/oh-my-claudecode:doctor
+/oh-my-claudecode:omc-doctor
 ```
 
 <h1 align="center">Your Claude Just Have been Steroided.</h1>

--- a/README.pt.md
+++ b/README.pt.md
@@ -75,7 +75,7 @@ Ative os times nativos do Claude Code em `~/.claude/settings.json`:
 Se você tiver problemas depois de atualizar, limpe o cache antigo do plugin:
 
 ```bash
-/oh-my-claudecode:doctor
+/oh-my-claudecode:omc-doctor
 ```
 
 <h1 align="center">Seu Claude acabou de tomar esteroides.</h1>

--- a/README.vi.md
+++ b/README.vi.md
@@ -75,7 +75,7 @@ Bật Claude Code native teams trong `~/.claude/settings.json`:
 Nếu gặp sự cố sau khi cập nhật, hãy xóa cache plugin cũ:
 
 ```bash
-/oh-my-claudecode:doctor
+/oh-my-claudecode:omc-doctor
 ```
 
 <h1 align="center">Your Claude Just Have been Steroided.</h1>

--- a/README.zh.md
+++ b/README.zh.md
@@ -51,7 +51,7 @@ autopilot: build a REST API for managing tasks
 如果更新后遇到问题，清除旧的插件缓存：
 
 ```bash
-/oh-my-claudecode:doctor
+/oh-my-claudecode:omc-doctor
 ```
 
 <h1 align="center">你的 Claude 已被注入超能力。</h1>

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.2.8 -->
+<!-- OMC:VERSION:4.2.9 -->
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
 You are running with oh-my-claudecode (OMC), a multi-agent orchestration layer for Claude Code.
@@ -178,7 +178,7 @@ Workflow Skills:
 - `ultrawork` ("ulw", "ultrawork"): maximum parallelism with parallel agent orchestration
 - `swarm` ("swarm"): compatibility facade over Team; preserves `/swarm` syntax, routes to Team staged pipeline
 - `ultrapilot` ("ultrapilot", "parallel build"): compatibility facade over Team; maps onto Team's staged runtime
-- `ecomode` ("eco", "ecomode", "budget"): token-efficient execution using haiku and sonnet
+- `ecomode` ("ecomode", "eco-mode", "eco mode", "save-tokens"): token-efficient execution using haiku and sonnet
 - `team` ("team", "coordinated team", "team ralph"): N coordinated agents using Claude Code native teams with stage-aware agent routing; supports `team ralph` for persistent team execution
 - `pipeline` ("pipeline", "chain agents"): sequential agent chaining with data passing
 - `ultraqa` (activated by autopilot): QA cycling -- test, verify, fix, repeat
@@ -207,9 +207,9 @@ MCP Delegation (auto-detected when an intent phrase is present):
 
 Notifications: `configure-discord` ("configure discord", "setup discord", "discord webhook"), `configure-telegram` ("configure telegram", "setup telegram", "telegram bot")
 
-Utilities: `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `doctor`, `help`, `trace`, `release`, `project-session-manager` (psm), `skill`, `writer-memory`, `ralph-init`, `learn-about-omc`
+Utilities: `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager` (psm), `skill`, `writer-memory`, `ralph-init`, `learn-about-omc`
 
-Conflict resolution: explicit mode keywords (`ulw`, `ultrawork`, `eco`, `ecomode`) override defaults. When both are present, ecomode wins. Generic "fast"/"parallel" reads `~/.claude/.omc-config.json` -> `defaultExecutionMode`. Ralph includes ultrawork (persistence wrapper). Ecomode is a model-routing modifier only. Autopilot can transition to ralph or ultraqa. Autopilot and ultrapilot are mutually exclusive.
+Conflict resolution: explicit mode keywords (`ulw`, `ultrawork`, `ecomode`, `eco-mode`, `eco mode`, `save-tokens`) override defaults. When both are present, ecomode wins. Generic "fast"/"parallel" reads `~/.claude/.omc-config.json` -> `defaultExecutionMode`. Ralph includes ultrawork (persistence wrapper). Ecomode is a model-routing modifier only. Autopilot can transition to ralph or ultraqa. Autopilot and ultrapilot are mutually exclusive.
 </skills>
 
 ---

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -238,7 +238,7 @@ All 2.x commands continue to work. Here's what changed:
 | `/oh-my-claudecode:frontend-ui-ux` | Say "UI", "styling", "component", "design" | ✅ YES (auto-detect) |
 | `/oh-my-claudecode:note "content"` | Say "remember this" or "save this" | ✅ YES (auto-detect) |
 | `/oh-my-claudecode:cancel-ralph` | Say "stop", "cancel", or "abort" | ✅ YES (auto-detect) |
-| `/oh-my-claudecode:doctor` | Invoke normally | ✅ YES (unchanged) |
+| `/oh-my-claudecode:omc-doctor` | Invoke normally | ✅ YES (unchanged) |
 | All other commands | Work exactly as before | ✅ YES |
 
 ### Magic Keywords
@@ -375,7 +375,7 @@ After migration, verify your setup:
    ```
 
 3. **Test a simple command**:
-   Run `/oh-my-claudecode:help` in Claude Code to ensure the plugin is loaded correctly.
+   Run `/oh-my-claudecode:omc-help` in Claude Code to ensure the plugin is loaded correctly.
 
 ### New Features in 3.0
 
@@ -948,8 +948,8 @@ A: Keywords are explicit shortcuts. Natural language triggers auto-detection. Bo
 
 ## Need Help?
 
-- **Diagnose issues**: Run `/oh-my-claudecode:doctor`
-- **See all commands**: Run `/oh-my-claudecode:help`
+- **Diagnose issues**: Run `/oh-my-claudecode:omc-doctor`
+- **See all commands**: Run `/oh-my-claudecode:omc-help`
 - **View real-time status**: Run `/oh-my-claudecode:hud setup`
 - **Review detailed changelog**: See [CHANGELOG.md](../CHANGELOG.md)
 - **Report bugs**: [GitHub Issues](https://github.com/Yeachan-Heo/oh-my-claude-sisyphus/issues)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -264,8 +264,8 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 | `note` | Save notes to compaction-resilient notepad | `/oh-my-claudecode:note` |
 | `cancel` | Unified cancellation for all modes | `/oh-my-claudecode:cancel` |
 | `omc-setup` | One-time setup wizard | `/oh-my-claudecode:omc-setup` |
-| `doctor` | Diagnose and fix installation issues | `/oh-my-claudecode:doctor` |
-| `help` | Show OMC usage guide | `/oh-my-claudecode:help` |
+| `omc-doctor` | Diagnose and fix installation issues | `/oh-my-claudecode:omc-doctor` |
+| `omc-help` | Show OMC usage guide | `/oh-my-claudecode:omc-help` |
 | `hud` | Configure HUD statusline | `/oh-my-claudecode:hud` |
 | `release` | Automated release workflow | `/oh-my-claudecode:release` |
 | `mcp-setup` | Configure MCP servers | `/oh-my-claudecode:mcp-setup` |
@@ -303,8 +303,8 @@ All skills are available as slash commands with the prefix `/oh-my-claudecode:`.
 | `/oh-my-claudecode:note <content>` | Save notes to notepad.md |
 | `/oh-my-claudecode:cancel` | Unified cancellation |
 | `/oh-my-claudecode:omc-setup` | One-time setup wizard |
-| `/oh-my-claudecode:doctor` | Diagnose and fix installation issues |
-| `/oh-my-claudecode:help` | Show OMC usage guide |
+| `/oh-my-claudecode:omc-doctor` | Diagnose and fix installation issues |
+| `/oh-my-claudecode:omc-help` | Show OMC usage guide |
 | `/oh-my-claudecode:hud` | Configure HUD statusline |
 | `/oh-my-claudecode:release` | Automated release workflow |
 | `/oh-my-claudecode:mcp-setup` | Configure MCP servers |
@@ -635,7 +635,7 @@ Enable detailed cost tracking in your status line:
 ### Diagnose Installation Issues
 
 ```bash
-/oh-my-claudecode:doctor
+/oh-my-claudecode:omc-doctor
 ```
 
 Checks for:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "4.2.8",
+      "version": "4.2.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",

--- a/seminar/quickref.md
+++ b/seminar/quickref.md
@@ -61,8 +61,8 @@
 |---------|---------|
 | `/oh-my-claudecode:omc-setup` | Initial setup wizard |
 | `/oh-my-claudecode:hud setup` | Enable HUD statusline |
-| `/oh-my-claudecode:doctor` | Diagnose issues |
-| `/oh-my-claudecode:help` | Show usage guide |
+| `/oh-my-claudecode:omc-doctor` | Diagnose issues |
+| `/oh-my-claudecode:omc-help` | Show usage guide |
 | `/oh-my-claudecode:cancel` | Stop current operation |
 | `/oh-my-claudecode:note` | Save compaction-resilient note |
 | `/oh-my-claudecode:learner` | Extract reusable skill |

--- a/seminar/slides.md
+++ b/seminar/slides.md
@@ -1206,8 +1206,8 @@ npm install -g oh-my-claude-sisyphus
 
 **Getting Help**
 ```
-/oh-my-claudecode:help    - Usage guide
-/oh-my-claudecode:doctor  - Diagnose issues
+/oh-my-claudecode:omc-help    - Usage guide
+/oh-my-claudecode:omc-doctor  - Diagnose issues
 ```
 
 Note: The GitHub repo has all documentation, examples, and issue tracking.

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -273,7 +273,7 @@ You can manually edit the config file. Each option can be set individually - any
 If the HUD is not showing:
 1. Run `/oh-my-claudecode:hud setup` to auto-install and configure
 2. Restart Claude Code after setup completes
-3. If still not working, run `/oh-my-claudecode:doctor` for full diagnostics
+3. If still not working, run `/oh-my-claudecode:omc-doctor` for full diagnostics
 
 Manual verification:
 - HUD script: `~/.claude/hud/omc-hud.mjs`

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -122,7 +122,7 @@ TROUBLESHOOTING:
 - If MCP servers don't appear, run `claude mcp list` to check status
 - Ensure you have Node.js 18+ installed for npx-based servers
 - For GitHub Docker option, ensure Docker is installed and running
-- Run /oh-my-claudecode:doctor to diagnose issues
+- Run /oh-my-claudecode:omc-doctor to diagnose issues
 
 MANAGING MCP SERVERS:
 - Add more servers: /oh-my-claudecode:mcp-setup or `claude mcp add ...`

--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: doctor
+name: omc-doctor
 description: Diagnose and fix oh-my-claudecode installation issues
 ---
 

--- a/skills/omc-help/SKILL.md
+++ b/skills/omc-help/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: help
+name: omc-help
 description: Guide on using oh-my-claudecode plugin
 ---
 

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -629,8 +629,8 @@ Ask user: "Would you like to install the OMC CLI for standalone analytics? (Reco
 The CLI (`omc` command) is **no longer supported** via npm/bun global install.
 
 All functionality is available through the plugin system:
-- Use `/oh-my-claudecode:help` for guidance
-- Use `/oh-my-claudecode:doctor` for diagnostics
+- Use `/oh-my-claudecode:omc-help` for guidance
+- Use `/oh-my-claudecode:omc-doctor` for diagnostics
 
 Skip this step - the plugin provides all features.
 

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -11,7 +11,7 @@ describe('Builtin Skills', () => {
     it('should return correct number of skills (41)', () => {
       const skills = createBuiltinSkills();
       // 41 skills: analyze, autopilot, build-fix, cancel, code-review, configure-discord, configure-telegram,
-      // deepinit, deepsearch, doctor, ecomode, external-context, frontend-ui-ux, git-master, help, hud,
+      // deepinit, deepsearch, omc-doctor, ecomode, external-context, frontend-ui-ux, git-master, omc-help, hud,
       // learn-about-omc, learner, mcp-setup, note, omc-setup, pipeline, plan, project-session-manager,
       // psm, ralph, ralph-init, ralplan, release, review, sciomc, security-review, skill, swarm, tdd,
       // team, trace, ultrapilot, ultraqa, ultrawork, writer-memory
@@ -74,12 +74,12 @@ describe('Builtin Skills', () => {
         'configure-telegram',
         'deepinit',
         'deepsearch',
-        'doctor',
+        'omc-doctor',
         'ecomode',
         'external-context',
         'frontend-ui-ux',
         'git-master',
-        'help',
+        'omc-help',
         'hud',
         'learn-about-omc',
         'learner',
@@ -161,8 +161,8 @@ describe('Builtin Skills', () => {
       expect(names).toContain('plan');
       expect(names).toContain('deepinit');
       expect(names).toContain('release');
-      expect(names).toContain('doctor');
-      expect(names).toContain('help');
+      expect(names).toContain('omc-doctor');
+      expect(names).toContain('omc-help');
       expect(names).toContain('hud');
       expect(names).toContain('note');
       expect(names).toContain('omc-setup');

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -445,10 +445,22 @@ World`);
     });
 
     describe('ecomode keyword', () => {
-      it('should detect eco keyword', () => {
+      it('should NOT detect bare eco keyword', () => {
         const result = detectKeywordsWithType('eco fix all errors');
         const ecoMatch = result.find((r) => r.type === 'ecomode');
-        expect(ecoMatch).toBeDefined();
+        expect(ecoMatch).toBeUndefined();
+      });
+
+      it('should NOT detect budget keyword', () => {
+        const result = detectKeywordsWithType('budget fix all errors');
+        const ecoMatch = result.find((r) => r.type === 'ecomode');
+        expect(ecoMatch).toBeUndefined();
+      });
+
+      it('should NOT detect efficient keyword', () => {
+        const result = detectKeywordsWithType('efficient fix all errors');
+        const ecoMatch = result.find((r) => r.type === 'ecomode');
+        expect(ecoMatch).toBeUndefined();
       });
 
       it('should detect ecomode keyword', () => {
@@ -457,14 +469,20 @@ World`);
         expect(ecoMatch).toBeDefined();
       });
 
-      it('should detect save-tokens keyword', () => {
-        const result = detectKeywordsWithType('save-tokens and fix errors');
+      it('should detect eco-mode keyword', () => {
+        const result = detectKeywordsWithType('eco-mode fix build');
         const ecoMatch = result.find((r) => r.type === 'ecomode');
         expect(ecoMatch).toBeDefined();
       });
 
-      it('should detect budget keyword', () => {
-        const result = detectKeywordsWithType('budget fix all errors');
+      it('should detect eco mode keyword', () => {
+        const result = detectKeywordsWithType('eco mode fix build');
+        const ecoMatch = result.find((r) => r.type === 'ecomode');
+        expect(ecoMatch).toBeDefined();
+      });
+
+      it('should detect save-tokens keyword', () => {
+        const result = detectKeywordsWithType('save-tokens and fix errors');
         const ecoMatch = result.find((r) => r.type === 'ecomode');
         expect(ecoMatch).toBeDefined();
       });
@@ -478,20 +496,20 @@ World`);
           mockedIsEcomodeEnabled.mockReturnValue(true);
         });
 
-        it('should NOT detect eco keyword when disabled', () => {
-          const result = detectKeywordsWithType('eco fix all errors');
-          const ecoMatch = result.find((r) => r.type === 'ecomode');
-          expect(ecoMatch).toBeUndefined();
-        });
-
         it('should NOT detect ecomode keyword when disabled', () => {
           const result = detectKeywordsWithType('ecomode fix build');
           const ecoMatch = result.find((r) => r.type === 'ecomode');
           expect(ecoMatch).toBeUndefined();
         });
 
+        it('should NOT detect eco-mode keyword when disabled', () => {
+          const result = detectKeywordsWithType('eco-mode fix build');
+          const ecoMatch = result.find((r) => r.type === 'ecomode');
+          expect(ecoMatch).toBeUndefined();
+        });
+
         it('should still detect ultrawork when ecomode is disabled', () => {
-          const result = detectKeywordsWithType('ulw eco fix errors');
+          const result = detectKeywordsWithType('ulw ecomode fix errors');
           const ultraworkMatch = result.find((r) => r.type === 'ultrawork');
           expect(ultraworkMatch).toBeDefined();
           const ecoMatch = result.find((r) => r.type === 'ecomode');
@@ -499,7 +517,7 @@ World`);
         });
 
         it('should not suppress ultrawork when ecomode disabled and both keywords present', () => {
-          const result = getAllKeywords('ulw eco fix errors');
+          const result = getAllKeywords('ulw ecomode fix errors');
           expect(result).toContain('ultrawork');
           expect(result).not.toContain('ecomode');
         });
@@ -751,13 +769,13 @@ World`);
     describe('multiple keyword conflict resolution', () => {
       it('should return ecomode over ultrawork when both present', () => {
         // ecomode wins over ultrawork per conflict resolution rules
-        const result = getPrimaryKeyword('ulw eco fix errors');
+        const result = getPrimaryKeyword('ulw ecomode fix errors');
         expect(result?.type).toBe('ecomode');
       });
 
       it('should return ecomode over ultrawork (ecomode has higher priority)', () => {
         // UPDATED: ecomode wins per conflict resolution
-        const result = getPrimaryKeyword('eco ultrawork fix errors');
+        const result = getPrimaryKeyword('ecomode ultrawork fix errors');
         expect(result?.type).toBe('ecomode');
       });
 
@@ -767,12 +785,12 @@ World`);
       });
 
       it('should return ralph over ultrawork and ecomode', () => {
-        const result = getPrimaryKeyword('ralph ulw eco fix errors');
+        const result = getPrimaryKeyword('ralph ulw ecomode fix errors');
         expect(result?.type).toBe('ralph');
       });
 
       it('should detect all keywords even when multiple present', () => {
-        const result = detectKeywordsWithType('ulw eco fix errors');
+        const result = detectKeywordsWithType('ulw ecomode fix errors');
         const types = result.map(r => r.type);
         expect(types).toContain('ultrawork');
         expect(types).toContain('ecomode');
@@ -824,7 +842,7 @@ World`);
     });
 
     it('should return ecomode over ultrawork when both present', () => {
-      expect(getAllKeywords('ulw eco fix errors')).toEqual(['ecomode']);
+      expect(getAllKeywords('ulw ecomode fix errors')).toEqual(['ecomode']);
     });
 
     it('should return team and ultrapilot when legacy ultrapilot trigger is present', () => {
@@ -848,7 +866,7 @@ World`);
     });
 
     it('should return ralph with ecomode but not ultrawork', () => {
-      const result = getAllKeywords('ralph eco ulw fix');
+      const result = getAllKeywords('ralph ecomode ulw fix');
       expect(result).toContain('ralph');
       expect(result).toContain('ecomode');
       expect(result).not.toContain('ultrawork');
@@ -962,7 +980,7 @@ World`);
 
     // Mixed keyword precedence tests
     it('should handle team + ecomode + ralph combination', () => {
-      const result = getAllKeywords('team ralph eco build the app');
+      const result = getAllKeywords('team ralph ecomode build the app');
       expect(result).toContain('ralph');
       expect(result).toContain('team');
       expect(result).toContain('ecomode');

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -66,7 +66,7 @@ const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   autopilot: /\b(autopilot|auto pilot|auto-pilot|autonomous|full auto|fullsend)\b/i,
   ultrapilot: /\b(ultrapilot|ultra-pilot)\b|\bparallel\s+build\b|\bswarm\s+build\b/i,
   ultrawork: /\b(ultrawork|ulw|uw)\b/i,
-  ecomode: /\b(eco|ecomode|eco-mode|efficient|save-tokens|budget)\b/i,
+  ecomode: /\b(ecomode|eco-mode|eco\s+mode|save-tokens)\b/i,
   swarm: /\bswarm\s+\d+\s+agents?\b|\bcoordinated\s+agents\b|\bteam\s+mode\b/i,
   team: /(?<!\b(?:my|the|our|a|his|her|their|its)\s)\bteam\b|\bcoordinated\s+team\b/i,
   pipeline: /\b(pipeline)\b|\bchain\s+agents\b/i,


### PR DESCRIPTION
## Summary

- **#632/#638**: Renamed `doctor` → `omc-doctor` and `help` → `omc-help` skills to avoid overriding Claude Code's built-in `/doctor` and `/help` commands. Now accessible only via `/oh-my-claudecode:omc-doctor` and `/oh-my-claudecode:omc-help`.
- **#292**: Tightened ecomode keyword patterns — removed overly broad triggers (`efficient`, `budget`, `eco`) that caused false activations. Only `ecomode`, `eco-mode`, `eco mode`, and `save-tokens` now activate ecomode.
- Version bump to 4.2.9

## Changes

- Renamed `skills/doctor/` → `skills/omc-doctor/` with frontmatter update
- Renamed `skills/help/` → `skills/omc-help/` with frontmatter update
- Updated all references across 21 files (docs, READMEs, seminar materials, skill cross-refs, tests)
- Tightened ecomode regex in keyword detector
- Added test coverage for false-positive prevention

## Test plan

- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Keyword detector tests pass (164/164)
- [x] Skills tests pass (15/15)
- [x] No remaining references to old skill names

Closes #632, closes #638, closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)