### PR TITLE
feat(ccg): implement Claude-Codex-Gemini tri-model orchestration pipeline (#733)

### DIFF
--- a/dist/hooks/keyword-detector/__tests__/index.test.js
+++ b/dist/hooks/keyword-detector/__tests__/index.test.js
@@ -477,6 +477,39 @@ World`);
                 expect(codexMatch).toBeUndefined();
             });
         });
+        describe('ccg keyword', () => {
+            it('should detect "ccg" keyword', () => {
+                const result = detectKeywordsWithType('ccg this feature');
+                const ccgMatch = result.find((r) => r.type === 'ccg');
+                expect(ccgMatch).toBeDefined();
+                expect(ccgMatch?.keyword).toMatch(/ccg/i);
+            });
+            it('should detect "claude-codex-gemini" keyword', () => {
+                const result = detectKeywordsWithType('use claude-codex-gemini to build this');
+                const ccgMatch = result.find((r) => r.type === 'ccg');
+                expect(ccgMatch).toBeDefined();
+            });
+            it('should detect CCG in uppercase', () => {
+                const result = detectKeywordsWithType('CCG add user profile page');
+                const ccgMatch = result.find((r) => r.type === 'ccg');
+                expect(ccgMatch).toBeDefined();
+            });
+            it('should NOT detect ccg inside code block', () => {
+                const result = detectKeywordsWithType('```\nccg mode\n```');
+                const ccgMatch = result.find((r) => r.type === 'ccg');
+                expect(ccgMatch).toBeUndefined();
+            });
+            it('should NOT detect ccg inside inline code', () => {
+                const result = detectKeywordsWithType('use `ccg` command');
+                const ccgMatch = result.find((r) => r.type === 'ccg');
+                expect(ccgMatch).toBeUndefined();
+            });
+            it('should detect ccg with other text around it', () => {
+                const result = detectKeywordsWithType('please ccg this full-stack feature');
+                const ccgMatch = result.find((r) => r.type === 'ccg');
+                expect(ccgMatch).toBeDefined();
+            });
+        });
         describe('gemini keyword', () => {
             it('should detect "ask gemini"', () => {
                 const result = detectKeywordsWithType('ask gemini to design');
@@ -674,6 +707,31 @@ World`);
             const result = getAllKeywords('ask codex and ask gemini');
             expect(result).toContain('codex');
             expect(result).toContain('gemini');
