### PR TITLE
fix(team): bypass gitignore for worker inbox task delivery (#1148)

### DIFF
--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -597,10 +597,13 @@ export async function spawnWorkerForTask(
     cwd: runtime.cwd,
   });
 
-  // For prompt-mode agents (e.g. Gemini Ink TUI), pass instruction via CLI
-  // flag so tmux send-keys never needs to interact with the TUI input widget.
+  // For prompt-mode agents (e.g. Gemini Ink TUI), pass the full task
+  // instruction inline via CLI flag. This bypasses gitignore restrictions
+  // (e.g. Gemini's respectGitIgnore=true ignoring .omc/ paths) by embedding
+  // the task content directly in the CLI argument instead of referencing an
+  // inbox file that may be invisible to the worker. See #1148.
   if (usePromptMode) {
-    const promptArgs = getPromptModeArgs(agentType, `Read and execute your task from: ${relInboxPath}`);
+    const promptArgs = getPromptModeArgs(agentType, instruction);
     launchArgs.push(...promptArgs);
   }
 


### PR DESCRIPTION
## Summary

- Inline full task instruction directly into CLI prompt argument for prompt-mode workers (Gemini/Codex) instead of referencing `.omc/state/.../inbox.md` file path
- Fixes worker task delivery when `.omc/` is in `.gitignore` and Gemini has `respectGitIgnore=true`
- Inbox file still written for debugging/reference purposes

## Root Cause

Prompt-mode agents received `"Read and execute your task from: .omc/.../inbox.md"` as their CLI prompt. When `.omc/` is gitignored, Gemini's file context loading skips the inbox file entirely, leaving the worker with no task instructions.

## Fix

Pass the full task instruction content (already built in memory) directly as the CLI argument instead of a file reference. Shell escaping via `shellEscape()` handles newlines and special characters correctly.

## Test plan

- [x] Updated existing prompt-mode tests to verify inline content instead of file path reference
- [x] Added 4 new tests in `gitignore bypass (#1148)` suite:
  - Prompt-mode agents receive full task content inline, not a file reference
  - Inbox.md is still written for debugging even when content is inlined
  - Interactive agents (Claude) still reference inbox via tmux send-keys
  - Inline prompt contains done.json path so worker can signal completion
- [x] `npm test` — 230 files, 5111 tests passed
- [x] `npx tsc --noEmit` — zero errors

Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)