### PR TITLE
feat(hooks): add context safety system with threshold blocking

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -65,6 +65,16 @@
             "timeout": 3
           }
         ]
+      },
+      {
+        "matcher": "TeamCreate|ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/context-safety.mjs\"",
+            "timeout": 3
+          }
+        ]
       }
     ],
     "PermissionRequest": [
@@ -141,6 +151,11 @@
       {
         "matcher": "*",
         "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/context-guard-stop.mjs\"",
+            "timeout": 5
+          },
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/persistent-mode.cjs\"",

--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+/**
+ * OMC Context Guard Hook (Stop)
+ *
+ * Suggests session refresh when context usage exceeds a warning threshold.
+ * This complements persistent-mode.cjs — it fires BEFORE modes like Ralph
+ * or Ultrawork process the stop, providing an early warning.
+ *
+ * Configurable via OMC_CONTEXT_GUARD_THRESHOLD env var (default: 75%).
+ *
+ * Safety rules:
+ *   - Never block context_limit stops (would cause compaction deadlock)
+ *   - Never block user-requested stops (respect Ctrl+C / cancel)
+ *   - Max 2 blocks per transcript (retry guard prevents infinite loops)
+ *
+ * Hook output:
+ *   - { decision: "block", reason: "..." } when context too high
+ *   - { continue: true, suppressOutput: true } otherwise
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readStdin } from './lib/stdin.mjs';
+
+const THRESHOLD = parseInt(process.env.OMC_CONTEXT_GUARD_THRESHOLD || '75', 10);
+const MAX_BLOCKS = 2;
+
+/**
+ * Detect if stop was triggered by context-limit related reasons.
+ * Mirrors the logic in persistent-mode.cjs to stay consistent.
+ */
+function isContextLimitStop(data) {
+  const reason = (data.stop_reason || data.stopReason || '').toLowerCase();
+  const contextPatterns = [
+    'context_limit', 'context_window', 'context_exceeded',
+    'context_full', 'max_context', 'token_limit',
+    'max_tokens', 'conversation_too_long', 'input_too_long',
+  ];
+
+  if (contextPatterns.some(p => reason.includes(p))) return true;
+
+  const endTurnReason = (data.end_turn_reason || data.endTurnReason || '').toLowerCase();
+  if (endTurnReason && contextPatterns.some(p => endTurnReason.includes(p))) return true;
+
+  return false;
+}
+
+/**
+ * Detect if stop was triggered by user abort.
+ */
+function isUserAbort(data) {
+  if (data.user_requested || data.userRequested) return true;
+
+  const reason = (data.stop_reason || data.stopReason || '').toLowerCase();
+  const exactPatterns = ['aborted', 'abort', 'cancel', 'interrupt'];
+  const substringPatterns = ['user_cancel', 'user_interrupt', 'ctrl_c', 'manual_stop'];
+
+  return (
+    exactPatterns.some(p => reason === p) ||
+    substringPatterns.some(p => reason.includes(p))
+  );
+}
+
+/**
+ * Estimate context usage percentage from the transcript file.
+ */
+function estimateContextPercent(transcriptPath) {
+  if (!transcriptPath) return 0;
+
+  let fd = -1;
+  try {
+    const stat = statSync(transcriptPath);
+    if (stat.size === 0) return 0;
+
+    fd = openSync(transcriptPath, 'r');
+    const readSize = Math.min(4096, stat.size);
+    const buf = Buffer.alloc(readSize);
+    readSync(fd, buf, 0, readSize, stat.size - readSize);
+    closeSync(fd);
+    fd = -1;
+
+    const tail = buf.toString('utf-8');
+
+    // Bounded quantifiers to avoid ReDoS on malformed input
+    const windowMatch = tail.match(/"context_window"\s{0,5}:\s{0,5}(\d+)/g);
+    const inputMatch = tail.match(/"input_tokens"\s{0,5}:\s{0,5}(\d+)/g);
+
+    if (!windowMatch || !inputMatch) return 0;
+
+    const lastWindow = parseInt(windowMatch[windowMatch.length - 1].match(/(\d+)/)[1], 10);
+    const lastInput = parseInt(inputMatch[inputMatch.length - 1].match(/(\d+)/)[1], 10);
+
+    if (lastWindow === 0) return 0;
+    return Math.round((lastInput / lastWindow) * 100);
+  } catch {
+    return 0;
+  } finally {
+    if (fd !== -1) try { closeSync(fd); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Retry guard: track how many times we've blocked this transcript.
+ * Prevents infinite block loops by capping at MAX_BLOCKS.
+ */
+function getBlockCount(sessionId) {
+  if (!sessionId) return 0;
+  const guardFile = join(tmpdir(), `omc-context-guard-${sessionId}.json`);
+  try {
+    if (existsSync(guardFile)) {
+      const data = JSON.parse(readFileSync(guardFile, 'utf-8'));
+      return data.blockCount || 0;
+    }
+  } catch { /* ignore */ }
+  return 0;
+}
+
+function incrementBlockCount(sessionId) {
+  if (!sessionId) return;
+  const guardFile = join(tmpdir(), `omc-context-guard-${sessionId}.json`);
+  try {
+    let count = 0;
+    if (existsSync(guardFile)) {
+      const data = JSON.parse(readFileSync(guardFile, 'utf-8'));
+      count = data.blockCount || 0;
+    }
+    writeFileSync(guardFile, JSON.stringify({ blockCount: count + 1 }));
+  } catch { /* ignore */ }
+}
+
+async function main() {
+  try {
+    const input = await readStdin();
+    const data = JSON.parse(input);
+
+    // CRITICAL: Never block context-limit stops (compaction deadlock)
+    if (isContextLimitStop(data)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    // Respect user abort
+    if (isUserAbort(data)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    const sessionId = data.session_id || data.sessionId || '';
+    const transcriptPath = data.transcript_path || data.transcriptPath || '';
+    const pct = estimateContextPercent(transcriptPath);
+
+    if (pct >= THRESHOLD) {
+      // Check retry guard
+      const blockCount = getBlockCount(sessionId);
+      if (blockCount >= MAX_BLOCKS) {
+        // Already blocked enough times — let it through
+        console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+        return;
+      }
+
+      incrementBlockCount(sessionId);
+
+      console.log(JSON.stringify({
+        decision: 'block',
+        reason: `[OMC] Context at ${pct}% (threshold: ${THRESHOLD}%). ` +
+          `Quality degrades at high context. Run /compact or start a fresh session. ` +
+          `(Block ${blockCount + 1}/${MAX_BLOCKS})`
+      }));
+      return;
+    }
+
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  } catch {
+    // On any error, allow stop (never block on hook failure)
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  }
+}
+
+main();

--- a/scripts/context-safety.mjs
+++ b/scripts/context-safety.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/**
+ * OMC Context Safety Hook (PreToolUse)
+ *
+ * Blocks expensive operations (TeamCreate, ExitPlanMode) when context usage
+ * exceeds a safe threshold. Spawning teams or exiting plan mode at high
+ * context leads to unrecoverable extended-thinking loops because the model
+ * cannot converge on a next action.
+ *
+ * Configurable via OMC_CONTEXT_SAFETY_THRESHOLD env var (default: 55%).
+ *
+ * Hook output:
+ *   - Block (exit 2 + stderr message) when context too high for the tool
+ *   - Allow ({ continue: true, suppressOutput: true }) otherwise
+ */
+
+import { statSync, openSync, readSync, closeSync } from 'node:fs';
+import { readStdin } from './lib/stdin.mjs';
+
+const THRESHOLD = parseInt(process.env.OMC_CONTEXT_SAFETY_THRESHOLD || '55', 10);
+const BLOCKED_TOOLS = new Set(['TeamCreate', 'ExitPlanMode']);
+
+/**
+ * Estimate context usage percentage from the transcript file.
+ * Reads the last 4KB of the transcript to find the most recent usage entry.
+ */
+function estimateContextPercent(transcriptPath) {
+  if (!transcriptPath) return 0;
+
+  let fd = -1;
+  try {
+    const stat = statSync(transcriptPath);
+    if (stat.size === 0) return 0;
+
+    // Read the last 4KB — covers ~50-100 JSONL entries for recent usage data
+    fd = openSync(transcriptPath, 'r');
+    const readSize = Math.min(4096, stat.size);
+    const buf = Buffer.alloc(readSize);
+    readSync(fd, buf, 0, readSize, stat.size - readSize);
+    closeSync(fd);
+    fd = -1;
+
+    const tail = buf.toString('utf-8');
+
+    // Look for context_window / input_tokens patterns in JSON lines
+    // Bounded quantifiers to avoid ReDoS on malformed input
+    const windowMatch = tail.match(/"context_window"\s{0,5}:\s{0,5}(\d+)/g);
+    const inputMatch = tail.match(/"input_tokens"\s{0,5}:\s{0,5}(\d+)/g);
+
+    if (!windowMatch || !inputMatch) return 0;
+
+    // Take the last occurrence of each
+    const lastWindow = parseInt(windowMatch[windowMatch.length - 1].match(/(\d+)/)[1], 10);
+    const lastInput = parseInt(inputMatch[inputMatch.length - 1].match(/(\d+)/)[1], 10);
+
+    if (lastWindow === 0) return 0;
+    return Math.round((lastInput / lastWindow) * 100);
+  } catch {
+    return 0;
+  } finally {
+    if (fd !== -1) try { closeSync(fd); } catch { /* ignore */ }
+  }
+}
+
+async function main() {
+  try {
+    const input = await readStdin();
+    const data = JSON.parse(input);
+
+    const toolName = data.tool_name || data.toolName || '';
+
+    if (!BLOCKED_TOOLS.has(toolName)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    const transcriptPath = data.transcript_path || data.transcriptPath || '';
+    const pct = estimateContextPercent(transcriptPath);
+
+    if (pct >= THRESHOLD) {
+      process.stderr.write(
+        `[OMC] Context at ${pct}% (threshold: ${THRESHOLD}%). ` +
+        `Too high for ${toolName}. Run /compact or start a fresh session to free context.\n`
+      );
+      process.exit(2);
+    }
+
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  } catch {
+    // On any error, allow the tool to proceed (never block on hook failure)
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  }
+}
+
+main();


### PR DESCRIPTION
## Problem

OMC has no context window protection. `persistent-mode.cjs` detects context_limit stops but only passively allows them. No preemptive blocking exists — users can spawn teams at 80% context, causing unrecoverable extended-thinking loops where the model cannot converge on a next action.

## Solution

Two new hooks that work together to protect against high-context failures:

### `scripts/context-safety.mjs` (PreToolUse)
- Blocks `TeamCreate` and `ExitPlanMode` when context usage exceeds **55%** threshold
- Threshold configurable via `OMC_CONTEXT_SAFETY_THRESHOLD` env var
- Reads the last 4KB of the transcript file to estimate current context %
- Uses `process.exit(2)` for PreToolUse blocking (Claude Code convention)

### `scripts/context-guard-stop.mjs` (Stop)
- Suggests session refresh when context exceeds **75%** threshold
- Threshold configurable via `OMC_CONTEXT_GUARD_THRESHOLD` env var
- **Never** blocks context_limit stops (would cause compaction deadlock, per #213)
- **Never** blocks user-requested stops (respects Ctrl+C / cancel)
- Retry guard: max 2 blocks per transcript (prevents infinite loops)
- Runs before `persistent-mode.cjs` in the Stop hook chain

### Design Decisions
- Both hooks follow OMC conventions: `lib/stdin.mjs` for timeout-protected stdin, graceful error handling (never block on failure), valid JSON output
- Context estimation uses regex on the transcript tail (lightweight, no full file parse)
- Stop hook uses `/tmp/` file for retry guard (survives across stops but not reboots)
- PreToolUse hook is matcher-scoped to `TeamCreate|ExitPlanMode` only (no overhead on other tools)

## Files Changed
- `scripts/context-safety.mjs` — NEW PreToolUse hook
- `scripts/context-guard-stop.mjs` — NEW Stop hook
- `hooks/hooks.json` — Register both new hooks

## Verification
- `node --check` passes on both scripts
- `hooks.json` is valid JSON
- No existing hooks or scripts are modified