### PR TITLE
fix(installer): normalize backslashes in Windows statusLine command path

### DIFF
--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -804,13 +804,13 @@ export function install(options: InstallOptions = {}): InstallResult {
         if (!existingSettings.statusLine) {
           existingSettings.statusLine = {
             type: 'command',
-            command: 'node ' + hudScriptPath
+            command: 'node ' + hudScriptPath.replace(/\\/g, '/')
           };
           log('  Configured statusLine');
         } else if (options.force && isOmcStatusLine(existingSettings.statusLine)) {
           existingSettings.statusLine = {
             type: 'command',
-            command: 'node ' + hudScriptPath
+            command: 'node ' + hudScriptPath.replace(/\\/g, '/')
           };
           log('  Updated statusLine (--force)');
         } else if (options.force) {


### PR DESCRIPTION
## Problem

On Windows, `path.join()` produces backslash-separated paths (e.g. `C:\Users\myhong\.claude\hud\omc-hud.mjs`). When Claude Code invokes the `statusLine` command via bash, the shell interprets backslashes as escape sequences, corrupting the path and silently failing to execute the HUD script.

**Example failure:**
```
# settings.json contained:
"command": "node C:\Users\myhong\.claude\hud\omc-hud.mjs"

# bash executed it as:
node C:\Usersmyhong.claudehubomc-hud.mjs   # invalid path -> MODULE_NOT_FOUND
```

Result: statusLine shows nothing, no debug.log created, no error visible to user.

## Fix

Apply `.replace(/\/g, '/')` on `hudScriptPath` before embedding it in the `statusLine` command string.

```typescript
// Before
command: 'node ' + hudScriptPath

// After
command: 'node ' + hudScriptPath.replace(/\/g, '/')
```

## Verification

Tested on Windows 11 with Claude Code 2.1.49, Git Bash shell:
- Before fix: `node C:\Users\myhong\.claude\hud\omc-hud.mjs` -> bash corrupts path -> silent failure
- After fix: `node C:/Users/myhong/.claude/hud/omc-hud.mjs` -> works correctly

Related to existing Windows HUD compatibility work (Issue #138, PR #139, PR #140).