### PR TITLE
test(cli): replace simulated win32 warning test with real bootstrap-path assertion

### DIFF
--- a/src/__tests__/cli-win32-warning.test.ts
+++ b/src/__tests__/cli-win32-warning.test.ts
@@ -6,60 +6,53 @@ describe('CLI win32 platform warning (#923)', () => {
 
   beforeEach(() => {
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.resetModules();
   });
 
   afterEach(() => {
-    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     warnSpy.mockRestore();
+    vi.resetModules();
   });
 
-  it('should warn on win32 platform', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' });
+  it('should warn on win32 platform', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
-    // Simulate the warning logic from src/cli/index.ts
-    if (process.platform === 'win32') {
-      console.warn('WARNING: Native Windows (win32) detected');
-      console.warn('OMC requires tmux, which is not available on native Windows.');
-      console.warn('Please use WSL2 instead');
-      console.warn('Native win32 support issues will not be accepted.');
-    }
+    const { warnIfWin32 } = await import('../cli/win32-warning.js');
+    warnIfWin32();
 
     expect(warnSpy).toHaveBeenCalled();
-    const allOutput = warnSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    const allOutput = warnSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(allOutput).toContain('win32');
     expect(allOutput).toContain('tmux');
     expect(allOutput).toContain('WSL2');
     expect(allOutput).toContain('will not be accepted');
   });
 
-  it('should NOT warn on linux platform', () => {
-    Object.defineProperty(process, 'platform', { value: 'linux' });
+  it('should NOT warn on linux platform', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
-    if (process.platform === 'win32') {
-      console.warn('WARNING: Native Windows (win32) detected');
-    }
-
-    expect(warnSpy).not.toHaveBeenCalled();
-  });
-
-  it('should NOT warn on darwin platform', () => {
-    Object.defineProperty(process, 'platform', { value: 'darwin' });
-
-    if (process.platform === 'win32') {
-      console.warn('WARNING: Native Windows (win32) detected');
-    }
+    const { warnIfWin32 } = await import('../cli/win32-warning.js');
+    warnIfWin32();
 
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('should not block execution after warning', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' });
+  it('should NOT warn on darwin platform', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
 
+    const { warnIfWin32 } = await import('../cli/win32-warning.js');
+    warnIfWin32();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not block execution after warning', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const { warnIfWin32 } = await import('../cli/win32-warning.js');
     let continued = false;
-    if (process.platform === 'win32') {
-      console.warn('WARNING: Native Windows (win32) detected');
-    }
-    // Code continues past the warning
+    warnIfWin32();
     continued = true;
 
     expect(continued).toBe(true);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -68,6 +68,7 @@ import {
 import { getRuntimePackageVersion } from '../lib/version.js';
 import { launchCommand } from './launch.js';
 import { interopCommand } from './interop.js';
+import { warnIfWin32 } from './win32-warning.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -76,13 +77,7 @@ const version = getRuntimePackageVersion();
 const program = new Command();
 
 // Win32 platform warning - OMC requires tmux which is not available on native Windows
-if (process.platform === 'win32') {
-  console.warn(chalk.yellow.bold('\n⚠  WARNING: Native Windows (win32) detected'));
-  console.warn(chalk.yellow('   OMC requires tmux, which is not available on native Windows.'));
-  console.warn(chalk.yellow('   Please use WSL2 instead: https://learn.microsoft.com/en-us/windows/wsl/install'));
-  console.warn(chalk.red('   Native win32 support issues will not be accepted. Figure it out yourself.'));
-  console.warn('');
-}
+warnIfWin32();
 
 // Helper functions for auto-backfill
 async function checkIfBackfillNeeded(): Promise<boolean> {

--- a/src/cli/win32-warning.ts
+++ b/src/cli/win32-warning.ts
@@ -1,0 +1,15 @@
+import chalk from 'chalk';
+
+/**
+ * Warn if running on native Windows (win32), where tmux is not available.
+ * Called at CLI startup from src/cli/index.ts.
+ */
+export function warnIfWin32(): void {
+  if (process.platform === 'win32') {
+    console.warn(chalk.yellow.bold('\n⚠  WARNING: Native Windows (win32) detected'));
+    console.warn(chalk.yellow('   OMC requires tmux, which is not available on native Windows.'));
+    console.warn(chalk.yellow('   Please use WSL2 instead: https://learn.microsoft.com/en-us/windows/wsl/install'));
+    console.warn(chalk.red('   Native win32 support issues will not be accepted. Figure it out yourself.'));
+    console.warn('');
+  }
+}


### PR DESCRIPTION
Fixes #936

## Summary
- Extracted `warnIfWin32` from `src/cli/index.ts` into a new standalone module `src/cli/win32-warning.ts` so it can be imported and tested without triggering the full CLI bootstrap (`program.parse` side-effects)
- Rewrote the test to import the actual `warnIfWin32` function with a mocked `process.platform`, ensuring test expectations track the real runtime warning text

## Test plan
- [x] Run the rewritten test: 4/4 pass, 0 unhandled errors
- [x] Verify test catches real win32 warning text (tmux, WSL2, win32, will not be accepted)
- [x] LSP diagnostics: 0 errors on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)