### PR TITLE
feat(ralplan): add RALPLAN-DR structured deliberation to consensus planning

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -22,6 +22,7 @@ disallowedTools: Write, Edit
     - Recommendations are concrete and implementable (not "consider refactoring")
     - Trade-offs are acknowledged for each recommendation
     - Analysis addresses the actual question, not adjacent concerns
+    - In ralplan consensus reviews, strongest steelman antithesis and at least one real tradeoff tension are explicit
   </Success_Criteria>
 
   <Constraints>
@@ -30,6 +31,7 @@ disallowedTools: Write, Edit
     - Never provide generic advice that could apply to any codebase.
     - Acknowledge uncertainty when present rather than speculating.
     - Hand off to: analyst (requirements gaps), planner (plan creation), critic (plan review), qa-tester (runtime verification).
+    - In ralplan consensus reviews, never rubber-stamp the favored option without a steelman counterargument.
   </Constraints>
 
   <Investigation_Protocol>
@@ -40,6 +42,7 @@ disallowedTools: Write, Edit
     5) Synthesize into: Summary, Diagnosis, Root Cause, Recommendations (prioritized), Trade-offs, References.
     6) For non-obvious bugs, follow the 4-phase protocol: Root Cause Analysis, Pattern Analysis, Hypothesis Testing, Recommendation.
     7) Apply the 3-failure circuit breaker: if 3+ fix attempts fail, question the architecture rather than trying variations.
+    8) For ralplan consensus reviews: include (a) strongest antithesis against favored direction, (b) at least one meaningful tradeoff tension, (c) synthesis if feasible, and (d) in deliberate mode, explicit principle-violation flags.
   </Investigation_Protocol>
 
   <Tool_Usage>
@@ -82,6 +85,12 @@ disallowedTools: Write, Edit
     | A | ... | ... |
     | B | ... | ... |
 
+    ## Consensus Addendum (ralplan reviews only)
+    - **Antithesis (steelman):** [Strongest counterargument against favored direction]
+    - **Tradeoff tension:** [Meaningful tension that cannot be ignored]
+    - **Synthesis (if viable):** [How to preserve strengths from competing options]
+    - **Principle violations (deliberate mode):** [Any principle broken, with severity]
+
     ## References
     - `path/to/file.ts:42` - [what it shows]
     - `path/to/other.ts:108` - [what it shows]
@@ -106,5 +115,7 @@ disallowedTools: Write, Edit
     - Is the root cause identified (not just symptoms)?
     - Are recommendations concrete and implementable?
     - Did I acknowledge trade-offs?
+    - If this was a ralplan review, did I provide antithesis + tradeoff tension (+ synthesis when possible)?
+    - In deliberate mode reviews, did I flag principle violations explicitly?
   </Final_Checklist>
 </Agent_Prompt>

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -22,6 +22,7 @@ disallowedTools: Write, Edit
     - Clear OKAY or REJECT verdict with specific justification
     - If rejecting, top 3-5 critical improvements are listed with concrete suggestions
     - Differentiate between certainty levels: "definitely missing" vs "possibly unclear"
+    - In ralplan reviews, principle-option consistency and verification rigor are explicitly gated
   </Success_Criteria>
 
   <Constraints>
@@ -30,6 +31,8 @@ disallowedTools: Write, Edit
     - When receiving a YAML file, reject it (not a valid plan format).
     - Report "no issues found" explicitly when the plan passes all criteria. Do not invent problems.
     - Hand off to: planner (plan needs revision), analyst (requirements unclear), architect (code analysis needed).
+    - In ralplan mode, explicitly REJECT shallow alternatives, driver contradictions, vague risks, or weak verification.
+    - In deliberate ralplan mode, explicitly REJECT missing/weak pre-mortem or missing/weak expanded test plan (unit/integration/e2e/observability).
   </Constraints>
 
   <Investigation_Protocol>
@@ -37,7 +40,9 @@ disallowedTools: Write, Edit
     2) Extract ALL file references and read each one to verify content matches plan claims.
     3) Apply four criteria: Clarity (can executor proceed without guessing?), Verification (does each task have testable acceptance criteria?), Completeness (is 90%+ of needed context provided?), Big Picture (does executor understand WHY and HOW tasks connect?).
     4) Simulate implementation of 2-3 representative tasks using actual files. Ask: "Does the worker have ALL context needed to execute this?"
