### PR TITLE
fix(mode-registry): session-scoped clearModeState removes foreign session marker files

### DIFF
--- a/src/hooks/mode-registry/__tests__/session-isolation.test.ts
+++ b/src/hooks/mode-registry/__tests__/session-isolation.test.ts
@@ -204,6 +204,29 @@ describe('Session-Scoped State Isolation', () => {
       expect(existsSync(markerB)).toBe(true);
       expect(existsSync(legacyMarker)).toBe(false);
     });
+
+    it('should NOT delete legacy marker file owned by a different session', () => {
+      // Regression test for issue #927:
+      // clearModeState with sessionId used to unconditionally delete the legacy
+      // marker file, bypassing the ownership check.
+      const sessionA = 'session-A';
+      const sessionB = 'session-B';
+
+      createSessionState(sessionA, 'ralph', { active: true, session_id: sessionA });
+
+      // Legacy marker is owned by session B (a different session)
+      const legacyMarkerDir = join(tempDir, '.omc', 'state');
+      mkdirSync(legacyMarkerDir, { recursive: true });
+      const legacyMarker = join(legacyMarkerDir, 'ralph-verification.json');
+      writeFileSync(legacyMarker, JSON.stringify({ pending: true, session_id: sessionB }));
+
+      // Clear session A's state — must NOT touch session B's marker
+      clearModeState('ralph', tempDir, sessionA);
+
+      expect(existsSync(legacyMarker)).toBe(true);
+      const remaining = JSON.parse(readFileSync(legacyMarker, 'utf-8'));
+      expect(remaining.session_id).toBe(sessionB);
+    });
   });
 
   describe('Stale session cleanup', () => {


### PR DESCRIPTION
Fixes #927

## Summary
- Made marker file deletion ownership-aware in `clearModeState` — when called with a `sessionId`, the legacy/shared marker file is now only deleted if it is unowned or owned by the calling session
- Added regression test `should NOT delete legacy marker file owned by a different session` covering the foreign-owner case

## Test plan
- [x] New regression test passes (32/32 tests green in `session-isolation.test.ts`)
- [x] LSP diagnostics: zero errors on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)