### PR TITLE
fix(team): resolve user's shell PATH for CLI detection and runtime spawn

### DIFF
--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -27,6 +27,7 @@ import { readFile } from 'fs/promises';
 import { homedir } from 'os';
 import { killWorkerPanes } from '../team/tmux-session.js';
 import { validateTeamName } from '../team/team-name.js';
+import { resolvedEnv } from '../team/shell-path.js';
 import { NudgeTracker } from '../team/idle-nudge.js';
 
 // ---------------------------------------------------------------------------
@@ -126,7 +127,7 @@ async function handleStart(args: unknown): Promise<{ content: Array<{ type: 'tex
   omcTeamJobs.set(jobId, job);
 
   const child = spawn('node', [runtimeCliPath], {
-    env: { ...process.env, OMC_JOB_ID: jobId, OMC_JOBS_DIR },
+    env: resolvedEnv({ OMC_JOB_ID: jobId, OMC_JOBS_DIR }),
     stdio: ['pipe', 'pipe', 'pipe'],
   });
   job.pid = child.pid;

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -95,7 +95,7 @@ describe('model-contract', () => {
 
       isCliAvailable('codex');
 
-      expect(mockSpawnSync).toHaveBeenCalledWith('codex', ['--version'], { timeout: 5000, shell: true });
+      expect(mockSpawnSync).toHaveBeenCalledWith('codex', ['--version'], expect.objectContaining({ timeout: 5000, shell: true }));
       mockSpawnSync.mockRestore();
     });
   });

