### PR TITLE
feat(notifications): add verbosity levels to CCNotifier (#761)

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   formatSessionIdle,
+  formatSessionEnd,
+  formatAgentCall,
   formatNotification,
 } from "../formatter.js";
 import type { NotificationPayload } from "../types.js";
@@ -83,5 +85,96 @@ describe("formatNotification routing", () => {
   it("should route ask-user-question correctly", () => {
     const result = formatNotification({ ...basePayload, event: "ask-user-question" });
     expect(result).toContain("# Input Needed");
+  });
+
+  it("should route agent-call correctly", () => {
+    const result = formatNotification({
+      ...basePayload,
+      event: "agent-call",
+      agentName: "executor",
+      agentType: "oh-my-claudecode:executor",
+    });
+    expect(result).toContain("# Agent Spawned");
+  });
+});
+
+describe("formatAgentCall", () => {
+  const basePayload: NotificationPayload = {
+    event: "agent-call",
+    sessionId: "test-session-123",
+    message: "",
+    timestamp: new Date().toISOString(),
+    projectPath: "/home/user/my-project",
+    projectName: "my-project",
+  };
+
+  it("should include agent spawned header", () => {
+    const result = formatAgentCall(basePayload);
+    expect(result).toContain("# Agent Spawned");
+  });
+
+  it("should include agent name when provided", () => {
+    const result = formatAgentCall({
+      ...basePayload,
+      agentName: "executor",
+    });
+    expect(result).toContain("**Agent:** `executor`");
+  });
+
+  it("should include agent type when provided", () => {
+    const result = formatAgentCall({
+      ...basePayload,
+      agentType: "oh-my-claudecode:executor",
+    });
+    expect(result).toContain("**Type:** `oh-my-claudecode:executor`");
+  });
+
+  it("should include footer with project info", () => {
+    const result = formatAgentCall(basePayload);
+    expect(result).toContain("`my-project`");
+  });
+});
+
+describe("tmuxTail in formatters", () => {
+  it("should include tmux tail in formatSessionIdle when present", () => {
+    const payload: NotificationPayload = {
+      event: "session-idle",
+      sessionId: "test-session",
+      message: "",
+      timestamp: new Date().toISOString(),
+      projectPath: "/tmp/test",
+      tmuxTail: "$ npm test\nAll tests passed",
+    };
+    const result = formatSessionIdle(payload);
+    expect(result).toContain("**Recent output:**");
+    expect(result).toContain("$ npm test");
+    expect(result).toContain("All tests passed");
+  });
+
+  it("should not include tmux tail section when not present", () => {
+    const payload: NotificationPayload = {
+      event: "session-idle",
+      sessionId: "test-session",
+      message: "",
+      timestamp: new Date().toISOString(),
+      projectPath: "/tmp/test",
+    };
+    const result = formatSessionIdle(payload);
+    expect(result).not.toContain("**Recent output:**");
+  });
+
+  it("should include tmux tail in formatSessionEnd when present", () => {
+    const payload: NotificationPayload = {
+      event: "session-end",
+      sessionId: "test-session",
+      message: "",
+      timestamp: new Date().toISOString(),
+      projectPath: "/tmp/test",
+      tmuxTail: "Build complete\nDone in 5.2s",
+    };
+    const result = formatSessionEnd(payload);
+    expect(result).toContain("**Recent output:**");
+    expect(result).toContain("Build complete");
+    expect(result).toContain("Done in 5.2s");
   });
 });

