### PR TITLE
fix: use correct Co-authored-by trailer casing per Git spec

### DIFF
--- a/dist/hooks/permission-handler/__tests__/index.test.js
+++ b/dist/hooks/permission-handler/__tests__/index.test.js
@@ -153,7 +153,7 @@ describe('permission-handler', () => {
             const safeCases = [
                 {
                     desc: 'git commit with HEREDOC message',
-                    cmd: `git commit -m "$(cat <<'EOF'\nCommit message here.\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`,
+                    cmd: `git commit -m "$(cat <<'EOF'\nCommit message here.\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`,
                 },
                 {
                     desc: 'git commit with unquoted EOF delimiter',
@@ -165,7 +165,7 @@ describe('permission-handler', () => {
                 },
                 {
                     desc: 'git commit with long multi-line message',
-                    cmd: `git commit -m "$(cat <<'EOF'\nfeat: add authentication module\n\nThis adds OAuth2 support with:\n- Google provider\n- GitHub provider\n- Session management\n\nCloses #123\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`,
+                    cmd: `git commit -m "$(cat <<'EOF'\nfeat: add authentication module\n\nThis adds OAuth2 support with:\n- Google provider\n- GitHub provider\n- Session management\n\nCloses #123\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`,
                 },
                 {
                     desc: 'git commit --amend with heredoc',
@@ -376,7 +376,7 @@ describe('permission-handler', () => {
         });
         describe('heredoc command handling (Issue #608)', () => {
             it('should auto-allow git commit with heredoc message', () => {
-                const cmd = `git commit -m "$(cat <<'EOF'\nfeat: add new feature\n\nDetailed description here.\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`;
+                const cmd = `git commit -m "$(cat <<'EOF'\nfeat: add new feature\n\nDetailed description here.\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`;
                 const result = processPermissionRequest(createInput(cmd));
                 expect(result.continue).toBe(true);
                 expect(result.hookSpecificOutput?.decision?.behavior).toBe('allow');

--- a/src/hooks/permission-handler/__tests__/index.test.ts
+++ b/src/hooks/permission-handler/__tests__/index.test.ts
@@ -174,7 +174,7 @@ describe('permission-handler', () => {
       const safeCases = [
         {
           desc: 'git commit with HEREDOC message',
-          cmd: `git commit -m "$(cat <<'EOF'\nCommit message here.\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`,
+          cmd: `git commit -m "$(cat <<'EOF'\nCommit message here.\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`,
         },
         {
           desc: 'git commit with unquoted EOF delimiter',
@@ -186,7 +186,7 @@ describe('permission-handler', () => {
         },
         {
           desc: 'git commit with long multi-line message',
-          cmd: `git commit -m "$(cat <<'EOF'\nfeat: add authentication module\n\nThis adds OAuth2 support with:\n- Google provider\n- GitHub provider\n- Session management\n\nCloses #123\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`,
+          cmd: `git commit -m "$(cat <<'EOF'\nfeat: add authentication module\n\nThis adds OAuth2 support with:\n- Google provider\n- GitHub provider\n- Session management\n\nCloses #123\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`,
         },
         {
           desc: 'git commit --amend with heredoc',
@@ -440,7 +440,7 @@ describe('permission-handler', () => {
 
     describe('heredoc command handling (Issue #608)', () => {
       it('should auto-allow git commit with heredoc message', () => {
-        const cmd = `git commit -m "$(cat <<'EOF'\nfeat: add new feature\n\nDetailed description here.\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`;
+        const cmd = `git commit -m "$(cat <<'EOF'\nfeat: add new feature\n\nDetailed description here.\n\nCo-authored-by: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`;
         const result = processPermissionRequest(createInput(cmd));
         expect(result.continue).toBe(true);
         expect(result.hookSpecificOutput?.decision?.behavior).toBe('allow');


### PR DESCRIPTION
## Summary

Fixes the casing of the `Co-Authored-By` trailer to the canonical `Co-authored-by` form.

> 💡 Originally spotted by @junhoyeo — thanks for the sharp eye!

## Why

The [official Git trailer spec](https://git-scm.com/docs/git-interpret-trailers) and [GitHub's documentation](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) both use lowercase `a`:

```
Co-authored-by: Name <email>  ✅ correct
Co-Authored-By: Name <email>  ❌ non-standard
```

While GitHub parses both variants, using the non-standard capitalization:
- Looks inconsistent in commit history and tooling
- Doesn't match the canonical format from `git interpret-trailers`
- May not be recognized by all Git tooling outside of GitHub

## Changes

- `src/hooks/permission-handler/__tests__/index.test.ts`: update test fixture commit messages
- `dist/hooks/permission-handler/__tests__/index.test.js`: sync dist