### PR TITLE
fix(security): replace shell interpolation with array-form spawn (#1056)

### DIFF
--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -12,7 +12,7 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { TaskTool } from '../hooks/beads-context/types.js';
 import { install as installOmc, HOOKS_DIR, isProjectScopedPlugin, isRunningAsPlugin } from '../installer/index.js';
 import { getConfigDir } from '../utils/config-dir.js';
@@ -41,26 +41,26 @@ function syncMarketplaceClone(verbose: boolean = false): { ok: boolean; message:
   const execOpts = { encoding: 'utf-8' as const, stdio: stdio as any, timeout: 60000 };
 
   try {
-    execSync(`git -C "${marketplacePath}" fetch --all --prune`, execOpts);
+    execFileSync('git', ['-C', marketplacePath, 'fetch', '--all', '--prune'], execOpts);
   } catch (err) {
     return { ok: false, message: `Failed to fetch marketplace clone: ${err instanceof Error ? err.message : err}` };
   }
 
   // Ensure we're on main (ignore errors for older clones on different branches)
-  try { execSync(`git -C "${marketplacePath}" checkout main`, { ...execOpts, timeout: 15000 }); } catch { /* ignore checkout errors on older clones */ }
+  try { execFileSync('git', ['-C', marketplacePath, 'checkout', 'main'], { ...execOpts, timeout: 15000 }); } catch { /* ignore checkout errors on older clones */ }
 
   // Reset to upstream state -- the marketplace clone is a managed read-only
   // checkout, so any local modifications (e.g. regenerated dist files) can be
   // safely discarded.  This avoids the "dirty worktree" failure that
   // `git pull --ff-only` would hit when untracked/modified files exist (#978).
   try {
-    execSync(`git -C "${marketplacePath}" reset --hard origin/main`, execOpts);
+    execFileSync('git', ['-C', marketplacePath, 'reset', '--hard', 'origin/main'], execOpts);
   } catch (err) {
     return { ok: false, message: `Failed to reset marketplace clone: ${err instanceof Error ? err.message : err}` };
   }
 
   try {
-    execSync(`git -C "${marketplacePath}" clean -fd`, execOpts);
+    execFileSync('git', ['-C', marketplacePath, 'clean', '-fd'], execOpts);
   } catch {
     // clean is best-effort; untracked leftovers won't break anything
   }
@@ -566,7 +566,7 @@ export async function performUpdate(options?: {
 
         // Re-exec with reconcile subcommand
         try {
-          execSync(`"${omcPath}" update-reconcile`, {
+          execFileSync(omcPath, ['update-reconcile'], {
             encoding: 'utf-8',
             stdio: options?.verbose ? 'inherit' : 'pipe',
             timeout: 60000,

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -306,6 +306,7 @@ export function isDaemonRunning(): boolean {
 export function sanitizeReplyInput(text: string): string {
   return text
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '')  // Strip control chars (keep \n, \r, \t)
+    .replace(/[\u202a-\u202e\u2066-\u2069]/g, '')      // Strip bidi override characters
     .replace(/\r?\n/g, ' ')                            // Newlines -> spaces
     .replace(/\\/g, '\\\\')                            // Escape backslashes
     .replace(/`/g, '\\`')                              // Escape backticks

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -5,7 +5,7 @@
  * Supports auto-detection and installation hints.
  */
 
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { extname } from 'path';
 
 export interface LspServerConfig {
@@ -153,13 +153,9 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
  * Check if a command exists in PATH
  */
 export function commandExists(command: string): boolean {
-  try {
-    const checkCommand = process.platform === 'win32' ? 'where' : 'which';
-    execSync(`${checkCommand} ${command}`, { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
+  const checkCommand = process.platform === 'win32' ? 'where' : 'which';
+  const result = spawnSync(checkCommand, [command], { stdio: 'ignore' });
+  return result.status === 0;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace all execSync template literal calls with spawnSync/execFileSync array form across 5 files
- Strip bidi override characters in reply-listener sanitization
- Eliminates 8+ command injection surfaces

Fixes #1056

## Changes
- `src/tools/lsp/servers.ts`: `commandExists` uses `spawnSync(checkCommand, [command])` instead of template literal interpolation
- `src/features/auto-update.ts`: All 4 `git -C "${marketplacePath}"` calls and `"${omcPath}" update-reconcile` use `execFileSync` with array args
- `src/notifications/reply-listener.ts`: `sanitizeReplyInput` strips bidi override characters `\u202a-\u202e\u2066-\u2069`
- `src/hooks/plugin-patterns/index.ts`: All 5 execSync template literal calls converted — `isFormatterAvailable`, `formatFile`, `lintFile` (availability check + run), `runTypeCheck`, `runTests`, `runLint`

## Test plan
- [x] All execSync template literals converted to array form
- [x] tsc --noEmit passes (pre-existing unrelated errors only)
- [x] No injection surfaces remain in changed files