### PR TITLE
fix(team): replace require() with ESM import in captureFileSnapshot

### DIFF
--- a/src/team/__tests__/capture-file-snapshot.test.ts
+++ b/src/team/__tests__/capture-file-snapshot.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { captureFileSnapshot } from '../mcp-team-bridge.js';
+
+/**
+ * Regression tests for issue #871:
+ * captureFileSnapshot() used require('child_process') inside an ESM module,
+ * which throws "require is not defined" when permissionEnforcement is enabled.
+ *
+ * Fix: use the top-level ESM import instead.
+ */
+describe('captureFileSnapshot (ESM regression - issue #871)', () => {
+  it('does not throw "require is not defined" when called in ESM context', () => {
+    // This would throw "require is not defined" before the fix.
+    // Any directory works — non-git dirs simply return an empty set.
+    const dir = tmpdir();
+    expect(() => captureFileSnapshot(dir)).not.toThrow();
+  });
+
+  it('returns a Set', () => {
+    const result = captureFileSnapshot(tmpdir());
+    expect(result).toBeInstanceOf(Set);
+  });
+
+  it('returns an empty set for a non-git directory', () => {
+    const nonGit = join(tmpdir(), `__non_git_${Date.now()}__`);
+    mkdirSync(nonGit, { recursive: true });
+    try {
+      const result = captureFileSnapshot(nonGit);
+      expect(result).toBeInstanceOf(Set);
+      expect(result.size).toBe(0);
+    } finally {
+      rmSync(nonGit, { recursive: true, force: true });
+    }
+  });
+
+  it('returns file paths as strings when run inside a git repo', () => {
+    // Run against the project root which is a real git repo
+    const projectRoot = join(import.meta.dirname, '../../../../');
+    const result = captureFileSnapshot(projectRoot);
+    expect(result).toBeInstanceOf(Set);
+    // Every entry must be a non-empty string
+    for (const entry of result) {
+      expect(typeof entry).toBe('string');
+      expect(entry.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -7,7 +7,7 @@
  * Polls task files, builds prompts, spawns CLI processes, reports results.
  */
 
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, execSync, ChildProcess } from 'child_process';
 import { existsSync, readFileSync, openSync, readSync, closeSync } from 'fs';
 import { join } from 'path';
 import { writeFileWithMode, ensureDirWithMode } from './fs-utils.js';
@@ -56,8 +56,7 @@ function sleep(ms: number): Promise<void> {
  * Uses `git status --porcelain` + `git ls-files --others --exclude-standard`.
  * Returns a Set of relative file paths that currently exist or are modified.
  */
-function captureFileSnapshot(cwd: string): Set<string> {
-  const { execSync } = require('child_process') as typeof import('child_process');
+export function captureFileSnapshot(cwd: string): Set<string> {
   const files = new Set<string>();
   try {
     // Get all tracked files that are modified, added, or staged


### PR DESCRIPTION
## Summary

Fixes #871.

`captureFileSnapshot()` in `src/team/mcp-team-bridge.ts` used a dynamic CommonJS `require('child_process')` call inside a TypeScript ESM module (`"type": "module"`). This caused a **`ReferenceError: require is not defined`** crash whenever `runBridge()` entered the permission enforcement path (`permissionEnforcement !== 'off'`).

**Root cause:**
```ts
// BEFORE (broken in ESM)
function captureFileSnapshot(cwd: string): Set<string> {
  const { execSync } = require('child_process') as typeof import('child_process');
```

**Fix:** add `execSync` to the existing top-level ESM `import` statement and remove the inline `require()`:
```ts
// AFTER
import { spawn, execSync, ChildProcess } from 'child_process';

export function captureFileSnapshot(cwd: string): Set<string> {
```

## Changes

- `src/team/mcp-team-bridge.ts` — add `execSync` to the ESM import; remove the `require()` call; export `captureFileSnapshot` for testability
- `src/team/__tests__/capture-file-snapshot.test.ts` — new regression tests covering: no throw in ESM context, returns `Set`, empty set for non-git dirs, string entries for git repos

## Test plan

- [x] `npm run build` — clean TypeScript compilation
- [x] New regression tests: 4/4 pass
- [x] Full test suite: 4879/4879 pass (216 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)