### PR TITLE
fix: prevent cancel re-arm race in ralph/ultrawork (#921)

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -437,9 +437,27 @@ async function processRalph(input: HookInput): Promise<HookOutput> {
     getArchitectVerificationPrompt,
     clearVerificationState,
   } = await import("./ralph/index.js");
+  const { isExplicitCancelCommand } = await import("./todo-continuation/index.js");
+
+  const stopContext: StopContext = {
+    stop_reason: (input as Record<string, unknown>).stop_reason as string | undefined,
+    stopReason: (input as Record<string, unknown>).stopReason as string | undefined,
+    end_turn_reason: (input as Record<string, unknown>).end_turn_reason as string | undefined,
+    endTurnReason: (input as Record<string, unknown>).endTurnReason as string | undefined,
+    prompt: input.prompt,
+    tool_name: (input as Record<string, unknown>).tool_name as string | undefined,
+    toolName: input.toolName,
+    tool_input: (input as Record<string, unknown>).tool_input,
+    toolInput: input.toolInput,
+  };
+
+  // Explicit cancel should bypass legacy ralph-loop re-enforcement.
+  if (isExplicitCancelCommand(stopContext)) {
+    return { continue: true };
+  }
 
   // Read Ralph state
-  const state = readRalphState(directory);
+  const state = readRalphState(directory, sessionId);
 
   if (!state || !state.active) {
     return { continue: true };
@@ -451,7 +469,7 @@ async function processRalph(input: HookInput): Promise<HookOutput> {
   }
 
   // Check for existing verification state (architect verification in progress)
-  const verificationState = readVerificationState(directory);
+  const verificationState = readVerificationState(directory, sessionId);
 
   if (verificationState?.pending) {
     // Check if architect has approved (by looking for the tag in transcript)
@@ -467,8 +485,8 @@ async function processRalph(input: HookInput): Promise<HookOutput> {
 
   // Check max iterations
   if (state.iteration >= state.max_iterations) {
-    clearRalphState(directory);
-    clearVerificationState(directory);
+    clearRalphState(directory, sessionId);
+    clearVerificationState(directory, sessionId);
     return {
       continue: true,
       message: `[RALPH LOOP STOPPED] Max iterations (${state.max_iterations}) reached without completion.`,
@@ -476,7 +494,7 @@ async function processRalph(input: HookInput): Promise<HookOutput> {
   }
 
   // Increment and continue
-  const newState = incrementRalphIteration(directory);
+  const newState = incrementRalphIteration(directory, sessionId);
   if (!newState) {
     return { continue: true };
   }
@@ -519,12 +537,25 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
     stopReason: (input as Record<string, unknown>).stopReason as
       | string
       | undefined,
+    end_turn_reason: (input as Record<string, unknown>).end_turn_reason as
+      | string
+      | undefined,
+    endTurnReason: (input as Record<string, unknown>).endTurnReason as
+      | string
+      | undefined,
     user_requested: (input as Record<string, unknown>).user_requested as
       | boolean
       | undefined,
     userRequested: (input as Record<string, unknown>).userRequested as
       | boolean
       | undefined,
+    prompt: input.prompt,
+    tool_name: (input as Record<string, unknown>).tool_name as
+      | string
+      | undefined,
+    toolName: input.toolName,
+    tool_input: (input as Record<string, unknown>).tool_input,
+    toolInput: input.toolInput,
   };
 
   const result = await checkPersistentModes(sessionId, directory, stopContext);

--- a/src/hooks/persistent-mode/__tests__/cancel-race.test.ts
+++ b/src/hooks/persistent-mode/__tests__/cancel-race.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { checkPersistentModes } from '../index.js';
+
+function makeRalphSession(tempDir: string, sessionId: string): string {
+  const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+  mkdirSync(stateDir, { recursive: true });
+
+  writeFileSync(
+    join(stateDir, 'ralph-state.json'),
+    JSON.stringify(
+      {
+        active: true,
+        iteration: 10,
+        max_iterations: 10,
+        started_at: new Date().toISOString(),
+        prompt: 'Finish all work',
+        session_id: sessionId,
+        project_path: tempDir,
+        linked_ultrawork: true
+      },
+      null,
+      2
+    )
+  );
+
+  return stateDir;
+}
+
+describe('persistent-mode cancel race guard (issue #921)', () => {
+  it.each([
+    '/oh-my-claudecode:cancel',
+    '/oh-my-claudecode:cancel --force'
+  ])('should not re-enforce while explicit cancel prompt is "%s"', async (cancelPrompt: string) => {
+    const sessionId = `session-921-${cancelPrompt.includes('force') ? 'force' : 'normal'}`;
+    const tempDir = mkdtempSync(join(tmpdir(), 'persistent-cancel-race-'));
+
+    try {
+      execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+      const stateDir = makeRalphSession(tempDir, sessionId);
+
+      const result = await checkPersistentModes(sessionId, tempDir, {
+        prompt: cancelPrompt
+      });
+
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('none');
+
+      const ralphState = JSON.parse(
+        readFileSync(join(stateDir, 'ralph-state.json'), 'utf-8')
+      ) as { iteration: number; max_iterations: number };
+      expect(ralphState.iteration).toBe(10);
+      expect(ralphState.max_iterations).toBe(10);
+      expect(existsSync(join(stateDir, 'ultrawork-state.json'))).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should not trigger ralph max-iteration extension or ultrawork self-heal when cancel signal exists', async () => {
+    const sessionId = 'session-921-cancel-signal';
+    const tempDir = mkdtempSync(join(tmpdir(), 'persistent-cancel-signal-'));
+
+    try {
+      execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+      const stateDir = makeRalphSession(tempDir, sessionId);
+
+      writeFileSync(
+        join(stateDir, 'cancel-signal-state.json'),
+        JSON.stringify(
+          {
+            active: true,
+            requested_at: new Date().toISOString(),
+            expires_at: new Date(Date.now() + 30_000).toISOString(),
+            source: 'test'
+          },
+          null,
+          2
+        )
+      );
+
+      const result = await checkPersistentModes(sessionId, tempDir, {
+        stop_reason: 'end_turn'
+      });
+
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('none');
+
+      const ralphState = JSON.parse(
+        readFileSync(join(stateDir, 'ralph-state.json'), 'utf-8')
+      ) as { iteration: number; max_iterations: number };
+      expect(ralphState.iteration).toBe(10);
+      expect(ralphState.max_iterations).toBe(10);
+
+      expect(existsSync(join(stateDir, 'ultrawork-state.json'))).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- prevent explicit /cancel(/--force) from being re-armed by persistent-mode/bridge reinforcement
- fix session-scoped clearModeState cleanup to remove ralph verification marker files
- guard ultrawork reinforcement and max-iteration auto-extend during cancel path
- add regression tests for cancel race and state cleanup

Closes #921