### PR TITLE
fix(cli): fix mouse wheel scroll in tmux wrapper (#890)

### DIFF
--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -119,6 +119,12 @@ export function runClaude(cwd: string, args: string[], sessionId: string): void 
  * Launches Claude in current pane
  */
 function runClaudeInsideTmux(cwd: string, args: string[]): void {
+  // Enable mouse scrolling in the current tmux session (non-fatal if it fails)
+  try {
+    execFileSync('tmux', ['set-option', 'mouse', 'on'], { stdio: 'ignore' });
+    execFileSync('tmux', ['set-option', 'terminal-overrides', '*:smcup@:rmcup@'], { stdio: 'ignore' });
+  } catch { /* non-fatal — user's tmux may not support these options */ }
+
   // Launch Claude in current pane
   try {
     execFileSync('claude', args, { cwd, stdio: 'inherit' });
@@ -144,7 +150,8 @@ function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string): 
   const tmuxArgs = [
     'new-session', '-d', '-s', sessionName, '-c', cwd,
     claudeCmd,
-    ';', 'set-option', '-g', 'mouse', 'on',
+    ';', 'set-option', '-t', sessionName, 'mouse', 'on',
+    ';', 'set-option', '-t', sessionName, 'terminal-overrides', '*:smcup@:rmcup@',
   ];
 
   // Attach to session


### PR DESCRIPTION
## Summary

Fixes #890 — mouse wheel triggers history navigation (Up/Down arrows) instead of scrolling the viewport when running Claude Code through the `omc` wrapper.

**Root cause:** Three compounding issues in `src/cli/launch.ts`:
1. `runClaudeOutsideTmux` used `set-option -g` (global) instead of session-targeted `-t <session>`
2. No `terminal-overrides` to disable alternate-screen detection, causing tmux to pass mouse wheel as xterm escape sequences interpreted as Up/Down
3. `runClaudeInsideTmux` had zero mouse configuration, leaving users already in tmux (e.g. WSL2) unaffected by any fix

**Changes:**
- Use `set-option -t <sessionName>` instead of `-g` in `runClaudeOutsideTmux` (matches pattern in `tmux-session.ts:273`)
- Add `terminal-overrides '*:smcup@:rmcup@'` to disable alternate-screen so tmux uses copy-mode scrollback
- Add mouse + terminal-overrides config to `runClaudeInsideTmux` (non-fatal try/catch)

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 25 tests pass in `src/cli/__tests__/launch.test.ts`
- [x] New test: verifies `-t sessionName` targeting (not `-g` global)
- [x] New test: verifies `terminal-overrides` is set in outside-tmux path
- [x] New test: verifies inside-tmux mouse config runs before claude launch
- [x] New test: verifies claude still launches if tmux mouse config fails
- [ ] Manual: run `omc` outside tmux, verify mouse wheel scrolls viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)