### PR TITLE
feat(openclaw): add CLI command gateway type with tmux tail context

### DIFF
--- a/src/openclaw/__tests__/config.test.ts
+++ b/src/openclaw/__tests__/config.test.ts
@@ -172,4 +172,58 @@ describe("resolveGateway", () => {
     const result = resolveGateway(configWithBadGateway, "session-start");
     expect(result).toBeNull();
   });
+
+  it("resolves a command gateway with type and command fields correctly", () => {
+    const configWithCommand: OpenClawConfig = {
+      enabled: true,
+      gateways: {
+        "cmd-gateway": {
+          type: "command",
+          command: "echo {{instruction}}",
+          timeout: 5000,
+        },
+      },
+      hooks: {
+        "session-start": {
+          gateway: "cmd-gateway",
+          instruction: "Session started",
+          enabled: true,
+        },
+      },
+    };
+    const result = resolveGateway(configWithCommand, "session-start");
+    expect(result).not.toBeNull();
+    expect(result!.gatewayName).toBe("cmd-gateway");
+    expect(result!.gateway).toEqual({ type: "command", command: "echo {{instruction}}", timeout: 5000 });
+    expect(result!.instruction).toBe("Session started");
+  });
+
+  it("returns null for command gateway when command field is missing", () => {
+    const configWithBrokenCommand: OpenClawConfig = {
+      enabled: true,
+      gateways: {
+        "cmd-gateway": {
+          type: "command",
+          command: "",
+        },
+      },
+      hooks: {
+        "session-start": {
+          gateway: "cmd-gateway",
+          instruction: "Session started",
+          enabled: true,
+        },
+      },
+    };
+    const result = resolveGateway(configWithBrokenCommand, "session-start");
+    expect(result).toBeNull();
+  });
+
+  it("resolves an HTTP gateway without a type field (backward compat)", () => {
+    const result = resolveGateway(validConfig, "session-start");
+    expect(result).not.toBeNull();
+    expect(result!.gatewayName).toBe("my-gateway");
+    // gateway has no type field — backward compat with pre-command-gateway configs
+    expect((result!.gateway as { type?: string }).type).toBeUndefined();
+  });
 });

