### PR TITLE
fix(hooks): resolve node binary for nvm/fnm users (closes #892)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,12 +7,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.mjs\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/skill-injector.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/skill-injector.mjs\"",
             "timeout": 3
           }
         ]
@@ -24,12 +24,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-session.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-session.mjs\"",
             "timeout": 5
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-init.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-init.mjs\"",
             "timeout": 30
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-maintenance.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-maintenance.mjs\"",
             "timeout": 60
           }
         ]
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-enforcer.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-enforcer.mjs\"",
             "timeout": 3
           }
         ]
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/context-safety.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/context-safety.mjs\"",
             "timeout": 3
           }
         ]
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/permission-handler.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/permission-handler.mjs\"",
             "timeout": 5
           }
         ]
@@ -95,12 +95,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-verifier.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-verifier.mjs\"",
             "timeout": 3
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-posttool.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-posttool.mjs\"",
             "timeout": 3
           }
         ]
@@ -112,7 +112,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use-failure.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use-failure.mjs\"",
             "timeout": 3
           }
         ]
@@ -124,7 +124,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-tracker.mjs\" start",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-tracker.mjs\" start",
             "timeout": 3
           }
         ]
@@ -136,12 +136,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-tracker.mjs\" stop",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-tracker.mjs\" stop",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/verify-deliverables.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/verify-deliverables.mjs\"",
             "timeout": 5
           }
         ]
@@ -153,12 +153,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-precompact.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-precompact.mjs\"",
             "timeout": 5
           }
         ]
@@ -170,17 +170,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/context-guard-stop.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/context-guard-stop.mjs\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/persistent-mode.cjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/persistent-mode.cjs\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/code-simplifier.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/code-simplifier.mjs\"",
             "timeout": 5
           }
         ]
@@ -192,7 +192,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\"",
             "timeout": 10
           }
         ]

--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# OMC Node.js Finder (find-node.sh)
+#
+# Locates the Node.js binary and executes it with the provided arguments.
+# Designed for nvm/fnm users where `node` is not on PATH in non-interactive
+# shells (e.g. Claude Code hook invocations). Fixes issue #892.
+#
+# Priority:
+#   1. nodeBinary stored in ~/.claude/.omc-config.json (set at setup time)
+#   2. `which node` (node is on PATH)
+#   3. nvm versioned paths  (~/.nvm/versions/node/*/bin/node)
+#   4. fnm versioned paths  (~/.fnm/node-versions/*/installation/bin/node)
+#   5. Homebrew / system paths (/opt/homebrew/bin/node, /usr/local/bin/node)
+#
+# Exits 0 on failure so it never blocks Claude Code hook processing.
+
+NODE_BIN=""
+
+# ---------------------------------------------------------------------------
+# 1. Read stored node path from OMC config
+# ---------------------------------------------------------------------------
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CONFIG_FILE="$CLAUDE_DIR/.omc-config.json"
+if [ -f "$CONFIG_FILE" ]; then
+  # POSIX-safe extraction without requiring jq
+  _stored=$(grep -o '"nodeBinary" *: *"[^"]*"' "$CONFIG_FILE" 2>/dev/null \
+    | head -1 \
+    | sed 's/.*"nodeBinary" *: *"//;s/".*//')
+  if [ -n "$_stored" ] && [ -x "$_stored" ]; then
+    NODE_BIN="$_stored"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. which node
+# ---------------------------------------------------------------------------
+if [ -z "$NODE_BIN" ] && command -v node >/dev/null 2>&1; then
+  NODE_BIN="node"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. nvm versioned paths: iterate to find the latest installed version
+# ---------------------------------------------------------------------------
+if [ -z "$NODE_BIN" ] && [ -d "$HOME/.nvm/versions/node" ]; then
+  # shellcheck disable=SC2231
+  for _path in "$HOME/.nvm/versions/node/"*/bin/node; do
+    [ -x "$_path" ] && NODE_BIN="$_path"
+    # Keep iterating — later entries tend to be newer (lexicographic order)
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# 4. fnm versioned paths (Linux and macOS default locations)
+# ---------------------------------------------------------------------------
+if [ -z "$NODE_BIN" ]; then
+  for _fnm_base in \
+    "$HOME/.fnm/node-versions" \
+    "$HOME/Library/Application Support/fnm/node-versions" \
+    "$HOME/.local/share/fnm/node-versions"; do
+    if [ -d "$_fnm_base" ]; then
+      # shellcheck disable=SC2231
+      for _path in "$_fnm_base/"*/installation/bin/node; do
+        [ -x "$_path" ] && NODE_BIN="$_path"
+      done
+      [ -n "$NODE_BIN" ] && break
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Common Homebrew / system paths
+# ---------------------------------------------------------------------------
+if [ -z "$NODE_BIN" ]; then
+  for _path in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+    if [ -x "$_path" ]; then
+      NODE_BIN="$_path"
+      break
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Invoke node with all provided arguments
+# ---------------------------------------------------------------------------
+if [ -z "$NODE_BIN" ]; then
+  printf '[OMC] Error: Could not find node binary. Run /oh-my-claudecode:omc-setup to fix.\n' >&2
+  exit 0  # exit 0 so this hook does not block Claude Code
+fi
+
+exec "$NODE_BIN" "$@"

