### PR TITLE
fix(analytics): rebuildStatsFromLog이 항상 null을 반환하여 세션 히스토리 누적 비용이 0으로 집계되는 버그 수정 (#773)

### DIFF
--- a/src/analytics/token-tracker.ts
+++ b/src/analytics/token-tracker.ts
@@ -243,6 +243,9 @@ export class TokenTracker {
       const stats = this.initializeSessionStats();
       stats.sessionId = sessionId;
 
+      const savedStats = this.sessionStats;
+      this.sessionStats = stats;
+
       for (const line of linesToProcess) {
         if (!line.trim()) continue;
         try {
@@ -254,6 +257,8 @@ export class TokenTracker {
           continue;
         }
       }
+
+      this.sessionStats = savedStats;
 
       return stats.totalInputTokens > 0 ? stats : null;
     } catch (error) {


### PR DESCRIPTION
## 요약

- **rebuildStatsFromLog의 잘못된 변수 스코프 수정**: `this.updateSessionStats(record)`는
  `this.sessionStats`(인스턴스 변수)를 수정하지만, 반환하는 것은 로컬 변수 `stats`.
  `stats`는 항상 초기화 상태이므로 로그에 데이터가 있어도 항상 `null` 반환.

## 근본 원인

```typescript
private async rebuildStatsFromLog(sessionId: string): Promise<SessionTokenStats | null> {
  const stats = this.initializeSessionStats();  // ← 로컬 변수 생성 (항상 0)

  for (const line of linesToProcess) {
    const record = JSON.parse(line);
    if (record.sessionId === sessionId) {
      this.updateSessionStats(record);  // ← this.sessionStats 수정 (stats 아님!)
    }
  }

  return stats.totalInputTokens > 0 ? stats : null;  // stats는 항상 0 → 항상 null
}
```

## 영향 범위

세션 종료 시 `addToHistory()`가 호출되고, 이 함수는 저장된 모든 과거 세션을 순회하며
`getSessionAnalytics(pastSessionId)` → `loadSessionStats(pastSessionId)` →
`rebuildStatsFromLog(pastSessionId)` 경로로 토큰 비용을 집계.

과거 세션 ID는 현재 상태 파일의 세션 ID와 항상 다르므로 모두 `rebuildStatsFromLog`를
거치고, 이 함수가 항상 `null`을 반환하므로 **모든 과거 세션의 비용 기여분이 0**.

결과: `history.totalCost`는 **현재 세션 비용만** 반영 → 세션이 쌓일수록 누적 비용이
실제보다 작게 집계됨.

## 변경 사항

### `src/analytics/token-tracker.ts`

루프 전 `this.sessionStats`를 `stats`로 임시 교체하여 `updateSessionStats`가
로컬 `stats`에 누적하도록 수정, 루프 후 원래 값으로 복원:

```diff
  const stats = this.initializeSessionStats();
  stats.sessionId = sessionId;

+ const savedStats = this.sessionStats;
+ this.sessionStats = stats;

  for (const line of linesToProcess) {
    ...
      this.updateSessionStats(record);
    ...
  }

+ this.sessionStats = savedStats;

  return stats.totalInputTokens > 0 ? stats : null;
```

## 테스트

- [x] `npx tsc --noEmit` — TypeScript 컴파일 통과
- [x] `npx vitest run` — 기존 58개 실패에서 56개로 감소 (2개 추가 통과, 새 실패 없음)
- [ ] 수동 검증: 2개 이상의 세션을 완료한 후 `history.totalCost`가 각 세션 비용의
      합계와 일치하는지 확인

Closes #773