### PR TITLE
fix(skills): deduplicate frontmatter parser, prevent CC command shadowing (#1060)

### DIFF
--- a/src/cli/commands/teleport.ts
+++ b/src/cli/commands/teleport.ts
@@ -550,11 +550,12 @@ export async function teleportListCommand(options: { json?: boolean }): Promise<
 
 /**
  * Remove a worktree
+ * Returns 0 on success, 1 on failure.
  */
 export async function teleportRemoveCommand(
   pathOrName: string,
   options: { force?: boolean; json?: boolean }
-): Promise<void> {
+): Promise<number> {
   const worktreeRoot = DEFAULT_WORKTREE_ROOT;
 
   // Resolve path - could be relative name or full path
@@ -570,7 +571,7 @@ export async function teleportRemoveCommand(
     } else {
       console.error(chalk.red(error));
     }
-    return;
+    return 1;
   }
 
   // Safety check: must be under worktree root
@@ -582,7 +583,7 @@ export async function teleportRemoveCommand(
     } else {
       console.error(chalk.red(error));
     }
-    return;
+    return 1;
   }
 
   try {
@@ -600,7 +601,7 @@ export async function teleportRemoveCommand(
         } else {
           console.error(chalk.red(error));
         }
-        return;
+        return 1;
       }
     }
 
@@ -631,6 +632,7 @@ export async function teleportRemoveCommand(
     } else {
       console.log(chalk.green(`Removed worktree: ${worktreePath}`));
     }
+    return 0;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (options.json) {
@@ -638,5 +640,6 @@ export async function teleportRemoveCommand(
     } else {
       console.error(chalk.red(`Failed to remove worktree: ${message}`));
     }
+    return 1;
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1237,7 +1237,8 @@ teleportCmd
   .option('-f, --force', 'Force removal even with uncommitted changes')
   .option('--json', 'Output as JSON')
   .action(async (path: string, options) => {
-    await teleportRemoveCommand(path, options);
+    const exitCode = await teleportRemoveCommand(path, options);
+    if (exitCode !== 0) process.exit(exitCode);
   });
 
 /**

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared frontmatter parsing utilities
+ *
+ * Parses YAML-like frontmatter from markdown files.
+ * Used by both the builtin-skills loader and the auto-slash-command executor.
+ */
+
+/**
+ * Remove surrounding single or double quotes from a trimmed value.
+ */
+export function stripOptionalQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+/**
+ * Parse YAML-like frontmatter from markdown content.
+ * Returns { metadata, body } where metadata is a flat string map.
+ */
+export function parseFrontmatter(content: string): { metadata: Record<string, string>; body: string } {
+  const frontmatterRegex = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { metadata: {}, body: content };
+  }
+
+  const [, yamlContent, body] = match;
+  const metadata: Record<string, string> = {};
+
+  for (const line of yamlContent.split('\n')) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) continue;
+
+    const key = line.slice(0, colonIndex).trim();
+    const value = stripOptionalQuotes(line.slice(colonIndex + 1));
+
+    metadata[key] = value;
+  }
+
+  return { metadata, body };
+}
+
+/**
+ * Parse the `aliases` frontmatter field into an array of strings.
+ * Supports inline YAML list: `aliases: [foo, bar]` or single value.
+ */
+export function parseFrontmatterAliases(rawAliases: string | undefined): string[] {
+  if (!rawAliases) return [];
+
+  const trimmed = rawAliases.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) return [];
+
+    return inner
+      .split(',')
+      .map((alias) => stripOptionalQuotes(alias))
+      .filter((alias) => alias.length > 0);
+  }
+
+  const singleAlias = stripOptionalQuotes(trimmed);
+  return singleAlias ? [singleAlias] : [];
+}


### PR DESCRIPTION
## Summary

Fixes #1060 — three distinct issues in the skills/command discovery subsystem:

- **Deduplicates frontmatter parser**: Extract shared `parseFrontmatter`, `parseFrontmatterAliases`, `stripOptionalQuotes` into `src/utils/frontmatter.ts`. Both `skills.ts` and `executor.ts` had identical inline implementations; they now import from the shared module.

- **Prevents CC native command shadowing**: `discoverAllCommands()` in `executor.ts` now applies `toSafeSkillName()` (same guard already used in `skills.ts`) so skills named `plan`, `review`, `help`, etc. are registered as `omc-plan`, `omc-review`, etc. instead of silently overriding Claude Code built-in slash commands.

- **Fixes `teleportRemoveCommand` exit code**: Function return type changed from `Promise<void>` to `Promise<number>`. All error paths return `1`; success returns `0`. Caller in `src/cli/index.ts` propagates via `process.exit()`.

## Files Changed

- `src/utils/frontmatter.ts` — new shared module
- `src/features/builtin-skills/skills.ts` — import from shared module
- `src/hooks/auto-slash-command/executor.ts` — import from shared module + CC guard
- `src/cli/commands/teleport.ts` — `Promise<number>` return type + exit codes
- `src/cli/index.ts` — propagate `teleportRemoveCommand` exit code

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Skills named `plan`/`review` load as `omc-plan`/`omc-review` in both discovery paths
- [ ] `omc teleport remove nonexistent` exits with code 1
- [ ] Existing skill/command tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)