### PR TITLE
fix(hooks): register omc as alias namespace for slash commands (#785)

### DIFF
--- a/src/__tests__/omc-shorthand.test.ts
+++ b/src/__tests__/omc-shorthand.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { isExcludedCommand, detectSlashCommand } from '../hooks/auto-slash-command/detector.js';
+import { processHook } from '../hooks/bridge.js';
+
+describe('omc: namespace shorthand (issue #785)', () => {
+  describe('auto-slash-command exclusion', () => {
+    it('should exclude bare "omc" command from auto-expansion', () => {
+      // /omc:autopilot is parsed as command="omc" by SLASH_COMMAND_PATTERN
+      // because ":" is not matched by [\w-]
+      expect(isExcludedCommand('omc')).toBe(true);
+    });
+
+    it('should exclude omc: prefixed commands from auto-expansion', () => {
+      expect(isExcludedCommand('omc:ralplan')).toBe(true);
+      expect(isExcludedCommand('omc:ultraqa')).toBe(true);
+      expect(isExcludedCommand('omc:learner')).toBe(true);
+      expect(isExcludedCommand('omc:plan')).toBe(true);
+      expect(isExcludedCommand('omc:cancel')).toBe(true);
+    });
+
+    it('should return null for /omc:* slash commands in detectSlashCommand', () => {
+      // /omc:autopilot should not be detected as an auto-slash command
+      // because "omc" is excluded
+      const result = detectSlashCommand('/omc:autopilot some args');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('bridge processPreToolUse - Skill tool omc: rewrite', () => {
+    it('should inject alias correction when Skill tool uses omc: prefix', async () => {
+      const result = await processHook('pre-tool-use', {
+        toolName: 'Skill',
+        toolInput: { skill: 'omc:autopilot' },
+        directory: process.cwd(),
+      });
+
+      expect(result.continue).toBe(true);
+      expect(result.message).toContain('oh-my-claudecode:autopilot');
+      expect(result.message).toContain('OMC NAMESPACE ALIAS');
+    });
+
+    it('should inject alias correction for various omc: skill names', async () => {
+      for (const skillName of ['ralph', 'cancel', 'team', 'ultrawork', 'plan']) {
+        const result = await processHook('pre-tool-use', {
+          toolName: 'Skill',
+          toolInput: { skill: `omc:${skillName}` },
+          directory: process.cwd(),
+        });
+
+        expect(result.continue).toBe(true);
+        expect(result.message).toContain(`oh-my-claudecode:${skillName}`);
+      }
+    });
+
+    it('should not intercept Skill tool with oh-my-claudecode: prefix', async () => {
+      const result = await processHook('pre-tool-use', {
+        toolName: 'Skill',
+        toolInput: { skill: 'oh-my-claudecode:autopilot' },
+        directory: process.cwd(),
+      });
+
+      // Should pass through to normal pre-tool-use processing
+      expect(result.continue).toBe(true);
+      // Should NOT contain the alias correction message
+      if (result.message) {
+        expect(result.message).not.toContain('OMC NAMESPACE ALIAS');
+      }
+    });
+
+    it('should not intercept non-Skill tool calls', async () => {
+      const result = await processHook('pre-tool-use', {
+        toolName: 'Bash',
+        toolInput: { command: 'echo test' },
+        directory: process.cwd(),
+      });
+
+      expect(result.continue).toBe(true);
+      if (result.message) {
+        expect(result.message).not.toContain('OMC NAMESPACE ALIAS');
+      }
+    });
+  });
+});

--- a/src/hooks/auto-slash-command/constants.ts
+++ b/src/hooks/auto-slash-command/constants.ts
@@ -26,6 +26,12 @@ export const EXCLUDED_COMMANDS = new Set([
   'oh-my-claudecode:learner',
   'oh-my-claudecode:plan',
   'oh-my-claudecode:cancel',
+  // omc: shorthand aliases (issue #785)
+  'omc:ralplan',
+  'omc:ultraqa',
+  'omc:learner',
+  'omc:plan',
+  'omc:cancel',
   // Claude Code built-in commands that shouldn't be expanded
   'help',
   'clear',

--- a/src/hooks/auto-slash-command/detector.ts
+++ b/src/hooks/auto-slash-command/detector.ts
@@ -49,7 +49,14 @@ export function parseSlashCommand(text: string): ParsedSlashCommand | null {
  * Check if a command should be excluded from auto-expansion
  */
 export function isExcludedCommand(command: string): boolean {
-  return EXCLUDED_COMMANDS.has(command.toLowerCase());
+  const lower = command.toLowerCase();
+  // Exclude commands in the explicit set
+  if (EXCLUDED_COMMANDS.has(lower)) return true;
+  // Exclude 'omc' bare command — /omc:skillname is parsed as command='omc'
+  // by SLASH_COMMAND_PATTERN since ':' is not in [\w-]. These are handled
+  // by the keyword-detector as omc: namespace alias (issue #785).
+  if (lower === 'omc') return true;
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `/omc:*` shorthand support so `/omc:autopilot` resolves to `/oh-my-claudecode:autopilot`
- Fix operates at three layers: UserPromptSubmit keyword-detector, PreToolUse Skill rewrite, and auto-slash-command exclusion
- Includes 7 new tests covering all alias resolution paths

## Changes

### `templates/hooks/keyword-detector.mjs`
- Detects `/omc:skillname` pattern early in the UserPromptSubmit hook
- Generates MAGIC KEYWORD invocation with full `oh-my-claudecode:skillname` prefix
- Handles state activation for persistent modes (ralph, autopilot, team, ultrawork)

### `templates/hooks/pre-tool-use.mjs` + `src/hooks/bridge.ts`
- When `Skill` tool is called with `omc:` prefix, injects context message correcting to `oh-my-claudecode:` prefix
- Fallback layer in case the model generates `Skill(skill="omc:...")` directly

### `src/hooks/auto-slash-command/detector.ts` + `constants.ts`
- Excludes bare `omc` command from auto-expansion (since `/omc:X` is parsed as command=`omc` by the slash command regex where `:` breaks the `[\w-]` pattern)
- Adds `omc:` prefixed exclusions to EXCLUDED_COMMANDS set

### `src/__tests__/omc-shorthand.test.ts`
- Tests auto-slash-command exclusion for `omc` and `omc:*` patterns
- Tests bridge processPreToolUse Skill tool alias rewriting
- Tests that `oh-my-claudecode:` prefix passes through unchanged

## Test plan
- [x] 7 new unit tests pass (`npx vitest run src/__tests__/omc-shorthand.test.ts`)
- [x] 143 existing tests pass (`hooks.test.ts` + `auto-slash-aliases.test.ts`)
- [x] TypeScript type check clean (`npx tsc --noEmit`)

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)