### PR TITLE
fix(team): harden worker spawn env + interop bootstrap fail-open

### DIFF
--- a/src/team/__tests__/runtime-interop-spawn-regression.test.ts
+++ b/src/team/__tests__/runtime-interop-spawn-regression.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const tmuxCalls = vi.hoisted(() => ({
+  args: [] as string[][],
+}));
+
+const interopMocks = vi.hoisted(() => ({
+  getInteropMode: vi.fn(() => 'active' as const),
+  bridgeBootstrapToOmx: vi.fn(),
+  pollOmxCompletion: vi.fn(async () => null),
+}));
+
+vi.mock('../../interop/mcp-bridge.js', () => ({
+  getInteropMode: interopMocks.getInteropMode,
+}));
+
+vi.mock('../../interop/worker-adapter.js', () => ({
+  bridgeBootstrapToOmx: interopMocks.bridgeBootstrapToOmx,
+  pollOmxCompletion: interopMocks.pollOmxCompletion,
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  const { promisify: utilPromisify } = await import('util');
+
+  function mockExecFile(
+    _cmd: string,
+    args: string[],
+    cb: (err: Error | null, stdout: string, stderr: string) => void
+  ) {
+    tmuxCalls.args.push(args);
+    if (args[0] === 'split-window') {
+      cb(null, '%77\n', '');
+      return {} as never;
+    }
+    cb(null, '', '');
+    return {} as never;
+  }
+
+  (mockExecFile as any)[utilPromisify.custom] = async (_cmd: string, args: string[]) => {
+    tmuxCalls.args.push(args);
+    if (args[0] === 'split-window') {
+      return { stdout: '%77\n', stderr: '' };
+    }
+    return { stdout: '', stderr: '' };
+  };
+
+  return {
+    ...actual,
+    execFile: mockExecFile,
+  };
+});
+
+import { spawnWorkerForTask, type TeamRuntime } from '../runtime.js';
+
+function makeRuntime(cwd: string): TeamRuntime {
+  return {
+    teamName: 'test-team',
+    sessionName: 'test-session:0',
+    leaderPaneId: '%0',
+    config: {
+      teamName: 'test-team',
+      workerCount: 1,
+      agentTypes: ['codex'],
+      tasks: [{ subject: 'Interop task', description: 'Do work' }],
+      cwd,
+      workerInteropConfigs: [
+        { workerName: 'worker-1', agentType: 'codex', interopMode: 'omx' },
+      ],
+    },
+    workerNames: ['worker-1'],
+    workerPaneIds: [],
+    activeWorkers: new Map(),
+    cwd,
+  };
+}
+
+function setupTaskDir(cwd: string): void {
+  const tasksDir = join(cwd, '.omc/state/team/test-team/tasks');
+  mkdirSync(tasksDir, { recursive: true });
+  writeFileSync(join(tasksDir, '1.json'), JSON.stringify({
+    id: '1',
+    subject: 'Interop task',
+    description: 'Do work',
+    status: 'pending',
+    owner: null,
+  }));
+  mkdirSync(join(cwd, '.omc/state/team/test-team/workers/worker-1'), { recursive: true });
+}
+
+describe('spawnWorkerForTask interop bootstrap fail-open', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    tmuxCalls.args = [];
+    cwd = mkdtempSync(join(tmpdir(), 'runtime-interop-spawn-'));
+    setupTaskDir(cwd);
+    interopMocks.getInteropMode.mockReset();
+    interopMocks.getInteropMode.mockReturnValue('active');
+    interopMocks.bridgeBootstrapToOmx.mockReset();
+    interopMocks.bridgeBootstrapToOmx.mockRejectedValue(new Error('bootstrap failed'));
+    interopMocks.pollOmxCompletion.mockReset();
+    interopMocks.pollOmxCompletion.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('does not reject or reset task when bridge bootstrap throws', async () => {
+    const runtime = makeRuntime(cwd);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const paneId = await spawnWorkerForTask(runtime, 'worker-1', 0);
+    expect(paneId).toBe('%77');
+
+    const taskPath = join(cwd, '.omc/state/team/test-team/tasks/1.json');
+    const task = JSON.parse(readFileSync(taskPath, 'utf-8')) as { status: string; owner: string | null; };
+
+    expect(task.status).toBe('in_progress');
+    expect(task.owner).toBe('worker-1');
+    expect(runtime.activeWorkers.get('worker-1')?.taskId).toBe('1');
+    expect(interopMocks.bridgeBootstrapToOmx).toHaveBeenCalledTimes(1);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warnMessage = String(warnSpy.mock.calls[0]?.[0] ?? '');
+    expect(warnMessage).toContain('worker-1');
+    expect(warnMessage).toContain('task 1');
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -137,11 +137,24 @@ export function buildWorkerCommand(agentType: CliAgentType, config: WorkerLaunch
 
 export function getWorkerEnv(teamName: string, workerName: string, agentType: CliAgentType): Record<string, string> {
   validateTeamName(teamName);
-  return {
+  const workerEnv: Record<string, string> = {
     OMC_TEAM_WORKER: `${teamName}/${workerName}`,
     OMC_TEAM_NAME: teamName,
     OMC_WORKER_AGENT_TYPE: agentType,
   };
+
+  // Keep worker spawn PATH aligned with CLI preflight checks (validateCliAvailable)
+  // while preserving key casing where possible (PATH vs Path).
+  const env = resolvedEnv();
+  const pathKey = Object.keys(env).find((key) => key.toUpperCase() === 'PATH');
+  if (pathKey) {
+    const pathValue = env[pathKey];
+    if (typeof pathValue === 'string') {
+      workerEnv[pathKey] = pathValue;
+    }
+  }
+
+  return workerEnv;
 }
 
 export function parseCliOutput(agentType: CliAgentType, rawOutput: string): string {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -722,7 +722,12 @@ export async function spawnWorkerForTask(
   if (isOmxInteropWorker(runtime, workerNameValue)) {
     const ctx = buildAdapterContext(runtime);
     if (ctx) {
-      await bridgeBootstrapToOmx(ctx, workerNameValue, { id: taskId, subject: task.subject, description: task.description });
+      try {
+        await bridgeBootstrapToOmx(ctx, workerNameValue, { id: taskId, subject: task.subject, description: task.description });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[spawnWorkerForTask] interop bootstrap failed for ${workerNameValue} task ${taskId}: ${message}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes worker pane spawn instability by addressing two failure vectors:

1. **Spawn PATH parity:** worker pane env now carries the same resolved shell PATH used by CLI preflight checks.
2. **Interop blast-radius reduction:** interop bootstrap failures during spawn are now fail-open (warn-only), so they don't abort worker/task lifecycle.

## Root cause context
- CLI availability checks use `resolvedEnv()` PATH, but worker spawn env previously did not include that resolved PATH explicitly.
- Interop bootstrap was awaited in spawn flow without local isolation, so adapter errors could bubble and fail startup.

## Changes
- `src/team/model-contract.ts`
  - `getWorkerEnv()` now injects resolved PATH while preserving key casing (`PATH`/`Path`).
- `src/team/runtime.ts`
  - `spawnWorkerForTask()` wraps `bridgeBootstrapToOmx(...)` in try/catch and emits concise warning with worker/task context.
- `src/team/__tests__/runtime-interop-spawn-regression.test.ts` (new)
  - Verifies interop bootstrap throw does **not** reject spawn or reset task state.
- `src/team/__tests__/model-contract.test.ts`
  - Adds coverage for PATH injection and casing behavior.

## Verification
```bash
npm test -- src/team/__tests__/runtime-interop-spawn-regression.test.ts src/team/__tests__/model-contract.test.ts src/team/__tests__/runtime-prompt-mode.test.ts
npm run build
```

Both passed locally:
- Test files: 3 passed
- Tests: 29 passed
- Build: passed

## Risk / compatibility
- Keeps behavior unchanged for healthy paths.
- Interop bootstrap errors are now non-fatal at spawn time by design (warning emitted).
