### PR TITLE
fix(shared-memory): atomic writes to prevent corruption on crash

### DIFF
--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -6,7 +6,7 @@
  * and file permissions so that individual mode modules don't duplicate this logic.
  */
 
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, renameSync } from 'fs';
 import {
   resolveStatePath,
   resolveSessionStatePath,
@@ -59,7 +59,9 @@ export function writeModeState(
     }
     const filePath = resolveFile(mode, directory, sessionId);
     const envelope = { ...state, _meta: { written_at: new Date().toISOString(), mode } };
-    writeFileSync(filePath, JSON.stringify(envelope, null, 2), { mode: 0o600 });
+    const tmpPath = filePath + '.tmp';
+    writeFileSync(tmpPath, JSON.stringify(envelope, null, 2), { mode: 0o600 });
+    renameSync(tmpPath, filePath);
     return true;
   } catch {
     return false;

--- a/src/lib/shared-memory.ts
+++ b/src/lib/shared-memory.ts
@@ -18,7 +18,7 @@
  * @see https://github.com/anthropics/oh-my-claudecode/issues/1119
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, readdirSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, readdirSync, renameSync } from 'fs';
 import { join, basename } from 'path';
 import { getOmcRoot } from './worktree-paths.js';
 
@@ -180,7 +180,9 @@ export function writeEntry(
     entry.expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
   }
 
-  writeFileSync(filePath, JSON.stringify(entry, null, 2), 'utf-8');
+  const tmpPath = filePath + '.tmp';
+  writeFileSync(tmpPath, JSON.stringify(entry, null, 2), 'utf-8');
+  renameSync(tmpPath, filePath);
   return entry;
 }
 


### PR DESCRIPTION
## Summary

- Replace direct `writeFileSync` with write-to-temp + `renameSync` (atomic on POSIX) in `mode-state-io.ts` and `shared-memory.ts`
- Ensures readers always see either the old or new complete state, never a partial write from a mid-write crash
- Add tests verifying no `.tmp` files linger and that leftover `.tmp` from prior crashes are handled correctly

Closes #1159

## Test plan

- [x] All 54 existing + new tests pass (`mode-state-io.test.ts`, `shared-memory.test.ts`)
- [x] New test: no `.tmp` file remains after successful write (both modules)
- [x] New test: leftover `.tmp` from a prior crash is overwritten on next write (both modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)