### PR TITLE
fix(cli): enable tmux mouse mode for proper scroll behavior (closes #890)

### DIFF
--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -181,6 +181,7 @@ function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string, h
   const tmuxArgs = [
     'new-session', '-d', '-s', sessionName, '-c', cwd,
     claudeCmd,
+    ';', 'set-option', '-g', 'mouse', 'on',
   ];
 
   // Add HUD pane if available


### PR DESCRIPTION
## Summary

- Mouse wheel was triggering command history navigation instead of scrolling the terminal viewport when launching Claude Code via omc
- Root cause: `runClaudeOutsideTmux` created the tmux session without enabling mouse mode, so scroll events were forwarded as Up/Down arrow key sequences
- Fix: add `set-option -g mouse on` to the tmux command chain (after `new-session`, before `attach-session`) so tmux captures scroll events and enters copy-mode for viewport scrolling

## Test plan

- [x] New test: `enables mouse mode in the new tmux session so scroll works instead of history navigation` — verifies `set-option`/`mouse`/`on` appear in the tmux args
- [x] New test: `places mouse mode setup before attach-session` — verifies ordering
- [x] All 24 existing tests still pass (`vitest run src/cli/__tests__/launch.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)