### PR TITLE
fix: update lsp-servers test count from 17 to 18 after swift server addition

### DIFF
--- a/src/__tests__/lsp-servers.test.ts
+++ b/src/__tests__/lsp-servers.test.ts
@@ -4,8 +4,8 @@ import { LSP_SERVERS, getServerForFile, getServerForLanguage } from '../tools/ls
 describe('LSP Server Configurations', () => {
   const serverKeys = Object.keys(LSP_SERVERS);
 
-  it('should have 17 configured servers', () => {
-    expect(serverKeys).toHaveLength(17);
+  it('should have 18 configured servers', () => {
+    expect(serverKeys).toHaveLength(18);
   });
 
   it.each(serverKeys)('server "%s" should have valid config', (key) => {


### PR DESCRIPTION
## Problem
CI was failing on main because `lsp-servers.test.ts` expected 17 servers but `swift` was added to `LSP_SERVERS` making it 18.

## Fix
Updated the assertion from `toHaveLength(17)` to `toHaveLength(18)`.

Fixes the broken CI on main.