### PR TITLE
fix(codex): normalize background inline prompts to prompt_file at callsite (#919)

### DIFF
--- a/dist/__tests__/codex-callsite-normalization.test.js
+++ b/dist/__tests__/codex-callsite-normalization.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+
+const mockHandleAskCodex = vi.fn(async (args) => ({
+    content: [{ type: 'text', text: JSON.stringify(args) }],
+    isError: false,
+}));
+
+vi.mock('../mcp/codex-core.js', () => ({
+    handleAskCodex: mockHandleAskCodex,
+    CODEX_DEFAULT_MODEL: 'gpt-5.3-codex',
+    CODEX_RECOMMENDED_ROLES: ['architect'],
+}));
+
+vi.mock('../mcp/job-management.js', () => ({
+    handleWaitForJob: vi.fn(),
+    handleCheckJobStatus: vi.fn(),
+    handleKillJob: vi.fn(),
+    handleListJobs: vi.fn(),
+    getJobManagementToolSchemas: vi.fn(() => []),
+}));
+
+describe('Codex call-site normalization', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+    });
+
+    it('in-process codex-server normalizes background + inline into prompt_file mode', async () => {
+        vi.doMock('@anthropic-ai/claude-agent-sdk', () => ({
+            tool: vi.fn((name, _description, _schema, handler) => ({ name, handler })),
+            createSdkMcpServer: vi.fn((config) => config),
+        }));
+
+        const mod = await import('../mcp/codex-server.js');
+        const askTool = mod.codexMcpServer.tools.find((t) => t.name === 'ask_codex');
+        expect(askTool).toBeDefined();
+
+        await askTool.handler({
+            agent_role: 'architect',
+            prompt: 'ask codex to review this code',
+            background: true,
+            working_directory: '/tmp',
+        });
+
+        expect(mockHandleAskCodex).toHaveBeenCalledTimes(1);
+        const normalized = mockHandleAskCodex.mock.calls[0][0];
+        expect(normalized.prompt).toBeUndefined();
+        expect(normalized.prompt_file).toContain('codex-inline-bg-');
+        expect(normalized.output_file).toContain('codex-inline-bg-response-');
+        expect(normalized.background).toBe(true);
+        expect(existsSync(normalized.prompt_file)).toBe(true);
+        expect(readFileSync(normalized.prompt_file, 'utf-8')).toBe('ask codex to review this code');
+        unlinkSync(normalized.prompt_file);
+    });
+
+    it('standalone codex-server normalizes background + inline into prompt_file mode', async () => {
+        let serverInstance;
+        const callSchema = Symbol('call-tool');
+        const listSchema = Symbol('list-tools');
+
+        vi.doMock('@modelcontextprotocol/sdk/server/index.js', () => ({
+            Server: class MockServer {
+                constructor() {
+                    this.handlers = new Map();
+                    serverInstance = this;
+                }
+                setRequestHandler(schema, handler) {
+                    this.handlers.set(schema, handler);
+                }
+                async connect() {
+                    return;
+                }
+            },
+        }));
+        vi.doMock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+            StdioServerTransport: class MockTransport {
+            },
+        }));
+        vi.doMock('@modelcontextprotocol/sdk/types.js', () => ({
+            CallToolRequestSchema: callSchema,
+            ListToolsRequestSchema: listSchema,
+        }));
+
+        await import('../mcp/codex-standalone-server.js');
+        const handler = serverInstance.handlers.get(callSchema);
+        expect(handler).toBeDefined();
+
+        await handler({
+            params: {
+                name: 'ask_codex',
+                arguments: {
+                    agent_role: 'architect',
+                    prompt: 'delegate to codex in background',
+                    background: true,
+                    working_directory: '/tmp',
+                },
+            },
+        });
+
+        expect(mockHandleAskCodex).toHaveBeenCalledTimes(1);
+        const normalized = mockHandleAskCodex.mock.calls[0][0];
+        expect(normalized.prompt).toBeUndefined();
+        expect(normalized.prompt_file).toContain('codex-inline-bg-');
+        expect(normalized.output_file).toContain('codex-inline-bg-response-');
+        expect(normalized.background).toBe(true);
+        expect(existsSync(normalized.prompt_file)).toBe(true);
+        expect(readFileSync(normalized.prompt_file, 'utf-8')).toBe('delegate to codex in background');
+        unlinkSync(normalized.prompt_file);
+    });
+});
+

