### PR TITLE
fix(hooks): dedup plugin hooks, remove ~/.claude/hooks installer path

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -106,6 +106,18 @@
         ]
       }
     ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use-failure.mjs\"",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "matcher": "*",
@@ -164,6 +176,11 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/persistent-mode.cjs\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/code-simplifier.mjs\"",
             "timeout": 5
           }
         ]

--- a/scripts/code-simplifier.mjs
+++ b/scripts/code-simplifier.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+/**
+ * OMC Code Simplifier Stop Hook (Node.js)
+ *
+ * Intercepts Stop events to automatically delegate recently modified source files
+ * to the code-simplifier agent for cleanup and simplification.
+ *
+ * Opt-in via ~/.omc/config.json: { "codeSimplifier": { "enabled": true } }
+ * Default: disabled (must explicitly opt in)
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  unlinkSync,
+} from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { execSync } from 'child_process';
+import { readStdin } from './lib/stdin.mjs';
+
+const DEFAULT_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs'];
+const DEFAULT_MAX_FILES = 10;
+const MARKER_FILENAME = 'code-simplifier-triggered.marker';
+
+function readJsonFile(filePath) {
+  try {
+    if (!existsSync(filePath)) return null;
+    return JSON.parse(readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function readOmcConfig() {
+  return readJsonFile(join(homedir(), '.omc', 'config.json'));
+}
+
+function isEnabled(config) {
+  return config?.codeSimplifier?.enabled === true;
+}
+
+function getModifiedFiles(cwd, extensions, maxFiles) {
+  try {
+    const output = execSync('git diff HEAD --name-only', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+
+    return output
+      .trim()
+      .split('\n')
+      .filter((f) => f.trim().length > 0)
+      .filter((f) => extensions.some((ext) => f.endsWith(ext)))
+      .slice(0, maxFiles);
+  } catch {
+    return [];
+  }
+}
+
+function buildMessage(files) {
+  const fileList = files.map((f) => `  - ${f}`).join('\n');
+  const fileArgs = files.join('\\n');
+  return (
+    `[CODE SIMPLIFIER] Recently modified files detected. Delegate to the ` +
+    `code-simplifier agent to simplify the following files for clarity, ` +
+    `consistency, and maintainability (without changing behavior):\n\n` +
+    `${fileList}\n\n` +
+    `Use: Task(subagent_type="oh-my-claudecode:code-simplifier", ` +
+    `prompt="Simplify the recently modified files:\\n${fileArgs}")`
+  );
+}
+
+async function main() {
+  try {
+    const input = await readStdin();
+    let data = {};
+    try {
+      data = JSON.parse(input);
+    } catch {
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+      return;
+    }
+
+    const cwd = data.cwd || data.directory || process.cwd();
+    const stateDir = join(cwd, '.omc', 'state');
+    const config = readOmcConfig();
+
+    if (!isEnabled(config)) {
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+      return;
+    }
+
+    const markerPath = join(stateDir, MARKER_FILENAME);
+
+    // If already triggered this turn, clear marker and allow stop
+    if (existsSync(markerPath)) {
+      try {
+        unlinkSync(markerPath);
+      } catch {
+        // ignore
+      }
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+      return;
+    }
+
+    const extensions = config?.codeSimplifier?.extensions ?? DEFAULT_EXTENSIONS;
+    const maxFiles = config?.codeSimplifier?.maxFiles ?? DEFAULT_MAX_FILES;
+    const files = getModifiedFiles(cwd, extensions, maxFiles);
+
+    if (files.length === 0) {
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+      return;
+    }
+
+    // Write trigger marker to prevent re-triggering within this turn cycle
+    try {
+      if (!existsSync(stateDir)) {
+        mkdirSync(stateDir, { recursive: true });
+      }
+      writeFileSync(markerPath, new Date().toISOString(), 'utf-8');
+    } catch {
+      // best-effort — proceed even if marker write fails
+    }
+
+    process.stdout.write(
+      JSON.stringify({ decision: 'block', reason: buildMessage(files) }) + '\n',
+    );
+  } catch (error) {
+    try {
+      process.stderr.write(`[code-simplifier] Error: ${error?.message || error}\n`);
+    } catch {
+      // ignore
+    }
+    try {
+      process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+    } catch {
+      process.exit(0);
+    }
+  }
+}
+
+process.on('uncaughtException', (error) => {
+  try {
+    process.stderr.write(`[code-simplifier] Uncaught: ${error?.message || error}\n`);
+  } catch {
+    // ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+  } catch {
+    // ignore
+  }
+  process.exit(0);
+});
+
+process.on('unhandledRejection', (error) => {
+  try {
+    process.stderr.write(`[code-simplifier] Unhandled: ${error?.message || error}\n`);
+  } catch {
+    // ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+  } catch {
+    // ignore
+  }
+  process.exit(0);
+});
+
+// Safety timeout: force exit after 10 seconds to prevent hook from hanging
+const safetyTimeout = setTimeout(() => {
+  try {
+    process.stderr.write('[code-simplifier] Safety timeout reached, forcing exit\n');
+  } catch {
+    // ignore
+  }
+  try {
+    process.stdout.write(JSON.stringify({ continue: true }) + '\n');
+  } catch {
+    // ignore
+  }
+  process.exit(0);
+}, 10000);
+
+main().finally(() => {
+  clearTimeout(safetyTimeout);
+});

--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -1,0 +1,95 @@
+/**
+ * Atomic file writes for oh-my-claudecode hooks.
+ * Self-contained module with no external dependencies.
+ *
+ * Mirrors templates/hooks/lib/atomic-write.mjs for use by plugin hook scripts.
+ */
+
+import { openSync, writeSync, fsyncSync, closeSync, renameSync, unlinkSync, mkdirSync, existsSync } from 'fs';
+import { dirname, basename, join } from 'path';
+import { randomUUID } from 'crypto';
+
+/**
+ * Ensure directory exists
+ */
+export function ensureDirSync(dir) {
+  if (existsSync(dir)) {
+    return;
+  }
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch (err) {
+    if (err.code === 'EEXIST') {
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Write string content atomically to a file.
+ * Uses temp file + atomic rename pattern with fsync for durability.
+ *
+ * @param {string} filePath Target file path
+ * @param {string} content String content to write
+ */
+export function atomicWriteFileSync(filePath, content) {
+  const dir = dirname(filePath);
+  const base = basename(filePath);
+  const tempPath = join(dir, `.${base}.tmp.${randomUUID()}`);
+
+  let fd = null;
+  let success = false;
+
+  try {
+    // Ensure parent directory exists
+    ensureDirSync(dir);
+
+    // Open temp file with exclusive creation (O_CREAT | O_EXCL | O_WRONLY)
+    fd = openSync(tempPath, 'wx', 0o600);
+
+    // Write content
+    writeSync(fd, content, 0, 'utf-8');
+
+    // Sync file data to disk before rename
+    fsyncSync(fd);
+
+    // Close before rename
+    closeSync(fd);
+    fd = null;
+
+    // Atomic rename - replaces target file if it exists
+    renameSync(tempPath, filePath);
+
+    success = true;
+
+    // Best-effort directory fsync to ensure rename is durable
+    try {
+      const dirFd = openSync(dir, 'r');
+      try {
+        fsyncSync(dirFd);
+      } finally {
+        closeSync(dirFd);
+      }
+    } catch {
+      // Some platforms don't support directory fsync - that's okay
+    }
+  } finally {
+    // Close fd if still open
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Ignore close errors
+      }
+    }
+    // Clean up temp file on error
+    if (!success) {
+      try {
+        unlinkSync(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}

--- a/scripts/post-tool-use-failure.mjs
+++ b/scripts/post-tool-use-failure.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// OMC Post-Tool-Use-Failure Hook (Node.js)
+// Tracks tool failures for retry guidance in Stop hook
+// Writes last-tool-error.json with tool name, input preview, error, and retry count
+
+import { existsSync, readFileSync, mkdirSync } from 'fs';
+import { join, sep, resolve } from 'path';
+import { readStdin } from './lib/stdin.mjs';
+import { atomicWriteFileSync } from './lib/atomic-write.mjs';
+
+// Constants
+const RETRY_WINDOW_MS = 60000; // 60 seconds
+const MAX_ERROR_LENGTH = 500;
+const MAX_INPUT_PREVIEW_LENGTH = 200;
+
+// Validate that targetPath is contained within basePath (prevent path traversal)
+function isPathContained(targetPath, basePath) {
+  const normalizedTarget = resolve(targetPath);
+  const normalizedBase = resolve(basePath);
+  return normalizedTarget.startsWith(normalizedBase + sep) || normalizedTarget === normalizedBase;
+}
+
+// Initialize .omc directory if needed
+function initOmcDir(directory) {
+  const cwd = process.cwd();
+  // Validate directory is contained within cwd
+  if (!isPathContained(directory, cwd)) {
+    // Fallback to cwd if directory attempts traversal
+    directory = cwd;
+  }
+  const omcDir = join(directory, '.omc');
+  const stateDir = join(omcDir, 'state');
+
+  if (!existsSync(omcDir)) {
+    try { mkdirSync(omcDir, { recursive: true }); } catch {}
+  }
+  if (!existsSync(stateDir)) {
+    try { mkdirSync(stateDir, { recursive: true }); } catch {}
+  }
+
+  return stateDir;
+}
+
+// Truncate string to max length
+function truncate(str, maxLength) {
+  if (!str) return '';
+  const text = String(str);
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + '...';
+}
+
+// Create input preview from tool_input
+function createInputPreview(toolInput) {
+  if (!toolInput) return '';
+
+  try {
+    // If it's an object, stringify it
+    const inputStr = typeof toolInput === 'string' ? toolInput : JSON.stringify(toolInput);
+    return truncate(inputStr, MAX_INPUT_PREVIEW_LENGTH);
+  } catch {
+    return truncate(String(toolInput), MAX_INPUT_PREVIEW_LENGTH);
+  }
+}
+
+// Read existing error state
+function readErrorState(statePath) {
+  try {
+    if (!existsSync(statePath)) return null;
+    const content = readFileSync(statePath, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+// Calculate retry count
+function calculateRetryCount(existingState, toolName, currentTime) {
+  if (!existingState || existingState.tool_name !== toolName) {
+    return 1; // First failure for this tool
+  }
+
+  const lastErrorTime = new Date(existingState.timestamp).getTime();
+  // Guard against NaN from invalid timestamps
+  if (!Number.isFinite(lastErrorTime)) {
+    return 1; // Treat as first failure if timestamp is invalid
+  }
+  const timeDiff = currentTime - lastErrorTime;
+
+  if (timeDiff > RETRY_WINDOW_MS) {
+    return 1; // Outside retry window, reset count
+  }
+
+  return (existingState.retry_count || 1) + 1;
+}
+
+// Write error state
+function writeErrorState(stateDir, toolName, toolInputPreview, error, retryCount) {
+  const statePath = join(stateDir, 'last-tool-error.json');
+
+  const errorState = {
+    tool_name: toolName,
+    tool_input_preview: toolInputPreview,
+    error: truncate(error, MAX_ERROR_LENGTH),
+    timestamp: new Date().toISOString(),
+    retry_count: retryCount,
+  };
+
+  try {
+    atomicWriteFileSync(statePath, JSON.stringify(errorState, null, 2));
+  } catch {}
+}
+
+async function main() {
+  try {
+    const input = await readStdin();
+    const data = JSON.parse(input);
+
+    // Official SDK fields (snake_case)
+    const toolName = data.tool_name || '';
+    const toolInput = data.tool_input;
+    const error = data.error || '';
+    const isInterrupt = data.is_interrupt || false;
+    const directory = data.cwd || data.directory || process.cwd();
+
+    // Ignore user interrupts
+    if (isInterrupt) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    // Skip if no tool name or error
+    if (!toolName || !error) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    // Initialize .omc/state directory
+    const stateDir = initOmcDir(directory);
+    const statePath = join(stateDir, 'last-tool-error.json');
+
+    // Read existing state and calculate retry count
+    const existingState = readErrorState(statePath);
+    const currentTime = Date.now();
+    const retryCount = calculateRetryCount(existingState, toolName, currentTime);
+
+    // Create input preview
+    const inputPreview = createInputPreview(toolInput);
+
+    // Write error state
+    writeErrorState(stateDir, toolName, inputPreview, error, retryCount);
+
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  } catch (error) {
+    // Never block on hook errors
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  }
+}
+
+main();

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -411,6 +411,10 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
 
 /**
  * Get the hooks settings config (Node.js only).
+ *
+ * @deprecated Hooks are now delivered via the plugin's hooks/hooks.json.
+ * settings.json hook entries are no longer written by the installer.
+ * Kept for test compatibility only.
  */
 export function getHooksSettingsConfig(): typeof HOOKS_SETTINGS_CONFIG_NODE {
   return HOOKS_SETTINGS_CONFIG_NODE;
@@ -423,6 +427,10 @@ export function getHooksSettingsConfig(): typeof HOOKS_SETTINGS_CONFIG_NODE {
 /**
  * Get Node.js hook scripts (Cross-platform)
  * Returns a record of filename -> content for all Node.js hooks
+ *
+ * @deprecated Hook scripts are no longer installed to ~/.claude/hooks/.
+ * All hooks are delivered via the plugin's hooks/hooks.json + scripts/.
+ * Kept for test compatibility only.
  */
 export function getHookScripts(): Record<string, string> {
   return {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -14,8 +14,6 @@ import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
 import {
-  getHookScripts,
-  getHooksSettingsConfig,
   isWindows,
   MIN_NODE_VERSION
 } from './hooks.js';
@@ -551,50 +549,10 @@ export function install(options: InstallOptions = {}): InstallResult {
         log('CLAUDE.md exists in home directory, skipping');
       }
 
-      // Install hook scripts
-      const hookScripts = getHookScripts();
-      log('Installing hook scripts...');
-
-      for (const [filename, content] of Object.entries(hookScripts)) {
-        const filepath = join(HOOKS_DIR, filename);
-        // Create subdirectory if needed (e.g., lib/)
-        const dir = dirname(filepath);
-        if (!existsSync(dir)) {
-          mkdirSync(dir, { recursive: true });
-        }
-        if (existsSync(filepath) && !options.force) {
-          log(`  Skipping ${filename} (already exists)`);
-        } else {
-          writeFileSync(filepath, content);
-          // Make script executable (skip on Windows - not needed)
-          if (!isWindows()) {
-            chmodSync(filepath, 0o755);
-          }
-          log(`  Installed ${filename}`);
-        }
-      }
-
-      // Note: hooks configuration is deferred to consolidated settings.json write below
-      result.hooksConfigured = true; // Will be set properly after consolidated write
-    } else if (allowPluginHookRefresh) {
-      // Refresh hooks in plugin context when explicitly requested (global plugin only)
-      log('Refreshing hook scripts for plugin reconciliation...');
-      if (!existsSync(HOOKS_DIR)) {
-        mkdirSync(HOOKS_DIR, { recursive: true });
-      }
-      const hookScripts = getHookScripts();
-      for (const [filename, content] of Object.entries(hookScripts)) {
-        const filepath = join(HOOKS_DIR, filename);
-        const dir = dirname(filepath);
-        if (!existsSync(dir)) {
-          mkdirSync(dir, { recursive: true });
-        }
-        writeFileSync(filepath, content);
-        if (!isWindows()) {
-          chmodSync(filepath, 0o755);
-        }
-      }
-      result.hooksConfigured = true;
+      // Note: hook scripts are no longer installed to ~/.claude/hooks/.
+      // All hooks are delivered via the plugin's hooks/hooks.json + scripts/.
+      // Legacy hook entries are cleaned up from settings.json below.
+      result.hooksConfigured = true; // Will be set properly after consolidated settings.json write
     } else {
       log('Skipping agent/command/hook files (managed by plugin system)');
     }
@@ -733,69 +691,35 @@ export function install(options: InstallOptions = {}): InstallResult {
         existingSettings = JSON.parse(settingsContent);
       }
 
-      // 1. Configure hooks (only if not running as plugin unless refresh requested)
-      if (!runningAsPlugin || allowPluginHookRefresh) {
-        const existingHooks = (existingSettings.hooks || {}) as Record<string, unknown>;
-        const hooksConfig = getHooksSettingsConfig();
-        const newHooks = hooksConfig.hooks;
-
-        // Merge hooks per event type:
-        //   - No force:        skip already-configured events; warn about non-OMC hooks
-        //   - --force (update): keep non-OMC groups, replace OMC groups; warn about preserved non-OMC hooks
-        //   - --force-hooks:   replace everything; warn before clobbering non-OMC hooks
+      // 1. Remove legacy ~/.claude/hooks/ entries from settings.json
+      // These were written by the old installer; hooks are now delivered via the plugin's hooks.json.
+      {
         type HookEntry = { type: string; command: string };
         type HookGroup = { hooks: HookEntry[] };
+        const existingHooks = (existingSettings.hooks || {}) as Record<string, unknown>;
+        let legacyRemoved = 0;
 
-        for (const [eventType, eventHooks] of Object.entries(newHooks)) {
-          const newOmcGroups = eventHooks as HookGroup[];
-
-          if (!existingHooks[eventType]) {
-            // No existing hooks for this event type — add OMC's directly
-            existingHooks[eventType] = newOmcGroups;
-            log(`  Added ${eventType} hook`);
-          } else {
-            const existingGroups = existingHooks[eventType] as HookGroup[];
-
-            // Partition existing groups: non-OMC groups are preserved, OMC groups are replaced
-            const nonOmcGroups = existingGroups.filter(group =>
-              group.hooks.some(h => h.type === 'command' && !isOmcHook(h.command))
+        for (const [eventType, groups] of Object.entries(existingHooks)) {
+          const groupList = groups as HookGroup[];
+          const filtered = groupList.filter(group => {
+            const isLegacy = group.hooks.every(h =>
+              h.type === 'command' && h.command.includes('/.claude/hooks/')
             );
-            const hasNonOmcHook = nonOmcGroups.length > 0;
-            const nonOmcCommand = hasNonOmcHook
-              ? nonOmcGroups[0].hooks.find(h => h.type === 'command' && !isOmcHook(h.command))?.command ?? ''
-              : '';
-
-            if (options.forceHooks && !allowPluginHookRefresh) {
-              // Explicit --force-hooks: replace everything; warn when clobbering non-OMC hooks
-              if (hasNonOmcHook) {
-                log(`  [OMC] Warning: Overwriting non-OMC ${eventType} hook with --force-hooks: ${nonOmcCommand}`);
-                result.hookConflicts.push({ eventType, existingCommand: nonOmcCommand });
-              }
-              existingHooks[eventType] = newOmcGroups;
-              log(`  Updated ${eventType} hook (--force-hooks)`);
-            } else if (options.force) {
-              // omc update path: merge — keep non-OMC groups, replace OMC groups
-              existingHooks[eventType] = [...nonOmcGroups, ...newOmcGroups];
-              if (hasNonOmcHook) {
-                log(`  Merged ${eventType} hooks (updated OMC hooks, preserved non-OMC hook: ${nonOmcCommand})`);
-                result.hookConflicts.push({ eventType, existingCommand: nonOmcCommand });
-              } else {
-                log(`  Updated ${eventType} hook (--force)`);
-              }
-            } else {
-              // No force: skip already-configured events; report non-OMC hooks
-              if (hasNonOmcHook) {
-                log(`  [OMC] Warning: ${eventType} hook has non-OMC hook. Skipping. Use --force-hooks to override.`);
-                result.hookConflicts.push({ eventType, existingCommand: nonOmcCommand });
-              } else {
-                log(`  ${eventType} hook already configured, skipping`);
-              }
-            }
+            if (isLegacy) legacyRemoved++;
+            return !isLegacy;
+          });
+          if (filtered.length === 0) {
+            delete existingHooks[eventType];
+          } else {
+            existingHooks[eventType] = filtered;
           }
         }
 
-        existingSettings.hooks = existingHooks;
-        log('  Hooks configured');
+        if (legacyRemoved > 0) {
+          log(`  Cleaned up ${legacyRemoved} legacy hook entries from settings.json`);
+        }
+
+        existingSettings.hooks = Object.keys(existingHooks).length > 0 ? existingHooks : undefined;
         result.hooksConfigured = true;
       }
 
@@ -843,8 +767,7 @@ export function install(options: InstallOptions = {}): InstallResult {
     }
 
     result.success = true;
-    const hookCount = Object.keys(getHookScripts()).length;
-    result.message = `Successfully installed ${result.installedAgents.length} agents, ${result.installedCommands.length} commands, ${result.installedSkills.length} skills, and ${hookCount} hooks`;
+    result.message = `Successfully installed ${result.installedAgents.length} agents, ${result.installedCommands.length} commands, ${result.installedSkills.length} skills (hooks delivered via plugin)`;
 
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

When OMC is installed as a plugin (`--plugin-dir`), `hooks/hooks.json` already registers all hook scripts via `${CLAUDE_PLUGIN_ROOT}/scripts/`. The installer was also writing duplicate hooks to `~/.claude/settings.json` and copying templates to `~/.claude/hooks/`, causing every hook to fire twice.

### Changes

- **`scripts/post-tool-use-failure.mjs`** (new) — moved from `templates/hooks/`, fixed static ESM imports
- **`scripts/code-simplifier.mjs`** (new) — moved from `templates/hooks/`, fixed static ESM imports (still opt-in via `~/.omc/config.json`)
- **`scripts/lib/atomic-write.mjs`** (new) — mirrored from `templates/hooks/lib/`, needed by post-tool-use-failure
- **`hooks/hooks.json`** — added `PostToolUseFailure` section + `code-simplifier.mjs` to Stop hooks
- **`src/installer/index.ts`** — removed `getHookScripts()` file writes and `getHooksSettingsConfig()` settings.json write; added migration step that strips legacy `/.claude/hooks/` entries from existing `settings.json`
- **`src/installer/hooks.ts`** — `@deprecated` JSDoc on `getHooksSettingsConfig()` and `getHookScripts()`

### Migration

On next `omc setup`, existing hook entries in `~/.claude/settings.json` pointing to `~/.claude/hooks/` are automatically removed.

## Test plan

- [ ] `echo '{}' | node scripts/post-tool-use-failure.mjs` → `{"continue":true,"suppressOutput":true}`
- [ ] `echo '{}' | node scripts/code-simplifier.mjs` → `{"continue":true}` (opt-in gate, disabled by default)
- [ ] `hooks/hooks.json` is valid JSON with PostToolUseFailure and code-simplifier entries
- [ ] Running `omc setup` cleans up old `~/.claude/settings.json` hook entries
- [ ] No hooks fire twice in a plugin session

🤖 Generated with [Claude Code](https://claude.com/claude-code)