### PR TITLE
feat(i18n): inject prompt translation dynamically via keyword-detector hook

### DIFF
--- a/src/agents/preamble.ts
+++ b/src/agents/preamble.ts
@@ -13,6 +13,7 @@ RULES:
 - Do NOT spawn sub-agents
 - Do NOT call TaskCreate or TaskUpdate
 - Report your results with absolute file paths
+- Task prompts are in English for consistent routing
 
 TASK:
 `;
@@ -47,6 +48,7 @@ RULES:
 - Do NOT edit files outside your task's described scope without lead approval
 - Do NOT change task owner fields (lead manages assignment)
 - Always use absolute file paths in your work
+- Task prompts and inter-agent messages are in English for consistent routing
 - Use SendMessage to communicate with team lead if blocked
 
 FAILURE PROTOCOL:
@@ -103,6 +105,7 @@ INSTRUCTIONS:
 - Run relevant verification commands (build, test, lint) to confirm your changes work
 - Write a clear summary of what you did to the output file
 - If you encounter blocking issues, document them clearly in your output
+- Task prompts and outputs are in English for consistent routing
 
 OUTPUT EXPECTATIONS:
 - Document all files you modified

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -19,7 +19,7 @@ import { join } from "path";
 import { resolveToWorktreeRoot } from "../lib/worktree-paths.js";
 
 // Hot-path imports: needed on every/most hook invocations (keyword-detector, pre/post-tool-use)
-import { removeCodeBlocks, getAllKeywordsWithSizeCheck, applyRalplanGate } from "./keyword-detector/index.js";
+import { removeCodeBlocks, getAllKeywordsWithSizeCheck, applyRalplanGate, sanitizeForKeywordDetection, NON_LATIN_SCRIPT_PATTERN } from "./keyword-detector/index.js";
 import { processOrchestratorPreTool, processOrchestratorPostTool } from "./omc-orchestrator/index.js";
 import { normalizeHookInput } from "./bridge-normalize.js";
 import {
@@ -34,6 +34,7 @@ import {
   SEARCH_MESSAGE,
   ANALYZE_MESSAGE,
   RALPH_MESSAGE,
+  PROMPT_TRANSLATION_MESSAGE,
 } from "../installer/hooks.js";
 // Agent dashboard is used in pre/post-tool-use hot path
 import {
@@ -358,6 +359,11 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
         `Use explicit mode keywords (e.g. \`ralph\`) only when you need full orchestration.`
       );
     }
+  }
+
+  const sanitizedText = sanitizeForKeywordDetection(cleanedText);
+  if (NON_LATIN_SCRIPT_PATTERN.test(sanitizedText)) {
+    messages.push(PROMPT_TRANSLATION_MESSAGE);
   }
 
   if (keywords.length === 0) {

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -86,6 +86,16 @@ export function removeCodeBlocks(text: string): string {
   return result;
 }
 
+
+/**
+ * Regex matching non-Latin script characters for prompt translation detection.
+ * Uses Unicode script ranges (not raw non-ASCII) to avoid false positives on emoji and accented Latin.
+ * Covers: CJK (Japanese/Chinese), Korean, Cyrillic, Arabic, Devanagari, Thai, Myanmar.
+ */
+export const NON_LATIN_SCRIPT_PATTERN =
+  // eslint-disable-next-line no-misleading-character-class -- Intentional: detecting script presence, not matching grapheme clusters
+  /[\u3000-\u9FFF\uAC00-\uD7AF\u0400-\u04FF\u0600-\u06FF\u0900-\u097F\u0E00-\u0E7F\u1000-\u109F]/u;
+
 /**
 * Sanitize text for keyword detection by removing structural noise.
  * Strips XML tags, URLs, file paths, and code blocks.

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -285,6 +285,15 @@ Ralph mode auto-activates Ultrawork for maximum parallel execution. Follow these
 Continue working until the task is truly done.
 `;
 
+/**
+ * Prompt translation message - injected when non-English input detected
+ * Reminds users to write prompts in English for consistent agent routing
+ */
+export const PROMPT_TRANSLATION_MESSAGE = `[PROMPT TRANSLATION] Non-English input detected.
+When delegating via Task(), write prompt arguments in English for consistent agent routing.
+Respond to the user in their original language.
+`;
+
 // =============================================================================
 // NODE.JS HOOK SCRIPTS (Cross-platform: Windows, macOS, Linux)
 // =============================================================================


### PR DESCRIPTION
## Summary

When users write prompts in non-Latin scripts (Japanese, Chinese, Korean, Cyrillic, Arabic, etc.), agent delegation via `Task()` can fail because prompts aren't consistently routed in English. This PR dynamically injects a translation reminder through OMC's existing hook injection pattern — the same mechanism used for `RALPH_MESSAGE`, `ULTRAWORK_MESSAGE`, etc.

## Problem

- Users typing in non-English languages pass those prompts directly to `Task()` calls
- Agent routing and keyword detection assume English input
- A static `<agent_protocol_language>` section in `CLAUDE.md` was previously attempted but doesn't fit OMC's dynamic architecture

## Solution

Detect non-Latin script characters in user input at the `processKeywordDetector()` hook and inject `PROMPT_TRANSLATION_MESSAGE` — a lightweight reminder to write `Task()` prompts in English while responding to the user in their original language.

## Design Decisions

- **Unicode script ranges** (`\u3000-\u9FFF`, `\uAC00-\uD7AF`, etc.) instead of raw `[^\x00-\x7F]` — avoids false positives on emoji (👍) and accented Latin (café, résumé)
- **Sanitized text** — runs `sanitizeForKeywordDetection()` before detection so non-Latin characters inside XML tags, URLs, file paths, and code blocks don't trigger
- **Placement before early return** — the check runs before `if (keywords.length === 0)` so it works even when no magic keywords are detected
- **Shared constant** — `NON_LATIN_SCRIPT_PATTERN` exported from `keyword-detector/index.ts` so source and tests reference the same value
- **Agent preambles updated** — added English routing instructions to solo, team, and pipeline agent preambles

## Changes

| File | Change |
|------|--------|
| `src/hooks/bridge.ts` | Non-Latin script detection + `PROMPT_TRANSLATION_MESSAGE` injection |
| `src/hooks/keyword-detector/index.ts` | Exported `NON_LATIN_SCRIPT_PATTERN` constant |
| `src/installer/hooks.ts` | Added `PROMPT_TRANSLATION_MESSAGE` constant |
| `src/agents/preamble.ts` | English routing instructions in agent preambles |
| `src/hooks/keyword-detector/__tests__/index.test.ts` | 17 new test cases (regex + sanitization) |

## Test Coverage (229 tests pass)

- 8 positive cases: Japanese hiragana/katakana, Chinese, Korean, Cyrillic, Arabic, Devanagari, mixed
- 5 negative cases: pure ASCII, emoji, accented Latin (French/Spanish), empty string
- 4 sanitization cases: code blocks stripped, URLs stripped, plain text preserved, mixed preserved