--- a/src/team/__tests__/shell-path.test.ts
+++ b/src/team/__tests__/shell-path.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveShellPath, resolvedEnv, _resetShellPathCache } from '../shell-path.js';
+import { spawnSync } from 'child_process';
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+const mockSpawnSync = vi.mocked(spawnSync);
+
+describe('shell-path', () => {
+  beforeEach(() => {
+    _resetShellPathCache();
+    mockSpawnSync.mockReset();
+  });
+
+  describe('resolveShellPath', () => {
+    it('parses PATH from env output', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('HOME=/Users/test\nPATH=/usr/local/bin:/usr/bin:/bin\nSHELL=/bin/zsh\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      expect(resolveShellPath()).toBe('/usr/local/bin:/usr/bin:/bin');
+    });
+
+    it('ignores dotfile stdout noise (conda init, greetings)', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('Welcome to my shell!\nconda activated\nHOME=/Users/test\nPATH=/opt/conda/bin:/usr/bin\nSHELL=/bin/bash\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      expect(resolveShellPath()).toBe('/opt/conda/bin:/usr/bin');
+    });
+
+    it('handles fish shell env output (colon-separated in env)', () => {
+      // fish's `env` command outputs PATH= with colons, unlike `echo $PATH` which is space-separated
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('HOME=/Users/test\nPATH=/Users/test/.local/bin:/usr/local/bin:/usr/bin\nSHELL=/usr/bin/fish\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      expect(resolveShellPath()).toBe('/Users/test/.local/bin:/usr/local/bin:/usr/bin');
+    });
+
+    it('falls back to process.env.PATH when spawnSync fails', () => {
+      mockSpawnSync.mockImplementation(() => { throw new Error('spawn failed'); });
+
+      const original = process.env.PATH;
+      process.env.PATH = '/fallback/bin';
+      try {
+        expect(resolveShellPath()).toBe('/fallback/bin');
+      } finally {
+        process.env.PATH = original;
+      }
+    });
+
+    it('falls back when spawnSync returns non-zero exit', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 1,
+        stdout: Buffer.from(''),
+        stderr: Buffer.from('error'),
+        pid: 0, output: [], signal: null,
+      });
+
+      const original = process.env.PATH;
+      process.env.PATH = '/fallback/bin';
+      try {
+        expect(resolveShellPath()).toBe('/fallback/bin');
+      } finally {
+        process.env.PATH = original;
+      }
+    });
+
+    it('falls back when env output has no PATH= line', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('HOME=/Users/test\nSHELL=/bin/zsh\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      const original = process.env.PATH;
+      process.env.PATH = '/fallback/bin';
+      try {
+        expect(resolveShellPath()).toBe('/fallback/bin');
+      } finally {
+        process.env.PATH = original;
+      }
+    });
+
+    it('invokes login shell with env command', () => {
+      const originalShell = process.env.SHELL;
+      process.env.SHELL = '/bin/zsh';
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('PATH=/usr/bin\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      resolveShellPath();
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        '/bin/zsh',
+        ['-ilc', 'env'],
+        expect.objectContaining({ timeout: 5000 }),
+      );
+      process.env.SHELL = originalShell;
+    });
+
+    it('skips spawn on Windows and uses process.env.PATH', () => {
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      const original = process.env.PATH;
+      process.env.PATH = '/windows/system32';
+
+      try {
+        expect(resolveShellPath()).toBe('/windows/system32');
+        expect(mockSpawnSync).not.toHaveBeenCalled();
+      } finally {
+        process.env.PATH = original;
+        if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    });
+
+    it('caches result on second call', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('PATH=/cached/bin\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      resolveShellPath();
+      resolveShellPath();
+
+      expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-resolves after cache reset', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('PATH=/first/bin\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      expect(resolveShellPath()).toBe('/first/bin');
+
+      _resetShellPathCache();
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('PATH=/second/bin\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      expect(resolveShellPath()).toBe('/second/bin');
+      expect(mockSpawnSync).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('resolvedEnv', () => {
+    it('merges resolved PATH and extra vars into process.env', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('PATH=/resolved/bin\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      const env = resolvedEnv({ MY_VAR: 'test' });
+      expect(env.PATH).toBe('/resolved/bin');
+      expect(env.MY_VAR).toBe('test');
+    });
+
+    it('extra vars override PATH if explicitly passed', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('PATH=/resolved/bin\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      const env = resolvedEnv({ PATH: '/override/bin' });
+      expect(env.PATH).toBe('/override/bin');
+    });
+
+    it('uses existing PATH key casing from process.env (Windows compat)', () => {
+      mockSpawnSync.mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('PATH=/resolved/bin\n'),
+        stderr: Buffer.from(''),
+        pid: 0, output: [], signal: null,
+      });
+
+      // Simulate Windows-style `Path` key
+      const origPath = process.env.PATH;
+      const origPathLower = process.env.Path;
+      delete process.env.PATH;
+      process.env.Path = '/windows/system32';
+      try {
+        const env = resolvedEnv();
+        // Should write to `Path` (existing casing), not create a new `PATH`
+        expect(env.Path).toBe('/resolved/bin');
+        expect(Object.keys(env).filter(k => k.toUpperCase() === 'PATH')).toHaveLength(1);
+      } finally {
+        delete process.env.Path;
+        if (origPath !== undefined) process.env.PATH = origPath;
+        if (origPathLower !== undefined) process.env.Path = origPathLower;
+      }
+    });
+  });
+});

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -2,6 +2,7 @@
 // and additional CLI detection utilities
 export { isCliAvailable, validateCliAvailable, getContract, type CliAgentType } from './model-contract.js';
 import { spawnSync } from 'child_process';
+import { resolvedEnv } from './shell-path.js';
 
 export interface CliInfo {
   available: boolean;
@@ -11,9 +12,10 @@ export interface CliInfo {
 
 export function detectCli(binary: string): CliInfo {
   try {
-    const versionResult = spawnSync(binary, ['--version'], { timeout: 5000 });
+    const env = resolvedEnv();
+    const versionResult = spawnSync(binary, ['--version'], { timeout: 5000, env });
     if (versionResult.status === 0) {
-      const pathResult = spawnSync('which', [binary], { timeout: 5000 });
+      const pathResult = spawnSync('which', [binary], { timeout: 5000, env });
       return {
         available: true,
         version: versionResult.stdout?.toString().trim(),

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -12,6 +12,7 @@
  */
 
 import { spawn, execSync, ChildProcess } from 'child_process';
+import { resolvedEnv } from './shell-path.js';
 import { existsSync, openSync, readSync, closeSync } from 'fs';
 import { join } from 'path';
 import { writeFileWithMode, ensureDirWithMode } from './fs-utils.js';
@@ -382,6 +383,7 @@ function spawnCliProcess(
   const child = spawn(cmd, args, {
     stdio: ['pipe', 'pipe', 'pipe'],
     cwd,
+    env: resolvedEnv(),
     ...(process.platform === 'win32' ? { shell: true } : {})
   });
 

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'child_process';
+import { resolvedEnv } from './shell-path.js';
 import { validateTeamName } from './team-name.js';
 
 export type CliAgentType = 'claude' | 'codex' | 'gemini';
@@ -97,7 +98,11 @@ export function getContract(agentType: CliAgentType): CliAgentContract {
 export function isCliAvailable(agentType: CliAgentType): boolean {
   const contract = getContract(agentType);
   try {
-    const result = spawnSync(contract.binary, ['--version'], { timeout: 5000, shell: true });
+    const result = spawnSync(contract.binary, ['--version'], {
+      timeout: 5000,
+      shell: true,
+      env: resolvedEnv(),
+    });
     return result.status === 0;
   } catch {
     return false;

--- a/src/team/shell-path.ts
+++ b/src/team/shell-path.ts
@@ -1,0 +1,77 @@
+/**
+ * Resolve the user's full shell PATH.
+ *
+ * MCP server processes are spawned by the Claude Code plugin system and may
+ * not inherit the user's interactive-shell PATH. Tools installed via version
+ * managers (mise, asdf, nvm, fnm, volta, etc.) or into /usr/local/bin are
+ * therefore invisible to child_process.spawn/spawnSync.
+ *
+ * This module resolves the real PATH once (lazy, cached) by running a login
+ * shell and reading $PATH from it.
+ */
+import { spawnSync } from 'child_process';
+
+let _resolved: string | null = null;
+
+/**
+ * Return the user's full interactive-shell PATH, falling back to
+ * process.env.PATH when resolution fails.
+ *
+ * Parses `env` output instead of `echo $PATH` to avoid stdout noise
+ * from interactive dotfiles (conda init, greeting messages).
+ *
+ * Note: On fish shell, the `-ilc` combined flags are not supported
+ * (fish requires `--login --interactive -c`), so resolution falls
+ * back to process.env.PATH. On Windows, SHELL is unset and
+ * resolution also falls back gracefully.
+ */
+export function resolveShellPath(): string {
+  if (_resolved !== null) return _resolved;
+
+  // On Windows, SHELL is unset and /bin/sh does not exist.
+  // Skip the spawn attempt to avoid a guaranteed-to-fail 5s timeout.
+  if (process.platform === 'win32') {
+    _resolved = process.env.PATH || '';
+    return _resolved;
+  }
+
+  try {
+    const shell = process.env.SHELL || '/bin/sh';
+    // Use `env` and parse PATH= line — works across all shells (bash, zsh, fish)
+    // and avoids stdout noise from interactive dotfiles (.bashrc, .zshrc, config.fish).
+    const result = spawnSync(shell, ['-ilc', 'env'], {
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    if (result.status === 0) {
+      const stdout = result.stdout?.toString() ?? '';
+      const pathLine = stdout.split('\n').find(l => l.startsWith('PATH='));
+      const path = pathLine?.slice(5)?.trim();
+      if (path) {
+        _resolved = path;
+        return _resolved;
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  _resolved = process.env.PATH || '';
+  return _resolved;
+}
+
+/**
+ * Return a copy of process.env with the resolved PATH merged in.
+ * Handles Windows where the key may be `Path` instead of `PATH`.
+ */
+export function resolvedEnv(extra?: Record<string, string>): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  const pathKey = Object.keys(env).find(k => k.toUpperCase() === 'PATH') || 'PATH';
+  env[pathKey] = resolveShellPath();
+  return { ...env, ...extra };
+}
+
+/** @internal For testing only. Resets the cached PATH so the next call re-resolves. */
+export function _resetShellPathCache(): void {
+  _resolved = null;
+}


### PR DESCRIPTION
## Summary

- MCP server processes spawned by the Claude Code plugin system do not inherit the user's interactive-shell PATH. Tools installed via version managers (mise, asdf, nvm, fnm, volta) or into `/usr/local/bin` are invisible to `child_process.spawn/spawnSync`.
- Add `src/team/shell-path.ts` that resolves the real PATH once (lazy, cached) by running a login shell and parsing `env` output — works across bash and zsh without stdout noise from dotfiles.
- Wire `resolvedEnv()` into all 4 CLI spawn sites: `isCliAvailable()`, `detectCli()`, `spawnCliProcess()`, and runtime-cli spawn in `team-server.ts`.
- Includes Windows early-return guard (skip guaranteed-to-fail spawn) and Windows `Path` vs `PATH` key casing compatibility in `resolvedEnv()`.

**Note:** On fish shell, the `-ilc` combined flags are not supported (fish requires `--login --interactive -c`), so resolution falls back to `process.env.PATH` gracefully. This is documented in the module docstring.

## Changed files

| File | Change |
|------|--------|
| `src/team/shell-path.ts` | **New** — core PATH resolution utility |
| `src/team/__tests__/shell-path.test.ts` | **New** — 13 unit tests |
| `src/team/model-contract.ts` | Use `resolvedEnv()` in `isCliAvailable()` |
| `src/team/cli-detection.ts` | Use `resolvedEnv()` in `detectCli()` |
| `src/mcp/team-server.ts` | Use `resolvedEnv()` for runtime-cli spawn |
| `src/team/mcp-team-bridge.ts` | Use `resolvedEnv()` in `spawnCliProcess()` |
| `src/team/__tests__/model-contract.test.ts` | Relax assertion to `expect.objectContaining` |

## Test plan

- [x] All 13 new shell-path tests pass (env parsing, dotfile noise, fish output, spawn failure fallback, non-zero exit, no PATH line, login shell args verification, Windows guard, caching, cache reset, resolvedEnv merge, PATH override, Windows Path casing)
- [x] All 21 model-contract tests pass
- [x] Build succeeds with no TypeScript errors on modified files
- [x] Manual test on macOS with mise-installed CLI (`gemini`) to verify end-to-end omc-teams execution

Fixes #1129