### PR TITLE
fix(docs): remove unnecessary whitespace

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -421,7 +421,7 @@ Just include these words anywhere in your prompt to activate enhanced modes:
 | Keyword | Effect |
 |---------|--------|
 | `ultrawork`, `ulw`, `uw` | Activates parallel agent orchestration |
-| ``, `eco`, `efficient`, `save-tokens`, `budget` | Token-efficient parallel execution |
+| `eco`, `efficient`, `save-tokens`, `budget` | Token-efficient parallel execution |
 | `autopilot`, `build me`, `I want a` | Full autonomous execution |
 | `ultrapilot`, `parallel build`, `swarm build` | Parallel autopilot (3-5x faster) |
 | `ralph`, `don't stop`, `must complete` | Persistence until verified complete |


### PR DESCRIPTION
# Summary
- Removed `REFERENCE.md` - `Magic Keywords` introduction contains an unnecessary string