### PR TITLE
fix(notifications): redact Slack/Telegram bot tokens in log and error paths

### DIFF
--- a/src/notifications/__tests__/redact.test.ts
+++ b/src/notifications/__tests__/redact.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { redactTokens } from '../redact.js';
+
+describe('redactTokens', () => {
+  // ── Slack tokens ──────────────────────────────────────────────────────
+
+  it('redacts Slack bot tokens (xoxb-)', () => {
+    const input = 'token is xoxb-123456789012-abcDEF here';
+    const result = redactTokens(input);
+    expect(result).not.toContain('123456789012-abcDEF');
+    expect(result).toContain('xoxb-****');
+  });
+
+  it('redacts xoxb- tokens behind Bearer prefix', () => {
+    const input = 'Authorization: Bearer xoxb-123456789012-abcDEF';
+    const result = redactTokens(input);
+    expect(result).not.toContain('123456789012-abcDEF');
+    expect(result).toContain('Bearer ****');
+  });
+
+  it('redacts Slack app tokens (xapp-)', () => {
+    const input = 'Token: xapp-1-A0B1C2D3E4F5-1234567890-abcdef0123456789';
+    const result = redactTokens(input);
+    expect(result).not.toContain('A0B1C2D3E4F5');
+    expect(result).toContain('xapp-****');
+  });
+
+  it('redacts Slack user tokens (xoxp-)', () => {
+    const input = 'xoxp-fake-test-value';
+    const result = redactTokens(input);
+    expect(result).not.toContain('fake-test-value');
+    expect(result).toContain('xoxp-****');
+  });
+
+  it('redacts xoxa- tokens', () => {
+    const input = 'token=xoxa-2-abc123def456';
+    const result = redactTokens(input);
+    expect(result).not.toContain('abc123def456');
+    expect(result).toContain('xoxa-****');
+  });
+
+  // ── Telegram tokens ───────────────────────────────────────────────────
+
+  it('redacts Telegram bot tokens in URL paths', () => {
+    const input = 'GET /bot1234567890:AAHfoo-bar_BazQux123456789/getUpdates';
+    const result = redactTokens(input);
+    expect(result).not.toContain('AAHfoo-bar_BazQux123456789');
+    expect(result).toContain('/bot1234567890:****');
+    expect(result).toContain('/getUpdates');
+  });
+
+  it('redacts standalone Telegram bot tokens', () => {
+    const input = 'Token is 1234567890:AAHdKq3lx_abcdefghij12345678901';
+    const result = redactTokens(input);
+    expect(result).not.toContain('AAHdKq3lx_abcdefghij12345678901');
+    expect(result).toContain('1234567890:****');
+  });
+
+  // ── Bearer / Bot auth values ──────────────────────────────────────────
+
+  it('redacts Bearer token values', () => {
+    const input = 'Error: request failed with Bearer xoxb-secret-token-value';
+    const result = redactTokens(input);
+    expect(result).not.toContain('secret-token-value');
+    expect(result).toContain('Bearer ****');
+  });
+
+  it('redacts Bot token values', () => {
+    const input = 'Authorization: Bot MTIzNDU2Nzg5MDEy.abc.xyz123';
+    const result = redactTokens(input);
+    expect(result).not.toContain('MTIzNDU2Nzg5MDEy');
+    expect(result).toContain('Bot ****');
+  });
+
+  it('is case-insensitive for Bearer/Bot', () => {
+    const input = 'BEARER some-secret and bearer another-secret';
+    const result = redactTokens(input);
+    expect(result).not.toContain('some-secret');
+    expect(result).not.toContain('another-secret');
+  });
+
+  // ── Safe strings (no false positives) ─────────────────────────────────
+
+  it('does not modify strings without tokens', () => {
+    const input = 'Slack Socket Mode connected';
+    expect(redactTokens(input)).toBe(input);
+  });
+
+  it('does not modify normal error messages', () => {
+    const input = 'HTTP 401 Unauthorized';
+    expect(redactTokens(input)).toBe(input);
+  });
+
+  it('does not modify short numeric sequences', () => {
+    const input = 'PID 12345 started';
+    expect(redactTokens(input)).toBe(input);
+  });
+
+  it('preserves non-token parts of the message', () => {
+    const input = 'Slack Socket Mode connection error: fetch failed for Bearer xoxb-secret-123';
+    const result = redactTokens(input);
+    expect(result).toContain('Slack Socket Mode connection error:');
+    expect(result).toContain('fetch failed for');
+    expect(result).not.toContain('secret-123');
+  });
+
+  // ── Multiple tokens in one string ─────────────────────────────────────
+
+  it('redacts multiple different tokens in one string', () => {
+    const input = 'appToken=xapp-1-AAA-BBB botToken=xoxb-123-secret channelId=C12345';
+    const result = redactTokens(input);
+    expect(result).not.toContain('AAA-BBB');
+    expect(result).not.toContain('123-secret');
+    expect(result).toContain('xapp-****');
+    expect(result).toContain('xoxb-****');
+    expect(result).toContain('channelId=C12345');
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────
+
+  it('handles empty string', () => {
+    expect(redactTokens('')).toBe('');
+  });
+
+  it('handles string with only whitespace', () => {
+    expect(redactTokens('   ')).toBe('   ');
+  });
+
+  it('redacts tokens in error stack-like strings', () => {
+    const input = 'Error: apps.connections.open failed\n  at fetch (Bearer xoxb-my-secret-token)';
+    const result = redactTokens(input);
+    expect(result).not.toContain('my-secret-token');
+  });
+});

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -77,6 +77,7 @@ export {
   validateTemplate,
   computeTemplateVariables,
 } from "./template-engine.js";
+export { redactTokens } from "./redact.js";
 
 import type {
   NotificationEvent,

--- a/src/notifications/redact.ts
+++ b/src/notifications/redact.ts
@@ -1,0 +1,33 @@
+/**
+ * Token Redaction Utility
+ *
+ * Masks sensitive tokens in strings to prevent exposure in logs, error messages,
+ * and persisted state. Covers Slack, Telegram, and generic Bearer/Bot tokens.
+ *
+ * @see https://github.com/Yeachan-Heo/oh-my-claudecode/issues/1162
+ */
+
+/**
+ * Redact sensitive tokens from a string.
+ *
+ * Patterns masked:
+ * - Slack bot tokens: xoxb-...
+ * - Slack app tokens: xapp-...
+ * - Slack user/workspace tokens: xoxp-..., xoxa-...
+ * - Telegram bot tokens in URL paths: /bot123456:ABC.../method
+ * - Telegram bot tokens standalone: 123456789:AAF-abc123...
+ * - Bearer and Bot authorization values
+ */
+export function redactTokens(input: string): string {
+  return input
+    // Slack tokens: xoxb-..., xapp-..., xoxp-..., xoxa-...
+    .replace(/\b(xox[bpae]-)[A-Za-z0-9-]+/g, '$1****')
+    .replace(/\b(xapp-)[A-Za-z0-9-]+/g, '$1****')
+    // Telegram bot tokens in URL paths: /bot123456:ABC.../
+    .replace(/\/bot(\d+):[A-Za-z0-9_-]+/g, '/bot$1:****')
+    // Telegram bot tokens standalone: 123456789:AAHfoo-bar_Baz
+    .replace(/\b(\d{8,12}):[A-Za-z0-9_-]{20,}\b/g, '$1:****')
+    // Bearer/Bot authorization values in error strings
+    .replace(/(Bearer\s+)\S+/gi, '$1****')
+    .replace(/(Bot\s+)\S+/gi, '$1****');
+}

--- a/src/notifications/slack-socket.ts
+++ b/src/notifications/slack-socket.ts
@@ -37,6 +37,8 @@ export interface SlackSocketConfig {
 type MessageHandler = (event: SlackMessageEvent) => void | Promise<void>;
 type LogFn = (message: string) => void;
 
+import { redactTokens } from './redact.js';
+
 /** Timeout for Slack API calls */
 const API_TIMEOUT_MS = 10_000;
 
@@ -59,11 +61,16 @@ export class SlackSocketClient {
   private isShuttingDown = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
+  private readonly log: LogFn;
+
   constructor(
     private readonly config: SlackSocketConfig,
     private readonly onMessage: MessageHandler,
-    private readonly log: LogFn,
-  ) {}
+    log: LogFn,
+  ) {
+    // Wrap the log function to automatically redact tokens from all messages
+    this.log = (msg: string) => log(redactTokens(msg));
+  }
 
   /**
    * Start the Socket Mode connection.


### PR DESCRIPTION
## Summary

- Add `redactTokens()` utility (`src/notifications/redact.ts`) that masks sensitive token patterns in strings: Slack (`xoxb-`, `xapp-`, `xoxp-`, `xoxa-`), Telegram bot tokens (in URL paths and standalone), and `Bearer`/`Bot` authorization values
- Wrap `SlackSocketClient.log` to auto-redact all messages before passing to the caller-provided log function
- Apply `redactTokens()` to the reply-listener daemon's `log()` function and all `state.lastError` assignments to prevent tokens from being written to log files or persisted state
- Replace `console.error(err)` in daemon spawn script with safe `err.message` extraction to avoid full error object serialization

Closes #1162

## Test plan

- [x] 18 new unit tests in `redact.test.ts` covering all token patterns, edge cases, and false-positive resistance
- [x] All 431 existing notification tests pass (15 test files)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)