### PR TITLE
fix(notifications): lookupByMessageId returns oldest mapping when duplicate message IDs exist

### DIFF
--- a/src/notifications/__tests__/session-registry.test.ts
+++ b/src/notifications/__tests__/session-registry.test.ts
@@ -343,6 +343,36 @@ describe("session-registry", () => {
       const result = lookupByMessageId("telegram", "123");
       expect(result).toBeNull();
     });
+
+    it("returns the most recent entry when duplicate message IDs exist", () => {
+      const older: SessionMapping = {
+        platform: "discord-bot",
+        messageId: "dup-id",
+        sessionId: "session-old",
+        tmuxPaneId: "%0",
+        tmuxSessionName: "old-session",
+        event: "session-start",
+        createdAt: new Date(Date.now() - 5000).toISOString(),
+      };
+
+      const newer: SessionMapping = {
+        platform: "discord-bot",
+        messageId: "dup-id",
+        sessionId: "session-new",
+        tmuxPaneId: "%1",
+        tmuxSessionName: "new-session",
+        event: "session-start",
+        createdAt: new Date().toISOString(),
+      };
+
+      registerMessage(older);
+      registerMessage(newer);
+
+      const result = lookupByMessageId("discord-bot", "dup-id");
+      expect(result).not.toBeNull();
+      expect(result?.sessionId).toBe("session-new");
+      expect(result?.tmuxPaneId).toBe("%1");
+    });
   });
 
   describe("removeSession", () => {

--- a/src/notifications/session-registry.ts
+++ b/src/notifications/session-registry.ts
@@ -355,13 +355,13 @@ function readAllMappingsUnsafe(): SessionMapping[] {
 
 /**
  * Look up a mapping by platform and message ID.
- * Returns the first match (most recent entry wins if duplicates exist).
+ * Returns the most recent entry when duplicates exist (last match in append-ordered JSONL).
  */
 export function lookupByMessageId(platform: string, messageId: string): SessionMapping | null {
   const mappings = loadAllMappings();
 
-  // Find first match (JSONL is append-only, so first occurrence is the original)
-  return mappings.find(m => m.platform === platform && m.messageId === messageId) || null;
+  // Use findLast so that the most recently appended entry wins when duplicates exist.
+  return mappings.findLast(m => m.platform === platform && m.messageId === messageId) ?? null;
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2023"],
     "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

- `lookupByMessageId()` used `Array.find()` on append-ordered JSONL data, returning the **oldest** match when duplicate `(platform, messageId)` entries existed
- This could route replies to a stale tmux pane/session instead of the current one
- Fix: replace `find()` with `findLast()` so the most recently appended entry wins
- Bump `tsconfig.json` lib from `ES2022` → `ES2023` to enable the `findLast` type definition (Node >=20 is already required and supports it at runtime)

## Test plan

- [x] Added regression test: registers two entries with the same `(platform, messageId)` and asserts the newer `sessionId`/`tmuxPaneId` is returned
- [x] All 21 existing `session-registry` tests pass
- [x] `npm run build` succeeds with no TypeScript errors

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)