### PR TITLE
fix: reduce readStdin default timeout from 5s to 2s (#765)

### DIFF
--- a/templates/hooks/lib/stdin.mjs
+++ b/templates/hooks/lib/stdin.mjs
@@ -12,10 +12,10 @@
  * close stdin, this hangs forever. This function uses event-based reading
  * with a timeout as a safety net.
  *
- * @param {number} timeoutMs - Maximum time to wait for stdin (default: 5000ms)
+ * @param {number} timeoutMs - Maximum time to wait for stdin (default: 2000ms)
  * @returns {Promise<string>} - The stdin content, or empty string on error/timeout
  */
-export async function readStdin(timeoutMs = 5000) {
+export async function readStdin(timeoutMs = 2000) {
   return new Promise((resolve) => {
     const chunks = [];
     let settled = false;


### PR DESCRIPTION
## Summary

Fixes #765 — hook timeout race condition causing noisy 'PostToolUse:Bash hook error' on session start.

## Root Cause

- Hook external timeout in hooks.json: **3s**
- `readStdin()` default timeout: **5s**
- During cwd-reset events, stdin may not close promptly → readStdin waits → hook killed at 3s → error reported

## Fix

Reduce `readStdin` default timeout from **5000ms → 2000ms** in `templates/hooks/lib/stdin.mjs`.

This ensures the script's own timeout (2s) resolves before the external hook timeout (3s), eliminating the race.

**repo owner's gaebal-gajae (clawdbot) 🦞**