### PR TITLE
docs: fix update instructions to use marketplace update command

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -41,12 +41,14 @@ Eso es todo. Todo lo demás es automático.
 ### Actualizar
 
 ```bash
-# 1. Actualizar el plugin
-/plugin install oh-my-claudecode
+# 1. Actualizar el clon del marketplace
+/plugin marketplace update omc
 
 # 2. Volver a ejecutar el setup para actualizar la configuracion
 /omc:omc-setup
 ```
+
+> **Nota:** Si la actualizacion automatica del marketplace no esta activada, debes ejecutar manualmente `/plugin marketplace update omc` para sincronizar la ultima version antes de ejecutar el setup.
 
 Si experimentas problemas despues de actualizar, limpia la cache antigua del plugin:
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -41,12 +41,14 @@ autopilot: build a REST API for managing tasks
 ### アップデート
 
 ```bash
-# 1. プラグインを更新
-/plugin install oh-my-claudecode
+# 1. マーケットプレイスクローンを更新
+/plugin marketplace update omc
 
 # 2. セットアップを再実行して設定を更新
 /omc:omc-setup
 ```
+
+> **注意:** マーケットプレイスの自動更新が有効になっていない場合は、セットアップ実行前に `/plugin marketplace update omc` を手動で実行して最新バージョンを同期する必要があります。
 
 更新後に問題が発生した場合は、古いプラグインキャッシュをクリアしてください：
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -41,12 +41,14 @@ autopilot: build a REST API for managing tasks
 ### 업데이트
 
 ```bash
-# 1. 플러그인 업데이트
-/plugin install oh-my-claudecode
+# 1. 마켓플레이스 클론 업데이트
+/plugin marketplace update omc
 
 # 2. 셋업을 다시 실행하여 설정 갱신
 /omc:omc-setup
 ```
+
+> **참고:** 마켓플레이스 auto-update가 활성화되어 있지 않은 경우, 셋업 실행 전에 `/plugin marketplace update omc`를 수동으로 실행하여 최신 버전을 동기화해야 합니다.
 
 업데이트 후 문제가 발생하면, 이전 플러그인 캐시를 정리하세요:
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ Enable Claude Code native teams in `~/.claude/settings.json`:
 ### Updating
 
 ```bash
-# 1. Update the plugin
-/plugin install oh-my-claudecode
+# 1. Update the marketplace clone
+/plugin marketplace update omc
 
 # 2. Re-run setup to refresh configuration
 /omc:omc-setup
 ```
+
+> **Note:** If marketplace auto-update is not enabled, you must manually run `/plugin marketplace update omc` to sync the latest version before running setup.
 
 If you experience issues after updating, clear the old plugin cache:
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -65,12 +65,14 @@ Ative os times nativos do Claude Code em `~/.claude/settings.json`:
 ### Atualizando
 
 ```bash
-# 1. Atualize o plugin
-/plugin install oh-my-claudecode
+# 1. Atualize o clone do marketplace
+/plugin marketplace update omc
 
 # 2. Execute o setup novamente para atualizar a configuração
 /omc:omc-setup
 ```
+
+> **Observação:** Se a atualização automática do marketplace não estiver habilitada, você precisa executar manualmente `/plugin marketplace update omc` para sincronizar a versão mais recente antes de executar o setup.
 
 Se você tiver problemas depois de atualizar, limpe o cache antigo do plugin:
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -65,12 +65,14 @@ Bật Claude Code native teams trong `~/.claude/settings.json`:
 ### Cập nhật
 
 ```bash
-# 1. Update the plugin
-/plugin install oh-my-claudecode
+# 1. Cập nhật bản sao marketplace
+/plugin marketplace update omc
 
-# 2. Re-run setup to refresh configuration
+# 2. Chạy lại setup để làm mới cấu hình
 /omc:omc-setup
 ```
+
+> **Lưu ý:** Nếu tự động cập nhật marketplace chưa được bật, bạn cần chạy `/plugin marketplace update omc` thủ công để đồng bộ phiên bản mới nhất trước khi chạy setup.
 
 Nếu gặp sự cố sau khi cập nhật, hãy xóa cache plugin cũ:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -41,12 +41,14 @@ autopilot: build a REST API for managing tasks
 ### 更新
 
 ```bash
-# 1. 更新插件
-/plugin install oh-my-claudecode
+# 1. 更新 marketplace 克隆
+/plugin marketplace update omc
 
 # 2. 重新运行设置以刷新配置
 /omc:omc-setup
 ```
+
+> **注意：** 如果 marketplace 自动更新未启用，您需要在运行设置之前手动执行 `/plugin marketplace update omc` 来同步最新版本。
 
 如果更新后遇到问题，清除旧的插件缓存：
 


### PR DESCRIPTION
## Summary

- Replace `/plugin install oh-my-claudecode` with `/plugin marketplace update omc` in update instructions across all 7 README translations
- `/plugin install` shows "Plugin 'oh-my-claudecode@omc' is already installed" warning and does not actually update when the plugin is already present
- Add note clarifying that manual `/plugin marketplace update omc` is required when marketplace auto-update is not enabled

## Context

Supersedes #705 which was merged but later removed from main. This PR corrects the update command:
- **Before (broken):** `/plugin install oh-my-claudecode` — triggers "already installed" warning, no actual update
- **Before (#705):** `/plugin marketplace update https://github.com/Yeachan-Heo/oh-my-claudecode` — incorrect URL format
- **After (correct):** `/plugin marketplace update omc` — properly syncs the marketplace clone to the latest version

## Changed files

All 7 README translations: `README.md`, `README.ko.md`, `README.ja.md`, `README.zh.md`, `README.es.md`, `README.vi.md`, `README.pt.md`

## Test plan

- [ ] Verify `/plugin marketplace update omc` correctly updates when auto-update is disabled
- [ ] Confirm all 7 README translations have consistent update instructions
- [ ] Verify the auto-update note is present and correctly translated in each README