### PR TITLE
fix(team): include .ready/done.json sentinel in inline worker task (#1151)

### DIFF
--- a/src/team/__tests__/runtime-prompt-mode.test.ts
+++ b/src/team/__tests__/runtime-prompt-mode.test.ts
@@ -202,6 +202,66 @@ describe('spawnWorkerForTask – prompt mode (Gemini & Codex)', () => {
 
     rmSync(cwd, { recursive: true, force: true });
   });
+
+  it('gemini worker inbox contains .ready sentinel instruction', async () => {
+    const runtime = makeRuntime(cwd, 'gemini');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const inboxPath = join(cwd, '.omc/state/team/test-team/workers/worker-1/inbox.md');
+    const content = readFileSync(inboxPath, 'utf-8');
+    expect(content).toContain('FIRST ACTION REQUIRED');
+    expect(content).toContain('.ready');
+    expect(content).toContain('touch');
+    expect(content).toContain('.omc/state/team/test-team/workers/worker-1/.ready');
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('gemini worker inbox contains done.json completion protocol', async () => {
+    const runtime = makeRuntime(cwd, 'gemini');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const inboxPath = join(cwd, '.omc/state/team/test-team/workers/worker-1/inbox.md');
+    const content = readFileSync(inboxPath, 'utf-8');
+    expect(content).toContain('done signal');
+    expect(content).toContain('done.json');
+    expect(content).toContain('.omc/state/team/test-team/workers/worker-1/done.json');
+    expect(content).toContain('"status":"completed"');
+    expect(content).toContain('For failures, set status to "failed"');
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('codex worker inbox contains .ready sentinel instruction', async () => {
+    const runtime = makeRuntime(cwd, 'codex');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const inboxPath = join(cwd, '.omc/state/team/test-team/workers/worker-1/inbox.md');
+    const content = readFileSync(inboxPath, 'utf-8');
+    expect(content).toContain('FIRST ACTION REQUIRED');
+    expect(content).toContain('.omc/state/team/test-team/workers/worker-1/.ready');
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('sentinel instruction appears before task description in inbox', async () => {
+    const runtime = makeRuntime(cwd, 'gemini');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const inboxPath = join(cwd, '.omc/state/team/test-team/workers/worker-1/inbox.md');
+    const content = readFileSync(inboxPath, 'utf-8');
+    const readyIdx = content.indexOf('.ready');
+    const descIdx = content.indexOf('Do something');
+    expect(readyIdx).toBeGreaterThan(-1);
+    expect(descIdx).toBeGreaterThan(-1);
+    expect(readyIdx).toBeLessThan(descIdx);
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
 });
 
 describe('spawnWorkerForTask – gitignore bypass (#1148)', () => {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -278,6 +278,7 @@ function buildInitialTaskInstruction(
   task: { subject: string; description: string },
   taskId: string
 ): string {
+  const readyPath = `.omc/state/team/${teamName}/workers/${workerName}/.ready`;
   const donePath = `.omc/state/team/${teamName}/workers/${workerName}/done.json`;
   const doneDir = `.omc/state/team/${teamName}/workers/${workerName}`;
   return [
@@ -286,12 +287,19 @@ function buildInitialTaskInstruction(
     `Worker: ${workerName}`,
     `Subject: ${task.subject}`,
     ``,
+    `## FIRST ACTION REQUIRED`,
+    `Before doing anything else, write your ready sentinel file:`,
+    '```bash',
+    `mkdir -p $(dirname ${readyPath}) && touch ${readyPath}`,
+    '```',
+    ``,
     task.description,
     ``,
     `When complete, write done signal using a bash command (do NOT use a file-write tool):`,
     '```bash',
     `mkdir -p ${doneDir} && echo '{"taskId":"${taskId}","status":"completed","summary":"done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' > ${donePath}`,
     '```',
+    `For failures, set status to "failed" and include the error in summary.`,
     ``,
     `IMPORTANT: Execute ONLY the task assigned to you in this inbox. After writing done.json, exit immediately. Do not read from the task directory or claim other tasks.`,
   ].join('\n');


### PR DESCRIPTION
## Summary

- Append `.ready` sentinel write instruction and `done.json` completion protocol directly into `buildInitialTaskInstruction()` so prompt-mode workers (Gemini, Codex) receive them in their inline inbox content
- Previously these instructions existed only in AGENTS.md overlay which Gemini doesn't auto-load, causing workers to get killed before writing `done.json`
- Add 4 tests verifying sentinel instructions appear in the inline prompt for both Gemini and Codex workers

## Test plan

- [x] All 9 prompt-mode tests pass (4 new + 5 existing)
- [x] All 7 worker-bootstrap tests pass (unchanged)
- [x] Full test suite: 230 files, 5111 tests pass
- [x] `npx tsc --noEmit` clean

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)