### PR TITLE
fix(team): omc_run_team_wait timeout does not kill workers

### DIFF
--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -103,11 +103,13 @@ mcp__team__omc_run_team_wait({
 })
 ```
 
-> **Timeout guidance:** Use `60000` (60 s) as the default. If the job times out, do NOT
-> retry with a longer timeout — instead check whether workers are still alive with
-> `mcp__team__omc_run_team_status`, then call `omc_run_team_cleanup` to kill stale panes,
-> and report the partial results to the user. Teams can silently stall due to stuck workers
-> or tmux session issues; a short wait timeout surfaces these problems faster.
+> **Timeout guidance:** Use `60000` (60 s) as the default. If the job times out,
+> **workers are left running** — the timeout does NOT kill them. You have two options:
+> - Call `omc_run_team_wait` again with the same `job_id` to keep waiting (workers continue)
+> - Call `omc_run_team_cleanup` to explicitly stop all worker panes when you want to cancel
+>
+> Teams can silently stall due to stuck workers or tmux session issues. Use
+> `mcp__team__omc_run_team_status` to inspect live progress before deciding to cancel.
 
 Returns when done:
 ```json

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -214,44 +214,11 @@ async function handleWait(args: unknown): Promise<{ content: Array<{ type: 'text
     pollDelay = Math.min(Math.floor(pollDelay * 1.5), 2000);
   }
 
-  // Timeout: SIGTERM → wait → SIGKILL escalation, then kill remaining worker panes
-  const timedOutJob = omcTeamJobs.get(job_id) ?? loadJobFromDisk(job_id);
-
-  // Set status immediately so the close handler won't override it
-  if (timedOutJob && timedOutJob.status === 'running') {
-    timedOutJob.status = 'timeout';
-  }
-
-  const panes = timedOutJob ? await loadPaneIds(job_id) : null;
-
-  if (timedOutJob?.pid != null) {
-    try { process.kill(timedOutJob.pid, 'SIGTERM'); } catch { /* already gone */ }
-
-    // Wait up to 10s for runtime-cli to exit cleanly (SIGTERM handler calls shutdownTeam)
-    const killDeadline = Date.now() + 10_000;
-    while (Date.now() < killDeadline) {
-      try { process.kill(timedOutJob.pid, 0); } catch { break; } // ESRCH = process gone
-      await new Promise<void>(r => setTimeout(r, 500));
-    }
-
-    // Escalate to SIGKILL if still alive
-    try { process.kill(timedOutJob.pid, 'SIGKILL'); } catch { /* gone */ }
-  }
-
-  // Backstop: kill any remaining worker panes (grace already elapsed above)
-  if (panes && timedOutJob) {
-    await killWorkerPanes({
-      paneIds: panes.paneIds,
-      leaderPaneId: panes.leaderPaneId,
-      teamName: timedOutJob.teamName ?? '',
-      cwd: timedOutJob.cwd ?? '',
-      graceMs: 0,
-    });
-  }
-
-  if (timedOutJob) persistJob(job_id, timedOutJob);
-
-  return { content: [{ type: 'text', text: JSON.stringify({ error: `Timed out waiting for job ${job_id} after ${(timeout_ms / 1000).toFixed(0)}s` }) }] };
+  // Timeout: leave workers running — caller must use omc_run_team_cleanup to stop them explicitly.
+  // Do NOT kill the process or panes here; the user may call omc_run_team_wait again to keep
+  // waiting, or omc_run_team_status to check progress.
+  const elapsed = ((Date.now() - (omcTeamJobs.get(job_id)?.startedAt ?? Date.now())) / 1000).toFixed(1);
+  return { content: [{ type: 'text', text: JSON.stringify({ error: `Timed out waiting for job ${job_id} after ${(timeout_ms / 1000).toFixed(0)}s — workers are still running; call omc_run_team_wait again to keep waiting or omc_run_team_cleanup to stop them`, jobId: job_id, status: 'running', elapsedSeconds: elapsed }) }] };
 }
 
 // ---------------------------------------------------------------------------
@@ -298,7 +265,7 @@ const TOOLS = [
   },
   {
     name: 'omc_run_team_wait',
-    description: 'Block (poll internally) until a background omc_run_team job reaches a terminal state (completed, failed, timeout). Returns the result when done. One call instead of N polling calls. Uses exponential backoff (500ms → 2000ms). No deadlock: the child process is independent and never calls back into this server.',
+    description: 'Block (poll internally) until a background omc_run_team job reaches a terminal state (completed, failed, timeout). Returns the result when done. One call instead of N polling calls. Uses exponential backoff (500ms → 2000ms). On timeout, workers are left running — call omc_run_team_wait again to keep waiting, or omc_run_team_cleanup to stop them explicitly.',
     inputSchema: {
       type: 'object' as const,
       properties: {


### PR DESCRIPTION
## Summary

- `omc_run_team_wait` previously sent SIGTERM → SIGKILL → killed all tmux panes when `timeout_ms` expired
- A wait timeout is a **caller-side deadline**, not an abort signal — workers should keep running
- Now `handleWait` simply returns a timeout response and leaves all workers untouched
- Callers can re-call `omc_run_team_wait` to keep polling, check via `omc_run_team_status`, or explicitly stop workers with `omc_run_team_cleanup`

## Changes

- `src/mcp/team-server.ts` — removed SIGTERM/SIGKILL/pane-kill block from `handleWait`; updated tool description
- `bridge/team-mcp.cjs` — rebuilt bundle
- `skills/omc-teams/SKILL.md` — updated timeout guidance to document new behaviour

## Test plan

- [ ] Start a long-running team job
- [ ] Call `omc_run_team_wait` with a short `timeout_ms` — verify it returns a timeout error without killing workers
- [ ] Verify workers are still visible in tmux panes and making progress
- [ ] Call `omc_run_team_wait` again — verify it continues polling and eventually returns results
- [ ] Verify `omc_run_team_cleanup` still kills panes explicitly when called

🤖 Generated with [Claude Code](https://claude.com/claude-code)