### PR TITLE
feat(notifications): add parseTmuxTail to clean tmux output in notifications

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -4,6 +4,7 @@ import {
   formatSessionEnd,
   formatAgentCall,
   formatNotification,
+  parseTmuxTail,
 } from "../formatter.js";
 import type { NotificationPayload } from "../types.js";
 
@@ -132,6 +133,101 @@ describe("formatAgentCall", () => {
   it("should include footer with project info", () => {
     const result = formatAgentCall(basePayload);
     expect(result).toContain("`my-project`");
+  });
+});
+
+describe("parseTmuxTail", () => {
+  it("returns empty string for empty input", () => {
+    expect(parseTmuxTail("")).toBe("");
+  });
+
+  it("strips ANSI escape codes", () => {
+    const result = parseTmuxTail("\x1b[32mhello\x1b[0m world");
+    expect(result).toBe("hello world");
+  });
+
+  it("strips multi-parameter ANSI sequences", () => {
+    const result = parseTmuxTail("\x1b[1;34mBold blue\x1b[0m");
+    expect(result).toBe("Bold blue");
+  });
+
+  it("removes lines starting with ●", () => {
+    const result = parseTmuxTail("● Running tests\nnormal line");
+    expect(result).toBe("normal line");
+    expect(result).not.toContain("●");
+  });
+
+  it("removes lines starting with ⎿", () => {
+    const result = parseTmuxTail("⎿ subtask detail\nnormal line");
+    expect(result).toBe("normal line");
+  });
+
+  it("removes lines starting with ✻", () => {
+    const result = parseTmuxTail("✻ spinning indicator\nnormal line");
+    expect(result).toBe("normal line");
+  });
+
+  it("removes lines starting with ·", () => {
+    const result = parseTmuxTail("· bullet item\nnormal line");
+    expect(result).toBe("normal line");
+  });
+
+  it("removes lines starting with ◼", () => {
+    const result = parseTmuxTail("◼ block item\nnormal line");
+    expect(result).toBe("normal line");
+  });
+
+  it("removes 'ctrl+o to expand' lines (case-insensitive)", () => {
+    const result = parseTmuxTail("some output\nctrl+o to expand\nmore output");
+    expect(result).not.toContain("ctrl+o to expand");
+    expect(result).toBe("some output\nmore output");
+  });
+
+  it("removes 'Ctrl+O to Expand' mixed-case variant", () => {
+    const result = parseTmuxTail("line1\nCtrl+O to Expand\nline2");
+    expect(result).not.toContain("Expand");
+    expect(result).toBe("line1\nline2");
+  });
+
+  it("skips blank lines", () => {
+    const result = parseTmuxTail("\n\nfoo\n\nbar\n\n");
+    expect(result).toBe("foo\nbar");
+  });
+
+  it("caps output at 10 meaningful lines", () => {
+    const input = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\n");
+    const result = parseTmuxTail(input);
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(10);
+    expect(lines[0]).toBe("line 1");
+    expect(lines[9]).toBe("line 10");
+  });
+
+  it("returns fewer than 10 lines when input has fewer meaningful lines", () => {
+    const result = parseTmuxTail("line 1\nline 2\nline 3");
+    expect(result.split("\n")).toHaveLength(3);
+  });
+
+  it("trims trailing whitespace from each line", () => {
+    const result = parseTmuxTail("hello   \nworld  ");
+    expect(result).toBe("hello\nworld");
+  });
+
+  it("handles mixed content: chrome + ANSI + normal lines", () => {
+    const input = [
+      "\x1b[32m● Starting task\x1b[0m",
+      "\x1b[1mBuilding project\x1b[0m",
+      "● Another chrome line",
+      "ctrl+o to expand",
+      "Tests passed: 42",
+    ].join("\n");
+    const result = parseTmuxTail(input);
+    expect(result).toBe("Building project\nTests passed: 42");
+  });
+
+  it("does not remove lines that merely contain chrome characters mid-line", () => {
+    const result = parseTmuxTail("status: ● ok");
+    expect(result).toBe("status: ● ok");
   });
 });
 

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -168,16 +168,56 @@ export function formatSessionIdle(payload: NotificationPayload): string {
   return lines.join("\n");
 }
 
+/** Matches ANSI escape sequences (CSI and two-character escapes). */
+const ANSI_ESCAPE_RE = /\x1b(?:[@-Z\\-_]|\[[0-9;]*[a-zA-Z])/g;
+
+/** Lines starting with these characters are OMC UI chrome, not output. */
+const UI_CHROME_RE = /^[●⎿✻·◼]/;
+
+/** Matches the "ctrl+o to expand" hint injected by OMC. */
+const CTRL_O_RE = /ctrl\+o to expand/i;
+
+/** Maximum number of meaningful lines to include in a notification. */
+const MAX_TAIL_LINES = 10;
+
+/**
+ * Parse raw tmux output into clean, human-readable lines.
+ * - Strips ANSI escape codes
+ * - Drops lines starting with OMC chrome characters (●, ⎿, ✻, ·, ◼)
+ * - Drops "ctrl+o to expand" hint lines
+ * - Returns at most 10 non-empty lines
+ */
+export function parseTmuxTail(raw: string): string {
+  const meaningful: string[] = [];
+
+  for (const line of raw.split("\n")) {
+    const stripped = line.replace(ANSI_ESCAPE_RE, "");
+    const trimmed = stripped.trim();
+
+    if (!trimmed) continue;
+    if (UI_CHROME_RE.test(trimmed)) continue;
+    if (CTRL_O_RE.test(trimmed)) continue;
+
+    meaningful.push(stripped.trimEnd());
+    if (meaningful.length >= MAX_TAIL_LINES) break;
+  }
+
+  return meaningful.join("\n");
+}
+
 /**
  * Append tmux tail content to a message if present in the payload.
  */
 function appendTmuxTail(lines: string[], payload: NotificationPayload): void {
   if (payload.tmuxTail) {
-    lines.push("");
-    lines.push("**Recent output:**");
-    lines.push("```");
-    lines.push(payload.tmuxTail.trimEnd());
-    lines.push("```");
+    const parsed = parseTmuxTail(payload.tmuxTail);
+    if (parsed) {
+      lines.push("");
+      lines.push("**Recent output:**");
+      lines.push("```");
+      lines.push(parsed);
+      lines.push("```");
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `parseTmuxTail()` to `src/notifications/formatter.ts` (exported for testability) that strips ANSI escape codes, removes OMC UI chrome lines starting with `●`/`⎿`/`✻`/`·`/`◼`, removes `ctrl+o to expand` marker lines, and caps output at 10 meaningful lines
- Updates `appendTmuxTail()` to call `parseTmuxTail()` so notifications receive clean, human-readable output instead of raw terminal content
- Skips the tmux tail section entirely if no meaningful lines remain after parsing

## Test plan

- [x] 15 new unit tests for `parseTmuxTail` covering: empty input, ANSI stripping, each chrome character, ctrl+o variants, blank-line skipping, 10-line cap, trailing whitespace trimming, mixed content, and mid-line chrome (not stripped)
- [x] All 34 formatter tests pass (`vitest run`)
- [x] `tsc --noEmit` clean

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)