### PR TITLE
feat: update default Gemini model to gemini-3.1-pro-preview

### DIFF
--- a/bridge/codex-server.cjs
+++ b/bridge/codex-server.cjs
@@ -15336,6 +15336,7 @@ var CODEX_MODEL_FALLBACKS = [
   "gpt-5.2"
 ];
 var GEMINI_MODEL_FALLBACKS = [
+  "gemini-3.1-pro-preview",
   "gemini-3-pro-preview",
   "gemini-3-flash-preview",
   "gemini-2.5-pro",
@@ -15343,7 +15344,7 @@ var GEMINI_MODEL_FALLBACKS = [
 ];
 var HARDCODED_DEFAULTS = {
   codex: "gpt-5.3-codex",
-  gemini: "gemini-3-pro-preview"
+  gemini: "gemini-3.1-pro-preview"
 };
 var DEFAULT_FALLBACK_POLICY = {
   onModelFailure: "provider_chain",
@@ -16425,7 +16426,7 @@ var DEFAULT_CONFIG = {
   externalModels: {
     defaults: {
       codexModel: process.env.OMC_CODEX_DEFAULT_MODEL || "gpt-5.3-codex",
-      geminiModel: process.env.OMC_GEMINI_DEFAULT_MODEL || "gemini-3-pro-preview"
+      geminiModel: process.env.OMC_GEMINI_DEFAULT_MODEL || "gemini-3.1-pro-preview"
     },
     fallbackPolicy: {
       onModelFailure: "provider_chain",
@@ -17399,7 +17400,7 @@ var spawnedPids2 = /* @__PURE__ */ new Set();
 function isSpawnedPid2(pid) {
   return spawnedPids2.has(pid);
 }
-var GEMINI_DEFAULT_MODEL = process.env.OMC_GEMINI_DEFAULT_MODEL || "gemini-3-pro-preview";
+var GEMINI_DEFAULT_MODEL = process.env.OMC_GEMINI_DEFAULT_MODEL || "gemini-3.1-pro-preview";
 var GEMINI_TIMEOUT = Math.min(Math.max(5e3, parseInt(process.env.OMC_GEMINI_TIMEOUT || "3600000", 10) || 36e5), 36e5);
 var MAX_FILE_SIZE2 = 5 * 1024 * 1024;
 var MAX_STDOUT_BYTES2 = 10 * 1024 * 1024;

--- a/bridge/gemini-server.cjs
+++ b/bridge/gemini-server.cjs
@@ -15178,6 +15178,7 @@ var CODEX_MODEL_FALLBACKS = [
   "gpt-5.2"
 ];
 var GEMINI_MODEL_FALLBACKS = [
+  "gemini-3.1-pro-preview",
   "gemini-3-pro-preview",
   "gemini-3-flash-preview",
   "gemini-2.5-pro",
@@ -15185,7 +15186,7 @@ var GEMINI_MODEL_FALLBACKS = [
 ];
 var HARDCODED_DEFAULTS = {
   codex: "gpt-5.3-codex",
-  gemini: "gemini-3-pro-preview"
+  gemini: "gemini-3.1-pro-preview"
 };
 var DEFAULT_FALLBACK_POLICY = {
   onModelFailure: "provider_chain",
@@ -16258,7 +16259,7 @@ var DEFAULT_CONFIG = {
   externalModels: {
     defaults: {
       codexModel: process.env.OMC_CODEX_DEFAULT_MODEL || "gpt-5.3-codex",
-      geminiModel: process.env.OMC_GEMINI_DEFAULT_MODEL || "gemini-3-pro-preview"
+      geminiModel: process.env.OMC_GEMINI_DEFAULT_MODEL || "gemini-3.1-pro-preview"
     },
     fallbackPolicy: {
       onModelFailure: "provider_chain",
@@ -16450,7 +16451,7 @@ function validateModelName(model) {
     throw new Error(`Invalid model name: "${model}". Model names must match pattern: alphanumeric start, followed by alphanumeric, dots, hyphens, or underscores (max 64 chars).`);
   }
 }
-var GEMINI_DEFAULT_MODEL = process.env.OMC_GEMINI_DEFAULT_MODEL || "gemini-3-pro-preview";
+var GEMINI_DEFAULT_MODEL = process.env.OMC_GEMINI_DEFAULT_MODEL || "gemini-3.1-pro-preview";
 var GEMINI_TIMEOUT = Math.min(Math.max(5e3, parseInt(process.env.OMC_GEMINI_TIMEOUT || "3600000", 10) || 36e5), 36e5);
 var GEMINI_RECOMMENDED_ROLES = ["designer", "writer", "vision"];
 var MAX_FILE_SIZE = 5 * 1024 * 1024;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -87,7 +87,7 @@ export const DEFAULT_CONFIG: PluginConfig = {
   externalModels: {
     defaults: {
       codexModel: process.env.OMC_CODEX_DEFAULT_MODEL || 'gpt-5.3-codex',
-      geminiModel: process.env.OMC_GEMINI_DEFAULT_MODEL || 'gemini-3-pro-preview',
+      geminiModel: process.env.OMC_GEMINI_DEFAULT_MODEL || 'gemini-3.1-pro-preview',
     },
     fallbackPolicy: {
       onModelFailure: 'provider_chain',
@@ -526,7 +526,7 @@ export function generateConfigSchema(): object {
               },
               geminiModel: {
                 type: 'string',
-                default: 'gemini-3-pro-preview',
+                default: 'gemini-3.1-pro-preview',
                 description: 'Default Gemini model'
               }
             }

--- a/src/features/delegation-routing/__tests__/resolver.test.ts
+++ b/src/features/delegation-routing/__tests__/resolver.test.ts
@@ -100,7 +100,7 @@ describe('resolveDelegation', () => {
     });
     expect(result.provider).toBe('gemini');
     expect(result.tool).toBe('ask_gemini');
-    expect(result.agentOrModel).toBe('gemini-3-pro-preview');
+    expect(result.agentOrModel).toBe('gemini-3.1-pro-preview');
   });
 
   // Test 9: Explicit ask_gemini with custom model
@@ -200,7 +200,7 @@ describe('resolveDelegation', () => {
     });
     expect(result.provider).toBe('gemini');
     expect(result.tool).toBe('ask_gemini');
-    expect(result.agentOrModel).toBe('gemini-3-pro-preview');
+    expect(result.agentOrModel).toBe('gemini-3.1-pro-preview');
   });
 
   // Test 15: Config enabled but role not in roles map
@@ -334,7 +334,7 @@ describe('resolveDelegation', () => {
     });
     expect(result.provider).toBe('gemini');
     expect(result.tool).toBe('ask_gemini');
-    expect(result.agentOrModel).toBe('gemini-3-pro-preview');
+    expect(result.agentOrModel).toBe('gemini-3.1-pro-preview');
     expect(result.reason).toContain('Fallback to default provider: gemini');
     expect(result.fallbackChain).toBeUndefined();
   });

--- a/src/features/delegation-routing/resolver.ts
+++ b/src/features/delegation-routing/resolver.ts
@@ -68,7 +68,7 @@ function resolveExplicitTool(
     case 'ask_gemini':
       provider = 'gemini';
       // Keep default consistent with Gemini core + external-model policy
-      agentOrModel = model || 'gemini-3-pro-preview';
+      agentOrModel = model || 'gemini-3.1-pro-preview';
       break;
     case 'Task':
     default:
@@ -154,7 +154,7 @@ function resolveDefault(
     return {
       provider: 'gemini',
       tool: 'ask_gemini',
-      agentOrModel: 'gemini-3-pro-preview',
+      agentOrModel: 'gemini-3.1-pro-preview',
       reason: `Fallback to default provider: ${defaultProvider}`,
     };
   }

--- a/src/features/model-routing/__tests__/external-model-policy.test.ts
+++ b/src/features/model-routing/__tests__/external-model-policy.test.ts
@@ -328,7 +328,7 @@ describe('external-model-policy', () => {
           const result = resolveExternalModel(config, options);
 
           expect(result.provider).toBe('gemini');
-          expect(result.model).toBe('gemini-3-pro-preview'); // hardcoded default
+          expect(result.model).toBe('gemini-3.1-pro-preview'); // hardcoded default
         });
       });
 
@@ -400,7 +400,7 @@ describe('external-model-policy', () => {
           const result = resolveExternalModel(config, options);
 
           expect(result.provider).toBe('gemini');
-          expect(result.model).toBe('gemini-3-pro-preview');
+          expect(result.model).toBe('gemini-3.1-pro-preview');
         });
 
         it('should default to codex provider when none specified', () => {
@@ -588,6 +588,7 @@ describe('external-model-policy', () => {
       ]);
 
       expect(GEMINI_MODEL_FALLBACKS).toEqual([
+        'gemini-3.1-pro-preview',
         'gemini-3-pro-preview',
         'gemini-3-flash-preview',
         'gemini-2.5-pro',

--- a/src/features/model-routing/external-model-policy.ts
+++ b/src/features/model-routing/external-model-policy.ts
@@ -22,6 +22,7 @@ export const CODEX_MODEL_FALLBACKS = [
 ];
 
 export const GEMINI_MODEL_FALLBACKS = [
+  'gemini-3.1-pro-preview',
   'gemini-3-pro-preview',
   'gemini-3-flash-preview',
   'gemini-2.5-pro',
@@ -31,7 +32,7 @@ export const GEMINI_MODEL_FALLBACKS = [
 // Hardcoded defaults (from codex-core.ts and gemini-core.ts)
 const HARDCODED_DEFAULTS = {
   codex: 'gpt-5.3-codex',
-  gemini: 'gemini-3-pro-preview',
+  gemini: 'gemini-3.1-pro-preview',
 };
 
 // Default fallback policy

--- a/src/mcp/gemini-core.ts
+++ b/src/mcp/gemini-core.ts
@@ -51,7 +51,7 @@ function validateModelName(model: string): void {
 }
 
 // Default model can be overridden via environment variable
-export const GEMINI_DEFAULT_MODEL = process.env.OMC_GEMINI_DEFAULT_MODEL || 'gemini-3-pro-preview';
+export const GEMINI_DEFAULT_MODEL = process.env.OMC_GEMINI_DEFAULT_MODEL || 'gemini-3.1-pro-preview';
 export const GEMINI_TIMEOUT = Math.min(Math.max(5000, parseInt(process.env.OMC_GEMINI_TIMEOUT || '3600000', 10) || 3600000), 3600000);
 
 // Gemini is best for design review and implementation tasks (recommended, not enforced)

--- a/src/team/__tests__/unified-team.test.ts
+++ b/src/team/__tests__/unified-team.test.ts
@@ -23,7 +23,7 @@ describe('unified-team', () => {
       teamName,
       name,
       agentType === 'mcp-codex' ? 'codex' : 'gemini',
-      agentType === 'mcp-codex' ? 'gpt-5.3-codex' : 'gemini-3-pro-preview',
+      agentType === 'mcp-codex' ? 'gpt-5.3-codex' : 'gemini-3.1-pro-preview',
       `tmux-${name}`,
       testDir,
       testDir


### PR DESCRIPTION
## Summary

- Update the default Gemini model from `gemini-3-pro-preview` to `gemini-3.1-pro-preview` across all routing layers
- Add `gemini-3.1-pro-preview` to the top of `GEMINI_MODEL_FALLBACKS` so it is tried first in fallback chains
- Update all related tests to reflect the new default model

## Changed Files

| File | Change |
|------|--------|
| `src/mcp/gemini-core.ts` | Update `GEMINI_DEFAULT_MODEL` constant |
| `src/config/loader.ts` | Update `DEFAULT_CONFIG` and JSON schema default |
| `src/features/model-routing/external-model-policy.ts` | Update `HARDCODED_DEFAULTS.gemini` + prepend to `GEMINI_MODEL_FALLBACKS` |
| `src/features/delegation-routing/resolver.ts` | Update hardcoded fallback model (2 places) |
| `src/features/model-routing/__tests__/external-model-policy.test.ts` | Update test expectations |
| `src/features/delegation-routing/__tests__/resolver.test.ts` | Update test expectations (3 places) |
| `src/team/__tests__/unified-team.test.ts` | Update test expectation |
| `bridge/codex-server.cjs` | Rebuild artifact |
| `bridge/gemini-server.cjs` | Rebuild artifact |

## Test plan

- [x] All model routing tests updated to expect `gemini-3.1-pro-preview`
- [x] `GEMINI_MODEL_FALLBACKS` includes both `gemini-3.1-pro-preview` (first) and `gemini-3-pro-preview` (second) for backward compatibility
- [ ] Run `npm test` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)