### PR TITLE
fix: 토큰 카운트 truthy 체크 및 레거시 상태 읽기 structuredClone 적용

### DIFF
--- a/src/features/state-manager/index.ts
+++ b/src/features/state-manager/index.ts
@@ -175,7 +175,7 @@ export function readState<T = StateData>(
           const data = JSON.parse(content) as T;
           return {
             exists: true,
-            data,
+            data: structuredClone(data) as T,
             foundAt: resolvedPath,
             legacyLocations: legacyPaths,
           };

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -1286,13 +1286,13 @@ export function updateTokenUsage(
           cost_usd: 0,
         };
       }
-      if (tokens.input_tokens)
+      if (tokens.input_tokens !== undefined)
         agent.token_usage.input_tokens += tokens.input_tokens;
-      if (tokens.output_tokens)
+      if (tokens.output_tokens !== undefined)
         agent.token_usage.output_tokens += tokens.output_tokens;
-      if (tokens.cache_read_tokens)
+      if (tokens.cache_read_tokens !== undefined)
         agent.token_usage.cache_read_tokens += tokens.cache_read_tokens;
-      if (tokens.cost_usd) agent.token_usage.cost_usd += tokens.cost_usd;
+      if (tokens.cost_usd !== undefined) agent.token_usage.cost_usd += tokens.cost_usd;
       writeTrackingState(directory, state);
     }
   } finally {


### PR DESCRIPTION
## 요약

- **subagent-tracker 토큰 누적 로직의 truthy 체크 수정**: `if (tokens.input_tokens)` 패턴은 값이 `0`일 때 `false`로 평가되어 `undefined`와 구분하지 못함. `!== undefined` 체크로 변경하여 의도를 명확히 함.
- **state-manager 레거시 읽기 경로에 structuredClone 적용**: 표준 경로는 `structuredClone(data)`를 반환하여 호출자의 실수로 인한 상태 변이를 방지하지만, 레거시 경로는 raw 객체를 직접 반환. 일관성을 위해 레거시 경로에도 동일한 방어적 복사 적용.

## 변경 사항

### `src/hooks/subagent-tracker/index.ts`
```diff
- if (tokens.input_tokens)
+ if (tokens.input_tokens !== undefined)
```
4개 필드(`input_tokens`, `output_tokens`, `cache_read_tokens`, `cost_usd`) 모두 동일하게 변경.

### `src/features/state-manager/index.ts`
```diff
- data,
+ data: structuredClone(data) as T,
```
레거시 읽기 경로에서 반환 시 structuredClone 적용.

## 테스트

- [x] `npx tsc --noEmit` — TypeScript 컴파일 통과
- [x] `npx vitest run` — 전체 4381개 테스트 통과 (189개 테스트 파일, 실패 0)