### PR TITLE
fix(hooks): replace sh+find-node.sh with cross-platform node+run.cjs chain (#909)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,12 +7,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.mjs\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/skill-injector.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/skill-injector.mjs\"",
             "timeout": 3
           }
         ]
@@ -24,12 +24,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-session.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-session.mjs\"",
             "timeout": 5
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-init.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-init.mjs\"",
             "timeout": 30
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-maintenance.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-maintenance.mjs\"",
             "timeout": 60
           }
         ]
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-enforcer.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-enforcer.mjs\"",
             "timeout": 3
           }
         ]
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/context-safety.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/context-safety.mjs\"",
             "timeout": 3
           }
         ]
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/permission-handler.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/permission-handler.mjs\"",
             "timeout": 5
           }
         ]
@@ -95,12 +95,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-verifier.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-verifier.mjs\"",
             "timeout": 3
           },
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-posttool.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-posttool.mjs\"",
             "timeout": 3
           }
         ]
@@ -112,7 +112,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use-failure.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use-failure.mjs\"",
             "timeout": 3
           }
         ]
@@ -124,7 +124,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-tracker.mjs\" start",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-tracker.mjs\" start",
             "timeout": 3
           }
         ]
@@ -136,12 +136,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-tracker.mjs\" stop",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-tracker.mjs\" stop",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/verify-deliverables.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/verify-deliverables.mjs\"",
             "timeout": 5
           }
         ]
@@ -153,12 +153,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-precompact.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/project-memory-precompact.mjs\"",
             "timeout": 5
           }
         ]
@@ -170,17 +170,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/context-guard-stop.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/context-guard-stop.mjs\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/persistent-mode.cjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/persistent-mode.cjs\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/code-simplifier.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/code-simplifier.mjs\"",
             "timeout": 5
           }
         ]
@@ -192,7 +192,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\"",
             "timeout": 10
           }
         ]

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * OMC Cross-platform hook runner (run.cjs)
+ *
+ * Uses process.execPath (the Node binary already running this script) to spawn
+ * the target .mjs hook, bypassing PATH / shell discovery issues.
+ *
+ * Replaces the `sh + find-node.sh` chain that fails on Windows because
+ * /usr/bin/sh is a PE32+ binary the OS refuses to execute natively.
+ * Fixes issues #909, #899, #892, #869.
+ *
+ * Usage (from hooks.json, after setup patches the absolute node path in):
+ *   /abs/path/to/node "${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs" \
+ *       "${CLAUDE_PLUGIN_ROOT}/scripts/<hook>.mjs" [args...]
+ *
+ * During post-install setup, the leading `node` token is replaced with
+ * process.execPath so nvm/fnm users and Windows users all get the right binary.
+ */
+
+const { spawnSync } = require('child_process');
+
+const target = process.argv[2];
+if (!target) {
+  // Nothing to run — exit cleanly so Claude Code hooks are never blocked.
+  process.exit(0);
+}
+
+const result = spawnSync(
+  process.execPath,
+  [target, ...process.argv.slice(3)],
+  {
+    stdio: 'inherit',
+    env: process.env,
+    windowsHide: true,
+  }
+);
+
+// Propagate the child exit code (null → 0 to avoid blocking hooks).
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary

Radical root fix for recurring Windows hook failures (#909, #899, #892, #869).

**Root cause:** All hooks used `sh "${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh" "…/X.mjs"`. On Windows, `/usr/bin/sh` is a PE32+ binary (MSYS2 / Git Bash) that the OS refuses to execute natively in Claude Code's hook subprocess, producing `cannot execute binary file: Exec format error`.

**Fix:**

- **`scripts/run.cjs`** — new cross-platform CJS wrapper that takes the target `.mjs` path as `argv[2]` and re-invokes it using `process.execPath` (the Node binary already running the script), passing stdin/stdout/stderr through via `stdio: 'inherit'`. No shell, no PATH discovery needed.

- **`hooks/hooks.json`** — every `sh "…/find-node.sh" "…/X.mjs"` entry replaced with `node "…/run.cjs" "…/X.mjs"`. The bare `node` token is a portable template; it gets replaced by `process.execPath` at install time (see below).

- **`scripts/plugin-setup.mjs`** — post-install patch now runs on **all platforms** (not just Windows). It replaces the leading `node` token in every `run.cjs` command with the absolute `process.execPath`, so nvm/fnm users (where `node` is not on PATH in non-interactive shells) and Windows users both get the right binary. A backward-compat branch (Windows only) also migrates old `sh find-node.sh` installs to the new `run.cjs` chain.

## How it works

```
Before (broken on Windows):
  sh "${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.mjs"
  └── sh = PE32+ binary → "cannot execute binary file"

After (all platforms):
  /abs/path/to/node "${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs" "${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.mjs"
  └── run.cjs → spawnSync(process.execPath, [target, ...args], { stdio: 'inherit' })
```

## Test plan

- [x] `npm run test:run` — 4802 tests pass, 0 failures
- [x] `npm run lint` — no new errors (2 pre-existing errors in unrelated test file)
- [ ] Manual verification on Windows (hook invocations no longer fail with exec format error)
- [ ] Manual verification on macOS with nvm (absolute node path from `process.execPath` used)

Closes #909. Related: #899, #892, #869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)