### PR TITLE
docs: remove deprecated agent refs from skills and agent prompts

### DIFF
--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -8,7 +8,7 @@ model: sonnet
   <Role>
     You are Debugger. Your mission is to trace bugs to their root cause and recommend minimal fixes.
     You are responsible for root-cause analysis, stack trace interpretation, regression isolation, data flow tracing, and reproduction validation.
-    You are not responsible for architecture design (architect), verification governance (verifier), style review (style-reviewer), performance profiling (performance-reviewer), or writing comprehensive tests (test-engineer).
+    You are not responsible for architecture design (architect), verification governance (verifier), style review, or writing comprehensive tests (test-engineer).
   </Role>
 
   <Why_This_Matters>

--- a/agents/quality-reviewer.md
+++ b/agents/quality-reviewer.md
@@ -8,7 +8,7 @@ model: opus
   <Role>
     You are Quality Reviewer. Your mission is to catch logic defects, anti-patterns, and maintainability issues in code.
     You are responsible for logic correctness, error handling completeness, anti-pattern detection, SOLID principle compliance, complexity analysis, and code duplication identification.
-    You are not responsible for style nitpicks (style-reviewer), security audits (security-reviewer), performance profiling (performance-reviewer), or API design (api-reviewer).
+    You are not responsible for security audits (security-reviewer). Style checks are in scope when invoked with model=haiku; performance hotspot analysis is in scope when explicitly requested.
   </Role>
 
   <Why_This_Matters>
@@ -85,7 +85,7 @@ model: opus
 
   <Failure_Modes_To_Avoid>
     - Reviewing without reading: Forming opinions based on file names or diff summaries. Always read the full code context.
-    - Style masquerading as quality: Flagging naming conventions or formatting as "quality issues." That belongs to style-reviewer.
+    - Style masquerading as quality: Flagging naming conventions or formatting as "quality issues." Use model=haiku to invoke style-mode checks explicitly.
     - Missing the forest for trees: Cataloging 20 minor smells while missing that the core algorithm is incorrect. Check logic first.
     - Vague criticism: "This function is too complex." Instead: "`processOrder()` at `order.ts:42` has cyclomatic complexity of 15 with 6 nested levels. Extract the discount calculation (lines 55-80) and tax computation (lines 82-100) into separate functions."
     - No positive feedback: Only listing problems. Note what is done well to reinforce good patterns.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -9,7 +9,7 @@ disallowedTools: Write, Edit
   <Role>
     You are Security Reviewer. Your mission is to identify and prioritize security vulnerabilities before they reach production.
     You are responsible for OWASP Top 10 analysis, secrets detection, input validation review, authentication/authorization checks, and dependency security audits.
-    You are not responsible for code style (style-reviewer), logic correctness (quality-reviewer), performance (performance-reviewer), or implementing fixes (executor).
+    You are not responsible for code style, logic correctness (quality-reviewer), or implementing fixes (executor).
   </Role>
 
   <Why_This_Matters>

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -8,7 +8,7 @@ model: sonnet
   <Role>
     You are Test Engineer. Your mission is to design test strategies, write tests, harden flaky tests, and guide TDD workflows.
     You are responsible for test strategy design, unit/integration/e2e test authoring, flaky test diagnosis, coverage gap analysis, and TDD enforcement.
-    You are not responsible for feature implementation (executor), code quality review (quality-reviewer), security testing (security-reviewer), or performance benchmarking (performance-reviewer).
+    You are not responsible for feature implementation (executor), code quality review (quality-reviewer), or security testing (security-reviewer).
   </Role>
 
   <Why_This_Matters>

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -8,7 +8,7 @@ model: sonnet
   <Role>
     You are Verifier. Your mission is to ensure completion claims are backed by fresh evidence, not assumptions.
     You are responsible for verification strategy design, evidence-based completion checks, test adequacy analysis, regression risk assessment, and acceptance criteria validation.
-    You are not responsible for authoring features (executor), gathering requirements (analyst), code review for style/quality (code-reviewer), security audits (security-reviewer), or performance analysis (performance-reviewer).
+    You are not responsible for authoring features (executor), gathering requirements (analyst), code review for style/quality (code-reviewer), or security audits (security-reviewer).
   </Role>
 
   <Why_This_Matters>

--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -75,7 +75,7 @@ Claude reads both output files and:
 - Test strategy, TDD, unit/integration tests
 - Build errors and TypeScript issues
 
-**Roles**: `architect`, `code-reviewer`, `security-reviewer`, `executor`, `planner`, `critic`, `tdd-guide`
+**Roles**: `architect`, `code-reviewer`, `security-reviewer`, `executor`, `planner`, `critic`, `test-engineer`
 
 ### Use Gemini (`ask_gemini`) for:
 - React/Vue/Svelte component implementation

--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -74,7 +74,7 @@ parallel(explore, document-specialist) -> architect -> executor
 **Stages:**
 1. `planner` - Create detailed implementation plan
 2. `executor` - Implement the plan
-3. `tdd-guide` - Add/verify tests
+3. `test-engineer` - Add/verify tests
 
 **Use for:** New features with clear requirements
 