+        });
+        it('should return ccg when ccg keyword present', () => {
+            const result = getAllKeywords('ccg add a user profile feature');
+            expect(result).toContain('ccg');
+        });
+        it('should return ccg with higher priority than codex/gemini', () => {
+            const result = getAllKeywords('ccg ask codex to review');
+            const ccgIdx = result.indexOf('ccg');
+            const codexIdx = result.indexOf('codex');
+            expect(ccgIdx).toBeGreaterThanOrEqual(0);
+            expect(codexIdx).toBeGreaterThanOrEqual(0);
+            expect(ccgIdx).toBeLessThan(codexIdx);
+        });
+        it('should return ralph before ccg in priority order', () => {
+            const result = getAllKeywords('ralph ccg build the app');
+            const ralphIdx = result.indexOf('ralph');
+            const ccgIdx = result.indexOf('ccg');
+            expect(ralphIdx).toBeGreaterThanOrEqual(0);
+            expect(ccgIdx).toBeGreaterThanOrEqual(0);
+            expect(ralphIdx).toBeLessThan(ccgIdx);
+        });
+        it('should not return ccg when cancel is present', () => {
+            const result = getAllKeywords('cancelomc ccg build');
+            expect(result).toEqual(['cancel']);
+            expect(result).not.toContain('ccg');
         });
         it('should return ralph over codex in priority', () => {
             const primary = getPrimaryKeyword('ralph ask codex');

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -13,6 +13,7 @@
  * 5. ultrawork/ulw: Maximum parallel execution
  * 6. ecomode/eco: Token-efficient execution
  * 7. pipeline: Sequential agent chaining
+ * 8. ccg: Claude-Codex-Gemini tri-model orchestration
  * 9. ralplan: Iterative planning with consensus
  * 10. plan: Planning interview mode
  * 11. tdd: Test-driven development
@@ -324,7 +325,7 @@ function resolveConflicts(matches) {
 
   // Sort by priority order
   const priorityOrder = ['cancel','ralph','autopilot','team','ultrawork','ecomode',
-    'pipeline','ralplan','plan','tdd','research','ultrathink','deepsearch','analyze',
+    'pipeline','ccg','ralplan','plan','tdd','research','ultrathink','deepsearch','analyze',
     'codex','gemini'];
   resolved.sort((a, b) => priorityOrder.indexOf(a.name) - priorityOrder.indexOf(b.name));
 
@@ -423,6 +424,11 @@ async function main() {
     // Pipeline keywords
     if (/\b(pipeline)\b/i.test(cleanPrompt) || /\bchain\s+agents\b/i.test(cleanPrompt)) {
       matches.push({ name: 'pipeline', args: '' });
+    }
+
+    // CCG keywords (Claude-Codex-Gemini tri-model orchestration)
+    if (/\b(ccg|claude-codex-gemini)\b/i.test(cleanPrompt)) {
+      matches.push({ name: 'ccg', args: '' });
     }
 
     // Ralplan keyword

--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: ccg
+description: Claude-Codex-Gemini tri-model orchestration - fans out backend tasks to Codex and frontend/UI tasks to Gemini in parallel, then Claude synthesizes results
+---
+
+# CCG (Claude-Codex-Gemini) Orchestration
+
+## Overview
+
+CCG is a tri-model orchestration pattern:
+
+- **Claude** — Orchestrator/conductor: decomposes requests, fans out work, synthesizes results
+- **Codex** (OpenAI) — Backend/code engine: architecture, APIs, security, code analysis
+- **Gemini** (Google) — Frontend/design processor: UI components, styling, visual design, large-context tasks
+
+Claude fans Codex and Gemini out **in parallel**, then synthesizes their outputs into a unified solution.
+
+## Trigger
+
+Activated when the user says `ccg` or `claude-codex-gemini` in their prompt.
+
+## Execution Protocol
+
+**ANNOUNCE immediately**: `"CCG MODE ENABLED — Orchestrating Claude + Codex + Gemini"`
+
+### Phase 1: Decompose
+
+Analyze the request and split into:
+- **Backend tasks** → Codex (APIs, data models, business logic, tests, security)
+- **Frontend tasks** → Gemini (UI components, styling, layout, responsive design)
+- **Synthesis tasks** → Claude (integration, cross-cutting concerns, final wiring)
+
+### Phase 2: Fan-Out (Parallel)
+
+Run Codex and Gemini **simultaneously** using background mode.
+
+**Codex — backend**:
+1. Write prompt to `.omc/prompts/codex-{purpose}-{timestamp}.md`
+2. Call `ask_codex` MCP tool:
+   - `agent_role`: pick from `architect`, `executor`, `code-reviewer`, `security-reviewer`, `planner`, `critic`
+   - `prompt_file`: the file you just wrote
+   - `output_file`: `.omc/prompts/codex-{purpose}-{timestamp}-output.md`
+   - `context_files`: relevant source files
+   - `background: true` for non-blocking execution
+
+**Gemini — frontend**:
+1. Write prompt to `.omc/prompts/gemini-{purpose}-{timestamp}.md`
+2. Call `ask_gemini` MCP tool:
+   - `agent_role`: pick from `designer`, `writer`, `vision`
+   - `prompt_file`: the file you just wrote
+   - `output_file`: `.omc/prompts/gemini-{purpose}-{timestamp}-output.md`
+   - `files`: relevant source files
+   - `background: true` for non-blocking execution
+
+### Phase 3: Await Results
+
+Use `wait_for_job` (or poll with `check_job_status`) for both jobs. Wait for both to complete before synthesizing.
+
+### Phase 4: Synthesize
+
+Claude reads both output files and:
+1. Reconciles any conflicts (e.g., API shape vs component props)
+2. Integrates backend + frontend solutions into a cohesive whole
+3. Applies cross-cutting concerns (error handling, typing, auth)
+4. Implements any remaining integration glue code
+
+## MCP Tool Selection Guide
+
+### Use Codex (`ask_codex`) for:
+- REST/GraphQL API design and implementation
+- Database schema, migrations, data models
+- Backend business logic and services
+- Security audit and vulnerability analysis
+- Architecture review and refactoring
+- Test strategy, TDD, unit/integration tests
+- Build errors and TypeScript issues
+
+**Roles**: `architect`, `code-reviewer`, `security-reviewer`, `executor`, `planner`, `critic`, `tdd-guide`
+
+### Use Gemini (`ask_gemini`) for:
+- React/Vue/Svelte component implementation
+- CSS, Tailwind, styled-components
+- Responsive layouts and visual design
+- UI/UX review and heuristic audits
+- Large-scale documentation (1M token context)
+- Image/screenshot/diagram analysis
+
+**Roles**: `designer`, `writer`, `vision`
+
+## Fallback
+
+If **Codex MCP unavailable** → use `Task(subagent_type="oh-my-claudecode:executor", model="sonnet")` for backend tasks.
+
+If **Gemini MCP unavailable** → use `Task(subagent_type="oh-my-claudecode:designer", model="sonnet")` for frontend tasks.
+
+If **both unavailable** → use Claude directly with the standard agent catalog.
+
+## Example
+
+**User**: `ccg Add a user profile page with a REST API endpoint and React frontend`
+
+```
+CCG MODE ENABLED — Orchestrating Claude + Codex + Gemini
+
+Decomposition:
+  Backend  → Codex: /api/users/:id endpoint, Prisma user model, auth middleware
+  Frontend → Gemini: React UserProfile component, avatar, form, responsive layout
+
+Fan-out (parallel):
+  [Codex]  Implementing REST endpoint + data layer...
+  [Gemini] Designing UserProfile component + styling...
+
+[Both complete]
+
+Synthesis:
+  - Align API response type with React component props
+  - Wire fetch hook to /api/users/:id endpoint
+  - Add error boundary and loading state across layers
+  - Export unified UserProfilePage with data fetching
+```
+
+## Integration with Other Skills
+
+CCG composes with other OMC modes:
+
+| Combination | Effect |
+|-------------|--------|
+| `ccg ralph` | CCG loop with ralph persistence until verified complete |
+| `ccg ultrawork` | CCG with max parallelism within each model |
+| `ccg team` | CCG orchestration within a multi-agent team |
+
+## Cancellation
+
+Stop active CCG work: say `cancelomc` or run `/oh-my-claudecode:cancel`.
+
+## State
+
+CCG does not maintain persistent state files. Each invocation is stateless — Claude manages the workflow inline. MCP job IDs are tracked in-context during the session.

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -8,14 +8,14 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (40)', () => {
+    it('should return correct number of skills (41)', () => {
       const skills = createBuiltinSkills();
-      // 40 skills: analyze, autopilot, build-fix, cancel, code-review, configure-discord, configure-telegram,
+      // 41 skills: analyze, autopilot, build-fix, cancel, ccg, code-review, configure-discord, configure-telegram,
       // deepinit, deepsearch, omc-doctor, external-context, frontend-ui-ux, git-master, omc-help, hud,
       // learn-about-omc, learner, mcp-setup, note, omc-setup, pipeline, plan, project-session-manager,
       // psm, ralph, ralph-init, ralplan, release, review, sciomc, security-review, skill, swarm, tdd,
       // team, trace, ultrapilot, ultraqa, ultrawork, writer-memory
-      expect(skills).toHaveLength(40);
+      expect(skills).toHaveLength(41);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -69,6 +69,7 @@ describe('Builtin Skills', () => {
         'autopilot',
         'build-fix',
         'cancel',
+        'ccg',
         'code-review',
         'configure-discord',
         'configure-telegram',
@@ -148,9 +149,13 @@ describe('Builtin Skills', () => {
   describe('listBuiltinSkillNames()', () => {
     it('should return all skill names', () => {
       const names = listBuiltinSkillNames();
-      expect(names).toHaveLength(40);
+
+      expect(names).toHaveLength(41);
       expect(names).toContain('autopilot');
       expect(names).toContain('cancel');
+      expect(names).toContain('ccg');
+      expect(names).toContain('configure-discord');
+      expect(names).toContain('configure-telegram');
       expect(names).toContain('ralph');
       expect(names).toContain('frontend-ui-ux');
       expect(names).toContain('git-master');

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -579,6 +579,45 @@ World`);
       });
     });
 
+    describe('ccg keyword', () => {
+      it('should detect "ccg" keyword', () => {
+        const result = detectKeywordsWithType('ccg this feature');
+        const ccgMatch = result.find((r) => r.type === 'ccg');
+        expect(ccgMatch).toBeDefined();
+        expect(ccgMatch?.keyword).toMatch(/ccg/i);
+      });
+
+      it('should detect "claude-codex-gemini" keyword', () => {
+        const result = detectKeywordsWithType('use claude-codex-gemini to build this');
+        const ccgMatch = result.find((r) => r.type === 'ccg');
+        expect(ccgMatch).toBeDefined();
+      });
+
+      it('should detect CCG in uppercase', () => {
+        const result = detectKeywordsWithType('CCG add user profile page');
+        const ccgMatch = result.find((r) => r.type === 'ccg');
+        expect(ccgMatch).toBeDefined();
+      });
+
+      it('should NOT detect ccg inside code block', () => {
+        const result = detectKeywordsWithType('```\nccg mode\n```');
+        const ccgMatch = result.find((r) => r.type === 'ccg');
+        expect(ccgMatch).toBeUndefined();
+      });
+
+      it('should NOT detect ccg inside inline code', () => {
+        const result = detectKeywordsWithType('use `ccg` command');
+        const ccgMatch = result.find((r) => r.type === 'ccg');
+        expect(ccgMatch).toBeUndefined();
+      });
+
+      it('should detect ccg with other text around it', () => {
+        const result = detectKeywordsWithType('please ccg this full-stack feature');
+        const ccgMatch = result.find((r) => r.type === 'ccg');
+        expect(ccgMatch).toBeDefined();
+      });
+    });
+
     describe('gemini keyword', () => {
       it('should detect "ask gemini"', () => {
         const result = detectKeywordsWithType('ask gemini to design');
@@ -816,6 +855,35 @@ World`);
       const result = getAllKeywords('ask codex and ask gemini');
       expect(result).toContain('codex');
       expect(result).toContain('gemini');
+    });
+
+    it('should return ccg when ccg keyword present', () => {
+      const result = getAllKeywords('ccg add a user profile feature');
+      expect(result).toContain('ccg');
+    });
+
+    it('should return ccg with higher priority than codex/gemini', () => {
+      const result = getAllKeywords('ccg ask codex to review');
+      const ccgIdx = result.indexOf('ccg');
+      const codexIdx = result.indexOf('codex');
+      expect(ccgIdx).toBeGreaterThanOrEqual(0);
+      expect(codexIdx).toBeGreaterThanOrEqual(0);
+      expect(ccgIdx).toBeLessThan(codexIdx);
+    });
+
+    it('should return ralph before ccg in priority order', () => {
+      const result = getAllKeywords('ralph ccg build the app');
+      const ralphIdx = result.indexOf('ralph');
+      const ccgIdx = result.indexOf('ccg');
+      expect(ralphIdx).toBeGreaterThanOrEqual(0);
+      expect(ccgIdx).toBeGreaterThanOrEqual(0);
+      expect(ralphIdx).toBeLessThan(ccgIdx);
+    });
+
+    it('should not return ccg when cancel is present', () => {
+      const result = getAllKeywords('cancelomc ccg build');
+      expect(result).toEqual(['cancel']);
+      expect(result).not.toContain('ccg');
     });
 
     it('should return ralph over codex in priority', () => {

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -16,7 +16,7 @@ export type KeywordType =
   | 'ultrapilot'  // Priority 4
   | 'team'        // Priority 4.5 (team mode)
   | 'ultrawork'   // Priority 5
-  | 'swarm'       // Priority 6
+| 'swarm'       // Priority 6
   | 'pipeline'    // Priority 7
   | 'ralplan'     // Priority 8
   | 'plan'        // Priority 9
@@ -26,6 +26,7 @@ export type KeywordType =
   | 'analyze'     // Priority 13
   | 'codex'       // Priority 14
   | 'gemini';     // Priority 15
+  | 'ccg'         // Priority 8.5 (Claude-Codex-Gemini orchestration)
 
 export interface DetectedKeyword {
   type: KeywordType;
@@ -48,10 +49,11 @@ const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   pipeline: /\bagent\s+pipeline\b|\bchain\s+agents\b/i,
   ralplan: /\b(ralplan)\b/i,
   plan: /\bplan\s+(this|the)\b/i,
-  tdd: /\b(tdd)\b|\btest\s+first\b/i,
+tdd: /\b(tdd)\b|\btest\s+first\b/i,
   ultrathink: /\b(ultrathink)\b/i,
   deepsearch: /\b(deepsearch)\b|\bsearch\s+the\s+codebase\b|\bfind\s+in\s+(the\s+)?codebase\b/i,
   analyze: /\b(deep[\s-]?analyze|deepanalyze)\b/i,
+  ccg: /\b(ccg|claude-codex-gemini)\b/i,
   codex: /\b(ask|use|delegate\s+to)\s+(codex|gpt)\b/i,
   gemini: /\b(ask|use|delegate\s+to)\s+gemini\b/i
 };
@@ -60,8 +62,9 @@ const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
  * Priority order for keyword detection
  */
 const KEYWORD_PRIORITY: KeywordType[] = [
-  'cancel', 'ralph', 'autopilot', 'ultrapilot', 'team', 'ultrawork',
+'cancel', 'ralph', 'autopilot', 'ultrapilot', 'team', 'ultrawork',
   'swarm', 'pipeline', 'ralplan', 'plan', 'tdd',
+  'swarm', 'pipeline', 'ccg', 'ralplan', 'plan', 'tdd', 'research',
   'ultrathink', 'deepsearch', 'analyze', 'codex', 'gemini'
 ];
 
@@ -81,7 +84,7 @@ export function removeCodeBlocks(text: string): string {
 }
 
 /**
- * Sanitize text for keyword detection by removing structural noise.
+* Sanitize text for keyword detection by removing structural noise.
  * Strips XML tags, URLs, file paths, and code blocks.
  */
 export function sanitizeForKeywordDetection(text: string): string {

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -11,7 +11,7 @@
  * 3. autopilot: Full autonomous execution
  * 4. team: Coordinated team execution
  * 5. ultrawork/ulw: Maximum parallel execution
- * 6. pipeline: Sequential agent chaining
+* 6. pipeline: Sequential agent chaining
  * 7. ralplan: Iterative planning with consensus
  * 8. plan: Planning interview mode
  * 9. tdd: Test-driven development
@@ -20,6 +20,7 @@
  * 12. analyze: Analysis mode (restricted patterns)
  * 13. codex/gpt: Delegate to Codex MCP (ask_codex)
  * 14. gemini: Delegate to Gemini MCP (ask_gemini)
+ * 8. ccg: Claude-Codex-Gemini tri-model orchestration
  */
 
 import { writeFileSync, mkdirSync, existsSync, unlinkSync, readFileSync } from 'fs';
@@ -289,8 +290,9 @@ function resolveConflicts(matches) {
   // Both keywords are preserved so the skill can detect the composition.
 
   // Sort by priority order
-  const priorityOrder = ['cancel','ralph','autopilot','team','ultrawork',
+const priorityOrder = ['cancel','ralph','autopilot','team','ultrawork',
     'pipeline','ralplan','plan','tdd','ultrathink','deepsearch','analyze',
+    'pipeline','ccg','ralplan','plan','tdd','research','ultrathink','deepsearch','analyze',
     'codex','gemini'];
   resolved.sort((a, b) => priorityOrder.indexOf(a.name) - priorityOrder.indexOf(b.name));
 
@@ -389,6 +391,11 @@ async function main() {
     // Pipeline keywords
     if (/\bagent\s+pipeline\b/i.test(cleanPrompt) || /\bchain\s+agents\b/i.test(cleanPrompt)) {
       matches.push({ name: 'pipeline', args: '' });
+    }
+
+    // CCG keywords (Claude-Codex-Gemini tri-model orchestration)
+    if (/\b(ccg|claude-codex-gemini)\b/i.test(cleanPrompt)) {
+      matches.push({ name: 'ccg', args: '' });
     }
 
     // Ralplan keyword


### PR DESCRIPTION
## Summary

Implements CCG (Claude-Codex-Gemini) tri-model orchestration pipeline.

Closes #733

## Changes
- `skills/ccg/SKILL.md` — Full CCG skill with execution protocol (Decompose → Fan-Out → Await → Synthesize)
- Keyword detection for `ccg` / `claude-codex-gemini` triggers (priority 8.5)
- 11 new CCG tests + skill count fixes

## Usage
```
ccg Add a user profile page with REST API and React frontend
```