### PR TITLE
fix(notifications): add null guard to resolveEventTemplate (#1043)

### DIFF
--- a/src/notifications/__tests__/hook-config.test.ts
+++ b/src/notifications/__tests__/hook-config.test.ts
@@ -152,6 +152,10 @@ describe("hook-config reader", () => {
       );
     });
 
+    it("returns null when hookConfig is null", () => {
+      expect(resolveEventTemplate(null as any, "session-start", "discord")).toBeNull();
+    });
+
     it("returns event template when no platform override", () => {
       expect(resolveEventTemplate(baseConfig, "session-end", "slack")).toBe(
         "Event: {{duration}}",

--- a/src/notifications/hook-config.ts
+++ b/src/notifications/hook-config.ts
@@ -65,10 +65,12 @@ export function resetHookConfigCache(): void {
  * Cascade: platform override > event template > defaultTemplate > null
  */
 export function resolveEventTemplate(
-  hookConfig: HookNotificationConfig,
+  hookConfig: HookNotificationConfig | null,
   event: NotificationEvent,
   platform: NotificationPlatform,
 ): string | null {
+  if (!hookConfig) return null;
+
   const eventConfig = hookConfig.events?.[event];
 
   if (eventConfig) {


### PR DESCRIPTION
## Summary
- Widened hookConfig parameter type to HookNotificationConfig | null
- Added early return null guard
- Added test case for null input

## Test plan
- [x] hook-config.test.ts passes
- [x] New test validates null input returns null

Fixes #1043