### PR TITLE
feat(shared-memory): add cross-session memory sync for multi-agent handoffs

### DIFF
--- a/src/__tests__/omc-tools-server.test.ts
+++ b/src/__tests__/omc-tools-server.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { omcToolsServer, omcToolNames, getOmcToolNames } from '../mcp/omc-tools-server.js';
 
 const interopEnabled = process.env.OMC_INTEROP_TOOLS_ENABLED === '1';
-const totalTools = interopEnabled ? 43 : 35;
-const withoutLsp = interopEnabled ? 31 : 23;
-const withoutAst = interopEnabled ? 41 : 33;
-const withoutPython = interopEnabled ? 42 : 34;
-const withoutSkills = interopEnabled ? 40 : 32;
+const totalTools = interopEnabled ? 48 : 40;
+const withoutLsp = interopEnabled ? 36 : 28;
+const withoutAst = interopEnabled ? 46 : 38;
+const withoutPython = interopEnabled ? 47 : 39;
+const withoutSkills = interopEnabled ? 45 : 37;
 
 describe('omc-tools-server', () => {
   describe('omcToolNames', () => {

--- a/src/__tests__/shared-memory.test.ts
+++ b/src/__tests__/shared-memory.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock getOmcRoot to use our test directory
+const mockGetOmcRoot = vi.fn<(worktreeRoot?: string) => string>();
+vi.mock('../lib/worktree-paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/worktree-paths.js')>();
+  return {
+    ...actual,
+    getOmcRoot: (...args: [string?]) => mockGetOmcRoot(...args),
+    validateWorkingDirectory: (dir?: string) => dir || '/tmp',
+  };
+});
+
+import {
+  writeEntry,
+  readEntry,
+  listEntries,
+  deleteEntry,
+  cleanupExpired,
+  listNamespaces,
+  isSharedMemoryEnabled,
+} from '../lib/shared-memory.js';
+
+describe('Shared Memory', () => {
+  let testDir: string;
+  let omcDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `shared-memory-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    omcDir = join(testDir, '.omc');
+    mkdirSync(omcDir, { recursive: true });
+    mockGetOmcRoot.mockReturnValue(omcDir);
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  // =========================================================================
+  // writeEntry + readEntry
+  // =========================================================================
+
+  describe('writeEntry / readEntry', () => {
+    it('should write and read a string value', () => {
+      const entry = writeEntry('test-ns', 'greeting', 'hello world');
+      expect(entry.key).toBe('greeting');
+      expect(entry.value).toBe('hello world');
+      expect(entry.namespace).toBe('test-ns');
+      expect(entry.createdAt).toBeTruthy();
+      expect(entry.updatedAt).toBeTruthy();
+
+      const read = readEntry('test-ns', 'greeting');
+      expect(read).not.toBeNull();
+      expect(read!.value).toBe('hello world');
+    });
+
+    it('should write and read an object value', () => {
+      const data = { decisions: ['use JWT', 'skip OAuth'], confidence: 0.9 };
+      writeEntry('pipeline-run-42', 'auth-context', data);
+
+      const read = readEntry('pipeline-run-42', 'auth-context');
+      expect(read!.value).toEqual(data);
+    });
+
+    it('should preserve createdAt on update', () => {
+      const first = writeEntry('ns', 'key1', 'v1');
+      const createdAt = first.createdAt;
+
+      // Small delay to ensure different timestamp
+      const second = writeEntry('ns', 'key1', 'v2');
+      expect(second.createdAt).toBe(createdAt);
+      expect(second.value).toBe('v2');
+    });
+
+    it('should return null for non-existent key', () => {
+      const read = readEntry('ns', 'no-such-key');
+      expect(read).toBeNull();
+    });
+
+    it('should return null for non-existent namespace', () => {
+      const read = readEntry('no-such-ns', 'key');
+      expect(read).toBeNull();
+    });
+
+    it('should create namespace directory automatically', () => {
+      writeEntry('auto-ns', 'k', 'v');
+      const nsDir = join(omcDir, 'state', 'shared-memory', 'auto-ns');
+      expect(existsSync(nsDir)).toBe(true);
+    });
+
+    it('should store entry as JSON file', () => {
+      writeEntry('ns', 'mykey', { x: 1 });
+      const filePath = join(omcDir, 'state', 'shared-memory', 'ns', 'mykey.json');
+      expect(existsSync(filePath)).toBe(true);
+      const content = JSON.parse(readFileSync(filePath, 'utf-8'));
+      expect(content.key).toBe('mykey');
+      expect(content.value).toEqual({ x: 1 });
+    });
+  });
+
+  // =========================================================================
+  // TTL support
+  // =========================================================================
+
+  describe('TTL support', () => {
+    it('should set ttl and expiresAt when ttl provided', () => {
+      const entry = writeEntry('ns', 'temp', 'data', 3600);
+      expect(entry.ttl).toBe(3600);
+      expect(entry.expiresAt).toBeTruthy();
+
+      const expiresAt = new Date(entry.expiresAt!).getTime();
+      const now = Date.now();
+      // Should be approximately 1 hour from now (allow 5s tolerance)
+      expect(expiresAt).toBeGreaterThan(now + 3595000);
+      expect(expiresAt).toBeLessThan(now + 3605000);
+    });
+
+    it('should not set ttl when omitted', () => {
+      const entry = writeEntry('ns', 'permanent', 'data');
+      expect(entry.ttl).toBeUndefined();
+      expect(entry.expiresAt).toBeUndefined();
+    });
+
+    it('should auto-delete expired entries on read', () => {
+      // Write entry with already-expired timestamp
+      const filePath = join(omcDir, 'state', 'shared-memory', 'ns');
+      mkdirSync(filePath, { recursive: true });
+      const expiredEntry = {
+        key: 'expired-key',
+        value: 'old',
+        namespace: 'ns',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        ttl: 60,
+        expiresAt: '2020-01-01T00:01:00.000Z',
+      };
+      writeFileSync(join(filePath, 'expired-key.json'), JSON.stringify(expiredEntry));
+
+      const read = readEntry('ns', 'expired-key');
+      expect(read).toBeNull();
+
+      // File should be deleted
+      expect(existsSync(join(filePath, 'expired-key.json'))).toBe(false);
+    });
+
+    it('should return non-expired entries normally', () => {
+      const entry = writeEntry('ns', 'fresh', 'data', 7200);
+      const read = readEntry('ns', 'fresh');
+      expect(read).not.toBeNull();
+      expect(read!.value).toBe('data');
+    });
+  });
+
+  // =========================================================================
+  // listEntries
+  // =========================================================================
+
+  describe('listEntries', () => {
+    it('should list all keys in a namespace', () => {
+      writeEntry('ns', 'alpha', 1);
+      writeEntry('ns', 'beta', 2);
+      writeEntry('ns', 'gamma', 3);
+
+      const items = listEntries('ns');
+      expect(items).toHaveLength(3);
+      expect(items.map(i => i.key)).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('should return empty array for empty namespace', () => {
+      const items = listEntries('empty-ns');
+      expect(items).toEqual([]);
+    });
+
+    it('should filter out expired entries', () => {
+      writeEntry('ns', 'live', 'ok');
+
+      // Manually write an expired entry
+      const nsDir = join(omcDir, 'state', 'shared-memory', 'ns');
+      const expiredEntry = {
+        key: 'dead',
+        value: 'expired',
+        namespace: 'ns',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        ttl: 1,
+        expiresAt: '2020-01-01T00:00:01.000Z',
+      };
+      writeFileSync(join(nsDir, 'dead.json'), JSON.stringify(expiredEntry));
+
+      const items = listEntries('ns');
+      expect(items).toHaveLength(1);
+      expect(items[0].key).toBe('live');
+    });
+
+    it('should include expiresAt in list items when present', () => {
+      writeEntry('ns', 'temp', 'data', 3600);
+      const items = listEntries('ns');
+      expect(items[0].expiresAt).toBeTruthy();
+    });
+  });
+
+  // =========================================================================
+  // deleteEntry
+  // =========================================================================
+
+  describe('deleteEntry', () => {
+    it('should delete an existing key', () => {
+      writeEntry('ns', 'to-delete', 'bye');
+      const deleted = deleteEntry('ns', 'to-delete');
+      expect(deleted).toBe(true);
+
+      const read = readEntry('ns', 'to-delete');
+      expect(read).toBeNull();
+    });
+
+    it('should return false for non-existent key', () => {
+      const deleted = deleteEntry('ns', 'nonexistent');
+      expect(deleted).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // cleanupExpired
+  // =========================================================================
+
+  describe('cleanupExpired', () => {
+    it('should remove expired entries from a namespace', () => {
+      writeEntry('ns', 'live', 'ok');
+
+      // Manually write expired entries
+      const nsDir = join(omcDir, 'state', 'shared-memory', 'ns');
+      for (const key of ['exp1', 'exp2']) {
+        writeFileSync(join(nsDir, `${key}.json`), JSON.stringify({
+          key,
+          value: 'old',
+          namespace: 'ns',
+          createdAt: '2020-01-01T00:00:00.000Z',
+          updatedAt: '2020-01-01T00:00:00.000Z',
+          ttl: 1,
+          expiresAt: '2020-01-01T00:00:01.000Z',
+        }));
+      }
+
+      const result = cleanupExpired('ns');
+      expect(result.removed).toBe(2);
+      expect(result.namespaces).toContain('ns');
+
+      // Live entry should remain
+      expect(readEntry('ns', 'live')).not.toBeNull();
+    });
+
+    it('should clean all namespaces when no namespace specified', () => {
+      // Create entries in two namespaces
+      writeEntry('ns1', 'live', 'ok');
+      writeEntry('ns2', 'live', 'ok');
+
+      // Add expired entries to both
+      for (const ns of ['ns1', 'ns2']) {
+        const nsDir = join(omcDir, 'state', 'shared-memory', ns);
+        writeFileSync(join(nsDir, 'expired.json'), JSON.stringify({
+          key: 'expired',
+          value: 'old',
+          namespace: ns,
+          createdAt: '2020-01-01T00:00:00.000Z',
+          updatedAt: '2020-01-01T00:00:00.000Z',
+          ttl: 1,
+          expiresAt: '2020-01-01T00:00:01.000Z',
+        }));
+      }
+
+      const result = cleanupExpired();
+      expect(result.removed).toBe(2);
+      expect(result.namespaces).toHaveLength(2);
+    });
+
+    it('should return 0 when no expired entries', () => {
+      writeEntry('ns', 'live', 'ok');
+      const result = cleanupExpired('ns');
+      expect(result.removed).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // listNamespaces
+  // =========================================================================
+
+  describe('listNamespaces', () => {
+    it('should list all namespaces', () => {
+      writeEntry('alpha-ns', 'k', 'v');
+      writeEntry('beta-ns', 'k', 'v');
+      writeEntry('gamma-ns', 'k', 'v');
+
+      const namespaces = listNamespaces();
+      expect(namespaces).toEqual(['alpha-ns', 'beta-ns', 'gamma-ns']);
+    });
+
+    it('should return empty array when no namespaces', () => {
+      const namespaces = listNamespaces();
+      expect(namespaces).toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  // Namespace isolation
+  // =========================================================================
+
+  describe('namespace isolation', () => {
+    it('should isolate keys between namespaces', () => {
+      writeEntry('ns1', 'key', 'value-1');
+      writeEntry('ns2', 'key', 'value-2');
+
+      expect(readEntry('ns1', 'key')!.value).toBe('value-1');
+      expect(readEntry('ns2', 'key')!.value).toBe('value-2');
+    });
+
+    it('should not affect other namespaces on delete', () => {
+      writeEntry('ns1', 'key', 'v1');
+      writeEntry('ns2', 'key', 'v2');
+
+      deleteEntry('ns1', 'key');
+
+      expect(readEntry('ns1', 'key')).toBeNull();
+      expect(readEntry('ns2', 'key')!.value).toBe('v2');
+    });
+  });
+
+  // =========================================================================
+  // Validation
+  // =========================================================================
+
+  describe('validation', () => {
+    it('should reject namespace with path traversal', () => {
+      expect(() => writeEntry('../etc', 'key', 'v')).toThrow('Invalid namespace');
+    });
+
+    it('should reject key with path traversal', () => {
+      expect(() => writeEntry('ns', '../passwd', 'v')).toThrow('Invalid key');
+    });
+
+    it('should reject empty namespace', () => {
+      expect(() => writeEntry('', 'key', 'v')).toThrow('Invalid namespace');
+    });
+
+    it('should reject empty key', () => {
+      expect(() => writeEntry('ns', '', 'v')).toThrow('Invalid key');
+    });
+
+    it('should reject namespace with special characters', () => {
+      expect(() => writeEntry('ns/foo', 'key', 'v')).toThrow('Invalid namespace');
+    });
+
+    it('should accept namespace with dots, hyphens, underscores', () => {
+      const entry = writeEntry('my-team.run_1', 'key', 'v');
+      expect(entry.namespace).toBe('my-team.run_1');
+    });
+  });
+
+  // =========================================================================
+  // Config gate
+  // =========================================================================
+
+  describe('isSharedMemoryEnabled', () => {
+    it('should return true by default (no config file)', () => {
+      expect(isSharedMemoryEnabled()).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Corrupted file handling
+  // =========================================================================
+
+  describe('corrupted files', () => {
+    it('should return null for corrupted entry file on read', () => {
+      const nsDir = join(omcDir, 'state', 'shared-memory', 'ns');
+      mkdirSync(nsDir, { recursive: true });
+      writeFileSync(join(nsDir, 'bad.json'), 'not json{{{');
+
+      const read = readEntry('ns', 'bad');
+      expect(read).toBeNull();
+    });
+
+    it('should skip corrupted files in list', () => {
+      writeEntry('ns', 'good', 'ok');
+      const nsDir = join(omcDir, 'state', 'shared-memory', 'ns');
+      writeFileSync(join(nsDir, 'bad.json'), 'corrupt');
+
+      const items = listEntries('ns');
+      expect(items).toHaveLength(1);
+      expect(items[0].key).toBe('good');
+    });
+  });
+});

--- a/src/constants/names.ts
+++ b/src/constants/names.ts
@@ -36,6 +36,7 @@ export const TOOL_CATEGORIES = {
   INTEROP: 'interop',
   CODEX: 'codex',
   GEMINI: 'gemini',
+  SHARED_MEMORY: 'shared-memory',
 } as const;
 export type ToolCategory = typeof TOOL_CATEGORIES[keyof typeof TOOL_CATEGORIES];
 

--- a/src/lib/shared-memory.ts
+++ b/src/lib/shared-memory.ts
@@ -1,0 +1,369 @@
+/**
+ * Shared Memory State Layer
+ *
+ * Filesystem-based key-value store for cross-session memory sync
+ * between agents in /team and /pipeline workflows.
+ *
+ * Storage: .omc/state/shared-memory/{namespace}/{key}.json
+ *
+ * Each entry is a JSON file containing:
+ * - key: string identifier
+ * - value: arbitrary JSON-serializable data
+ * - namespace: grouping identifier (session group, pipeline run, etc.)
+ * - createdAt: ISO timestamp
+ * - updatedAt: ISO timestamp
+ * - ttl: optional time-to-live in seconds
+ * - expiresAt: optional ISO timestamp (computed from ttl)
+ *
+ * @see https://github.com/anthropics/oh-my-claudecode/issues/1119
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, readdirSync } from 'fs';
+import { join, basename } from 'path';
+import { getOmcRoot } from './worktree-paths.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SharedMemoryEntry {
+  key: string;
+  value: unknown;
+  namespace: string;
+  createdAt: string;
+  updatedAt: string;
+  /** TTL in seconds. Omitted or 0 means no expiry. */
+  ttl?: number;
+  /** Absolute expiry timestamp (ISO). Computed from ttl on write. */
+  expiresAt?: string;
+}
+
+export interface SharedMemoryListItem {
+  key: string;
+  updatedAt: string;
+  expiresAt?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const CONFIG_FILE_NAME = '.omc-config.json';
+
+/**
+ * Check if shared memory is enabled via config.
+ *
+ * Reads `agents.sharedMemory.enabled` from ~/.claude/.omc-config.json.
+ * Defaults to true when the config key is absent (opt-out rather than opt-in
+ * once the feature ships, but tools check this gate).
+ */
+export function isSharedMemoryEnabled(): boolean {
+  try {
+    const configPath = join(
+      process.env.HOME || process.env.USERPROFILE || '',
+      '.claude',
+      CONFIG_FILE_NAME,
+    );
+    if (!existsSync(configPath)) return true; // default enabled
+    const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const enabled = raw?.agents?.sharedMemory?.enabled;
+    if (typeof enabled === 'boolean') return enabled;
+    return true; // default enabled when key absent
+  } catch {
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+const SHARED_MEMORY_DIR = 'state/shared-memory';
+
+/** Validate namespace: alphanumeric, hyphens, underscores, dots. Max 128 chars. */
+function validateNamespace(namespace: string): void {
+  if (!namespace || namespace.length > 128) {
+    throw new Error(`Invalid namespace: must be 1-128 characters (got ${namespace.length})`);
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(namespace)) {
+    throw new Error(`Invalid namespace: must be alphanumeric with hyphens/underscores/dots (got "${namespace}")`);
+  }
+  if (namespace.includes('..')) {
+    throw new Error('Invalid namespace: path traversal not allowed');
+  }
+}
+
+/** Validate key: alphanumeric, hyphens, underscores, dots. Max 128 chars. */
+function validateKey(key: string): void {
+  if (!key || key.length > 128) {
+    throw new Error(`Invalid key: must be 1-128 characters (got ${key.length})`);
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(key)) {
+    throw new Error(`Invalid key: must be alphanumeric with hyphens/underscores/dots (got "${key}")`);
+  }
+  if (key.includes('..')) {
+    throw new Error('Invalid key: path traversal not allowed');
+  }
+}
+
+/** Get the directory path for a namespace. */
+function getNamespaceDir(namespace: string, worktreeRoot?: string): string {
+  validateNamespace(namespace);
+  const omcRoot = getOmcRoot(worktreeRoot);
+  return join(omcRoot, SHARED_MEMORY_DIR, namespace);
+}
+
+/** Get the file path for a specific key within a namespace. */
+function getEntryPath(namespace: string, key: string, worktreeRoot?: string): string {
+  validateKey(key);
+  return join(getNamespaceDir(namespace, worktreeRoot), `${key}.json`);
+}
+
+/** Ensure the namespace directory exists. */
+function ensureNamespaceDir(namespace: string, worktreeRoot?: string): string {
+  const dir = getNamespaceDir(namespace, worktreeRoot);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Check expiry
+// ---------------------------------------------------------------------------
+
+function isExpired(entry: SharedMemoryEntry): boolean {
+  if (!entry.expiresAt) return false;
+  return new Date(entry.expiresAt).getTime() <= Date.now();
+}
+
+// ---------------------------------------------------------------------------
+// Core operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a key-value pair to shared memory.
+ *
+ * Creates or updates the entry. If ttl is provided, computes expiresAt.
+ */
+export function writeEntry(
+  namespace: string,
+  key: string,
+  value: unknown,
+  ttl?: number,
+  worktreeRoot?: string,
+): SharedMemoryEntry {
+  ensureNamespaceDir(namespace, worktreeRoot);
+  const filePath = getEntryPath(namespace, key, worktreeRoot);
+  const now = new Date().toISOString();
+
+  let existingCreatedAt = now;
+  if (existsSync(filePath)) {
+    try {
+      const existing: SharedMemoryEntry = JSON.parse(readFileSync(filePath, 'utf-8'));
+      existingCreatedAt = existing.createdAt || now;
+    } catch {
+      // Corrupted file, treat as new
+    }
+  }
+
+  const entry: SharedMemoryEntry = {
+    key,
+    value,
+    namespace,
+    createdAt: existingCreatedAt,
+    updatedAt: now,
+  };
+
+  if (ttl && ttl > 0) {
+    entry.ttl = ttl;
+    entry.expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
+  }
+
+  writeFileSync(filePath, JSON.stringify(entry, null, 2), 'utf-8');
+  return entry;
+}
+
+/**
+ * Read a key from shared memory.
+ *
+ * Returns null if the key doesn't exist or has expired.
+ * Expired entries are automatically deleted on read.
+ */
+export function readEntry(
+  namespace: string,
+  key: string,
+  worktreeRoot?: string,
+): SharedMemoryEntry | null {
+  validateNamespace(namespace);
+  validateKey(key);
+
+  const filePath = getEntryPath(namespace, key, worktreeRoot);
+  if (!existsSync(filePath)) return null;
+
+  try {
+    const entry: SharedMemoryEntry = JSON.parse(readFileSync(filePath, 'utf-8'));
+
+    // Auto-cleanup expired entries
+    if (isExpired(entry)) {
+      try { unlinkSync(filePath); } catch { /* ignore */ }
+      return null;
+    }
+
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List all keys in a namespace.
+ *
+ * Expired entries are filtered out (but not deleted during list).
+ */
+export function listEntries(
+  namespace: string,
+  worktreeRoot?: string,
+): SharedMemoryListItem[] {
+  validateNamespace(namespace);
+
+  const dir = getNamespaceDir(namespace, worktreeRoot);
+  if (!existsSync(dir)) return [];
+
+  const items: SharedMemoryListItem[] = [];
+
+  try {
+    const files = readdirSync(dir).filter(f => f.endsWith('.json'));
+    for (const file of files) {
+      try {
+        const filePath = join(dir, file);
+        const entry: SharedMemoryEntry = JSON.parse(readFileSync(filePath, 'utf-8'));
+        if (!isExpired(entry)) {
+          items.push({
+            key: entry.key,
+            updatedAt: entry.updatedAt,
+            expiresAt: entry.expiresAt,
+          });
+        }
+      } catch {
+        // Skip corrupted files
+      }
+    }
+  } catch {
+    // Directory read error
+  }
+
+  return items.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/**
+ * Delete a specific key from shared memory.
+ *
+ * Returns true if the key existed and was deleted.
+ */
+export function deleteEntry(
+  namespace: string,
+  key: string,
+  worktreeRoot?: string,
+): boolean {
+  validateNamespace(namespace);
+  validateKey(key);
+
+  const filePath = getEntryPath(namespace, key, worktreeRoot);
+  if (!existsSync(filePath)) return false;
+
+  try {
+    unlinkSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Clean up expired entries in a namespace (or all namespaces).
+ *
+ * Returns the count of entries removed.
+ */
+export function cleanupExpired(
+  namespace?: string,
+  worktreeRoot?: string,
+): { removed: number; namespaces: string[] } {
+  const omcRoot = getOmcRoot(worktreeRoot);
+  const sharedMemDir = join(omcRoot, SHARED_MEMORY_DIR);
+
+  if (!existsSync(sharedMemDir)) return { removed: 0, namespaces: [] };
+
+  const namespacesToClean: string[] = [];
+
+  if (namespace) {
+    validateNamespace(namespace);
+    namespacesToClean.push(namespace);
+  } else {
+    // All namespaces
+    try {
+      const entries = readdirSync(sharedMemDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          namespacesToClean.push(entry.name);
+        }
+      }
+    } catch {
+      return { removed: 0, namespaces: [] };
+    }
+  }
+
+  let removed = 0;
+  const cleanedNamespaces: string[] = [];
+
+  for (const ns of namespacesToClean) {
+    const nsDir = join(sharedMemDir, ns);
+    if (!existsSync(nsDir)) continue;
+
+    let nsRemoved = 0;
+    try {
+      const files = readdirSync(nsDir).filter(f => f.endsWith('.json'));
+      for (const file of files) {
+        try {
+          const filePath = join(nsDir, file);
+          const entry: SharedMemoryEntry = JSON.parse(readFileSync(filePath, 'utf-8'));
+          if (isExpired(entry)) {
+            unlinkSync(filePath);
+            nsRemoved++;
+          }
+        } catch {
+          // Skip corrupted files
+        }
+      }
+    } catch {
+      // Skip inaccessible namespace
+    }
+
+    if (nsRemoved > 0) {
+      cleanedNamespaces.push(ns);
+      removed += nsRemoved;
+    }
+  }
+
+  return { removed, namespaces: cleanedNamespaces };
+}
+
+/**
+ * List all namespaces that have shared memory entries.
+ */
+export function listNamespaces(worktreeRoot?: string): string[] {
+  const omcRoot = getOmcRoot(worktreeRoot);
+  const sharedMemDir = join(omcRoot, SHARED_MEMORY_DIR);
+
+  if (!existsSync(sharedMemDir)) return [];
+
+  try {
+    const entries = readdirSync(sharedMemDir, { withFileTypes: true });
+    return entries
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -30,6 +30,7 @@ export const OmcPaths = {
   SCIENTIST: '.omc/scientist',
   AUTOPILOT: '.omc/autopilot',
   SKILLS: '.omc/skills',
+  SHARED_MEMORY: '.omc/state/shared-memory',
 } as const;
 
 /**

--- a/src/mcp/omc-tools-server.ts
+++ b/src/mcp/omc-tools-server.ts
@@ -14,6 +14,7 @@ import { stateTools } from "../tools/state-tools.js";
 import { notepadTools } from "../tools/notepad-tools.js";
 import { memoryTools } from "../tools/memory-tools.js";
 import { traceTools } from "../tools/trace-tools.js";
+import { sharedMemoryTools } from "../tools/shared-memory-tools.js";
 import { getInteropTools } from "../interop/mcp-bridge.js";
 import { TOOL_CATEGORIES, type ToolCategory } from "../constants/index.js";
 
@@ -49,6 +50,7 @@ export const DISABLE_TOOLS_GROUP_MAP: Record<string, ToolCategory> = {
   'interop': TOOL_CATEGORIES.INTEROP,
   'codex': TOOL_CATEGORIES.CODEX,
   'gemini': TOOL_CATEGORIES.GEMINI,
+  'shared-memory': TOOL_CATEGORIES.SHARED_MEMORY,
 };
 
 /**
@@ -95,6 +97,7 @@ const allTools: ToolDef[] = [
   ...tagCategory(notepadTools as unknown as ToolDef[], TOOL_CATEGORIES.NOTEPAD),
   ...tagCategory(memoryTools as unknown as ToolDef[], TOOL_CATEGORIES.MEMORY),
   ...tagCategory(traceTools as unknown as ToolDef[], TOOL_CATEGORIES.TRACE),
+  ...tagCategory(sharedMemoryTools as unknown as ToolDef[], TOOL_CATEGORIES.SHARED_MEMORY),
   ...interopTools,
 ];
 
@@ -153,6 +156,7 @@ export function getOmcToolNames(options?: {
   includeMemory?: boolean;
   includeTrace?: boolean;
   includeInterop?: boolean;
+  includeSharedMemory?: boolean;
 }): string[] {
   const {
     includeLsp = true,
@@ -163,7 +167,8 @@ export function getOmcToolNames(options?: {
     includeNotepad = true,
     includeMemory = true,
     includeTrace = true,
-    includeInterop = true
+    includeInterop = true,
+    includeSharedMemory = true,
   } = options || {};
 
   const excludedCategories = new Set<ToolCategory>();
@@ -176,6 +181,7 @@ export function getOmcToolNames(options?: {
   if (!includeMemory) excludedCategories.add(TOOL_CATEGORIES.MEMORY);
   if (!includeTrace) excludedCategories.add(TOOL_CATEGORIES.TRACE);
   if (!includeInterop) excludedCategories.add(TOOL_CATEGORIES.INTEROP);
+  if (!includeSharedMemory) excludedCategories.add(TOOL_CATEGORIES.SHARED_MEMORY);
 
   if (excludedCategories.size === 0) return [...omcToolNames];
 
@@ -198,6 +204,7 @@ export function _getAllToolNamesForTests(options?: {
   includeMemory?: boolean;
   includeTrace?: boolean;
   includeInterop?: boolean;
+  includeSharedMemory?: boolean;
 }): string[] {
   const {
     includeLsp = true,
@@ -209,6 +216,7 @@ export function _getAllToolNamesForTests(options?: {
     includeMemory = true,
     includeTrace = true,
     includeInterop = true,
+    includeSharedMemory = true,
   } = options || {};
 
   const excludedCategories = new Set<ToolCategory>();
@@ -221,6 +229,7 @@ export function _getAllToolNamesForTests(options?: {
   if (!includeMemory) excludedCategories.add(TOOL_CATEGORIES.MEMORY);
   if (!includeTrace) excludedCategories.add(TOOL_CATEGORIES.TRACE);
   if (!includeInterop) excludedCategories.add(TOOL_CATEGORIES.INTEROP);
+  if (!includeSharedMemory) excludedCategories.add(TOOL_CATEGORIES.SHARED_MEMORY);
 
   return allTools
     .filter(t => !t.category || !excludedCategories.has(t.category))

--- a/src/tools/shared-memory-tools.ts
+++ b/src/tools/shared-memory-tools.ts
@@ -1,0 +1,302 @@
+/**
+ * Shared Memory MCP Tools
+ *
+ * Provides tools for cross-session memory sync between agents
+ * in /team and /pipeline workflows. Agents can write, read, list,
+ * delete, and clean up shared key-value entries namespaced by
+ * session group or pipeline run.
+ *
+ * Storage: .omc/state/shared-memory/{namespace}/{key}.json
+ * Config gate: agents.sharedMemory.enabled in ~/.claude/.omc-config.json
+ *
+ * @see https://github.com/anthropics/oh-my-claudecode/issues/1119
+ */
+
+import { z } from 'zod';
+import { validateWorkingDirectory } from '../lib/worktree-paths.js';
+import {
+  isSharedMemoryEnabled,
+  writeEntry,
+  readEntry,
+  listEntries,
+  deleteEntry,
+  cleanupExpired,
+  listNamespaces,
+} from '../lib/shared-memory.js';
+import type { ToolDefinition } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DISABLED_MSG = 'Shared memory is disabled. Set agents.sharedMemory.enabled = true in ~/.claude/.omc-config.json to enable.';
+
+function disabledResponse() {
+  return {
+    content: [{ type: 'text' as const, text: DISABLED_MSG }],
+    isError: true,
+  };
+}
+
+function errorResponse(msg: string) {
+  return {
+    content: [{ type: 'text' as const, text: msg }],
+    isError: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// shared_memory_write
+// ---------------------------------------------------------------------------
+
+export const sharedMemoryWriteTool: ToolDefinition<{
+  key: z.ZodString;
+  value: z.ZodUnknown;
+  namespace: z.ZodString;
+  ttl: z.ZodOptional<z.ZodNumber>;
+  workingDirectory: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'shared_memory_write',
+  description: 'Write a key-value pair to shared memory for cross-agent handoffs. Namespace by session group or pipeline run. Supports optional TTL for auto-expiry.',
+  schema: {
+    key: z.string().min(1).max(128).describe('Key identifier (alphanumeric, hyphens, underscores, dots)'),
+    value: z.unknown().describe('JSON-serializable value to store'),
+    namespace: z.string().min(1).max(128).describe('Namespace for grouping (e.g., team name, pipeline run ID, session group)'),
+    ttl: z.number().int().min(1).max(604800).optional().describe('Time-to-live in seconds (max 7 days). Omit for no expiry.'),
+    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
+  },
+  handler: async (args) => {
+    if (!isSharedMemoryEnabled()) return disabledResponse();
+
+    try {
+      const root = validateWorkingDirectory(args.workingDirectory);
+      const entry = writeEntry(args.namespace, args.key, args.value, args.ttl, root);
+
+      let text = `Successfully wrote to shared memory.\n\n- **Namespace:** ${entry.namespace}\n- **Key:** ${entry.key}\n- **Updated:** ${entry.updatedAt}`;
+      if (entry.ttl) {
+        text += `\n- **TTL:** ${entry.ttl}s\n- **Expires:** ${entry.expiresAt}`;
+      }
+
+      return { content: [{ type: 'text' as const, text }] };
+    } catch (error) {
+      return errorResponse(`Error writing shared memory: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// shared_memory_read
+// ---------------------------------------------------------------------------
+
+export const sharedMemoryReadTool: ToolDefinition<{
+  key: z.ZodString;
+  namespace: z.ZodString;
+  workingDirectory: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'shared_memory_read',
+  description: 'Read a value from shared memory by key and namespace. Returns null if the key does not exist or has expired.',
+  schema: {
+    key: z.string().min(1).max(128).describe('Key to read'),
+    namespace: z.string().min(1).max(128).describe('Namespace to read from'),
+    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
+  },
+  handler: async (args) => {
+    if (!isSharedMemoryEnabled()) return disabledResponse();
+
+    try {
+      const root = validateWorkingDirectory(args.workingDirectory);
+      const entry = readEntry(args.namespace, args.key, root);
+
+      if (!entry) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Key "${args.key}" not found in namespace "${args.namespace}" (or has expired).`,
+          }],
+        };
+      }
+
+      const meta = [
+        `- **Namespace:** ${entry.namespace}`,
+        `- **Key:** ${entry.key}`,
+        `- **Created:** ${entry.createdAt}`,
+        `- **Updated:** ${entry.updatedAt}`,
+      ];
+      if (entry.expiresAt) {
+        meta.push(`- **Expires:** ${entry.expiresAt}`);
+      }
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `## Shared Memory Entry\n\n${meta.join('\n')}\n\n### Value\n\n\`\`\`json\n${JSON.stringify(entry.value, null, 2)}\n\`\`\``,
+        }],
+      };
+    } catch (error) {
+      return errorResponse(`Error reading shared memory: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// shared_memory_list
+// ---------------------------------------------------------------------------
+
+export const sharedMemoryListTool: ToolDefinition<{
+  namespace: z.ZodOptional<z.ZodString>;
+  workingDirectory: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'shared_memory_list',
+  description: 'List keys in a shared memory namespace, or list all namespaces if no namespace is provided.',
+  schema: {
+    namespace: z.string().min(1).max(128).optional().describe('Namespace to list keys from. Omit to list all namespaces.'),
+    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
+  },
+  handler: async (args) => {
+    if (!isSharedMemoryEnabled()) return disabledResponse();
+
+    try {
+      const root = validateWorkingDirectory(args.workingDirectory);
+
+      if (!args.namespace) {
+        // List all namespaces
+        const namespaces = listNamespaces(root);
+        if (namespaces.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: 'No shared memory namespaces found.' }],
+          };
+        }
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `## Shared Memory Namespaces\n\n${namespaces.map(ns => `- ${ns}`).join('\n')}`,
+          }],
+        };
+      }
+
+      // List keys in namespace
+      const items = listEntries(args.namespace, root);
+      if (items.length === 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `No entries in namespace "${args.namespace}".`,
+          }],
+        };
+      }
+
+      const lines = items.map(item => {
+        let line = `- **${item.key}** (updated: ${item.updatedAt})`;
+        if (item.expiresAt) line += ` [expires: ${item.expiresAt}]`;
+        return line;
+      });
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `## Shared Memory: ${args.namespace}\n\n${items.length} entries:\n\n${lines.join('\n')}`,
+        }],
+      };
+    } catch (error) {
+      return errorResponse(`Error listing shared memory: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// shared_memory_delete
+// ---------------------------------------------------------------------------
+
+export const sharedMemoryDeleteTool: ToolDefinition<{
+  key: z.ZodString;
+  namespace: z.ZodString;
+  workingDirectory: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'shared_memory_delete',
+  description: 'Delete a key from shared memory.',
+  schema: {
+    key: z.string().min(1).max(128).describe('Key to delete'),
+    namespace: z.string().min(1).max(128).describe('Namespace to delete from'),
+    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
+  },
+  handler: async (args) => {
+    if (!isSharedMemoryEnabled()) return disabledResponse();
+
+    try {
+      const root = validateWorkingDirectory(args.workingDirectory);
+      const deleted = deleteEntry(args.namespace, args.key, root);
+
+      if (!deleted) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Key "${args.key}" not found in namespace "${args.namespace}".`,
+          }],
+        };
+      }
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Deleted key "${args.key}" from namespace "${args.namespace}".`,
+        }],
+      };
+    } catch (error) {
+      return errorResponse(`Error deleting shared memory: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// shared_memory_cleanup
+// ---------------------------------------------------------------------------
+
+export const sharedMemoryCleanupTool: ToolDefinition<{
+  namespace: z.ZodOptional<z.ZodString>;
+  workingDirectory: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'shared_memory_cleanup',
+  description: 'Remove expired entries from shared memory. Cleans a specific namespace or all namespaces.',
+  schema: {
+    namespace: z.string().min(1).max(128).optional().describe('Namespace to clean. Omit to clean all namespaces.'),
+    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
+  },
+  handler: async (args) => {
+    if (!isSharedMemoryEnabled()) return disabledResponse();
+
+    try {
+      const root = validateWorkingDirectory(args.workingDirectory);
+      const result = cleanupExpired(args.namespace, root);
+
+      if (result.removed === 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'No expired entries found.',
+          }],
+        };
+      }
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `## Cleanup Results\n\n- **Removed:** ${result.removed} expired entries\n- **Namespaces cleaned:** ${result.namespaces.join(', ')}`,
+        }],
+      };
+    } catch (error) {
+      return errorResponse(`Error cleaning shared memory: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export all tools
+// ---------------------------------------------------------------------------
+
+export const sharedMemoryTools = [
+  sharedMemoryWriteTool,
+  sharedMemoryReadTool,
+  sharedMemoryListTool,
+  sharedMemoryDeleteTool,
+  sharedMemoryCleanupTool,
+];


### PR DESCRIPTION
## Summary

- Add persistent shared memory layer at `.omc/state/shared-memory/{namespace}/{key}.json` for cross-session agent handoffs
- Add 5 MCP tools: `shared_memory_write`, `shared_memory_read`, `shared_memory_list`, `shared_memory_delete`, `shared_memory_cleanup`
- Support TTL-based auto-expiry, namespace isolation, path traversal validation, and corrupted file handling

## Details

Agents in `/team` and `/pipeline` workflows currently lose working context across agent restarts — Agent B only sees Agent A's final summary, not the reasoning or rejected alternatives. This PR adds a filesystem-based shared memory store that agents can use to persist and share structured context.

### New files
- `src/lib/shared-memory.ts` — Core state layer (write, read, list, delete, cleanup, config gate)
- `src/tools/shared-memory-tools.ts` — 5 MCP tools registered as `mcp__t__shared_memory_*`
- `src/__tests__/shared-memory.test.ts` — 33 unit tests

### Modified files
- `src/constants/names.ts` — Add `SHARED_MEMORY` tool category
- `src/lib/worktree-paths.ts` — Add `SHARED_MEMORY` path constant
- `src/mcp/omc-tools-server.ts` — Register tools, add to disable map and filter options
- `src/__tests__/omc-tools-server.test.ts` — Update tool counts (+5)

### Config
Enabled by default. Disable via `.omc-config.json`:
```json
{ "agents": { "sharedMemory": { "enabled": false } } }
```

## Test plan
- [x] 33 new unit tests covering write/read, TTL expiry, auto-cleanup, namespace isolation, validation, corrupted files
- [x] All 249 existing + new tests pass
- [x] `tsc --noEmit` clean

Fixes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)