### PR TITLE
fix(cli): platform flag defaults should not override env vars (#1042)

### DIFF
--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -356,9 +356,9 @@ describe('runClaude inside-tmux — mouse configuration (issue #890)', () => {
 // extractTelegramFlag
 // ---------------------------------------------------------------------------
 describe('extractTelegramFlag', () => {
-  it('returns telegramEnabled=false when --telegram flag is not present', () => {
+  it('returns telegramEnabled=undefined when --telegram flag is not present', () => {
     const result = extractTelegramFlag(['--madmax']);
-    expect(result.telegramEnabled).toBe(false);
+    expect(result.telegramEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual(['--madmax']);
   });
 
@@ -404,9 +404,9 @@ describe('extractTelegramFlag', () => {
     expect(result.remainingArgs).toEqual(['myfile.txt']);
   });
 
-  it('returns telegramEnabled=false for empty args', () => {
+  it('returns telegramEnabled=undefined for empty args', () => {
     const result = extractTelegramFlag([]);
-    expect(result.telegramEnabled).toBe(false);
+    expect(result.telegramEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual([]);
   });
 
@@ -421,9 +421,9 @@ describe('extractTelegramFlag', () => {
 // extractDiscordFlag
 // ---------------------------------------------------------------------------
 describe('extractDiscordFlag', () => {
-  it('returns discordEnabled=false when --discord flag is not present', () => {
+  it('returns discordEnabled=undefined when --discord flag is not present', () => {
     const result = extractDiscordFlag(['--madmax']);
-    expect(result.discordEnabled).toBe(false);
+    expect(result.discordEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual(['--madmax']);
   });
 
@@ -469,9 +469,9 @@ describe('extractDiscordFlag', () => {
     expect(result.remainingArgs).toEqual(['myfile.txt']);
   });
 
-  it('returns discordEnabled=false for empty args', () => {
+  it('returns discordEnabled=undefined for empty args', () => {
     const result = extractDiscordFlag([]);
-    expect(result.discordEnabled).toBe(false);
+    expect(result.discordEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual([]);
   });
 
@@ -557,9 +557,9 @@ describe('extractOpenClawFlag', () => {
 // extractSlackFlag
 // ---------------------------------------------------------------------------
 describe('extractSlackFlag', () => {
-  it('returns slackEnabled=false when --slack flag is not present', () => {
+  it('returns slackEnabled=undefined when --slack flag is not present', () => {
     const result = extractSlackFlag(['--madmax']);
-    expect(result.slackEnabled).toBe(false);
+    expect(result.slackEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual(['--madmax']);
   });
 
@@ -601,9 +601,9 @@ describe('extractSlackFlag', () => {
     expect(result.remainingArgs).toEqual(['myfile.txt']);
   });
 
-  it('returns slackEnabled=false for empty args', () => {
+  it('returns slackEnabled=undefined for empty args', () => {
     const result = extractSlackFlag([]);
-    expect(result.slackEnabled).toBe(false);
+    expect(result.slackEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual([]);
   });
 });
@@ -612,9 +612,9 @@ describe('extractSlackFlag', () => {
 // extractWebhookFlag
 // ---------------------------------------------------------------------------
 describe('extractWebhookFlag', () => {
-  it('returns webhookEnabled=false when --webhook flag is not present', () => {
+  it('returns webhookEnabled=undefined when --webhook flag is not present', () => {
     const result = extractWebhookFlag(['--madmax']);
-    expect(result.webhookEnabled).toBe(false);
+    expect(result.webhookEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual(['--madmax']);
   });
 
@@ -656,9 +656,9 @@ describe('extractWebhookFlag', () => {
     expect(result.remainingArgs).toEqual(['myfile.txt']);
   });
 
-  it('returns webhookEnabled=false for empty args', () => {
+  it('returns webhookEnabled=undefined for empty args', () => {
     const result = extractWebhookFlag([]);
-    expect(result.webhookEnabled).toBe(false);
+    expect(result.webhookEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual([]);
   });
 });
@@ -757,6 +757,20 @@ describe('launchCommand — env var propagation', () => {
     process.env.OMC_TELEGRAM = '1';
     await launchCommand(['--telegram=0']);
     expect(process.env.OMC_TELEGRAM).toBe('0');
+  });
+
+  it('preserves inherited platform env vars when no platform flags are passed', async () => {
+    process.env.OMC_TELEGRAM = '1';
+    process.env.OMC_DISCORD = '1';
+    process.env.OMC_SLACK = '1';
+    process.env.OMC_WEBHOOK = '1';
+
+    await launchCommand(['--print']);
+
+    expect(process.env.OMC_TELEGRAM).toBe('1');
+    expect(process.env.OMC_DISCORD).toBe('1');
+    expect(process.env.OMC_SLACK).toBe('1');
+    expect(process.env.OMC_WEBHOOK).toBe('1');
   });
 
   it('OMC flags are stripped from args passed to Claude', async () => {

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -96,8 +96,8 @@ export function extractOpenClawFlag(args: string[]): { openclawEnabled: boolean;
  * Does NOT consume the next positional arg (no space-separated value).
  * This flag is stripped before passing args to Claude CLI.
  */
-export function extractTelegramFlag(args: string[]): { telegramEnabled: boolean; remainingArgs: string[] } {
-  let telegramEnabled = false;
+export function extractTelegramFlag(args: string[]): { telegramEnabled: boolean | undefined; remainingArgs: string[] } {
+  let telegramEnabled: boolean | undefined = undefined;
   const remainingArgs: string[] = [];
   for (const arg of args) {
     if (arg === TELEGRAM_FLAG) { telegramEnabled = true; continue; }
@@ -123,8 +123,8 @@ export function extractTelegramFlag(args: string[]): { telegramEnabled: boolean;
  * Does NOT consume the next positional arg (no space-separated value).
  * This flag is stripped before passing args to Claude CLI.
  */
-export function extractDiscordFlag(args: string[]): { discordEnabled: boolean; remainingArgs: string[] } {
-  let discordEnabled = false;
+export function extractDiscordFlag(args: string[]): { discordEnabled: boolean | undefined; remainingArgs: string[] } {
+  let discordEnabled: boolean | undefined = undefined;
   const remainingArgs: string[] = [];
   for (const arg of args) {
     if (arg === DISCORD_FLAG) { discordEnabled = true; continue; }
@@ -150,8 +150,8 @@ export function extractDiscordFlag(args: string[]): { discordEnabled: boolean; r
  * Does NOT consume the next positional arg (no space-separated value).
  * This flag is stripped before passing args to Claude CLI.
  */
-export function extractSlackFlag(args: string[]): { slackEnabled: boolean; remainingArgs: string[] } {
-  let slackEnabled = false;
+export function extractSlackFlag(args: string[]): { slackEnabled: boolean | undefined; remainingArgs: string[] } {
+  let slackEnabled: boolean | undefined = undefined;
   const remainingArgs: string[] = [];
   for (const arg of args) {
     if (arg === SLACK_FLAG) { slackEnabled = true; continue; }
@@ -177,8 +177,8 @@ export function extractSlackFlag(args: string[]): { slackEnabled: boolean; remai
  * Does NOT consume the next positional arg (no space-separated value).
  * This flag is stripped before passing args to Claude CLI.
  */
-export function extractWebhookFlag(args: string[]): { webhookEnabled: boolean; remainingArgs: string[] } {
-  let webhookEnabled = false;
+export function extractWebhookFlag(args: string[]): { webhookEnabled: boolean | undefined; remainingArgs: string[] } {
+  let webhookEnabled: boolean | undefined = undefined;
   const remainingArgs: string[] = [];
   for (const arg of args) {
     if (arg === WEBHOOK_FLAG) { webhookEnabled = true; continue; }


### PR DESCRIPTION
## Summary
- Changed extract*Flag return types from boolean to boolean | undefined
- When flag is absent, returns undefined instead of false
- launchCommand only sets OMC_* env vars when flag is explicitly passed
- Allows env-var-only notification activation

## Test plan
- [x] launch.test.ts passes
- [x] Absent flag returns undefined (not false)
- [x] Explicit --flag=false still sets OMC_*=0

Fixes #1042