### PR TITLE
fix(mcp): add SUBAGENT_HEADER to prevent recursive Codex/Gemini spawning (closes #828)

### DIFF
--- a/src/__tests__/prompt-injection.test.ts
+++ b/src/__tests__/prompt-injection.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { resolveSystemPrompt, buildPromptWithSystemContext, VALID_AGENT_ROLES, getValidAgentRoles, isValidAgentRoleName } from '../mcp/prompt-injection.js';
+import { resolveSystemPrompt, buildPromptWithSystemContext, VALID_AGENT_ROLES, getValidAgentRoles, isValidAgentRoleName, SUBAGENT_HEADER } from '../mcp/prompt-injection.js';
 
 describe('prompt-injection', () => {
   describe('VALID_AGENT_ROLES', () => {
@@ -149,9 +149,9 @@ describe('prompt-injection', () => {
   });
 
   describe('buildPromptWithSystemContext', () => {
-    test('returns just user prompt when no extras', () => {
+    test('returns subagent header + user prompt when no extras', () => {
       const result = buildPromptWithSystemContext('Hello', undefined, undefined);
-      expect(result).toBe('Hello');
+      expect(result).toBe(`${SUBAGENT_HEADER}\n\nHello`);
     });
 
     test('prepends system prompt with delimiters', () => {

--- a/src/mcp/__tests__/prompt-injection.test.ts
+++ b/src/mcp/__tests__/prompt-injection.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { SUBAGENT_HEADER, buildPromptWithSystemContext } from '../prompt-injection.js';
+
+describe('SUBAGENT_HEADER', () => {
+  it('contains the required subagent mode marker', () => {
+    expect(SUBAGENT_HEADER).toContain('[SUBAGENT MODE]');
+  });
+
+  it('instructs against recursive subagent spawning', () => {
+    expect(SUBAGENT_HEADER).toContain('DO NOT spawn additional subagents');
+    expect(SUBAGENT_HEADER).toContain('Codex/Gemini CLI recursively');
+  });
+});
+
+describe('buildPromptWithSystemContext', () => {
+  it('always prepends SUBAGENT_HEADER as the first element', () => {
+    const result = buildPromptWithSystemContext('my prompt', undefined, undefined);
+    expect(result.startsWith(SUBAGENT_HEADER)).toBe(true);
+  });
+
+  it('prepends header before system-instructions when system prompt provided', () => {
+    const result = buildPromptWithSystemContext('task', undefined, 'be helpful');
+    const headerIdx = result.indexOf(SUBAGENT_HEADER);
+    const sysIdx = result.indexOf('<system-instructions>');
+    expect(headerIdx).toBe(0);
+    expect(sysIdx).toBeGreaterThan(headerIdx);
+  });
+
+  it('prepends header before file context', () => {
+    const result = buildPromptWithSystemContext('task', 'file contents', undefined);
+    const headerIdx = result.indexOf(SUBAGENT_HEADER);
+    const fileIdx = result.indexOf('UNTRUSTED DATA');
+    expect(headerIdx).toBe(0);
+    expect(fileIdx).toBeGreaterThan(headerIdx);
+  });
+
+  it('preserves order: header > system > file > user', () => {
+    const result = buildPromptWithSystemContext('user task', 'file data', 'system role');
+    const headerIdx = result.indexOf(SUBAGENT_HEADER);
+    const sysIdx = result.indexOf('<system-instructions>');
+    const fileIdx = result.indexOf('UNTRUSTED DATA');
+    const userIdx = result.indexOf('user task');
+    expect(headerIdx).toBeLessThan(sysIdx);
+    expect(sysIdx).toBeLessThan(fileIdx);
+    expect(fileIdx).toBeLessThan(userIdx);
+  });
+
+  it('works with no system prompt and no file context', () => {
+    const result = buildPromptWithSystemContext('hello', undefined, undefined);
+    expect(result).toBe(`${SUBAGENT_HEADER}\n\nhello`);
+  });
+});

--- a/src/mcp/prompt-injection.ts
+++ b/src/mcp/prompt-injection.ts
@@ -173,9 +173,15 @@ export function inlineSuccessBlocks(metadataText: string, wrappedResponse: strin
 }
 
 /**
+ * Header prepended to all prompts sent to subagent CLIs (Codex/Gemini).
+ * Prevents recursive subagent spawning and rate limit cascade issues.
+ */
+export const SUBAGENT_HEADER = '[SUBAGENT MODE] You are running as a subagent. DO NOT spawn additional subagents or call Codex/Gemini CLI recursively. Focus only on your assigned task.';
+
+/**
  * Build the full prompt with system prompt prepended.
  *
- * Order: system_prompt > file_context > user_prompt
+ * Order: subagent_header > system_prompt > file_context > user_prompt
  *
  * Uses clear XML-like delimiters so the external model can distinguish sections.
  * File context is wrapped with untrusted data warnings to mitigate prompt injection.
@@ -186,6 +192,8 @@ export function buildPromptWithSystemContext(
   systemPrompt: string | undefined
 ): string {
   const parts: string[] = [];
+
+  parts.push(SUBAGENT_HEADER);
 
   if (systemPrompt) {
     parts.push(`<system-instructions>\n${systemPrompt}\n</system-instructions>`);


### PR DESCRIPTION
## Summary
- Adds `SUBAGENT_HEADER` constant to `src/mcp/prompt-injection.ts` with the text: `[SUBAGENT MODE] You are running as a subagent. DO NOT spawn additional subagents or call Codex/Gemini CLI recursively. Focus only on your assigned task.`
- Prepends this header as the first element in `buildPromptWithSystemContext()`, before system-instructions, file context, and user prompt
- Both `codex-core.ts` and `gemini-core.ts` already route through `buildPromptWithSystemContext()`, so the fix covers all prompt paths for both providers

## Test plan
- [ ] New test file `src/mcp/__tests__/prompt-injection.test.ts` — 7 tests covering header content, ordering, and all `buildPromptWithSystemContext` branch combinations
- [ ] Updated `src/__tests__/prompt-injection.test.ts` to reflect new header-prepend behavior
- [ ] Full suite: 4830 tests passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)