### PR TITLE
fix(team): prevent tmux focus race when creating worker panes (#966)

### DIFF
--- a/src/team/__tests__/tmux-session.create-team.test.ts
+++ b/src/team/__tests__/tmux-session.create-team.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+const mockedCalls = vi.hoisted(() => ({
+  execFileArgs: [] as string[][],
+  splitCount: 0,
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  const runMockExec = (args: string[]): { stdout: string; stderr: string } => {
+    mockedCalls.execFileArgs.push(args);
+
+    if (args[0] === 'display-message' && args.includes('#S:#I #{pane_id}')) {
+      return { stdout: 'fallback:2 %42\n', stderr: '' };
+    }
+
+    if (args[0] === 'display-message' && args.includes('#S:#I')) {
+      return { stdout: 'omx:4\n', stderr: '' };
+    }
+
+    if (args[0] === 'display-message' && args.includes('#{window_width}')) {
+      return { stdout: '160\n', stderr: '' };
+    }
+
+    if (args[0] === 'split-window') {
+      mockedCalls.splitCount += 1;
+      return { stdout: `%50${mockedCalls.splitCount}\n`, stderr: '' };
+    }
+
+    return { stdout: '', stderr: '' };
+  };
+
+  const execFileMock = vi.fn((_cmd: string, args: string[], cb: ExecFileCallback) => {
+    const { stdout, stderr } = runMockExec(args);
+    cb(null, stdout, stderr);
+    return {} as never;
+  });
+
+  const promisifyCustom = Symbol.for('nodejs.util.promisify.custom');
+  (execFileMock as unknown as Record<symbol, unknown>)[promisifyCustom] =
+    async (_cmd: string, args: string[]) => runMockExec(args);
+
+  return {
+    ...actual,
+    execFile: execFileMock,
+  };
+});
+
+import { createTeamSession } from '../tmux-session.js';
+
+describe('createTeamSession context resolution', () => {
+  beforeEach(() => {
+    mockedCalls.execFileArgs = [];
+    mockedCalls.splitCount = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('anchors context to TMUX_PANE to avoid focus races', async () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,1,1');
+    vi.stubEnv('TMUX_PANE', '%732');
+
+    const session = await createTeamSession('race-team', 1, '/tmp');
+
+    const targetedContextCall = mockedCalls.execFileArgs.find(args =>
+      args[0] === 'display-message' &&
+      args[1] === '-p' &&
+      args[2] === '-t' &&
+      args[3] === '%732' &&
+      args[4] === '#S:#I'
+    );
+    expect(targetedContextCall).toBeDefined();
+
+    const fallbackContextCall = mockedCalls.execFileArgs.find(args =>
+      args[0] === 'display-message' &&
+      args.includes('#S:#I #{pane_id}')
+    );
+    expect(fallbackContextCall).toBeUndefined();
+
+    const firstSplitCall = mockedCalls.execFileArgs.find(args => args[0] === 'split-window');
+    expect(firstSplitCall).toEqual(expect.arrayContaining(['split-window', '-h', '-t', '%732']));
+    expect(session.leaderPaneId).toBe('%732');
+    expect(session.sessionName).toBe('omx:4');
+    expect(session.workerPaneIds).toEqual(['%501']);
+  });
+
+  it('falls back to default context discovery when TMUX_PANE is invalid', async () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,1,1');
+    vi.stubEnv('TMUX_PANE', 'not-a-pane-id');
+
+    const session = await createTeamSession('race-team', 0, '/tmp');
+
+    const targetedContextCall = mockedCalls.execFileArgs.find(args =>
+      args[0] === 'display-message' &&
+      args[1] === '-p' &&
+      args[2] === '-t' &&
+      args[4] === '#S:#I'
+    );
+    expect(targetedContextCall).toBeUndefined();
+
+    const fallbackContextCall = mockedCalls.execFileArgs.find(args =>
+      args[0] === 'display-message' &&
+      args[1] === '-p' &&
+      args[2] === '#S:#I #{pane_id}'
+    );
+    expect(fallbackContextCall).toBeDefined();
+
+    expect(session.leaderPaneId).toBe('%42');
+    expect(session.sessionName).toBe('fallback:2');
+    expect(session.workerPaneIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- fix tmux focus race in team pane creation by anchoring context to the invoking `TMUX_PANE`
- resolve `session:window` via `tmux display-message -t <TMUX_PANE> '#S:#I'` when available
- keep fallback path for missing/invalid `TMUX_PANE`
- add regression tests for anchored and fallback context resolution

## Why
When users switch tmux windows during startup, worker panes can spawn in the active window instead of the leader window (issue #966).

## Validation
- `npx vitest run src/team/__tests__/tmux-session.create-team.test.ts src/team/__tests__/tmux-session.spawn.test.ts src/team/__tests__/tmux-session.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/team/tmux-session.ts src/team/__tests__/tmux-session.create-team.test.ts`

Closes #966
