### PR TITLE
fix(hooks): bridge 정규화 불일치로 인한 서브에이전트 추적 실패 및 orchestrator file_path 추출 누락 수정

### DIFF
--- a/src/hooks/omc-orchestrator/index.ts
+++ b/src/hooks/omc-orchestrator/index.ts
@@ -376,8 +376,10 @@ export function processOrchestratorPreTool(input: ToolExecuteInput): ToolExecute
     return { continue: true };
   }
 
-  // Extract file path from tool input
-  const filePath = (toolInput?.filePath ?? toolInput?.path ?? toolInput?.file) as string | undefined;
+  // Extract file path from tool input.
+  // Claude Code sends file_path (snake_case) for Write/Edit tools and notebook_path for NotebookEdit.
+  // toolInput is the tool's own parameter object, NOT normalized by normalizeHookInput.
+  const filePath = (toolInput?.file_path ?? toolInput?.filePath ?? toolInput?.path ?? toolInput?.file ?? toolInput?.notebook_path) as string | undefined;
 
   // Allow if path is in allowed prefix
   if (!filePath || isAllowedPath(filePath, directory)) {


### PR DESCRIPTION
## 요약

- **bridge.ts의 subagent-start/stop 정규화 불일치 수정**: `normalizeHookInput()`이 `cwd`→`directory`, `session_id`→`sessionId`로 변환하지만, subagent 핸들러는 원본 snake_case 필드(`startInput.cwd`, `startInput.session_id`)에 접근하여 항상 `undefined`를 받음. 이로 인해 서브에이전트 추적, 세션 리플레이(`/trace`), HUD 에이전트 라이프사이클 이벤트가 작동하지 않음.
- **중복 `recordAgentStart`/`recordAgentStop` 호출 제거**: `bridge.ts`에서 직접 호출하고, `processSubagentStart`/`processSubagentStop` 내부에서도 호출 — 정규화 수정 후 세션 리플레이에 중복 기록 발생.
- **orchestrator `file_path` 추출 누락 수정**: Claude Code의 Write/Edit 도구는 `file_path`(snake_case)를 전송하지만, 코드는 `filePath`/`path`/`file`만 체크. `toolInput`은 `normalizeHookInput`의 정규화 대상이 아니므로 실제 필드명과 매칭되지 않아 쓰기 감시 기능이 사실상 비활성화됨.

## 근본 원인

`bridge-normalize.ts`의 `normalizeHookInput()`이 snake_case → camelCase 변환 수행:

```
원본 입력:    { cwd: "/path", session_id: "abc", agent_id: "x", ... }
정규화 후:    { directory: "/path", sessionId: "abc", agent_id: "x", ... }
```

`validateHookInput()`은 `["sessionId", "directory"]`를 체크 → 통과 ✅
하지만 `startInput.cwd` / `startInput.session_id` → `undefined` ❌

결과: `acquireLock(undefined)` → `join(undefined, '.omc', ...)` → 무음 실패 → 서브에이전트 추적 전체 스킵.

## 변경 사항

### `src/hooks/bridge.ts`
- 정규화된 입력에서 올바른 필드 매핑으로 `SubagentStartInput`/`SubagentStopInput` 재구성 (`directory`→`cwd`, `sessionId`→`session_id`)
- 중복 `recordAgentStart`/`recordAgentStop` 호출 제거 (`processSubagentStart`/`processSubagentStop` 내부에서 이미 처리)

### `src/hooks/omc-orchestrator/index.ts`
- 파일 경로 추출 체인에 `file_path`와 `notebook_path` 추가하여 Claude Code의 실제 필드명과 매칭

## 테스트

- [x] `npm run build` — TypeScript 컴파일 통과
- [x] `npx vitest run` — 전체 4381개 테스트 통과 (189개 테스트 파일, 실패 0)
- [ ] 수동 검증: `/trace`에서 에이전트 라이프사이클 이벤트 표시 확인 (실제 Claude Code 세션 환경 필요)
- [ ] 수동 검증: orchestrator 로그에서 올바른 파일 경로 추출 확인 (실제 Write/Edit 도구 호출 환경 필요)