--- a/src/openclaw/__tests__/dispatcher.test.ts
+++ b/src/openclaw/__tests__/dispatcher.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { interpolateInstruction, wakeGateway } from "../dispatcher.js";
-import type { OpenClawGatewayConfig, OpenClawPayload } from "../types.js";
+import { interpolateInstruction, wakeGateway, shellEscapeArg, isCommandGateway, wakeCommandGateway } from "../dispatcher.js";
+import type { OpenClawGatewayConfig, OpenClawPayload, OpenClawCommandGatewayConfig } from "../types.js";
+
+// Mock child_process so wakeCommandGateway's dynamic import resolves to our mock
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
 
 const baseGatewayConfig: OpenClawGatewayConfig = {
   url: "https://example.com/wake",
@@ -258,5 +263,188 @@ describe("wakeGateway", () => {
     await wakeGateway("test", config, basePayload);
     expect(abortSignalSpy).toHaveBeenCalledWith(5000);
     abortSignalSpy.mockRestore();
+  });
+});
+
+describe("shellEscapeArg", () => {
+  it("wraps a simple string in single quotes", () => {
+    expect(shellEscapeArg("hello")).toBe("'hello'");
+  });
+
+  it("escapes internal single quotes using the apostrophe sequence", () => {
+    expect(shellEscapeArg("it's")).toBe("'it'\\''s'");
+  });
+
+  it("wraps an empty string in single quotes", () => {
+    expect(shellEscapeArg("")).toBe("''");
+  });
+
+  it("safely quotes shell metacharacters so they are inert", () => {
+    const dangerous = '$(rm -rf /); echo "pwned" | cat';
+    const escaped = shellEscapeArg(dangerous);
+    // Must start and end with single quote — entire string is wrapped
+    expect(escaped.startsWith("'")).toBe(true);
+    expect(escaped.endsWith("'")).toBe(true);
+    // No unquoted $ or backtick must escape — the content is preserved literally
+    expect(escaped).toBe("'$(rm -rf /); echo \"pwned\" | cat'");
+  });
+
+  it("wraps a string containing newlines in single quotes", () => {
+    const result = shellEscapeArg("line1\nline2");
+    expect(result).toBe("'line1\nline2'");
+  });
+
+  it("safely quotes backtick command substitution", () => {
+    const result = shellEscapeArg("`whoami`");
+    expect(result).toBe("'`whoami`'");
+  });
+
+  it("escapes multiple consecutive single quotes", () => {
+    expect(shellEscapeArg("a'b'c")).toBe("'a'\\''b'\\''c'");
+  });
+});
+
+describe("isCommandGateway", () => {
+  it("returns true for a config with type: command", () => {
+    const config: OpenClawCommandGatewayConfig = { type: "command", command: "echo test" };
+    expect(isCommandGateway(config)).toBe(true);
+  });
+
+  it("returns false for an HTTP config with no type field", () => {
+    const config: OpenClawGatewayConfig = { url: "https://example.com" };
+    expect(isCommandGateway(config)).toBe(false);
+  });
+
+  it("returns false for a config with type: http", () => {
+    const config: OpenClawGatewayConfig = { type: "http", url: "https://example.com" };
+    expect(isCommandGateway(config)).toBe(false);
+  });
+});
+
+describe("wakeCommandGateway", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  let execFileMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    // Grab the mock installed by vi.mock("child_process") and wire it up
+    const cp = await import("child_process");
+    execFileMock = vi.mocked(cp.execFile);
+    // Default: simulate successful execution — promisify calls execFile with a callback
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        cb(null, { stdout: "", stderr: "" });
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns success result with the gateway name on successful execution", async () => {
+    const config: OpenClawCommandGatewayConfig = { type: "command", command: "echo hello" };
+    const result = await wakeCommandGateway("test", config, {});
+    expect(result).toEqual({ gateway: "test", success: true });
+  });
+
+  it("returns failure result with error message when execFile calls back with an error", async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error) => void) => {
+        cb(new Error("Command failed: exit code 1"));
+      },
+    );
+    const config: OpenClawCommandGatewayConfig = { type: "command", command: "false" };
+    const result = await wakeCommandGateway("test", config, {});
+    expect(result.gateway).toBe("test");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Command failed");
+  });
+
+  it("interpolates {{instruction}} variable with shell escaping", async () => {
+    let capturedArgs: string[] = [];
+    execFileMock.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedArgs = args;
+        cb(null, { stdout: "", stderr: "" });
+      },
+    );
+    const config: OpenClawCommandGatewayConfig = {
+      type: "command",
+      command: "notify {{instruction}}",
+    };
+    const result = await wakeCommandGateway("test", config, { instruction: "hello world" });
+    expect(result.success).toBe(true);
+    // The interpolated command is passed as the -c argument to sh
+    expect(capturedArgs[1]).toContain("'hello world'");
+  });
+
+  it("leaves unresolved {{variables}} as-is in the command", async () => {
+    let capturedArgs: string[] = [];
+    execFileMock.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedArgs = args;
+        cb(null, { stdout: "", stderr: "" });
+      },
+    );
+    const config: OpenClawCommandGatewayConfig = {
+      type: "command",
+      command: "echo {{missing}}",
+    };
+    await wakeCommandGateway("test", config, {});
+    expect(capturedArgs[1]).toContain("{{missing}}");
+  });
+
+  it("passes sh -c as the executable and arguments", async () => {
+    let capturedCmd = "";
+    let capturedArgs: string[] = [];
+    execFileMock.mockImplementation(
+      (cmd: string, args: string[], _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedCmd = cmd;
+        capturedArgs = args;
+        cb(null, { stdout: "", stderr: "" });
+      },
+    );
+    const config: OpenClawCommandGatewayConfig = { type: "command", command: "echo hello" };
+    await wakeCommandGateway("gw", config, {});
+    expect(capturedCmd).toBe("sh");
+    expect(capturedArgs[0]).toBe("-c");
+  });
+
+  it("uses the default timeout of 10000ms when config.timeout is not specified", async () => {
+    let capturedOpts: Record<string, unknown> = {};
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], opts: Record<string, unknown>, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedOpts = opts;
+        cb(null, { stdout: "", stderr: "" });
+      },
+    );
+    const config: OpenClawCommandGatewayConfig = { type: "command", command: "echo hello" };
+    await wakeCommandGateway("gw", config, {});
+    expect(capturedOpts.timeout).toBe(10_000);
+  });
+
+  it("uses custom timeout from config when specified", async () => {
+    let capturedOpts: Record<string, unknown> = {};
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], opts: Record<string, unknown>, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedOpts = opts;
+        cb(null, { stdout: "", stderr: "" });
+      },
+    );
+    const config: OpenClawCommandGatewayConfig = { type: "command", command: "echo hello", timeout: 3000 };
+    await wakeCommandGateway("gw", config, {});
+    expect(capturedOpts.timeout).toBe(3000);
+  });
+
+  it("returns failure with Unknown error message when a non-Error value is thrown", async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: (err: string) => void) => {
+        cb("some string error");
+      },
+    );
+    const config: OpenClawCommandGatewayConfig = { type: "command", command: "echo hello" };
+    const result = await wakeCommandGateway("gw", config, {});
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Unknown error");
   });
 });