--- a/src/__tests__/resolve-node.test.ts
+++ b/src/__tests__/resolve-node.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for src/utils/resolve-node.ts
+ *
+ * Covers resolveNodeBinary() priority logic and pickLatestVersion() helper.
+ * Issue #892: Node.js not in PATH for nvm/fnm users causes hook errors.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { existsSync } from 'fs';
+
+// We test the pure helper directly without mocking the filesystem
+import { pickLatestVersion } from '../utils/resolve-node.js';
+
+// -------------------------------------------------------------------------
+// pickLatestVersion — pure logic, no I/O
+// -------------------------------------------------------------------------
+
+describe('pickLatestVersion', () => {
+  it('returns the highest semver from a list', () => {
+    expect(pickLatestVersion(['v18.0.0', 'v20.11.0', 'v16.20.0'])).toBe('v20.11.0');
+  });
+
+  it('handles versions without leading v', () => {
+    expect(pickLatestVersion(['18.0.0', '20.11.0', '16.20.0'])).toBe('20.11.0');
+  });
+
+  it('handles a single entry', () => {
+    expect(pickLatestVersion(['v22.1.0'])).toBe('v22.1.0');
+  });
+
+  it('returns undefined for an empty array', () => {
+    expect(pickLatestVersion([])).toBeUndefined();
+  });
+
+  it('filters out non-version entries', () => {
+    expect(pickLatestVersion(['default', 'v18.0.0', 'system'])).toBe('v18.0.0');
+  });
+
+  it('compares patch versions correctly', () => {
+    expect(pickLatestVersion(['v20.0.0', 'v20.0.1', 'v20.0.9'])).toBe('v20.0.9');
+  });
+
+  it('compares minor versions correctly', () => {
+    expect(pickLatestVersion(['v20.1.0', 'v20.9.0', 'v20.10.0'])).toBe('v20.10.0');
+  });
+});
+
+// -------------------------------------------------------------------------
+// resolveNodeBinary — integration-style: the current process.execPath must
+// be returned as the highest-priority result.
+// -------------------------------------------------------------------------
+
+describe('resolveNodeBinary', () => {
+  it('returns process.execPath when it exists (priority 1)', async () => {
+    // process.execPath is always set in any Node.js process, so this
+    // test verifies the happy path without any mocking.
+    const { resolveNodeBinary } = await import('../utils/resolve-node.js');
+    const result = resolveNodeBinary();
+    // Must be an absolute path (not bare 'node') in a real Node.js process
+    expect(result).toBe(process.execPath);
+    expect(result.length).toBeGreaterThan(4); // not empty / not just 'node'
+  });
+
+  it('returns a string (never throws)', async () => {
+    const { resolveNodeBinary } = await import('../utils/resolve-node.js');
+    expect(() => resolveNodeBinary()).not.toThrow();
+    expect(typeof resolveNodeBinary()).toBe('string');
+  });
+
+  it('returned path points to an existing binary', async () => {
+    const { resolveNodeBinary } = await import('../utils/resolve-node.js');
+    const result = resolveNodeBinary();
+    // When resolveNodeBinary returns a non-fallback path it must exist
+    if (result !== 'node') {
+      expect(existsSync(result)).toBe(true);
+    }
+  });
+});

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -153,6 +153,9 @@ export interface OMCConfig {
   /** Whether to prompt for upgrade at session start when a new version is available (default: true).
    *  Set to false to show a passive notification instead of an interactive prompt. */
   autoUpgradePrompt?: boolean;
+  /** Absolute path to the Node.js binary detected at setup time.
+   *  Used by find-node.sh so hooks work for nvm/fnm users where node is not on PATH. */
+  nodeBinary?: string;
 }
 
 /**

--- a/src/utils/resolve-node.ts
+++ b/src/utils/resolve-node.ts
@@ -1,0 +1,113 @@
+import { existsSync, readdirSync } from 'fs';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { homedir } from 'os';
+
+/**
+ * Resolve the absolute path to the Node.js binary.
+ *
+ * Priority order:
+ * 1. process.execPath  — current Node.js process (always available, most reliable)
+ * 2. which/where node  — if Node is on PATH
+ * 3. nvm versioned paths (~/.nvm/versions/node/<latest>/bin/node)
+ * 4. fnm versioned paths (~/.fnm/node-versions/<latest>/installation/bin/node)
+ * 5. Homebrew / system paths (/opt/homebrew/bin/node, /usr/local/bin/node, /usr/bin/node)
+ * 6. Fallback: bare 'node' (lets the shell resolve at runtime)
+ *
+ * This is used at setup time to embed the absolute node path into the HUD
+ * statusLine command and into .omc-config.json so that hook scripts can
+ * locate node even when it is not on PATH (nvm/fnm users, non-interactive
+ * shells, issue #892).
+ *
+ * @returns Absolute path to the node binary, or 'node' as a last-resort fallback.
+ */
+export function resolveNodeBinary(): string {
+  // 1. Current process's node — same binary that is running OMC right now.
+  if (process.execPath && existsSync(process.execPath)) {
+    return process.execPath;
+  }
+
+  // 2. which / where node
+  try {
+    const cmd = process.platform === 'win32' ? 'where node' : 'which node';
+    const result = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' })
+      .trim()
+      .split('\n')[0]
+      .trim();
+    if (result && existsSync(result)) {
+      return result;
+    }
+  } catch {
+    // node not on PATH — continue to version-manager fallbacks
+  }
+
+  // Unix-only fallbacks below (nvm and fnm are not used on Windows)
+  if (process.platform === 'win32') {
+    return 'node';
+  }
+
+  const home = homedir();
+
+  // 3. nvm: ~/.nvm/versions/node/<version>/bin/node
+  const nvmBase = join(home, '.nvm', 'versions', 'node');
+  if (existsSync(nvmBase)) {
+    try {
+      const latest = pickLatestVersion(readdirSync(nvmBase));
+      if (latest) {
+        const nodePath = join(nvmBase, latest, 'bin', 'node');
+        if (existsSync(nodePath)) return nodePath;
+      }
+    } catch {
+      // ignore directory read errors
+    }
+  }
+
+  // 4. fnm: multiple possible base directories
+  const fnmBases = [
+    join(home, '.fnm', 'node-versions'),
+    join(home, 'Library', 'Application Support', 'fnm', 'node-versions'),
+    join(home, '.local', 'share', 'fnm', 'node-versions'),
+  ];
+  for (const fnmBase of fnmBases) {
+    if (existsSync(fnmBase)) {
+      try {
+        const latest = pickLatestVersion(readdirSync(fnmBase));
+        if (latest) {
+          const nodePath = join(fnmBase, latest, 'installation', 'bin', 'node');
+          if (existsSync(nodePath)) return nodePath;
+        }
+      } catch {
+        // ignore directory read errors
+      }
+    }
+  }
+
+  // 5. Common system / Homebrew paths
+  for (const p of ['/opt/homebrew/bin/node', '/usr/local/bin/node', '/usr/bin/node']) {
+    if (existsSync(p)) return p;
+  }
+
+  // 6. Last-resort fallback
+  return 'node';
+}
+
+/**
+ * Pick the latest semver version from a list of version strings.
+ * Handles both "v20.0.0" and "20.0.0" formats.
+ * Returns undefined if the list is empty.
+ */
+export function pickLatestVersion(versions: string[]): string | undefined {
+  if (versions.length === 0) return undefined;
+
+  return versions
+    .filter(v => /^v?\d/.test(v))
+    .sort((a, b) => {
+      const pa = a.replace(/^v/, '').split('.').map(s => parseInt(s, 10) || 0);
+      const pb = b.replace(/^v/, '').split('.').map(s => parseInt(s, 10) || 0);
+      for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+        const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+        if (diff !== 0) return diff;
+      }
+      return 0;
+    })[0];
+}


