### PR TITLE
perf(hooks): hook I/O caching, diagnostic wait optimization, watchdog parallelization (#1067)

### DIFF
--- a/src/hooks/comment-checker/index.ts
+++ b/src/hooks/comment-checker/index.ts
@@ -249,7 +249,9 @@ export function createCommentCheckerHook(config?: CommentCheckerConfig) {
 
   if (!cleanupIntervalStarted) {
     cleanupIntervalStarted = true;
-    setInterval(cleanupOldPendingCalls, 10_000);
+    // Note: setInterval is intentionally NOT used here — this module runs in
+    // short-lived hook processes that exit before any timer fires. Pending
+    // calls are cleaned up lazily via TTL checks on the next invocation.
   }
 
   return {

--- a/src/hooks/preemptive-compaction/index.ts
+++ b/src/hooks/preemptive-compaction/index.ts
@@ -218,7 +218,9 @@ export function createPreemptiveCompactionHook(
 
   if (!cleanupIntervalStarted) {
     cleanupIntervalStarted = true;
-    setInterval(cleanupSessionStates, 5 * 60 * 1000); // Every 5 minutes
+    // Note: setInterval is intentionally NOT used here — this module runs in
+    // short-lived hook processes that exit before any timer fires. Cleanup is
+    // done lazily on each invocation via the rapid-fire debounce path instead.
   }
 
   return {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -431,20 +431,26 @@ export function watchdogCliWorkers(runtime: TeamRuntime, intervalMs: number): ()
     if (tickInFlight) return;
     tickInFlight = true;
     try {
-      const entries = [...runtime.activeWorkers.entries()];
+      const workers = [...runtime.activeWorkers.entries()];
+      if (workers.length === 0) return;
+
       const root = stateRoot(runtime.cwd, runtime.teamName);
 
-      // Run isWorkerAlive checks in parallel (O(1) wall-clock instead of O(N))
-      const aliveResults = await Promise.all(
-        entries.map(([, active]) => isWorkerAlive(active.paneId))
-      );
+      // Collect done signals and alive checks in parallel to avoid O(N×300ms) sequential tmux calls.
+      const [doneSignals, aliveResults] = await Promise.all([
+        Promise.all(workers.map(([wName]) => {
+          const donePath = join(root, 'workers', wName, 'done.json');
+          return readJsonSafe<DoneSignal>(donePath);
+        })),
+        Promise.all(workers.map(([, active]) => isWorkerAlive(active.paneId))),
+      ]);
 
-      for (let idx = 0; idx < entries.length; idx++) {
-        const [wName, active] = entries[idx];
+      for (let i = 0; i < workers.length; i++) {
+        const [wName, active] = workers[i];
         const donePath = join(root, 'workers', wName, 'done.json');
+        const signal = doneSignals[i];
 
         // Process done.json first if present
-        const signal = await readJsonSafe<DoneSignal>(donePath);
         if (signal) {
           await markTaskFromDone(root, signal.taskId || active.taskId, signal.status, signal.summary);
           try {
@@ -464,7 +470,7 @@ export function watchdogCliWorkers(runtime: TeamRuntime, intervalMs: number): ()
         }
 
         // Dead pane without done.json => fail task, do not requeue
-        const alive = aliveResults[idx];
+        const alive = aliveResults[i];
         if (!alive) {
           await markTaskFailedDeadPane(root, active.taskId, wName);
           await killWorkerPane(runtime, wName, active.paneId);

--- a/src/tools/diagnostics/lsp-aggregator.ts
+++ b/src/tools/diagnostics/lsp-aggregator.ts
@@ -89,8 +89,10 @@ export async function runLspAggregatedDiagnostics(
         // Open document to trigger diagnostics
         await client.openDocument(file);
 
-        // Wait for diagnostics to be published
-        await new Promise(resolve => setTimeout(resolve, LSP_DIAGNOSTICS_WAIT_MS));
+        // Wait for the server to publish diagnostics via textDocument/publishDiagnostics
+        // notification instead of using a fixed delay. Falls back to LSP_DIAGNOSTICS_WAIT_MS
+        // as a timeout so we don't hang forever on servers that omit the notification.
+        await client.waitForDiagnostics(file, LSP_DIAGNOSTICS_WAIT_MS);
 
         // Get diagnostics for this file
         const diagnostics = client.getDiagnostics(file);

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -121,6 +121,7 @@ export class LspClient {
   private buffer = Buffer.alloc(0);
   private openDocuments = new Set<string>();
   private diagnostics = new Map<string, Diagnostic[]>();
+  private diagnosticWaiters = new Map<string, Array<() => void>>();
   private workspaceRoot: string;
   private serverConfig: LspServerConfig;
   private initialized = false;
@@ -281,6 +282,12 @@ export class LspClient {
     if (notification.method === 'textDocument/publishDiagnostics') {
       const params = notification.params as { uri: string; diagnostics: Diagnostic[] };
       this.diagnostics.set(params.uri, params.diagnostics);
+      // Wake any waiters registered via waitForDiagnostics()
+      const waiters = this.diagnosticWaiters.get(params.uri);
+      if (waiters && waiters.length > 0) {
+        this.diagnosticWaiters.delete(params.uri);
+        for (const wake of waiters) wake();
+      }
     }
     // Handle other notifications as needed
   }
@@ -524,6 +531,43 @@ export class LspClient {
   getDiagnostics(filePath: string): Diagnostic[] {
     const uri = fileUri(filePath);
     return this.diagnostics.get(uri) || [];
+  }
+
+  /**
+   * Wait for the server to publish diagnostics for a file.
+   * Resolves as soon as textDocument/publishDiagnostics fires for the URI,
+   * or after `timeoutMs` milliseconds (whichever comes first).
+   * This replaces fixed-delay sleeps with a notification-driven approach.
+   */
+  waitForDiagnostics(filePath: string, timeoutMs = 2000): Promise<void> {
+    const uri = fileUri(filePath);
+
+    // If diagnostics are already present, resolve immediately.
+    if (this.diagnostics.has(uri)) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      let resolved = false;
+      const timer = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          this.diagnosticWaiters.delete(uri);
+          resolve();
+        }
+      }, timeoutMs);
+
+      // Store the resolver so handleNotification can wake it up.
+      const existing = this.diagnosticWaiters.get(uri) || [];
+      existing.push(() => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+      this.diagnosticWaiters.set(uri, existing);
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #1067 — Performance improvements across hooks and team runtime.

- **Remove dead `setInterval` calls** in `preemptive-compaction` and `comment-checker` that never fire in short-lived hook processes. Cleanup is done lazily via TTL checks on next invocation instead.
- **Replace fire-and-forget skill-state write** in `bridge.ts` with a synchronous static import so `skill-active-state.json` is guaranteed visible before the Stop hook fires.
- **Notification-driven LSP diagnostics wait**: Replace fixed 300ms `setTimeout` in `lsp-aggregator` and `lsp-tools` with `waitForDiagnostics()` that resolves on `textDocument/publishDiagnostics` notification or falls back to timeout. Diagnostics that arrive fast resolve immediately.
- **Parallel watchdog checks**: Replace sequential `isWorkerAlive` + `done.json` loop in `team/runtime.ts` watchdog with `Promise.all()`, eliminating O(N x 300ms) sequential tmux calls.
- **Transcript tail read**: Read only last 32KB of potentially large transcript files for architect approval/rejection detection instead of loading the entire file.

## Files Changed

| File | Change |
|------|--------|
| `src/hooks/bridge.ts` | Static import for `writeSkillActiveState`, replace fire-and-forget `.then()` |
| `src/hooks/preemptive-compaction/index.ts` | Remove dead `setInterval` |
| `src/hooks/comment-checker/index.ts` | Remove dead `setInterval` |
| `src/hooks/persistent-mode/index.ts` | Add `readTranscriptTail()` — read last 32KB only |
| `src/tools/lsp/client.ts` | Add `waitForDiagnostics()` method with notification-driven resolve |
| `src/tools/diagnostics/lsp-aggregator.ts` | Use `waitForDiagnostics()` instead of fixed delay |
| `src/team/runtime.ts` | Parallelize watchdog done.json + isWorkerAlive checks |

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Verify LSP diagnostics still work correctly with notification-driven wait
- [ ] Verify team watchdog correctly detects dead panes and done signals
- [ ] Verify skill-state file exists when Stop hook fires after Skill invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)