### PR TITLE
fix(mcp): harden ToolSearch discovery with 3-step sequence to prevent false negatives

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -91,10 +91,12 @@ Compatibility aliases may still be normalized during routing, but canonical runt
 <mcp_routing>
 For read-only analysis tasks, prefer MCP tools over spawning Claude agents -- they are faster and cheaper.
 
-**IMPORTANT -- Deferred Tool Discovery:** MCP tools (`ask_codex`, `ask_gemini`, and their job management tools) are deferred and NOT in your tool list at session start. Before your first use of any MCP tool, you MUST call `ToolSearch` to discover it:
-- `ToolSearch("mcp")` -- discovers all MCP tools (preferred, do this once early)
-- `ToolSearch("ask_codex")` -- discovers Codex tools specifically
-- `ToolSearch("ask_gemini")` -- discovers Gemini tools specifically
+**IMPORTANT -- Deferred Tool Discovery:** MCP tools (`ask_codex`, `ask_gemini`, and their job management tools) are deferred and NOT in your tool list at session start. Use this 3-step discovery sequence before your first MCP tool use:
+1. `ToolSearch("mcp")` -- broad search; finds all deferred MCP tools at once
+2. From results, select the full tool name: look for `mcp__x__ask_codex` or `mcp__g__ask_gemini`
+3. Fall back to the equivalent Claude agent **only if** step 1 returns no results
+
+**Never use `ToolSearch("ask_codex")` or `ToolSearch("ask_gemini")` as the primary search** -- narrow searches can return false negatives even when MCP tools are present. Always start with `ToolSearch("mcp")`.
 If ToolSearch returns no results, the MCP server is not configured -- fall back to the equivalent Claude agent. Never block on unavailable MCP tools.
 
 Available MCP providers:

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -43,7 +43,7 @@ Deep investigation requires a different approach than quick lookups or code chan
 </Steps>
 
 <Tool_Usage>
-- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
+- Before first MCP tool use, run the 3-step discovery: (1) `ToolSearch("mcp")`, (2) select the full name from results (e.g., `mcp__x__ask_codex`), (3) fall back to the equivalent Claude agent only if step 1 returns empty. Never use `ToolSearch("ask_codex")` as the primary search -- it can return false negatives even when MCP tools are present.
 - Use `ask_codex` with `agent_role: "architect"` as the preferred analysis route
 - Pass `context_files` with all relevant source files for grounded analysis
 - Use `Task(subagent_type="oh-my-claudecode:architect", model="opus", ...)` as fallback when ToolSearch finds no MCP tools or Codex is unavailable

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -92,9 +92,8 @@ The code-reviewer agent SHOULD consult Codex for cross-validation.
 - Small, isolated changes
 
 ### Tool Usage
-Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
+Before first MCP tool use, run the 3-step discovery: (1) `ToolSearch("mcp")`, (2) look for `mcp__x__ask_codex` in the results, (3) fall back to the `code-reviewer` Claude agent only if step 1 returns empty. Never use `ToolSearch("ask_codex")` as the primary search -- it can return false negatives even when MCP tools are present.
 Use `mcp__x__ask_codex` with `agent_role: "code-reviewer"`.
-If ToolSearch finds no MCP tools, fall back to the `code-reviewer` Claude agent.
 
 **Note:** Codex calls can take up to 1 hour. Consider the review timeline before consulting.
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -110,7 +110,7 @@ Plans are saved to `.omc/plans/`. Drafts go to `.omc/drafts/`.
 </Steps>
 
 <Tool_Usage>
-- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
+- Before first MCP tool use, run the 3-step discovery: (1) `ToolSearch("mcp")`, (2) select the full name from results (e.g., `mcp__x__ask_codex`), (3) fall back to the equivalent Claude agent only if step 1 returns empty. Never use `ToolSearch("ask_codex")` as the primary search -- it can return false negatives even when MCP tools are present.
 - Use `AskUserQuestion` for preference questions (scope, priority, timeline, risk tolerance) -- provides clickable UI
 - Use plain text for questions needing specific values (port numbers, names, follow-up clarifications)
 - Use `explore` agent (Haiku, 30s timeout) to gather codebase facts before asking the user

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -60,7 +60,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 </Steps>
 
 <Tool_Usage>
-- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
+- Before first MCP tool use, run the 3-step discovery: (1) `ToolSearch("mcp")`, (2) select the full name from results (e.g., `mcp__x__ask_codex`), (3) fall back to the equivalent Claude agent only if step 1 returns empty. Never use `ToolSearch("ask_codex")` as the primary search -- it can return false negatives even when MCP tools are present.
 - Use `ask_codex` with `agent_role: "architect"` for verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
 - Skip Codex consultation for simple feature additions, well-tested changes, or time-critical verification
 - If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -110,9 +110,8 @@ The security-reviewer agent SHOULD consult Codex for cross-validation.
 - Code with existing security tests
 
 ### Tool Usage
-Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
+Before first MCP tool use, run the 3-step discovery: (1) `ToolSearch("mcp")`, (2) look for `mcp__x__ask_codex` in the results, (3) fall back to the `security-reviewer` Claude agent only if step 1 returns empty. Never use `ToolSearch("ask_codex")` as the primary search -- it can return false negatives even when MCP tools are present.
 Use `mcp__x__ask_codex` with `agent_role: "security-reviewer"`.
-If ToolSearch finds no MCP tools, fall back to the `security-reviewer` Claude agent.
 
 **Note:** Security second opinions are high-value. Consider consulting for CRITICAL/HIGH findings.
 

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -99,8 +99,7 @@ The test-engineer agent SHOULD consult Codex for test strategy validation.
 - Small, isolated functionality
 
 ### Tool Usage
-Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
+Before first MCP tool use, run the 3-step discovery: (1) `ToolSearch("mcp")`, (2) look for `mcp__x__ask_codex` in the results, (3) fall back to the `test-engineer` Claude agent only if step 1 returns empty. Never use `ToolSearch("ask_codex")` as the primary search -- it can return false negatives even when MCP tools are present.
 Use `mcp__x__ask_codex` with `agent_role: "test-engineer"`.
-If ToolSearch finds no MCP tools, fall back to the `test-engineer` Claude agent.
 
 **Remember:** The discipline IS the value. Shortcuts destroy the benefit.

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -630,7 +630,7 @@ The lead runs #1 (Codex analysis), then #2 and #3 in parallel (Codex refactors b
 
 For large ambiguous tasks, run analysis before team creation:
 
-1. Call `ToolSearch("mcp")` to discover deferred MCP tools (required before first use)
+1. Call `ToolSearch("mcp")` to discover deferred MCP tools; from the results, confirm `mcp__x__ask_codex` is present before proceeding. Never use `ToolSearch("ask_codex")` as the primary search -- it can return false negatives even when MCP tools are present.
 2. Call `ask_codex` (planner role) with task description + codebase context
 3. Use the analysis to produce better task decomposition
 4. Create team and tasks with enriched context


### PR DESCRIPTION
## Summary

- `ToolSearch("ask_codex")` can return false negatives even when deferred MCP tools are present, because the actual registered name is `mcp__x__ask_codex` (not `ask_codex`)
- Replace single-step narrow searches with an explicit 3-step discovery sequence in all affected locations
- Add a clear prohibition on using `ToolSearch("ask_codex")` or `ToolSearch("ask_gemini")` as the primary search

## Changes

**3-step discovery sequence:**
1. `ToolSearch("mcp")` -- broad search, reliably finds all deferred tools
2. Select the full tool name from results (`mcp__x__ask_codex` / `mcp__g__ask_gemini`)
3. Fall back to equivalent Claude agent **only if** step 1 returns empty

**Files updated:**
- `docs/CLAUDE.md` — `mcp_routing` section rewritten with numbered 3-step sequence
- `skills/plan/SKILL.md`, `skills/analyze/SKILL.md`, `skills/ralph/SKILL.md` — single-line preflight updated
- `skills/code-review/SKILL.md`, `skills/security-review/SKILL.md`, `skills/tdd/SKILL.md` — Tool Usage block updated, redundant fallback line removed
- `skills/team/SKILL.md` — MCP Pre-flight step 1 clarified

## Test plan

- [ ] Verify `ToolSearch("mcp")` is the only recommended primary search across all changed files
- [ ] Verify no remaining references to `ToolSearch("ask_codex")` as a recommended call
- [ ] Verify fallback language is consistent: "only if step 1 returns empty"

Closes #814, #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)