### PR TITLE
fix(cli-launch): propagate Claude non-zero exit codes instead of swallowing them

### DIFF
--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../tmux-utils.js', () => ({
+  resolveLaunchPolicy: vi.fn(),
+  buildTmuxSessionName: vi.fn(() => 'test-session'),
+  buildTmuxShellCommand: vi.fn(() => ''),
+  quoteShellArg: vi.fn((s: string) => s),
+  listHudWatchPaneIdsInCurrentWindow: vi.fn(() => []),
+  createHudWatchPane: vi.fn(() => null),
+  killTmuxPane: vi.fn(),
+  isClaudeAvailable: vi.fn(() => true),
+}));
+
+import { runClaude } from '../launch.js';
+import { resolveLaunchPolicy } from '../tmux-utils.js';
+
+describe('runClaude — exit code propagation', () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+  });
+
+  describe('direct policy', () => {
+    beforeEach(() => {
+      (resolveLaunchPolicy as ReturnType<typeof vi.fn>).mockReturnValue('direct');
+    });
+
+    it('propagates Claude non-zero exit code', () => {
+      const err = Object.assign(new Error('Command failed'), { status: 2 });
+      (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => { throw err; });
+
+      runClaude('/tmp', [], 'sid');
+
+      expect(processExitSpy).toHaveBeenCalledWith(2);
+    });
+
+    it('exits with code 1 when status is null', () => {
+      const err = Object.assign(new Error('Command failed'), { status: null });
+      (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => { throw err; });
+
+      runClaude('/tmp', [], 'sid');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('exits with code 1 on ENOENT', () => {
+      const err = Object.assign(new Error('Not found'), { code: 'ENOENT' });
+      (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => { throw err; });
+
+      runClaude('/tmp', [], 'sid');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('does not call process.exit on success', () => {
+      (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
+
+      runClaude('/tmp', [], 'sid');
+
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('inside-tmux policy', () => {
+    beforeEach(() => {
+      (resolveLaunchPolicy as ReturnType<typeof vi.fn>).mockReturnValue('inside-tmux');
+      process.env.TMUX_PANE = '%0';
+    });
+
+    afterEach(() => {
+      delete process.env.TMUX_PANE;
+    });
+
+    it('propagates Claude non-zero exit code', () => {
+      const err = Object.assign(new Error('Command failed'), { status: 3 });
+      (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => { throw err; });
+
+      runClaude('/tmp', [], 'sid');
+
+      expect(processExitSpy).toHaveBeenCalledWith(3);
+    });
+
+    it('exits with code 1 when status is null', () => {
+      const err = Object.assign(new Error('Command failed'), { status: null });
+      (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => { throw err; });
+
+      runClaude('/tmp', [], 'sid');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('exits with code 1 on ENOENT', () => {
+      const err = Object.assign(new Error('Not found'), { code: 'ENOENT' });
+      (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => { throw err; });
+
+      runClaude('/tmp', [], 'sid');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('does not call process.exit on success', () => {
+      (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
+
+      runClaude('/tmp', [], 'sid');
+
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -152,12 +152,13 @@ function runClaudeInsideTmux(cwd: string, args: string[], hudCmd: string): void 
   try {
     execFileSync('claude', args, { cwd, stdio: 'inherit' });
   } catch (error) {
-    const err = error as NodeJS.ErrnoException;
+    const err = error as NodeJS.ErrnoException & { status?: number | null };
     if (err.code === 'ENOENT') {
       console.error('[omc] Error: claude CLI not found in PATH.');
       process.exit(1);
     }
-    // Normal exit (non-zero status codes throw in execFileSync) — ignore
+    // Propagate Claude's exit code so omc does not swallow failures
+    process.exit(typeof err.status === 'number' ? err.status : 1);
   } finally {
     // Cleanup HUD pane on exit
     if (hudPaneId) {
@@ -213,12 +214,13 @@ function runClaudeDirect(cwd: string, args: string[]): void {
   try {
     execFileSync('claude', args, { cwd, stdio: 'inherit' });
   } catch (error) {
-    const err = error as NodeJS.ErrnoException;
+    const err = error as NodeJS.ErrnoException & { status?: number | null };
     if (err.code === 'ENOENT') {
       console.error('[omc] Error: claude CLI not found in PATH.');
       process.exit(1);
     }
-    // Normal exit (non-zero status codes throw in execFileSync) — ignore
+    // Propagate Claude's exit code so omc does not swallow failures
+    process.exit(typeof err.status === 'number' ? err.status : 1);
   }
 }
 


### PR DESCRIPTION
## Summary

- `runClaudeInsideTmux` and `runClaudeDirect` both caught `execFileSync` errors and silently ignored non-zero exit codes with a comment `// Normal exit — ignore`, causing `omc` to always return success even when Claude failed.
- Extract `err.status` from the thrown error and call `process.exit(status)`, so Claude's exit code is correctly propagated. Falls back to exit code `1` when `status` is `null` or absent.

## Changes

- `src/cli/launch.ts`: Replace the ignore comment in both catch blocks with `process.exit(typeof err.status === 'number' ? err.status : 1)`.
- `src/cli/__tests__/launch.test.ts`: New test file covering `direct` and `inside-tmux` policies — non-zero exit code propagation, null-status fallback, ENOENT, and clean exit.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run test:run` — 216 test files, 4883 tests, all passed

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)