### PR TITLE
fix(hud): fix --watch mode repeated setup error via stdin cache

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1655,7 +1655,7 @@ program
     if (options.watch) {
       const intervalMs = parseInt(options.interval, 10);
       while (true) {
-        await hudMain();
+        await hudMain(true);
         await new Promise<void>(resolve => setTimeout(resolve, intervalMs));
       }
     } else {


### PR DESCRIPTION
## Summary

- In `--watch` mode stdin is always a TTY, so `readStdin()` returns `null` and the HUD incorrectly printed `[OMC] run /omc-setup to install properly` every second (issue #908)
- After a successful statusline-path read, the stdin JSON is now persisted to `.omc/state/hud-stdin-cache.json`
- The `--watch` polling loop reads from that cache when stdin is a TTY, so it always has fresh data
- Before the cache is populated (first poll before the statusline fires), the HUD shows `[OMC] Starting...` instead of the misleading setup error

## Changes

| File | Change |
|---|---|
| `src/hud/stdin.ts` | Add `writeStdinCache()` / `readStdinCache()` for `.omc/state/hud-stdin-cache.json` |
| `src/hud/index.ts` | Accept `watchMode` param; write cache on success; fall back to cache in watch mode |
| `src/cli/index.ts` | Pass `watchMode=true` to `hudMain()` in the `--watch` loop |

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 4802 tests pass (`npm test`)
- [x] Lint warnings are pre-existing, no new errors introduced
- [ ] Manual: run `omc hud --watch` in a tmux pane — should show `[OMC] Starting...` on first tick, then live HUD data on subsequent ticks (after statusline fires once)

Fixes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)