-    5) Issue verdict: OKAY (actionable) or REJECT (gaps found, with specific improvements).
+    5) For ralplan reviews, apply gate checks: principle-option consistency, fairness of alternative exploration, risk mitigation clarity, testable acceptance criteria, and concrete verification steps.
+    6) If deliberate mode is active, verify pre-mortem (3 scenarios) quality and expanded test plan coverage (unit/integration/e2e/observability).
+    7) Issue verdict: OKAY (actionable) or REJECT (gaps found, with specific improvements).
   </Investigation_Protocol>
 
   <Tool_Usage>
@@ -62,6 +67,10 @@ disallowedTools: Write, Edit
     - Verifiability: [Brief assessment]
     - Completeness: [Brief assessment]
     - Big Picture: [Brief assessment]
+    - Principle/Option Consistency (ralplan): [Pass/Fail + reason]
+    - Alternatives Depth (ralplan): [Pass/Fail + reason]
+    - Risk/Verification Rigor (ralplan): [Pass/Fail + reason]
+    - Deliberate Additions (if required): [Pass/Fail + reason]
 
     [If REJECT: Top 3-5 critical improvements with specific suggestions]
   </Output_Format>
@@ -72,6 +81,8 @@ disallowedTools: Write, Edit
     - Vague rejections: "The plan needs more detail." Instead: "Task 3 references `auth.ts` but doesn't specify which function to modify. Add: modify `validateToken()` at line 42."
     - Skipping simulation: Approving without mentally walking through implementation steps. Always simulate 2-3 tasks.
     - Confusing certainty levels: Treating a minor ambiguity the same as a critical missing requirement. Differentiate severity.
+    - Letting weak deliberation pass: Never approve plans with shallow alternatives, driver contradictions, vague risks, or weak verification.
+    - Ignoring deliberate-mode requirements: Never approve deliberate ralplan output without a credible pre-mortem and expanded test plan.
   </Failure_Modes_To_Avoid>
 
   <Examples>
@@ -85,5 +96,7 @@ disallowedTools: Write, Edit
     - Is my verdict clearly OKAY or REJECT (not ambiguous)?
     - If rejecting, are my improvement suggestions specific and actionable?
     - Did I differentiate certainty levels for my findings?
+    - For ralplan reviews, did I verify principle-option consistency and alternative quality?
+    - For deliberate mode, did I enforce pre-mortem + expanded test plan quality?
   </Final_Checklist>
 </Agent_Prompt>

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -23,6 +23,7 @@ model: claude-opus-4-6
     - User was only asked about preferences/priorities (not codebase facts)
     - Plan is saved to `.omc/plans/{name}.md`
     - User explicitly confirmed the plan before any handoff
+    - In consensus mode, RALPLAN-DR structure is complete and ready for Architect/Critic review
   </Success_Criteria>
 
   <Constraints>
@@ -34,6 +35,10 @@ model: claude-opus-4-6
     - Default to 3-6 step plans. Avoid architecture redesign unless the task requires it.
     - Stop planning when the plan is actionable. Do not over-specify.
     - Consult analyst before generating the final plan to catch missing requirements.
+    - In consensus mode, include RALPLAN-DR summary before Architect review: Principles (3-5), Decision Drivers (top 3), >=2 viable options with bounded pros/cons.
+    - If only one viable option remains, explicitly document why alternatives were invalidated.
+    - In deliberate consensus mode (`--deliberate` or explicit high-risk signal), include pre-mortem (3 scenarios) and expanded test plan (unit/integration/e2e/observability).
+    - Final consensus plans must include ADR: Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups.
   </Constraints>
 
   <Investigation_Protocol>
@@ -45,6 +50,15 @@ model: claude-opus-4-6
     6) Display confirmation summary and wait for explicit user approval.
     7) On approval, hand off to `/oh-my-claudecode:start-work {plan-name}`.
   </Investigation_Protocol>
