### PR TITLE
feat(interop): add OMC-OMX cross-platform worker adapter (#1117)

### DIFF
--- a/src/interop/__tests__/worker-adapter-integration.test.ts
+++ b/src/interop/__tests__/worker-adapter-integration.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { existsSync } from 'fs';
+import {
+  bridgeBootstrapToOmx,
+  bridgeBootstrapToOmc,
+  pollOmxCompletion,
+  bridgeDoneSignalToOmx,
+  teamConfigToOmx,
+  omxTaskToTaskFile,
+  taskFileToOmxTask,
+} from '../worker-adapter.js';
+import type { AdapterContext } from '../adapter-types.js';
+import type { DoneSignal } from '../../team/types.js';
+import type { OmxTeamTask } from '../omx-team-state.js';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'omc-interop-test-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function activeCtx(teamName = 'test-team'): AdapterContext {
+  return { lead: 'omc', teamName, cwd: tempDir, interopMode: 'active' };
+}
+
+function offCtx(teamName = 'test-team'): AdapterContext {
+  return { lead: 'omc', teamName, cwd: tempDir, interopMode: 'off' };
+}
+
+// ============================================================================
+// Bootstrap Integration
+// ============================================================================
+
+describe('bridgeBootstrapToOmx (file I/O)', () => {
+  it('writes OMX mailbox file when interopMode is active', async () => {
+    const ctx = activeCtx();
+    await bridgeBootstrapToOmx(ctx, 'worker-1', {
+      id: '1', subject: 'Fix auth', description: 'Fix the auth module',
+    });
+
+    const mailboxPath = join(tempDir, '.omx', 'state', 'team', 'test-team', 'mailbox', 'worker-1.json');
+    expect(existsSync(mailboxPath)).toBe(true);
+
+    const content = JSON.parse(await readFile(mailboxPath, 'utf-8'));
+    expect(content.worker).toBe('worker-1');
+    expect(content.messages).toHaveLength(1);
+    expect(content.messages[0].from_worker).toBe('omc-lead');
+    expect(content.messages[0].to_worker).toBe('worker-1');
+    expect(content.messages[0].body).toContain('Fix auth');
+    expect(content.messages[0].body).toContain('Fix the auth module');
+    expect(content.messages[0].message_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('is a no-op when interopMode is off', async () => {
+    const ctx = offCtx();
+    await bridgeBootstrapToOmx(ctx, 'worker-1', {
+      id: '1', subject: 'Fix auth', description: 'Fix the auth module',
+    });
+
+    const mailboxPath = join(tempDir, '.omx', 'state', 'team', 'test-team', 'mailbox', 'worker-1.json');
+    expect(existsSync(mailboxPath)).toBe(false);
+  });
+
+  it('is a no-op when interopMode is observe', async () => {
+    const ctx: AdapterContext = { lead: 'omc', teamName: 'test-team', cwd: tempDir, interopMode: 'observe' };
+    await bridgeBootstrapToOmx(ctx, 'worker-1', {
+      id: '1', subject: 'Fix auth', description: 'Fix the auth module',
+    });
+
+    const mailboxPath = join(tempDir, '.omx', 'state', 'team', 'test-team', 'mailbox', 'worker-1.json');
+    expect(existsSync(mailboxPath)).toBe(false);
+  });
+});
+
+describe('bridgeBootstrapToOmc (file I/O)', () => {
+  it('writes AGENTS.md overlay and inbox.md', async () => {
+    const ctx = activeCtx();
+    await bridgeBootstrapToOmc(ctx, 'worker-1', 'claude', {
+      id: '1', subject: 'Fix auth', description: 'Fix the auth module',
+    });
+
+    const overlayPath = join(tempDir, '.omc', 'state', 'team', 'test-team', 'workers', 'worker-1', 'AGENTS.md');
+    expect(existsSync(overlayPath)).toBe(true);
+    const overlay = await readFile(overlayPath, 'utf-8');
+    expect(overlay).toContain('Team Worker Protocol');
+    expect(overlay).toContain('worker-1');
+
+    const inboxPath = join(tempDir, '.omc', 'state', 'team', 'test-team', 'workers', 'worker-1', 'inbox.md');
+    expect(existsSync(inboxPath)).toBe(true);
+    const inbox = await readFile(inboxPath, 'utf-8');
+    expect(inbox).toContain('Fix auth');
+  });
+});
+
+// ============================================================================
+// Completion Signal Integration (done.json shim)
+// ============================================================================
+
+describe('pollOmxCompletion (done.json shim)', () => {
+  it('synthesizes done.json in .omc/ when OMX task is completed', async () => {
+    const ctx = activeCtx();
+
+    // Write an OMX task file that is completed
+    const taskDir = join(tempDir, '.omx', 'state', 'team', 'test-team', 'tasks');
+    await mkdir(taskDir, { recursive: true });
+    await writeFile(join(taskDir, 'task-1.json'), JSON.stringify({
+      id: '1', subject: 'Fix bug', description: 'Fix it',
+      status: 'completed', result: 'Bug fixed', created_at: '2026-02-27T00:00:00Z',
+      completed_at: '2026-02-27T01:00:00Z',
+    }));
+
+    // Ensure .omc worker dir exists
+    const workerDir = join(tempDir, '.omc', 'state', 'team', 'test-team', 'workers', 'worker-1');
+    await mkdir(workerDir, { recursive: true });
+
+    const signal = await pollOmxCompletion(ctx, 'worker-1', '1');
+    expect(signal).not.toBeNull();
+    expect(signal!.taskId).toBe('1');
+    expect(signal!.status).toBe('completed');
+    expect(signal!.summary).toBe('Bug fixed');
+
+    // Verify done.json was written to .omc/ (NOT .omx/)
+    const donePath = join(tempDir, '.omc', 'state', 'team', 'test-team', 'workers', 'worker-1', 'done.json');
+    expect(existsSync(donePath)).toBe(true);
+
+    const doneContent = JSON.parse(await readFile(donePath, 'utf-8'));
+    expect(doneContent.taskId).toBe('1');
+    expect(doneContent.status).toBe('completed');
+
+    // Verify NO done.json in .omx/
+    const omxDonePath = join(tempDir, '.omx', 'state', 'team', 'test-team', 'workers', 'worker-1', 'done.json');
+    expect(existsSync(omxDonePath)).toBe(false);
+  });
+
+  it('synthesizes done.json for failed OMX tasks', async () => {
+    const ctx = activeCtx();
+
+    const taskDir = join(tempDir, '.omx', 'state', 'team', 'test-team', 'tasks');
+    await mkdir(taskDir, { recursive: true });
+    await writeFile(join(taskDir, 'task-2.json'), JSON.stringify({
+      id: '2', subject: 'Deploy', description: 'Deploy to prod',
+      status: 'failed', error: 'Timeout', created_at: '2026-02-27T00:00:00Z',
+    }));
+
+    const signal = await pollOmxCompletion(ctx, 'worker-1', '2');
+    expect(signal).not.toBeNull();
+    expect(signal!.status).toBe('failed');
+    expect(signal!.summary).toBe('Timeout');
+  });
+
+  it('returns null for non-terminal OMX tasks', async () => {
+    const ctx = activeCtx();
+
+    const taskDir = join(tempDir, '.omx', 'state', 'team', 'test-team', 'tasks');
+    await mkdir(taskDir, { recursive: true });
+    await writeFile(join(taskDir, 'task-3.json'), JSON.stringify({
+      id: '3', subject: 'WIP', description: 'Still working',
+      status: 'in_progress', created_at: '2026-02-27T00:00:00Z',
+    }));
+
+    const signal = await pollOmxCompletion(ctx, 'worker-1', '3');
+    expect(signal).toBeNull();
+  });
+
+  it('returns null when OMX task does not exist', async () => {
+    const ctx = activeCtx();
+    const signal = await pollOmxCompletion(ctx, 'worker-1', '999');
+    expect(signal).toBeNull();
+  });
+});
+
+describe('bridgeDoneSignalToOmx (file I/O)', () => {
+  it('updates OMX task file and appends event', async () => {
+    const ctx: AdapterContext = { lead: 'omx', teamName: 'test-team', cwd: tempDir, interopMode: 'active' };
+
+    // Create OMX task file
+    const taskDir = join(tempDir, '.omx', 'state', 'team', 'test-team', 'tasks');
+    await mkdir(taskDir, { recursive: true });
+    await writeFile(join(taskDir, 'task-1.json'), JSON.stringify({
+      id: '1', subject: 'Fix it', description: 'Fix the thing',
+      status: 'in_progress', owner: 'worker-1',
+      created_at: '2026-02-27T00:00:00Z',
+    }));
+
+    const doneSignal: DoneSignal = {
+      taskId: '1',
+      status: 'completed',
+      summary: 'Fixed successfully',
+      completedAt: '2026-02-27T01:00:00Z',
+    };
+
+    await bridgeDoneSignalToOmx(ctx, 'worker-1', doneSignal);
+
+    // Verify task file updated
+    const taskContent = JSON.parse(await readFile(join(taskDir, 'task-1.json'), 'utf-8'));
+    expect(taskContent.status).toBe('completed');
+    expect(taskContent.result).toBe('Fixed successfully');
+    expect(taskContent.completed_at).toBe('2026-02-27T01:00:00Z');
+
+    // Verify event log appended
+    const eventPath = join(tempDir, '.omx', 'state', 'team', 'test-team', 'events', 'events.ndjson');
+    expect(existsSync(eventPath)).toBe(true);
+    const eventLine = (await readFile(eventPath, 'utf-8')).trim();
+    const event = JSON.parse(eventLine);
+    expect(event.type).toBe('task_completed');
+    expect(event.worker).toBe('worker-1');
+    expect(event.task_id).toBe('1');
+  });
+
+  it('sets error field for failed tasks', async () => {
+    const ctx: AdapterContext = { lead: 'omx', teamName: 'test-team', cwd: tempDir, interopMode: 'active' };
+
+    const taskDir = join(tempDir, '.omx', 'state', 'team', 'test-team', 'tasks');
+    await mkdir(taskDir, { recursive: true });
+    await writeFile(join(taskDir, 'task-2.json'), JSON.stringify({
+      id: '2', subject: 'Deploy', description: 'Deploy',
+      status: 'in_progress', created_at: '2026-02-27T00:00:00Z',
+    }));
+
+    const doneSignal: DoneSignal = {
+      taskId: '2',
+      status: 'failed',
+      summary: 'Connection refused',
+      completedAt: '2026-02-27T01:00:00Z',
+    };
+
+    await bridgeDoneSignalToOmx(ctx, 'worker-1', doneSignal);
+
+    const taskContent = JSON.parse(await readFile(join(taskDir, 'task-2.json'), 'utf-8'));
+    expect(taskContent.status).toBe('failed');
+    expect(taskContent.error).toBe('Connection refused');
+  });
+});
+
+// ============================================================================
+// End-to-End Translation Round-Trip
+// ============================================================================
+
+describe('end-to-end task translation round-trip', () => {
+  it('OMX task → OMC TaskFile → OMX task preserves blocked status', () => {
+    const original: OmxTeamTask = {
+      id: '7', subject: 'Blocked task', description: 'Waiting on dep',
+      status: 'blocked', blocked_by: ['3'], depends_on: ['3'],
+      owner: 'worker-2', created_at: '2026-02-27T00:00:00Z',
+    };
+
+    const taskFile = omxTaskToTaskFile(original);
+    expect(taskFile.status).toBe('pending'); // lossy: blocked → pending
+
+    const recovered = taskFileToOmxTask(taskFile);
+    expect(recovered.status).toBe('blocked'); // recovered via metadata
+    expect(recovered.blocked_by).toEqual(['3']);
+  });
+
+  it('OMC config → OMX config preserves structure', () => {
+    const omcConfig = {
+      teamName: 'roundtrip-team',
+      workerCount: 2,
+      agentTypes: ['claude', 'gemini'] as ('claude' | 'codex' | 'gemini')[],
+      tasks: [{ subject: 'Task A', description: 'Do A' }],
+      cwd: '/tmp',
+    };
+
+    const omxConfig = teamConfigToOmx(omcConfig);
+    expect(omxConfig.name).toBe('roundtrip-team');
+    expect(omxConfig.worker_count).toBe(2);
+    expect(omxConfig.workers[0].role).toBe('claude');
+    expect(omxConfig.workers[1].role).toBe('gemini');
+  });
+});

--- a/src/interop/__tests__/worker-adapter.test.ts
+++ b/src/interop/__tests__/worker-adapter.test.ts
@@ -1,0 +1,482 @@
+import { describe, expect, it } from 'vitest';
+import {
+  omxStatusToOmc,
+  omcStatusToOmx,
+  teamConfigToOmx,
+  omxConfigToTeam,
+  omxTaskToTaskFile,
+  taskFileToOmxTask,
+  mapOmxRoleToCliAgent,
+  outboxMessageToOmxMailbox,
+  omxMailboxToInboxMarkdown,
+  isOmxWorker,
+} from '../worker-adapter.js';
+import type { TaskFile, OutboxMessage } from '../../team/types.js';
+import type { OmxTeamTask, OmxTeamConfig, OmxTeamMailboxMessage } from '../omx-team-state.js';
+import type { TeamConfig } from '../../team/runtime.js';
+import type { StatusAnnotation } from '../adapter-types.js';
+
+// ============================================================================
+// Status Mapping
+// ============================================================================
+
+describe('omxStatusToOmc', () => {
+  it('maps pending directly (non-lossy)', () => {
+    const result = omxStatusToOmc('pending');
+    expect(result.status).toBe('pending');
+    expect(result.annotation.lossy).toBe(false);
+    expect(result.annotation.originalSystem).toBe('omx');
+  });
+
+  it('maps in_progress directly (non-lossy)', () => {
+    const result = omxStatusToOmc('in_progress');
+    expect(result.status).toBe('in_progress');
+    expect(result.annotation.lossy).toBe(false);
+  });
+
+  it('maps completed directly (non-lossy)', () => {
+    const result = omxStatusToOmc('completed');
+    expect(result.status).toBe('completed');
+    expect(result.annotation.lossy).toBe(false);
+  });
+
+  it('maps failed directly (non-lossy, enabled by Phase 0)', () => {
+    const result = omxStatusToOmc('failed');
+    expect(result.status).toBe('failed');
+    expect(result.annotation.lossy).toBe(false);
+    expect(result.annotation.originalStatus).toBe('failed');
+  });
+
+  it('maps blocked to pending (lossy)', () => {
+    const result = omxStatusToOmc('blocked');
+    expect(result.status).toBe('pending');
+    expect(result.annotation.lossy).toBe(true);
+    expect(result.annotation.originalStatus).toBe('blocked');
+    expect(result.annotation.originalSystem).toBe('omx');
+  });
+
+  it('includes ISO timestamp in annotation', () => {
+    const result = omxStatusToOmc('pending');
+    expect(result.annotation.mappedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('omcStatusToOmx', () => {
+  it('maps pending directly', () => {
+    expect(omcStatusToOmx('pending')).toBe('pending');
+  });
+
+  it('maps in_progress directly', () => {
+    expect(omcStatusToOmx('in_progress')).toBe('in_progress');
+  });
+
+  it('maps completed directly', () => {
+    expect(omcStatusToOmx('completed')).toBe('completed');
+  });
+
+  it('maps failed directly', () => {
+    expect(omcStatusToOmx('failed')).toBe('failed');
+  });
+
+  it('recovers blocked from lossy metadata annotation (round-trip)', () => {
+    // Simulate: OMX blocked → OMC pending (with annotation) → OMX blocked
+    const { status, annotation } = omxStatusToOmc('blocked');
+    expect(status).toBe('pending');
+
+    const recovered = omcStatusToOmx(status, { _interop: annotation });
+    expect(recovered).toBe('blocked');
+  });
+
+  it('does not recover when metadata has non-lossy annotation', () => {
+    const annotation: StatusAnnotation = {
+      originalSystem: 'omx',
+      originalStatus: 'completed',
+      mappedStatus: 'completed',
+      mappedAt: new Date().toISOString(),
+      lossy: false,
+    };
+    // Should not override — annotation is non-lossy
+    const result = omcStatusToOmx('completed', { _interop: annotation });
+    expect(result).toBe('completed');
+  });
+
+  it('handles missing metadata gracefully', () => {
+    expect(omcStatusToOmx('pending', undefined)).toBe('pending');
+    expect(omcStatusToOmx('failed', {})).toBe('failed');
+  });
+});
+
+describe('round-trip status mapping', () => {
+  it('blocked survives round-trip via metadata', () => {
+    const step1 = omxStatusToOmc('blocked');
+    const step2 = omcStatusToOmx(step1.status, { _interop: step1.annotation });
+    expect(step2).toBe('blocked');
+  });
+
+  it('failed maps directly both ways (no metadata needed)', () => {
+    const step1 = omxStatusToOmc('failed');
+    expect(step1.status).toBe('failed');
+    expect(step1.annotation.lossy).toBe(false);
+
+    const step2 = omcStatusToOmx('failed');
+    expect(step2).toBe('failed');
+  });
+
+  for (const status of ['pending', 'in_progress', 'completed', 'failed'] as const) {
+    it(`OMC ${status} → OMX → OMC round-trips losslessly`, () => {
+      const omxStatus = omcStatusToOmx(status);
+      const { status: omcStatus } = omxStatusToOmc(omxStatus);
+      expect(omcStatus).toBe(status);
+    });
+  }
+});
+
+// ============================================================================
+// Config Translation
+// ============================================================================
+
+describe('mapOmxRoleToCliAgent', () => {
+  it('maps codex to codex', () => {
+    expect(mapOmxRoleToCliAgent('codex')).toBe('codex');
+  });
+
+  it('maps gemini to gemini', () => {
+    expect(mapOmxRoleToCliAgent('gemini')).toBe('gemini');
+  });
+
+  it('maps executor/coder/developer to claude', () => {
+    expect(mapOmxRoleToCliAgent('executor')).toBe('claude');
+    expect(mapOmxRoleToCliAgent('coder')).toBe('claude');
+    expect(mapOmxRoleToCliAgent('developer')).toBe('claude');
+  });
+
+  it('defaults unknown roles to claude', () => {
+    expect(mapOmxRoleToCliAgent('unknown')).toBe('claude');
+    expect(mapOmxRoleToCliAgent('')).toBe('claude');
+  });
+
+  it('is case-insensitive', () => {
+    expect(mapOmxRoleToCliAgent('CODEX')).toBe('codex');
+    expect(mapOmxRoleToCliAgent('Gemini')).toBe('gemini');
+  });
+});
+
+describe('teamConfigToOmx', () => {
+  const omcConfig: TeamConfig = {
+    teamName: 'test-team',
+    workerCount: 2,
+    agentTypes: ['claude', 'codex'],
+    tasks: [
+      { subject: 'Fix auth', description: 'Fix the auth module' },
+      { subject: 'Add tests', description: 'Add unit tests' },
+    ],
+    cwd: '/tmp/test',
+  };
+
+  it('translates team name', () => {
+    const result = teamConfigToOmx(omcConfig);
+    expect(result.name).toBe('test-team');
+  });
+
+  it('joins task subjects for the task field', () => {
+    const result = teamConfigToOmx(omcConfig);
+    expect(result.task).toBe('Fix auth; Add tests');
+  });
+
+  it('maps worker count correctly', () => {
+    const result = teamConfigToOmx(omcConfig);
+    expect(result.worker_count).toBe(2);
+    expect(result.max_workers).toBe(2);
+  });
+
+  it('creates worker entries with correct roles', () => {
+    const result = teamConfigToOmx(omcConfig);
+    expect(result.workers).toHaveLength(2);
+    expect(result.workers[0].name).toBe('worker-1');
+    expect(result.workers[0].role).toBe('claude');
+    expect(result.workers[1].role).toBe('codex');
+  });
+
+  it('sets next_task_id based on task count', () => {
+    const result = teamConfigToOmx(omcConfig);
+    expect(result.next_task_id).toBe(3);
+  });
+
+  it('includes ISO timestamp for created_at', () => {
+    const result = teamConfigToOmx(omcConfig);
+    expect(result.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('omxConfigToTeam', () => {
+  const omxConfig: OmxTeamConfig = {
+    name: 'omx-team',
+    task: 'Fix all bugs',
+    agent_type: 'executor',
+    worker_count: 3,
+    max_workers: 5,
+    workers: [
+      { name: 'w1', index: 0, role: 'executor', assigned_tasks: [] },
+      { name: 'w2', index: 1, role: 'codex', assigned_tasks: [] },
+      { name: 'w3', index: 2, role: 'gemini', assigned_tasks: [] },
+    ],
+    created_at: '2026-02-27T00:00:00Z',
+    tmux_session: 'omx-session',
+    next_task_id: 4,
+  };
+
+  const tasks: OmxTeamTask[] = [
+    {
+      id: '1', subject: 'Task 1', description: 'Desc 1',
+      status: 'pending', created_at: '2026-02-27T00:00:00Z',
+    },
+  ];
+
+  it('translates team name and worker count', () => {
+    const result = omxConfigToTeam(omxConfig, tasks, '/tmp/test');
+    expect(result.teamName).toBe('omx-team');
+    expect(result.workerCount).toBe(3);
+  });
+
+  it('maps worker roles to CliAgentType', () => {
+    const result = omxConfigToTeam(omxConfig, tasks, '/tmp/test');
+    expect(result.agentTypes).toEqual(['claude', 'codex', 'gemini']);
+  });
+
+  it('translates tasks', () => {
+    const result = omxConfigToTeam(omxConfig, tasks, '/tmp/test');
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].subject).toBe('Task 1');
+  });
+
+  it('uses provided cwd', () => {
+    const result = omxConfigToTeam(omxConfig, tasks, '/custom/path');
+    expect(result.cwd).toBe('/custom/path');
+  });
+});
+
+// ============================================================================
+// Task Translation
+// ============================================================================
+
+describe('omxTaskToTaskFile', () => {
+  it('translates basic task fields', () => {
+    const omxTask: OmxTeamTask = {
+      id: '42', subject: 'Fix bug', description: 'Fix the login bug',
+      status: 'in_progress', owner: 'worker-1',
+      created_at: '2026-02-27T00:00:00Z',
+    };
+    const result = omxTaskToTaskFile(omxTask);
+    expect(result.id).toBe('42');
+    expect(result.subject).toBe('Fix bug');
+    expect(result.description).toBe('Fix the login bug');
+    expect(result.status).toBe('in_progress');
+    expect(result.owner).toBe('worker-1');
+  });
+
+  it('maps blocked to pending with annotation', () => {
+    const omxTask: OmxTeamTask = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'blocked', blocked_by: ['2'],
+      created_at: '2026-02-27T00:00:00Z',
+    };
+    const result = omxTaskToTaskFile(omxTask);
+    expect(result.status).toBe('pending');
+    expect(result.blockedBy).toEqual(['2']);
+    const annotation = result.metadata?._interop as StatusAnnotation;
+    expect(annotation.lossy).toBe(true);
+    expect(annotation.originalStatus).toBe('blocked');
+  });
+
+  it('maps failed directly', () => {
+    const omxTask: OmxTeamTask = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'failed', error: 'Timeout',
+      created_at: '2026-02-27T00:00:00Z',
+    };
+    const result = omxTaskToTaskFile(omxTask);
+    expect(result.status).toBe('failed');
+    expect(result.metadata?._interopError).toBe('Timeout');
+  });
+
+  it('preserves error and result in metadata', () => {
+    const omxTask: OmxTeamTask = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'completed', result: 'All tests pass', error: undefined,
+      created_at: '2026-02-27T00:00:00Z',
+    };
+    const result = omxTaskToTaskFile(omxTask);
+    expect(result.metadata?._interopResult).toBe('All tests pass');
+    expect(result.metadata?._interopError).toBeUndefined();
+  });
+
+  it('maps depends_on to blockedBy when blocked_by is absent', () => {
+    const omxTask: OmxTeamTask = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'pending', depends_on: ['3', '4'],
+      created_at: '2026-02-27T00:00:00Z',
+    };
+    const result = omxTaskToTaskFile(omxTask);
+    expect(result.blockedBy).toEqual(['3', '4']);
+  });
+
+  it('defaults owner to empty string when absent', () => {
+    const omxTask: OmxTeamTask = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'pending', created_at: '2026-02-27T00:00:00Z',
+    };
+    const result = omxTaskToTaskFile(omxTask);
+    expect(result.owner).toBe('');
+  });
+});
+
+describe('taskFileToOmxTask', () => {
+  it('translates basic fields', () => {
+    const taskFile: TaskFile = {
+      id: '10', subject: 'Refactor', description: 'Refactor auth',
+      status: 'completed', owner: 'worker-2',
+      blocks: [], blockedBy: [],
+    };
+    const result = taskFileToOmxTask(taskFile);
+    expect(result.id).toBe('10');
+    expect(result.subject).toBe('Refactor');
+    expect(result.status).toBe('completed');
+    expect(result.owner).toBe('worker-2');
+  });
+
+  it('maps failed directly', () => {
+    const taskFile: TaskFile = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'failed', owner: '',
+      blocks: [], blockedBy: [],
+    };
+    const result = taskFileToOmxTask(taskFile);
+    expect(result.status).toBe('failed');
+  });
+
+  it('recovers blocked from lossy metadata annotation', () => {
+    const annotation: StatusAnnotation = {
+      originalSystem: 'omx',
+      originalStatus: 'blocked',
+      mappedStatus: 'pending',
+      mappedAt: new Date().toISOString(),
+      lossy: true,
+    };
+    const taskFile: TaskFile = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'pending', owner: '', blocks: [], blockedBy: ['2'],
+      metadata: { _interop: annotation },
+    };
+    const result = taskFileToOmxTask(taskFile);
+    expect(result.status).toBe('blocked');
+  });
+
+  it('preserves blockedBy as both blocked_by and depends_on', () => {
+    const taskFile: TaskFile = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'pending', owner: '', blocks: [], blockedBy: ['5', '6'],
+    };
+    const result = taskFileToOmxTask(taskFile);
+    expect(result.blocked_by).toEqual(['5', '6']);
+    expect(result.depends_on).toEqual(['5', '6']);
+  });
+
+  it('preserves error and result from metadata', () => {
+    const taskFile: TaskFile = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'failed', owner: '', blocks: [], blockedBy: [],
+      metadata: { _interopError: 'Crash', _interopResult: 'partial' },
+    };
+    const result = taskFileToOmxTask(taskFile);
+    expect(result.error).toBe('Crash');
+    expect(result.result).toBe('partial');
+  });
+
+  it('omits owner when empty string', () => {
+    const taskFile: TaskFile = {
+      id: '1', subject: 'S', description: 'D',
+      status: 'pending', owner: '', blocks: [], blockedBy: [],
+    };
+    const result = taskFileToOmxTask(taskFile);
+    expect(result.owner).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Message Format Bridging
+// ============================================================================
+
+describe('outboxMessageToOmxMailbox', () => {
+  it('translates outbox message to OMX mailbox format', () => {
+    const msg: OutboxMessage = {
+      type: 'task_complete',
+      taskId: '1',
+      summary: 'Task completed successfully',
+      message: 'All tests pass',
+      timestamp: '2026-02-27T12:00:00Z',
+    };
+    const result = outboxMessageToOmxMailbox(msg, 'worker-1', 'omc-lead');
+    expect(result.from_worker).toBe('worker-1');
+    expect(result.to_worker).toBe('omc-lead');
+    expect(result.body).toBe('All tests pass');
+    expect(result.created_at).toBe('2026-02-27T12:00:00Z');
+    expect(result.message_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('falls back to summary when message is absent', () => {
+    const msg: OutboxMessage = {
+      type: 'idle',
+      summary: 'Worker idle',
+      timestamp: '2026-02-27T12:00:00Z',
+    };
+    const result = outboxMessageToOmxMailbox(msg, 'w1', 'w2');
+    expect(result.body).toBe('Worker idle');
+  });
+
+  it('falls back to JSON when both message and summary are absent', () => {
+    const msg: OutboxMessage = {
+      type: 'heartbeat',
+      timestamp: '2026-02-27T12:00:00Z',
+    };
+    const result = outboxMessageToOmxMailbox(msg, 'w1', 'w2');
+    expect(result.body).toContain('heartbeat');
+  });
+
+  it('produces unique message IDs', () => {
+    const msg: OutboxMessage = { type: 'idle', timestamp: '2026-02-27T12:00:00Z' };
+    const r1 = outboxMessageToOmxMailbox(msg, 'w1', 'w2');
+    const r2 = outboxMessageToOmxMailbox(msg, 'w1', 'w2');
+    expect(r1.message_id).not.toBe(r2.message_id);
+  });
+});
+
+describe('omxMailboxToInboxMarkdown', () => {
+  it('produces markdown with sender and timestamp', () => {
+    const msg: OmxTeamMailboxMessage = {
+      message_id: 'abc-123',
+      from_worker: 'omx-worker-1',
+      to_worker: 'omc-lead',
+      body: 'Task completed.\nAll tests pass.',
+      created_at: '2026-02-27T12:00:00Z',
+    };
+    const result = omxMailboxToInboxMarkdown(msg);
+    expect(result).toContain('---');
+    expect(result).toContain('## Message from omx-worker-1');
+    expect(result).toContain('*2026-02-27T12:00:00Z*');
+    expect(result).toContain('Task completed.\nAll tests pass.');
+  });
+});
+
+// ============================================================================
+// Utility
+// ============================================================================
+
+describe('isOmxWorker', () => {
+  it('returns true for omx interopMode', () => {
+    expect(isOmxWorker({ workerName: 'w1', agentType: 'claude', interopMode: 'omx' })).toBe(true);
+  });
+
+  it('returns false for omc interopMode', () => {
+    expect(isOmxWorker({ workerName: 'w1', agentType: 'claude', interopMode: 'omc' })).toBe(false);
+  });
+});

--- a/src/interop/adapter-types.ts
+++ b/src/interop/adapter-types.ts
@@ -1,0 +1,45 @@
+/**
+ * Interop Adapter Types
+ *
+ * Type definitions for the OMC-OMX cross-platform worker interop layer.
+ * Used by worker-adapter.ts for bidirectional translation between
+ * OMC (.omc/state/team/) and OMX (.omx/state/team/) state formats.
+ */
+
+import type { InteropMode } from './mcp-bridge.js';
+import type { CliAgentType } from '../team/model-contract.js';
+
+/** Which system is the lead (controls the team) */
+export type InteropLead = 'omc' | 'omx';
+
+/** Per-worker interop mode: signals that a worker uses OMX state conventions */
+export type WorkerInteropMode = 'omc' | 'omx';
+
+/** Unified task status superset for translation */
+export type UnifiedTaskStatus = 'pending' | 'blocked' | 'in_progress' | 'completed' | 'failed';
+
+/** Metadata annotation for lossless round-trip */
+export interface StatusAnnotation {
+  originalSystem: 'omc' | 'omx';
+  originalStatus: string;
+  mappedStatus: string;
+  mappedAt: string; // ISO timestamp
+  lossy: boolean;   // true if the mapping lost information
+}
+
+/** Adapter context passed through all translation functions */
+export interface AdapterContext {
+  lead: InteropLead;
+  teamName: string;
+  cwd: string;
+  interopMode: InteropMode;
+}
+
+/** Per-worker config extension for interop */
+export interface WorkerInteropConfig {
+  workerName: string;
+  /** The underlying CLI agent type (claude/codex/gemini) */
+  agentType: CliAgentType;
+  /** Whether this worker uses OMX or OMC state conventions */
+  interopMode: WorkerInteropMode;
+}

--- a/src/interop/worker-adapter.ts
+++ b/src/interop/worker-adapter.ts
@@ -1,0 +1,407 @@
+/**
+ * OMC-OMX Worker Adapter
+ *
+ * Bidirectional translation between OMC and OMX state formats at
+ * worker lifecycle boundaries. Composes omx-team-state.ts read functions
+ * for OMX data access.
+ *
+ * Design: .omc/plans/interop-design.md (issue #1117)
+ *
+ * Write policy (Principle 2 + 2a):
+ *   - Ongoing operation: READ .omx/, WRITE only to .omc/
+ *   - Spawn initialization: may WRITE to .omx/ when interopMode === 'active'
+ */
+
+import { join, dirname } from 'path';
+import { mkdir } from 'fs/promises';
+import { randomUUID } from 'crypto';
+import { atomicWriteJson } from '../lib/atomic-write.js';
+import type { TaskFile, DoneSignal, OutboxMessage } from '../team/types.js';
+import type { CliAgentType } from '../team/model-contract.js';
+import type { TeamConfig } from '../team/runtime.js';
+import {
+  readOmxTeamConfig, readOmxTask, listOmxTasks,
+  appendOmxTeamEvent,
+  type OmxTeamConfig, type OmxTeamTask, type OmxTeamMailboxMessage,
+} from './omx-team-state.js';
+import type {
+  AdapterContext, StatusAnnotation, WorkerInteropConfig,
+} from './adapter-types.js';
+import {
+  generateWorkerOverlay, composeInitialInbox, ensureWorkerStateDir,
+  writeWorkerOverlay,
+} from '../team/worker-bootstrap.js';
+
+// ============================================================================
+// Status Mapping (Step 1 + Step 3)
+// ============================================================================
+
+/**
+ * Map OMX task status to OMC TaskFile status.
+ *
+ * OMX has 5 statuses: pending | blocked | in_progress | completed | failed
+ * OMC has 4 statuses: pending | in_progress | completed | failed
+ *
+ * Only lossy mapping: OMX 'blocked' → OMC 'pending' (with metadata annotation)
+ */
+export function omxStatusToOmc(
+  status: OmxTeamTask['status'],
+): { status: TaskFile['status']; annotation: StatusAnnotation } {
+  const now = new Date().toISOString();
+
+  if (status === 'blocked') {
+    return {
+      status: 'pending',
+      annotation: {
+        originalSystem: 'omx',
+        originalStatus: 'blocked',
+        mappedStatus: 'pending',
+        mappedAt: now,
+        lossy: true,
+      },
+    };
+  }
+
+  // Direct mappings: pending, in_progress, completed, failed
+  const directMap: Record<string, TaskFile['status']> = {
+    pending: 'pending',
+    in_progress: 'in_progress',
+    completed: 'completed',
+    failed: 'failed',
+  };
+
+  const mapped = directMap[status] ?? 'pending';
+  return {
+    status: mapped,
+    annotation: {
+      originalSystem: 'omx',
+      originalStatus: status,
+      mappedStatus: mapped,
+      mappedAt: now,
+      lossy: false,
+    },
+  };
+}
+
+/**
+ * Map OMC TaskFile status to OMX task status.
+ *
+ * Checks metadata for round-trip recovery of lossy mappings (e.g., 'blocked').
+ */
+export function omcStatusToOmx(
+  status: TaskFile['status'],
+  metadata?: Record<string, unknown>,
+): OmxTeamTask['status'] {
+  // Check for round-trip recovery via metadata annotation
+  const interop = metadata?._interop as StatusAnnotation | undefined;
+  if (interop?.lossy && interop.originalSystem === 'omx' && interop.originalStatus) {
+    return interop.originalStatus as OmxTeamTask['status'];
+  }
+
+  // Direct mappings
+  const directMap: Record<string, OmxTeamTask['status']> = {
+    pending: 'pending',
+    in_progress: 'in_progress',
+    completed: 'completed',
+    failed: 'failed',
+  };
+
+  return directMap[status] ?? 'pending';
+}
+
+// ============================================================================
+// Config Translation (Step 2)
+// ============================================================================
+
+/**
+ * Map OMX worker role string to OMC CliAgentType.
+ */
+export function mapOmxRoleToCliAgent(role: string): CliAgentType {
+  const normalized = role.toLowerCase();
+  if (normalized === 'codex') return 'codex';
+  if (normalized === 'gemini') return 'gemini';
+  // executor, coder, developer, and anything else → claude
+  return 'claude';
+}
+
+/**
+ * Translate OMC TeamConfig to OMX OmxTeamConfig.
+ */
+export function teamConfigToOmx(config: TeamConfig): OmxTeamConfig {
+  return {
+    name: config.teamName,
+    task: config.tasks.map(t => t.subject).join('; '),
+    agent_type: config.agentTypes[0] ?? 'claude',
+    worker_count: config.workerCount,
+    max_workers: config.workerCount,
+    workers: config.agentTypes.map((type, i) => ({
+      name: `worker-${i + 1}`,
+      index: i,
+      role: type,
+      assigned_tasks: [] as string[],
+    })),
+    created_at: new Date().toISOString(),
+    tmux_session: `omc-team-${config.teamName}`,
+    next_task_id: config.tasks.length + 1,
+  };
+}
+
+/**
+ * Translate OMX OmxTeamConfig to OMC TeamConfig.
+ * Caller should override `cwd` on the returned config.
+ */
+export function omxConfigToTeam(
+  config: OmxTeamConfig,
+  tasks: OmxTeamTask[],
+  cwd: string,
+): TeamConfig {
+  return {
+    teamName: config.name,
+    workerCount: config.worker_count,
+    agentTypes: config.workers.map(w => mapOmxRoleToCliAgent(w.role)),
+    tasks: tasks.map(t => ({ subject: t.subject, description: t.description })),
+    cwd,
+  };
+}
+
+// ============================================================================
+// Task Translation (Step 3)
+// ============================================================================
+
+/**
+ * Translate OMX OmxTeamTask to OMC TaskFile.
+ */
+export function omxTaskToTaskFile(task: OmxTeamTask): TaskFile {
+  const { status, annotation } = omxStatusToOmc(task.status);
+  return {
+    id: task.id,
+    subject: task.subject,
+    description: task.description,
+    status,
+    owner: task.owner ?? '',
+    blocks: [],
+    blockedBy: task.blocked_by ?? task.depends_on ?? [],
+    metadata: {
+      _interop: annotation,
+      ...(task.error ? { _interopError: task.error } : {}),
+      ...(task.result ? { _interopResult: task.result } : {}),
+    },
+  };
+}
+
+/**
+ * Translate OMC TaskFile to OMX OmxTeamTask.
+ */
+export function taskFileToOmxTask(task: TaskFile): OmxTeamTask {
+  // Check for lossy round-trip recovery via metadata annotation
+  const interopMeta = task.metadata?._interop as StatusAnnotation | undefined;
+  const actualStatus = interopMeta?.lossy && interopMeta.originalStatus
+    ? interopMeta.originalStatus as OmxTeamTask['status']
+    : omcStatusToOmx(task.status, task.metadata);
+
+  return {
+    id: task.id,
+    subject: task.subject,
+    description: task.description,
+    status: actualStatus,
+    owner: task.owner || undefined,
+    blocked_by: task.blockedBy.length > 0 ? task.blockedBy : undefined,
+    depends_on: task.blockedBy.length > 0 ? task.blockedBy : undefined,
+    created_at: new Date().toISOString(),
+    ...(task.metadata?._interopError ? { error: String(task.metadata._interopError) } : {}),
+    ...(task.metadata?._interopResult ? { result: String(task.metadata._interopResult) } : {}),
+  };
+}
+
+// ============================================================================
+// Worker Lifecycle Bridging (Step 4)
+// ============================================================================
+
+// --- 4a: Bootstrap Translation ---
+
+/**
+ * Bootstrap an OMX-format worker from an OMC lead.
+ *
+ * Writes an OMX-format mailbox message so the OMX worker can read its
+ * assignment in native format.
+ *
+ * NARROW EXCEPTION (Principle 2a): writes to .omx/ during spawn initialization
+ * only when interopMode === 'active'.
+ */
+export async function bridgeBootstrapToOmx(
+  ctx: AdapterContext,
+  workerName: string,
+  task: { id: string; subject: string; description: string },
+): Promise<void> {
+  if (ctx.interopMode !== 'active') return;
+
+  const message: OmxTeamMailboxMessage = {
+    message_id: randomUUID(),
+    from_worker: 'omc-lead',
+    to_worker: workerName,
+    body: `## Task Assignment\nTask ID: ${task.id}\nSubject: ${task.subject}\n\n${task.description}`,
+    created_at: new Date().toISOString(),
+  };
+
+  const mailboxPath = join(
+    ctx.cwd, '.omx', 'state', 'team', ctx.teamName,
+    'mailbox', `${workerName}.json`,
+  );
+  await mkdir(dirname(mailboxPath), { recursive: true });
+  await atomicWriteJson(mailboxPath, { worker: workerName, messages: [message] });
+}
+
+/**
+ * Bootstrap an OMC-format worker from an OMX lead.
+ *
+ * Creates AGENTS.md overlay + inbox.md so the OMC worker can bootstrap
+ * in its native format.
+ */
+export async function bridgeBootstrapToOmc(
+  ctx: AdapterContext,
+  workerName: string,
+  agentType: CliAgentType,
+  task: { id: string; subject: string; description: string },
+): Promise<void> {
+  await ensureWorkerStateDir(ctx.teamName, workerName, ctx.cwd);
+  await writeWorkerOverlay({
+    teamName: ctx.teamName,
+    workerName,
+    agentType,
+    tasks: [task],
+    cwd: ctx.cwd,
+  });
+
+  const instruction = [
+    `# Task Assignment`,
+    ``,
+    `**Task ID:** ${task.id}`,
+    `**Subject:** ${task.subject}`,
+    ``,
+    task.description,
+  ].join('\n');
+  await composeInitialInbox(ctx.teamName, workerName, instruction, ctx.cwd);
+}
+
+// --- 4b: Completion Signal Translation (done.json shim) ---
+
+/**
+ * Poll OMX task file for completion and synthesize a DoneSignal.
+ *
+ * READS from .omx/ (allowed in any mode).
+ * WRITES synthesized done.json to .omc/ worker state dir (Principle 2 compliant).
+ *
+ * Returns the DoneSignal if the task is terminal, null otherwise.
+ */
+export async function pollOmxCompletion(
+  ctx: AdapterContext,
+  workerName: string,
+  taskId: string,
+): Promise<DoneSignal | null> {
+  const task = await readOmxTask(ctx.teamName, taskId, ctx.cwd);
+  if (!task) return null;
+
+  if (task.status === 'completed' || task.status === 'failed') {
+    const signal: DoneSignal = {
+      taskId: task.id,
+      status: task.status,
+      summary: task.result ?? task.error ?? `Task ${task.status}`,
+      completedAt: task.completed_at ?? new Date().toISOString(),
+    };
+
+    // Write done.json shim to .omc/ (not .omx/) so existing watchdog picks it up
+    const donePath = join(
+      ctx.cwd, '.omc', 'state', 'team', ctx.teamName,
+      'workers', workerName, 'done.json',
+    );
+    await mkdir(dirname(donePath), { recursive: true });
+    await atomicWriteJson(donePath, signal);
+
+    return signal;
+  }
+  return null;
+}
+
+/**
+ * Bridge an OMC worker's DoneSignal to OMX task file format.
+ *
+ * Used when OMX is the lead: translates done.json into an OMX task file
+ * status update + event log entry.
+ *
+ * Note: appendOmxTeamEvent is marked @deprecated for the old interop pattern,
+ * but is intentionally used here — the adapter is the new canonical write path
+ * for the OMX-lead direction.
+ */
+export async function bridgeDoneSignalToOmx(
+  ctx: AdapterContext,
+  workerName: string,
+  doneSignal: DoneSignal,
+): Promise<void> {
+  const task = await readOmxTask(ctx.teamName, doneSignal.taskId, ctx.cwd);
+  if (task) {
+    task.status = doneSignal.status;
+    task.result = doneSignal.summary;
+    task.completed_at = doneSignal.completedAt;
+    if (doneSignal.status === 'failed') {
+      task.error = doneSignal.summary;
+    }
+    const taskPath = join(
+      ctx.cwd, '.omx', 'state', 'team', ctx.teamName,
+      'tasks', `task-${doneSignal.taskId}.json`,
+    );
+    await atomicWriteJson(taskPath, task);
+  }
+
+  // Append event to OMX event log
+  await appendOmxTeamEvent(ctx.teamName, {
+    type: 'task_completed',
+    worker: workerName,
+    task_id: doneSignal.taskId,
+  }, ctx.cwd);
+}
+
+// ============================================================================
+// Message Format Bridging (Step 5)
+// ============================================================================
+
+/**
+ * Translate OMC OutboxMessage to OMX OmxTeamMailboxMessage.
+ */
+export function outboxMessageToOmxMailbox(
+  msg: OutboxMessage,
+  fromWorker: string,
+  toWorker: string,
+): OmxTeamMailboxMessage {
+  return {
+    message_id: randomUUID(),
+    from_worker: fromWorker,
+    to_worker: toWorker,
+    body: msg.message ?? msg.summary ?? JSON.stringify(msg),
+    created_at: msg.timestamp,
+  };
+}
+
+/**
+ * Translate OMX OmxTeamMailboxMessage to OMC inbox markdown format.
+ * Compatible with appendToInbox() function.
+ */
+export function omxMailboxToInboxMarkdown(msg: OmxTeamMailboxMessage): string {
+  return [
+    `---`,
+    `## Message from ${msg.from_worker}`,
+    `*${msg.created_at}*`,
+    ``,
+    msg.body,
+  ].join('\n');
+}
+
+// ============================================================================
+// Utility: check if a worker uses OMX conventions
+// ============================================================================
+
+/**
+ * Determine if a worker config indicates OMX state conventions.
+ */
+export function isOmxWorker(config: WorkerInteropConfig): boolean {
+  return config.interopMode === 'omx';
+}

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -36,7 +36,7 @@ export interface TaskFile {
   subject: string;
   description: string;
   activeForm?: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
   owner: string;
   blocks: string[];
   blockedBy: string[];


### PR DESCRIPTION
## Summary

- Implement bidirectional adapter (`src/interop/worker-adapter.ts`) that translates between OMC and OMX state formats at worker lifecycle boundaries, enabling cross-platform team orchestration
- Add `adapter-types.ts` with `AdapterContext`, `WorkerInteropConfig`, `StatusAnnotation` types
- Fix `TaskFile.status` to include `'failed'` (Phase 0 prerequisite — the type was lying about what runtime.ts already writes)
- Integrate adapter at 4 lifecycle points in `runtime.ts`: spawn, watchdog tick, startTeam config, shutdown — all gated by `interopMode` checks

## Design

Follows the RALPLAN-approved design at `.omc/plans/interop-design.md`:

- **Adapter Pattern**: pure translation functions, no new daemons or polling loops
- **Read Foreign, Write Native**: ongoing operation reads `.omx/`, writes only to `.omc/`; narrow spawn exception writes to `.omx/` when `interopMode === 'active'`
- **Lossy round-trip recovery**: OMX `blocked` maps to OMC `pending` with metadata annotation; recovered on reverse translation
- **done.json shim**: `pollOmxCompletion` reads OMX task files, writes synthesized `done.json` to `.omc/` worker state dir for existing watchdog to pick up unchanged

## Files Changed

| File | Change |
|------|--------|
| `src/interop/adapter-types.ts` | NEW — interop type definitions |
| `src/interop/worker-adapter.ts` | NEW — all translation functions (~400 lines) |
| `src/interop/__tests__/worker-adapter.test.ts` | NEW — 53 unit tests |
| `src/interop/__tests__/worker-adapter-integration.test.ts` | NEW — 12 integration tests with file I/O |
| `src/team/types.ts` | MOD — add `'failed'` to `TaskFile.status` union |
| `src/team/runtime.ts` | MOD — 4 adapter call sites at lifecycle hooks |

## Test plan

- [x] 53 unit tests covering all pure translation functions (status, config, task, message, utility)
- [x] 12 integration tests with real file I/O (bootstrap, completion shim, done signal, round-trips)
- [x] All 3 existing mcp-bridge tests still pass (68 total)
- [x] `tsc --noEmit` passes with zero errors
- [x] No changes to `model-contract.ts` or `CliAgentType` union

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)