### PR TITLE
fix(keyword-detector): reduce false positives in FP-prone patterns

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -378,9 +378,7 @@ async function main() {
 
     // Autopilot keywords
     if (/\b(autopilot|auto pilot|auto-pilot|autonomous|full auto|fullsend)\b/i.test(cleanPrompt) ||
-        /\bbuild\s+me\s+/i.test(cleanPrompt) ||
-        /\bcreate\s+me\s+/i.test(cleanPrompt) ||
-        /\bmake\s+me\s+/i.test(cleanPrompt) ||
+        /\b(build|create|make)\s+me\s+(an?\s+)?(app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b/i.test(cleanPrompt) ||
         /\bi\s+want\s+a\s+/i.test(cleanPrompt) ||
         /\bi\s+want\s+an\s+/i.test(cleanPrompt) ||
         /\bhandle\s+it\s+all\b/i.test(cleanPrompt) ||
@@ -427,11 +425,6 @@ async function main() {
       matches.push({ name: 'ralplan', args: '' });
     }
 
-    // Plan keywords
-    if (/\b(plan this|plan the)\b/i.test(cleanPrompt)) {
-      matches.push({ name: 'plan', args: '' });
-    }
-
     // TDD keywords
     if (/\b(tdd)\b/i.test(cleanPrompt) ||
         /\btest\s+first\b/i.test(cleanPrompt) ||
@@ -439,10 +432,8 @@ async function main() {
       matches.push({ name: 'tdd', args: '' });
     }
 
-    // Research keywords
-    if (/\b(research)\b/i.test(cleanPrompt) ||
-        /\banalyze\s+data\b/i.test(cleanPrompt) ||
-        /\bstatistics\b/i.test(cleanPrompt)) {
+    // Sciomc keywords
+    if (/\banalyze\s+data\b/i.test(cleanPrompt)) {
       matches.push({ name: 'sciomc', args: '' });
     }
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -303,16 +303,14 @@ describe('Keyword Detector', () => {
       expect(detected[0].keyword).toBe('ralplan');
     });
 
-    it('should detect plan patterns', () => {
+    it('should NOT detect "plan this" / "plan the" patterns (FP-prone, removed in #824)', () => {
       const patterns = [
         'plan this feature',
         'plan the refactoring'
       ];
       for (const pattern of patterns) {
         const detected = detectKeywordsWithType(pattern);
-        expect(detected.length).toBeGreaterThan(0);
-        const hasPlan = detected.some(d => d.type === 'plan');
-        expect(hasPlan).toBe(true);
+        expect(detected).toHaveLength(0);
       }
     });
 
@@ -533,10 +531,9 @@ describe('Keyword Detector', () => {
       expect(primary!.type).toBe('ralplan');
     });
 
-    it('should detect plan correctly', () => {
+    it('should NOT detect plan for "plan this feature" (FP-prone pattern removed in #824)', () => {
       const primary = getPrimaryKeyword('plan this feature');
-      expect(primary).not.toBeNull();
-      expect(primary!.type).toBe('plan');
+      expect(primary).toBeNull();
     });
 
     it('should prioritize tdd correctly', () => {

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -373,7 +373,6 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
       case "team":
       case "pipeline":
       case "ralplan":
-      case "plan":
       case "tdd":
         messages.push(
           `[MODE: ${keywordType.toUpperCase()}] Skill invocation handled by UserPromptSubmit hook.`,

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -25,8 +25,7 @@ export type KeywordType =
 | 'swarm'       // Priority 6
   | 'pipeline'    // Priority 7
   | 'ralplan'     // Priority 8
-  | 'plan'        // Priority 9
-  | 'tdd'         // Priority 10
+  | 'tdd'         // Priority 9
   | 'ultrathink'  // Priority 11
   | 'deepsearch'  // Priority 12
   | 'analyze'     // Priority 13
@@ -54,8 +53,7 @@ const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   team: /(?<!\b(?:my|the|our|a|his|her|their|its)\s)\bteam\b|\bcoordinated\s+team\b/i,
   pipeline: /\bagent\s+pipeline\b|\bchain\s+agents\b/i,
   ralplan: /\b(ralplan)\b/i,
-  plan: /\bplan\s+(this|the)\b/i,
-tdd: /\b(tdd)\b|\btest\s+first\b/i,
+  tdd: /\b(tdd)\b|\btest\s+first\b/i,
   ultrathink: /\b(ultrathink)\b/i,
   deepsearch: /\b(deepsearch)\b|\bsearch\s+the\s+codebase\b|\bfind\s+in\s+(the\s+)?codebase\b/i,
   analyze: /\b(deep[\s-]?analyze|deepanalyze)\b/i,
@@ -69,7 +67,7 @@ tdd: /\b(tdd)\b|\btest\s+first\b/i,
  */
 const KEYWORD_PRIORITY: KeywordType[] = [
   'cancel', 'ralph', 'autopilot', 'ultrapilot', 'team', 'ultrawork',
-  'swarm', 'pipeline', 'ccg', 'ralplan', 'plan', 'tdd',
+  'swarm', 'pipeline', 'ccg', 'ralplan', 'tdd',
   'ultrathink', 'deepsearch', 'analyze', 'codex', 'gemini'
 ];
 

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -403,11 +403,6 @@ async function main() {
       matches.push({ name: 'ralplan', args: '' });
     }
 
-    // Plan keywords
-    if (/\b(plan this|plan the)\b/i.test(cleanPrompt)) {
-      matches.push({ name: 'plan', args: '' });
-    }
-
     // TDD keywords
     if (/\b(tdd)\b/i.test(cleanPrompt) ||
         /\btest\s+first\b/i.test(cleanPrompt)) {


### PR DESCRIPTION
## Summary

- **Remove `research` from sciomc triggers** — skill is deprecated; bare word triggered on unrelated prompts
- **Remove `statistics` from sciomc triggers** — far too broad (any statistical analysis mention fired sciomc)
- **Tighten `build/create/make me` autopilot patterns** — now require a product-noun suffix (`app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension`), preventing FP on "build me a regex", "make me a list", etc.
- **Remove `plan this` / `plan the` from plan triggers** — matched too easily in ordinary prose; plan skill is still invocable via `/plan` or `ralplan`

## Files changed

| File | Change |
|------|--------|
| `scripts/keyword-detector.mjs` | All 4 pattern fixes |
| `templates/hooks/keyword-detector.mjs` | Remove plan triggers |
| `src/hooks/keyword-detector/index.ts` | Remove `plan` from `KeywordType`, `KEYWORD_PATTERNS`, `KEYWORD_PRIORITY` |
| `src/hooks/bridge.ts` | Remove `case "plan"` from keyword switch |
| `src/__tests__/hooks.test.ts` | Update plan tests to expect no detection |

## Test plan

- [x] All 4736 tests pass (`vitest run`)
- [x] TypeScript build clean (`tsc --noEmit` via `npm install`)
- [x] "build me a regex" → no autopilot trigger
- [x] "build me an app" → autopilot triggers
- [x] "plan this feature" → no plan trigger
- [x] "research this topic" → no sciomc trigger
- [x] "analyze data" → sciomc still triggers (kept)

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)