### PR TITLE
feat(hud): add API key source indicator (#1146)

### DIFF
--- a/src/__tests__/hud-api-key-source.test.ts
+++ b/src/__tests__/hud-api-key-source.test.ts
@@ -1,0 +1,160 @@
+/**
+ * OMC HUD - API Key Source Element Tests
+ *
+ * Tests for detecting and rendering the ANTHROPIC_API_KEY source.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectApiKeySource, renderApiKeySource } from '../hud/elements/api-key-source.js';
+import type { ApiKeySource } from '../hud/elements/api-key-source.js';
+
+// Mock fs module
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+// Mock paths utility
+vi.mock('../utils/paths.js', () => ({
+  getClaudeConfigDir: vi.fn(() => '/home/user/.claude'),
+}));
+
+import { existsSync, readFileSync } from 'fs';
+
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+
+describe('API Key Source Element', () => {
+  const originalEnv = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.ANTHROPIC_API_KEY = originalEnv;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  describe('detectApiKeySource', () => {
+    it('should return "project" when key is in project settings', () => {
+      mockedExistsSync.mockImplementation((path) =>
+        String(path) === '/my/project/.claude/settings.local.json'
+      );
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-xxx' } })
+      );
+
+      expect(detectApiKeySource('/my/project')).toBe('project');
+    });
+
+    it('should return "global" when key is in global settings', () => {
+      mockedExistsSync.mockImplementation((path) =>
+        String(path) === '/home/user/.claude/settings.json'
+      );
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-xxx' } })
+      );
+
+      expect(detectApiKeySource('/my/project')).toBe('global');
+    });
+
+    it('should return "env" when key is only in environment', () => {
+      mockedExistsSync.mockReturnValue(false);
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-xxx';
+
+      expect(detectApiKeySource('/my/project')).toBe('env');
+    });
+
+    it('should return null when no key is found anywhere', () => {
+      mockedExistsSync.mockReturnValue(false);
+
+      expect(detectApiKeySource('/my/project')).toBeNull();
+    });
+
+    it('should prioritize project over global', () => {
+      mockedExistsSync.mockReturnValue(true);
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-xxx' } })
+      );
+
+      expect(detectApiKeySource('/my/project')).toBe('project');
+    });
+
+    it('should prioritize global over env', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-xxx';
+      mockedExistsSync.mockImplementation((path) =>
+        String(path) === '/home/user/.claude/settings.json'
+      );
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-xxx' } })
+      );
+
+      expect(detectApiKeySource('/my/project')).toBe('global');
+    });
+
+    it('should handle malformed JSON gracefully', () => {
+      mockedExistsSync.mockReturnValue(true);
+      mockedReadFileSync.mockReturnValue('not valid json');
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-xxx';
+
+      expect(detectApiKeySource('/my/project')).toBe('env');
+    });
+
+    it('should handle settings without env block', () => {
+      mockedExistsSync.mockReturnValue(true);
+      mockedReadFileSync.mockReturnValue(JSON.stringify({ someOtherKey: true }));
+
+      expect(detectApiKeySource('/my/project')).toBeNull();
+    });
+
+    it('should handle null cwd', () => {
+      mockedExistsSync.mockImplementation((path) =>
+        String(path) === '/home/user/.claude/settings.json'
+      );
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ env: { ANTHROPIC_API_KEY: 'sk-ant-xxx' } })
+      );
+
+      expect(detectApiKeySource()).toBe('global');
+    });
+  });
+
+  describe('renderApiKeySource', () => {
+    it('should return null for null source', () => {
+      expect(renderApiKeySource(null)).toBeNull();
+    });
+
+    it('should render "project" source', () => {
+      const result = renderApiKeySource('project');
+      expect(result).not.toBeNull();
+      expect(result).toContain('key:');
+      expect(result).toContain('project');
+    });
+
+    it('should render "global" source', () => {
+      const result = renderApiKeySource('global');
+      expect(result).not.toBeNull();
+      expect(result).toContain('key:');
+      expect(result).toContain('global');
+    });
+
+    it('should render "env" source', () => {
+      const result = renderApiKeySource('env');
+      expect(result).not.toBeNull();
+      expect(result).toContain('key:');
+      expect(result).toContain('env');
+    });
+
+    it('should render all valid sources without errors', () => {
+      const sources: ApiKeySource[] = ['project', 'global', 'env'];
+      for (const source of sources) {
+        expect(() => renderApiKeySource(source)).not.toThrow();
+      }
+    });
+  });
+});

--- a/src/__tests__/hud/version-display.test.ts
+++ b/src/__tests__/hud/version-display.test.ts
@@ -27,6 +27,7 @@ function createMinimalContext(overrides: Partial<HudRenderContext> = {}): HudRen
     agentCallCount: 0,
     skillCallCount: 0,
     promptTime: null,
+    apiKeySource: null,
     ...overrides,
   };
 }

--- a/src/hud/elements/api-key-source.ts
+++ b/src/hud/elements/api-key-source.ts
@@ -1,0 +1,71 @@
+/**
+ * OMC HUD - API Key Source Element
+ *
+ * Detects and renders where the active ANTHROPIC_API_KEY comes from:
+ * - 'project': set in .claude/settings.local.json (project-level)
+ * - 'global': set in ~/.claude/settings.json (user-level)
+ * - 'env': present only as an environment variable
+ *
+ * Never displays the actual key value.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { dim, cyan } from '../colors.js';
+import { getClaudeConfigDir } from '../../utils/paths.js';
+
+export type ApiKeySource = 'project' | 'global' | 'env';
+
+/**
+ * Check whether a settings file defines ANTHROPIC_API_KEY in its env block.
+ */
+function settingsFileHasApiKey(filePath: string): boolean {
+  try {
+    if (!existsSync(filePath)) return false;
+    const content = readFileSync(filePath, 'utf-8');
+    const settings = JSON.parse(content);
+    const env = settings?.env;
+    if (typeof env !== 'object' || env === null) return false;
+    return 'ANTHROPIC_API_KEY' in env;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect where the active ANTHROPIC_API_KEY comes from.
+ *
+ * Priority:
+ * 1. Project-level: .claude/settings.local.json in cwd
+ * 2. Global-level: ~/.claude/settings.json
+ * 3. Environment variable
+ *
+ * @param cwd - Current working directory (project root)
+ * @returns The source identifier, or null if no key is found
+ */
+export function detectApiKeySource(cwd?: string): ApiKeySource | null {
+  // 1. Project-level config
+  if (cwd) {
+    const projectSettings = join(cwd, '.claude', 'settings.local.json');
+    if (settingsFileHasApiKey(projectSettings)) return 'project';
+  }
+
+  // 2. Global config
+  const globalSettings = join(getClaudeConfigDir(), 'settings.json');
+  if (settingsFileHasApiKey(globalSettings)) return 'global';
+
+  // 3. Environment variable
+  if (process.env.ANTHROPIC_API_KEY) return 'env';
+
+  return null;
+}
+
+/**
+ * Render API key source element.
+ *
+ * Format: key:project / key:global / key:env
+ */
+export function renderApiKeySource(source: ApiKeySource | null): string | null {
+  if (!source) return null;
+  return `${dim('key:')}${cyan(source)}`;
+}

--- a/src/hud/elements/index.ts
+++ b/src/hud/elements/index.ts
@@ -20,3 +20,4 @@ export { renderCwd } from './cwd.js';
 export { renderGitRepo, renderGitBranch, getGitRepoName, getGitBranch } from './git.js';
 export { renderModel, formatModelName } from './model.js';
 export { renderPromptTime } from './prompt-time.js';
+export { detectApiKeySource, renderApiKeySource, type ApiKeySource } from './api-key-source.js';

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -24,6 +24,7 @@ import {
 import { getUsage } from "./usage-api.js";
 import { executeCustomProvider } from "./custom-rate-provider.js";
 import { render } from "./render.js";
+import { detectApiKeySource } from "./elements/api-key-source.js";
 import { sanitizeOutput } from "./sanitize.js";
 import type {
   HudRenderContext,
@@ -192,6 +193,9 @@ async function main(watchMode = false): Promise<void> {
       skillCallCount: transcriptData.skillCallCount,
       promptTime: hudState?.lastPromptTimestamp
         ? new Date(hudState.lastPromptTimestamp)
+        : null,
+      apiKeySource: config.elements.apiKeySource
+        ? detectApiKeySource(cwd)
         : null,
     };
 

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -23,6 +23,7 @@ import { renderAutopilot } from './elements/autopilot.js';
 import { renderCwd } from './elements/cwd.js';
 import { renderGitRepo, renderGitBranch } from './elements/git.js';
 import { renderModel } from './elements/model.js';
+import { renderApiKeySource } from './elements/api-key-source.js';
 import { renderCallCounts } from './elements/call-counts.js';
 import { renderContextLimitWarning } from './elements/context-warning.js';
 
@@ -76,6 +77,12 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   if (enabledElements.model && context.modelName) {
     const modelElement = renderModel(context.modelName, enabledElements.modelFormat);
     if (modelElement) gitElements.push(modelElement);
+  }
+
+  // API key source
+  if (enabledElements.apiKeySource && context.apiKeySource) {
+    const keySource = renderApiKeySource(context.apiKeySource);
+    if (keySource) gitElements.push(keySource);
   }
 
   // [OMC#X.Y.Z] label with optional update notification

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -5,9 +5,10 @@
  */
 
 import type { AutopilotStateForHud } from './elements/autopilot.js';
+import type { ApiKeySource } from './elements/api-key-source.js';
 
 // Re-export for convenience
-export type { AutopilotStateForHud };
+export type { AutopilotStateForHud, ApiKeySource };
 
 // ============================================================================
 // HUD State
@@ -308,6 +309,9 @@ export interface HudRenderContext {
 
   /** Last prompt submission time (from HUD state) */
   promptTime: Date | null;
+
+  /** API key source: 'project', 'global', or 'env' */
+  apiKeySource: ApiKeySource | null;
 }
 
 // ============================================================================
@@ -376,6 +380,7 @@ export interface HudElementConfig {
   permissionStatus: boolean;  // Show pending permission indicator
   thinking: boolean;          // Show extended thinking indicator
   thinkingFormat: ThinkingFormat;  // Thinking indicator format
+  apiKeySource: boolean;       // Show API key source (project/global/env)
   promptTime: boolean;        // Show last prompt submission time (HH:MM:SS)
   sessionHealth: boolean;     // Show session health/duration
   showSessionDuration?: boolean;  // Show session:19m duration display (default: true if sessionHealth is true)
@@ -441,6 +446,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     permissionStatus: false,  // Disabled: heuristic-based, causes false positives
     thinking: true,
     thinkingFormat: 'text',   // Text format for backward compatibility
+    apiKeySource: false, // Disabled by default
     promptTime: true,  // Show last prompt time by default
     sessionHealth: true,
     useBars: false,  // Disabled by default for backwards compatibility
@@ -485,6 +491,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,
     thinking: false,
     thinkingFormat: 'text',
+    apiKeySource: false,
     promptTime: false,
     sessionHealth: false,
     useBars: false,
@@ -515,6 +522,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,
     thinking: true,
     thinkingFormat: 'text',
+    apiKeySource: false,
     promptTime: true,
     sessionHealth: true,
     useBars: true,
@@ -545,6 +553,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,
     thinking: true,
     thinkingFormat: 'text',
+    apiKeySource: true,
     promptTime: true,
     sessionHealth: true,
     useBars: true,
@@ -575,6 +584,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,
     thinking: true,
     thinkingFormat: 'text',
+    apiKeySource: false,
     promptTime: true,
     sessionHealth: true,
     useBars: false,
@@ -605,6 +615,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     permissionStatus: false,
     thinking: true,
     thinkingFormat: 'text',
+    apiKeySource: true,
     promptTime: true,
     sessionHealth: true,
     useBars: true,


### PR DESCRIPTION
Closes #1146

## Summary
- Add `detectApiKeySource()` function that checks project config (`.claude/settings.local.json`), global config (`~/.claude/settings.json`), and environment variable to determine where `ANTHROPIC_API_KEY` comes from
- Add new `apiKeySource` HUD element config (toggleable, disabled by default; enabled in `full` and `dense` presets)
- Display as `key:project` / `key:global` / `key:env` in the HUD info line — never exposes the actual key value
- Add 14 tests covering detection priority, error handling, and rendering

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] `npm test` — all 231 test files pass (5121 tests)
- [x] New test file `hud-api-key-source.test.ts` — 14/14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)