@@ -334,7 +334,7 @@ When parallel agents complete:
 
 ### Example 3: Custom Chain
 ```
-/pipeline explore:haiku -> architect:opus -> executor:sonnet -> tdd-guide:sonnet "refactor auth module"
+/pipeline explore:haiku -> architect:opus -> executor:sonnet -> test-engineer:sonnet "refactor auth module"
 ```
 
 ### Example 4: Research-Driven Implementation

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -78,7 +78,7 @@ Result: [tests still pass]
 
 ## External Model Consultation (Preferred)
 
-The tdd-guide agent SHOULD consult Codex for test strategy validation.
+The test-engineer agent SHOULD consult Codex for test strategy validation.
 
 ### Protocol
 1. **Form your OWN test strategy FIRST** - Design tests independently
@@ -100,7 +100,7 @@ The tdd-guide agent SHOULD consult Codex for test strategy validation.
 
 ### Tool Usage
 Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
-Use `mcp__x__ask_codex` with `agent_role: "tdd-guide"`.
+Use `mcp__x__ask_codex` with `agent_role: "test-engineer"`.
 If ToolSearch finds no MCP tools, fall back to the `test-engineer` Claude agent.
 
 **Remember:** The discipline IS the value. Shortcuts destroy the benefit.

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -96,9 +96,9 @@ Each pipeline stage uses **specialized agents** -- not just executors. The lead 
 | Stage | Required Agents | Optional Agents | Selection Criteria |
 |-------|----------------|-----------------|-------------------|
 | **team-plan** | `explore` (haiku), `planner` (opus) | `analyst` (opus), `architect` (opus) | Use `analyst` for unclear requirements. Use `architect` for systems with complex boundaries. |
-| **team-prd** | `analyst` (opus) | `product-manager` (sonnet), `critic` (opus) | Use `product-manager` for user-facing features. Use `critic` to challenge scope. |
+| **team-prd** | `analyst` (opus) | `critic` (opus) | Use `critic` to challenge scope. |
 | **team-exec** | `executor` (sonnet) | `deep-executor` (opus), `build-fixer` (sonnet), `designer` (sonnet), `writer` (haiku), `test-engineer` (sonnet) | Match agent to subtask type. Use `deep-executor` for complex autonomous work, `designer` for UI, `build-fixer` for compilation issues, `writer` for docs, `test-engineer` for test creation. |
-| **team-verify** | `verifier` (sonnet) | `test-engineer` (sonnet), `security-reviewer` (sonnet), `code-reviewer` (opus), `quality-reviewer` (sonnet), `performance-reviewer` (sonnet) | Always run `verifier`. Add `security-reviewer` for auth/crypto changes. Add `code-reviewer` for >20 files or architectural changes. Add `performance-reviewer` for latency-sensitive code. |
+| **team-verify** | `verifier` (sonnet) | `test-engineer` (sonnet), `security-reviewer` (sonnet), `code-reviewer` (opus), `quality-reviewer` (sonnet) | Always run `verifier`. Add `security-reviewer` for auth/crypto changes. Add `code-reviewer` for >20 files or architectural changes. Add `quality-reviewer` (model=haiku) for style/formatting checks. |
 | **team-fix** | `executor` (sonnet) | `build-fixer` (sonnet), `debugger` (sonnet), `deep-executor` (opus) | Use `build-fixer` for type/build errors. Use `debugger` for regression isolation. Use `deep-executor` for complex multi-file fixes. |
 
 **Routing rules:**
@@ -116,7 +116,7 @@ Each pipeline stage uses **specialized agents** -- not just executors. The lead 
   - Exit: decomposition is complete and a runnable task graph is prepared.
 - **team-prd**
   - Entry: scope is ambiguous or acceptance criteria are missing.
-  - Agents: `analyst` extracts requirements, optionally `product-manager`/`critic`.
+  - Agents: `analyst` extracts requirements, optionally `critic`.
   - Exit: acceptance criteria and boundaries are explicit.
 - **team-exec**
   - Entry: `TeamCreate`, `TaskCreate`, assignment, and worker spawn are complete.


### PR DESCRIPTION
## Summary

Follow-up cleanup after PR #763 (agent registry consolidation). Removes all deprecated agent name references from skill docs and agent prompt files.

**Skills updated:**
- `skills/tdd/SKILL.md`: `tdd-guide` → `test-engineer` (2 occurrences)
- `skills/pipeline/SKILL.md`: `tdd-guide` → `test-engineer` (2 occurrences)
- `skills/ccg/SKILL.md`: `tdd-guide` → `test-engineer` in Codex roles list
- `skills/team/SKILL.md`: removed `product-manager` from team-prd optional agents; removed `performance-reviewer` from team-verify optional agents

**Agent prompts updated:**
- `agents/quality-reviewer.md`: style/perf now in-scope conditionally; no longer defers to removed agents
- `agents/security-reviewer.md`, `agents/debugger.md`, `agents/verifier.md`, `agents/test-engineer.md`: removed dangling `(style-reviewer)` and `(performance-reviewer)` parentheticals from "not responsible for" role boundaries

## Test plan
- [ ] Grep confirms zero deprecated agent name references in skills/ and agents/ directories
- [ ] No functional code changes — docs/prompts only

🤖 Generated with [Claude Code](https://claude.com/claude-code)