### PR TITLE
fix(installer): quote node/script paths in generated command strings

### DIFF
--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -123,7 +123,7 @@ try {
   const nodeBin = process.execPath || 'node';
   settings.statusLine = {
     type: 'command',
-    command: `${nodeBin} ${hudScriptPath.replace(/\\/g, "/")}`
+    command: `"${nodeBin}" "${hudScriptPath.replace(/\\/g, "/")}"`
   };
   writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2));
   console.log('[OMC] Configured HUD statusLine in settings.json');
@@ -182,7 +182,7 @@ try {
           // New run.cjs format — replace bare `node` with absolute path (all platforms)
           const m1 = hook.command.match(runCjsPattern);
           if (m1) {
-            hook.command = `${nodeBin} ${m1[1]}`;
+            hook.command = `"${nodeBin}" ${m1[1]}`;
             patched = true;
             continue;
           }
@@ -191,7 +191,7 @@ try {
           if (process.platform === 'win32') {
             const m2 = hook.command.match(findNodePattern);
             if (m2) {
-              hook.command = `${nodeBin} "\${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs" "${m2[1]}"${m2[2]}`;
+              hook.command = `"${nodeBin}" "\${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs" "${m2[1]}"${m2[2]}`;
               patched = true;
             }
           }

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -730,7 +730,7 @@ export function install(options: InstallOptions = {}): InstallResult {
         // Use absolute node path so nvm/fnm users don't get "node not found"
         // errors when Claude Code invokes the statusLine in a non-interactive shell.
         const nodeBin = resolveNodeBinary();
-        const statusLineCommand = nodeBin + ' ' + hudScriptPath.replace(/\\/g, '/');
+        const statusLineCommand = '"' + nodeBin + '" "' + hudScriptPath.replace(/\\/g, '/') + '"';
         if (!existingSettings.statusLine) {
           existingSettings.statusLine = {
             type: 'command',


### PR DESCRIPTION
Fixes #931

## Summary
- Quoted node/script paths in installer generated commands (`src/installer/index.ts:733`)
- Quoted node binary path in plugin-setup.mjs statusLine command (line 126)
- Quoted node binary in hook command pattern 1 replacement (line 185)
- Quoted node binary in hook command pattern 2 migration (line 194)

## Test plan
- [ ] Verify generated commands work with paths containing spaces (e.g. `C:\Program Files\nodejs\node.exe`)
- [ ] Verify normal paths still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)