+
+  <Consensus_RALPLAN_DR_Protocol>
+    When running inside `/plan --consensus` (ralplan):
+    1) Emit a compact summary for step-2 AskUserQuestion alignment: Principles (3-5), Decision Drivers (top 3), and viable options with bounded pros/cons.
+    2) Ensure at least 2 viable options. If only 1 survives, add explicit invalidation rationale for alternatives.
+    3) Mark mode as SHORT (default) or DELIBERATE (`--deliberate`/high-risk).
+    4) DELIBERATE mode must add: pre-mortem (3 failure scenarios) and expanded test plan (unit/integration/e2e/observability).
+    5) Final revised plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups).
+  </Consensus_RALPLAN_DR_Protocol>
 
   <Tool_Usage>
     - Use AskUserQuestion for all preference/priority questions (provides clickable options).
@@ -71,6 +85,10 @@ model: claude-opus-4-6
     **Key Deliverables:**
     1. [Deliverable 1]
     2. [Deliverable 2]
+
+    **Consensus mode (if applicable):**
+    - RALPLAN-DR: Principles (3-5), Drivers (top 3), Options (>=2 or explicit invalidation rationale)
+    - ADR: Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups
 
     **Does this plan capture your intent?**
     - "proceed" - Begin implementation via /oh-my-claudecode:start-work
@@ -113,5 +131,8 @@ model: claude-opus-4-6
     - Did I wait for user confirmation before handoff?
     - Is the plan saved to `.omc/plans/`?
     - Are open questions written to `.omc/plans/open-questions.md`?
+    - In consensus mode, did I provide principles/drivers/options summary for step-2 alignment?
+    - In consensus mode, does the final plan include ADR fields?
+    - In deliberate consensus mode, are pre-mortem + expanded test plan present?
   </Final_Checklist>
 </Agent_Prompt>

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-01-31 | Updated: 2026-01-31 -->
+<!-- Generated: 2026-01-31 | Updated: 2026-02-24 -->
 
 # docs
 
@@ -97,4 +97,6 @@ Use consistent version heading format with blank line after heading:
 
 None - pure markdown files.
 
-<!-- MANUAL: -->
+<!-- MANUAL:
+- When documenting `plan`/`ralplan`, include consensus structured deliberation (RALPLAN-DR) and note `--deliberate` high-risk mode behavior.
+-->

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -138,8 +138,8 @@ Workflow Skills:
 - `ccg` ("ccg", "tri-model", "claude codex gemini"): Fan out backend/analytical tasks to Codex + frontend/UI tasks to Gemini in parallel tmux panes, then Claude synthesizes; requires codex and gemini CLIs. Priority: matches when all three model names appear together, overriding bare "codex"/"gemini" routing to omc-teams
 - `pipeline` ("pipeline", "chain agents"): sequential agent chaining with data passing
 - `ultraqa` (activated by autopilot): QA cycling -- test, verify, fix, repeat
-- `plan` ("plan this", "plan the"): strategic planning; supports `--consensus` and `--review` modes
-- `ralplan` ("ralplan", "consensus plan"): alias for `/plan --consensus` -- iterative planning with Planner, Architect, Critic until consensus
+- `plan` ("plan this", "plan the"): strategic planning; supports `--consensus` and `--review` modes, with RALPLAN-DR structured deliberation in consensus mode
+- `ralplan` ("ralplan", "consensus plan"): alias for `/plan --consensus` -- iterative planning with Planner, Architect, Critic until consensus; short deliberation by default, `--deliberate` for high-risk work (adds pre-mortem + expanded unit/integration/e2e/observability test planning)
 - `sciomc` ("sciomc"): parallel scientist agents for comprehensive analysis
 - `external-context`: invoke parallel document-specialist agents for web searches
 - `deepinit` ("deepinit"): deep codebase init with hierarchical AGENTS.md

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -236,8 +236,8 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 | `ralph` | Self-referential development until completion | `/oh-my-claudecode:ralph` |
 | `ralph-init` | Initialize PRD for structured task tracking | `/oh-my-claudecode:ralph-init` |
 | `ultraqa` | Autonomous QA cycling workflow | `/oh-my-claudecode:ultraqa` |
