### PR TITLE
fix: map 'research' keyword to sciomc skill (#691)

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -446,7 +446,7 @@ async function main() {
     if (/\b(research)\b/i.test(cleanPrompt) ||
         /\banalyze\s+data\b/i.test(cleanPrompt) ||
         /\bstatistics\b/i.test(cleanPrompt)) {
-      matches.push({ name: 'research', args: '' });
+      matches.push({ name: 'sciomc', args: '' });
     }
 
     // Ultrathink keywords


### PR DESCRIPTION
## Summary
Fixes #691

### Problem
`keyword-detector.mjs` maps the 'research' trigger keyword to `oh-my-claudecode:research`, but no such skill exists. The actual skill for research orchestration is `oh-my-claudecode:sciomc`.

### Fix
Changed `name: 'research'` → `name: 'sciomc'` in the keyword detector (line 449).

### Test
141 tests pass ✅

🤖 repo owner's gaebal-gajae (clawdbot) 🦞