### PR TITLE
fix(team): clarify wait-timeout semantics and avoid implicit cleanup guidance

### DIFF
--- a/bridge/team-mcp.cjs
+++ b/bridge/team-mcp.cjs
@@ -17824,7 +17824,7 @@ var startSchema = external_exports.object({
     description: external_exports.string().describe("Full task description")
   })).describe("Tasks to distribute to workers"),
   cwd: external_exports.string().describe("Working directory (absolute path)"),
-  timeoutSeconds: external_exports.number().optional().describe("Timeout in seconds (default: 300)")
+  timeoutSeconds: external_exports.number().optional().describe("Optional runtime timeout in seconds (default: 0 = no implicit runtime timeout; set explicitly to enforce one)")
 });
 var statusSchema = external_exports.object({
   job_id: external_exports.string().describe("Job ID returned by omc_run_team_start")
@@ -17964,7 +17964,7 @@ var TOOLS = [
           description: "Tasks to distribute to workers"
         },
         cwd: { type: "string", description: "Working directory (absolute path)" },
-        timeoutSeconds: { type: "number", description: "Timeout in seconds (default: 300)" }
+        timeoutSeconds: { type: "number", description: "Optional runtime timeout in seconds (default: 0 = no implicit runtime timeout; set explicitly to enforce one)" }
       },
       required: ["teamName", "agentTypes", "tasks", "cwd"]
     }

--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -65,8 +65,7 @@ mcp__team__omc_run_team_start({
     {"subject": "Codex task: ...", "description": "Full description of analytical work..."},
     {"subject": "Gemini task: ...", "description": "Full description of design/UI work..."}
   ],
-  "cwd": "{cwd}",
-  "timeoutSeconds": 300
+  "cwd": "{cwd}"
 })
 ```
 
@@ -83,8 +82,9 @@ mcp__team__omc_run_team_wait({
 })
 ```
 
-> **Timeout guidance:** Use `60000` (60 s) as default. On timeout, workers keep running.
-> Call `omc_run_team_wait` again to keep waiting, or `omc_run_team_cleanup` to cancel.
+> **Timeout guidance:** `timeout_ms` is optional; the default wait timeout is fine.
+> If wait times out, workers/panes keep running. Call `omc_run_team_wait` again to keep
+> waiting. Use `omc_run_team_cleanup` only for explicit cancel intent.
 
 Returns when done:
 ```json

--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -83,8 +83,7 @@ mcp__team__omc_run_team_start({
     {"subject": "Subtask 1 title", "description": "Full description..."},
     {"subject": "Subtask 2 title", "description": "Full description..."}
   ],
-  "cwd": "{cwd}",
-  "timeoutSeconds": 300
+  "cwd": "{cwd}"
 })
 ```
 
@@ -103,10 +102,11 @@ mcp__team__omc_run_team_wait({
 })
 ```
 
-> **Timeout guidance:** Use `60000` (60 s) as the default. If the job times out,
-> **workers are left running** — the timeout does NOT kill them. You have two options:
+> **Timeout guidance:** `timeout_ms` is optional; the default wait timeout is fine.
+> If a wait call times out, **workers are left running** — wait timeout does NOT kill
+> worker processes or panes. You have two options:
 > - Call `omc_run_team_wait` again with the same `job_id` to keep waiting (workers continue)
-> - Call `omc_run_team_cleanup` to explicitly stop all worker panes when you want to cancel
+> - Call `omc_run_team_cleanup` only when you explicitly want to cancel and stop panes
 >
 > Teams can silently stall due to stuck workers or tmux session issues. Use
 > `mcp__team__omc_run_team_status` to inspect live progress before deciding to cancel.
@@ -155,7 +155,7 @@ state_write(mode="team", current_phase="completed", active=false)
 | `not inside tmux` | Shell not running inside a tmux session | Start tmux and rerun |
 | `codex: command not found` | Codex CLI not installed | `npm install -g @openai/codex` |
 | `gemini: command not found` | Gemini CLI not installed | `npm install -g @google/gemini-cli` |
-| `status: timeout` | Workers exceeded 300s | Reduce task scope or raise `timeoutSeconds` in config |
+| `status: timeout` | Explicit runtime timeout (`timeoutSeconds`) was reached | Increase explicit `timeoutSeconds` or remove it to run without runtime timeout; note `wait timeout_ms` only ends the wait call and does not stop workers |
 | `status: failed` | All workers exited with work remaining | Check stderr for crash details |
 
 ---

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -86,7 +86,7 @@ const startSchema = z.object({
     description: z.string().describe('Full task description'),
   })).describe('Tasks to distribute to workers'),
   cwd: z.string().describe('Working directory (absolute path)'),
-  timeoutSeconds: z.number().optional().describe('Timeout in seconds (default: 300)'),
+  timeoutSeconds: z.number().optional().describe('Optional runtime timeout in seconds (default: 0 = no implicit runtime timeout; set explicitly to enforce one)'),
 });
 
 const statusSchema = z.object({
@@ -247,7 +247,7 @@ const TOOLS = [
           description: 'Tasks to distribute to workers',
         },
         cwd: { type: 'string', description: 'Working directory (absolute path)' },
-        timeoutSeconds: { type: 'number', description: 'Timeout in seconds (default: 300)' },
+        timeoutSeconds: { type: 'number', description: 'Optional runtime timeout in seconds (default: 0 = no implicit runtime timeout; set explicitly to enforce one)' },
       },
       required: ['teamName', 'agentTypes', 'tasks', 'cwd'],
     },


### PR DESCRIPTION
## Summary
- keep `omc_run_team_wait` default timeout behavior unchanged (`timeout_ms` default remains `300000`)
- clarify MCP schema/docs that `timeoutSeconds` is an optional runtime timeout (default: no implicit runtime timeout unless explicitly set)
- remove hardcoded `"timeoutSeconds": 300` from `omc-teams` and `ccg` skill examples
- update skill timeout guidance so wait timeout does **not** imply killing worker panes; cleanup is for explicit cancel intent

## Validation
- `npm run build:team-server`
- `npm run test:run -- src/mcp/__tests__/team-cleanup.test.ts`

## Context
This prevents orchestrators from being misled into cleaning up worker panes on wait timeout while preserving bounded wait defaults.