### PR TITLE
chore: bump version to 4.2.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claudecode",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
-      "version": "4.2.9",
+      "version": "4.2.11",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"
@@ -27,5 +27,5 @@
       ]
     }
   ],
-  "version": "4.2.9"
+  "version": "4.2.11"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "4.2.9",
+  "version": "4.2.11",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
     "name": "oh-my-claudecode contributors"

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.2.9 -->
+<!-- OMC:VERSION:4.2.11 -->
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
 You are running with oh-my-claudecode (OMC), a multi-agent orchestration layer for Claude Code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.2.9",
+  "version": "4.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "4.2.9",
+      "version": "4.2.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.2.9",
+  "version": "4.2.11",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps version from 4.2.9 to 4.2.11 across all version files (package.json, package-lock.json, plugin.json, marketplace.json, docs/CLAUDE.md)

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] 4119/4119 relevant tests pass (3 pre-existing SQLite native module test failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)