### PR DESCRIPTION
## Summary

- **Root cause**: All hook commands in `hooks/hooks.json` and the HUD `statusLine` use bare `node`, which is not on PATH in non-interactive shells for nvm/fnm users.
- **Fix**: Detect the absolute node binary at setup time and use a POSIX shell wrapper (`find-node.sh`) in hook commands that probes multiple fallback locations.

## Changes

### New files
- **`src/utils/resolve-node.ts`** — `resolveNodeBinary()` utility: probes `process.execPath` → `which node` → nvm versioned paths → fnm versioned paths → Homebrew/system paths; exports `pickLatestVersion()` helper for semver sorting.
- **`scripts/find-node.sh`** — POSIX shell wrapper invoked by every hook command; reads stored `nodeBinary` from `~/.claude/.omc-config.json`, then falls back through the same chain; exits 0 on failure to never block Claude Code.
- **`src/__tests__/resolve-node.test.ts`** — 10 tests covering `pickLatestVersion()` and `resolveNodeBinary()` (all passing ✅).

### Modified files
- **`hooks/hooks.json`** — all `node "${CLAUDE_PLUGIN_ROOT}/scripts/..."` commands replaced with `sh "${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/..."`.
- **`src/installer/index.ts`** — HUD `statusLine` command now uses `resolveNodeBinary()`; also persists detected path as `nodeBinary` in `.omc-config.json`.
- **`scripts/plugin-setup.mjs`** — HUD `statusLine` uses `process.execPath`; persists `nodeBinary` to `.omc-config.json`.
- **`src/features/auto-update.ts`** — adds `nodeBinary?: string` to `OMCConfig` interface.

## Test plan

- [x] `npx vitest run src/__tests__/resolve-node.test.ts` — 10/10 pass
- [x] `npm run build` — clean build, no TypeScript errors
- [x] `npx vitest run` — 4970 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)