### PR TITLE
docs: add oh-my-codex reference for Codex users

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ English | [한국어](README.ko.md) | [中文](README.zh.md) | [日本語](READM
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Sponsor](https://img.shields.io/badge/Sponsor-❤️-red?style=flat&logo=github)](https://github.com/sponsors/Yeachan-Heo)
 
+> **For Codex users:** Check out [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) — the same orchestration experience for OpenAI Codex CLI.
+
 **Multi-agent orchestration for Claude Code. Zero learning curve.**
 
 *Don't learn Claude Code. Just use OMC.*


### PR DESCRIPTION
## Summary
- Add a cross-reference note for Codex users below the badge section in README.md
- Points to [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) for users who use OpenAI Codex CLI

## Test plan
- [ ] Verify the blockquote renders correctly on GitHub
- [ ] Confirm the link to oh-my-codex is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)