### PR TITLE
fix(windows): replace WMIC-only process queries with fallback strategy

### DIFF
--- a/src/platform/process-utils.ts
+++ b/src/platform/process-utils.ts
@@ -100,22 +100,78 @@ async function getProcessStartTimeWindows(pid: number): Promise<number | undefin
       'get', 'CreationDate', '/format:csv'
     ], { timeout: 5000, windowsHide: true });
 
-    const lines = stdout.trim().split(/\r?\n/).filter(l => l.trim());
-    if (lines.length < 2) return undefined;
+    const wmicTime = parseWmicCreationDate(stdout);
+    if (wmicTime !== undefined) return wmicTime;
+  } catch {
+    // WMIC is deprecated on newer Windows builds; fall back to PowerShell.
+  }
 
-    const match = lines[1].match(/,(\d{14})/);
-    if (!match) return undefined;
+  const cimTime = await getProcessStartTimeWindowsPowerShellCim(pid);
+  if (cimTime !== undefined) return cimTime;
 
-    const d = match[1];
-    const date = new Date(
-      parseInt(d.slice(0, 4)),
-      parseInt(d.slice(4, 6)) - 1,
-      parseInt(d.slice(6, 8)),
-      parseInt(d.slice(8, 10)),
-      parseInt(d.slice(10, 12)),
-      parseInt(d.slice(12, 14))
+  return getProcessStartTimeWindowsPowerShellProcess(pid);
+}
+
+function parseWmicCreationDate(stdout: string): number | undefined {
+  const lines = stdout.trim().split(/\r?\n/).filter(l => l.trim());
+  if (lines.length < 2) return undefined;
+
+  const candidate = lines.find(line => /,\d{14}/.test(line)) ?? lines[1];
+  const match = candidate.match(/,(\d{14})/);
+  if (!match) return undefined;
+
+  const d = match[1];
+  const date = new Date(
+    parseInt(d.slice(0, 4), 10),
+    parseInt(d.slice(4, 6), 10) - 1,
+    parseInt(d.slice(6, 8), 10),
+    parseInt(d.slice(8, 10), 10),
+    parseInt(d.slice(10, 12), 10),
+    parseInt(d.slice(12, 14), 10)
+  );
+
+  const value = date.getTime();
+  return Number.isNaN(value) ? undefined : value;
+}
+
+function parseWindowsEpochMilliseconds(stdout: string): number | undefined {
+  const match = stdout.trim().match(/-?\d+/);
+  if (!match) return undefined;
+  const value = parseInt(match[0], 10);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+async function getProcessStartTimeWindowsPowerShellCim(pid: number): Promise<number | undefined> {
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction Stop; if ($p -and $p.CreationDate) { [DateTimeOffset]$p.CreationDate | ForEach-Object { $_.ToUnixTimeMilliseconds() } }`
+      ],
+      { timeout: 5000, windowsHide: true }
     );
-    return date.getTime();
+    return parseWindowsEpochMilliseconds(stdout);
+  } catch {
+    return undefined;
+  }
+}
+
+async function getProcessStartTimeWindowsPowerShellProcess(pid: number): Promise<number | undefined> {
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `$p = Get-Process -Id ${pid} -ErrorAction SilentlyContinue; if ($p -and $p.StartTime) { [DateTimeOffset]$p.StartTime | ForEach-Object { $_.ToUnixTimeMilliseconds() } }`
+      ],
+      { timeout: 5000, windowsHide: true }
+    );
+    return parseWindowsEpochMilliseconds(stdout);
   } catch {
     return undefined;
   }

--- a/src/tools/python-repl/session-lock.ts
+++ b/src/tools/python-repl/session-lock.ts
@@ -143,28 +143,53 @@ export async function isProcessAlive(pid: number, recordedStartTime?: number): P
       return false;
     }
   } else if (process.platform === 'win32') {
-    // On Windows, check if process exists and optionally verify start time
-    try {
-      process.kill(pid, 0);
-
-      if (recordedStartTime !== undefined) {
-        const currentStartTime = await getProcessStartTime(pid);
-        if (currentStartTime === undefined) {
-          return false;
-        }
-        if (currentStartTime !== recordedStartTime) {
-          return false;
-        }
-      }
-
-      return true;
-    } catch {
+    // On Windows, check process existence first and then verify start time when available.
+    const exists = await isWindowsProcessAlive(pid);
+    if (!exists) {
       return false;
     }
+
+    if (recordedStartTime !== undefined) {
+      const currentStartTime = await getProcessStartTime(pid);
+      // If start-time metadata is unavailable, avoid misclassifying a live process as dead.
+      if (currentStartTime !== undefined && currentStartTime !== recordedStartTime) {
+        return false; // PID reuse detected
+      }
+    }
+
+    return true;
   }
 
   // Unknown platform: conservative assumption that process is alive
   return true;
+}
+
+async function isWindowsProcessAlive(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    // Fallback for environments where signal probing is restricted/unreliable.
+    return isWindowsProcessAlivePowerShell(pid);
+  }
+}
+
+async function isWindowsProcessAlivePowerShell(pid: number): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction SilentlyContinue; if (-not $p) { $p = Get-Process -Id ${pid} -ErrorAction SilentlyContinue }; if ($p) { '1' }`
+      ],
+      { timeout: 5000, windowsHide: true }
+    );
+    return stdout.trim() === '1';
+  } catch {
+    return false;
+  }
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixes #932

## Summary
- Added PowerShell/CIM fallback for WMIC process queries
- Graceful handling of undefined start-time

## Test plan
- [ ] Verify process queries work without wmic
- [ ] Verify existing wmic path still works

Generated with Codex CLI