### PR TITLE
docs(rules): add Karpathy coding guidelines template

### DIFF
--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -1114,3 +1114,24 @@ EXAMPLES:
 
 For more info: https://github.com/Yeachan-Heo/oh-my-claudecode
 ```
+
+## Optional Rule Templates
+
+OMC includes rule templates you can copy to your project's `.claude/rules/` directory for automatic context injection:
+
+| Template | Purpose |
+|----------|---------|
+| `coding-style.md` | Code style, immutability, file organization |
+| `testing.md` | TDD workflow, 80% coverage target |
+| `security.md` | Secret management, input validation |
+| `performance.md` | Model selection, context management |
+| `git-workflow.md` | Commit conventions, PR workflow |
+| `karpathy-guidelines.md` | Coding discipline — think before coding, simplicity, surgical changes |
+
+Copy with:
+```bash
+mkdir -p .claude/rules
+cp "${CLAUDE_PLUGIN_ROOT}/templates/rules/"*.md .claude/rules/
+```
+
+See `templates/rules/README.md` for details.

--- a/templates/rules/README.md
+++ b/templates/rules/README.md
@@ -18,6 +18,7 @@ This directory contains rule templates that you can copy to your project's `.cla
 | `security.md` | Security checklist and best practices |
 | `performance.md` | Performance guidelines and model selection |
 | `git-workflow.md` | Git commit and PR workflow |
+| `karpathy-guidelines.md` | Coding discipline — think before coding, simplicity, surgical changes |
 
 ## Auto-Discovery
 

--- a/templates/rules/karpathy-guidelines.md
+++ b/templates/rules/karpathy-guidelines.md
@@ -1,0 +1,59 @@
+# Karpathy Coding Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls. These principles bias toward caution over speed — for trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.


### PR DESCRIPTION
## Problem

OMC has no coding discipline guidelines for LLM agents. LLMs tend to overengineer, add speculative features, make unnecessary changes to adjacent code, and lack clear completion criteria. These are the exact pitfalls Andrej Karpathy identified in his observations on LLM coding behavior.

## Solution

Add `templates/rules/karpathy-guidelines.md` with four principles:

1. **Think Before Coding** — State assumptions explicitly, surface tradeoffs, ask when uncertain
2. **Simplicity First** — Minimum code that solves the problem, nothing speculative
3. **Surgical Changes** — Touch only what you must, match existing style, clean up only your own mess
4. **Goal-Driven Execution** — Define success criteria, transform tasks into verifiable goals

These guidelines are most effective when placed in a project's `.claude/rules/` directory where they're auto-injected into every agent's context.

Also adds an "Optional Rule Templates" section to `skills/omc-setup/SKILL.md` that lists all available rule templates with copy instructions. This makes template discovery easier during setup.

## Files Changed
- `templates/rules/karpathy-guidelines.md` — NEW rule template
- `templates/rules/README.md` — Add new template to table
- `skills/omc-setup/SKILL.md` — Add template listing section

## Attribution
Based on Andrej Karpathy's observations on LLM coding pitfalls, adapted for OMC's agent context.