### PR TITLE
fix(cli): use UTC timestamp in tmux session naming

### DIFF
--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -175,10 +175,9 @@ function runClaudeInsideTmux(cwd: string, args: string[], hudCmd: string): void 
  * Run Claude outside tmux - create new session
  * Creates tmux session with Claude + HUD pane
  */
-function runClaudeOutsideTmux(cwd: string, args: string[], sessionId: string, hudCmd: string): void {
+function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string, hudCmd: string): void {
   const claudeCmd = buildTmuxShellCommand('claude', args);
-  const tmuxSessionId = `omc-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const sessionName = buildTmuxSessionName(cwd, tmuxSessionId);
+  const sessionName = buildTmuxSessionName(cwd);
 
   const tmuxArgs = [
     'new-session', '-d', '-s', sessionName, '-c', cwd,

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -52,10 +52,11 @@ export function resolveLaunchPolicy(env: NodeJS.ProcessEnv = process.env): Claud
 }
 
 /**
- * Build tmux session name from directory and git branch
- * Format: omc-{dir}-{branch}-{session}
+ * Build tmux session name from directory, git branch, and UTC timestamp
+ * Format: omc-{dir}-{branch}-{utctimestamp}
+ * e.g.  omc-myproject-dev-20260221143052
  */
-export function buildTmuxSessionName(cwd: string, sessionId: string): string {
+export function buildTmuxSessionName(cwd: string): string {
   const dirToken = sanitizeTmuxToken(basename(cwd));
   let branchToken = 'detached';
 
@@ -72,8 +73,17 @@ export function buildTmuxSessionName(cwd: string, sessionId: string): string {
     // Non-git directory or git unavailable
   }
 
-  const sessionToken = sanitizeTmuxToken(sessionId.replace(/^omc-/, ''));
-  const name = `omc-${dirToken}-${branchToken}-${sessionToken}`;
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const utcTimestamp =
+    `${now.getUTCFullYear()}` +
+    `${pad(now.getUTCMonth() + 1)}` +
+    `${pad(now.getUTCDate())}` +
+    `${pad(now.getUTCHours())}` +
+    `${pad(now.getUTCMinutes())}` +
+    `${pad(now.getUTCSeconds())}`;
+
+  const name = `omc-${dirToken}-${branchToken}-${utcTimestamp}`;
   return name.length > 120 ? name.slice(0, 120) : name;
 }
 


### PR DESCRIPTION
## Summary

- Replaces the random `Date.now()-randomhex` suffix in tmux session names with a compact UTC timestamp (`YYYYMMDDHHmmss`)
- Sessions now follow the format `omc-{dir}-{branch}-{utctimestamp}` (e.g. `omc-myproject-dev-20260221143052`)
- Drops the redundant `tmuxSessionId` local variable in `runClaudeOutsideTmux`
- Removes the unused `sessionId` parameter from `buildTmuxSessionName`

## Test plan

- [ ] Run `omc` outside tmux — verify new session name matches `omc-{dir}-{branch}-{YYYYMMDDHHmmss}`
- [ ] Run `omc --dangerously-skip-permissions` — verify all flags still forwarded to claude
- [ ] Run in a non-git directory — verify session falls back to `omc-{dir}-detached-{timestamp}`
- [ ] TypeScript: `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)