### PR TITLE
docs(ralplan): clarify ITERATE/REJECT re-review loop semantics (#992)

### DIFF
--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -36,7 +36,13 @@ The consensus workflow:
 2. **User feedback** *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the draft plan before review (Proceed to review / Request changes / Skip review). Otherwise, automatically proceed to review.
 3. **Architect** reviews for architectural soundness — **await completion before step 4**
 4. **Critic** evaluates against quality criteria — run only after step 3 completes
-5. If Critic rejects: iterate with feedback (max 5 iterations)
+5. **Re-review loop** (max 5 iterations): Any non-`APPROVE` Critic verdict (`ITERATE` or `REJECT`) MUST run the same full closed loop:
+   a. Collect Architect + Critic feedback
+   b. Revise the plan with Planner
+   c. Return to Architect review
+   d. Return to Critic evaluation
+   e. Repeat this loop until Critic returns `APPROVE` or 5 iterations are reached
+   f. If 5 iterations are reached without `APPROVE`, present the best version to the user
 6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and execute via ralph / Approve and implement via team / Clear context and implement / Request changes / Reject). Otherwise, output the final plan and stop.
 7. *(--interactive only)* User chooses: Approve (ralph or team), Request changes, or Reject
 8. *(--interactive only)* On approval: invoke `Skill("oh-my-claudecode:ralph")` for sequential execution or `Skill("oh-my-claudecode:team")` for parallel team execution -- never implement directly


### PR DESCRIPTION
## Summary
- Clarified Step 5 in `skills/ralplan/SKILL.md` with explicit closed-loop semantics
- Defined that any non-`APPROVE` Critic verdict (`ITERATE` or `REJECT`) follows the same full re-review loop
- Added explicit sub-steps (a–f): collect feedback, revise with Planner, return to Architect, return to Critic, repeat up to 5 iterations, and present best version if max reached
- Kept wording concise and unambiguous

Closes #992