### PR TITLE
fix(models): update opus alias to resolve to claude-opus-4-6 (fixes #681)

### DIFF
--- a/agents.codex/analyst.md
+++ b/agents.codex/analyst.md
@@ -1,7 +1,7 @@
 ---
 name: analyst
 description: Pre-planning consultant for requirements analysis (Opus)
-model: opus
+model: claude-opus-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/api-reviewer.md
+++ b/agents.codex/api-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: api-reviewer
 description: API contracts, backward compatibility, versioning, error semantics
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 > **Deprecated**: `api-reviewer` is an alias for `code-reviewer`. This file is kept for reference only.

--- a/agents.codex/architect.md
+++ b/agents.codex/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Strategic Architecture & Debugging Advisor (Opus, READ-ONLY)
-model: opus
+model: claude-opus-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/build-fixer.md
+++ b/agents.codex/build-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: build-fixer
 description: Build and compilation error resolution specialist (minimal diffs, no architecture changes)
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 **Role**

--- a/agents.codex/code-reviewer.md
+++ b/agents.codex/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Expert code review specialist with severity-rated feedback
-model: opus
+model: claude-opus-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/critic.md
+++ b/agents.codex/critic.md
@@ -1,7 +1,7 @@
 ---
 name: critic
 description: Work plan review expert and critic (Opus)
-model: opus
+model: claude-opus-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/debugger.md
+++ b/agents.codex/debugger.md
@@ -1,7 +1,7 @@
 ---
 name: debugger
 description: Root-cause analysis, regression isolation, stack trace analysis
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 **Role**

--- a/agents.codex/deep-executor.md
+++ b/agents.codex/deep-executor.md
@@ -1,7 +1,7 @@
 ---
 name: deep-executor
 description: Autonomous deep worker for complex goal-oriented tasks (Opus)
-model: opus
+model: claude-opus-4-6
 ---
 
 **Role**

--- a/agents.codex/dependency-expert.md
+++ b/agents.codex/dependency-expert.md
@@ -1,7 +1,7 @@
 ---
 name: dependency-expert
 description: Dependency Expert - External SDK/API/Package Evaluator
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/designer.md
+++ b/agents.codex/designer.md
@@ -1,7 +1,7 @@
 ---
 name: designer
 description: UI/UX Designer-Developer for stunning interfaces (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 **Role**

--- a/agents.codex/executor.md
+++ b/agents.codex/executor.md
@@ -1,7 +1,7 @@
 ---
 name: executor
 description: Focused task executor for implementation work (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 **Role**

--- a/agents.codex/explore.md
+++ b/agents.codex/explore.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Codebase search specialist for finding files and code patterns
-model: haiku
+model: claude-haiku-4-5
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/git-master.md
+++ b/agents.codex/git-master.md
@@ -1,7 +1,7 @@
 ---
 name: git-master
 description: Git expert for atomic commits, rebasing, and history management with style detection
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 **Role**

--- a/agents.codex/information-architect.md
+++ b/agents.codex/information-architect.md
@@ -1,7 +1,7 @@
 ---
 name: information-architect
 description: Information hierarchy, taxonomy, navigation models, and naming consistency (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/performance-reviewer.md
+++ b/agents.codex/performance-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: performance-reviewer
 description: Hotspots, algorithmic complexity, memory/latency tradeoffs, profiling plans
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 > **Deprecated**: `performance-reviewer` is an alias for `quality-reviewer`. This file is kept for reference only.

--- a/agents.codex/planner.md
+++ b/agents.codex/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: Strategic planning consultant with interview workflow (Opus)
-model: opus
+model: claude-opus-4-6
 ---
 
 **Role**

--- a/agents.codex/product-analyst.md
+++ b/agents.codex/product-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: product-analyst
 description: Product metrics, event schemas, funnel analysis, and experiment measurement design (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/product-manager.md
+++ b/agents.codex/product-manager.md
@@ -1,7 +1,7 @@
 ---
 name: product-manager
 description: Problem framing, value hypothesis, prioritization, and PRD generation (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch, write_file
 ---
 

--- a/agents.codex/qa-tester.md
+++ b/agents.codex/qa-tester.md
@@ -1,7 +1,7 @@
 ---
 name: qa-tester
 description: Interactive CLI testing specialist using tmux for session management
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 **Role**

--- a/agents.codex/quality-reviewer.md
+++ b/agents.codex/quality-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: quality-reviewer
 description: Logic defects, maintainability, anti-patterns, SOLID principles
-model: opus
+model: claude-opus-4-6
 ---
 
 **Role**

--- a/agents.codex/quality-strategist.md
+++ b/agents.codex/quality-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: quality-strategist
 description: Quality strategy, release readiness, risk assessment, and quality gates (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch, write_file
 ---
 

--- a/agents.codex/researcher.md
+++ b/agents.codex/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
 description: External Documentation & Reference Researcher
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/scientist.md
+++ b/agents.codex/scientist.md
@@ -1,7 +1,7 @@
 ---
 name: scientist
 description: Data analysis and research execution specialist
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch, write_file
 ---
 

--- a/agents.codex/security-reviewer.md
+++ b/agents.codex/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)
-model: opus
+model: claude-opus-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/style-reviewer.md
+++ b/agents.codex/style-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: style-reviewer
 description: Formatting, naming conventions, idioms, lint/style conventions
-model: haiku
+model: claude-haiku-4-5
 ---
 
 **Role**

--- a/agents.codex/test-engineer.md
+++ b/agents.codex/test-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: test-engineer
 description: Test strategy, integration/e2e coverage, flaky test hardening, TDD workflows
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 **Role**

--- a/agents.codex/ux-researcher.md
+++ b/agents.codex/ux-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: ux-researcher
 description: Usability research, heuristic audits, and user evidence synthesis (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/verifier.md
+++ b/agents.codex/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Verification strategy, evidence-based completion checks, test adequacy
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 **Role**

--- a/agents.codex/vision.md
+++ b/agents.codex/vision.md
@@ -1,7 +1,7 @@
 ---
 name: vision
 description: Visual/media file analyzer for images, PDFs, and diagrams (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: apply_patch
 ---
 

--- a/agents.codex/writer.md
+++ b/agents.codex/writer.md
@@ -1,7 +1,7 @@
 ---
 name: writer
 description: Technical documentation writer for README, API docs, and comments (Haiku)
-model: haiku
+model: claude-haiku-4-5
 ---
 
 **Role**

--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -1,7 +1,7 @@
 ---
 name: analyst
 description: Pre-planning consultant for requirements analysis (Opus)
-model: opus
+model: claude-opus-4-6
 disallowedTools: Write, Edit
 ---
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Strategic Architecture & Debugging Advisor (Opus, READ-ONLY)
-model: opus
+model: claude-opus-4-6
 disallowedTools: Write, Edit
 ---
 

--- a/agents/build-fixer.md
+++ b/agents/build-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: build-fixer
 description: Build and compilation error resolution specialist (minimal diffs, no architecture changes)
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Expert code review specialist with severity-rated feedback
-model: opus
+model: claude-opus-4-6
 disallowedTools: Write, Edit
 ---
 

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise.
-model: opus
+model: claude-opus-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -1,7 +1,7 @@
 ---
 name: critic
 description: Work plan review expert and critic (Opus)
-model: opus
+model: claude-opus-4-6
 disallowedTools: Write, Edit
 ---
 

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -1,7 +1,7 @@
 ---
 name: debugger
 description: Root-cause analysis, regression isolation, stack trace analysis
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/deep-executor.md
+++ b/agents/deep-executor.md
@@ -1,7 +1,7 @@
 ---
 name: deep-executor
 description: Autonomous deep worker for complex goal-oriented tasks (Opus)
-model: opus
+model: claude-opus-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -1,7 +1,7 @@
 ---
 name: designer
 description: UI/UX Designer-Developer for stunning interfaces (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/document-specialist.md
+++ b/agents/document-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: document-specialist
 description: External Documentation & Reference Specialist
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: Write, Edit
 ---
 

--- a/agents/executor.md
+++ b/agents/executor.md
@@ -1,7 +1,7 @@
 ---
 name: executor
 description: Focused task executor for implementation work (Sonnet)
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Codebase search specialist for finding files and code patterns
-model: haiku
+model: claude-haiku-4-5
 disallowedTools: Write, Edit
 ---
 

--- a/agents/git-master.md
+++ b/agents/git-master.md
@@ -1,7 +1,7 @@
 ---
 name: git-master
 description: Git expert for atomic commits, rebasing, and history management with style detection
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: Strategic planning consultant with interview workflow (Opus)
-model: opus
+model: claude-opus-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/qa-tester.md
+++ b/agents/qa-tester.md
@@ -1,7 +1,7 @@
 ---
 name: qa-tester
 description: Interactive CLI testing specialist using tmux for session management
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/quality-reviewer.md
+++ b/agents/quality-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: quality-reviewer
 description: Logic defects, maintainability, anti-patterns, SOLID principles
-model: opus
+model: claude-opus-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/scientist.md
+++ b/agents/scientist.md
@@ -1,7 +1,7 @@
 ---
 name: scientist
 description: Data analysis and research execution specialist
-model: sonnet
+model: claude-sonnet-4-6
 disallowedTools: Write, Edit
 ---
 

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)
-model: opus
+model: claude-opus-4-6
 disallowedTools: Write, Edit
 ---
 

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: test-engineer
 description: Test strategy, integration/e2e coverage, flaky test hardening, TDD workflows
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Verification strategy, evidence-based completion checks, test adequacy
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 <Agent_Prompt>

--- a/agents/writer.md
+++ b/agents/writer.md
@@ -1,7 +1,7 @@
 ---
 name: writer
 description: Technical documentation writer for README, API docs, and comments (Haiku)
-model: haiku
+model: claude-haiku-4-5
 ---
 
 <Agent_Prompt>

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -124,21 +124,21 @@ describe('Installer Constants', () => {
 
     it('should have consistent model assignments', () => {
       const modelExpectations: Record<string, string> = {
-        'architect.md': 'opus',
-        'executor.md': 'sonnet',
-        'designer.md': 'sonnet',
-        'writer.md': 'haiku',
-        'critic.md': 'opus',
-        'analyst.md': 'opus',
-        'planner.md': 'opus',
-        'qa-tester.md': 'sonnet',
-        'debugger.md': 'sonnet',
-        'verifier.md': 'sonnet',
-        'quality-reviewer.md': 'opus',
-        'test-engineer.md': 'sonnet',
-        'security-reviewer.md': 'opus',
-        'build-fixer.md': 'sonnet',
-        'git-master.md': 'sonnet',
+        'architect.md': 'claude-opus-4-6',
+        'executor.md': 'claude-sonnet-4-6',
+        'designer.md': 'claude-sonnet-4-6',
+        'writer.md': 'claude-haiku-4-5',
+        'critic.md': 'claude-opus-4-6',
+        'analyst.md': 'claude-opus-4-6',
+        'planner.md': 'claude-opus-4-6',
+        'qa-tester.md': 'claude-sonnet-4-6',
+        'debugger.md': 'claude-sonnet-4-6',
+        'verifier.md': 'claude-sonnet-4-6',
+        'quality-reviewer.md': 'claude-opus-4-6',
+        'test-engineer.md': 'claude-sonnet-4-6',
+        'security-reviewer.md': 'claude-opus-4-6',
+        'build-fixer.md': 'claude-sonnet-4-6',
+        'git-master.md': 'claude-sonnet-4-6',
       };
 
       for (const [filename, expectedModel] of Object.entries(modelExpectations)) {


### PR DESCRIPTION
## Summary

- Replace short model aliases (`opus`, `sonnet`, `haiku`) in all agent `.md` frontmatter with explicit model IDs (`claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`)
- Applies to both `agents/` and `agents.codex/` directories (52 files total)
- Update `installer.test.ts` expectations to match the new explicit IDs

**Root cause:** Claude Code was resolving the `opus` alias to `claude-opus-4-1@20250805` (old version) instead of `claude-opus-4-6`. By specifying the full model family name, Claude Code resolves to the correct current-generation model.

**Also fixed:** Same alias resolution issue for `sonnet` and `haiku` — now pinned to `claude-sonnet-4-6` and `claude-haiku-4-5` respectively.

## Test plan

- [x] All 4736 tests pass (`204 test files passed, 1 skipped`)
- [x] `installer.test.ts` model expectation assertions updated and passing
- [x] No short aliases (`^model: opus$`, `^model: sonnet$`, `^model: haiku$`) remain in `agents/` or `agents.codex/`

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)