### PR TITLE
fix(hooks): reduce readStdin timeout to prevent Stop hook race condition

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -176,7 +176,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs\" \"${CLAUDE_PLUGIN_ROOT}/scripts/persistent-mode.cjs\"",
-            "timeout": 5
+            "timeout": 10
           },
           {
             "type": "command",

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -18,7 +18,7 @@ const {
 const { join, dirname, resolve, normalize } = require("path");
 const { homedir } = require("os");
 
-async function readStdin(timeoutMs = 5000) {
+async function readStdin(timeoutMs = 2000) {
   return new Promise((resolve) => {
     const chunks = [];
     let settled = false;


### PR DESCRIPTION
## Summary
- Reduced `readStdin()` default timeout from 5000ms to 2000ms in `scripts/persistent-mode.cjs` to leave headroom for state reads and decision logic
- Increased Stop hook external timeout from 5s to 10s in `hooks/hooks.json`

This prevents the race condition where the process gets killed before outputting its decision, causing active sessions to terminate silently.

Closes #982

## Test plan
- [ ] Activate a persistent mode (ralph/ultrawork) under moderate system load
- [ ] Verify sessions no longer terminate unexpectedly with `Error: Exit code 128`
- [ ] Verify Stop hook reliably outputs block/continue decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)