-| `plan` | Start planning session | `/oh-my-claudecode:plan` |
-| `ralplan` | Iterative planning (Planner+Architect+Critic) | `/oh-my-claudecode:ralplan` |
+| `plan` | Start planning session (consensus mode uses RALPLAN-DR structured deliberation) | `/oh-my-claudecode:plan` |
+| `ralplan` | Iterative planning (Planner+Architect+Critic) with structured deliberation; short mode default, `--deliberate` for high-risk pre-mortem + expanded test plan | `/oh-my-claudecode:ralplan` |
 | `review` | Review work plans with critic | `/oh-my-claudecode:review` |
 
 ### Enhancement Skills
@@ -291,8 +291,8 @@ All skills are available as slash commands with the prefix `/oh-my-claudecode:`.
 | `/oh-my-claudecode:ralph-init <task>` | Initialize PRD for structured task tracking |
 | `/oh-my-claudecode:ralph <task>` | Self-referential loop until task completion |
 | `/oh-my-claudecode:ultraqa <goal>` | Autonomous QA cycling workflow |
-| `/oh-my-claudecode:plan <description>` | Start planning session |
-| `/oh-my-claudecode:ralplan <description>` | Iterative planning with consensus |
+| `/oh-my-claudecode:plan <description>` | Start planning session (supports consensus structured deliberation) |
+| `/oh-my-claudecode:ralplan <description>` | Iterative planning with consensus structured deliberation (`--deliberate` for high-risk mode) |
 | `/oh-my-claudecode:review [plan-path]` | Review a plan with critic |
 | `/oh-my-claudecode:deepsearch <query>` | Thorough multi-strategy codebase search |
 | `/oh-my-claudecode:deepinit [path]` | Index codebase with hierarchical AGENTS.md files |
@@ -426,7 +426,7 @@ Just include these words anywhere in your prompt to activate enhanced modes:
 | `ultrapilot`, `parallel build`, `swarm build` | Parallel autopilot (3-5x faster) |
 | `ralph`, `don't stop`, `must complete` | Persistence until verified complete |
 | `plan this`, `plan the` | Planning interview workflow |
-| `ralplan` | Iterative planning consensus |
+| `ralplan` | Iterative planning consensus with structured deliberation (`--deliberate` for high-risk mode) |
 | `search`, `find`, `locate` | Enhanced search mode |
 | `analyze`, `investigate`, `debug` | Deep analysis mode |
 | `sciomc` | Parallel research orchestration |

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -31,7 +31,7 @@ Skills are reusable workflow templates that can be invoked via `/oh-my-claudecod
 | File | Skill | Purpose |
 |-----------|-------|---------|
 | `plan/SKILL.md` | plan | Strategic planning with interview workflow |
-| `ralplan/SKILL.md` | ralplan | Iterative planning (Planner+Architect+Critic) |
+| `ralplan/SKILL.md` | ralplan | Iterative planning (Planner+Architect+Critic) with RALPLAN-DR structured deliberation (`--deliberate` for high-risk) |
 | `review/SKILL.md` | review | Review plan with Critic |
 | `analyze/SKILL.md` | analyze | Deep analysis and investigation |
 | `ralph-init/SKILL.md` | ralph-init | Initialize PRD for structured ralph |

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -5,7 +5,7 @@ description: Alias for /plan --consensus
 
 # Ralplan (Consensus Planning Alias)
 
-Ralplan is a shorthand alias for `/oh-my-claudecode:plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached.
+Ralplan is a shorthand alias for `/oh-my-claudecode:plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work).
 
 ## Usage
 
@@ -16,6 +16,7 @@ Ralplan is a shorthand alias for `/oh-my-claudecode:plan --consensus`. It trigge
 ## Flags
 
 - `--interactive`: Enables user prompts at key decision points (draft review in step 2 and final approval in step 6). Without this flag the workflow runs fully automated — Planner → Architect → Critic loop — and outputs the final plan without asking for confirmation.
+- `--deliberate`: Forces deliberate mode for high-risk work. Adds pre-mortem (3 scenarios) and expanded test planning (unit/integration/e2e/observability). Without this flag, deliberate mode can still auto-enable when the request explicitly signals high risk (auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage).
 
 ## Usage with interactive mode
 
@@ -32,10 +33,15 @@ This skill invokes the Plan skill in consensus mode:
 ```
 
 The consensus workflow:
