### PR TITLE
fix(hooks): add skill-active-state lifecycle to prevent premature stops (#1033)

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -921,6 +921,18 @@ function processPreToolUse(input: HookInput): HookOutput {
     _notify.askUserQuestion(input.sessionId, directory, input.toolInput);
   }
 
+  // Activate skill state when Skill tool is invoked (issue #1033)
+  // This writes skill-active-state.json so the Stop hook can prevent premature
+  // session termination while a skill is executing.
+  if (input.toolName === "Skill") {
+    const skillName = getInvokedSkillName(input.toolInput);
+    if (skillName) {
+      import("./skill-state/index.js").then(({ writeSkillActiveState }) => {
+        writeSkillActiveState(directory, skillName, input.sessionId);
+      }).catch(() => {});
+    }
+  }
+
   // Notify when a new agent is spawned via Task tool (issue #761)
   // Fire-and-forget: verbosity filtering is handled inside notify()
   if (input.toolName === "Task" && input.sessionId) {

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -472,6 +472,16 @@ export function clearAllModeStates(cwd: string): boolean {
     }
   }
 
+  // Clear skill-active-state.json (issue #1033)
+  const skillStatePath = join(getStateDir(cwd), 'skill-active-state.json');
+  try {
+    if (existsSync(skillStatePath)) {
+      unlinkSync(skillStatePath);
+    }
+  } catch {
+    success = false;
+  }
+
   // Also clean up session directories
   try {
     const sessionIds = listSessionIds(cwd);

--- a/src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { checkPersistentModes } from '../index.js';
+
+function makeTempProject(): string {
+  const tempDir = mkdtempSync(join(tmpdir(), 'skill-stop-'));
+  execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+  return tempDir;
+}
+
+function writeSkillState(
+  tempDir: string,
+  sessionId: string,
+  skillName: string,
+  overrides: Record<string, unknown> = {}
+): void {
+  const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+  mkdirSync(stateDir, { recursive: true });
+
+  writeFileSync(
+    join(stateDir, 'skill-active-state.json'),
+    JSON.stringify(
+      {
+        active: true,
+        skill_name: skillName,
+        session_id: sessionId,
+        started_at: new Date().toISOString(),
+        last_checked_at: new Date().toISOString(),
+        reinforcement_count: 0,
+        max_reinforcements: 5,
+        stale_ttl_ms: 15 * 60 * 1000,
+        ...overrides,
+      },
+      null,
+      2
+    )
+  );
+}
+
+describe('persistent-mode skill-state stop integration (issue #1033)', () => {
+  it('blocks stop when a skill is actively executing', async () => {
+    const sessionId = 'session-skill-1033-block';
+    const tempDir = makeTempProject();
+
+    try {
+      writeSkillState(tempDir, sessionId, 'code-review');
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(true);
+      expect(result.message).toContain('code-review');
+      expect(result.message).toContain('SKILL ACTIVE');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows stop when no skill is active', async () => {
+    const sessionId = 'session-skill-1033-allow';
+    const tempDir = makeTempProject();
+
+    try {
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows stop when skill reinforcement limit is reached', async () => {
+    const sessionId = 'session-skill-1033-limit';
+    const tempDir = makeTempProject();
+
+    try {
+      writeSkillState(tempDir, sessionId, 'tdd', {
+        reinforcement_count: 3,
+        max_reinforcements: 3,
+      });
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows stop when skill state is stale', async () => {
+    const sessionId = 'session-skill-1033-stale';
+    const tempDir = makeTempProject();
+
+    try {
+      const past = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30 min ago
+      writeSkillState(tempDir, sessionId, 'analyze', {
+        started_at: past,
+        last_checked_at: past,
+        stale_ttl_ms: 5 * 60 * 1000, // 5 min TTL
+      });
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('respects session isolation for skill state', async () => {
+    const sessionId = 'session-skill-1033-iso-a';
+    const tempDir = makeTempProject();
+
+    try {
+      // Write skill state for a DIFFERENT session
+      writeSkillState(tempDir, 'session-skill-1033-iso-b', 'code-review');
+
+      // Check with our session - should not be blocked
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ralph takes priority over skill state', async () => {
+    const sessionId = 'session-skill-1033-ralph';
+    const tempDir = makeTempProject();
+
+    try {
+      // Write both ralph and skill state
+      const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(stateDir, { recursive: true });
+
+      writeFileSync(
+        join(stateDir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          iteration: 1,
+          max_iterations: 10,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          prompt: 'Test task',
+          session_id: sessionId,
+          project_path: tempDir,
+          linked_ultrawork: false,
+        }, null, 2)
+      );
+
+      writeSkillState(tempDir, sessionId, 'code-review');
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      // Ralph should take priority
+      expect(result.shouldBlock).toBe(true);
+      expect(result.mode).toBe('ralph');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not block on context-limit stops even with active skill', async () => {
+    const sessionId = 'session-skill-1033-ctx';
+    const tempDir = makeTempProject();
+
+    try {
+      writeSkillState(tempDir, sessionId, 'security-review');
+
+      const result = await checkPersistentModes(sessionId, tempDir, {
+        stop_reason: 'context_limit',
+      });
+      expect(result.shouldBlock).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not block on user abort even with active skill', async () => {
+    const sessionId = 'session-skill-1033-abort';
+    const tempDir = makeTempProject();
+
+    try {
+      writeSkillState(tempDir, sessionId, 'plan');
+
+      const result = await checkPersistentModes(sessionId, tempDir, {
+        user_requested: true,
+      });
+      expect(result.shouldBlock).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hooks/skill-state/__tests__/skill-state.test.ts
+++ b/src/hooks/skill-state/__tests__/skill-state.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import {
+  getSkillProtection,
+  getSkillConfig,
+  readSkillActiveState,
+  writeSkillActiveState,
+  clearSkillActiveState,
+  isSkillStateStale,
+  checkSkillActiveState,
+  type SkillActiveState,
+} from '../index.js';
+
+function makeTempDir(): string {
+  const tempDir = mkdtempSync(join(tmpdir(), 'skill-state-'));
+  execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+  return tempDir;
+}
+
+describe('skill-state', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // getSkillProtection
+  // -----------------------------------------------------------------------
+  describe('getSkillProtection', () => {
+    it('returns none for skills with dedicated mode state', () => {
+      expect(getSkillProtection('ralph')).toBe('none');
+      expect(getSkillProtection('autopilot')).toBe('none');
+      expect(getSkillProtection('team')).toBe('none');
+      expect(getSkillProtection('ultrawork')).toBe('none');
+      expect(getSkillProtection('cancel')).toBe('none');
+    });
+
+    it('returns none for instant/read-only skills', () => {
+      expect(getSkillProtection('trace')).toBe('none');
+      expect(getSkillProtection('hud')).toBe('none');
+      expect(getSkillProtection('omc-help')).toBe('none');
+      expect(getSkillProtection('omc-doctor')).toBe('none');
+    });
+
+    it('returns light for simple agent shortcuts', () => {
+      expect(getSkillProtection('tdd')).toBe('light');
+      expect(getSkillProtection('build-fix')).toBe('light');
+      expect(getSkillProtection('analyze')).toBe('light');
+    });
+
+    it('returns medium for review/planning skills', () => {
+      expect(getSkillProtection('code-review')).toBe('medium');
+      expect(getSkillProtection('security-review')).toBe('medium');
+      expect(getSkillProtection('plan')).toBe('medium');
+      expect(getSkillProtection('external-context')).toBe('medium');
+    });
+
+    it('returns heavy for long-running skills', () => {
+      expect(getSkillProtection('deepinit')).toBe('heavy');
+    });
+
+    it('defaults to light for unknown skills', () => {
+      expect(getSkillProtection('unknown-skill')).toBe('light');
+      expect(getSkillProtection('my-custom-skill')).toBe('light');
+    });
+
+    it('strips oh-my-claudecode: prefix', () => {
+      expect(getSkillProtection('oh-my-claudecode:code-review')).toBe('medium');
+      expect(getSkillProtection('oh-my-claudecode:ralph')).toBe('none');
+    });
+
+    it('is case-insensitive', () => {
+      expect(getSkillProtection('TDD')).toBe('light');
+      expect(getSkillProtection('Code-Review')).toBe('medium');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getSkillConfig
+  // -----------------------------------------------------------------------
+  describe('getSkillConfig', () => {
+    it('returns correct config for light protection', () => {
+      const config = getSkillConfig('tdd');
+      expect(config.maxReinforcements).toBe(3);
+      expect(config.staleTtlMs).toBe(5 * 60 * 1000);
+    });
+
+    it('returns correct config for medium protection', () => {
+      const config = getSkillConfig('code-review');
+      expect(config.maxReinforcements).toBe(5);
+      expect(config.staleTtlMs).toBe(15 * 60 * 1000);
+    });
+
+    it('returns correct config for heavy protection', () => {
+      const config = getSkillConfig('deepinit');
+      expect(config.maxReinforcements).toBe(10);
+      expect(config.staleTtlMs).toBe(30 * 60 * 1000);
+    });
+
+    it('returns zero config for none protection', () => {
+      const config = getSkillConfig('ralph');
+      expect(config.maxReinforcements).toBe(0);
+      expect(config.staleTtlMs).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // writeSkillActiveState
+  // -----------------------------------------------------------------------
+  describe('writeSkillActiveState', () => {
+    it('writes state file for protected skills', () => {
+      const state = writeSkillActiveState(tempDir, 'code-review', 'session-1');
+      expect(state).not.toBeNull();
+      expect(state!.active).toBe(true);
+      expect(state!.skill_name).toBe('code-review');
+      expect(state!.session_id).toBe('session-1');
+      expect(state!.reinforcement_count).toBe(0);
+      expect(state!.max_reinforcements).toBe(5);
+    });
+
+    it('returns null for skills with none protection', () => {
+      const state = writeSkillActiveState(tempDir, 'ralph', 'session-1');
+      expect(state).toBeNull();
+    });
+
+    it('creates state file on disk', () => {
+      writeSkillActiveState(tempDir, 'tdd', 'session-1');
+      const stateDir = join(tempDir, '.omc', 'state', 'sessions', 'session-1');
+      const files = existsSync(stateDir);
+      expect(files).toBe(true);
+    });
+
+    it('strips namespace prefix from skill name', () => {
+      const state = writeSkillActiveState(tempDir, 'oh-my-claudecode:code-review', 'session-1');
+      expect(state!.skill_name).toBe('code-review');
+    });
+
+    it('overwrites existing state when new skill is invoked', () => {
+      writeSkillActiveState(tempDir, 'code-review', 'session-1');
+      const state2 = writeSkillActiveState(tempDir, 'security-review', 'session-1');
+      expect(state2!.skill_name).toBe('security-review');
+
+      const readBack = readSkillActiveState(tempDir, 'session-1');
+      expect(readBack!.skill_name).toBe('security-review');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // readSkillActiveState
+  // -----------------------------------------------------------------------
+  describe('readSkillActiveState', () => {
+    it('returns null when no state exists', () => {
+      expect(readSkillActiveState(tempDir, 'session-1')).toBeNull();
+    });
+
+    it('reads written state correctly', () => {
+      writeSkillActiveState(tempDir, 'plan', 'session-1');
+      const state = readSkillActiveState(tempDir, 'session-1');
+      expect(state).not.toBeNull();
+      expect(state!.skill_name).toBe('plan');
+      expect(state!.active).toBe(true);
+    });
+
+    it('returns null for invalid JSON', () => {
+      const stateDir = join(tempDir, '.omc', 'state', 'sessions', 'session-1');
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(join(stateDir, 'skill-active-state.json'), 'not json');
+      expect(readSkillActiveState(tempDir, 'session-1')).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // clearSkillActiveState
+  // -----------------------------------------------------------------------
+  describe('clearSkillActiveState', () => {
+    it('removes the state file', () => {
+      writeSkillActiveState(tempDir, 'tdd', 'session-1');
+      expect(readSkillActiveState(tempDir, 'session-1')).not.toBeNull();
+
+      clearSkillActiveState(tempDir, 'session-1');
+      expect(readSkillActiveState(tempDir, 'session-1')).toBeNull();
+    });
+
+    it('returns true when no state exists', () => {
+      expect(clearSkillActiveState(tempDir, 'session-1')).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // isSkillStateStale
+  // -----------------------------------------------------------------------
+  describe('isSkillStateStale', () => {
+    it('returns false for fresh state', () => {
+      const state: SkillActiveState = {
+        active: true,
+        skill_name: 'tdd',
+        started_at: new Date().toISOString(),
+        last_checked_at: new Date().toISOString(),
+        reinforcement_count: 0,
+        max_reinforcements: 3,
+        stale_ttl_ms: 5 * 60 * 1000,
+      };
+      expect(isSkillStateStale(state)).toBe(false);
+    });
+
+    it('returns true for inactive state', () => {
+      const state: SkillActiveState = {
+        active: false,
+        skill_name: 'tdd',
+        started_at: new Date().toISOString(),
+        last_checked_at: new Date().toISOString(),
+        reinforcement_count: 0,
+        max_reinforcements: 3,
+        stale_ttl_ms: 5 * 60 * 1000,
+      };
+      expect(isSkillStateStale(state)).toBe(true);
+    });
+
+    it('returns true when TTL is exceeded', () => {
+      const past = new Date(Date.now() - 10 * 60 * 1000).toISOString(); // 10 min ago
+      const state: SkillActiveState = {
+        active: true,
+        skill_name: 'tdd',
+        started_at: past,
+        last_checked_at: past,
+        reinforcement_count: 0,
+        max_reinforcements: 3,
+        stale_ttl_ms: 5 * 60 * 1000, // 5 min TTL
+      };
+      expect(isSkillStateStale(state)).toBe(true);
+    });
+
+    it('uses last_checked_at over started_at when more recent', () => {
+      const past = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+      const recent = new Date().toISOString();
+      const state: SkillActiveState = {
+        active: true,
+        skill_name: 'code-review',
+        started_at: past,
+        last_checked_at: recent,
+        reinforcement_count: 2,
+        max_reinforcements: 5,
+        stale_ttl_ms: 5 * 60 * 1000,
+      };
+      expect(isSkillStateStale(state)).toBe(false);
+    });
+
+    it('returns true when no timestamps are available', () => {
+      const state: SkillActiveState = {
+        active: true,
+        skill_name: 'tdd',
+        started_at: '',
+        last_checked_at: '',
+        reinforcement_count: 0,
+        max_reinforcements: 3,
+        stale_ttl_ms: 5 * 60 * 1000,
+      };
+      expect(isSkillStateStale(state)).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // checkSkillActiveState (Stop hook integration)
+  // -----------------------------------------------------------------------
+  describe('checkSkillActiveState', () => {
+    it('returns shouldBlock=false when no state exists', () => {
+      const result = checkSkillActiveState(tempDir, 'session-1');
+      expect(result.shouldBlock).toBe(false);
+    });
+
+    it('blocks stop when skill is active within reinforcement limit', () => {
+      writeSkillActiveState(tempDir, 'code-review', 'session-1');
+      const result = checkSkillActiveState(tempDir, 'session-1');
+      expect(result.shouldBlock).toBe(true);
+      expect(result.message).toContain('code-review');
+      expect(result.skillName).toBe('code-review');
+    });
+
+    it('increments reinforcement count on each check', () => {
+      writeSkillActiveState(tempDir, 'tdd', 'session-1');
+
+      checkSkillActiveState(tempDir, 'session-1'); // count → 1
+      checkSkillActiveState(tempDir, 'session-1'); // count → 2
+
+      const state = readSkillActiveState(tempDir, 'session-1');
+      expect(state!.reinforcement_count).toBe(2);
+    });
+
+    it('allows stop when reinforcement limit is reached', () => {
+      writeSkillActiveState(tempDir, 'tdd', 'session-1'); // max_reinforcements = 3
+
+      checkSkillActiveState(tempDir, 'session-1'); // 1
+      checkSkillActiveState(tempDir, 'session-1'); // 2
+      checkSkillActiveState(tempDir, 'session-1'); // 3
+
+      // 4th check should allow stop (3 >= 3)
+      const result = checkSkillActiveState(tempDir, 'session-1');
+      expect(result.shouldBlock).toBe(false);
+    });
+
+    it('clears state when reinforcement limit is reached', () => {
+      writeSkillActiveState(tempDir, 'tdd', 'session-1');
+
+      for (let i = 0; i < 3; i++) {
+        checkSkillActiveState(tempDir, 'session-1');
+      }
+
+      // State should be cleared
+      checkSkillActiveState(tempDir, 'session-1'); // triggers clear
+      expect(readSkillActiveState(tempDir, 'session-1')).toBeNull();
+    });
+
+    it('respects session isolation', () => {
+      writeSkillActiveState(tempDir, 'code-review', 'session-1');
+
+      // Different session should not be blocked
+      const result = checkSkillActiveState(tempDir, 'session-2');
+      expect(result.shouldBlock).toBe(false);
+    });
+
+    it('clears stale state and allows stop', () => {
+      writeSkillActiveState(tempDir, 'tdd', 'session-1');
+
+      // Manually make the state stale
+      const state = readSkillActiveState(tempDir, 'session-1')!;
+      const past = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+      state.started_at = past;
+      state.last_checked_at = past;
+      const statePath = join(tempDir, '.omc', 'state', 'sessions', 'session-1', 'skill-active-state.json');
+      writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+      const result = checkSkillActiveState(tempDir, 'session-1');
+      expect(result.shouldBlock).toBe(false);
+      // State should be cleaned up
+      expect(readSkillActiveState(tempDir, 'session-1')).toBeNull();
+    });
+
+    it('includes skill name in blocking message', () => {
+      writeSkillActiveState(tempDir, 'security-review', 'session-1');
+      const result = checkSkillActiveState(tempDir, 'session-1');
+      expect(result.message).toContain('security-review');
+      expect(result.message).toContain('SKILL ACTIVE');
+    });
+
+    it('works without session ID (legacy path)', () => {
+      writeSkillActiveState(tempDir, 'analyze');
+      const result = checkSkillActiveState(tempDir);
+      expect(result.shouldBlock).toBe(true);
+      expect(result.skillName).toBe('analyze');
+    });
+  });
+});

--- a/src/hooks/skill-state/index.ts
+++ b/src/hooks/skill-state/index.ts
@@ -1,0 +1,310 @@
+/**
+ * Skill Active State Management
+ *
+ * Tracks when a skill is actively executing so the persistent-mode Stop hook
+ * can prevent premature session termination.
+ *
+ * Skills like code-review, plan, tdd, analyze, build-fix, security-review,
+ * external-context, deepinit etc. don't write mode state files (ralph-state.json,
+ * etc.), so the Stop hook previously had no way to know they were running.
+ *
+ * This module provides:
+ * 1. A protection level registry for all skills (none/light/medium/heavy)
+ * 2. Read/write/clear functions for skill-active-state.json
+ * 3. A check function for the Stop hook to determine if blocking is needed
+ *
+ * Fix for: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/1033
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { join, dirname } from 'path';
+import { resolveSessionStatePath } from '../../lib/worktree-paths.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SkillProtectionLevel = 'none' | 'light' | 'medium' | 'heavy';
+
+export interface SkillStateConfig {
+  /** Max stop-hook reinforcements before allowing stop */
+  maxReinforcements: number;
+  /** Time-to-live in ms before state is considered stale */
+  staleTtlMs: number;
+}
+
+export interface SkillActiveState {
+  active: boolean;
+  skill_name: string;
+  session_id?: string;
+  started_at: string;
+  last_checked_at: string;
+  reinforcement_count: number;
+  max_reinforcements: number;
+  stale_ttl_ms: number;
+}
+
+// ---------------------------------------------------------------------------
+// Protection configuration per level
+// ---------------------------------------------------------------------------
+
+const PROTECTION_CONFIGS: Record<SkillProtectionLevel, SkillStateConfig> = {
+  none: { maxReinforcements: 0, staleTtlMs: 0 },
+  light: { maxReinforcements: 3, staleTtlMs: 5 * 60 * 1000 },      // 5 min
+  medium: { maxReinforcements: 5, staleTtlMs: 15 * 60 * 1000 },     // 15 min
+  heavy: { maxReinforcements: 10, staleTtlMs: 30 * 60 * 1000 },     // 30 min
+};
+
+// ---------------------------------------------------------------------------
+// Skill → protection level mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps each skill name to its protection level.
+ *
+ * - 'none': Already has dedicated mode state (ralph, autopilot, etc.) or is
+ *   instant/read-only (trace, hud, omc-help, etc.)
+ * - 'light': Quick agent shortcuts (tdd, build-fix, analyze)
+ * - 'medium': Review/planning skills that run multiple agents
+ * - 'heavy': Long-running skills (deepinit, omc-setup)
+ */
+const SKILL_PROTECTION: Record<string, SkillProtectionLevel> = {
+  // === Already have mode state → no additional protection ===
+  autopilot: 'none',
+  ralph: 'none',
+  ultrawork: 'none',
+  ultrapilot: 'none',
+  team: 'none',
+  'omc-teams': 'none',
+  ultraqa: 'none',
+  pipeline: 'none',
+  cancel: 'none',
+
+  // === Instant / read-only → no protection needed ===
+  trace: 'none',
+  hud: 'none',
+  'omc-doctor': 'none',
+  'omc-help': 'none',
+  'learn-about-omc': 'none',
+  note: 'none',
+
+  // === Light protection (simple agent shortcuts, 3 reinforcements) ===
+  tdd: 'light',
+  'build-fix': 'light',
+  analyze: 'light',
+  skill: 'light',
+  'configure-notifications': 'light',
+
+  // === Medium protection (review/planning, 5 reinforcements) ===
+  'code-review': 'medium',
+  'security-review': 'medium',
+  plan: 'medium',
+  ralplan: 'medium',
+  review: 'medium',
+  'external-context': 'medium',
+  sciomc: 'medium',
+  learner: 'medium',
+  'omc-setup': 'medium',
+  'mcp-setup': 'medium',
+  'project-session-manager': 'medium',
+  'writer-memory': 'medium',
+  'ralph-init': 'medium',
+  ccg: 'medium',
+
+  // === Heavy protection (long-running, 10 reinforcements) ===
+  deepinit: 'heavy',
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the protection level for a skill.
+ * Unknown skills default to 'light' for safety.
+ */
+export function getSkillProtection(skillName: string): SkillProtectionLevel {
+  const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, '');
+  return SKILL_PROTECTION[normalized] ?? 'light';
+}
+
+/**
+ * Get the protection config for a skill.
+ */
+export function getSkillConfig(skillName: string): SkillStateConfig {
+  return PROTECTION_CONFIGS[getSkillProtection(skillName)];
+}
+
+/**
+ * Resolve the path to skill-active-state.json.
+ * Uses session-scoped path when sessionId is provided.
+ */
+export function getSkillStatePath(directory: string, sessionId?: string): string {
+  if (sessionId) {
+    return resolveSessionStatePath('skill-active', sessionId, directory);
+  }
+  return join(directory, '.omc', 'state', 'skill-active-state.json');
+}
+
+/**
+ * Read the current skill active state.
+ * Returns null if no state exists or state is invalid.
+ */
+export function readSkillActiveState(
+  directory: string,
+  sessionId?: string
+): SkillActiveState | null {
+  const statePath = getSkillStatePath(directory, sessionId);
+
+  try {
+    if (!existsSync(statePath)) {
+      return null;
+    }
+    const content = readFileSync(statePath, 'utf-8');
+    const state = JSON.parse(content) as SkillActiveState;
+
+    if (!state || typeof state.active !== 'boolean') {
+      return null;
+    }
+
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write skill active state.
+ * Called when a skill is invoked via the Skill tool.
+ */
+export function writeSkillActiveState(
+  directory: string,
+  skillName: string,
+  sessionId?: string
+): SkillActiveState | null {
+  const protection = getSkillProtection(skillName);
+
+  // Skills with 'none' protection don't need state tracking
+  if (protection === 'none') {
+    return null;
+  }
+
+  const config = PROTECTION_CONFIGS[protection];
+  const now = new Date().toISOString();
+  const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, '');
+
+  const state: SkillActiveState = {
+    active: true,
+    skill_name: normalized,
+    session_id: sessionId,
+    started_at: now,
+    last_checked_at: now,
+    reinforcement_count: 0,
+    max_reinforcements: config.maxReinforcements,
+    stale_ttl_ms: config.staleTtlMs,
+  };
+
+  const statePath = getSkillStatePath(directory, sessionId);
+
+  try {
+    const dir = dirname(statePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(statePath, JSON.stringify(state, null, 2));
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clear skill active state.
+ * Called when a skill completes or is cancelled.
+ */
+export function clearSkillActiveState(directory: string, sessionId?: string): boolean {
+  const statePath = getSkillStatePath(directory, sessionId);
+
+  try {
+    if (existsSync(statePath)) {
+      unlinkSync(statePath);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if the skill state is stale (exceeded its TTL).
+ */
+export function isSkillStateStale(state: SkillActiveState): boolean {
+  if (!state.active) return true;
+
+  const lastChecked = state.last_checked_at
+    ? new Date(state.last_checked_at).getTime()
+    : 0;
+  const startedAt = state.started_at
+    ? new Date(state.started_at).getTime()
+    : 0;
+  const mostRecent = Math.max(lastChecked, startedAt);
+
+  if (mostRecent === 0) return true;
+
+  const age = Date.now() - mostRecent;
+  return age > (state.stale_ttl_ms || 5 * 60 * 1000);
+}
+
+/**
+ * Check skill active state for the Stop hook.
+ * Returns blocking decision with continuation message.
+ *
+ * Called by checkPersistentModes() in the persistent-mode hook.
+ */
+export function checkSkillActiveState(
+  directory: string,
+  sessionId?: string
+): { shouldBlock: boolean; message: string; skillName?: string } {
+  const state = readSkillActiveState(directory, sessionId);
+
+  if (!state || !state.active) {
+    return { shouldBlock: false, message: '' };
+  }
+
+  // Session isolation
+  if (sessionId && state.session_id && state.session_id !== sessionId) {
+    return { shouldBlock: false, message: '' };
+  }
+
+  // Staleness check
+  if (isSkillStateStale(state)) {
+    clearSkillActiveState(directory, sessionId);
+    return { shouldBlock: false, message: '' };
+  }
+
+  // Reinforcement limit check
+  if (state.reinforcement_count >= state.max_reinforcements) {
+    clearSkillActiveState(directory, sessionId);
+    return { shouldBlock: false, message: '' };
+  }
+
+  // Block the stop and increment reinforcement count
+  state.reinforcement_count += 1;
+  state.last_checked_at = new Date().toISOString();
+
+  const statePath = getSkillStatePath(directory, sessionId);
+  try {
+    writeFileSync(statePath, JSON.stringify(state, null, 2));
+  } catch {
+    // If we can't write, don't block
+    return { shouldBlock: false, message: '' };
+  }
+
+  const message = `[SKILL ACTIVE: ${state.skill_name}] The "${state.skill_name}" skill is still executing (reinforcement ${state.reinforcement_count}/${state.max_reinforcements}). Continue working on the skill's instructions. Do not stop until the skill completes its workflow.`;
+
+  return {
+    shouldBlock: true,
+    message,
+    skillName: state.skill_name,
+  };
+}


### PR DESCRIPTION
## Summary

- Fixes session stopping prematurely after tool calls when no persistent mode is active
- The persistent-mode Stop hook only checked 8 explicit mode state files (ralph, autopilot, ultrapilot, swarm, ultrawork, ultraqa, pipeline, team)
- Skills like code-review, plan, tdd, analyze, build-fix, security-review, external-context, deepinit etc. had **no state file**, so the stop hook allowed session termination mid-skill

## Changes

### New: `src/hooks/skill-state/index.ts`
- Protection level registry mapping all 30+ skills to `none` / `light` / `medium` / `heavy`
- `none`: Skills with dedicated mode state (ralph, autopilot, etc.) or instant/read-only (trace, hud)
- `light`: 3 reinforcements, 5 min TTL (tdd, build-fix, analyze)
- `medium`: 5 reinforcements, 15 min TTL (code-review, plan, security-review, external-context)
- `heavy`: 10 reinforcements, 30 min TTL (deepinit)
- Unknown skills default to `light` for safety
- Full read/write/clear lifecycle with session isolation and staleness detection

### Modified: `src/hooks/bridge.ts`
- PreToolUse for Skill tool writes `skill-active-state.json` when a skill is invoked

### Modified: `src/hooks/persistent-mode/index.ts`
- `checkPersistentModes()` now checks skill state as Priority 3 (after ultrawork, before "no blocking")

### Modified: `templates/hooks/persistent-mode.mjs`
- Runtime Stop hook checks `skill-active-state.json` as Priority 9 (after all mode checks)
- Includes `isStaleSkillState()` helper with per-skill TTL

### Modified: `src/hooks/mode-registry/index.ts`
- `clearAllModeStates()` now clears `skill-active-state.json` on force cancel

### Tests: 44 new tests
- `src/hooks/skill-state/__tests__/skill-state.test.ts` — 36 unit tests
- `src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts` — 8 integration tests

## Test plan

- [x] 414 existing tests pass (zero regressions)
- [x] 44 new tests pass covering:
  - Protection level registry for all skill categories
  - Namespace prefix stripping and case-insensitivity
  - Write/read/clear round-trip with session isolation
  - Staleness detection with per-skill TTL
  - Reinforcement counting and limit expiry
  - Stop hook blocks on active skill, allows on stale/limit/context-limit/user-abort
  - Ralph priority over skill state
- [x] TypeScript compiles with zero errors
- [x] Build succeeds

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)