### PR TITLE
feat(team): blocking shutdown protocol with orphan detection

### DIFF
--- a/scripts/cleanup-orphans.mjs
+++ b/scripts/cleanup-orphans.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+/**
+ * OMC Orphan Agent Cleanup
+ *
+ * Detects and terminates orphan agent processes — agents whose team
+ * config has been deleted (via TeamDelete) but whose OS processes
+ * are still running. This happens when TeamDelete fires before all
+ * teammates confirm shutdown.
+ *
+ * Usage:
+ *   node cleanup-orphans.mjs [--team-name <name>] [--dry-run]
+ *
+ * When --team-name is provided, only checks for orphans from that team.
+ * When omitted, scans for ALL orphan claude agent processes.
+ *
+ * --dry-run: Report orphans without killing them.
+ *
+ * Exit codes:
+ *   0 - Success (orphans cleaned or none found)
+ *   1 - Error during cleanup
+ */
+
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const args = process.argv.slice(2);
+const teamNameIdx = args.indexOf('--team-name');
+const rawTeamName = teamNameIdx !== -1 ? args[teamNameIdx + 1] : null;
+const dryRun = args.includes('--dry-run');
+
+// Validate team name to prevent path traversal and injection
+const TEAM_NAME_RE = /^[\w][\w-]{0,63}$/;
+const teamName = rawTeamName && TEAM_NAME_RE.test(rawTeamName) ? rawTeamName : null;
+if (rawTeamName && !teamName) {
+  console.error(`[cleanup-orphans] Invalid team name: ${rawTeamName}`);
+  process.exit(1);
+}
+
+/**
+ * Find claude agent processes that match team patterns.
+ * Cross-platform: uses ps on Unix, tasklist on Windows.
+ */
+function findOrphanProcesses(filterTeam) {
+  const orphans = [];
+
+  try {
+    if (process.platform === 'win32') {
+      // Windows: use WMIC to find node/claude processes
+      const output = execSync(
+        'wmic process where "name like \'%node%\' or name like \'%claude%\'" get processid,commandline /format:csv',
+        { encoding: 'utf-8', timeout: 10000 }
+      ).trim();
+
+      for (const line of output.split('\n')) {
+        if (line.includes('--team-name') || line.includes('team_name')) {
+          // Restrict team name match to valid slug characters (alphanumeric + hyphens)
+          const match = line.match(/--team-name[=\s]+([\w][\w-]{0,63})/i) || line.match(/team_name[=:]\s*"?([\w][\w-]{0,63})"?/i);
+          if (match) {
+            const procTeam = match[1];
+            if (filterTeam && procTeam !== filterTeam) continue;
+
+            const pidMatch = line.match(/,(\d+)\s*$/);
+            if (pidMatch) {
+              orphans.push({ pid: parseInt(pidMatch[1], 10), team: procTeam, cmd: line.trim() });
+            }
+          }
+        }
+      }
+    } else {
+      // Unix (macOS / Linux): use ps
+      const output = execSync('ps aux', { encoding: 'utf-8', timeout: 10000 });
+
+      for (const line of output.split('\n')) {
+        // Match claude agent processes with team context
+        if ((line.includes('claude') || line.includes('node')) &&
+            (line.includes('--team-name') || line.includes('team_name'))) {
+
+          // Restrict team name match to valid slug characters
+          const match = line.match(/--team-name[=\s]+([\w][\w-]{0,63})/i) || line.match(/team_name[=:]\s*"?([\w][\w-]{0,63})"?/i);
+          if (match) {
+            const procTeam = match[1];
+            if (filterTeam && procTeam !== filterTeam) continue;
+
+            const parts = line.trim().split(/\s+/);
+            const pid = parseInt(parts[1], 10);
+            if (pid && pid !== process.pid && pid !== process.ppid) {
+              orphans.push({ pid, team: procTeam, cmd: line.trim().substring(0, 200) });
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // ps/wmic failed — can't detect orphans
+  }
+
+  return orphans;
+}
+
+/**
+ * Check if a team's config still exists (i.e., team is still active).
+ */
+function teamConfigExists(name) {
+  const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+  const configPath = join(configDir, 'teams', name, 'config.json');
+  return existsSync(configPath);
+}
+
+/**
+ * Kill a process: SIGTERM first, SIGKILL after 5s if still alive.
+ */
+function killProcess(pid) {
+  // Validate PID is a positive integer (prevent command injection)
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+
+  try {
+    if (process.platform === 'win32') {
+      execSync(`taskkill /PID ${pid} /F`, { timeout: 10000 });
+    } else {
+      // Send SIGTERM
+      process.kill(pid, 'SIGTERM');
+
+      // Wait 5s, then SIGKILL if still alive
+      setTimeout(() => {
+        try {
+          process.kill(pid, 0); // Check if still running
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // Process already exited
+        }
+      }, 5000);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  const processes = findOrphanProcesses(teamName);
+
+  if (processes.length === 0) {
+    console.log(JSON.stringify({
+      orphans: 0,
+      message: teamName
+        ? `No orphan processes found for team "${teamName}".`
+        : 'No orphan agent processes found.',
+    }));
+    process.exit(0);
+  }
+
+  // Filter to actual orphans: processes whose team config no longer exists
+  const orphans = processes.filter(p => !teamConfigExists(p.team));
+
+  if (orphans.length === 0) {
+    console.log(JSON.stringify({
+      orphans: 0,
+      message: `Found ${processes.length} team process(es) but all have active team configs.`,
+    }));
+    process.exit(0);
+  }
+
+  const results = [];
+
+  for (const orphan of orphans) {
+    if (dryRun) {
+      results.push({ pid: orphan.pid, team: orphan.team, action: 'would_kill' });
+      console.error(`[dry-run] Would kill PID ${orphan.pid} (team: ${orphan.team})`);
+    } else {
+      const killed = killProcess(orphan.pid);
+      results.push({ pid: orphan.pid, team: orphan.team, action: killed ? 'killed' : 'failed' });
+      console.error(`[cleanup] ${killed ? 'Killed' : 'Failed to kill'} PID ${orphan.pid} (team: ${orphan.team})`);
+    }
+  }
+
+  console.log(JSON.stringify({
+    orphans: orphans.length,
+    dryRun,
+    results,
+    message: dryRun
+      ? `Found ${orphans.length} orphan(s). Re-run without --dry-run to clean up.`
+      : `Cleaned up ${results.filter(r => r.action === 'killed').length}/${orphans.length} orphan(s).`,
+  }));
+}
+
+main();

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -169,8 +169,23 @@ After graceful pass:
   3. Check for linked ralph: state_read(mode="ralph") — if linked_team is true:
      a. Clear ralph state: state_clear(mode="ralph")
      b. Clear linked ultrawork if present: state_clear(mode="ultrawork")
-  4. Emit structured cancel report
+  4. Run orphan scan (see below)
+  5. Emit structured cancel report
 ```
+
+**Orphan Detection (Post-Cleanup):**
+
+After TeamDelete, verify no agent processes remain:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-orphans.mjs" --team-name "{team_name}"
+```
+
+The orphan scanner:
+1. Checks `ps aux` (Unix) or `tasklist` (Windows) for processes with `--team-name` matching the deleted team
+2. For each orphan whose team config no longer exists: sends SIGTERM, waits 5s, sends SIGKILL if still alive
+3. Reports cleanup results as JSON
+
+Use `--dry-run` to inspect without killing. The scanner is safe to run multiple times.
 
 **Structured Cancel Report:**
 ```

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -471,7 +471,16 @@ Do NOT mark the task as completed. Leave it in_progress so the lead can reassign
 }
 ```
 
-### Shutdown Protocol
+### Shutdown Protocol (BLOCKING)
+
+**CRITICAL: Steps must execute in exact order. Never call TeamDelete before shutdown is confirmed.**
+
+**Step 1: Verify completion**
+```
+Call TaskList — verify all real tasks (non-internal) are completed or failed.
+```
+
+**Step 2: Request shutdown from each teammate**
 
 **Lead sends:**
 ```json
@@ -481,6 +490,11 @@ Do NOT mark the task as completed. Leave it in_progress so the lead can reassign
   "content": "All work complete, shutting down team"
 }
 ```
+
+**Step 3: Wait for responses (BLOCKING)**
+- Wait up to 30s per teammate for `shutdown_response`
+- Track which teammates confirmed vs timed out
+- If a teammate doesn't respond within 30s: log warning, mark as unresponsive
 
 **Teammate receives and responds:**
 ```json
@@ -495,6 +509,24 @@ After approval:
 - Teammate process terminates
 - Teammate auto-removed from `config.json` members array
 - Internal task for that teammate completes
+
+**Step 4: TeamDelete — only after ALL teammates confirmed or timed out**
+```json
+{ "team_name": "fix-ts-errors" }
+```
+
+**Step 5: Orphan scan**
+
+Check for agent processes that survived TeamDelete:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-orphans.mjs" --team-name fix-ts-errors
+```
+
+This scans for processes matching the team name whose config no longer exists, and terminates them (SIGTERM → 5s wait → SIGKILL). Supports `--dry-run` for inspection.
+
+**Shutdown sequence is BLOCKING:** Do not proceed to TeamDelete until all teammates have either:
+- Confirmed shutdown (`shutdown_response` with `approve: true`), OR
+- Timed out (30s with no response)
 
 **IMPORTANT:** The `request_id` is provided in the shutdown request message that the teammate receives. The teammate must extract it and pass it back. Do NOT fabricate request IDs.
 


### PR DESCRIPTION
## Problem

OMC's cancel skill sends `shutdown_request` but doesn't reliably wait for responses. `TeamDelete` can fire before agents confirm, creating orphan processes — agent OS processes that continue running after their team config is deleted. There is no mechanism to detect or clean up these orphans.

## Solution

### Blocking Shutdown Protocol (`skills/team/SKILL.md`)

Rewrites the Shutdown Protocol section to be explicitly **blocking** with ordered steps:

1. **Verify completion** — `TaskList` confirms all tasks are terminal
2. **Request shutdown** — `shutdown_request` to each teammate
3. **WAIT for responses** — 30s timeout per teammate (blocking)
4. **TeamDelete** — only after all confirmed or timed out
5. **Orphan scan** — catch any leaked processes post-deletion

Key rule: `TeamDelete` must **never** fire before all teammates have either confirmed shutdown or timed out.

### Orphan Detection (`scripts/cleanup-orphans.mjs`)

New standalone utility that:
- Scans `ps aux` (Unix) or WMIC (Windows) for agent processes with `--team-name` context
- Checks if each process's team config still exists in `~/.claude/teams/`
- If config is gone → orphan. Sends SIGTERM, waits 5s, SIGKILL if still alive
- Outputs JSON results for programmatic consumption
- Supports `--team-name <name>` filter and `--dry-run` inspection mode

### Cancel Skill Enhancement (`skills/cancel/SKILL.md`)

Adds Orphan Detection (Post-Cleanup) step to the TeamDelete + Cleanup flow. After TeamDelete, the cancel skill now runs `cleanup-orphans.mjs` as a safety net.

## Files Changed
- `skills/team/SKILL.md` — Rewrite Shutdown Protocol section
- `skills/cancel/SKILL.md` — Add orphan detection step
- `scripts/cleanup-orphans.mjs` — NEW orphan scanner utility

## Verification
- `node --check scripts/cleanup-orphans.mjs` passes
- No existing hooks or compiled code modified
- SKILL.md changes are additive (expand existing section, don't remove content)