### PR TITLE
feat(ralplan): enforce pre-execution gate for underspecified requests (#997)

### DIFF
--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -77,6 +77,24 @@ The ralplan-first gate intercepts underspecified execution requests and redirect
 - `force: ralph refactor the auth module`
 - `! autopilot optimize everything`
 
+### When the Gate Does NOT Trigger
+
+The gate auto-passes when it detects **any** concrete signal. You do not need all of them — one is enough:
+
+| Signal Type | Example prompt | Why it passes |
+|---|---|---|
+| File path | `ralph fix src/hooks/bridge.ts` | References a specific file |
+| Issue/PR number | `ralph implement #42` | Has a concrete work item |
+| camelCase symbol | `ralph fix processKeywordDetector` | Names a specific function |
+| PascalCase symbol | `ralph update UserModel` | Names a specific class |
+| snake_case symbol | `team fix user_model` | Names a specific identifier |
+| Test runner | `ralph npm test && fix failures` | Has an explicit test target |
+| Numbered steps | `ralph do:\n1. Add X\n2. Test Y` | Structured deliverables |
+| Acceptance criteria | `ralph add login - acceptance criteria: ...` | Explicit success definition |
+| Error reference | `ralph fix TypeError in auth` | Specific error to address |
+| Code block | `ralph add: \`\`\`ts ... \`\`\`` | Concrete code provided |
+| Escape prefix | `force: ralph do it` or `! ralph do it` | Explicit user override |
+
 ### End-to-End Flow Example
 
 1. User types: `ralph add user authentication`


### PR DESCRIPTION
## Summary

- Adds a **ralplan-first gate** that intercepts underspecified execution-mode requests (ralph, autopilot, team, ultrawork, ultrapilot) and redirects them through consensus planning before any code is written
- Adds `isUnderspecifiedForExecution()` with well-specified signal detection (file refs, function names, issue refs, code blocks, structured lists, acceptance criteria)
- Adds `applyRalplanGate()` to replace execution keywords with `ralplan` when the gate fires
- Integrates the gate into the bridge `processKeywordDetector` pipeline
- Adds escape hatches: `force:` and `!` prefixes bypass the gate
- Adds documentation to `skills/ralplan/SKILL.md`: why gate exists, good vs bad prompts, end-to-end flow example, troubleshooting

## Acceptance Criteria Mapping

| Requirement | Status | Evidence |
|---|---|---|
| Underspecified requests cannot enter execution before PRD scope confirmed | Done | `isUnderspecifiedForExecution()` + `applyRalplanGate()` in keyword-detector |
| Gate redirects to ralplan for consensus planning | Done | Bridge injects `[RALPLAN GATE]` message and replaces execution keywords with `ralplan` |
| Escape hatch to bypass gate | Done | `force:` and `!` prefixes |
| Docs: why gate exists | Done | `skills/ralplan/SKILL.md` "Why the Gate Exists" section |
| Docs: good vs bad prompts | Done | `skills/ralplan/SKILL.md` "Good vs Bad Prompts" section |
| Docs: end-to-end flow example | Done | `skills/ralplan/SKILL.md` "End-to-End Flow Example" section |
| Docs: troubleshooting | Done | `skills/ralplan/SKILL.md` "Troubleshooting" table |
| Tests for gate logic | Done | 30 new tests (194 total pass) |
| TypeScript type check passes | Done | `tsc --noEmit` clean |

## Changed Files

- `src/hooks/keyword-detector/index.ts` — gate logic (`isUnderspecifiedForExecution`, `applyRalplanGate`, signal regexes)
- `src/hooks/bridge.ts` — gate integration in `processKeywordDetector`
- `src/hooks/keyword-detector/__tests__/index.test.ts` — 30 new test cases
- `skills/ralplan/SKILL.md` — documentation (gate, prompts, flow, troubleshooting)

## Test plan

- [x] All 194 keyword-detector tests pass (`npx vitest run src/hooks/keyword-detector/__tests__/index.test.ts`)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] Gate fires on underspecified prompts (e.g., `ralph fix this`)
- [x] Gate passes well-specified prompts (e.g., `ralph fix src/hooks/bridge.ts`)
- [x] Escape hatches work (`force:` and `!` prefixes)
- [x] Cancel keyword bypasses gate
- [x] Non-execution keywords (tdd, ultrathink) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)