-1. **Planner** creates initial plan
-2. **User feedback** *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the draft plan before review (Proceed to review / Request changes / Skip review). Otherwise, automatically proceed to review.
-3. **Architect** reviews for architectural soundness — **await completion before step 4**
-4. **Critic** evaluates against quality criteria — run only after step 3 completes
+1. **Planner** creates initial plan and a compact **RALPLAN-DR summary** before review:
+   - Principles (3-5)
+   - Decision Drivers (top 3)
+   - Viable Options (>=2) with bounded pros/cons
+   - If only one viable option remains, explicit invalidation rationale for alternatives
+   - Deliberate mode only: pre-mortem (3 scenarios) + expanded test plan (unit/integration/e2e/observability)
+2. **User feedback** *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the draft plan **plus the Principles / Drivers / Options summary** before review (Proceed to review / Request changes / Skip review). Otherwise, automatically proceed to review.
+3. **Architect** reviews for architectural soundness and must provide the strongest steelman antithesis, at least one real tradeoff tension, and (when possible) synthesis — **await completion before step 4**. In deliberate mode, Architect should explicitly flag principle violations.
+4. **Critic** evaluates against quality criteria — run only after step 3 completes. Critic must enforce principle-option consistency, fair alternatives, risk mitigation clarity, testable acceptance criteria, and concrete verification steps. In deliberate mode, Critic must reject missing/weak pre-mortem or expanded test plan.
 5. **Re-review loop** (max 5 iterations): Any non-`APPROVE` Critic verdict (`ITERATE` or `REJECT`) MUST run the same full closed loop:
    a. Collect Architect + Critic feedback
    b. Revise the plan with Planner
@@ -43,7 +49,7 @@ The consensus workflow:
    d. Return to Critic evaluation
    e. Repeat this loop until Critic returns `APPROVE` or 5 iterations are reached
    f. If 5 iterations are reached without `APPROVE`, present the best version to the user
-6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and execute via ralph / Approve and implement via team / Clear context and implement / Request changes / Reject). Otherwise, output the final plan and stop.
+6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and execute via ralph / Approve and implement via team / Clear context and implement / Request changes / Reject). Final plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups). Otherwise, output the final plan and stop.
 7. *(--interactive only)* User chooses: Approve (ralph or team), Request changes, or Reject
 8. *(--interactive only)* On approval: invoke `Skill("oh-my-claudecode:ralph")` for sequential execution or `Skill("oh-my-claudecode:team")` for parallel team execution -- never implement directly
 

--- a/src/__tests__/consensus-execution-handoff.test.ts
+++ b/src/__tests__/consensus-execution-handoff.test.ts
@@ -1,12 +1,14 @@
 /**
  * Issue #595: Consensus mode execution handoff regression tests
  * Issue #600: User feedback step between Planner and Architect/Critic
+ * Issue #999: Structured deliberation protocol (RALPLAN-DR)
  *
  * Verifies that the plan skill's consensus mode (ralplan) mandates:
  * 1. Structured AskUserQuestion for approval (not plain text)
  * 2. Explicit Skill("oh-my-claudecode:ralph") invocation on approval
  * 3. Prohibition of direct implementation from the planning agent
  * 4. User feedback step after Planner but before Architect/Critic (#600)
+ * 5. RALPLAN-DR short mode and deliberate mode requirements (#999)
  *
  * Also verifies that non-consensus modes (interview, direct, review) are unaffected.
  */
@@ -116,6 +118,47 @@ describe('Issue #595: Consensus mode execution handoff', () => {
       // Old vague language should be gone
       expect(escalation).not.toContain('transition to execution mode (ralph or executor)');
     });
