### PR TITLE
fix(outbox-reader): backtrack cursor when read window ends mid-JSON line

### DIFF
--- a/src/team/__tests__/outbox-reader.test.ts
+++ b/src/team/__tests__/outbox-reader.test.ts
@@ -85,6 +85,38 @@ describe('readNewOutboxMessages', () => {
     expect(msgs).toHaveLength(1);
     expect(msgs[0].type).toBe('idle');
   });
+
+  it('does not drop messages when read window ends mid-JSON line', () => {
+    const outbox = join(TEAMS_DIR, 'outbox', 'w1.jsonl');
+    const cursorFile = join(TEAMS_DIR, 'outbox', 'w1.outbox-offset');
+
+    const msg1: OutboxMessage = { type: 'task_complete', taskId: 't1', timestamp: '2026-01-01T00:00:00Z' };
+    const msg2: OutboxMessage = { type: 'idle', message: 'standing by', timestamp: '2026-01-01T00:01:00Z' };
+    const msg2json = JSON.stringify(msg2);
+
+    // Write first complete line plus a partial second line (no trailing newline)
+    writeFileSync(outbox, JSON.stringify(msg1) + '\n' + msg2json.slice(0, 10));
+
+    const batch1 = readNewOutboxMessages(TEST_TEAM, 'w1');
+    // Only the complete first line should be returned
+    expect(batch1).toHaveLength(1);
+    expect(batch1[0].type).toBe('task_complete');
+
+    // Cursor must NOT have advanced past the partial line; verify by checking
+    // that the cursor points to the byte just after the first newline
+    const cursor = JSON.parse(readFileSync(cursorFile, 'utf-8'));
+    const firstLineBytes = Buffer.byteLength(JSON.stringify(msg1) + '\n', 'utf-8');
+    expect(cursor.bytesRead).toBe(firstLineBytes);
+
+    // Now complete the second line
+    writeFileSync(outbox, JSON.stringify(msg1) + '\n' + msg2json + '\n');
+
+    const batch2 = readNewOutboxMessages(TEST_TEAM, 'w1');
+    // The previously partial line should now be delivered
+    expect(batch2).toHaveLength(1);
+    expect(batch2[0].type).toBe('idle');
+    expect(batch2[0].message).toBe('standing by');
+  });
 });
 
 describe('readAllTeamOutboxMessages', () => {

--- a/src/team/outbox-reader.ts
+++ b/src/team/outbox-reader.ts
@@ -72,7 +72,8 @@ export function readNewOutboxMessages(
     closeSync(fd);
   }
 
-  const lines = buf.toString('utf-8').split('\n').filter(l => l.trim());
+  const chunk = buf.toString('utf-8');
+  const lines = chunk.split('\n').filter(l => l.trim());
   const messages: OutboxMessage[] = [];
   for (const line of lines) {
     try {
@@ -80,8 +81,18 @@ export function readNewOutboxMessages(
     } catch { /* skip malformed lines */ }
   }
 
+  // If the buffer ends mid-line (no trailing newline), backtrack the cursor
+  // to the start of that partial line so it is retried on the next read.
+  let consumed = bytesToRead;
+  if (!chunk.endsWith('\n')) {
+    const lastNewline = chunk.lastIndexOf('\n');
+    consumed = lastNewline >= 0
+      ? Buffer.byteLength(chunk.slice(0, lastNewline + 1), 'utf-8')
+      : 0;
+  }
+
   // Update cursor atomically to prevent corruption on crash
-  const newCursor: OutboxCursor = { bytesRead: cursor.bytesRead + bytesToRead };
+  const newCursor: OutboxCursor = { bytesRead: cursor.bytesRead + consumed };
   const cursorDir = join(teamsDir(), safeName, 'outbox');
   ensureDirWithMode(cursorDir);
   atomicWriteJson(cursorPath, newCursor);


### PR DESCRIPTION
## Summary

- `readNewOutboxMessages()` advanced its byte cursor by the full read window even when the buffer ended in a partial JSON line
- The truncated line failed `JSON.parse`, was silently skipped, and the cursor moved past it permanently — the message was lost forever
- Fix: after decoding the buffer, if the chunk does not end with `\n`, find the last newline and only advance the cursor that far, so the partial line is retried on the next read

## Test plan

- [ ] New regression test in `outbox-reader.test.ts`: writes a complete line + a partial second line, asserts cursor stays at the first-line boundary, then completes the second line and confirms it is delivered on the next read
- [ ] All 10 outbox-reader tests pass (`npx vitest run src/team/__tests__/outbox-reader.test.ts`)
- [ ] `npm run build` succeeds

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)