### PR TITLE
fix(team): remove --full-auto from codex worker args

### DIFF
--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -66,7 +66,7 @@ var CONTRACTS = {
     binary: "codex",
     installInstructions: "Install Codex CLI: npm install -g @openai/codex",
     buildLaunchArgs(model, extraFlags = []) {
-      const args = ["--full-auto", "--dangerously-bypass-approvals-and-sandbox"];
+      const args = ["--dangerously-bypass-approvals-and-sandbox"];
       if (model) args.push("--model", model);
       return [...args, ...extraFlags];
     },

--- a/bridge/team-bridge.cjs
+++ b/bridge/team-bridge.cjs
@@ -1252,7 +1252,7 @@ function spawnCliProcess(provider, prompt, model, cwd, timeoutMs) {
   let cmd;
   if (provider === "codex") {
     cmd = "codex";
-    args = ["exec", "-m", model || "gpt-5.3-codex", "--json", "--full-auto", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check"];
+    args = ["exec", "-m", model || "gpt-5.3-codex", "--json", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check"];
   } else {
     cmd = "gemini";
     args = ["--yolo"];

--- a/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
+++ b/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
@@ -6,7 +6,7 @@ describe('mcp-team-bridge spawn args', () => {
   const source = readFileSync(join(__dirname, '..', 'mcp-team-bridge.ts'), 'utf-8');
 
   it('includes bypass approvals/sandbox and --skip-git-repo-check for Codex bridge spawns', () => {
-    expect(source).toMatch(/args = \['exec', '-m', model \|\| 'gpt-5\.3-codex', '--json', '--full-auto', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'\]/);
+    expect(source).toMatch(/args = \['exec', '-m', model \|\| 'gpt-5\.3-codex', '--json', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'\]/);
   });
 
   it('keeps Gemini bridge spawn args unchanged (no skip-git-repo-check)', () => {

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -28,9 +28,9 @@ describe('model-contract', () => {
       const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp' });
       expect(args).toContain('--dangerously-skip-permissions');
     });
-    it('codex includes --full-auto and bypass approvals/sandbox', () => {
+    it('codex includes --dangerously-bypass-approvals-and-sandbox', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp' });
-      expect(args).toContain('--full-auto');
+      expect(args).not.toContain('--full-auto');
       expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
     });
     it('gemini includes --yolo', () => {
@@ -61,7 +61,6 @@ describe('model-contract', () => {
     it('builds binary + args', () => {
       expect(buildWorkerArgv('codex', { teamName: 'my-team', workerName: 'worker-1', cwd: '/tmp' })).toEqual([
         'codex',
-        '--full-auto',
         '--dangerously-bypass-approvals-and-sandbox',
       ]);
     });

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -372,7 +372,7 @@ function spawnCliProcess(
 
   if (provider === 'codex') {
     cmd = 'codex';
-    args = ['exec', '-m', model || 'gpt-5.3-codex', '--json', '--full-auto', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'];
+    args = ['exec', '-m', model || 'gpt-5.3-codex', '--json', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'];
   } else {
     cmd = 'gemini';
     args = ['--yolo'];

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -38,7 +38,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     binary: 'codex',
     installInstructions: 'Install Codex CLI: npm install -g @openai/codex',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
-      const args = ['--full-auto', '--dangerously-bypass-approvals-and-sandbox'];
+      const args = ['--dangerously-bypass-approvals-and-sandbox'];
       if (model) args.push('--model', model);
       return [...args, ...extraFlags];
     },


### PR DESCRIPTION
## Summary
- Remove `--full-auto` flag from codex worker spawning args across all call sites
- `--full-auto` conflicts with `--dangerously-bypass-approvals-and-sandbox` in recent codex CLI versions
- Keep only `--dangerously-bypass-approvals-and-sandbox` which provides the needed permissions

## Test plan
- [x] `model-contract.test.ts` passes (16 tests)
- [x] `mcp-team-bridge.spawn-args.test.ts` passes (2 tests)
- [x] Tests verify `--full-auto` is NOT present in codex args

🤖 Generated with [Claude Code](https://claude.com/claude-code)