### PR TITLE
chore(code-quality): clean remaining runtime dead code / unused imports

### DIFF
--- a/src/analytics/transcript-scanner.ts
+++ b/src/analytics/transcript-scanner.ts
@@ -12,15 +12,6 @@ function isWindowsEncodedPath(dirName: string): boolean {
 }
 
 /**
- * Normalize decoded path to use OS-native separators consistently
- */
-function _normalizePathForOS(decodedPath: string): string {
-  // On Windows, convert forward slashes to backslashes for consistency
-  // But existsSync works with both, so we normalize to forward slashes for cross-platform
-  return decodedPath.replace(/\\/g, '/');
-}
-
-/**
  * Metadata for a discovered transcript file
  */
 export interface TranscriptFile {

--- a/src/features/delegation-routing/resolver.ts
+++ b/src/features/delegation-routing/resolver.ts
@@ -9,7 +9,6 @@ import type {
   DelegationRoute,
   DelegationDecision,
   ResolveDelegationOptions,
-  DelegationProvider,
   DelegationTool,
 } from '../../shared/types.js';
 import {

--- a/src/hooks/pre-compact/index.ts
+++ b/src/hooks/pre-compact/index.ts
@@ -19,7 +19,7 @@ import {
 } from "fs";
 import { promises as fsPromises } from "fs";
 import { join } from "path";
-import { initJobDb, getActiveJobs, getRecentJobs, getJobStats, closeJobDb } from '../../lib/job-state-db.js';
+import { initJobDb, getActiveJobs, getRecentJobs, getJobStats } from '../../lib/job-state-db.js';
 
 // ============================================================================
 // Types

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,5 +1,4 @@
-import { execSync, spawnSync } from 'child_process';
-import * as path from 'path';
+import { spawnSync } from 'child_process';
 
 export type CliAgentType = 'claude' | 'codex' | 'gemini';
 


### PR DESCRIPTION
Fixes #941

## Summary
- Removed unused `DelegationProvider` import from `resolver.ts`
- Removed unused `execSync` and `path` imports from `model-contract.ts`
- Removed unused `closeJobDb` import from `pre-compact/index.ts`
- Removed unused `_normalizePathForOS` helper from `transcript-scanner.ts`

## Test plan
- [x] TypeScript diagnostics pass (zero errors on all four modified files)
- [x] No runtime regressions (only dead code removed, no logic changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)