### PR TITLE
fix(agents-overlay): remove duplicate truncation note (closes #844)

### DIFF
--- a/src/hooks/__tests__/codebase-map.test.ts
+++ b/src/hooks/__tests__/codebase-map.test.ts
@@ -327,4 +327,16 @@ describe('buildAgentsOverlay', () => {
     expect(result.hasCodebaseMap).toBe(false);
     expect(result.message).toBe('');
   });
+
+  it('includes truncation note exactly once when map is truncated (closes #844)', () => {
+    // Create 201 files to exceed the default maxFiles limit of 200
+    for (let i = 0; i < 201; i++) {
+      writeFile(tempDir, `file${i}.ts`, '');
+    }
+    const result = buildAgentsOverlay(tempDir);
+    expect(result.hasCodebaseMap).toBe(true);
+    const matches = result.message.match(/\[Map truncated/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(1);
+  });
 });

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -49,10 +49,6 @@ export function buildAgentsOverlay(
     return { message: '', hasCodebaseMap: false };
   }
 
-  const truncationNote = result.truncated
-    ? `\n[Map truncated at ${mergedOptions.maxFiles} files — use Glob/Grep for full search]`
-    : '';
-
   const message = `<session-restore>
 
 [CODEBASE MAP]
@@ -60,7 +56,7 @@ export function buildAgentsOverlay(
 Project structure for: ${directory}
 Use this map to navigate efficiently. Prefer Glob/Grep over blind file exploration.
 
-${result.map}${truncationNote}
+${result.map}
 
 </session-restore>
 


### PR DESCRIPTION
## Summary

- The `[Map truncated...]` message was emitted twice: once inside `result.map` (from `codebase-map.ts:263`) and again as a suffix appended in `agents-overlay.ts:52-54`.
- Removed the redundant `truncationNote` block from `agents-overlay.ts`. `codebase-map.ts` remains the single source of truth.
- Added a regression test in `buildAgentsOverlay` that creates 201 files (exceeding the default 200-file limit) and asserts the truncation note appears exactly once in the final message.

## Test plan

- [x] `npm run build` passes
- [x] `npm test src/hooks/__tests__/codebase-map.test.ts` — all 34 tests pass, including the new regression test
- [x] New test: `includes truncation note exactly once when map is truncated (closes #844)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)