### PR TITLE
fix(cli): update teleport help to avoid shell comment pitfall

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1459,14 +1459,16 @@ waitCmd
  */
 const teleportCmd = program
   .command('teleport [ref]')
-  .description('Create git worktree for isolated development (e.g., omc teleport #123)')
+  .description('Create git worktree for isolated development (e.g., omc teleport \'#123\')')
   .option('--worktree', 'Create worktree (default behavior, flag kept for compatibility)')
   .option('-p, --path <path>', 'Custom worktree path (default: ~/Workspace/omc-worktrees/)')
   .option('-b, --base <branch>', 'Base branch to create from (default: main)')
   .option('--json', 'Output as JSON')
   .addHelpText('after', `
+Note: Quote the # sign in your shell, e.g., omc teleport '#42'
+
 Examples:
-  $ omc teleport #42             Create worktree for issue/PR #42
+  $ omc teleport '#42'           Create worktree for issue/PR #42
   $ omc teleport add-auth        Create worktree for a feature branch
   $ omc teleport list            List existing worktrees
   $ omc teleport remove ./path   Remove a worktree`)
@@ -1480,13 +1482,13 @@ Examples:
       console.log('  omc teleport remove <path>   Remove a worktree');
       console.log('');
       console.log('Reference formats:');
-      console.log('  #123                         Issue/PR in current repo');
+      console.log('  \'#123\'                       Issue/PR in current repo (# must be quoted)');
       console.log('  owner/repo#123               Issue/PR in specific repo');
       console.log('  my-feature                   Feature branch name');
       console.log('  https://github.com/...       GitHub URL');
       console.log('');
       console.log('Examples:');
-      console.log('  omc teleport #42             Create worktree for issue #42');
+      console.log('  omc teleport \'#42\'           Create worktree for issue #42');
       console.log('  omc teleport add-auth        Create worktree for feature "add-auth"');
       console.log('');
       return;


### PR DESCRIPTION
## Summary
- Fixes #968
- Unquoted `#N` arguments (e.g., `omc teleport #7`) are silently interpreted as shell comments by bash/zsh, causing the ref to be dropped and help text to display instead of creating a worktree.
- Updated teleport help text and examples to use quoted format `'#N'` as the primary example.
- Added a `Note:` line reminding users to quote the `#` sign in their shell.

## Test plan
- [x] Existing teleport tests pass (`vitest run src/cli/commands/__tests__/teleport.test.ts`)
- [x] TypeScript type check passes (`tsc --project tsconfig.json --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)