### PR TITLE
fix: prevent sibling cascade failure in parallel ask_codex calls (#754)

### DIFF
--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -24,11 +24,13 @@ This skill invokes the Plan skill in consensus mode:
 The consensus workflow:
 1. **Planner** creates initial plan
 2. **User feedback**: **MUST** use `AskUserQuestion` to present the draft plan before review (Proceed to review / Request changes / Skip review)
-3. **Architect** reviews for architectural soundness
-4. **Critic** evaluates against quality criteria
+3. **Architect** reviews for architectural soundness — **await completion before step 4**
+4. **Critic** evaluates against quality criteria — run only after step 3 completes
 5. If Critic rejects: iterate with feedback (max 5 iterations)
 6. On Critic approval: **MUST** use `AskUserQuestion` to present the plan with approval options
 7. User chooses: Approve, Request changes, or Reject
 8. On approval: **MUST** invoke `Skill("oh-my-claudecode:ralph")` for execution -- never implement directly
+
+> **Important:** Steps 3 and 4 MUST run sequentially. Do NOT issue both `ask_codex` calls in the same parallel batch — if one hits a 429 rate-limit error, Claude Code will cancel the sibling call ("Sibling tool call errored"), causing the entire review to fail. On a rate-limit error, retry once after 5–10 s; on second failure fall back to the equivalent Claude agent.
 
 Follow the Plan skill's full documentation for consensus mode details.


### PR DESCRIPTION
## Summary

- **Root cause**: In `ralplan`/`plan --consensus` mode, the Architect (step 3) and Critic (step 4) `ask_codex` calls were implicitly parallelizable. When Claude issues two tool calls in the same batch and one hits a 429 rate-limit, Claude Code cancels the sibling with _"Sibling tool call errored"_, failing the entire consensus review.
- **Fix**: Explicitly require sequential execution of steps 3→4 in both `skills/plan/SKILL.md` and `skills/ralplan/SKILL.md`, with a clear note explaining the sibling cascade risk.
- **Fallback guidance**: Added retry instructions (wait 5–10 s, retry once; on second failure fall back to the equivalent Claude agent `Task`).

## Changes

- `skills/plan/SKILL.md`: Steps 3 & 4 now mandate sequential execution with inline explanation of the cascade failure; `Tool_Usage` section adds a CRITICAL note and rate-limit retry/fallback rules.
- `skills/ralplan/SKILL.md`: Steps 3 & 4 updated to show sequential dependency; blockquote warning added with retry/fallback guidance.

## Test plan

- [ ] Run `/ralplan` on a non-trivial task and verify Architect review completes before Critic review begins (no parallel tool calls in the same batch)
- [ ] Simulate a 429 by temporarily rate-limiting the Codex endpoint; verify the skill retries once then falls back to the Claude agent instead of cascading
- [ ] Confirm existing consensus workflow (plan → user feedback → approve → ralph) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)