### PR TITLE
fix(setup): replace BSD-incompatible sed with portable awk in omc-setup

### DIFF
--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -226,8 +226,8 @@ fi
 
 # Strip existing markers from downloaded content (idempotency)
 if grep -q '<!-- OMC:START -->' "$TEMP_OMC"; then
-  # Extract content between markers
-  sed -n '/<!-- OMC:START -->/,/<!-- OMC:END -->/{//!p}' "$TEMP_OMC" > "${TEMP_OMC}.clean"
+  # Extract content between markers (awk is portable across GNU/BSD)
+  awk '/<!-- OMC:END -->/{p=0} p; /<!-- OMC:START -->/{p=1}' "$TEMP_OMC" > "${TEMP_OMC}.clean"
   mv "${TEMP_OMC}.clean" "$TEMP_OMC"
 fi
 
@@ -244,8 +244,9 @@ else
   # Merge: preserve user content outside OMC markers
   if grep -q '<!-- OMC:START -->' "$TARGET_PATH"; then
     # Has markers: replace OMC section, keep user content
-    BEFORE_OMC=$(sed -n '1,/<!-- OMC:START -->/{ /<!-- OMC:START -->/!p }' "$TARGET_PATH")
-    AFTER_OMC=$(sed -n '/<!-- OMC:END -->/,${  /<!-- OMC:END -->/!p }' "$TARGET_PATH")
+    # Use awk instead of sed for cross-platform compatibility (GNU/BSD)
+    BEFORE_OMC=$(awk '/<!-- OMC:START -->/{exit} {print}' "$TARGET_PATH")
+    AFTER_OMC=$(awk 'p; /<!-- OMC:END -->/{p=1}' "$TARGET_PATH")
     {
       [ -n "$BEFORE_OMC" ] && printf '%s\n' "$BEFORE_OMC"
       echo '<!-- OMC:START -->'
@@ -365,8 +366,8 @@ fi
 
 # Strip existing markers from downloaded content (idempotency)
 if grep -q '<!-- OMC:START -->' "$TEMP_OMC"; then
-  # Extract content between markers
-  sed -n '/<!-- OMC:START -->/,/<!-- OMC:END -->/{//!p}' "$TEMP_OMC" > "${TEMP_OMC}.clean"
+  # Extract content between markers (awk is portable across GNU/BSD)
+  awk '/<!-- OMC:END -->/{p=0} p; /<!-- OMC:START -->/{p=1}' "$TEMP_OMC" > "${TEMP_OMC}.clean"
   mv "${TEMP_OMC}.clean" "$TEMP_OMC"
 fi
 
@@ -383,8 +384,9 @@ else
   # Merge: preserve user content outside OMC markers
   if grep -q '<!-- OMC:START -->' "$TARGET_PATH"; then
     # Has markers: replace OMC section, keep user content
-    BEFORE_OMC=$(sed -n '1,/<!-- OMC:START -->/{ /<!-- OMC:START -->/!p }' "$TARGET_PATH")
-    AFTER_OMC=$(sed -n '/<!-- OMC:END -->/,${  /<!-- OMC:END -->/!p }' "$TARGET_PATH")
+    # Use awk instead of sed for cross-platform compatibility (GNU/BSD)
+    BEFORE_OMC=$(awk '/<!-- OMC:START -->/{exit} {print}' "$TARGET_PATH")
+    AFTER_OMC=$(awk 'p; /<!-- OMC:END -->/{p=1}' "$TARGET_PATH")
     {
       [ -n "$BEFORE_OMC" ] && printf '%s\n' "$BEFORE_OMC"
       echo '<!-- OMC:START -->'


### PR DESCRIPTION
## Summary

- Replace 6 GNU sed commands with portable awk equivalents in the omc-setup SKILL.md
- Fixes macOS BSD sed errors when re-running `/oh-my-claudecode:omc-setup` after an OMC update
- Both Step 2A (local config) and Step 2B (global config) marker extraction are now cross-platform

## Problem

The `sed -n '/pattern/{//!p}'` and `sed -n '1,/pattern/{ /pattern/!p }'` syntax used for extracting content around `<!-- OMC:START/END -->` markers is GNU sed-specific. On macOS (BSD sed), these commands fail silently or produce errors on re-run, causing version detection to show "vunknown" and CLAUDE.md corruption.

## Fix

Replaced all 6 sed commands with equivalent awk one-liners:
- `sed -n '...{//!p}'` → `awk '/END/{p=0} p; /START/{p=1}'` (extract between markers)
- `sed -n '1,/START/{...!p}'` → `awk '/START/{exit} {print}'` (extract before marker)
- `sed -n '/END/,${...!p}'` → `awk 'p; /END/{p=1}'` (extract after marker)

## Test plan

- [x] All 231 test files pass (5118 tests)
- [x] Build succeeds
- [ ] Manual test: run `omc-setup --global` on macOS to verify no sed errors
- [ ] Manual test: re-run `omc-setup` to verify idempotent update works

Fixes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)