### PR TITLE
fix(skills): avoid overriding builtin Claude Code commands

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: plan
+name: omc-plan
 description: Strategic planning with optional interview workflow
 ---
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: review
+name: omc-review
 description: Alias for /plan --review
 ---
 

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: security-review
+name: omc-security-review
 description: Run a comprehensive security review on code
 ---
 


### PR DESCRIPTION
# PR: fix(skills): avoid overriding builtin Claude Code commands

## Summary

- Prefix `name` field in SKILL.md front matter for `plan`, `review`, and `security-review` skills with `omc-` to prevent shadowing builtin Claude Code `/plan`, `/review`, and `/security-review` commands

## Problem

The three skills (`plan`, `review`, `security-review`) had bare `name` values in their SKILL.md front matter that collided with Claude Code's builtin commands of the same name. While the runtime `toSafeSkillName()` function in `skills.ts` was silently prefixing `omc-` at load time, the front matter itself was misleading -- it showed `name: plan` when the actual registered name was `omc-plan`.

## Changes

| File | Before | After |
|------|--------|-------|
| `skills/plan/SKILL.md` | `name: plan` | `name: omc-plan` |
| `skills/review/SKILL.md` | `name: review` | `name: omc-review` |
| `skills/security-review/SKILL.md` | `name: security-review` | `name: omc-security-review` |

## Why this approach

- Makes the SKILL.md front matter the explicit source of truth for skill names
- Aligns with existing convention used by `omc-doctor` and `omc-help` skills
- The `toSafeSkillName()` / `CC_NATIVE_COMMANDS` safety net is preserved as defense-in-depth for future or user-authored skills
- Zero test changes required -- all tests already expected the `omc-*` prefixed names

## Test plan

- [x] `src/__tests__/skills.test.ts` -- 19 tests pass
- [x] `src/__tests__/consolidation-contracts.test.ts` -- 7 tests pass
- [x] `src/__tests__/consensus-execution-handoff.test.ts` -- 16 tests pass
- [x] No test modifications needed (42/42 pass)

# Open Questions

## align-omc-prefixed-skills - 2026-02-26
- [ ] Should a comment be added to `CC_NATIVE_COMMANDS` in `skills.ts` and `executor.ts` noting that existing skills already use `omc-` prefixed names in front matter, and the guard is for future skills? -- Low priority, improves developer onboarding clarity
- [ ] Should `sync-metadata --verify` be extended to flag SKILL.md files that use bare CC-native names in their front matter? -- Would prevent this class of issue from recurring
- [ ] The `toSafeSkillName()` function and `CC_NATIVE_COMMANDS` set are duplicated in two files (`src/features/builtin-skills/skills.ts` and `src/hooks/auto-slash-command/executor.ts`). Should this be consolidated into a shared utility? -- Not part of this bugfix scope, but worth tracking as tech debt