--- a/dist/mcp/codex-request-normalizer.js
+++ b/dist/mcp/codex-request-normalizer.js
@@ -1,0 +1,59 @@
+import { mkdirSync, realpathSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { generatePromptId, slugify } from './prompt-persistence.js';
+
+/**
+ * Normalize ask_codex arguments so background executions always use prompt_file mode.
+ *
+ * Contract enforced at call-site:
+ * - foreground: inline prompt mode is allowed
+ * - background: prompt_file mode only
+ *
+ * For explicit natural-language invocations (background + inline prompt, no prompt_file),
+ * this helper deterministically persists the inline prompt and injects prompt_file/output_file.
+ */
+export function normalizeCodexAskArgsForCallSite(rawArgs) {
+    const args = rawArgs && typeof rawArgs === 'object' && !Array.isArray(rawArgs)
+        ? { ...rawArgs }
+        : {};
+    const hasPromptFileField = Object.prototype.hasOwnProperty.call(args, 'prompt_file') && args.prompt_file !== undefined;
+    const inlinePrompt = typeof args.prompt === 'string' ? args.prompt : undefined;
+    const hasInlineIntent = inlinePrompt !== undefined && !hasPromptFileField;
+    const isInlineMode = hasInlineIntent && inlinePrompt.trim().length > 0;
+    if (!args.background || !isInlineMode) {
+        return args;
+    }
+    const workingDirectoryInput = typeof args.working_directory === 'string' && args.working_directory.trim()
+        ? args.working_directory
+        : process.cwd();
+    let workingDirectory;
+    try {
+        // If workdir is invalid, let core validation return the canonical E_WORKDIR_INVALID error.
+        workingDirectory = realpathSync(workingDirectoryInput);
+    }
+    catch {
+        return args;
+    }
+    const promptsDir = join(workingDirectory, '.omc', 'prompts');
+    try {
+        mkdirSync(promptsDir, { recursive: true });
+        const requestId = generatePromptId();
+        const slug = slugify(inlinePrompt);
+        const promptFile = join(promptsDir, `codex-inline-bg-${slug}-${requestId}.md`);
+        writeFileSync(promptFile, inlinePrompt, { encoding: 'utf-8', mode: 0o600 });
+        const outputFile = (typeof args.output_file === 'string' && args.output_file.trim())
+            ? args.output_file
+            : join(promptsDir, `codex-inline-bg-response-${slug}-${requestId}.md`);
+        const { prompt: _inlinePrompt, ...rest } = args;
+        return {
+            ...rest,
+            working_directory: workingDirectory,
+            prompt_file: promptFile,
+            output_file: outputFile,
+        };
+    }
+    catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to persist inline prompt for background execution: ${reason}`);
+    }
+}

--- a/dist/mcp/codex-standalone-server.js
+++ b/dist/mcp/codex-standalone-server.js
@@ -9,6 +9,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema, } from '@modelcontextprotocol/sdk/types.js';
 import { CODEX_RECOMMENDED_ROLES, CODEX_DEFAULT_MODEL, handleAskCodex, } from './codex-core.js';
 import { handleWaitForJob, handleCheckJobStatus, handleKillJob, handleListJobs, getJobManagementToolSchemas, } from './job-management.js';
+import { normalizeCodexAskArgsForCallSite } from './codex-request-normalizer.js';
 const askCodexTool = {
     name: 'ask_codex',
     description: `Send a prompt to OpenAI Codex CLI for analytical/planning tasks. Codex excels at architecture review, planning validation, critical analysis, and code/security review validation. Recommended roles: ${CODEX_RECOMMENDED_ROLES.join(', ')}. Any valid OMC agent role is accepted. Requires Codex CLI (npm install -g @openai/codex).`,
@@ -19,13 +20,13 @@ const askCodexTool = {
                 type: 'string',
                 description: `Required. Agent perspective for Codex. Recommended: ${CODEX_RECOMMENDED_ROLES.join(', ')}. Any valid OMC agent role is accepted.`
             },
-            prompt: { type: 'string', description: 'Inline prompt text. Alternative to prompt_file -- the tool auto-persists to a file for audit trail. Use for simpler invocations where file management is unnecessary. If both prompt and prompt_file are provided, prompt_file takes precedence.' },
+            prompt: { type: 'string', description: 'Inline prompt text for foreground runs. Alternative to prompt_file -- the tool auto-persists to a file for audit trail. If both prompt and prompt_file are provided, prompt_file takes precedence.' },
             prompt_file: { type: 'string', description: 'Path to file containing the prompt. A defined (non-undefined) prompt_file value selects file mode; prompt_file must be a non-empty string when used. Passing null or non-string values triggers file-mode validation (not inline fallback).' },
             output_file: { type: 'string', description: 'Required for file-based mode (prompt_file). Auto-generated in inline mode (prompt). Response content is returned inline only when using prompt parameter.' },
             context_files: { type: 'array', items: { type: 'string' }, description: 'File paths to pass to Codex for reference (Codex will read them using its own file tools)' },
             model: { type: 'string', description: `Codex model to use (default: ${CODEX_DEFAULT_MODEL}). Set OMC_CODEX_DEFAULT_MODEL env var to change default.` },
             reasoning_effort: { type: 'string', description: "Codex reasoning effort level: 'minimal', 'low', 'medium' (Codex CLI default), 'high', or 'xhigh' (model-dependent). Maps to Codex CLI -c model_reasoning_effort. If omitted, uses Codex CLI default from ~/.codex/config.toml." },
-            background: { type: 'boolean', description: 'Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion. Not available with inline prompt.' },
+            background: { type: 'boolean', description: 'Run in background (non-blocking). Returns immediately with job metadata and file paths. Check response file for completion. Call-site contract: background execution uses prompt_file mode; inline prompt requests are normalized to prompt_file before execution.' },
             working_directory: { type: 'string', description: 'Working directory for path resolution and CLI execution. Defaults to process.cwd().' },
         },
         required: ['agent_role'],
@@ -39,7 +40,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
     if (name === 'ask_codex') {
-        const { prompt, prompt_file, output_file, agent_role, model, reasoning_effort, context_files, background, working_directory } = (args ?? {});
+        let normalizedArgs;
+        try {
+            normalizedArgs = normalizeCodexAskArgsForCallSite(args ?? {});
+        }
+        catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            return { content: [{ type: 'text', text: `Failed to prepare background prompt_file contract: ${reason}` }], isError: true };
+        }
+        const { prompt, prompt_file, output_file, agent_role, model, reasoning_effort, context_files, background, working_directory } = normalizedArgs;
         return handleAskCodex({ prompt, prompt_file, output_file, agent_role, model, reasoning_effort, context_files, background, working_directory });
     }
     if (name === 'wait_for_job') {


### PR DESCRIPTION
## Summary
- normalize `ask_codex` call-site arguments so `background=true` + inline `prompt` is auto-persisted into `prompt_file`/`output_file` before execution
- apply the normalization in both in-process and standalone Codex MCP tool entrypoints
- add a regression test covering the explicit natural-language / background inline path

## Root cause
`handleAskCodex` correctly rejects inline prompt mode for background execution, but some explicit natural-language Codex invocation paths could still arrive at the call-site with `background=true` + inline `prompt` and no `prompt_file`, causing the intermittent foreground-only inline-mode error.

## Notes
This is a dist-layer hotfix because the Codex MCP implementation on this branch is bundled in `dist/` (no `src/mcp/codex-*.ts` source files present on current dev branch).

Closes #919
