### PR TITLE
fix(launch): remove terminal-overrides regression (#1041)

### DIFF
--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -276,15 +276,15 @@ describe('runClaude outside-tmux — mouse scrolling (issue #890)', () => {
     expect(tmuxArgs).not.toContain('-g');
   });
 
-  it('sets terminal-overrides to disable alternate screen so scroll works in TUI', () => {
+  it('does not set terminal-overrides in tmux args', () => {
     runClaude('/tmp', [], 'sid');
 
     const calls = vi.mocked(execFileSync).mock.calls;
     const tmuxCall = calls.find(([cmd]) => cmd === 'tmux');
     const tmuxArgs = tmuxCall![1] as string[];
 
-    expect(tmuxArgs).toContain('terminal-overrides');
-    expect(tmuxArgs).toContain('*:smcup@:rmcup@');
+    expect(tmuxArgs).not.toContain('terminal-overrides');
+    expect(tmuxArgs).not.toContain('*:smcup@:rmcup@');
   });
 
   it('places mouse mode setup before attach-session', () => {
@@ -319,20 +319,18 @@ describe('runClaude inside-tmux — mouse configuration (issue #890)', () => {
     processExitSpy.mockRestore();
   });
 
-  it('enables mouse mode and terminal-overrides before launching claude', () => {
+  it('enables mouse mode before launching claude', () => {
     runClaude('/tmp', [], 'sid');
 
     const calls = vi.mocked(execFileSync).mock.calls;
 
-    // First two calls should be tmux set-option for mouse config
-    expect(calls.length).toBeGreaterThanOrEqual(3);
+    // First call should be tmux set-option for mouse config
+    expect(calls.length).toBeGreaterThanOrEqual(2);
     expect(calls[0][0]).toBe('tmux');
     expect(calls[0][1]).toEqual(['set-option', 'mouse', 'on']);
-    expect(calls[1][0]).toBe('tmux');
-    expect(calls[1][1]).toEqual(['set-option', 'terminal-overrides', '*:smcup@:rmcup@']);
 
-    // Third call should be claude
-    expect(calls[2][0]).toBe('claude');
+    // Second call should be claude
+    expect(calls[1][0]).toBe('claude');
   });
 
   it('still launches claude even if tmux mouse config fails', () => {

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -270,7 +270,6 @@ function runClaudeInsideTmux(cwd: string, args: string[]): void {
   // Enable mouse scrolling in the current tmux session (non-fatal if it fails)
   try {
     execFileSync('tmux', ['set-option', 'mouse', 'on'], { stdio: 'ignore' });
-    execFileSync('tmux', ['set-option', 'terminal-overrides', '*:smcup@:rmcup@'], { stdio: 'ignore' });
   } catch { /* non-fatal — user's tmux may not support these options */ }
 
   // Launch Claude in current pane
@@ -304,7 +303,6 @@ function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string): 
     'new-session', '-d', '-s', sessionName, '-c', cwd,
     claudeCmd,
     ';', 'set-option', '-t', sessionName, 'mouse', 'on',
-    ';', 'set-option', '-t', sessionName, 'terminal-overrides', '*:smcup@:rmcup@',
   ];
 
   // Attach to session


### PR DESCRIPTION
## Summary
- Re-applies PR #1020 fix that was overwritten by PR #1024
- Removes terminal-overrides smcup@/rmcup@ that cause Ink TUI rendering corruption in tmux

## Test plan
- [x] launch.test.ts passes
- [x] Verified lines 273 and 307 no longer contain terminal-overrides

Fixes #1041