### PR TITLE
fix(hooks): inject continuation guidance in PostToolUseFailure hook

### DIFF
--- a/templates/hooks/post-tool-use-failure.mjs
+++ b/templates/hooks/post-tool-use-failure.mjs
@@ -155,10 +155,28 @@ async function main() {
     // Write error state
     writeErrorState(stateDir, toolName, inputPreview, error, retryCount);
 
-    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    // Inject continuation guidance so the model analyzes the error instead of stopping.
+    // Without this, PostToolUseFailure returns silently and the model may end its turn.
+    // The PostToolUse hook (post-tool-verifier.mjs) provides similar guidance for
+    // successful Bash calls with error patterns, but PostToolUseFailure is a separate
+    // event that needs its own guidance injection.
+    let guidance;
+    if (retryCount >= 5) {
+      guidance = `Tool "${toolName}" has failed ${retryCount} times. Stop retrying the same approach — try a different command, check dependencies, or ask the user for guidance.`;
+    } else {
+      guidance = `Tool "${toolName}" failed. Analyze the error, fix the issue, and continue working.`;
+    }
+
+    console.log(JSON.stringify({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUseFailure',
+        additionalContext: guidance,
+      },
+    }));
   } catch (error) {
     // Never block on hook errors
-    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    console.log(JSON.stringify({ continue: true }));
   }
 }
 


### PR DESCRIPTION
## Summary

- Inject `hookSpecificOutput.additionalContext` in `PostToolUseFailure` hook to guide the model to analyze errors and continue working
- Escalate messaging after 5+ retries to suggest alternative approaches
- Remove `suppressOutput: true` from the catch block to avoid potential context suppression

Fixes #963

## Test plan

- [x] Verified first-failure path outputs correct guidance message
- [x] Verified retry ≥5 path outputs escalation message
- [x] 26 existing tool-error tests pass (`vitest run src/hooks/persistent-mode/__tests__/tool-error.test.ts`)
- [x] End-to-end test simulating `bun test` failure confirms `hookSpecificOutput.additionalContext` is present
- [x] Manual verification: restart Claude Code, run a failing command, confirm model continues reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)