### PR TITLE
fix(launch): remove terminal-overrides smcup@/rmcup@ causing Ink rendering corruption

### DIFF
--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -119,10 +119,17 @@ export function runClaude(cwd: string, args: string[], sessionId: string): void 
  * Launches Claude in current pane
  */
 function runClaudeInsideTmux(cwd: string, args: string[]): void {
-  // Enable mouse scrolling in the current tmux session (non-fatal if it fails)
+  // Enable mouse support in the current tmux session (non-fatal if it fails)
   try {
     execFileSync('tmux', ['set-option', 'mouse', 'on'], { stdio: 'ignore' });
-    execFileSync('tmux', ['set-option', 'terminal-overrides', '*:smcup@:rmcup@'], { stdio: 'ignore' });
+    // Unbind disruptive mouse actions from root table
+    execFileSync('tmux', ['unbind-key', '-T', 'root', 'MouseDrag1Pane'], { stdio: 'ignore' });
+    execFileSync('tmux', ['unbind-key', '-T', 'root', 'DoubleClick1Pane'], { stdio: 'ignore' });
+    execFileSync('tmux', ['unbind-key', '-T', 'root', 'TripleClick1Pane'], { stdio: 'ignore' });
+    // Bind pane selection and stop-selection for copy modes
+    execFileSync('tmux', ['bind-key', '-T', 'root', 'MouseDown1Pane', 'select-pane', '-t='], { stdio: 'ignore' });
+    execFileSync('tmux', ['bind-key', '-T', 'copy-mode', 'MouseDragEnd1Pane', 'send-keys', '-X', 'stop-selection'], { stdio: 'ignore' });
+    execFileSync('tmux', ['bind-key', '-T', 'copy-mode-vi', 'MouseDragEnd1Pane', 'send-keys', '-X', 'stop-selection'], { stdio: 'ignore' });
   } catch { /* non-fatal — user's tmux may not support these options */ }
 
   // Launch Claude in current pane
@@ -156,7 +163,14 @@ function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string): 
     'new-session', '-d', '-s', sessionName, '-c', cwd,
     claudeCmd,
     ';', 'set-option', '-t', sessionName, 'mouse', 'on',
-    ';', 'set-option', '-t', sessionName, 'terminal-overrides', '*:smcup@:rmcup@',
+    // Unbind disruptive mouse actions from root table
+    ';', 'unbind-key', '-T', 'root', 'MouseDrag1Pane',
+    ';', 'unbind-key', '-T', 'root', 'DoubleClick1Pane',
+    ';', 'unbind-key', '-T', 'root', 'TripleClick1Pane',
+    // Bind pane selection and stop-selection for copy modes
+    ';', 'bind-key', '-T', 'root', 'MouseDown1Pane', 'select-pane', '-t=',
+    ';', 'bind-key', '-T', 'copy-mode', 'MouseDragEnd1Pane', 'send-keys', '-X', 'stop-selection',
+    ';', 'bind-key', '-T', 'copy-mode-vi', 'MouseDragEnd1Pane', 'send-keys', '-X', 'stop-selection',
   ];
 
   // Attach to session


### PR DESCRIPTION
## Summary
- Removed `terminal-overrides *:smcup@:rmcup@` from both `runClaudeInsideTmux` and `runClaudeOutsideTmux` in `src/cli/launch.ts` — this setting disabled the alternate screen buffer, causing progressive rendering corruption with Ink TUI
- Added targeted mouse bindings: unbind `MouseDrag1Pane`, `DoubleClick1Pane`, `TripleClick1Pane` from root table; bind `MouseDown1Pane` to `select-pane -t=`; bind `MouseDragEnd1Pane` in `copy-mode` and `copy-mode-vi` to `stop-selection`
- Updated tests to verify the removal and new bindings

## Test plan
- [x] All 4837 tests pass (220 files)
- [x] Build succeeds
- [x] Verified `terminal-overrides` no longer present in launch paths
- [x] Verified mouse bindings are correctly set in both inside-tmux and outside-tmux paths

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)