### PR TITLE
fix(plugin-patterns): validateCommitMessage now respects CommitConfig.types

### DIFF
--- a/src/__tests__/hooks/plugin-patterns.test.ts
+++ b/src/__tests__/hooks/plugin-patterns.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { validateCommitMessage } from '../../hooks/plugin-patterns/index.js';
+
+describe('validateCommitMessage', () => {
+  describe('default types (no config)', () => {
+    it('accepts a valid conventional commit message', () => {
+      const result = validateCommitMessage('feat: add new feature');
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('accepts all default types', () => {
+      const defaultTypes = ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert'];
+      for (const type of defaultTypes) {
+        const result = validateCommitMessage(`${type}: some description`);
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    it('rejects an unknown type', () => {
+      const result = validateCommitMessage('ship: deploy changes');
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('conventional commit format'))).toBe(true);
+    });
+
+    it('includes default type list in error message', () => {
+      const result = validateCommitMessage('ship: deploy changes');
+      expect(result.errors.some(e => e.includes('feat'))).toBe(true);
+    });
+  });
+
+  describe('custom types via config.types', () => {
+    it('accepts a custom type when configured', () => {
+      const result = validateCommitMessage('ship: deploy changes', { types: ['ship', 'rollback'] });
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('rejects a default type not present in the custom list', () => {
+      const result = validateCommitMessage('feat: add feature', { types: ['ship', 'rollback'] });
+      expect(result.valid).toBe(false);
+    });
+
+    it('includes custom types in the error message', () => {
+      const result = validateCommitMessage('unknown: change', { types: ['ship', 'rollback'] });
+      expect(result.errors.some(e => e.includes('ship'))).toBe(true);
+      expect(result.errors.some(e => e.includes('rollback'))).toBe(true);
+    });
+
+    it('does not mention default types when custom types are provided', () => {
+      const result = validateCommitMessage('unknown: change', { types: ['ship'] });
+      // Error should list 'ship', not the whole default set
+      const typeError = result.errors.find(e => e.startsWith('Allowed types:'));
+      expect(typeError).toBeDefined();
+      expect(typeError).toContain('ship');
+      expect(typeError).not.toContain('feat');
+    });
+
+    it('falls back to default types when config.types is an empty array', () => {
+      const result = validateCommitMessage('feat: add feature', { types: [] });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts a custom type with scope', () => {
+      const result = validateCommitMessage('ship(api): deploy api changes', { types: ['ship'] });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts a custom type with breaking-change marker', () => {
+      const result = validateCommitMessage('ship!: breaking deploy', { types: ['ship'] });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('other config options still work alongside custom types', () => {
+    it('enforces maxSubjectLength with custom types', () => {
+      const result = validateCommitMessage('ship: ' + 'a'.repeat(70), {
+        types: ['ship'],
+        maxSubjectLength: 50,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('exceeds'))).toBe(true);
+    });
+
+    it('enforces requireScope with custom types', () => {
+      const result = validateCommitMessage('ship: change without scope', {
+        types: ['ship'],
+        requireScope: true,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Scope is required'))).toBe(true);
+    });
+
+    it('enforces requireBody with custom types', () => {
+      const result = validateCommitMessage('ship: change without body', {
+        types: ['ship'],
+        requireBody: true,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('body is required'))).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('rejects an empty commit message', () => {
+      const result = validateCommitMessage('', { types: ['ship'] });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Commit message cannot be empty');
+    });
+
+    it('rejects a whitespace-only commit message', () => {
+      const result = validateCommitMessage('   ', { types: ['ship'] });
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/src/hooks/plugin-patterns/index.ts
+++ b/src/hooks/plugin-patterns/index.ts
@@ -218,12 +218,18 @@ export function validateCommitMessage(
     return { valid: false, errors };
   }
 
+  // Determine effective types: prefer config.types when non-empty
+  const effectiveTypes = config?.types?.length ? config.types : DEFAULT_COMMIT_TYPES;
+  const commitRegex = effectiveTypes === DEFAULT_COMMIT_TYPES
+    ? CONVENTIONAL_COMMIT_REGEX
+    : new RegExp(`^(${effectiveTypes.join('|')})(\\([a-z0-9-]+\\))?(!)?:\\s.+$`);
+
   // Check conventional commit format
-  if (!CONVENTIONAL_COMMIT_REGEX.test(subject)) {
+  if (!commitRegex.test(subject)) {
     errors.push(
       'Subject must follow conventional commit format: type(scope?): description'
     );
-    errors.push(`Allowed types: ${DEFAULT_COMMIT_TYPES.join(', ')}`);
+    errors.push(`Allowed types: ${effectiveTypes.join(', ')}`);
   }
 
   // Check subject length


### PR DESCRIPTION
## Summary

- `validateCommitMessage()` accepted an optional `CommitConfig`, but the `types` field was never used — the function always validated against the hardcoded `CONVENTIONAL_COMMIT_REGEX` and reported errors using `DEFAULT_COMMIT_TYPES`.
- Build a dynamic regex from `config.types` when it is non-empty, so custom commit types are accepted and shown in error messages.
- Fall back to defaults (`DEFAULT_COMMIT_TYPES` / `CONVENTIONAL_COMMIT_REGEX`) when `config.types` is absent or empty, preserving all existing behaviour.

Fixes #872

## Changes

- `src/hooks/plugin-patterns/index.ts`: derive `effectiveTypes` from `config.types` (if non-empty) and build the commit regex dynamically from it.
- `src/__tests__/hooks/plugin-patterns.test.ts`: 16 new tests covering default types, custom types, mixed config options, and edge cases.

## Test plan

- [x] `npx vitest run src/__tests__/hooks/plugin-patterns.test.ts` — 16/16 tests pass
- [x] `npm run build` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)