### PR TITLE
fix: remove conflicting --dangerously-bypass-approvals-and-sandbox from Codex CLI args

### DIFF
--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -66,7 +66,7 @@ var CONTRACTS = {
     binary: "codex",
     installInstructions: "Install Codex CLI: npm install -g @openai/codex",
     buildLaunchArgs(model, extraFlags = []) {
-      const args = ["--full-auto", "--dangerously-bypass-approvals-and-sandbox"];
+      const args = ["--full-auto"];
       if (model) args.push("--model", model);
       return [...args, ...extraFlags];
     },

--- a/bridge/team-bridge.cjs
+++ b/bridge/team-bridge.cjs
@@ -1252,7 +1252,7 @@ function spawnCliProcess(provider, prompt, model, cwd, timeoutMs) {
   let cmd;
   if (provider === "codex") {
     cmd = "codex";
-    args = ["exec", "-m", model || "gpt-5.3-codex", "--json", "--full-auto", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check"];
+    args = ["exec", "-m", model || "gpt-5.3-codex", "--json", "--full-auto", "--skip-git-repo-check"];
   } else {
     cmd = "gemini";
     args = ["--yolo"];

--- a/dist/team/__tests__/mcp-team-bridge.spawn-args.test.js
+++ b/dist/team/__tests__/mcp-team-bridge.spawn-args.test.js
@@ -3,8 +3,8 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 describe('mcp-team-bridge spawn args', () => {
     const source = readFileSync(join(__dirname, '..', 'mcp-team-bridge.ts'), 'utf-8');
-    it('includes bypass approvals/sandbox and --skip-git-repo-check for Codex bridge spawns', () => {
-        expect(source).toMatch(/args = \['exec', '-m', model \|\| 'gpt-5\.3-codex', '--json', '--full-auto', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'\]/);
+    it('includes --full-auto and --skip-git-repo-check for Codex bridge spawns (no conflicting bypass flag)', () => {
+        expect(source).toMatch(/args = \['exec', '-m', model \|\| 'gpt-5\.3-codex', '--json', '--full-auto', '--skip-git-repo-check'\]/);
     });
     it('keeps Gemini bridge spawn args unchanged (no skip-git-repo-check)', () => {
         expect(source).toContain("args = ['--yolo']");

--- a/dist/team/__tests__/model-contract.test.js
+++ b/dist/team/__tests__/model-contract.test.js
@@ -26,10 +26,10 @@ describe('model-contract', () => {
             const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp' });
             expect(args).toContain('--dangerously-skip-permissions');
         });
-        it('codex includes --full-auto and bypass approvals/sandbox', () => {
+        it('codex includes --full-auto only (no conflicting bypass flag)', () => {
             const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp' });
             expect(args).toContain('--full-auto');
-            expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
+            expect(args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
         });
         it('gemini includes --yolo', () => {
             const args = buildLaunchArgs('gemini', { teamName: 't', workerName: 'w', cwd: '/tmp' });
@@ -57,7 +57,6 @@ describe('model-contract', () => {
             expect(buildWorkerArgv('codex', { teamName: 'my-team', workerName: 'worker-1', cwd: '/tmp' })).toEqual([
                 'codex',
                 '--full-auto',
-                '--dangerously-bypass-approvals-and-sandbox',
             ]);
         });
     });

--- a/dist/team/mcp-team-bridge.js
+++ b/dist/team/mcp-team-bridge.js
@@ -322,7 +322,7 @@ function spawnCliProcess(provider, prompt, model, cwd, timeoutMs) {
     let cmd;
     if (provider === 'codex') {
         cmd = 'codex';
-        args = ['exec', '-m', model || 'gpt-5.3-codex', '--json', '--full-auto', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'];
+        args = ['exec', '-m', model || 'gpt-5.3-codex', '--json', '--full-auto', '--skip-git-repo-check'];
     }
     else {
         cmd = 'gemini';

--- a/dist/team/model-contract.js
+++ b/dist/team/model-contract.js
@@ -20,7 +20,7 @@ const CONTRACTS = {
         binary: 'codex',
         installInstructions: 'Install Codex CLI: npm install -g @openai/codex',
         buildLaunchArgs(model, extraFlags = []) {
-            const args = ['--full-auto', '--dangerously-bypass-approvals-and-sandbox'];
+            const args = ['--full-auto'];
             if (model)
                 args.push('--model', model);
             return [...args, ...extraFlags];

--- a/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
+++ b/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
@@ -5,8 +5,8 @@ import { join } from 'path';
 describe('mcp-team-bridge spawn args', () => {
   const source = readFileSync(join(__dirname, '..', 'mcp-team-bridge.ts'), 'utf-8');
 
-  it('includes bypass approvals/sandbox and --skip-git-repo-check for Codex bridge spawns', () => {
-    expect(source).toMatch(/args = \['exec', '-m', model \|\| 'gpt-5\.3-codex', '--json', '--full-auto', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'\]/);
+  it('includes --full-auto and --skip-git-repo-check for Codex bridge spawns (no conflicting bypass flag)', () => {
+    expect(source).toMatch(/args = \['exec', '-m', model \|\| 'gpt-5\.3-codex', '--json', '--full-auto', '--skip-git-repo-check'\]/);
   });
 
   it('keeps Gemini bridge spawn args unchanged (no skip-git-repo-check)', () => {

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -28,10 +28,10 @@ describe('model-contract', () => {
       const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp' });
       expect(args).toContain('--dangerously-skip-permissions');
     });
-    it('codex includes --full-auto and bypass approvals/sandbox', () => {
+    it('codex includes --full-auto only (no conflicting bypass flag)', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp' });
       expect(args).toContain('--full-auto');
-      expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
+      expect(args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
     });
     it('gemini includes --yolo', () => {
       const args = buildLaunchArgs('gemini', { teamName: 't', workerName: 'w', cwd: '/tmp' });
@@ -62,7 +62,6 @@ describe('model-contract', () => {
       expect(buildWorkerArgv('codex', { teamName: 'my-team', workerName: 'worker-1', cwd: '/tmp' })).toEqual([
         'codex',
         '--full-auto',
-        '--dangerously-bypass-approvals-and-sandbox',
       ]);
     });
   });

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -372,7 +372,7 @@ function spawnCliProcess(
 
   if (provider === 'codex') {
     cmd = 'codex';
-    args = ['exec', '-m', model || 'gpt-5.3-codex', '--json', '--full-auto', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'];
+    args = ['exec', '-m', model || 'gpt-5.3-codex', '--json', '--full-auto', '--skip-git-repo-check'];
   } else {
     cmd = 'gemini';
     args = ['--yolo'];

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -38,7 +38,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     binary: 'codex',
     installInstructions: 'Install Codex CLI: npm install -g @openai/codex',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
-      const args = ['--full-auto', '--dangerously-bypass-approvals-and-sandbox'];
+      const args = ['--full-auto'];
       if (model) args.push('--model', model);
       return [...args, ...extraFlags];
     },


### PR DESCRIPTION
## Summary

- Remove `--dangerously-bypass-approvals-and-sandbox` from all Codex CLI spawn paths, keeping only `--full-auto`
- Codex CLI >=0.104.0 treats these flags as mutually exclusive — combining them causes immediate process exit
- Update tests to assert the new flag set

Fixes #973

## Changed Files (10)

| File | Change |
|------|--------|
| `bridge/runtime-cli.cjs` | Remove bypass flag from `buildLaunchArgs` |
| `bridge/team-bridge.cjs` | Remove bypass flag from `spawnCliProcess` |
| `src/team/model-contract.ts` | Remove bypass flag from codex config |
| `src/team/mcp-team-bridge.ts` | Remove bypass flag from codex spawn args |
| `dist/team/model-contract.js` | Compiled output |
| `dist/team/mcp-team-bridge.js` | Compiled output |
| `src/team/__tests__/model-contract.test.ts` | Update assertions |
| `src/team/__tests__/mcp-team-bridge.spawn-args.test.ts` | Update regex match |
| `dist/team/__tests__/model-contract.test.js` | Compiled test |
| `dist/team/__tests__/mcp-team-bridge.spawn-args.test.js` | Compiled test |

## Test plan

- [x] Verify `codex exec --help` confirms both flags exist but are mutually exclusive
- [x] Confirm `--full-auto` alone provides workspace-write sandbox + auto-approval (sufficient for tmux workers)
- [ ] Run `omc-teams 1:codex "test task"` with patched code — worker should start successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)