+
+    it('should require RALPLAN-DR structured deliberation in consensus mode', () => {
+      const skill = getBuiltinSkill('omc-plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toContain('RALPLAN-DR');
+      expect(consensusSection).toContain('**Principles** (3-5)');
+      expect(consensusSection).toContain('**Decision Drivers** (top 3)');
+      expect(consensusSection).toContain('**Viable Options** (>=2)');
+      expect(consensusSection).toContain('**invalidation rationale**');
+    });
+
+    it('should require ADR fields in final consensus output', () => {
+      const skill = getBuiltinSkill('omc-plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toContain('ADR');
+      expect(consensusSection).toContain('**Decision**');
+      expect(consensusSection).toContain('**Drivers**');
+      expect(consensusSection).toContain('**Alternatives considered**');
+      expect(consensusSection).toContain('**Why chosen**');
+      expect(consensusSection).toContain('**Consequences**');
+      expect(consensusSection).toContain('**Follow-ups**');
+    });
+
+    it('should mention deliberate mode requirements in consensus mode', () => {
+      const skill = getBuiltinSkill('omc-plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toContain('**Deliberate**');
+      expect(consensusSection).toContain('`--deliberate`');
+      expect(consensusSection).toContain('pre-mortem');
+      expect(consensusSection).toContain('expanded test plan');
+      expect(consensusSection).toContain('unit / integration / e2e / observability');
+    });
   });
 
   describe('Issue #600: User feedback step between Planner and Architect/Critic', () => {
@@ -176,6 +219,19 @@ describe('Issue #595: Consensus mode execution handoff', () => {
       expect(architectIdx).toBeGreaterThan(-1);
       expect(criticIdx).toBeGreaterThan(-1);
       expect(criticIdx).toBeGreaterThan(architectIdx);
+    });
+
+    it('should require architect antithesis and critic rejection gates in consensus flow', () => {
+      const skill = getBuiltinSkill('omc-plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toContain('steelman counterargument (antithesis)');
+      expect(consensusSection).toContain('tradeoff tension');
+      expect(consensusSection).toContain('Critic **MUST** explicitly reject shallow alternatives');
+      expect(consensusSection).toContain('driver contradictions');
+      expect(consensusSection).toContain('weak verification');
     });
 
   });

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-01-28 | Updated: 2026-02-22 -->
+<!-- Generated: 2026-01-28 | Updated: 2026-02-24 -->
 
 # agents
 
@@ -244,4 +244,7 @@ None - pure TypeScript definitions.
 | Review | code-reviewer | Code quality |
 | Data | scientist, scientist-high | Data analysis |
 
-<!-- MANUAL: Legacy alias wording was removed from active prompts to keep agent naming consistent with current conventions. -->
+<!-- MANUAL:
+- Legacy alias wording was removed from active prompts to keep agent naming consistent with current conventions.
+- Consensus planning prompts (planner/architect/critic) now enforce RALPLAN-DR structured deliberation, including `--deliberate` high-risk checks.
+-->


### PR DESCRIPTION
## Summary

Implements the Issue #999 proposal to strengthen `ralplan` / `plan --consensus` quality via structured deliberation (RALPLAN-DR), while preserving current execution handoff safety.

### What changed

- Added **RALPLAN-DR** protocol to consensus planning:
  - **Short mode (default)** with bounded structure:
    - Principles (3–5)
    - Decision Drivers (top 3)
    - Viable Options (>=2) with bounded pros/cons
    - Explicit invalidation rationale when only 1 option remains
  - **Deliberate mode** (`--deliberate` or high-risk signals):
    - Pre-mortem (3 scenarios)
    - Expanded test plan (unit / integration / e2e / observability)

- Updated planner/architect/critic roles:
  - **Planner**: must produce principles/drivers/options summary + ADR output
  - **Architect**: must provide steelman antithesis, tradeoff tension, optional synthesis
  - **Critic**: enforces gates for principle-option alignment, alternatives depth, risks, and verification rigor; deliberate mode rejects weak/missing pre-mortem or expanded test plan

- Preserved FM3 safety behavior:
  - Final approval via `AskUserQuestion`
  - Execution handoff via `Skill("oh-my-claudecode:ralph")` or team
  - No direct implementation in planning flow

- Added/updated regression tests and docs accordingly.

## Files updated

- `skills/plan/SKILL.md`
- `skills/ralplan/SKILL.md`
- `agents/planner.md`
- `agents/architect.md`
- `agents/critic.md`
- `src/__tests__/consensus-execution-handoff.test.ts`
- `docs/CLAUDE.md`
- `docs/REFERENCE.md`
- `skills/AGENTS.md`
- `docs/AGENTS.md`
- `src/agents/AGENTS.md`

## Validation

- `npm test -- src/__tests__/consensus-execution-handoff.test.ts src/__tests__/tier0-docs-consistency.test.ts` ✅ (22/22)
- `npm run build` ✅

## Reference

- Proposal/comment: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/999#issuecomment-3955365340
