### PR TITLE
feat: add code-simplifier stop hook for auto refactoring (#753)

### DIFF
--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -1,0 +1,91 @@
+---
+name: code-simplifier
+description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise.
+model: opus
+---
+
+<Agent_Prompt>
+  <Role>
+    You are Code Simplifier, an expert code simplification specialist focused on enhancing
+    code clarity, consistency, and maintainability while preserving exact functionality.
+    Your expertise lies in applying project-specific best practices to simplify and improve
+    code without altering its behavior. You prioritize readable, explicit code over overly
+    compact solutions.
+  </Role>
+
+  <Core_Principles>
+    1. **Preserve Functionality**: Never change what the code does — only how it does it.
+       All original features, outputs, and behaviors must remain intact.
+
+    2. **Apply Project Standards**: Follow the established coding conventions:
+       - Use ES modules with proper import sorting and `.js` extensions
+       - Prefer `function` keyword over arrow functions for top-level declarations
+       - Use explicit return type annotations for top-level functions
+       - Maintain consistent naming conventions (camelCase for variables, PascalCase for types)
+       - Follow TypeScript strict mode patterns
+
+    3. **Enhance Clarity**: Simplify code structure by:
+       - Reducing unnecessary complexity and nesting
+       - Eliminating redundant code and abstractions
+       - Improving readability through clear variable and function names
+       - Consolidating related logic
+       - Removing unnecessary comments that describe obvious code
+       - IMPORTANT: Avoid nested ternary operators — prefer `switch` statements or `if`/`else`
+         chains for multiple conditions
+       - Choose clarity over brevity — explicit code is often better than overly compact code
+
+    4. **Maintain Balance**: Avoid over-simplification that could:
+       - Reduce code clarity or maintainability
+       - Create overly clever solutions that are hard to understand
+       - Combine too many concerns into single functions or components
+       - Remove helpful abstractions that improve code organization
+       - Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
+       - Make the code harder to debug or extend
+
+    5. **Focus Scope**: Only refine code that has been recently modified or touched in the
+       current session, unless explicitly instructed to review a broader scope.
+  </Core_Principles>
+
+  <Process>
+    1. Identify the recently modified code sections provided
+    2. Analyze for opportunities to improve elegance and consistency
+    3. Apply project-specific best practices and coding standards
+    4. Ensure all functionality remains unchanged
+    5. Verify the refined code is simpler and more maintainable
+    6. Document only significant changes that affect understanding
+  </Process>
+
+  <Constraints>
+    - Work ALONE. Do not spawn sub-agents.
+    - Do not introduce behavior changes — only structural simplifications.
+    - Do not add features, tests, or documentation unless explicitly requested.
+    - Skip files where simplification would yield no meaningful improvement.
+    - If unsure whether a change preserves behavior, leave the code unchanged.
+    - Run `lsp_diagnostics` on each modified file to verify zero type errors after changes.
+  </Constraints>
+
+  <Output_Format>
+    ## Files Simplified
+    - `path/to/file.ts:line`: [brief description of changes]
+
+    ## Changes Applied
+    - [Category]: [what was changed and why]
+
+    ## Skipped
+    - `path/to/file.ts`: [reason no changes were needed]
+
+    ## Verification
+    - Diagnostics: [N errors, M warnings per file]
+  </Output_Format>
+
+  <Failure_Modes_To_Avoid>
+    - Behavior changes: Renaming exported symbols, changing function signatures, or reordering
+      logic in ways that affect control flow. Instead, only change internal style.
+    - Scope creep: Refactoring files that were not in the provided list. Instead, stay within
+      the specified files.
+    - Over-abstraction: Introducing new helpers for one-time use. Instead, keep code inline
+      when abstraction adds no clarity.
+    - Comment removal: Deleting comments that explain non-obvious decisions. Instead, only
+      remove comments that restate what the code already makes obvious.
+  </Failure_Modes_To_Avoid>
+</Agent_Prompt>

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -358,6 +358,45 @@ Oh-my-claudecode includes 31 lifecycle hooks that enhance Claude Code's behavior
 | `empty-message-sanitizer` | Empty message handling |
 | `permission-handler` | Permission requests and validation |
 | `think-mode` | Extended thinking detection |
+| `code-simplifier` | Auto-simplify recently modified files on Stop (opt-in) |
+
+### Code Simplifier Hook
+
+The `code-simplifier` Stop hook automatically delegates recently modified source files to the
+`code-simplifier` agent after each Claude turn. It is **disabled by default** and must be
+explicitly enabled via `~/.omc/config.json`.
+
+**Enable:**
+```json
+{
+  "codeSimplifier": {
+    "enabled": true
+  }
+}
+```
+
+**Full config options:**
+```json
+{
+  "codeSimplifier": {
+    "enabled": true,
+    "extensions": [".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs"],
+    "maxFiles": 10
+  }
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `boolean` | `false` | Opt-in to automatic simplification |
+| `extensions` | `string[]` | `[".ts",".tsx",".js",".jsx",".py",".go",".rs"]` | File extensions to consider |
+| `maxFiles` | `number` | `10` | Maximum files simplified per turn |
+
+**How it works:**
+1. When Claude stops, the hook runs `git diff HEAD --name-only` to find modified files
+2. If modified source files are found, the hook injects a message asking Claude to delegate to the `code-simplifier` agent
+3. The agent simplifies the files for clarity and consistency without changing behavior
+4. A turn-scoped marker prevents the hook from triggering more than once per turn cycle
 
 ### Coordination & Environment
 

--- a/src/hooks/code-simplifier/index.ts
+++ b/src/hooks/code-simplifier/index.ts
@@ -1,0 +1,187 @@
+/**
+ * Code Simplifier Stop Hook
+ *
+ * Intercepts Stop events to automatically delegate recently modified files
+ * to the code-simplifier agent for cleanup and simplification.
+ *
+ * Opt-in via ~/.omc/config.json: { "codeSimplifier": { "enabled": true } }
+ * Default: disabled (opt-in only)
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { execSync } from 'child_process';
+
+/** Config shape for the code-simplifier feature */
+export interface CodeSimplifierConfig {
+  enabled: boolean;
+  /** File extensions to include (default: common source extensions) */
+  extensions?: string[];
+  /** Maximum number of files to simplify per stop event (default: 10) */
+  maxFiles?: number;
+}
+
+/** Global OMC config shape (subset relevant to code-simplifier) */
+interface OmcGlobalConfig {
+  codeSimplifier?: CodeSimplifierConfig;
+}
+
+/** Result returned to the Stop hook dispatcher */
+export interface CodeSimplifierHookResult {
+  shouldBlock: boolean;
+  message: string;
+}
+
+const DEFAULT_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs'];
+const DEFAULT_MAX_FILES = 10;
+
+/** Marker filename used to prevent re-triggering within the same turn cycle */
+export const TRIGGER_MARKER_FILENAME = 'code-simplifier-triggered.marker';
+
+/**
+ * Read the global OMC config from ~/.omc/config.json.
+ * Returns null if the file does not exist or cannot be parsed.
+ */
+export function readOmcConfig(): OmcGlobalConfig | null {
+  const configPath = join(homedir(), '.omc', 'config.json');
+
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf-8')) as OmcGlobalConfig;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether the code-simplifier feature is enabled in config.
+ * Disabled by default — requires explicit opt-in.
+ */
+export function isCodeSimplifierEnabled(): boolean {
+  const config = readOmcConfig();
+  return config?.codeSimplifier?.enabled === true;
+}
+
+/**
+ * Get list of recently modified source files via `git diff HEAD --name-only`.
+ * Returns an empty array if git is unavailable or no files are modified.
+ */
+export function getModifiedFiles(
+  cwd: string,
+  extensions: string[] = DEFAULT_EXTENSIONS,
+  maxFiles: number = DEFAULT_MAX_FILES,
+): string[] {
+  try {
+    const output = execSync('git diff HEAD --name-only', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+
+    return output
+      .trim()
+      .split('\n')
+      .filter((file) => file.trim().length > 0)
+      .filter((file) => extensions.some((ext) => file.endsWith(ext)))
+      .slice(0, maxFiles);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Check whether the code-simplifier was already triggered this turn
+ * (marker file present in the state directory).
+ */
+export function isAlreadyTriggered(stateDir: string): boolean {
+  return existsSync(join(stateDir, TRIGGER_MARKER_FILENAME));
+}
+
+/**
+ * Write the trigger marker to prevent re-triggering in the same turn cycle.
+ */
+export function writeTriggerMarker(stateDir: string): void {
+  try {
+    if (!existsSync(stateDir)) {
+      mkdirSync(stateDir, { recursive: true });
+    }
+    writeFileSync(join(stateDir, TRIGGER_MARKER_FILENAME), new Date().toISOString(), 'utf-8');
+  } catch {
+    // Ignore write errors — marker is best-effort
+  }
+}
+
+/**
+ * Clear the trigger marker after a completed simplification round,
+ * allowing the hook to trigger again on the next turn.
+ */
+export function clearTriggerMarker(stateDir: string): void {
+  try {
+    const markerPath = join(stateDir, TRIGGER_MARKER_FILENAME);
+    if (existsSync(markerPath)) {
+      unlinkSync(markerPath);
+    }
+  } catch {
+    // Ignore removal errors
+  }
+}
+
+/**
+ * Build the message injected into Claude's context when code-simplifier triggers.
+ */
+export function buildSimplifierMessage(files: string[]): string {
+  const fileList = files.map((f) => `  - ${f}`).join('\n');
+  const fileArgs = files.join('\\n');
+
+  return `[CODE SIMPLIFIER] Recently modified files detected. Delegate to the code-simplifier agent to simplify the following files for clarity, consistency, and maintainability (without changing behavior):
+
+${fileList}
+
+Use: Task(subagent_type="oh-my-claudecode:code-simplifier", prompt="Simplify the recently modified files:\\n${fileArgs}")`;
+}
+
+/**
+ * Process the code-simplifier stop hook.
+ *
+ * Logic:
+ * 1. Return early (no block) if the feature is disabled
+ * 2. If already triggered this turn (marker present), clear marker and allow stop
+ * 3. Get modified files via git diff HEAD
+ * 4. Return early if no relevant files are modified
+ * 5. Write trigger marker and inject the simplifier delegation message
+ */
+export function processCodeSimplifier(
+  cwd: string,
+  stateDir: string,
+): CodeSimplifierHookResult {
+  if (!isCodeSimplifierEnabled()) {
+    return { shouldBlock: false, message: '' };
+  }
+
+  // If already triggered this turn, clear marker and allow stop
+  if (isAlreadyTriggered(stateDir)) {
+    clearTriggerMarker(stateDir);
+    return { shouldBlock: false, message: '' };
+  }
+
+  const config = readOmcConfig();
+  const extensions = config?.codeSimplifier?.extensions ?? DEFAULT_EXTENSIONS;
+  const maxFiles = config?.codeSimplifier?.maxFiles ?? DEFAULT_MAX_FILES;
+  const files = getModifiedFiles(cwd, extensions, maxFiles);
+
+  if (files.length === 0) {
+    return { shouldBlock: false, message: '' };
+  }
+
+  writeTriggerMarker(stateDir);
+
+  return {
+    shouldBlock: true,
+    message: buildSimplifierMessage(files),
+  };
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -828,3 +828,18 @@ export {
   recordModeChange,
 } from './subagent-tracker/flow-tracer.js';
 
+export {
+  // Code Simplifier Stop Hook
+  processCodeSimplifier,
+  isCodeSimplifierEnabled,
+  getModifiedFiles,
+  readOmcConfig,
+  isAlreadyTriggered,
+  writeTriggerMarker,
+  clearTriggerMarker,
+  buildSimplifierMessage,
+  TRIGGER_MARKER_FILENAME,
+  type CodeSimplifierConfig,
+  type CodeSimplifierHookResult,
+} from './code-simplifier/index.js';
+

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -303,6 +303,9 @@ export const STOP_CONTINUATION_SCRIPT_NODE = loadTemplate(
 /** Node.js persistent mode hook script - loaded from templates/hooks/persistent-mode.mjs */
 export const PERSISTENT_MODE_SCRIPT_NODE = loadTemplate("persistent-mode.mjs");
 
+/** Node.js code simplifier hook script - loaded from templates/hooks/code-simplifier.mjs */
+export const CODE_SIMPLIFIER_SCRIPT_NODE = loadTemplate("code-simplifier.mjs");
+
 /** Node.js session start hook script - loaded from templates/hooks/session-start.mjs */
 export const SESSION_START_SCRIPT_NODE = loadTemplate("session-start.mjs");
 
@@ -392,6 +395,16 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
           },
         ],
       },
+      {
+        hooks: [
+          {
+            type: "command" as const,
+            command: isWindows()
+              ? 'node "%USERPROFILE%\\.claude\\hooks\\code-simplifier.mjs"'
+              : 'node "$HOME/.claude/hooks/code-simplifier.mjs"',
+          },
+        ],
+      },
     ],
   },
 };
@@ -420,6 +433,7 @@ export function getHookScripts(): Record<string, string> {
     "pre-tool-use.mjs": loadTemplate("pre-tool-use.mjs"),
     "post-tool-use.mjs": loadTemplate("post-tool-use.mjs"),
     "post-tool-use-failure.mjs": loadTemplate("post-tool-use-failure.mjs"),
+    "code-simplifier.mjs": loadTemplate("code-simplifier.mjs"),
     // Shared library modules (in lib/ subdirectory)
     "lib/stdin.mjs": loadTemplate("lib/stdin.mjs"),
     "lib/atomic-write.mjs": loadTemplate("lib/atomic-write.mjs"),

--- a/templates/hooks/code-simplifier.mjs
+++ b/templates/hooks/code-simplifier.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+/**
+ * OMC Code Simplifier Stop Hook (Node.js)
+ *
+ * Intercepts Stop events to automatically delegate recently modified source files
+ * to the code-simplifier agent for cleanup and simplification.
+ *
+ * Opt-in via ~/.omc/config.json: { "codeSimplifier": { "enabled": true } }
+ * Default: disabled (must explicitly opt in)
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  unlinkSync,
+} from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { execSync } from 'child_process';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+const DEFAULT_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs'];
+const DEFAULT_MAX_FILES = 10;
+const MARKER_FILENAME = 'code-simplifier-triggered.marker';
+
+function readJsonFile(filePath) {
+  try {
+    if (!existsSync(filePath)) return null;
+    return JSON.parse(readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function readOmcConfig() {
+  return readJsonFile(join(homedir(), '.omc', 'config.json'));
+}
+
+function isEnabled(config) {
+  return config?.codeSimplifier?.enabled === true;
+}
+
+function getModifiedFiles(cwd, extensions, maxFiles) {
+  try {
+    const output = execSync('git diff HEAD --name-only', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+
+    return output
+      .trim()
+      .split('\n')
+      .filter((f) => f.trim().length > 0)
+      .filter((f) => extensions.some((ext) => f.endsWith(ext)))
+      .slice(0, maxFiles);
+  } catch {
+    return [];
+  }
+}
+
+function buildMessage(files) {
+  const fileList = files.map((f) => `  - ${f}`).join('\n');
+  const fileArgs = files.join('\\n');
+  return (
+    `[CODE SIMPLIFIER] Recently modified files detected. Delegate to the ` +
+    `code-simplifier agent to simplify the following files for clarity, ` +
+    `consistency, and maintainability (without changing behavior):\n\n` +
+    `${fileList}\n\n` +
+    `Use: Task(subagent_type="oh-my-claudecode:code-simplifier", ` +
+    `prompt="Simplify the recently modified files:\\n${fileArgs}")`
+  );
+}
+
+async function main() {
+  try {
+    const input = await readStdin();
+    let data = {};
+    try {
+      data = JSON.parse(input);
+    } catch {
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+      return;
+    }
+
+    const cwd = data.cwd || data.directory || process.cwd();
+    const stateDir = join(cwd, '.omc', 'state');
+    const config = readOmcConfig();
+
+    if (!isEnabled(config)) {
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+      return;
+    }
+
+    const markerPath = join(stateDir, MARKER_FILENAME);
+
+    // If already triggered this turn, clear marker and allow stop
+    if (existsSync(markerPath)) {
+      try {
+        unlinkSync(markerPath);
+      } catch {
+        // ignore
+      }
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+      return;
+    }
+
+    const extensions = config?.codeSimplifier?.extensions ?? DEFAULT_EXTENSIONS;
+    const maxFiles = config?.codeSimplifier?.maxFiles ?? DEFAULT_MAX_FILES;
+    const files = getModifiedFiles(cwd, extensions, maxFiles);
+
+    if (files.length === 0) {
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+      return;
+    }
+
+    // Write trigger marker to prevent re-triggering within this turn cycle
+    try {
+      if (!existsSync(stateDir)) {
+        mkdirSync(stateDir, { recursive: true });
+      }
+      writeFileSync(markerPath, new Date().toISOString(), 'utf-8');
+    } catch {
+      // best-effort — proceed even if marker write fails
+    }
+
+    process.stdout.write(
+      JSON.stringify({ decision: 'block', reason: buildMessage(files) }) + '\n',
+    );
+  } catch (error) {
+    try {
+      process.stderr.write(`[code-simplifier] Error: ${error?.message || error}\n`);
+    } catch {
+      // ignore
+    }
+    try {
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+    } catch {
+      process.exit(0);
+    }
+  }
+}
+
+process.on('uncaughtException', (error) => {
+  try {
+    process.stderr.write(`[code-simplifier] Uncaught: ${error?.message || error}\n`);
+  } catch {
+    // ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+  } catch {
+    // ignore
+  }
+  process.exit(0);
+});
+
+process.on('unhandledRejection', (error) => {
+  try {
+    process.stderr.write(`[code-simplifier] Unhandled: ${error?.message || error}\n`);
+  } catch {
+    // ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+  } catch {
+    // ignore
+  }
+  process.exit(0);
+});
+
+// Safety timeout: force exit after 10 seconds to prevent hook from hanging
+const safetyTimeout = setTimeout(() => {
+  try {
+    process.stderr.write('[code-simplifier] Safety timeout reached, forcing exit\n');
+  } catch {
+    // ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+  } catch {
+    // ignore
+  }
+  process.exit(0);
+}, 10000);
+
+main().finally(() => {
+  clearTimeout(safetyTimeout);
+});


### PR DESCRIPTION
## Summary

- **`agents/code-simplifier.md`**: New agent forked from the [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-simplifier/agents/code-simplifier.md) reference, adjusted for OMC conventions (TypeScript `function` keyword, explicit return types, ES modules, `if`/`else` over nested ternaries)
- **`src/hooks/code-simplifier/index.ts`**: Stop hook logic — reads `~/.omc/config.json` for `{ codeSimplifier: { enabled: true } }`, gets changed files via `git diff HEAD --name-only`, injects a delegation message to the code-simplifier agent; a turn-scoped marker file prevents re-triggering within the same stop cycle
- **`templates/hooks/code-simplifier.mjs`**: Standalone Node.js hook template installed to `~/.claude/hooks/`, mirrors bridge logic for reliability
- **`src/hooks/index.ts`**: Exports the code-simplifier public API
- **`src/hooks/bridge.ts`**: Adds `"code-simplifier"` to `HookType` and a lazy-loaded case in `processHook`
- **`src/installer/hooks.ts`**: Loads template constant, registers second `Stop` hook entry, includes in `getHookScripts()`
- **`docs/REFERENCE.md`**: Documents the hook, config schema, and behaviour

## Behaviour

**Disabled by default** (opt-in). Enable via `~/.omc/config.json`:
```json
{ "codeSimplifier": { "enabled": true } }
```

Full options:
```json
{
  "codeSimplifier": {
    "enabled": true,
    "extensions": [".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs"],
    "maxFiles": 10
  }
}
```

**Loop prevention**: A `.omc/state/code-simplifier-triggered.marker` file is written on first trigger and cleared on the second Stop event, ensuring the hook fires exactly once per turn cycle.

## Test plan

- [ ] With feature disabled (default): Stop hook returns `{ continue: true }` immediately, no marker written
- [ ] With feature enabled + no git changes: hook returns `{ continue: true }`
- [ ] With feature enabled + modified `.ts` files: hook blocks stop and injects delegation message listing the files
- [ ] On second Stop event (after simplifier ran): marker is present → cleared → stop allowed
- [ ] Extensions filter: non-matching files (`.md`, `.json`) are excluded
- [ ] Safety timeout (10 s) prevents hook from hanging Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)