### PR TITLE
fix(agents): fix vision enforcer, decomposer thresholds, routing gaps (#1061)

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -8,7 +8,7 @@
  * Adapted from oh-my-opencode's background-agent feature.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { getClaudeConfigDir } from '../../utils/paths.js';
 import { ConcurrencyManager } from './concurrency.js';
@@ -96,7 +96,6 @@ export class BackgroundManager {
     if (!existsSync(BACKGROUND_TASKS_DIR)) return;
 
     try {
-      const { readdirSync } = require('fs');
       const files = readdirSync(BACKGROUND_TASKS_DIR) as string[];
 
       for (const file of files) {

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -9,6 +9,7 @@
  */
 
 import { getAgentDefinitions } from '../agents/definitions.js';
+import { normalizeDelegationRole } from './delegation-routing/types.js';
 import type { ModelType } from '../shared/types.js';
 
 /**
@@ -61,7 +62,9 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
   }
 
   // Extract agent type (strip oh-my-claudecode: prefix if present)
-  const agentType = agentInput.subagent_type.replace(/^oh-my-claudecode:/, '');
+  const rawAgentType = agentInput.subagent_type.replace(/^oh-my-claudecode:/, '');
+  // Normalize deprecated role aliases before registry lookup
+  const agentType = normalizeDelegationRole(rawAgentType);
 
   // Get agent definition
   const agentDefs = getAgentDefinitions();

--- a/src/features/delegation-routing/types.ts
+++ b/src/features/delegation-routing/types.ts
@@ -56,6 +56,8 @@ export const ROLE_CATEGORY_DEFAULTS: Record<string, string> = {
   debugger: 'debugger',
   scientist: 'scientist',
   'build-fixer': 'build-fixer',
+  'git-master': 'executor',
+  'code-simplifier': 'executor',
 };
 
 /**

--- a/src/features/model-routing/router.ts
+++ b/src/features/model-routing/router.ts
@@ -59,18 +59,30 @@ export function routeTask(
   // Calculate score for confidence and logging
   const score = calculateComplexityScore(signals);
   const scoreTier = scoreToTier(score);
-  const confidence = calculateConfidence(score, ruleResult.tier);
+  let confidence = calculateConfidence(score, ruleResult.tier);
 
   let finalTier = ruleResult.tier;
+  const tierOrder: ComplexityTier[] = ['LOW', 'MEDIUM', 'HIGH'];
+  const ruleIdx = tierOrder.indexOf(ruleResult.tier);
+  const scoreIdx = tierOrder.indexOf(scoreTier);
+
+  // When scorer and rules diverge by more than 1 level, reduce confidence
+  // and prefer the higher tier to avoid under-provisioning
+  const divergence = Math.abs(ruleIdx - scoreIdx);
+  if (divergence > 1) {
+    confidence = Math.min(confidence, 0.5);
+    finalTier = tierOrder[Math.max(ruleIdx, scoreIdx)];
+  }
+
   const reasons = [
     ruleResult.reason,
     `Rule: ${ruleResult.ruleName}`,
     `Score: ${score} (${scoreTier} tier by score)`,
+    ...(divergence > 1 ? [`Scorer/rules divergence (${divergence} levels): confidence reduced, preferred higher tier`] : []),
   ];
 
   // Enforce minTier if configured
   if (mergedConfig.minTier) {
-    const tierOrder: ComplexityTier[] = ['LOW', 'MEDIUM', 'HIGH'];
     const currentIdx = tierOrder.indexOf(finalTier);
     const minIdx = tierOrder.indexOf(mergedConfig.minTier);
     if (currentIdx < minIdx) {

--- a/src/features/task-decomposer/index.ts
+++ b/src/features/task-decomposer/index.ts
@@ -285,12 +285,20 @@ function detectTaskType(task: string): TaskType {
     return 'refactoring';
   }
 
-  if (
-    task.includes('fix') ||
-    task.includes('bug') ||
-    task.includes('error') ||
-    task.includes('issue')
-  ) {
+  // Require 2+ distinct signals to classify as bug-fix, to avoid false positives
+  // (e.g. "resolve the performance issue" should not be classified as bug-fix)
+  const bugFixSignals = [
+    /\bfix\b/,
+    /\bbug\b/,
+    /\berror\b/,
+    /\bissue\b/,
+    /\bbroken\b/,
+    /\bcrash\b/,
+    /\bfailure\b/,
+    /\bregression\b/,
+  ];
+  const bugFixMatches = bugFixSignals.filter((re) => re.test(task)).length;
+  if (bugFixMatches >= 2) {
     return 'bug-fix';
   }
 


### PR DESCRIPTION
## Summary

Fixes #1061 — multiple delegation system bugs across 5 files.

- **delegation-enforcer**: Call `normalizeDelegationRole` before registry lookup so deprecated aliases like `vision` resolve to `document-specialist` instead of throwing `Unknown agent type: vision`
- **task-decomposer**: Require 2+ word-boundary regex signals for `bug-fix` classification to prevent false positives (e.g. "resolve the performance issue" no longer suppresses parallelism)
- **delegation-routing/types**: Add `git-master` and `code-simplifier` to `ROLE_CATEGORY_DEFAULTS` so they get proper routing reasons instead of "Fallback to Claude Task"
- **model-routing/router**: When scorer and rules diverge by >1 tier, reduce confidence to ≤0.5 and prefer the higher tier to avoid silent under-provisioning
- **background-agent/manager**: Replace CJS `require('fs')` at line 99 with ESM static import (`readdirSync` added to existing import)

## Test plan

- [x] `npx tsc --noEmit` — no errors in changed files
- [x] `npx vitest run src/features/ --reporter=verbose` — 65/65 tests pass
- [ ] Verify `oh-my-claudecode:vision` resolves without error
- [ ] Verify "resolve the issue" doesn't classify as bug-fix
- [ ] Verify routing confidence reduced when scorer/rules disagree by >1 tier
- [ ] Verify git-master/code-simplifier get proper routing reasons

🤖 Generated with [Claude Code](https://claude.com/claude-code)