### PR TITLE
fix(error-handling): gc session state, reject LSP pending on exit, escalate watchdog (#1064)

### DIFF
--- a/src/hooks/recovery/context-window.ts
+++ b/src/hooks/recovery/context-window.ts
@@ -50,6 +50,26 @@ const sessionStates = new Map<string, SessionState>();
 const STATE_TTL = 300_000; // 5 minutes
 
 /**
+ * Remove session state for a given session ID (call on context window exhaustion).
+ */
+export function clearSessionState(sessionId: string): void {
+  sessionStates.delete(sessionId);
+}
+
+/**
+ * GC: remove all session state entries older than STATE_TTL.
+ * Called automatically on context window exhaustion to free memory.
+ */
+function gcSessionStates(): void {
+  const now = Date.now();
+  for (const [id, state] of sessionStates.entries()) {
+    if (now - state.lastErrorTime > STATE_TTL) {
+      sessionStates.delete(id);
+    }
+  }
+}
+
+/**
  * Patterns indicating thinking block structure errors (NOT token limit)
  */
 const THINKING_BLOCK_ERROR_PATTERNS = [
@@ -385,6 +405,9 @@ export function handleContextWindowRecovery(
   }
 
   debugLog('detected token limit error', { sessionId, parsed });
+
+  // GC stale session state on every context window exhaustion event
+  gcSessionStates();
 
   const state = getSessionState(sessionId);
   state.lastErrorTime = Date.now();


### PR DESCRIPTION
## Summary

Fixes four error-handling gaps identified in issue #1064:

- **context-window.ts**: Added `gcSessionStates()` to remove stale session state entries older than the 5-minute TTL. Called automatically on every context window exhaustion event via `handleContextWindowRecovery`. Also exports `clearSessionState()` for explicit per-session cleanup.

- **lsp/client.ts**: Added `rejectPendingRequests()` method that clears all pending LSP requests with a rejection error. Called from the `process.on('exit')` handler so promises are never left dangling when the language server exits unexpectedly.

- **team/runtime.ts**: Watchdog now tracks consecutive unresponsive ticks per worker (alive pane with stale heartbeat). After 3 consecutive failures it escalates from log-only to kill+reassign: kills the pane, marks the task failed, and spawns a new worker for the next pending task.

- **rate-limit-wait/daemon.ts**: Added `registerDaemonCleanup()` that registers SIGINT, SIGTERM, and `exit` handlers. Called from `pollLoop` (the subprocess entry point used by `startDaemon`) so the PID file and state file are always cleaned up on daemon exit.

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test` — 229 test files, 5054 tests passed, 7 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)