### PR TITLE
fix(live-data): skip directives inside unterminated fenced code blocks (closes #853)

### DIFF
--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -75,6 +75,24 @@ describe('resolveLiveData - basic', () => {
     expect(mockedExecSync).toHaveBeenCalledTimes(1);
   });
 
+  it('skips !lines inside an unclosed/unterminated fenced code block', () => {
+    mockedExecSync.mockReturnValue('ran\n');
+    // Opening fence is never closed — directive must not execute
+    const input = '```\n!echo skip-me';
+    const result = resolveLiveData(input);
+    expect(result).toContain('!echo skip-me');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
+  it('skips multiple !lines after an unclosed fence', () => {
+    mockedExecSync.mockReturnValue('ran\n');
+    const input = 'before\n```bash\n!echo one\n!echo two';
+    const result = resolveLiveData(input);
+    expect(result).toContain('!echo one');
+    expect(result).toContain('!echo two');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
   it('handles failed commands with error attribute', () => {
     const error = new Error('command failed') as Error & { stderr: string };
     error.stderr = 'permission denied\n';

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -212,6 +212,10 @@ function getCodeBlockRanges(lines: string[]): Array<[number, number]> {
       }
     }
   }
+  // Unclosed fence: treat every line after the opening fence as inside a code block
+  if (openIndex !== null) {
+    ranges.push([openIndex, lines.length]);
+  }
   return ranges;
 }
 


### PR DESCRIPTION
## Summary

- `getCodeBlockRanges()` only recorded closed fence pairs; an unclosed opening fence left `openIndex` dangling so no range was pushed
- Lines after the unclosed fence were not excluded by `isInsideCodeBlock()`, causing `!` directives to execute inside unterminated code blocks
- Fix: after the loop, if `openIndex !== null` push `[openIndex, lines.length]` so every line after the opening fence is treated as inside the block

## Test plan

- [ ] `skips !lines inside an unclosed/unterminated fenced code block` — single directive after unclosed fence is preserved, `execSync` not called
- [ ] `skips multiple !lines after an unclosed fence` — multiple directives after unclosed fence all preserved
- [ ] All 35 existing tests continue to pass (`npx vitest run src/__tests__/live-data.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)