### PR TITLE
feat(cli): add --telegram, --discord, --slack, --webhook platform flags

### DIFF
--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -361,32 +361,42 @@ export async function launchCommand(args: string[]): Promise<void> {
 
   // Extract OMC-specific --openclaw flag (presence-based, no value consumption)
   const { openclawEnabled, remainingArgs: argsAfterOpenclaw } = extractOpenClawFlag(remainingArgs);
-  if (openclawEnabled) {
+  if (openclawEnabled === true) {
     process.env.OMC_OPENCLAW = '1';
+  } else if (openclawEnabled === false) {
+    process.env.OMC_OPENCLAW = '0';
   }
 
   // Extract OMC-specific --telegram flag (presence-based)
   const { telegramEnabled, remainingArgs: argsAfterTelegram } = extractTelegramFlag(argsAfterOpenclaw);
-  if (telegramEnabled) {
+  if (telegramEnabled === true) {
     process.env.OMC_TELEGRAM = '1';
+  } else if (telegramEnabled === false) {
+    process.env.OMC_TELEGRAM = '0';
   }
 
   // Extract OMC-specific --discord flag (presence-based)
   const { discordEnabled, remainingArgs: argsAfterDiscord } = extractDiscordFlag(argsAfterTelegram);
-  if (discordEnabled) {
+  if (discordEnabled === true) {
     process.env.OMC_DISCORD = '1';
+  } else if (discordEnabled === false) {
+    process.env.OMC_DISCORD = '0';
   }
 
   // Extract OMC-specific --slack flag (presence-based)
   const { slackEnabled, remainingArgs: argsAfterSlack } = extractSlackFlag(argsAfterDiscord);
-  if (slackEnabled) {
+  if (slackEnabled === true) {
     process.env.OMC_SLACK = '1';
+  } else if (slackEnabled === false) {
+    process.env.OMC_SLACK = '0';
   }
 
   // Extract OMC-specific --webhook flag (presence-based)
   const { webhookEnabled, remainingArgs: argsAfterWebhook } = extractWebhookFlag(argsAfterSlack);
-  if (webhookEnabled) {
+  if (webhookEnabled === true) {
     process.env.OMC_WEBHOOK = '1';
+  } else if (webhookEnabled === false) {
+    process.env.OMC_WEBHOOK = '0';
   }
 
   const cwd = process.cwd();


### PR DESCRIPTION
## Summary

- **Platform activation flags**: Add `--telegram`, `--discord`, `--slack`, `--webhook` CLI flags to `omc` launcher
- **Default-off behavior**: All notification platforms are disabled by default and only activated when explicitly requested via CLI flags
- **Env var propagation**: Each flag sets `OMC_<PLATFORM>=1` environment variable, which the notification config system reads to gate platform activation

## Files Changed

| File | Change |
|------|--------|
| `src/cli/launch.ts` | Modified — Parse and propagate platform activation flags |
| `src/cli/__tests__/launch.test.ts` | Modified — Tests for flag parsing and env var propagation |

## Dependencies

- Works with PR #1022 (hook config enhancement) which reads `OMC_*` env vars for platform gating

## Test plan

- [x] CLI flag parsing tests pass
- [x] Env var propagation tests pass
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)