### PR TITLE
chore: bump version to 4.2.15

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claudecode",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
-      "version": "4.2.14",
+      "version": "4.2.15",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"
@@ -27,5 +27,5 @@
       ]
     }
   ],
-  "version": "4.2.14"
+  "version": "4.2.15"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "4.2.14",
+  "version": "4.2.15",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
     "name": "oh-my-claudecode contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
-# oh-my-claudecode vNext: Deprecate Ecomode
+# oh-my-claudecode v4.2.15
 
-Ecomode execution mode has been fully removed. It was a token-efficient parallel execution mode that routed tasks to cheaper models. Use the standard execution modes (ultrawork, autopilot, ralph) instead.
+### Added
+
+- **CCG skill** (#744): Added `claude-developer-platform` skill (`ccg`) for building programs that call the Claude API or Anthropic SDK.
 
 ### Removed
 
 - **Ecomode execution mode** (#737): Removed `ecomode` from `KeywordType`, `ExecutionMode`, `MODE_CONFIGS`, and all hook scripts. The `persistent-mode` stop hook no longer has a Priority 8 ecomode continuation block. The keyword detector no longer recognizes `eco`, `ecomode`, `eco-mode`, `efficient`, `save-tokens`, or `budget` as execution mode triggers.
+
+### Fixed
+
+- **Windows HUD not showing** (#742): Fixed HUD rendering on Windows by correcting `NODE_PATH` separator handling.
+- **WSL2 scroll fix**: Fixed scroll behavior in WSL2 environments.
+- **tmux session name resolution** (#736, #740, #741): Use `TMUX_PANE` env variable to correctly resolve the tmux session name in notifications.
+
+### Docs
+
+- **oh-my-codex cross-reference** (#744): Added cross-reference documentation for Codex users.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.2.14",
+  "version": "4.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "4.2.14",
+      "version": "4.2.15",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.2.14",
+  "version": "4.2.15",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version from 4.2.14 to 4.2.15
- Updated `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
- Added CHANGELOG.md entry for v4.2.15

## Changes in this release
- CCG skill added
- Ecomode deprecated/removed
- Windows HUD fix
- WSL2 scroll fix
- tmux session name fix (TMUX_PANE)
- oh-my-codex cross-reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)