### PR TITLE
fix(formatter): return last N lines in parseTmuxTail instead of first N

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -194,13 +194,13 @@ describe("parseTmuxTail", () => {
     expect(result).toBe("foo\nbar");
   });
 
-  it("caps output at 10 meaningful lines", () => {
+  it("caps output at 10 meaningful lines, returning the LAST 10", () => {
     const input = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\n");
     const result = parseTmuxTail(input);
     const lines = result.split("\n");
     expect(lines).toHaveLength(10);
-    expect(lines[0]).toBe("line 1");
-    expect(lines[9]).toBe("line 10");
+    expect(lines[0]).toBe("line 11");
+    expect(lines[9]).toBe("line 20");
   });
 
   it("returns fewer than 10 lines when input has fewer meaningful lines", () => {

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -199,10 +199,9 @@ export function parseTmuxTail(raw: string): string {
     if (CTRL_O_RE.test(trimmed)) continue;
 
     meaningful.push(stripped.trimEnd());
-    if (meaningful.length >= MAX_TAIL_LINES) break;
   }
 
-  return meaningful.join("\n");
+  return meaningful.slice(-MAX_TAIL_LINES).join("\n");
 }
 
 /**


### PR DESCRIPTION
## Summary

- `parseTmuxTail` was collecting meaningful lines and breaking early once `MAX_TAIL_LINES` was reached, returning the **first** N lines
- Changed to collect all meaningful lines then use `.slice(-MAX_TAIL_LINES)` to return the **last** N lines (most recent output)
- Updated the corresponding test to assert the correct last-N behavior

## Test plan

- [x] Updated existing `"caps output at 10 meaningful lines"` test to verify last-10 lines are returned (lines 11–20 from a 20-line input)
- [x] All 40 formatter tests pass (`npm test formatter`)
- [x] Build passes (`npm run build`)

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)