### PR TITLE
fix(keyword-detector): prevent ralph-init from triggering ralph loop

### DIFF
--- a/skills/ralph-init/SKILL.md
+++ b/skills/ralph-init/SKILL.md
@@ -22,7 +22,9 @@ Initialize a PRD (Product Requirements Document) for structured ralph-loop execu
    - Acceptance criteria (testable)
    - Technical constraints
    - Implementation phases
-3. **Link to Ralph** so that `/oh-my-claudecode:ralph` can use the PRD as its completion criteria
+3. **Output the PRD path** and instruct the user to run ralph separately
+
+**IMPORTANT: This is a planning-only skill. After creating the PRD, you MUST stop and wait for user input. Do NOT automatically start execution, invoke ralph, or begin implementing the PRD. Simply tell the user the PRD path and how to start ralph with it.**
 
 ## Output
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -507,6 +507,24 @@ describe('Keyword Detector', () => {
       expect(primary!.type).toBe('ralph');
     });
 
+    it('should not detect ralph in ralph-init compound name', () => {
+      const detected = detectKeywordsWithType('ralph-init "create a PRD"');
+      const ralphMatch = detected.find(d => d.type === 'ralph');
+      expect(ralphMatch).toBeUndefined();
+    });
+
+    it('should not detect ralph in /oh-my-claudecode:ralph-init', () => {
+      const primary = getPrimaryKeyword('/oh-my-claudecode:ralph-init "my project"');
+      expect(primary?.type).not.toBe('ralph');
+    });
+
+    it('should still detect ralph when standalone', () => {
+      const detected = detectKeywordsWithType('use ralph for this task');
+      const ralphMatch = detected.find(d => d.type === 'ralph');
+      expect(ralphMatch).toBeDefined();
+      expect(ralphMatch!.keyword).toBe('ralph');
+    });
+
     it('should prioritize ultrapilot for legacy ultrapilot trigger', () => {
       const primary = getPrimaryKeyword('ultrapilot this task');
       expect(primary).not.toBeNull();

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -45,7 +45,7 @@ export interface DetectedKeyword {
  */
 const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   cancel: /\b(cancelomc|stopomc)\b/i,
-  ralph: /\b(ralph)\b/i,
+  ralph: /\b(ralph)\b(?!-)/i,
   autopilot: /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b/i,
   ultrapilot: /\b(ultrapilot|ultra-pilot)\b|\bparallel\s+build\b|\bswarm\s+build\b/i,
   ultrawork: /\b(ultrawork|ulw)\b/i,


### PR DESCRIPTION
## Summary

- The `\b(ralph)\b` regex in keyword-detector matched "ralph" within "ralph-init" because `-` is a word boundary character in regex
- This caused ralph loop state to activate when users invoked `ralph-init`, and the persistent-mode stop hook then blocked Claude from stopping after creating the PRD — resulting in automatic execution instead of the expected planning-only behavior
- Added negative lookahead `(?!-)` to the ralph keyword pattern to exclude compound names like `ralph-init`
- Added explicit STOP instruction to `ralph-init/SKILL.md` to reinforce planning-only behavior
- Added 3 test cases to verify the fix

## Test plan

- [x] Existing 144 tests pass (including 3 new tests)
- [x] Manually invoke `/oh-my-claudecode:ralph-init "test"` and verify it stops after PRD creation
- [x] Verify standalone `ralph` keyword still triggers ralph loop correctly

Fix #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)