### PR TITLE
feat(interop): gate interop tools and direct-write bridge by mode

### DIFF
--- a/src/__tests__/cli-interop-flags.test.ts
+++ b/src/__tests__/cli-interop-flags.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { readInteropRuntimeFlags, validateInteropRuntimeFlags } from '../cli/interop.js';
+
+describe('cli interop flag validation', () => {
+  it('reads defaults', () => {
+    const flags = readInteropRuntimeFlags({} as NodeJS.ProcessEnv);
+    expect(flags.enabled).toBe(false);
+    expect(flags.mode).toBe('off');
+    expect(flags.omcInteropToolsEnabled).toBe(false);
+    expect(flags.failClosed).toBe(true);
+  });
+
+  it('rejects non-off mode when interop is disabled', () => {
+    const flags = readInteropRuntimeFlags({
+      OMX_OMC_INTEROP_ENABLED: '0',
+      OMX_OMC_INTEROP_MODE: 'observe',
+      OMC_INTEROP_TOOLS_ENABLED: '0',
+    } as NodeJS.ProcessEnv);
+
+    const verdict = validateInteropRuntimeFlags(flags);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('must be "off"');
+  });
+
+  it('rejects active mode without interop tools enabled', () => {
+    const flags = readInteropRuntimeFlags({
+      OMX_OMC_INTEROP_ENABLED: '1',
+      OMX_OMC_INTEROP_MODE: 'active',
+      OMC_INTEROP_TOOLS_ENABLED: '0',
+    } as NodeJS.ProcessEnv);
+
+    const verdict = validateInteropRuntimeFlags(flags);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toContain('OMC_INTEROP_TOOLS_ENABLED=1');
+  });
+
+  it('accepts active mode when required flags are enabled', () => {
+    const flags = readInteropRuntimeFlags({
+      OMX_OMC_INTEROP_ENABLED: '1',
+      OMX_OMC_INTEROP_MODE: 'active',
+      OMC_INTEROP_TOOLS_ENABLED: '1',
+      OMX_OMC_INTEROP_FAIL_CLOSED: '1',
+    } as NodeJS.ProcessEnv);
+
+    const verdict = validateInteropRuntimeFlags(flags);
+    expect(verdict.ok).toBe(true);
+  });
+});

--- a/src/__tests__/disable-tools.test.ts
+++ b/src/__tests__/disable-tools.test.ts
@@ -96,6 +96,11 @@ describe('OMC_DISABLE_TOOLS', () => {
         expect(result.has(TOOL_CATEGORIES.SKILLS)).toBe(true);
       });
 
