### PR TITLE
fix(setup): /omc-setup 재실행 시 Windows HUD가 다시 깨지는 버그 수정

### DIFF
--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -119,7 +119,7 @@ try {
   // Update statusLine to use new HUD path
   settings.statusLine = {
     type: 'command',
-    command: `node ${hudScriptPath}`
+    command: `node ${hudScriptPath.replace(/\\/g, "/")}`
   };
   writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2));
   console.log('[OMC] Configured HUD statusLine in settings.json');


### PR DESCRIPTION
## 요약

- **plugin-setup.mjs의 Windows 경로 역슬래시 변환 누락 수정**: `path.join()`이 Windows에서 역슬래시(`\`)를 반환하지만, Claude Code 2.1.47+의 `settings.json` `statusLine` command는 역슬래시 경로를 실행할 수 없음.
- PR #759가 배포된 `settings.json`에서 역슬래시를 직접 수정했지만, `plugin-setup.mjs`의 재설치 로직은 수정되지 않아 `/omc-setup` 재실행 시 동일한 버그가 재발함.

## 근본 원인

PR #759는 기설치된 환경의 `settings.json`을 일회성으로 수정했지만, 재설치 경로(`plugin-setup.mjs`)는 수정하지 않음:

```js
// scripts/plugin-setup.mjs:122 (수정 전)
settings.statusLine = {
  type: 'command',
  command: `node ${hudScriptPath}`  // Windows: C:\Users\user\.claude\hud\omc-hud.mjs
};
// → Claude Code 2.1.47+에서 역슬래시 경로 실행 실패 → HUD 표시 안 됨
```

`/omc-setup` 또는 플러그인 재설치 시 이 코드가 다시 실행되어 역슬래시 경로를 `settings.json`에 기록, HUD가 재설치마다 깨짐.

## 변경 사항

### `scripts/plugin-setup.mjs`
```diff
  settings.statusLine = {
    type: 'command',
-   command: `node ${hudScriptPath}`
+   command: `node ${hudScriptPath.replace(/\\/g, "/")}`
  };
```

## 테스트

- [x] `npx vitest run` — 기존 실패와 동일 (내 변경으로 인한 새 실패 없음)
- [ ] 수동 검증: Windows 환경에서 `/omc-setup` 실행 후 `settings.json`의 `statusLine.command` 경로가 포워드슬래시인지 확인