### PR TITLE
fix(hooks): add OMC_SKIP_HOOKS guard to standalone hook scripts

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -343,6 +343,13 @@ function createHookOutput(additionalContext) {
 
 // Main
 async function main() {
+  // Skip guard: check OMC_SKIP_HOOKS env var (see issue #838)
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('keyword-detector')) {
+    console.log(JSON.stringify({ continue: true }));
+    return;
+  }
+
   try {
     const input = await readStdin();
     if (!input.trim()) {

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -324,6 +324,13 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory) 
 }
 
 async function main() {
+  // Skip guard: check OMC_SKIP_HOOKS env var (see issue #838)
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('post-tool-use')) {
+    console.log(JSON.stringify({ continue: true }));
+    return;
+  }
+
   try {
     const input = await readStdin();
     const data = JSON.parse(input);

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -126,6 +126,13 @@ async function recordToolInvocation(data, directory) {
 }
 
 async function main() {
+  // Skip guard: check OMC_SKIP_HOOKS env var (see issue #838)
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('pre-tool-use')) {
+    console.log(JSON.stringify({ continue: true }));
+    return;
+  }
+
   try {
     const input = await readStdin();
 


### PR DESCRIPTION
## Summary
- Add `OMC_SKIP_HOOKS` env var guard to `pre-tool-enforcer.mjs`, `post-tool-verifier.mjs`, and `keyword-detector.mjs`
- Also checks `DISABLE_OMC=1` for full disable

## Problem
The `.mjs` hook scripts run independently of `bridge.ts` and had no skip guard. The `skipHooks` config in `.omc-config.json` and the `OMC_SKIP_HOOKS` env var were both ignored — hooks always fired.

This causes:
- "Command failed" system-reminders on every non-zero bash exit (benign git/build failures)
- "Read multiple files in parallel" noise on every Read call
- False keyword triggers flooding context

## Fix
Early-exit guard at the top of `main()` in all three scripts:

```js
const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('pre-tool-use')) {
  console.log(JSON.stringify({ continue: true }));
  return;
}
```

## Usage
```bash
export OMC_SKIP_HOOKS="keyword-detector,pre-tool-use,post-tool-use"
```

Fixes #838