--- a/src/notifications/__tests__/notify-registry-integration.test.ts
+++ b/src/notifications/__tests__/notify-registry-integration.test.ts
@@ -23,6 +23,9 @@ vi.mock("../config.js", () => ({
   getNotificationConfig: (profileName?: string) => mockGetNotificationConfig(profileName),
   isEventEnabled: (config: unknown, event: unknown) => mockIsEventEnabled(config, event),
   getEnabledPlatforms: () => ["discord-bot"],
+  getVerbosity: () => "session",
+  isEventAllowedByVerbosity: () => true,
+  shouldIncludeTmuxTail: () => false,
   parseMentionAllowedMentions: () => ({
     users: undefined,
     roles: undefined,

--- a/src/notifications/__tests__/verbosity.test.ts
+++ b/src/notifications/__tests__/verbosity.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getVerbosity,
+  isEventAllowedByVerbosity,
+  shouldIncludeTmuxTail,
+} from "../config.js";
+import type { NotificationConfig, VerbosityLevel, NotificationEvent } from "../types.js";
+
+describe("getVerbosity", () => {
+  const baseConfig: NotificationConfig = {
+    enabled: true,
+  };
+
+  beforeEach(() => {
+    vi.stubEnv("OMC_NOTIFY_VERBOSITY", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 'session' by default when no config or env", () => {
+    expect(getVerbosity(baseConfig)).toBe("session");
+  });
+
+  it("returns config value when set", () => {
+    const config: NotificationConfig = { ...baseConfig, verbosity: "minimal" };
+    expect(getVerbosity(config)).toBe("minimal");
+  });
+
+  it("returns config value 'verbose'", () => {
+    const config: NotificationConfig = { ...baseConfig, verbosity: "verbose" };
+    expect(getVerbosity(config)).toBe("verbose");
+  });
+
+  it("returns config value 'agent'", () => {
+    const config: NotificationConfig = { ...baseConfig, verbosity: "agent" };
+    expect(getVerbosity(config)).toBe("agent");
+  });
+
+  it("returns env var value when set (overrides config)", () => {
+    vi.stubEnv("OMC_NOTIFY_VERBOSITY", "verbose");
+    const config: NotificationConfig = { ...baseConfig, verbosity: "minimal" };
+    expect(getVerbosity(config)).toBe("verbose");
+  });
+
+  it("returns 'session' for invalid env var value", () => {
+    vi.stubEnv("OMC_NOTIFY_VERBOSITY", "invalid-level");
+    expect(getVerbosity(baseConfig)).toBe("session");
+  });
+
+  it("returns config value when env var is invalid", () => {
+    vi.stubEnv("OMC_NOTIFY_VERBOSITY", "invalid");
+    const config: NotificationConfig = { ...baseConfig, verbosity: "agent" };
+    expect(getVerbosity(config)).toBe("agent");
+  });
+
+  it("returns 'session' when config verbosity is invalid", () => {
+    const config: NotificationConfig = {
+      ...baseConfig,
+      verbosity: "bogus" as VerbosityLevel,
+    };
+    expect(getVerbosity(config)).toBe("session");
+  });
+});
+
+describe("isEventAllowedByVerbosity", () => {
+  const sessionEvents: NotificationEvent[] = [
+    "session-start",
+    "session-stop",
+    "session-end",
+    "session-idle",
+  ];
+
+  describe("minimal", () => {
+    it("allows session-start", () => {
+      expect(isEventAllowedByVerbosity("minimal", "session-start")).toBe(true);
+    });
+
+    it("allows session-stop", () => {
+      expect(isEventAllowedByVerbosity("minimal", "session-stop")).toBe(true);
+    });
+
+    it("allows session-end", () => {
+      expect(isEventAllowedByVerbosity("minimal", "session-end")).toBe(true);
+    });
+
+    it("allows session-idle", () => {
+      expect(isEventAllowedByVerbosity("minimal", "session-idle")).toBe(true);
+    });
+
+    it("blocks ask-user-question", () => {
+      expect(isEventAllowedByVerbosity("minimal", "ask-user-question")).toBe(false);
+    });
+
+    it("blocks agent-call", () => {
+      expect(isEventAllowedByVerbosity("minimal", "agent-call")).toBe(false);
+    });
+  });
+
+  describe("session", () => {
+    it("allows all session events", () => {
+      for (const event of sessionEvents) {
+        expect(isEventAllowedByVerbosity("session", event)).toBe(true);
+      }
+    });
+
+    it("blocks ask-user-question", () => {
+      expect(isEventAllowedByVerbosity("session", "ask-user-question")).toBe(false);
+    });
+
+    it("blocks agent-call", () => {
+      expect(isEventAllowedByVerbosity("session", "agent-call")).toBe(false);
+    });
+  });
+
+  describe("agent", () => {
+    it("allows all session events", () => {
+      for (const event of sessionEvents) {
+        expect(isEventAllowedByVerbosity("agent", event)).toBe(true);
+      }
+    });
+
+    it("allows agent-call", () => {
+      expect(isEventAllowedByVerbosity("agent", "agent-call")).toBe(true);
+    });
+
+    it("blocks ask-user-question", () => {
+      expect(isEventAllowedByVerbosity("agent", "ask-user-question")).toBe(false);
+    });
+  });
+
+  describe("verbose", () => {
+    it("allows all events", () => {
+      const allEvents: NotificationEvent[] = [
+        ...sessionEvents,
+        "ask-user-question",
+        "agent-call",
+      ];
+      for (const event of allEvents) {
+        expect(isEventAllowedByVerbosity("verbose", event)).toBe(true);
+      }
+    });
+  });
+});
+
+describe("shouldIncludeTmuxTail", () => {
+  it("returns false for minimal", () => {
+    expect(shouldIncludeTmuxTail("minimal")).toBe(false);
+  });
+
+  it("returns true for session", () => {
+    expect(shouldIncludeTmuxTail("session")).toBe(true);
+  });
+
+  it("returns true for agent", () => {
+    expect(shouldIncludeTmuxTail("agent")).toBe(true);
+  });
+
+  it("returns true for verbose", () => {
+    expect(shouldIncludeTmuxTail("verbose")).toBe(true);
+  });
+});

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -134,6 +134,8 @@ export function formatSessionEnd(payload: NotificationPayload): string {
     lines.push("", `**Summary:** ${payload.contextSummary}`);
   }
 
+  appendTmuxTail(lines, payload);
+
   lines.push("");
   lines.push(buildFooter(payload, true));
 
@@ -156,6 +158,42 @@ export function formatSessionIdle(payload: NotificationPayload): string {
 
   if (payload.modesUsed && payload.modesUsed.length > 0) {
     lines.push(`**Modes:** ${payload.modesUsed.join(", ")}`);
+  }
+
+  appendTmuxTail(lines, payload);
+
+  lines.push("");
+  lines.push(buildFooter(payload, true));
+
+  return lines.join("\n");
+}
+
+/**
+ * Append tmux tail content to a message if present in the payload.
+ */
+function appendTmuxTail(lines: string[], payload: NotificationPayload): void {
+  if (payload.tmuxTail) {
+    lines.push("");
+    lines.push("**Recent output:**");
+    lines.push("```");
+    lines.push(payload.tmuxTail.trimEnd());
+    lines.push("```");
+  }
+}
+
+/**
+ * Format agent-call notification message.
+ * Sent when a new agent (Task) is spawned.
+ */
+export function formatAgentCall(payload: NotificationPayload): string {
+  const lines = [`# Agent Spawned`, ""];
+
+  if (payload.agentName) {
+    lines.push(`**Agent:** \`${payload.agentName}\``);
+  }
+
+  if (payload.agentType) {
+    lines.push(`**Type:** \`${payload.agentType}\``);
   }
 
   lines.push("");
@@ -199,6 +237,8 @@ export function formatNotification(payload: NotificationPayload): string {
       return formatSessionIdle(payload);
     case "ask-user-question":
       return formatAskUserQuestion(payload);
+    case "agent-call":
+      return formatAgentCall(payload);
     default:
       return payload.message || `Event: ${payload.event}`;
   }

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -41,6 +41,7 @@ export {
   formatSessionEnd,
   formatSessionIdle,
   formatAskUserQuestion,
+  formatAgentCall,
 } from "./formatter.js";
 export {
   getCurrentTmuxSession,
@@ -52,6 +53,9 @@ export {
   getNotificationConfig,
   isEventEnabled,
   getEnabledPlatforms,
+  getVerbosity,
+  isEventAllowedByVerbosity,
+  shouldIncludeTmuxTail,
 } from "./config.js";
 
 import type {
@@ -59,7 +63,13 @@ import type {
   NotificationPayload,
   DispatchResult,
 } from "./types.js";
-import { getNotificationConfig, isEventEnabled } from "./config.js";
+import {
+  getNotificationConfig,
+  isEventEnabled,
+  getVerbosity,
+  isEventAllowedByVerbosity,
+  shouldIncludeTmuxTail,
+} from "./config.js";
 import { formatNotification } from "./formatter.js";
 import { dispatchNotifications } from "./dispatcher.js";
 import { getCurrentTmuxSession } from "./tmux.js";
@@ -82,6 +92,12 @@ export async function notify(
   try {
     const config = getNotificationConfig(data.profileName);
     if (!config || !isEventEnabled(config, event)) {
+      return null;
+    }
+
+    // Verbosity filter (second gate after isEventEnabled)
+    const verbosity = getVerbosity(config);
+    if (!isEventAllowedByVerbosity(verbosity, event)) {
       return null;
     }
 
@@ -111,7 +127,28 @@ export async function notify(
       maxIterations: data.maxIterations,
       question: data.question,
       incompleteTasks: data.incompleteTasks,
+      agentName: data.agentName,
+      agentType: data.agentType,
     };
+
+    // Capture tmux tail for events that benefit from it
+    if (
+      shouldIncludeTmuxTail(verbosity) &&
+      payload.tmuxPaneId &&
+      (event === "session-idle" || event === "session-end" || event === "session-stop")
+    ) {
+      try {
+        const { capturePaneContent } = await import(
+          "../features/rate-limit-wait/tmux-detector.js"
+        );
+        const tail = capturePaneContent(payload.tmuxPaneId, 15);
+        if (tail) {
+          payload.tmuxTail = tail;
+        }
+      } catch {
+        // Non-blocking: tmux capture is best-effort
+      }
+    }
 
     // Format the message
     payload.message = data.message || formatNotification(payload);

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -6,13 +6,17 @@
  * session lifecycle events (start, stop, end, ask-user-question).
  */
 
+/** Verbosity levels for notification filtering (ordered most to least verbose) */
+export type VerbosityLevel = "verbose" | "agent" | "session" | "minimal";
+
 /** Events that can trigger notifications */
 export type NotificationEvent =
   | "session-start"
   | "session-stop"
   | "session-end"
   | "session-idle"
-  | "ask-user-question";
+  | "ask-user-question"
+  | "agent-call";
 
 /** Supported notification platforms */
 export type NotificationPlatform =
@@ -106,6 +110,9 @@ export interface NotificationConfig {
   /** Global enable/disable for all notifications */
   enabled: boolean;
 
+  /** Verbosity level controlling which events fire and tmux tail inclusion */
+  verbosity?: VerbosityLevel;
+
   /** Default platform configs (used when event-specific config is not set) */
   discord?: DiscordNotificationConfig;
   "discord-bot"?: DiscordBotNotificationConfig;
@@ -120,6 +127,7 @@ export interface NotificationConfig {
     "session-end"?: EventNotificationConfig;
     "session-idle"?: EventNotificationConfig;
     "ask-user-question"?: EventNotificationConfig;
+    "agent-call"?: EventNotificationConfig;
   };
 }
 
@@ -163,6 +171,12 @@ export interface NotificationPayload {
   incompleteTasks?: number;
   /** tmux pane ID for reply injection target */
   tmuxPaneId?: string;
+  /** Agent name for agent-call events (e.g., "executor", "architect") */
+  agentName?: string;
+  /** Agent type for agent-call events (e.g., "oh-my-claudecode:executor") */
+  agentType?: string;
+  /** Captured tmux pane content (last N lines) */
+  tmuxTail?: string;
 }
 
 /** Named notification profiles (keyed by profile name) */


### PR DESCRIPTION
## Summary
- Add configurable verbosity levels (`verbose` > `agent` > `session` > `minimal`) to the notification system
- `minimal`: session-start/idle/end/stop only (no tmux tail)
- `session` (default): same events + 15-line tmux pane tail in idle/end/stop messages
- `agent`: session events + per-agent-call notifications on Task tool usage
- `verbose`: all events including ask-user-question
- Config via `notifications.verbosity` in `.omc-config.json` or `OMC_NOTIFY_VERBOSITY` env var
- New `agent-call` event dispatched from bridge.ts when Task tool is invoked

## Changed files
- `src/notifications/types.ts` — `VerbosityLevel` type, `agent-call` event, new payload fields
- `src/notifications/config.ts` — `getVerbosity()`, `isEventAllowedByVerbosity()`, `shouldIncludeTmuxTail()`
- `src/notifications/formatter.ts` — `formatAgentCall()`, tmux tail appending to idle/end
- `src/notifications/index.ts` — verbosity filtering gate, tmux pane capture
- `src/hooks/bridge.ts` — agent-call dispatch on Task tool usage
- `src/notifications/__tests__/verbosity.test.ts` — 25 new tests
- `src/notifications/__tests__/formatter.test.ts` — 11 new tests
- `src/notifications/__tests__/notify-registry-integration.test.ts` — mock fix for new exports

## Test plan
- [x] All 295 notification tests pass (11 test files)
- [x] New verbosity.test.ts covers getVerbosity, isEventAllowedByVerbosity, shouldIncludeTmuxTail
- [x] Formatter tests cover formatAgentCall, tmuxTail inclusion/exclusion
- [ ] Manual: set `"verbosity": "minimal"` and confirm no tmux tail in idle messages
- [ ] Manual: set `"verbosity": "agent"` and confirm agent-call notifications fire on Task usage

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)