### PR TITLE
fix(mcp): add --skip-git-repo-check to Codex CLI invocations (closes #888)

### DIFF
--- a/src/mcp/__tests__/codex-reasoning-effort.test.ts
+++ b/src/mcp/__tests__/codex-reasoning-effort.test.ts
@@ -92,7 +92,7 @@ describe('executeCodex reasoning effort', () => {
     await promise;
 
     const [, spawnArgs] = spawnMock.mock.calls[0];
-    expect(spawnArgs).toEqual(['exec', '-m', 'gpt-5.3-codex', '--json', '--full-auto']);
+    expect(spawnArgs).toEqual(['exec', '-m', 'gpt-5.3-codex', '--json', '--full-auto', '--skip-git-repo-check']);
     expect(spawnArgs).not.toContain('-c');
   });
 
@@ -133,6 +133,14 @@ describe('executeCodex reasoning effort', () => {
 
     const [, spawnArgs] = spawnMock.mock.calls[0];
     expect(spawnArgs).not.toContain('-c');
+  });
+
+  it('should always include --skip-git-repo-check to support untrusted directories', async () => {
+    setupSpawnMock();
+    await executeCodex('test prompt', 'gpt-5.3-codex');
+
+    const [, spawnArgs] = spawnMock.mock.calls[0];
+    expect(spawnArgs).toContain('--skip-git-repo-check');
   });
 });
 

--- a/src/mcp/codex-core.ts
+++ b/src/mcp/codex-core.ts
@@ -214,7 +214,7 @@ export function executeCodex(prompt: string, model: string, cwd?: string, reason
   return new Promise((resolve, reject) => {
     validateModelName(model);
     let settled = false;
-    const args = ['exec', '-m', model, '--json', '--full-auto'];
+    const args = ['exec', '-m', model, '--json', '--full-auto', '--skip-git-repo-check'];
     // Per-call reasoning effort override via Codex CLI -c flag
     if (reasoningEffort && VALID_REASONING_EFFORTS.includes(reasoningEffort)) {
       args.push('-c', `model_reasoning_effort="${reasoningEffort}"`);
@@ -393,7 +393,7 @@ export function executeCodexBackground(
     // Helper to try spawning with a specific model
     const trySpawnWithModel = (tryModel: string, remainingModels: string[], rateLimitAttempt: number = 0): { pid: number } | { error: string } => {
       validateModelName(tryModel);
-      const args = ['exec', '-m', tryModel, '--json', '--full-auto'];
+      const args = ['exec', '-m', tryModel, '--json', '--full-auto', '--skip-git-repo-check'];
       // Per-call reasoning effort override for background execution
       if (reasoningEffort && VALID_REASONING_EFFORTS.includes(reasoningEffort)) {
         args.push('-c', `model_reasoning_effort="${reasoningEffort}"`);


### PR DESCRIPTION
## Summary

- Codex CLI exits with code 1 when run outside a trusted Git repository unless `--skip-git-repo-check` is passed
- Added the flag to both foreground (`executeCodex`) and background (`executeCodexBackground`) spawn arg arrays in `src/mcp/codex-core.ts`
- Updated the existing args-equality assertion to match the new args and added a dedicated test verifying the flag is always present

## Test plan

- [x] `npm run build` passes with zero errors
- [x] `npm test src/mcp/__tests__/codex-reasoning-effort.test.ts` — all 15 tests pass, including the new `--skip-git-repo-check` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)