### PR TITLE
test(notifications): make session-registry tests hermetic via temp dir

### DIFF
--- a/src/notifications/__tests__/session-registry.test.ts
+++ b/src/notifications/__tests__/session-registry.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   existsSync,
+  mkdtempSync,
+  rmSync,
   unlinkSync,
   statSync,
   readFileSync,
@@ -10,7 +12,7 @@ import {
   closeSync,
 } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { tmpdir } from "os";
 import { spawn } from "child_process";
 import {
   registerMessage,
@@ -22,9 +24,11 @@ import {
   type SessionMapping,
 } from "../session-registry.js";
 
-const REGISTRY_PATH = join(homedir(), ".omc", "state", "reply-session-registry.jsonl");
-const LOCK_PATH = join(homedir(), ".omc", "state", "reply-session-registry.lock");
 const SESSION_REGISTRY_MODULE_PATH = join(process.cwd(), "src", "notifications", "session-registry.ts");
+
+let testDir: string;
+let REGISTRY_PATH: string;
+let LOCK_PATH: string;
 
 function registerMessageInChildProcess(mapping: SessionMapping): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -60,23 +64,17 @@ registerMessage(mapping);
 
 describe("session-registry", () => {
   beforeEach(() => {
-    // Clean up registry before each test
-    if (existsSync(REGISTRY_PATH)) {
-      unlinkSync(REGISTRY_PATH);
-    }
-    if (existsSync(LOCK_PATH)) {
-      unlinkSync(LOCK_PATH);
-    }
+    // Create a fresh temp directory for each test so registry I/O is fully
+    // isolated from the real ~/.omc/state and from other parallel test runs.
+    testDir = mkdtempSync(join(tmpdir(), "omc-session-registry-test-"));
+    process.env["OMC_TEST_REGISTRY_DIR"] = testDir;
+    REGISTRY_PATH = join(testDir, "reply-session-registry.jsonl");
+    LOCK_PATH = join(testDir, "reply-session-registry.lock");
   });
 
   afterEach(() => {
-    // Clean up registry after each test
-    if (existsSync(REGISTRY_PATH)) {
-      unlinkSync(REGISTRY_PATH);
-    }
-    if (existsSync(LOCK_PATH)) {
-      unlinkSync(LOCK_PATH);
-    }
+    delete process.env["OMC_TEST_REGISTRY_DIR"];
+    rmSync(testDir, { recursive: true, force: true });
   });
 
   describe("registerMessage", () => {


### PR DESCRIPTION
## Summary

Fixes #877 — `session-registry.test.ts` was using the real `~/.omc/state/reply-session-registry.jsonl` and `.lock` paths, making tests non-hermetic.

- Running the test suite could delete a user's live reply registry file
- Tests could interfere with a running reply-listener daemon
- Parallel test runs could race on the same global lock file

## Changes

**`src/notifications/session-registry.ts`**
- Removed module-level `REGISTRY_PATH` / `REGISTRY_LOCK_PATH` constants (evaluated once at import time)
- Added `getRegistryStateDir()`, `getRegistryPath()`, `getLockPath()` lazy getters called on each operation
- `getRegistryStateDir()` honours `OMC_TEST_REGISTRY_DIR` env var to redirect I/O in tests; falls back to the existing `~/.omc/state` default in production

**`src/notifications/__tests__/session-registry.test.ts`**
- `beforeEach`: creates a fresh `mkdtempSync` directory and sets `OMC_TEST_REGISTRY_DIR`
- `afterEach`: unsets `OMC_TEST_REGISTRY_DIR` and removes the temp dir with `rmSync`
- Child processes spawned by contention tests inherit `OMC_TEST_REGISTRY_DIR` via `...process.env` spread (no changes needed)
- Removed `homedir` import, replaced with `tmpdir`

## Test plan

- [x] All 20 existing session-registry tests pass (`vitest run`)
- [x] `npm run build` succeeds with no type errors
- [x] No reads/writes to `~/.omc/state` during test execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)