### PR TITLE
docs(cli): align Windows support policy messaging between docs and startup warning

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -482,11 +482,13 @@ pipeline: analyze → fix → test this bug
 
 | Platform | Install Method | Hook Type |
 |----------|---------------|-----------|
-| **Windows** | `npm install -g` | Node.js (.mjs) |
+| **Windows** | WSL2 recommended (see note) | Node.js (.mjs) |
 | **macOS** | curl or npm | Bash (.sh) |
 | **Linux** | curl or npm | Bash (.sh) |
 
 > **Note**: Bash hooks are fully portable across macOS and Linux (no GNU-specific dependencies).
+
+> **Windows**: Native Windows (win32) support is experimental. OMC requires tmux, which is not available on native Windows. **WSL2 is strongly recommended** for Windows users. See the [WSL2 installation guide](https://learn.microsoft.com/en-us/windows/wsl/install). Native Windows issues may have limited support.
 
 > **Advanced**: Set `OMC_USE_NODE_HOOKS=1` to use Node.js hooks on macOS/Linux.
 

--- a/src/cli/win32-warning.ts
+++ b/src/cli/win32-warning.ts
@@ -8,8 +8,8 @@ export function warnIfWin32(): void {
   if (process.platform === 'win32') {
     console.warn(chalk.yellow.bold('\n⚠  WARNING: Native Windows (win32) detected'));
     console.warn(chalk.yellow('   OMC requires tmux, which is not available on native Windows.'));
-    console.warn(chalk.yellow('   Please use WSL2 instead: https://learn.microsoft.com/en-us/windows/wsl/install'));
-    console.warn(chalk.red('   Native win32 support issues will not be accepted. Figure it out yourself.'));
+    console.warn(chalk.yellow('   Native Windows support is experimental and may have limited functionality.'));
+    console.warn(chalk.yellow('   WSL2 is strongly recommended: https://learn.microsoft.com/en-us/windows/wsl/install'));
     console.warn('');
   }
 }


### PR DESCRIPTION
Fixes #939

## Summary
- Aligned Windows support policy between `docs/REFERENCE.md` and CLI startup warning
- Docs now mark Windows as experimental with WSL2 strongly recommended
- CLI warning removes the dismissive "Figure it out yourself" line, replaced with consistent professional messaging recommending WSL2

## Test plan
- [ ] Read both docs and CLI warning for consistency
- [ ] Verify startup warning still displays on win32

🤖 Generated with [Claude Code](https://claude.com/claude-code)