### PR TITLE
fix: clean up deprecation inconsistencies after agent consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ oh-my-claudecode enhances Claude Code with:
    | Build errors | `build-fixer` | sonnet |
    | Testing | `qa-tester` | sonnet |
    | Code review | `code-reviewer` | opus |
-   | TDD | `tdd-guide` / `tdd-guide-low` | sonnet/haiku |
+   | TDD | `test-engineer` / `test-engineer-low` | sonnet/haiku |
    | Data analysis | `scientist` / `scientist-high` | sonnet/opus |
 
 2. **LSP/AST Tools**: Use IDE-like tools for code intelligence:
@@ -215,14 +215,14 @@ import { allCustomTools, lspTools, astTools } from './tools';
 |-------|-------|---------|
 | security-reviewer | opus | Security vulnerability detection and audits |
 | build-fixer | sonnet | Build/type error resolution (multi-language) |
-| tdd-guide | sonnet | Test-driven development workflow |
+| test-engineer | sonnet | Test-driven development workflow |
 | code-reviewer | opus | Expert code review and quality assessment |
 
 ### Tiered Variants (12)
 
 | Tier | Agents |
 |------|--------|
-| **LOW** (Haiku) | `architect-low`, `executor-low`, `designer-low`, `security-reviewer-low`, `tdd-guide-low` (5) |
+| **LOW** (Haiku) | `architect-low`, `executor-low`, `designer-low`, `security-reviewer-low`, `test-engineer-low` (5) |
 | **MEDIUM** (Sonnet) | `architect-medium` (1) |
 | **HIGH** (Opus) | `executor-high`, `designer-high`, `explore-high`, `scientist-high`, `deep-executor` (5) |
 

--- a/agents.codex/api-reviewer.md
+++ b/agents.codex/api-reviewer.md
@@ -4,6 +4,8 @@ description: API contracts, backward compatibility, versioning, error semantics
 model: sonnet
 ---
 
+> **Deprecated**: `api-reviewer` is an alias for `code-reviewer`. This file is kept for reference only.
+
 **Role**
 You are API Reviewer. You ensure public APIs are well-designed, stable, backward-compatible, and documented. You focus on the public contract and caller experience -- not implementation details, style, security, or internal code quality.
 

--- a/agents.codex/dependency-expert.md
+++ b/agents.codex/dependency-expert.md
@@ -5,6 +5,8 @@ model: sonnet
 disallowedTools: apply_patch
 ---
 
+> **Deprecated**: `dependency-expert` is an alias for `document-specialist`. This file is kept for reference only.
+
 **Role**
 You are Dependency Expert. You evaluate external SDKs, APIs, and packages to help teams make informed adoption decisions. You cover package evaluation, version compatibility, SDK comparison, migration paths, and dependency risk analysis. You do not search internal codebases, implement code, review code, or make architecture decisions.
 

--- a/agents.codex/performance-reviewer.md
+++ b/agents.codex/performance-reviewer.md
@@ -4,6 +4,8 @@ description: Hotspots, algorithmic complexity, memory/latency tradeoffs, profili
 model: sonnet
 ---
 
+> **Deprecated**: `performance-reviewer` is an alias for `quality-reviewer`. This file is kept for reference only.
+
 **Role**
 You are Performance Reviewer. You identify performance hotspots and recommend data-driven optimizations covering algorithmic complexity, memory usage, I/O latency, caching opportunities, and concurrency. You do not review code style, logic correctness, security, or API design.
 

--- a/agents.codex/quality-strategist.md
+++ b/agents.codex/quality-strategist.md
@@ -5,6 +5,8 @@ model: sonnet
 disallowedTools: apply_patch, write_file
 ---
 
