### PR TITLE
regression(pre-compact): remove remaining implicit-cwd fallback usage in job-state queries

### DIFF
--- a/src/hooks/pre-compact/index.ts
+++ b/src/hooks/pre-compact/index.ts
@@ -319,13 +319,13 @@ async function getActiveJobsSummary(directory: string): Promise<{
       return { activeJobs: [], recentJobs: [], stats: null };
     }
 
-    const active = getActiveJobs();
-    const recent = getRecentJobs(undefined, 5 * 60 * 1000); // Last 5 minutes
+    const active = getActiveJobs(undefined, directory);
+    const recent = getRecentJobs(undefined, 5 * 60 * 1000, directory); // Last 5 minutes
 
     // Filter recent to only completed/failed (not active ones which are already listed)
     const recentCompleted = recent.filter(j => j.status === 'completed' || j.status === 'failed');
 
-    const stats = getJobStats();
+    const stats = getJobStats(directory);
 
     return {
       activeJobs: active.map(j => ({


### PR DESCRIPTION
Fixes #940

## Summary
- Pass cwd explicitly to all job-state-db query calls in pre-compact
- Eliminates deprecated _lastCwd fallback warnings

## Test plan
- [ ] Verify pre-compact tests pass without deprecation warnings
- [ ] Verify job state queries work correctly with explicit cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)