### PR TITLE
fix(windows): use forward slashes in statusLine path for Claude Code 2.1.47+ (#758)

### DIFF
--- a/dist/installer/index.js
+++ b/dist/installer/index.js
@@ -547,7 +547,7 @@ export function install(options = {}) {
                 }
                 // Build the HUD script content (compiled from src/hud/index.ts)
                 // Create a wrapper that checks multiple locations for the HUD module
-                hudScriptPath = join(HUD_DIR, 'omc-hud.mjs');
+                hudScriptPath = join(HUD_DIR, 'omc-hud.mjs').replace(/\\/g, '/');
                 const hudScriptLines = [
                     '#!/usr/bin/env node',
                     '/**',

--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -25,7 +25,7 @@ if (!existsSync(HUD_DIR)) {
 }
 
 // 2. Create HUD wrapper script
-const hudScriptPath = join(HUD_DIR, 'omc-hud.mjs');
+const hudScriptPath = join(HUD_DIR, 'omc-hud.mjs').replace(/\\/g, '/');
 const hudScript = `#!/usr/bin/env node
 /**
  * OMC HUD - Statusline Script

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -620,7 +620,7 @@ export function install(options: InstallOptions = {}): InstallResult {
 
       // Build the HUD script content (compiled from src/hud/index.ts)
       // Create a wrapper that checks multiple locations for the HUD module
-      hudScriptPath = join(HUD_DIR, 'omc-hud.mjs');
+      hudScriptPath = join(HUD_DIR, 'omc-hud.mjs').replace(/\\/g, '/');
       const hudScriptLines = [
         '#!/usr/bin/env node',
         '/**',


### PR DESCRIPTION
## Summary
- Normalize `hudScriptPath` to forward slashes with `.replace(/\\/g, '/')` in both the installer (`src/installer/index.ts`) and plugin setup script (`scripts/plugin-setup.mjs`)
- `path.join()` produces backslash paths on Windows (e.g. `C:\Users\user\.claude\hud\omc-hud.mjs`), which breaks the `statusLine` command in `~/.claude/settings.json` since Claude Code 2.1.47

## Test plan
- [x] Existing 17 HUD installer tests pass
- [x] Build succeeds
- [x] Verified fix appears in compiled `dist/installer/index.js`

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)