### PR TITLE
fix(persistent-mode): scope idle notification cooldown by session

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -523,7 +523,8 @@ ${newState.prompt}`;
  * Unified handler for ultrawork, ralph, and todo-continuation
  */
 async function processPersistentMode(input: HookInput): Promise<HookOutput> {
-  const sessionId = input.sessionId;
+  const rawSessionId = (input as Record<string, unknown>).session_id as string | undefined;
+  const sessionId = input.sessionId ?? rawSessionId;
   const directory = resolveToWorktreeRoot(input.directory);
 
   // Lazy-load persistent-mode and todo-continuation modules
@@ -570,10 +571,10 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
       const isContextLimit = stopContext.stop_reason === "context_limit" || stopContext.stopReason === "context_limit";
       if (!isAbort && !isContextLimit) {
         // Per-session cooldown: prevent notification spam when the session idles repeatedly.
-        // Mirrors the cooldown logic in scripts/persistent-mode.cjs (closes #842).
+        // Uses session-scoped state so one session does not suppress another.
         const stateDir = join(directory, ".omc", "state");
-        if (shouldSendIdleNotification(stateDir)) {
-          recordIdleNotificationSent(stateDir);
+        if (shouldSendIdleNotification(stateDir, sessionId)) {
+          recordIdleNotificationSent(stateDir, sessionId);
           import("../notifications/index.js").then(({ notify }) =>
             notify("session-idle", {
               sessionId,

--- a/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
@@ -35,6 +35,13 @@ vi.mock('os', async () => {
 
 const TEST_STATE_DIR = '/project/.omc/state';
 const COOLDOWN_PATH = join(TEST_STATE_DIR, 'idle-notif-cooldown.json');
+const TEST_SESSION_ID = 'session-123';
+const SESSION_COOLDOWN_PATH = join(
+  TEST_STATE_DIR,
+  'sessions',
+  TEST_SESSION_ID,
+  'idle-notif-cooldown.json'
+);
 const CONFIG_PATH = '/home/testuser/.omc/config.json';
 
 describe('getIdleNotificationCooldownSeconds', () => {
@@ -198,6 +205,24 @@ describe('shouldSendIdleNotification', () => {
     expect(shouldSendIdleNotification(TEST_STATE_DIR)).toBe(true);
   });
 
+  it('uses session-scoped cooldown file when sessionId is provided', () => {
+    const recentTimestamp = new Date(Date.now() - 10_000).toISOString(); // 10s ago
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === CONFIG_PATH) return true;
+      if (p === SESSION_COOLDOWN_PATH) return true;
+      return false;
+    });
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === CONFIG_PATH) {
+        return JSON.stringify({ notificationCooldown: { sessionIdleSeconds: 30 } });
+      }
+      if (p === SESSION_COOLDOWN_PATH) return JSON.stringify({ lastSentAt: recentTimestamp });
+      throw new Error('not found');
+    });
+
+    expect(shouldSendIdleNotification(TEST_STATE_DIR, TEST_SESSION_ID)).toBe(false);
+  });
+
   it('blocks notification when within custom shorter cooldown', () => {
     const recentTimestamp = new Date(Date.now() - 10_000).toISOString(); // 10s ago
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
@@ -237,6 +262,16 @@ describe('recordIdleNotificationSent', () => {
     const ts = new Date(written.lastSentAt).getTime();
     expect(ts).toBeGreaterThanOrEqual(before);
     expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('writes session-scoped cooldown file when sessionId is provided', () => {
+    (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    recordIdleNotificationSent(TEST_STATE_DIR, TEST_SESSION_ID);
+
+    expect(mkdirSync).toHaveBeenCalledWith(join(TEST_STATE_DIR, 'sessions', TEST_SESSION_ID), { recursive: true });
+    const [calledPath] = (writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(calledPath).toBe(SESSION_COOLDOWN_PATH);
   });
 
   it('creates state directory if it does not exist', () => {

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -253,15 +253,23 @@ export function getIdleNotificationCooldownSeconds(): number {
   return 60;
 }
 
+function getIdleNotificationCooldownPath(stateDir: string, sessionId?: string): string {
+  // Keep session segments filesystem-safe; fall back to legacy global path otherwise.
+  if (sessionId && /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) {
+    return join(stateDir, 'sessions', sessionId, 'idle-notif-cooldown.json');
+  }
+  return join(stateDir, 'idle-notif-cooldown.json');
+}
+
 /**
  * Check whether the session-idle notification cooldown has elapsed.
  * Returns true if the notification should be sent.
  */
-export function shouldSendIdleNotification(stateDir: string): boolean {
+export function shouldSendIdleNotification(stateDir: string, sessionId?: string): boolean {
   const cooldownSecs = getIdleNotificationCooldownSeconds();
   if (cooldownSecs === 0) return true; // cooldown disabled
 
-  const cooldownPath = join(stateDir, 'idle-notif-cooldown.json');
+  const cooldownPath = getIdleNotificationCooldownPath(stateDir, sessionId);
   try {
     if (!existsSync(cooldownPath)) return true;
     const data = JSON.parse(readFileSync(cooldownPath, 'utf-8')) as Record<string, unknown>;
@@ -278,8 +286,8 @@ export function shouldSendIdleNotification(stateDir: string): boolean {
 /**
  * Record that the session-idle notification was sent at the current timestamp.
  */
-export function recordIdleNotificationSent(stateDir: string): void {
-  const cooldownPath = join(stateDir, 'idle-notif-cooldown.json');
+export function recordIdleNotificationSent(stateDir: string, sessionId?: string): void {
+  const cooldownPath = getIdleNotificationCooldownPath(stateDir, sessionId);
   try {
     const dir = dirname(cooldownPath);
     if (!existsSync(dir)) {


### PR DESCRIPTION
Fixes #934

## Summary
- Moved idle notification cooldown to session-scoped path
- Falls back to project-global path when sessionId unavailable

## Test plan
- [ ] Verify separate sessions have independent cooldowns
- [ ] Verify fallback works without sessionId

Generated with Codex CLI