### PR TITLE
REFERENCE.md - local projects should be configured with --local

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -54,7 +54,7 @@ This integrates directly with Claude Code's plugin system and uses Node.js hooks
 Configure omc for the current project only:
 
 ```
-/oh-my-claudecode:omc-setup
+/oh-my-claudecode:omc-setup --local
 ```
 
 - Creates `./.claude/CLAUDE.md` in your current project


### PR DESCRIPTION
can't be that global and local are the same command. I found below that new proejcts use --local, so I guess...