+> **Deprecated**: `quality-strategist` is an alias for `quality-reviewer`. This file is kept for reference only.
+
 **Role**
 Aegis -- Quality Strategist. You own quality strategy across changes and releases: risk models, quality gates, release readiness criteria, regression risk assessments, and quality KPIs (flake rate, escape rate, coverage health). You define quality posture -- you do not implement tests, run interactive test sessions, or verify individual claims.
 

--- a/agents.codex/researcher.md
+++ b/agents.codex/researcher.md
@@ -5,6 +5,8 @@ model: sonnet
 disallowedTools: apply_patch
 ---
 
+> **Deprecated**: `researcher` is an alias for `document-specialist`. This file is kept for reference only.
+
 **Role**
 You are Researcher (Librarian). You find and synthesize information from external sources: official docs, GitHub repos, package registries, and technical references. You produce documented answers with source URLs, version compatibility notes, and code examples. You never search internal codebases (use explore agent), implement code, review code, or make architecture decisions.
 

--- a/agents.codex/vision.md
+++ b/agents.codex/vision.md
@@ -5,6 +5,8 @@ model: sonnet
 disallowedTools: apply_patch
 ---
 
+> **Deprecated**: `vision` is an alias for `document-specialist`. This file is kept for reference only.
+
 **Role**
 You are Vision. You extract specific information from media files that cannot be read as plain text -- images, PDFs, diagrams, charts, and visual content. You return only the information requested. You never modify files, implement features, or process plain text files.
 

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -36,7 +36,7 @@ export { plannerAgent, PLANNER_PROMPT_METADATA } from './planner.js';
 export { qaTesterAgent, QA_TESTER_PROMPT_METADATA } from './qa-tester.js';
 export { scientistAgent, SCIENTIST_PROMPT_METADATA } from './scientist.js';
 // Backward compatibility: Deprecated researcher export
-/** @deprecated Use dependency-expert agent instead */
+/** @deprecated Use document-specialist agent instead */
 export { documentSpecialistAgent, DOCUMENT_SPECIALIST_PROMPT_METADATA } from './document-specialist.js';
 /** @deprecated Use document-specialist agent instead */
 export { documentSpecialistAgent as researcherAgent } from './document-specialist.js';

--- a/src/hud/elements/agents.ts
+++ b/src/hud/elements/agents.ts
@@ -130,7 +130,7 @@ const AGENT_TYPE_CODES: Record<string, string> = {
   // ============================================================
   // BACKWARD COMPATIBILITY (Deprecated)
   // ============================================================
-  // Researcher - 'R' for Researcher (deprecated, points to dependency-expert)
+  // Researcher - 'r' for Researcher (deprecated, points to document-specialist)
   researcher: 'r',          // sonnet
 };
 


### PR DESCRIPTION
## Summary

- Fix two wrong `@deprecated` comments that pointed to `dependency-expert` (itself deprecated) instead of `document-specialist`
- Update `AGENTS.md` delegation/agent/tier tables to replace stale `tdd-guide`/`tdd-guide-low` with canonical `test-engineer`/`test-engineer-low`
- Add deprecation notices to 6 orphaned `agents.codex/` prompt files (`researcher`, `api-reviewer`, `performance-reviewer`, `dependency-expert`, `quality-strategist`, `vision`) so browsing the directory no longer misleads

## Files changed
- `src/agents/index.ts` — wrong `@deprecated` comment
- `src/hud/elements/agents.ts` — wrong HUD comment
- `AGENTS.md` — 3 stale `tdd-guide` references
- `agents.codex/researcher.md`, `api-reviewer.md`, `performance-reviewer.md`, `dependency-expert.md`, `quality-strategist.md`, `vision.md` — orphaned files

## Test plan
- [ ] No functional code changed — comments and docs only
- [ ] Verify `src/agents/index.ts:39` says `document-specialist`
- [ ] Verify `src/hud/elements/agents.ts:133` says `document-specialist`
- [ ] Verify `AGENTS.md` has no `tdd-guide` references
- [ ] Verify each `agents.codex/` deprecated file has a blockquote notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)