### PR TITLE
fix(session-end): normalize cwd to git worktree root before resolving .omc/ paths

### DIFF
--- a/src/hooks/session-end/__tests__/subdirectory-cwd.test.ts
+++ b/src/hooks/session-end/__tests__/subdirectory-cwd.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for issue #891: MCP state tools and stop hook resolve .omc/state/
+ * differently when cwd is a subdirectory.
+ *
+ * processSessionEnd must normalize input.cwd to the git worktree root before
+ * building any .omc/ paths, so it always operates on the same directory that
+ * the MCP state tools write to.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+vi.mock('../callbacks.js', () => ({
+  triggerStopCallbacks: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../notifications/index.js', () => ({
+  notify: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../tools/python-repl/bridge-manager.js', () => ({
+  cleanupBridgeSessions: vi.fn(async () => ({
+    requestedSessions: 0,
+    foundSessions: 0,
+    terminatedSessions: 0,
+    errors: [],
+  })),
+}));
+
+// Mock resolveToWorktreeRoot so we can simulate the subdirectory → root mapping
+// without needing an actual git repository in the temp dir.
+vi.mock('../../../lib/worktree-paths.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/worktree-paths.js')>(
+    '../../../lib/worktree-paths.js'
+  );
+  return {
+    ...actual,
+    resolveToWorktreeRoot: vi.fn((dir?: string) => dir ?? process.cwd()),
+  };
+});
+
+import { processSessionEnd } from '../index.js';
+import { resolveToWorktreeRoot } from '../../../lib/worktree-paths.js';
+
+const mockResolveToWorktreeRoot = vi.mocked(resolveToWorktreeRoot);
+
+describe('processSessionEnd cwd normalization (issue #891)', () => {
+  let worktreeRoot: string;
+  let subdirectory: string;
+
+  beforeEach(() => {
+    worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'omc-891-root-'));
+    subdirectory = path.join(worktreeRoot, 'src', 'deep', 'nested');
+    fs.mkdirSync(subdirectory, { recursive: true });
+
+    // Simulate resolveToWorktreeRoot mapping subdirectory -> worktreeRoot
+    mockResolveToWorktreeRoot.mockImplementation((dir?: string) => {
+      if (dir === subdirectory) return worktreeRoot;
+      return dir ?? worktreeRoot;
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('calls resolveToWorktreeRoot with the raw cwd before building any paths', async () => {
+    await processSessionEnd({
+      session_id: 'test-session-891',
+      transcript_path: '',
+      cwd: subdirectory,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    expect(mockResolveToWorktreeRoot).toHaveBeenCalledWith(subdirectory);
+  });
+
+  it('reads and cleans up state written at worktree root, not subdirectory', async () => {
+    // Write an active state file at the worktree root (as MCP tools would)
+    const stateDir = path.join(worktreeRoot, '.omc', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'ultrawork-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: 'test-session-891',
+        started_at: new Date().toISOString(),
+      }),
+    );
+
+    await processSessionEnd({
+      session_id: 'test-session-891',
+      transcript_path: '',
+      cwd: subdirectory,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    // State at worktree root must have been cleaned up
+    expect(fs.existsSync(path.join(stateDir, 'ultrawork-state.json'))).toBe(false);
+  });
+
+  it('writes session summary to worktree root, not subdirectory', async () => {
+    await processSessionEnd({
+      session_id: 'test-session-891-summary',
+      transcript_path: '',
+      cwd: subdirectory,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    // Session summary should appear under worktreeRoot/.omc/sessions/
+    const summaryPath = path.join(worktreeRoot, '.omc', 'sessions', 'test-session-891-summary.json');
+    expect(fs.existsSync(summaryPath)).toBe(true);
+
+    // Nothing should have been written under the subdirectory
+    expect(fs.existsSync(path.join(subdirectory, '.omc'))).toBe(false);
+  });
+
+  it('leaves state at worktree root untouched when cwd is already the root', async () => {
+    // When cwd IS the root, resolveToWorktreeRoot returns it unchanged
+    mockResolveToWorktreeRoot.mockImplementation((dir?: string) => dir ?? worktreeRoot);
+
+    const stateDir = path.join(worktreeRoot, '.omc', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    // Write a state file that is inactive — should NOT be removed
+    fs.writeFileSync(
+      path.join(stateDir, 'ralph-state.json'),
+      JSON.stringify({ active: false, session_id: 'other-session' }),
+    );
+
+    await processSessionEnd({
+      session_id: 'test-session-root',
+      transcript_path: '',
+      cwd: worktreeRoot,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    // Inactive state for a different session must remain
+    expect(fs.existsSync(path.join(stateDir, 'ralph-state.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `processSessionEnd` used `input.cwd` raw when building `.omc/state/` paths. If Claude Code runs from a subdirectory (e.g. `src/`), it looked for state at `/project/src/.omc/state/` while MCP state tools (which call `validateWorkingDirectory()`) wrote to `/project/.omc/state/`.
- **Fix**: Add `resolveToWorktreeRoot(input.cwd)` at the start of `processSessionEnd` and pass the normalized root to all internal functions (`recordSessionMetrics`, `exportSessionSummary`, `cleanupTransientState`, `cleanupModeStates`).
- **No changes to MCP state tools** — `validateWorkingDirectory()` already handles normalization there correctly.

## Test plan

- [x] New test file `src/hooks/session-end/__tests__/subdirectory-cwd.test.ts` with 4 cases:
  - `resolveToWorktreeRoot` is called with the raw `cwd` value
  - Active state written at worktree root is cleaned up when `cwd` is a subdirectory
  - Session summary is written at worktree root, not under the subdirectory
  - Inactive state for a different session is left untouched
- [x] All 50 session-end tests pass (`npm run test -- src/hooks/session-end/`)
- [x] No regressions in existing test suite

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)