### PR TITLE
fix(team): add prompt-mode support for codex CLI workers

### DIFF
--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -65,6 +65,9 @@ var CONTRACTS = {
     agentType: "codex",
     binary: "codex",
     installInstructions: "Install Codex CLI: npm install -g @openai/codex",
+    supportsPromptMode: true,
+    // Codex accepts prompt as a positional argument (no flag needed):
+    //   codex [OPTIONS] [PROMPT]
     buildLaunchArgs(model, extraFlags = []) {
       const args = ["--dangerously-bypass-approvals-and-sandbox"];
       if (model) args.push("--model", model);
@@ -146,14 +149,17 @@ function getWorkerEnv(teamName, workerName2, agentType) {
 }
 function isPromptModeAgent(agentType) {
   const contract = getContract(agentType);
-  return !!(contract.supportsPromptMode && contract.promptModeFlag);
+  return !!contract.supportsPromptMode;
 }
 function getPromptModeArgs(agentType, instruction) {
   const contract = getContract(agentType);
-  if (contract.supportsPromptMode && contract.promptModeFlag) {
+  if (!contract.supportsPromptMode) {
+    return [];
+  }
+  if (contract.promptModeFlag) {
     return [contract.promptModeFlag, instruction];
   }
-  return [];
+  return [instruction];
 }
 
 // src/team/tmux-session.ts

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -91,8 +91,11 @@ describe('model-contract', () => {
       expect(isPromptModeAgent('claude')).toBe(false);
     });
 
-    it('codex does not support prompt mode', () => {
-      expect(isPromptModeAgent('codex')).toBe(false);
+    it('codex supports prompt mode (positional argument, no flag)', () => {
+      expect(isPromptModeAgent('codex')).toBe(true);
+      const c = getContract('codex');
+      expect(c.supportsPromptMode).toBe(true);
+      expect(c.promptModeFlag).toBeUndefined();
     });
 
     it('getPromptModeArgs returns flag + instruction for gemini', () => {
@@ -100,9 +103,13 @@ describe('model-contract', () => {
       expect(args).toEqual(['-p', 'Read inbox']);
     });
 
+    it('getPromptModeArgs returns instruction only (positional) for codex', () => {
+      const args = getPromptModeArgs('codex', 'Read inbox');
+      expect(args).toEqual(['Read inbox']);
+    });
+
     it('getPromptModeArgs returns empty array for non-prompt-mode agents', () => {
       expect(getPromptModeArgs('claude', 'Read inbox')).toEqual([]);
-      expect(getPromptModeArgs('codex', 'Read inbox')).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `supportsPromptMode: true` to codex contract so task instruction is passed as a positional argument (`codex [OPTIONS] [PROMPT]`) instead of via `tmux send-keys`
- Generalize `isPromptModeAgent()` and `getPromptModeArgs()` to support both flag-based (gemini `-p`) and positional (codex) prompt modes
- Rename test file from `runtime-gemini-prompt.test.ts` to `runtime-prompt-mode.test.ts` to reflect broadened scope

Closes #1029

## Test plan

- [x] `model-contract.test.ts` — 20/20 passing (codex prompt mode, positional args, backward compat)
- [x] `runtime-prompt-mode.test.ts` — 5/5 passing (codex launch args, skip interactive send-keys)
- [x] TypeScript type check — zero errors
- [x] Verified in tmux: `codex --dangerously-bypass-approvals-and-sandbox '<prompt>'` correctly receives and executes the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)