### PR TITLE
fix(plugin-patterns): runPreCommitChecks skips test/lint validation (#870)

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -459,6 +459,7 @@ export {
   validateCommitMessage,
   runTypeCheck,
   runTests,
+  runLint,
   runPreCommitChecks,
   getPreCommitReminderMessage,
   getAutoFormatMessage,


### PR DESCRIPTION
## Summary

- `runPreCommitChecks()` previously only ran type-check and commit-message validation, allowing `canCommit: true` even when tests were failing or lint errors existed
- Added `runLint(directory)` — a project-level lint runner that detects `npm run lint` in `package.json` (mirrors the pattern of the existing `runTests()`)
- Wired both `runTests()` and `runLint()` into `runPreCommitChecks()`, so all four checks (type check, tests, lint, commit message) must pass before `canCommit` is true
- Exported `runLint` from `src/hooks/index.ts`

Fixes #870

## Test plan

- [x] `src/__tests__/hooks/plugin-patterns.test.ts` added — 12 tests covering:
  - `runPreCommitChecks` includes Tests and Lint checks in results
  - `canCommit: false` when tests fail
  - `canCommit: false` when lint fails
  - `canCommit: true` when no test runner / lint script found (graceful skip)
  - Commit message check still works as before
- [x] All 12 tests pass (`npm test -- run src/__tests__/hooks/plugin-patterns.test.ts`)
- [x] Pre-existing build error (`Cannot find type definition file for 'node'`) is unrelated to this change and present on `main` before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)