### PR TITLE
fix(hud): use forward slashes in HUD skill Windows path example

### DIFF
--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -145,8 +145,10 @@ Read `~/.claude/settings.json`, then update/add the `statusLine` field.
 
 First, determine the correct path:
 ```bash
-node -e "const p=require('path').join(require('os').homedir(),'.claude','hud','omc-hud.mjs');console.log(JSON.stringify(p))"
+node -e "const p=require('path').join(require('os').homedir(),'.claude','hud','omc-hud.mjs').split(require('path').sep).join('/');console.log(JSON.stringify(p))"
 ```
+
+**IMPORTANT:** The command path MUST use forward slashes on all platforms. Claude Code executes statusLine commands via bash, which interprets backslashes as escape characters and breaks the path.
 
 Then set the `statusLine` field using the resolved path. On Unix it will look like:
 ```json
@@ -158,12 +160,12 @@ Then set the `statusLine` field using the resolved path. On Unix it will look li
 }
 ```
 
-On Windows it will look like:
+On Windows the path uses forward slashes (not backslashes):
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "node C:\\Users\\username\\.claude\\hud\\omc-hud.mjs"
+    "command": "node C:/Users/username/.claude/hud/omc-hud.mjs"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- The `/hud setup` skill's SKILL.md instructed LLMs to write backslash paths in `settings.json` on Windows
- Claude Code executes `statusLine` commands via bash, which interprets backslashes as escape characters, breaking the path entirely (e.g. `C:\Users` becomes `C:Users`)
- Use `split(path.sep).join('/')` in the `node -e` command and update the Windows example to use forward slashes

This complements the code-level fixes in #759, #771, #775 which normalized paths in `installer/index.ts` and `plugin-setup.mjs` but missed the LLM-facing skill documentation.

Related: #758

## Changes
- `skills/hud/SKILL.md`: Normalize path output with `split(path.sep).join('/')` in `node -e` command
- `skills/hud/SKILL.md`: Change Windows example from `C:\Users\...` to `C:/Users/...`
- `skills/hud/SKILL.md`: Add IMPORTANT note explaining why forward slashes are required

## Test plan
- [ ] Run `/hud setup` on Windows and verify `settings.json` gets forward-slash path
- [ ] Run `/hud setup` on Unix and verify behavior unchanged
- [ ] Verify HUD renders after restart with the generated path