--- a/src/openclaw/config.ts
+++ b/src/openclaw/config.ts
@@ -9,7 +9,7 @@
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { getClaudeConfigDir } from "../utils/paths.js";
-import type { OpenClawConfig, OpenClawHookEvent, OpenClawGatewayConfig } from "./types.js";
+import type { OpenClawConfig, OpenClawHookEvent, OpenClawGatewayConfig, OpenClawCommandGatewayConfig } from "./types.js";
 
 const CONFIG_FILE = process.env.OMC_OPENCLAW_CONFIG
   || join(getClaudeConfigDir(), "omc_config.openclaw.json");
@@ -71,8 +71,15 @@ export function resolveGateway(
   }
 
   const gateway = config.gateways[mapping.gateway];
-  if (!gateway || !gateway.url) {
+  if (!gateway) {
     return null;
+  }
+  // Validate based on gateway type
+  if ((gateway as OpenClawCommandGatewayConfig).type === "command") {
+    if (!(gateway as OpenClawCommandGatewayConfig).command) return null;
+  } else {
+    // HTTP gateway (default when type is absent or "http")
+    if (!("url" in gateway) || !gateway.url) return null;
   }
 
   return { gatewayName: mapping.gateway, gateway, instruction: mapping.instruction };

--- a/src/openclaw/types.ts
+++ b/src/openclaw/types.ts
@@ -15,9 +15,11 @@ export type OpenClawHookEvent =
   | "keyword-detector"
   | "ask-user-question";
 
-/** Single gateway endpoint configuration */
-export interface OpenClawGatewayConfig {
-  /** Gateway endpoint URL (HTTPS required) */
+/** HTTP gateway configuration (default when type is absent or "http") */
+export interface OpenClawHttpGatewayConfig {
+  /** Gateway type discriminator (optional for backward compat) */
+  type?: "http";
+  /** Gateway endpoint URL (HTTPS required, HTTP allowed for localhost) */
   url: string;
   /** Optional custom headers (e.g., Authorization) */
   headers?: Record<string, string>;
@@ -26,6 +28,20 @@ export interface OpenClawGatewayConfig {
   /** Per-request timeout in ms (default: 10000) */
   timeout?: number;
 }
+
+/** CLI command gateway configuration */
+export interface OpenClawCommandGatewayConfig {
+  /** Gateway type discriminator */
+  type: "command";
+  /** Command template with {{variable}} placeholders.
+   *  Variables are shell-escaped automatically before interpolation. */
+  command: string;
+  /** Per-command timeout in ms (default: 10000) */
+  timeout?: number;
+}
+
+/** Gateway configuration — HTTP or CLI command */
+export type OpenClawGatewayConfig = OpenClawHttpGatewayConfig | OpenClawCommandGatewayConfig;
 
 /** Per-hook-event mapping to a gateway + instruction */
 export interface OpenClawHookMapping {
@@ -63,6 +79,8 @@ export interface OpenClawPayload {
   projectName?: string;
   /** Tmux session name (if running inside tmux) */
   tmuxSession?: string;
+  /** Recent tmux pane output (for stop/session-end events) */
+  tmuxTail?: string;
   /** Context data from the hook (whitelisted fields only) */
   context: OpenClawContext;
 }
@@ -82,6 +100,8 @@ export interface OpenClawContext {
   contextSummary?: string;
   reason?: string;
   question?: string;
+  /** Recent tmux pane output (captured automatically for stop/session-end events) */
+  tmuxTail?: string;
 }
 
 /** Result of a gateway wake attempt */


### PR DESCRIPTION
## Summary

- Adds `"command"` gateway type to OpenClaw for CLI-based gateways (Clawdbot/OpenClaw)
- HTTP POST was silently failing (405) against WebSocket-based gateways — command gateways execute shell commands instead (e.g., `openclaw agent --message ... --deliver`)
- Shell-escaped `{{variable}}` interpolation prevents injection in command templates
- Adds `tmuxTail` to `OpenClawContext`/`OpenClawPayload` with auto-capture for `stop`/`session-end` events
- Updates `configure-openclaw` skill to auto-detect `openclaw`/`clawdbot` CLI and guide command gateway setup

## Changes

- `src/openclaw/types.ts` — Discriminated union: `OpenClawHttpGatewayConfig` + `OpenClawCommandGatewayConfig`
- `src/openclaw/dispatcher.ts` — `isCommandGateway()`, `shellEscapeArg()`, `wakeCommandGateway()`
- `src/openclaw/config.ts` — `resolveGateway()` accepts command gateways
- `src/openclaw/index.ts` — Type-based routing, tmux tail auto-capture, new exports
- Tests: 78 total (25 new) across 3 test files

## Test plan

- [x] All 78 OpenClaw tests pass
- [x] 9 bridge-openclaw tests pass
- [x] 0 TypeScript errors (LSP clean)
- [ ] E2E: test with `openclaw agent --message "test" --deliver --reply-channel discord --reply-to "#omc-dev"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)