### PR TITLE
feat(notifications): hook config, template engine, and platform gating

### DIFF
--- a/src/notifications/__tests__/hook-config.test.ts
+++ b/src/notifications/__tests__/hook-config.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for hook notification config reader (omc_config.hook.json).
+ *
+ * Covers:
+ * - File missing → null
+ * - File disabled → null
+ * - Valid config parsing and caching
+ * - Cache reset
+ * - Template cascade resolution
+ * - Merge into NotificationConfig (event enabled/disabled overrides)
+ * - OMC_HOOK_CONFIG env var override
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  getHookConfig,
+  resetHookConfigCache,
+  resolveEventTemplate,
+  mergeHookConfigIntoNotificationConfig,
+} from "../hook-config.js";
+import type { HookNotificationConfig } from "../hook-config-types.js";
+import type { NotificationConfig } from "../types.js";
+
+const TEST_DIR = join(tmpdir(), `omc-hook-config-test-${process.pid}`);
+const TEST_CONFIG_PATH = join(TEST_DIR, "omc_config.hook.json");
+
+function writeTestConfig(config: object): void {
+  mkdirSync(TEST_DIR, { recursive: true });
+  writeFileSync(TEST_CONFIG_PATH, JSON.stringify(config, null, 2));
+}
+
+describe("hook-config reader", () => {
+  beforeEach(() => {
+    resetHookConfigCache();
+    vi.stubEnv("OMC_HOOK_CONFIG", TEST_CONFIG_PATH);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetHookConfigCache();
+    try {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  });
+
+  // -----------------------------------------------------------------------
+  // getHookConfig
+  // -----------------------------------------------------------------------
+
+  it("returns null when file does not exist", () => {
+    vi.stubEnv("OMC_HOOK_CONFIG", join(TEST_DIR, "nonexistent.json"));
+    expect(getHookConfig()).toBeNull();
+  });
+
+  it("returns null when enabled is false", () => {
+    writeTestConfig({ version: 1, enabled: false });
+    expect(getHookConfig()).toBeNull();
+  });
+
+  it("parses valid config correctly", () => {
+    writeTestConfig({
+      version: 1,
+      enabled: true,
+      events: {
+        "session-end": {
+          enabled: true,
+          template: "Session ended: {{duration}}",
+        },
+      },
+    });
+    const config = getHookConfig();
+    expect(config).not.toBeNull();
+    expect(config!.version).toBe(1);
+    expect(config!.enabled).toBe(true);
+    expect(config!.events?.["session-end"]?.template).toBe(
+      "Session ended: {{duration}}",
+    );
+  });
+
+  it("caches after first read", () => {
+    writeTestConfig({ version: 1, enabled: true });
+    const first = getHookConfig();
+    const second = getHookConfig();
+    expect(first).toBe(second); // same reference
+  });
+
+  it("resetHookConfigCache clears the cache", () => {
+    writeTestConfig({ version: 1, enabled: true });
+    const first = getHookConfig();
+    resetHookConfigCache();
+    // Rewrite with different content
+    writeTestConfig({
+      version: 1,
+      enabled: true,
+      defaultTemplate: "changed",
+    });
+    const second = getHookConfig();
+    expect(second).not.toBe(first);
+    expect(second!.defaultTemplate).toBe("changed");
+  });
+
+  it("returns null for invalid JSON", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(TEST_CONFIG_PATH, "not json{{{");
+    expect(getHookConfig()).toBeNull();
+  });
+
+  it("OMC_HOOK_CONFIG env var overrides default path", () => {
+    const altDir = join(TEST_DIR, "alt");
+    const altPath = join(altDir, "custom-hook.json");
+    mkdirSync(altDir, { recursive: true });
+    writeFileSync(
+      altPath,
+      JSON.stringify({ version: 1, enabled: true, defaultTemplate: "custom" }),
+    );
+    vi.stubEnv("OMC_HOOK_CONFIG", altPath);
+    resetHookConfigCache();
+    const config = getHookConfig();
+    expect(config!.defaultTemplate).toBe("custom");
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveEventTemplate
+  // -----------------------------------------------------------------------
+
+  describe("resolveEventTemplate", () => {
+    const baseConfig: HookNotificationConfig = {
+      version: 1,
+      enabled: true,
+      defaultTemplate: "Global: {{event}}",
+      events: {
+        "session-end": {
+          enabled: true,
+          template: "Event: {{duration}}",
+          platforms: {
+            discord: { template: "Discord: {{projectDisplay}}" },
+            telegram: { enabled: true },
+          },
+        },
+        "session-start": {
+          enabled: true,
+        },
+      },
+    };
+
+    it("returns platform override when present", () => {
+      expect(resolveEventTemplate(baseConfig, "session-end", "discord")).toBe(
+        "Discord: {{projectDisplay}}",
+      );
+    });
+
+    it("returns event template when no platform override", () => {
+      expect(resolveEventTemplate(baseConfig, "session-end", "slack")).toBe(
+        "Event: {{duration}}",
+      );
+    });
+
+    it("returns event template when platform has no template field", () => {
+      expect(resolveEventTemplate(baseConfig, "session-end", "telegram")).toBe(
+        "Event: {{duration}}",
+      );
+    });
+
+    it("returns defaultTemplate when event has no template", () => {
+      expect(
+        resolveEventTemplate(baseConfig, "session-start", "discord"),
+      ).toBe("Global: {{event}}");
+    });
+
+    it("returns defaultTemplate when event is not in config", () => {
+      expect(
+        resolveEventTemplate(baseConfig, "session-idle", "discord"),
+      ).toBe("Global: {{event}}");
+    });
+
+    it("returns null when no template at any level", () => {
+      const minimal: HookNotificationConfig = {
+        version: 1,
+        enabled: true,
+        events: { "session-end": { enabled: true } },
+      };
+      expect(resolveEventTemplate(minimal, "session-end", "discord")).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // mergeHookConfigIntoNotificationConfig
+  // -----------------------------------------------------------------------
+
+  describe("mergeHookConfigIntoNotificationConfig", () => {
+    const baseNotifConfig: NotificationConfig = {
+      enabled: true,
+      telegram: {
+        enabled: true,
+        botToken: "tok-123",
+        chatId: "chat-456",
+      },
+      events: {
+        "session-end": { enabled: true },
+        "session-start": { enabled: true },
+      },
+    };
+
+    it("overrides event enabled flag", () => {
+      const hookConfig: HookNotificationConfig = {
+        version: 1,
+        enabled: true,
+        events: {
+          "session-start": { enabled: false },
+        },
+      };
+      const merged = mergeHookConfigIntoNotificationConfig(
+        hookConfig,
+        baseNotifConfig,
+      );
+      expect(merged.events?.["session-start"]?.enabled).toBe(false);
+      expect(merged.events?.["session-end"]?.enabled).toBe(true);
+    });
+
+    it("preserves platform credentials", () => {
+      const hookConfig: HookNotificationConfig = {
+        version: 1,
+        enabled: true,
+        events: {
+          "session-end": { enabled: false },
+        },
+      };
+      const merged = mergeHookConfigIntoNotificationConfig(
+        hookConfig,
+        baseNotifConfig,
+      );
+      expect(merged.telegram?.botToken).toBe("tok-123");
+      expect(merged.telegram?.chatId).toBe("chat-456");
+    });
+
+    it("adds new event entries from hook config", () => {
+      const hookConfig: HookNotificationConfig = {
+        version: 1,
+        enabled: true,
+        events: {
+          "session-idle": { enabled: true },
+        },
+      };
+      const merged = mergeHookConfigIntoNotificationConfig(
+        hookConfig,
+        baseNotifConfig,
+      );
+      expect(merged.events?.["session-idle"]?.enabled).toBe(true);
+    });
+
+    it("returns unmodified config when hookConfig has no events", () => {
+      const hookConfig: HookNotificationConfig = {
+        version: 1,
+        enabled: true,
+      };
+      const merged = mergeHookConfigIntoNotificationConfig(
+        hookConfig,
+        baseNotifConfig,
+      );
+      expect(merged).toEqual(baseNotifConfig);
+    });
+  });
+});

--- a/src/notifications/__tests__/platform-gating.test.ts
+++ b/src/notifications/__tests__/platform-gating.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for platform activation gating in getEnabledPlatforms.
+ *
+ * Covers:
+ * - Telegram requires OMC_TELEGRAM=1 to be included
+ * - Discord and discord-bot require OMC_DISCORD=1 to be included
+ * - Slack requires OMC_SLACK=1 to be included
+ * - Webhook requires OMC_WEBHOOK=1 to be included
+ * - Combined env vars enable all platforms
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getEnabledPlatforms } from '../config.js';
+import type { NotificationConfig } from '../types.js';
+
+/**
+ * A full notification config with all platforms enabled.
+ * Used as the base for gating tests.
+ */
+function makeFullConfig(): NotificationConfig {
+  return {
+    enabled: true,
+    telegram: {
+      enabled: true,
+      botToken: 'test-bot-token',
+      chatId: 'test-chat-id',
+    },
+    discord: {
+      enabled: true,
+      webhookUrl: 'https://discord.com/api/webhooks/test',
+    },
+    'discord-bot': {
+      enabled: true,
+      botToken: 'test-discord-bot-token',
+      channelId: 'test-channel-id',
+    },
+    slack: {
+      enabled: true,
+      webhookUrl: 'https://hooks.slack.com/services/test',
+    },
+    webhook: {
+      enabled: true,
+      url: 'https://example.com/webhook',
+    },
+  };
+}
+
+describe('platform gating via getEnabledPlatforms', () => {
+  beforeEach(() => {
+    // Clear all platform gate env vars before each test
+    vi.stubEnv('OMC_TELEGRAM', '');
+    vi.stubEnv('OMC_DISCORD', '');
+    vi.stubEnv('OMC_SLACK', '');
+    vi.stubEnv('OMC_WEBHOOK', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Telegram gating
+  // ---------------------------------------------------------------------------
+
+  it('excludes telegram when OMC_TELEGRAM is not set', () => {
+    vi.stubEnv('OMC_TELEGRAM', '');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).not.toContain('telegram');
+  });
+
+  it('includes telegram when OMC_TELEGRAM=1', () => {
+    vi.stubEnv('OMC_TELEGRAM', '1');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).toContain('telegram');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Discord gating
+  // ---------------------------------------------------------------------------
+
+  it('excludes discord when OMC_DISCORD is not set', () => {
+    vi.stubEnv('OMC_DISCORD', '');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).not.toContain('discord');
+  });
+
+  it('excludes discord-bot when OMC_DISCORD is not set', () => {
+    vi.stubEnv('OMC_DISCORD', '');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).not.toContain('discord-bot');
+  });
+
+  it('includes discord when OMC_DISCORD=1', () => {
+    vi.stubEnv('OMC_DISCORD', '1');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).toContain('discord');
+  });
+
+  it('includes discord-bot when OMC_DISCORD=1', () => {
+    vi.stubEnv('OMC_DISCORD', '1');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).toContain('discord-bot');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Slack gating
+  // ---------------------------------------------------------------------------
+
+  it('excludes slack when OMC_SLACK is not set', () => {
+    vi.stubEnv('OMC_SLACK', '');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).not.toContain('slack');
+  });
+
+  it('includes slack when OMC_SLACK=1', () => {
+    vi.stubEnv('OMC_SLACK', '1');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).toContain('slack');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Webhook gating
+  // ---------------------------------------------------------------------------
+
+  it('excludes webhook when OMC_WEBHOOK is not set', () => {
+    vi.stubEnv('OMC_WEBHOOK', '');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).not.toContain('webhook');
+  });
+
+  it('includes webhook when OMC_WEBHOOK=1', () => {
+    vi.stubEnv('OMC_WEBHOOK', '1');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).toContain('webhook');
+  });
+
+  // ---------------------------------------------------------------------------
+  // No platforms when no env vars set
+  // ---------------------------------------------------------------------------
+
+  it('returns empty array when no platform env vars are set', () => {
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Combined: all gates open
+  // ---------------------------------------------------------------------------
+
+  it('includes all platforms when all env vars are set', () => {
+    vi.stubEnv('OMC_TELEGRAM', '1');
+    vi.stubEnv('OMC_DISCORD', '1');
+    vi.stubEnv('OMC_SLACK', '1');
+    vi.stubEnv('OMC_WEBHOOK', '1');
+    const platforms = getEnabledPlatforms(makeFullConfig(), 'session-end');
+    expect(platforms).toContain('telegram');
+    expect(platforms).toContain('discord');
+    expect(platforms).toContain('discord-bot');
+    expect(platforms).toContain('slack');
+    expect(platforms).toContain('webhook');
+  });
+});

--- a/src/notifications/__tests__/template-engine.test.ts
+++ b/src/notifications/__tests__/template-engine.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Tests for the template interpolation engine.
+ *
+ * Covers:
+ * - Simple variable interpolation
+ * - Missing variables become empty string
+ * - {{#if}}...{{/if}} conditionals
+ * - Computed variables (duration, time, modesDisplay, etc.)
+ * - Default template parity with formatter.ts
+ * - Template validation
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  interpolateTemplate,
+  getDefaultTemplate,
+  validateTemplate,
+  computeTemplateVariables,
+} from "../template-engine.js";
+import {
+  formatSessionStart,
+  formatSessionEnd,
+  formatSessionStop,
+  formatSessionIdle,
+  formatAskUserQuestion,
+  formatAgentCall,
+} from "../formatter.js";
+import type { NotificationPayload, NotificationEvent } from "../types.js";
+
+/** Build a minimal payload for testing. */
+function makePayload(
+  overrides: Partial<NotificationPayload> = {},
+): NotificationPayload {
+  return {
+    event: "session-end",
+    sessionId: "test-session-123",
+    message: "",
+    timestamp: "2026-02-25T10:30:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("interpolateTemplate", () => {
+  it("replaces simple variables", () => {
+    const payload = makePayload({ projectName: "my-project" });
+    const result = interpolateTemplate("Hello {{projectName}}", payload);
+    expect(result).toBe("Hello my-project");
+  });
+
+  it("replaces multiple variables", () => {
+    const payload = makePayload({
+      sessionId: "s1",
+      projectName: "proj",
+    });
+    const result = interpolateTemplate(
+      "Session {{sessionId}} in {{projectName}}",
+      payload,
+    );
+    expect(result).toBe("Session s1 in proj");
+  });
+
+  it("replaces unknown/missing variables with empty string", () => {
+    const payload = makePayload();
+    const result = interpolateTemplate("Value: {{nonexistent}}", payload);
+    expect(result).toBe("Value:");
+  });
+
+  it("replaces undefined payload fields with empty string", () => {
+    const payload = makePayload({ projectName: undefined });
+    const result = interpolateTemplate("Project: {{projectName}}", payload);
+    expect(result).toBe("Project:");
+  });
+});
+
+describe("{{#if}} conditionals", () => {
+  it("shows content when variable is truthy", () => {
+    const payload = makePayload({ tmuxSession: "omc-session" });
+    const result = interpolateTemplate(
+      "{{#if tmuxSession}}tmux: {{tmuxSession}}{{/if}}",
+      payload,
+    );
+    expect(result).toBe("tmux: omc-session");
+  });
+
+  it("hides content when variable is empty", () => {
+    const payload = makePayload({ tmuxSession: undefined });
+    const result = interpolateTemplate(
+      "{{#if tmuxSession}}tmux: {{tmuxSession}}{{/if}}",
+      payload,
+    );
+    expect(result).toBe("");
+  });
+
+  it("hides content when variable is falsy (empty string)", () => {
+    const payload = makePayload({ reason: "" });
+    const result = interpolateTemplate(
+      "{{#if reason}}Reason: {{reason}}{{/if}}",
+      payload,
+    );
+    expect(result).toBe("");
+  });
+
+  it("handles incompleteTasks=0 as falsy", () => {
+    const payload = makePayload({ incompleteTasks: 0 });
+    const result = interpolateTemplate(
+      "{{#if incompleteTasks}}Tasks: {{incompleteTasks}}{{/if}}",
+      payload,
+    );
+    expect(result).toBe("");
+  });
+
+  it("handles incompleteTasks>0 as truthy", () => {
+    const payload = makePayload({ incompleteTasks: 5 });
+    const result = interpolateTemplate(
+      "{{#if incompleteTasks}}Tasks: {{incompleteTasks}}{{/if}}",
+      payload,
+    );
+    expect(result).toBe("Tasks: 5");
+  });
+
+  it("handles multiline conditional content", () => {
+    const payload = makePayload({ contextSummary: "did work" });
+    const result = interpolateTemplate(
+      "{{#if contextSummary}}\n**Summary:** {{contextSummary}}{{/if}}",
+      payload,
+    );
+    expect(result).toBe("\n**Summary:** did work");
+  });
+});
+
+describe("computed variables", () => {
+  it("duration formats milliseconds", () => {
+    const payload = makePayload({ durationMs: 323000 });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.duration).toBe("5m 23s");
+  });
+
+  it("duration handles hours", () => {
+    const payload = makePayload({ durationMs: 7323000 });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.duration).toBe("2h 2m 3s");
+  });
+
+  it("duration handles zero/undefined as unknown", () => {
+    expect(computeTemplateVariables(makePayload({ durationMs: 0 })).duration).toBe("unknown");
+    expect(computeTemplateVariables(makePayload({ durationMs: undefined })).duration).toBe("unknown");
+  });
+
+  it("time formats timestamp", () => {
+    const payload = makePayload({ timestamp: "2026-02-25T10:30:00.000Z" });
+    const vars = computeTemplateVariables(payload);
+    // Just check it's non-empty (locale-dependent)
+    expect(vars.time).toBeTruthy();
+  });
+
+  it("modesDisplay joins modes", () => {
+    const payload = makePayload({ modesUsed: ["ralph", "ultrawork"] });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.modesDisplay).toBe("ralph, ultrawork");
+  });
+
+  it("modesDisplay is empty when no modes", () => {
+    const payload = makePayload({ modesUsed: [] });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.modesDisplay).toBe("");
+  });
+
+  it("iterationDisplay formats X/Y", () => {
+    const payload = makePayload({ iteration: 3, maxIterations: 10 });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.iterationDisplay).toBe("3/10");
+  });
+
+  it("iterationDisplay is empty when either is null", () => {
+    expect(
+      computeTemplateVariables(makePayload({ iteration: 3 })).iterationDisplay,
+    ).toBe("");
+    expect(
+      computeTemplateVariables(makePayload({ maxIterations: 10 }))
+        .iterationDisplay,
+    ).toBe("");
+  });
+
+  it("agentDisplay formats completed/total", () => {
+    const payload = makePayload({
+      agentsSpawned: 5,
+      agentsCompleted: 3,
+    });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.agentDisplay).toBe("3/5 completed");
+  });
+
+  it("agentDisplay defaults completed to 0", () => {
+    const payload = makePayload({ agentsSpawned: 5 });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.agentDisplay).toBe("0/5 completed");
+  });
+
+  it("agentDisplay is empty when agentsSpawned is undefined", () => {
+    const payload = makePayload();
+    const vars = computeTemplateVariables(payload);
+    expect(vars.agentDisplay).toBe("");
+  });
+
+  it("projectDisplay uses projectName", () => {
+    const payload = makePayload({ projectName: "my-proj" });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.projectDisplay).toBe("my-proj");
+  });
+
+  it("projectDisplay falls back to basename of projectPath", () => {
+    const payload = makePayload({
+      projectName: undefined,
+      projectPath: "/home/user/workspace/cool-project",
+    });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.projectDisplay).toBe("cool-project");
+  });
+
+  it("projectDisplay defaults to unknown", () => {
+    const payload = makePayload({
+      projectName: undefined,
+      projectPath: undefined,
+    });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.projectDisplay).toBe("unknown");
+  });
+
+  it("footer includes tmux and project", () => {
+    const payload = makePayload({
+      tmuxSession: "omc-1",
+      projectName: "proj",
+    });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.footer).toBe("**tmux:** `omc-1` | **project:** `proj`");
+  });
+
+  it("footer omits tmux when not set", () => {
+    const payload = makePayload({ projectName: "proj" });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.footer).toBe("**project:** `proj`");
+  });
+
+  it("tmuxTailBlock formats with code fence", () => {
+    const payload = makePayload({ tmuxTail: "line1\nline2" });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.tmuxTailBlock).toContain("**Recent output:**");
+    expect(vars.tmuxTailBlock).toContain("```");
+  });
+
+  it("tmuxTailBlock is empty when no tmuxTail", () => {
+    const payload = makePayload();
+    const vars = computeTemplateVariables(payload);
+    expect(vars.tmuxTailBlock).toBe("");
+  });
+
+  it("reasonDisplay falls back to unknown", () => {
+    const payload = makePayload({ reason: undefined });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.reasonDisplay).toBe("unknown");
+  });
+
+  it("reasonDisplay uses reason when present", () => {
+    const payload = makePayload({ reason: "user_request" });
+    const vars = computeTemplateVariables(payload);
+    expect(vars.reasonDisplay).toBe("user_request");
+  });
+});
+
+describe("validateTemplate", () => {
+  it("valid template has no unknown vars", () => {
+    const result = validateTemplate("Hello {{projectName}} at {{time}}");
+    expect(result.valid).toBe(true);
+    expect(result.unknownVars).toEqual([]);
+  });
+
+  it("detects unknown variables", () => {
+    const result = validateTemplate("{{typoVariable}} and {{sessionId}}");
+    expect(result.valid).toBe(false);
+    expect(result.unknownVars).toContain("typoVariable");
+    expect(result.unknownVars).not.toContain("sessionId");
+  });
+
+  it("detects unknown vars in conditionals", () => {
+    const result = validateTemplate("{{#if badVar}}content{{/if}}");
+    expect(result.valid).toBe(false);
+    expect(result.unknownVars).toContain("badVar");
+  });
+
+  it("does not duplicate unknown vars", () => {
+    const result = validateTemplate("{{bad}} and {{bad}}");
+    expect(result.unknownVars).toEqual(["bad"]);
+  });
+});
+
+describe("getDefaultTemplate", () => {
+  it("returns a template for each event type", () => {
+    const events: NotificationEvent[] = [
+      "session-start",
+      "session-stop",
+      "session-end",
+      "session-idle",
+      "ask-user-question",
+      "agent-call",
+    ];
+    for (const event of events) {
+      const template = getDefaultTemplate(event);
+      expect(template).toBeTruthy();
+      expect(typeof template).toBe("string");
+    }
+  });
+
+  it("returns fallback for unknown event", () => {
+    const template = getDefaultTemplate("unknown-event" as NotificationEvent);
+    expect(template).toBe("Event: {{event}}");
+  });
+});
+
+describe("default template parity with formatter.ts", () => {
+  // These tests verify that default templates produce identical output
+  // to the hardcoded formatters.
+
+  const fullPayload = makePayload({
+    event: "session-end",
+    sessionId: "test-session-abc",
+    timestamp: "2026-02-25T10:30:00.000Z",
+    tmuxSession: "omc-test",
+    projectName: "my-project",
+    projectPath: "/home/user/my-project",
+    durationMs: 323000,
+    reason: "user_request",
+    agentsSpawned: 5,
+    agentsCompleted: 3,
+    modesUsed: ["ralph", "ultrawork"],
+    contextSummary: "Implemented the feature",
+    activeMode: "ralph",
+    iteration: 3,
+    maxIterations: 10,
+    incompleteTasks: 2,
+    question: "What should I do next?",
+    agentName: "executor",
+    agentType: "oh-my-claudecode:executor",
+  });
+
+  it("session-start matches formatSessionStart", () => {
+    const p = { ...fullPayload, event: "session-start" as const };
+    const fromFormatter = formatSessionStart(p);
+    const fromTemplate = interpolateTemplate(getDefaultTemplate("session-start"), p);
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("session-stop matches formatSessionStop", () => {
+    const p = { ...fullPayload, event: "session-stop" as const };
+    const fromFormatter = formatSessionStop(p);
+    const fromTemplate = interpolateTemplate(getDefaultTemplate("session-stop"), p);
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("session-end matches formatSessionEnd", () => {
+    const p = { ...fullPayload, event: "session-end" as const };
+    const fromFormatter = formatSessionEnd(p);
+    const fromTemplate = interpolateTemplate(getDefaultTemplate("session-end"), p);
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("session-idle matches formatSessionIdle", () => {
+    const p = { ...fullPayload, event: "session-idle" as const };
+    const fromFormatter = formatSessionIdle(p);
+    const fromTemplate = interpolateTemplate(getDefaultTemplate("session-idle"), p);
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("ask-user-question matches formatAskUserQuestion", () => {
+    const p = { ...fullPayload, event: "ask-user-question" as const };
+    const fromFormatter = formatAskUserQuestion(p);
+    const fromTemplate = interpolateTemplate(
+      getDefaultTemplate("ask-user-question"),
+      p,
+    );
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("agent-call matches formatAgentCall", () => {
+    const p = { ...fullPayload, event: "agent-call" as const };
+    const fromFormatter = formatAgentCall(p);
+    const fromTemplate = interpolateTemplate(
+      getDefaultTemplate("agent-call"),
+      p,
+    );
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  // Minimal payloads (no optional fields) - ensures conditionals work
+  it("session-end minimal matches formatter", () => {
+    const p = makePayload({
+      event: "session-end",
+      sessionId: "s1",
+      durationMs: 5000,
+      projectPath: "/tmp/proj",
+    });
+    const fromFormatter = formatSessionEnd(p);
+    const fromTemplate = interpolateTemplate(
+      getDefaultTemplate("session-end"),
+      p,
+    );
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("session-idle minimal matches formatter", () => {
+    const p = makePayload({
+      event: "session-idle",
+      projectName: "proj",
+    });
+    const fromFormatter = formatSessionIdle(p);
+    const fromTemplate = interpolateTemplate(
+      getDefaultTemplate("session-idle"),
+      p,
+    );
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("ask-user-question without question matches formatter", () => {
+    const p = makePayload({
+      event: "ask-user-question",
+      projectName: "proj",
+    });
+    const fromFormatter = formatAskUserQuestion(p);
+    const fromTemplate = interpolateTemplate(
+      getDefaultTemplate("ask-user-question"),
+      p,
+    );
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("agent-call minimal matches formatter", () => {
+    const p = makePayload({
+      event: "agent-call",
+      projectName: "proj",
+    });
+    const fromFormatter = formatAgentCall(p);
+    const fromTemplate = interpolateTemplate(
+      getDefaultTemplate("agent-call"),
+      p,
+    );
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("session-start without tmux matches formatter", () => {
+    const p = makePayload({
+      event: "session-start",
+      projectName: "proj",
+      tmuxSession: undefined,
+    });
+    const fromFormatter = formatSessionStart(p);
+    const fromTemplate = interpolateTemplate(
+      getDefaultTemplate("session-start"),
+      p,
+    );
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+
+  it("session-stop minimal matches formatter", () => {
+    const p = makePayload({
+      event: "session-stop",
+      projectName: "proj",
+    });
+    const fromFormatter = formatSessionStop(p);
+    const fromTemplate = interpolateTemplate(
+      getDefaultTemplate("session-stop"),
+      p,
+    );
+    expect(fromTemplate).toBe(fromFormatter);
+  });
+});
+
+describe("post-processing", () => {
+  it("preserves consecutive newlines (no collapsing)", () => {
+    const payload = makePayload({ projectName: "proj" });
+    const template = "Line1\n\n\n\nLine2";
+    const result = interpolateTemplate(template, payload);
+    expect(result).toBe("Line1\n\n\n\nLine2");
+  });
+
+  it("trims trailing whitespace", () => {
+    const payload = makePayload({ projectName: "proj" });
+    const template = "Content\n\n";
+    const result = interpolateTemplate(template, payload);
+    expect(result).toBe("Content");
+  });
+});

--- a/src/notifications/config.ts
+++ b/src/notifications/config.ts
@@ -18,6 +18,10 @@ import type {
   TelegramNotificationConfig,
   VerbosityLevel,
 } from "./types.js";
+import {
+  getHookConfig,
+  mergeHookConfigIntoNotificationConfig,
+} from "./hook-config.js";
 
 const CONFIG_FILE = join(getClaudeConfigDir(), ".omc-config.json");
 
@@ -278,6 +282,21 @@ function mergeEnvIntoFileConfig(
 }
 
 /**
+ * Apply hook config merge then env-var mention patching and platform merge.
+ * Hook config event flags override event enabled/disabled (Priority 1).
+ * Env platforms fill missing blocks (Priority 3).
+ */
+function applyHookAndEnvMerge(config: NotificationConfig): NotificationConfig {
+  // Priority 1: Hook config event overrides
+  const hookConfig = getHookConfig();
+  let merged = config;
+  if (hookConfig?.enabled && hookConfig.events) {
+    merged = mergeHookConfigIntoNotificationConfig(hookConfig, merged);
+  }
+  return applyEnvMerge(merged);
+}
+
+/**
  * Apply env-var mention patching and platform merge to a notification config.
  * Shared logic used by both profile and default config resolution paths.
  */
@@ -405,7 +424,7 @@ export function getNotificationConfig(profileName?: string): NotificationConfig 
       if (typeof profileConfig.enabled !== "boolean") {
         return null;
       }
-      return applyEnvMerge(profileConfig);
+      return applyHookAndEnvMerge(profileConfig);
     }
     // Profile requested but not found — warn and fall through to default
     console.warn(
@@ -413,14 +432,14 @@ export function getNotificationConfig(profileName?: string): NotificationConfig 
     );
   }
 
-  // Priority 1: Explicit notifications config in .omc-config.json
+  // Priority 2: Explicit notifications config in .omc-config.json
   if (raw) {
     const notifications = raw.notifications as NotificationConfig | undefined;
     if (notifications) {
       if (typeof notifications.enabled !== "boolean") {
         return null;
       }
-      return applyEnvMerge(notifications);
+      return applyHookAndEnvMerge(notifications);
     }
   }
 
@@ -434,6 +453,23 @@ export function getNotificationConfig(profileName?: string): NotificationConfig 
   }
 
   return null;
+}
+
+/**
+ * Check if a platform is activated for this session.
+ * Each platform requires its corresponding CLI flag:
+ *   --telegram  -> OMC_TELEGRAM=1
+ *   --discord   -> OMC_DISCORD=1
+ *   --slack     -> OMC_SLACK=1
+ *   --webhook   -> OMC_WEBHOOK=1
+ */
+function isPlatformActivated(platform: NotificationPlatform): boolean {
+  if (platform === "telegram") return process.env.OMC_TELEGRAM === "1";
+  if (platform === "discord" || platform === "discord-bot")
+    return process.env.OMC_DISCORD === "1";
+  if (platform === "slack") return process.env.OMC_SLACK === "1";
+  if (platform === "webhook") return process.env.OMC_WEBHOOK === "1";
+  return false;
 }
 
 /**
@@ -453,32 +489,32 @@ export function isEventEnabled(
   // If event has no specific config, check if any top-level platform is enabled
   if (!eventConfig) {
     return !!(
-      config.discord?.enabled ||
-      config["discord-bot"]?.enabled ||
-      config.telegram?.enabled ||
-      config.slack?.enabled ||
-      config.webhook?.enabled
+      (isPlatformActivated("discord") && config.discord?.enabled) ||
+      (isPlatformActivated("discord-bot") && config["discord-bot"]?.enabled) ||
+      (isPlatformActivated("telegram") && config.telegram?.enabled) ||
+      (isPlatformActivated("slack") && config.slack?.enabled) ||
+      (isPlatformActivated("webhook") && config.webhook?.enabled)
     );
   }
 
   // Check event-specific platform overrides
   if (
-    eventConfig.discord?.enabled ||
-    eventConfig["discord-bot"]?.enabled ||
-    eventConfig.telegram?.enabled ||
-    eventConfig.slack?.enabled ||
-    eventConfig.webhook?.enabled
+    (isPlatformActivated("discord") && eventConfig.discord?.enabled) ||
+    (isPlatformActivated("discord-bot") && eventConfig["discord-bot"]?.enabled) ||
+    (isPlatformActivated("telegram") && eventConfig.telegram?.enabled) ||
+    (isPlatformActivated("slack") && eventConfig.slack?.enabled) ||
+    (isPlatformActivated("webhook") && eventConfig.webhook?.enabled)
   ) {
     return true;
   }
 
   // Fall back to top-level platforms
   return !!(
-    config.discord?.enabled ||
-    config["discord-bot"]?.enabled ||
-    config.telegram?.enabled ||
-    config.slack?.enabled ||
-    config.webhook?.enabled
+    (isPlatformActivated("discord") && config.discord?.enabled) ||
+    (isPlatformActivated("discord-bot") && config["discord-bot"]?.enabled) ||
+    (isPlatformActivated("telegram") && config.telegram?.enabled) ||
+    (isPlatformActivated("slack") && config.slack?.enabled) ||
+    (isPlatformActivated("webhook") && config.webhook?.enabled)
   );
 }
 
@@ -498,6 +534,8 @@ export function getEnabledPlatforms(
   if (eventConfig && eventConfig.enabled === false) return [];
 
   const checkPlatform = (platform: NotificationPlatform) => {
+    if (!isPlatformActivated(platform)) return;
+
     const eventPlatform =
       eventConfig?.[platform as keyof EventNotificationConfig];
     if (

--- a/src/notifications/dispatcher.ts
+++ b/src/notifications/dispatcher.ts
@@ -510,8 +510,15 @@ export async function dispatchNotifications(
   config: NotificationConfig,
   event: NotificationEvent,
   payload: NotificationPayload,
+  platformMessages?: Map<NotificationPlatform, string>,
 ): Promise<DispatchResult> {
   const promises: Promise<NotificationResult>[] = [];
+
+  /** Get payload for a platform, using per-platform message if available. */
+  const payloadFor = (platform: NotificationPlatform): NotificationPayload =>
+    platformMessages?.has(platform)
+      ? { ...payload, message: platformMessages.get(platform)! }
+      : payload;
 
   // Discord
   const discordConfig = getEffectivePlatformConfig<DiscordNotificationConfig>(
@@ -520,7 +527,7 @@ export async function dispatchNotifications(
     event,
   );
   if (discordConfig?.enabled) {
-    promises.push(sendDiscord(discordConfig, payload));
+    promises.push(sendDiscord(discordConfig, payloadFor("discord")));
   }
 
   // Telegram
@@ -530,7 +537,7 @@ export async function dispatchNotifications(
     event,
   );
   if (telegramConfig?.enabled) {
-    promises.push(sendTelegram(telegramConfig, payload));
+    promises.push(sendTelegram(telegramConfig, payloadFor("telegram")));
   }
 
   // Slack
@@ -540,7 +547,7 @@ export async function dispatchNotifications(
     event,
   );
   if (slackConfig?.enabled) {
-    promises.push(sendSlack(slackConfig, payload));
+    promises.push(sendSlack(slackConfig, payloadFor("slack")));
   }
 
   // Webhook
@@ -550,7 +557,7 @@ export async function dispatchNotifications(
     event,
   );
   if (webhookConfig?.enabled) {
-    promises.push(sendWebhook(webhookConfig, payload));
+    promises.push(sendWebhook(webhookConfig, payloadFor("webhook")));
   }
 
   // Discord Bot
@@ -561,7 +568,7 @@ export async function dispatchNotifications(
       event,
     );
   if (discordBotConfig?.enabled) {
-    promises.push(sendDiscordBot(discordBotConfig, payload));
+    promises.push(sendDiscordBot(discordBotConfig, payloadFor("discord-bot")));
   }
 
   if (promises.length === 0) {

--- a/src/notifications/hook-config-types.ts
+++ b/src/notifications/hook-config-types.ts
@@ -1,0 +1,65 @@
+/**
+ * Hook Notification Configuration Types
+ *
+ * Schema for omc_config.hook.json — user-customizable message templates
+ * with per-event, per-platform overrides.
+ */
+
+import type { NotificationPlatform } from "./types.js";
+
+/** Template variables available for interpolation in message templates. */
+export type TemplateVariable =
+  // Raw payload fields
+  | "event" | "sessionId" | "message" | "timestamp" | "tmuxSession"
+  | "projectPath" | "projectName" | "modesUsed" | "contextSummary"
+  | "durationMs" | "agentsSpawned" | "agentsCompleted"
+  | "reason" | "activeMode" | "iteration" | "maxIterations"
+  | "question" | "incompleteTasks" | "agentName" | "agentType"
+  | "tmuxTail" | "tmuxPaneId"
+  // Computed variables (derived from payload, not direct fields)
+  | "duration"          // human-readable from durationMs (e.g., "5m 23s")
+  | "time"              // locale time string from timestamp
+  | "modesDisplay"      // modesUsed.join(", ") or empty string
+  | "iterationDisplay"  // "3/10" format or empty string
+  | "agentDisplay"      // "2/5 completed" or empty string
+  | "projectDisplay"    // projectName || basename(projectPath) || "unknown"
+  | "footer"            // buildFooter() composite output
+  | "tmuxTailBlock"     // formatted tmux tail with code fence or empty string
+  | "reasonDisplay";    // reason || "unknown" (for session-end)
+
+/** Per-platform message template override */
+export interface PlatformTemplateOverride {
+  /** Message template with {{variable}} placeholders */
+  template?: string;
+  /** Whether to send this event to this platform (inherits from event-level if not set) */
+  enabled?: boolean;
+}
+
+/** Per-event hook configuration */
+export interface HookEventConfig {
+  /** Whether this event fires notifications */
+  enabled: boolean;
+  /** Default message template for this event (all platforms) */
+  template?: string;
+  /** Per-platform template overrides */
+  platforms?: Partial<Record<NotificationPlatform, PlatformTemplateOverride>>;
+}
+
+/** Top-level schema for omc_config.hook.json */
+export interface HookNotificationConfig {
+  /** Schema version for future migration */
+  version: 1;
+  /** Global enable/disable */
+  enabled: boolean;
+  /** Default templates per event (used when no platform override exists) */
+  events?: {
+    "session-start"?: HookEventConfig;
+    "session-stop"?: HookEventConfig;
+    "session-end"?: HookEventConfig;
+    "session-idle"?: HookEventConfig;
+    "ask-user-question"?: HookEventConfig;
+    "agent-call"?: HookEventConfig;
+  };
+  /** Global default template (fallback when event has no template) */
+  defaultTemplate?: string;
+}

--- a/src/notifications/hook-config.ts
+++ b/src/notifications/hook-config.ts
@@ -1,0 +1,115 @@
+/**
+ * Hook Notification Config Reader
+ *
+ * Reads omc_config.hook.json for user-customizable message templates.
+ * Follows the OpenClaw config reader pattern (file-based, cached).
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { getClaudeConfigDir } from "../utils/paths.js";
+import type { HookNotificationConfig } from "./hook-config-types.js";
+import type {
+  NotificationConfig,
+  NotificationEvent,
+  NotificationPlatform,
+} from "./types.js";
+
+const DEFAULT_CONFIG_PATH = join(getClaudeConfigDir(), "omc_config.hook.json");
+
+/** Cached hook config. `undefined` = not yet read, `null` = read but absent/disabled. */
+let cachedConfig: HookNotificationConfig | null | undefined;
+
+/**
+ * Read and cache the hook notification config.
+ *
+ * - Returns null when file does not exist (no error)
+ * - Returns null when file has `enabled: false`
+ * - Caches after first read for performance
+ * - File path overridable via OMC_HOOK_CONFIG env var (for testing)
+ */
+export function getHookConfig(): HookNotificationConfig | null {
+  if (cachedConfig !== undefined) return cachedConfig;
+
+  const configPath = process.env.OMC_HOOK_CONFIG || DEFAULT_CONFIG_PATH;
+
+  if (!existsSync(configPath)) {
+    cachedConfig = null;
+    return null;
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (!raw || raw.enabled === false) {
+      cachedConfig = null;
+      return null;
+    }
+    cachedConfig = raw as HookNotificationConfig;
+    return cachedConfig;
+  } catch {
+    cachedConfig = null;
+    return null;
+  }
+}
+
+/**
+ * Clear the cached hook config. Call in tests to reset state.
+ */
+export function resetHookConfigCache(): void {
+  cachedConfig = undefined;
+}
+
+/**
+ * Resolve the template for a specific event and platform.
+ *
+ * Cascade: platform override > event template > defaultTemplate > null
+ */
+export function resolveEventTemplate(
+  hookConfig: HookNotificationConfig,
+  event: NotificationEvent,
+  platform: NotificationPlatform,
+): string | null {
+  const eventConfig = hookConfig.events?.[event];
+
+  if (eventConfig) {
+    // Platform-specific override
+    const platformOverride = eventConfig.platforms?.[platform];
+    if (platformOverride?.template) return platformOverride.template;
+
+    // Event-level template
+    if (eventConfig.template) return eventConfig.template;
+  }
+
+  // Global default template
+  return hookConfig.defaultTemplate || null;
+}
+
+/**
+ * Merge hook config event enabled/disabled flags into a NotificationConfig.
+ *
+ * Hook config takes precedence for event gating:
+ * - hook event `enabled: false` overrides `.omc-config.json` event `enabled: true`
+ * - Platform credentials are NOT affected (they stay in .omc-config.json)
+ */
+export function mergeHookConfigIntoNotificationConfig(
+  hookConfig: HookNotificationConfig,
+  notifConfig: NotificationConfig,
+): NotificationConfig {
+  if (!hookConfig.events) return notifConfig;
+
+  const merged = { ...notifConfig };
+  const events = { ...(merged.events || {}) };
+
+  for (const [eventName, hookEventConfig] of Object.entries(hookConfig.events)) {
+    if (!hookEventConfig) continue;
+    const event = eventName as NotificationEvent;
+    const existing = events[event as keyof typeof events];
+    (events as Record<string, unknown>)[event] = {
+      ...(existing || {}),
+      enabled: hookEventConfig.enabled,
+    };
+  }
+
+  merged.events = events as NotificationConfig["events"];
+  return merged;
+}

--- a/src/notifications/template-engine.ts
+++ b/src/notifications/template-engine.ts
@@ -1,0 +1,293 @@
+/**
+ * Template Interpolation Engine
+ *
+ * Lightweight {{variable}} interpolation with {{#if var}}...{{/if}} conditionals.
+ * No external dependencies. Produces output matching current formatter.ts functions.
+ */
+
+import type { NotificationPayload, NotificationEvent } from "./types.js";
+import { parseTmuxTail } from "./formatter.js";
+import { basename } from "path";
+
+/** Set of known template variables for validation */
+const KNOWN_VARIABLES = new Set<string>([
+  // Raw payload fields
+  "event", "sessionId", "message", "timestamp", "tmuxSession",
+  "projectPath", "projectName", "modesUsed", "contextSummary",
+  "durationMs", "agentsSpawned", "agentsCompleted",
+  "reason", "activeMode", "iteration", "maxIterations",
+  "question", "incompleteTasks", "agentName", "agentType",
+  "tmuxTail", "tmuxPaneId",
+  // Computed variables
+  "duration", "time", "modesDisplay", "iterationDisplay",
+  "agentDisplay", "projectDisplay", "footer", "tmuxTailBlock",
+  "reasonDisplay",
+]);
+
+/**
+ * Format duration from milliseconds to human-readable string.
+ * Mirrors formatDuration() in formatter.ts.
+ */
+function formatDuration(ms?: number): string {
+  if (!ms) return "unknown";
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m ${seconds % 60}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  return `${seconds}s`;
+}
+
+/**
+ * Get project display name from payload.
+ * Mirrors projectDisplay() in formatter.ts.
+ */
+function getProjectDisplay(payload: NotificationPayload): string {
+  if (payload.projectName) return payload.projectName;
+  if (payload.projectPath) return basename(payload.projectPath);
+  return "unknown";
+}
+
+/**
+ * Build common footer with tmux and project info (markdown).
+ * Mirrors buildFooter(payload, true) in formatter.ts.
+ */
+function buildFooterText(payload: NotificationPayload): string {
+  const parts: string[] = [];
+  if (payload.tmuxSession) {
+    parts.push(`**tmux:** \`${payload.tmuxSession}\``);
+  }
+  parts.push(`**project:** \`${getProjectDisplay(payload)}\``);
+  return parts.join(" | ");
+}
+
+/**
+ * Build tmux tail block with code fence, or empty string.
+ * Mirrors appendTmuxTail() in formatter.ts.
+ * Includes two leading newlines (blank line separator) to match formatter output.
+ */
+function buildTmuxTailBlock(payload: NotificationPayload): string {
+  if (!payload.tmuxTail) return "";
+  const parsed = parseTmuxTail(payload.tmuxTail);
+  if (!parsed) return "";
+  return `\n\n**Recent output:**\n\`\`\`\n${parsed}\n\`\`\``;
+}
+
+/**
+ * Build the full variable map from a notification payload.
+ * Includes raw payload fields (string-converted) and computed variables.
+ */
+export function computeTemplateVariables(
+  payload: NotificationPayload,
+): Record<string, string> {
+  const vars: Record<string, string> = {};
+
+  // Raw payload fields (null/undefined → "")
+  vars.event = payload.event || "";
+  vars.sessionId = payload.sessionId || "";
+  vars.message = payload.message || "";
+  vars.timestamp = payload.timestamp || "";
+  vars.tmuxSession = payload.tmuxSession || "";
+  vars.projectPath = payload.projectPath || "";
+  vars.projectName = payload.projectName || "";
+  vars.modesUsed = payload.modesUsed?.join(", ") || "";
+  vars.contextSummary = payload.contextSummary || "";
+  vars.durationMs =
+    payload.durationMs != null ? String(payload.durationMs) : "";
+  vars.agentsSpawned =
+    payload.agentsSpawned != null ? String(payload.agentsSpawned) : "";
+  vars.agentsCompleted =
+    payload.agentsCompleted != null ? String(payload.agentsCompleted) : "";
+  vars.reason = payload.reason || "";
+  vars.activeMode = payload.activeMode || "";
+  vars.iteration =
+    payload.iteration != null ? String(payload.iteration) : "";
+  vars.maxIterations =
+    payload.maxIterations != null ? String(payload.maxIterations) : "";
+  vars.question = payload.question || "";
+  // incompleteTasks: 0 or null → "" (so {{#if}} is falsy for 0)
+  vars.incompleteTasks =
+    payload.incompleteTasks != null && payload.incompleteTasks > 0
+      ? String(payload.incompleteTasks)
+      : "";
+  vars.agentName = payload.agentName || "";
+  vars.agentType = payload.agentType || "";
+  vars.tmuxTail = payload.tmuxTail || "";
+  vars.tmuxPaneId = payload.tmuxPaneId || "";
+
+  // Computed variables
+  vars.duration = formatDuration(payload.durationMs);
+  vars.time = payload.timestamp
+    ? new Date(payload.timestamp).toLocaleTimeString()
+    : "";
+  vars.modesDisplay =
+    payload.modesUsed && payload.modesUsed.length > 0
+      ? payload.modesUsed.join(", ")
+      : "";
+  vars.iterationDisplay =
+    payload.iteration != null && payload.maxIterations != null
+      ? `${payload.iteration}/${payload.maxIterations}`
+      : "";
+  vars.agentDisplay =
+    payload.agentsSpawned != null
+      ? `${payload.agentsCompleted ?? 0}/${payload.agentsSpawned} completed`
+      : "";
+  vars.projectDisplay = getProjectDisplay(payload);
+  vars.footer = buildFooterText(payload);
+  vars.tmuxTailBlock = buildTmuxTailBlock(payload);
+  vars.reasonDisplay = payload.reason || "unknown";
+
+  return vars;
+}
+
+/**
+ * Process {{#if var}}...{{/if}} conditionals.
+ * Only simple truthy checks (non-empty string). No nesting, no else.
+ */
+function processConditionals(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(
+    /\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g,
+    (_match, varName: string, content: string) => {
+      const value = vars[varName] || "";
+      return value ? content : "";
+    },
+  );
+}
+
+/**
+ * Replace {{variable}} placeholders with values.
+ * Unknown/missing variables become empty string.
+ */
+function replaceVariables(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(
+    /\{\{(\w+)\}\}/g,
+    (_match, varName: string) => vars[varName] ?? "",
+  );
+}
+
+/**
+ * Post-process interpolated text:
+ * - Trim trailing whitespace
+ *
+ * Note: No newline collapsing — templates use self-contained conditionals
+ * (leading \n inside {{#if}} blocks) to produce exact output.
+ */
+function postProcess(text: string): string {
+  return text.trimEnd();
+}
+
+/**
+ * Interpolate a template string with payload values.
+ *
+ * 1. Process {{#if var}}...{{/if}} conditionals
+ * 2. Replace {{variable}} placeholders
+ * 3. Post-process to normalize blank lines
+ */
+export function interpolateTemplate(
+  template: string,
+  payload: NotificationPayload,
+): string {
+  const vars = computeTemplateVariables(payload);
+  let result = processConditionals(template, vars);
+  result = replaceVariables(result, vars);
+  result = postProcess(result);
+  return result;
+}
+
+/**
+ * Validate a template string for unknown variables.
+ * Returns { valid, unknownVars }.
+ */
+export function validateTemplate(
+  template: string,
+): { valid: boolean; unknownVars: string[] } {
+  const unknownVars: string[] = [];
+
+  // Check {{#if var}} conditionals
+  for (const m of template.matchAll(/\{\{#if\s+(\w+)\}\}/g)) {
+    if (!KNOWN_VARIABLES.has(m[1]) && !unknownVars.includes(m[1])) {
+      unknownVars.push(m[1]);
+    }
+  }
+
+  // Check {{variable}} placeholders (skip {{#if}}, {{/if}})
+  for (const m of template.matchAll(/\{\{(?!#if\s|\/if)(\w+)\}\}/g)) {
+    if (!KNOWN_VARIABLES.has(m[1]) && !unknownVars.includes(m[1])) {
+      unknownVars.push(m[1]);
+    }
+  }
+
+  return { valid: unknownVars.length === 0, unknownVars };
+}
+
+/**
+ * Default templates that produce output identical to formatter.ts functions.
+ *
+ * These use self-contained conditionals: each {{#if}} block includes its own
+ * leading \n so that false conditionals leave zero residual whitespace.
+ * No post-processing collapsing is needed.
+ */
+const DEFAULT_TEMPLATES: Record<NotificationEvent, string> = {
+  "session-start":
+    "# Session Started\n\n" +
+    "**Session:** `{{sessionId}}`\n" +
+    "**Project:** `{{projectDisplay}}`\n" +
+    "**Time:** {{time}}" +
+    "{{#if tmuxSession}}\n**tmux:** `{{tmuxSession}}`{{/if}}",
+
+  "session-stop":
+    "# Session Continuing\n" +
+    "{{#if activeMode}}\n**Mode:** {{activeMode}}{{/if}}" +
+    "{{#if iterationDisplay}}\n**Iteration:** {{iterationDisplay}}{{/if}}" +
+    "{{#if incompleteTasks}}\n**Incomplete tasks:** {{incompleteTasks}}{{/if}}" +
+    "\n\n{{footer}}",
+
+  "session-end":
+    "# Session Ended\n\n" +
+    "**Session:** `{{sessionId}}`\n" +
+    "**Duration:** {{duration}}\n" +
+    "**Reason:** {{reasonDisplay}}" +
+    "{{#if agentDisplay}}\n**Agents:** {{agentDisplay}}{{/if}}" +
+    "{{#if modesDisplay}}\n**Modes:** {{modesDisplay}}{{/if}}" +
+    "{{#if contextSummary}}\n\n**Summary:** {{contextSummary}}{{/if}}" +
+    "{{tmuxTailBlock}}" +
+    "\n\n{{footer}}",
+
+  "session-idle":
+    "# Session Idle\n\n" +
+    "Claude has finished and is waiting for input.\n" +
+    "{{#if reason}}\n**Reason:** {{reason}}{{/if}}" +
+    "{{#if modesDisplay}}\n**Modes:** {{modesDisplay}}{{/if}}" +
+    "{{tmuxTailBlock}}" +
+    "\n\n{{footer}}",
+
+  "ask-user-question":
+    "# Input Needed\n" +
+    "{{#if question}}\n**Question:** {{question}}\n{{/if}}" +
+    "\nClaude is waiting for your response.\n\n{{footer}}",
+
+  "agent-call":
+    "# Agent Spawned\n" +
+    "{{#if agentName}}\n**Agent:** `{{agentName}}`{{/if}}" +
+    "{{#if agentType}}\n**Type:** `{{agentType}}`{{/if}}" +
+    "\n\n{{footer}}",
+};
+
+/**
+ * Get the default template for an event type.
+ * When interpolated, produces output identical to formatter.ts functions.
+ */
+export function getDefaultTemplate(event: NotificationEvent): string {
+  return DEFAULT_TEMPLATES[event] || `Event: {{event}}`;
+}

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -95,8 +95,6 @@ export type PlatformConfig =
 export interface EventNotificationConfig {
   /** Whether this event triggers notifications */
   enabled: boolean;
-  /** Custom message template (optional, uses default if not set) */
-  messageTemplate?: string;
   /** Platform overrides for this event (inherits from top-level if not set) */
   discord?: DiscordNotificationConfig;
   "discord-bot"?: DiscordBotNotificationConfig;


### PR DESCRIPTION
## Summary

- **Hook config system** (`omc_config.hook.json`): User-customizable notification templates with per-event and per-platform overrides, cascade resolution (platform override > event template > defaultTemplate), and merge into `NotificationConfig` at Priority 1 in the config cascade
- **Template interpolation engine**: `{{variable}}` placeholders with `{{#if var}}...{{/if}}` conditionals and computed variables (duration, modesDisplay, agentDisplay, footer, etc.) — default templates produce output byte-identical to `formatter.ts`
- **Platform gating**: All platforms (telegram, discord, slack, webhook) require explicit `--telegram`/`--discord`/`--slack`/`--webhook` CLI flags (sets `OMC_*=1` env vars) for activation, disabled by default
- **Per-platform message dispatch**: `dispatchNotifications()` accepts an optional `platformMessages` map for platform-specific template resolution

## Files Changed

| File | Change |
|------|--------|
| `src/notifications/hook-config-types.ts` | New — TypeScript schema for `omc_config.hook.json` |
| `src/notifications/hook-config.ts` | New — Config reader with caching, cascade resolution, merge |
| `src/notifications/template-engine.ts` | New — Interpolation engine with 6 default templates |
| `src/notifications/config.ts` | Modified — Hook config merge via `applyHookAndEnvMerge()` |
| `src/notifications/dispatcher.ts` | Modified — Per-platform `platformMessages` support |
| `src/notifications/index.ts` | Modified — Template resolution in `notify()`, new exports |
| `src/notifications/types.ts` | Modified — Remove dead `messageTemplate` field |
| `skills/configure-notifications/SKILL.md` | Modified — Platform flags + hook template docs |
| 3 new test files | 67 new tests (template-engine, hook-config, platform-gating) |

## Test plan

- [x] All 50 template-engine tests pass (interpolation, conditionals, computed vars, parity with formatter.ts)
- [x] All 17 hook-config tests pass (reader, cache, cascade, merge)
- [x] All 12 platform-gating tests pass
- [x] All 391 notification tests pass (14 test files, zero regressions)
- [x] TypeScript typecheck passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)