### PR TITLE
fix(team): use Codex bypass approvals/sandbox flag for teammate spawns

### DIFF
--- a/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
+++ b/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
@@ -5,8 +5,8 @@ import { join } from 'path';
 describe('mcp-team-bridge spawn args', () => {
   const source = readFileSync(join(__dirname, '..', 'mcp-team-bridge.ts'), 'utf-8');
 
-  it('includes --skip-git-repo-check for Codex bridge spawns', () => {
-    expect(source).toMatch(/args = \['exec', '-m', model \|\| 'gpt-5\.3-codex', '--json', '--full-auto', '--skip-git-repo-check'\]/);
+  it('includes bypass approvals/sandbox and --skip-git-repo-check for Codex bridge spawns', () => {
+    expect(source).toMatch(/args = \['exec', '-m', model \|\| 'gpt-5\.3-codex', '--json', '--full-auto', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'\]/);
   });
 
   it('keeps Gemini bridge spawn args unchanged (no skip-git-repo-check)', () => {
@@ -14,4 +14,3 @@ describe('mcp-team-bridge spawn args', () => {
     expect(source).toMatch(/else \{\s*cmd = 'gemini';\s*args = \['--yolo'\];/s);
   });
 });
-

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -28,9 +28,10 @@ describe('model-contract', () => {
       const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp' });
       expect(args).toContain('--dangerously-skip-permissions');
     });
-    it('codex includes --full-auto', () => {
+    it('codex includes --full-auto and bypass approvals/sandbox', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp' });
       expect(args).toContain('--full-auto');
+      expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
     });
     it('gemini includes --yolo', () => {
       const args = buildLaunchArgs('gemini', { teamName: 't', workerName: 'w', cwd: '/tmp' });

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -372,7 +372,7 @@ function spawnCliProcess(
 
   if (provider === 'codex') {
     cmd = 'codex';
-    args = ['exec', '-m', model || 'gpt-5.3-codex', '--json', '--full-auto', '--skip-git-repo-check'];
+    args = ['exec', '-m', model || 'gpt-5.3-codex', '--json', '--full-auto', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'];
   } else {
     cmd = 'gemini';
     args = ['--yolo'];

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -38,7 +38,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     binary: 'codex',
     installInstructions: 'Install Codex CLI: npm install -g @openai/codex',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
-      const args = ['--full-auto'];
+      const args = ['--full-auto', '--dangerously-bypass-approvals-and-sandbox'];
       if (model) args.push('--model', model);
       return [...args, ...extraFlags];
     },


### PR DESCRIPTION
## Summary\n- switch Codex teammate default launch args to include `--dangerously-bypass-approvals-and-sandbox` in `src/team/model-contract.ts`\n- update MCP Codex spawn args in `src/team/mcp-team-bridge.ts` to include the same bypass flag\n- update team tests to assert the new Codex spawn/launch args\n- leave Gemini behavior unchanged\n\n## Testing\n- attempted: `npm test -- src/team/__tests__/model-contract.test.ts src/team/__tests__/mcp-team-bridge.spawn-args.test.ts`\n- result: fails locally because `vitest` is not installed in this worktree (no `node_modules`)\n