### PR TITLE
docs: add marketplace sync step to update instructions

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -41,10 +41,13 @@ Eso es todo. Todo lo demás es automático.
 ### Actualizar
 
 ```bash
-# 1. Actualizar el plugin
+# 1. Sincronizar el marketplace para obtener la ultima version
+/plugin marketplace update https://github.com/Yeachan-Heo/oh-my-claudecode
+
+# 2. Reinstalar el plugin desde el marketplace actualizado
 /plugin install oh-my-claudecode
 
-# 2. Volver a ejecutar el setup para actualizar la configuracion
+# 3. Volver a ejecutar el setup para actualizar la configuracion
 /oh-my-claudecode:omc-setup
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -41,10 +41,13 @@ autopilot: build a REST API for managing tasks
 ### アップデート
 
 ```bash
-# 1. プラグインを更新
+# 1. マーケットプレイスを同期して最新バージョンを取得
+/plugin marketplace update https://github.com/Yeachan-Heo/oh-my-claudecode
+
+# 2. 更新されたマーケットプレイスからプラグインを再インストール
 /plugin install oh-my-claudecode
 
-# 2. セットアップを再実行して設定を更新
+# 3. セットアップを再実行して設定を更新
 /oh-my-claudecode:omc-setup
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -41,10 +41,13 @@ autopilot: build a REST API for managing tasks
 ### 업데이트
 
 ```bash
-# 1. 플러그인 업데이트
+# 1. 마켓플레이스를 동기화하여 최신 버전을 가져오기
+/plugin marketplace update https://github.com/Yeachan-Heo/oh-my-claudecode
+
+# 2. 업데이트된 마켓플레이스에서 플러그인 재설치
 /plugin install oh-my-claudecode
 
-# 2. 셋업을 다시 실행하여 설정 갱신
+# 3. 셋업을 다시 실행하여 설정 갱신
 /oh-my-claudecode:omc-setup
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,13 @@ Enable Claude Code native teams in `~/.claude/settings.json`:
 ### Updating
 
 ```bash
-# 1. Update the plugin
+# 1. Sync the marketplace to fetch the latest version
+/plugin marketplace update https://github.com/Yeachan-Heo/oh-my-claudecode
+
+# 2. Reinstall the plugin from the updated marketplace
 /plugin install oh-my-claudecode
 
-# 2. Re-run setup to refresh configuration
+# 3. Re-run setup to refresh configuration
 /oh-my-claudecode:omc-setup
 ```
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -65,10 +65,13 @@ Ative os times nativos do Claude Code em `~/.claude/settings.json`:
 ### Atualizando
 
 ```bash
-# 1. Atualize o plugin
+# 1. Sincronize o marketplace para buscar a versão mais recente
+/plugin marketplace update https://github.com/Yeachan-Heo/oh-my-claudecode
+
+# 2. Reinstale o plugin a partir do marketplace atualizado
 /plugin install oh-my-claudecode
 
-# 2. Execute o setup novamente para atualizar a configuração
+# 3. Execute o setup novamente para atualizar a configuração
 /oh-my-claudecode:omc-setup
 ```
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -65,10 +65,13 @@ Bật Claude Code native teams trong `~/.claude/settings.json`:
 ### Cập nhật
 
 ```bash
-# 1. Update the plugin
+# 1. Đồng bộ marketplace để lấy phiên bản mới nhất
+/plugin marketplace update https://github.com/Yeachan-Heo/oh-my-claudecode
+
+# 2. Cài lại plugin từ marketplace đã cập nhật
 /plugin install oh-my-claudecode
 
-# 2. Re-run setup to refresh configuration
+# 3. Chạy lại setup để làm mới cấu hình
 /oh-my-claudecode:omc-setup
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -41,10 +41,13 @@ autopilot: build a REST API for managing tasks
 ### 更新
 
 ```bash
-# 1. 更新插件
+# 1. 同步 marketplace 以获取最新版本
+/plugin marketplace update https://github.com/Yeachan-Heo/oh-my-claudecode
+
+# 2. 从更新后的 marketplace 重新安装插件
 /plugin install oh-my-claudecode
 
-# 2. 重新运行设置以刷新配置
+# 3. 重新运行设置以刷新配置
 /oh-my-claudecode:omc-setup
 ```
 


### PR DESCRIPTION
## Summary

- Add `/plugin marketplace update` step before `/plugin install` in update instructions
- When marketplace auto-update is disabled, the local clone stays stale and `/plugin install` silently reinstalls the old version
- The new step ensures the marketplace clone is synced regardless of auto-update settings
- Applied to all 7 README files (en, ko, zh, ja, es, vi, pt)

## Context

The existing `syncMarketplaceClone()` in `src/features/auto-update.ts` (see #506) only runs during npm-based updates, not the plugin install path. This docs change uses Claude Code's native `/plugin marketplace update` command to solve the problem without code changes.

## Test plan

- [ ] Verify `/plugin marketplace update` + `/plugin install` correctly updates when auto-update is disabled
- [ ] Confirm all 7 README translations have consistent update instructions