+      it('disables interop group', () => {
+        const result = parseDisabledGroups('interop');
+        expect(result.has(TOOL_CATEGORIES.INTEROP)).toBe(true);
+      });
+
       it('accepts codex group (reserved, no tools in t server)', () => {
         const result = parseDisabledGroups('codex');
         expect(result.has(TOOL_CATEGORIES.CODEX)).toBe(true);
@@ -190,7 +195,7 @@ describe('OMC_DISABLE_TOOLS', () => {
 
   describe('DISABLE_TOOLS_GROUP_MAP', () => {
     it('contains all issue-722 specified group names', () => {
-      const requiredGroups = ['lsp', 'ast', 'python-repl', 'gemini', 'codex', 'trace', 'state', 'notepad', 'project-memory'];
+      const requiredGroups = ['lsp', 'ast', 'python-repl', 'gemini', 'codex', 'trace', 'state', 'notepad', 'project-memory', 'interop'];
       for (const group of requiredGroups) {
         expect(DISABLE_TOOLS_GROUP_MAP).toHaveProperty(group);
       }

--- a/src/__tests__/omc-tools-server-interop.test.ts
+++ b/src/__tests__/omc-tools-server-interop.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const savedInteropFlag = process.env.OMC_INTEROP_TOOLS_ENABLED;
+
+async function importFresh() {
+  vi.resetModules();
+  return import('../mcp/omc-tools-server.js');
+}
+
+describe('omc-tools-server interop gating', () => {
+  beforeEach(() => {
+    delete process.env.OMC_INTEROP_TOOLS_ENABLED;
+  });
+
+  afterEach(() => {
+    if (savedInteropFlag === undefined) {
+      delete process.env.OMC_INTEROP_TOOLS_ENABLED;
+    } else {
+      process.env.OMC_INTEROP_TOOLS_ENABLED = savedInteropFlag;
+    }
+    vi.resetModules();
+  });
+
+  it('does not register interop tools by default', async () => {
+    const mod = await importFresh();
+    expect(mod.omcToolNames.some((name) => name.includes('interop_'))).toBe(false);
+  });
+
+  it('registers interop tools when OMC_INTEROP_TOOLS_ENABLED=1', async () => {
+    process.env.OMC_INTEROP_TOOLS_ENABLED = '1';
+    const mod = await importFresh();
+
+    expect(mod.omcToolNames).toContain('mcp__t__interop_send_task');
+    expect(mod.omcToolNames).toContain('mcp__t__interop_send_omx_message');
+  });
+
+  it('filters interop tools when includeInterop=false', async () => {
+    process.env.OMC_INTEROP_TOOLS_ENABLED = '1';
+    const mod = await importFresh();
+
+    const withInterop = mod.getOmcToolNames({ includeInterop: true });
+    const withoutInterop = mod.getOmcToolNames({ includeInterop: false });
+
+    expect(withInterop.some((name) => name.includes('interop_'))).toBe(true);
+    expect(withoutInterop.some((name) => name.includes('interop_'))).toBe(false);
+  });
+});

--- a/src/__tests__/omc-tools-server.test.ts
+++ b/src/__tests__/omc-tools-server.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { omcToolsServer, omcToolNames, getOmcToolNames } from '../mcp/omc-tools-server.js';
 
+const interopEnabled = process.env.OMC_INTEROP_TOOLS_ENABLED === '1';
+const totalTools = interopEnabled ? 43 : 35;
+const withoutLsp = interopEnabled ? 31 : 23;
+const withoutAst = interopEnabled ? 41 : 33;
+const withoutPython = interopEnabled ? 42 : 34;
+const withoutSkills = interopEnabled ? 40 : 32;
+
 describe('omc-tools-server', () => {
   describe('omcToolNames', () => {
-    it('should export 35 tools total', () => {
-      expect(omcToolNames).toHaveLength(35);
+    it('should export expected tools total', () => {
+      expect(omcToolNames).toHaveLength(totalTools);
     });
 
     it('should have 12 LSP tools', () => {
@@ -31,36 +38,46 @@ describe('omc-tools-server', () => {
   describe('getOmcToolNames', () => {
     it('should return all tools by default', () => {
       const tools = getOmcToolNames();
-      expect(tools).toHaveLength(35);
+      expect(tools).toHaveLength(totalTools);
     });
 
     it('should filter out LSP tools when includeLsp is false', () => {
       const tools = getOmcToolNames({ includeLsp: false });
       expect(tools.some(t => t.includes('lsp_'))).toBe(false);
-      expect(tools).toHaveLength(23); // 2 AST + 1 python + 3 skills + 5 state + 6 notepad + 4 memory + 2 trace
+      expect(tools).toHaveLength(withoutLsp);
     });
 
     it('should filter out AST tools when includeAst is false', () => {
       const tools = getOmcToolNames({ includeAst: false });
       expect(tools.some(t => t.includes('ast_'))).toBe(false);
-      expect(tools).toHaveLength(33); // 12 LSP + 1 python + 3 skills + 5 state + 6 notepad + 4 memory + 2 trace
+      expect(tools).toHaveLength(withoutAst);
     });
 
     it('should filter out python_repl when includePython is false', () => {
       const tools = getOmcToolNames({ includePython: false });
       expect(tools.some(t => t.includes('python_repl'))).toBe(false);
-      expect(tools).toHaveLength(34); // 12 LSP + 2 AST + 3 skills + 5 state + 6 notepad + 4 memory + 2 trace
+      expect(tools).toHaveLength(withoutPython);
     });
 
     it('should filter out skills tools', () => {
       const names = getOmcToolNames({ includeSkills: false });
-      expect(names).toHaveLength(32);
+      expect(names).toHaveLength(withoutSkills);
       expect(names.every(n => !n.includes('load_omc_skills') && !n.includes('list_omc_skills'))).toBe(true);
     });
 
     it('should have 3 skills tools', () => {
       const skillsTools = omcToolNames.filter(n => n.includes('load_omc_skills') || n.includes('list_omc_skills'));
       expect(skillsTools).toHaveLength(3);
+    });
+
+    it('supports includeInterop filter option', () => {
+      const withInterop = getOmcToolNames({ includeInterop: true });
+      const withoutInterop = getOmcToolNames({ includeInterop: false });
+
+      if (interopEnabled) {
+        expect(withInterop.some(n => n.includes('interop_'))).toBe(true);
+      }
+      expect(withoutInterop.some(n => n.includes('interop_'))).toBe(false);
     });
   });
 

--- a/src/cli/interop.ts
+++ b/src/cli/interop.ts
@@ -10,6 +10,38 @@ import { randomUUID } from 'crypto';
 import { isTmuxAvailable, isClaudeAvailable } from './tmux-utils.js';
 import { initInteropSession } from '../interop/shared-state.js';
 
+export type InteropMode = 'off' | 'observe' | 'active';
+
+export interface InteropRuntimeFlags {
+  enabled: boolean;
+  mode: InteropMode;
+  omcInteropToolsEnabled: boolean;
+  failClosed: boolean;
+}
+
+export function readInteropRuntimeFlags(env: NodeJS.ProcessEnv = process.env): InteropRuntimeFlags {
+  const rawMode = (env.OMX_OMC_INTEROP_MODE || 'off').toLowerCase();
+  const mode: InteropMode = rawMode === 'observe' || rawMode === 'active' ? rawMode : 'off';
+  return {
+    enabled: env.OMX_OMC_INTEROP_ENABLED === '1',
+    mode,
+    omcInteropToolsEnabled: env.OMC_INTEROP_TOOLS_ENABLED === '1',
+    failClosed: env.OMX_OMC_INTEROP_FAIL_CLOSED !== '0',
+  };
+}
+
+export function validateInteropRuntimeFlags(flags: InteropRuntimeFlags): { ok: boolean; reason?: string } {
+  if (!flags.enabled && flags.mode !== 'off') {
+    return { ok: false, reason: 'OMX_OMC_INTEROP_MODE must be "off" when OMX_OMC_INTEROP_ENABLED=0.' };
+  }
+
+  if (flags.mode === 'active' && !flags.omcInteropToolsEnabled) {
+    return { ok: false, reason: 'Active mode requires OMC_INTEROP_TOOLS_ENABLED=1.' };
+  }
+
+  return { ok: true };
+}
+
 /**
  * Check if codex CLI is available
  */
@@ -26,6 +58,16 @@ function isCodexAvailable(): boolean {
  * Launch interop session with split tmux panes
  */
 export function launchInteropSession(cwd: string = process.cwd()): void {
+  const flags = readInteropRuntimeFlags();
+  const flagCheck = validateInteropRuntimeFlags(flags);
+
+  console.log(`[interop] mode=${flags.mode}, enabled=${flags.enabled ? '1' : '0'}, tools=${flags.omcInteropToolsEnabled ? '1' : '0'}, failClosed=${flags.failClosed ? '1' : '0'}`);
+  if (!flagCheck.ok) {
+    console.error(`Error: ${flagCheck.reason}`);
+    console.error('Refusing to start interop in invalid flag configuration.');
+    process.exit(1);
+  }
+
   // Check prerequisites
   if (!isTmuxAvailable()) {
     console.error('Error: tmux is not available. Install tmux to use interop mode.');

--- a/src/constants/names.ts
+++ b/src/constants/names.ts
@@ -27,6 +27,7 @@ export const TOOL_CATEGORIES = {
   MEMORY: 'memory',
   TRACE: 'trace',
   SKILLS: 'skills',
+  INTEROP: 'interop',
   CODEX: 'codex',
   GEMINI: 'gemini',
 } as const;

--- a/src/interop/__tests__/mcp-bridge.test.ts
+++ b/src/interop/__tests__/mcp-bridge.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { canUseOmxDirectWriteBridge, getInteropMode, interopSendOmxMessageTool } from '../mcp-bridge.js';
+
+describe('interop mcp bridge gating', () => {
+  it('getInteropMode normalizes invalid values to off', () => {
+    expect(getInteropMode({ OMX_OMC_INTEROP_MODE: 'ACTIVE' } as NodeJS.ProcessEnv)).toBe('active');
+    expect(getInteropMode({ OMX_OMC_INTEROP_MODE: 'observe' } as NodeJS.ProcessEnv)).toBe('observe');
+    expect(getInteropMode({ OMX_OMC_INTEROP_MODE: 'nonsense' } as NodeJS.ProcessEnv)).toBe('off');
+  });
+
+  it('canUseOmxDirectWriteBridge requires all active flags', () => {
+    expect(canUseOmxDirectWriteBridge({
+      OMX_OMC_INTEROP_ENABLED: '1',
+      OMX_OMC_INTEROP_MODE: 'active',
+      OMC_INTEROP_TOOLS_ENABLED: '1',
+    } as NodeJS.ProcessEnv)).toBe(true);
+
+    expect(canUseOmxDirectWriteBridge({
+      OMX_OMC_INTEROP_ENABLED: '1',
+      OMX_OMC_INTEROP_MODE: 'observe',
+      OMC_INTEROP_TOOLS_ENABLED: '1',
+    } as NodeJS.ProcessEnv)).toBe(false);
+
+    expect(canUseOmxDirectWriteBridge({
+      OMX_OMC_INTEROP_ENABLED: '0',
+      OMX_OMC_INTEROP_MODE: 'active',
+      OMC_INTEROP_TOOLS_ENABLED: '1',
+    } as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it('interop_send_omx_message rejects when direct write path is disabled', async () => {
+    const savedEnabled = process.env.OMX_OMC_INTEROP_ENABLED;
+    const savedMode = process.env.OMX_OMC_INTEROP_MODE;
+    const savedTools = process.env.OMC_INTEROP_TOOLS_ENABLED;
+
+    process.env.OMX_OMC_INTEROP_ENABLED = '0';
+    process.env.OMX_OMC_INTEROP_MODE = 'off';
+    process.env.OMC_INTEROP_TOOLS_ENABLED = '0';
+
+    try {
+      const response = await interopSendOmxMessageTool.handler({
+        teamName: 'alpha-team',
+        fromWorker: 'omc-bridge',
+        toWorker: 'worker-1',
+        body: 'blocked',
+      });
+
+      expect(response.isError).toBe(true);
+      const text = response.content[0]?.text ?? '';
+      expect(text.toLowerCase()).toContain('disabled');
+    } finally {
+      if (savedEnabled === undefined) delete process.env.OMX_OMC_INTEROP_ENABLED;
+      else process.env.OMX_OMC_INTEROP_ENABLED = savedEnabled;
+
+      if (savedMode === undefined) delete process.env.OMX_OMC_INTEROP_MODE;
+      else process.env.OMX_OMC_INTEROP_MODE = savedMode;
+
+      if (savedTools === undefined) delete process.env.OMC_INTEROP_TOOLS_ENABLED;
+      else process.env.OMC_INTEROP_TOOLS_ENABLED = savedTools;
+    }
+  });
+});

--- a/src/interop/omx-team-state.ts
+++ b/src/interop/omx-team-state.ts
@@ -241,6 +241,9 @@ export async function listOmxMailboxMessages(
 
 /**
  * Send a direct message to an omx worker's mailbox
+ *
+ * @deprecated Interop active write path must go through broker -> OMX team_* MCP APIs.
+ * Kept for legacy compatibility and observe-mode tooling only.
  */
 export async function sendOmxDirectMessage(
   teamName: string,
@@ -280,6 +283,8 @@ export async function sendOmxDirectMessage(
 
 /**
  * Broadcast a message to all workers in an omx team
+ *
+ * @deprecated Interop active write path must go through broker -> OMX team_* MCP APIs.
  */
 export async function broadcastOmxMessage(
   teamName: string,
@@ -300,6 +305,8 @@ export async function broadcastOmxMessage(
 
 /**
  * Mark a message as delivered in an omx worker's mailbox
+ *
+ * @deprecated Interop active write path must go through broker -> OMX team_* MCP APIs.
  */
 export async function markOmxMessageDelivered(
   teamName: string,
@@ -378,6 +385,8 @@ export async function listOmxTasks(
 
 /**
  * Append an event to the omx team event log
+ *
+ * @deprecated Interop active write path must go through broker -> OMX team_* MCP APIs.
  */
 export async function appendOmxTeamEvent(
   teamName: string,


### PR DESCRIPTION
## Summary
- add `interop` tool category and disable-group wiring
- register interop MCP tools only when `OMC_INTEROP_TOOLS_ENABLED=1`
- add `includeInterop` filtering support in OMC tool-name helpers
- add runtime flag parsing/validation for interop launcher (`off` / `observe` / `active`)
- guard direct OMX mailbox-write bridge so it only runs in explicit active mode with required flags
- mark legacy direct-write helpers as deprecated for active-path usage
- add focused tests for interop tool registration, bridge gating, and CLI flag validation

## Why
This keeps interop fail-closed by default and prevents accidental direct state mutation paths, while still enabling explicit active-mode cooperation with OMX.

## Validation
- `npm run test:run -- src/__tests__/cli-interop-flags.test.ts src/interop/__tests__/mcp-bridge.test.ts src/__tests__/omc-tools-server-interop.test.ts src/__tests__/disable-tools.test.ts src/__tests__/omc-tools-server.test.ts`
