### PR TITLE
fix(shared-memory): concurrent agent writes cause silent data loss

### DIFF
--- a/src/__tests__/file-lock.test.ts
+++ b/src/__tests__/file-lock.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  acquireFileLockSync,
+  releaseFileLockSync,
+  withFileLockSync,
+  acquireFileLock,
+  releaseFileLock,
+  withFileLock,
+  lockPathFor,
+} from '../lib/file-lock.js';
+
+describe('file-lock', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(
+      tmpdir(),
+      `file-lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('lockPathFor', () => {
+    it('should append .lock to the file path', () => {
+      expect(lockPathFor('/path/to/file.json')).toBe('/path/to/file.json.lock');
+    });
+  });
+
+  describe('acquireFileLockSync / releaseFileLockSync', () => {
+    it('should acquire and release a lock successfully', () => {
+      const lockPath = join(testDir, 'test.lock');
+      const handle = acquireFileLockSync(lockPath);
+
+      expect(handle).not.toBeNull();
+      expect(existsSync(lockPath)).toBe(true);
+
+      // Verify lock payload contains PID
+      const payload = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(payload.pid).toBe(process.pid);
+      expect(payload.timestamp).toBeGreaterThan(0);
+
+      releaseFileLockSync(handle!);
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    it('should fail to acquire when lock is already held', () => {
+      const lockPath = join(testDir, 'test.lock');
+      const handle1 = acquireFileLockSync(lockPath);
+      expect(handle1).not.toBeNull();
+
+      // Second attempt should fail (same process, but O_EXCL prevents it)
+      const handle2 = acquireFileLockSync(lockPath);
+      expect(handle2).toBeNull();
+
+      releaseFileLockSync(handle1!);
+    });
+
+    it('should reap stale lock from dead PID', () => {
+      const lockPath = join(testDir, 'test.lock');
+
+      // Create a fake lock file with a dead PID
+      writeFileSync(
+        lockPath,
+        JSON.stringify({ pid: 999999999, timestamp: Date.now() - 60_000 }),
+      );
+
+      // Backdate the file's mtime so it looks old to stat()
+      const oldTime = new Date(Date.now() - 60_000);
+      utimesSync(lockPath, oldTime, oldTime);
+
+      // Should reap the stale lock and succeed
+      const handle = acquireFileLockSync(lockPath, { staleLockMs: 1000 });
+      expect(handle).not.toBeNull();
+
+      releaseFileLockSync(handle!);
+    });
+
+    it('should not reap lock from alive PID', () => {
+      const lockPath = join(testDir, 'test.lock');
+
+      // Create a lock file with current (alive) PID but old timestamp
+      writeFileSync(
+        lockPath,
+        JSON.stringify({ pid: process.pid, timestamp: Date.now() - 60_000 }),
+      );
+
+      // Should not reap because PID is alive
+      const handle = acquireFileLockSync(lockPath, { staleLockMs: 1000 });
+      expect(handle).toBeNull();
+
+      // Cleanup
+      rmSync(lockPath, { force: true });
+    });
+
+    it('should retry with timeout and acquire stale lock', () => {
+      const lockPath = join(testDir, 'test.lock');
+
+      // Create a lock held by a dead PID with old mtime
+      writeFileSync(
+        lockPath,
+        JSON.stringify({ pid: 999999999, timestamp: Date.now() - 60_000 }),
+      );
+      const oldTime = new Date(Date.now() - 60_000);
+      utimesSync(lockPath, oldTime, oldTime);
+
+      // Acquire with retry -- should detect stale and reap on retry
+      const handle = acquireFileLockSync(lockPath, { timeoutMs: 1000, retryDelayMs: 50, staleLockMs: 1000 });
+      expect(handle).not.toBeNull();
+
+      releaseFileLockSync(handle!);
+    });
+
+    it('should fail after timeout expires', () => {
+      const lockPath = join(testDir, 'test.lock');
+
+      // Create a lock held by current (alive) PID
+      writeFileSync(
+        lockPath,
+        JSON.stringify({ pid: process.pid, timestamp: Date.now() }),
+      );
+
+      const start = Date.now();
+      const handle = acquireFileLockSync(lockPath, { timeoutMs: 200, retryDelayMs: 50 });
+      const elapsed = Date.now() - start;
+
+      expect(handle).toBeNull();
+      expect(elapsed).toBeGreaterThanOrEqual(150); // Should have waited
+
+      // Cleanup
+      rmSync(lockPath, { force: true });
+    });
+  });
+
+  describe('withFileLockSync', () => {
+    it('should execute function under lock and release', () => {
+      const lockPath = join(testDir, 'test.lock');
+      const result = withFileLockSync(lockPath, () => {
+        expect(existsSync(lockPath)).toBe(true);
+        return 42;
+      });
+
+      expect(result).toBe(42);
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    it('should release lock even on error', () => {
+      const lockPath = join(testDir, 'test.lock');
+
+      expect(() => {
+        withFileLockSync(lockPath, () => {
+          throw new Error('test error');
+        });
+      }).toThrow('test error');
+
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    it('should throw when lock cannot be acquired', () => {
+      const lockPath = join(testDir, 'test.lock');
+
+      // Hold the lock
+      writeFileSync(
+        lockPath,
+        JSON.stringify({ pid: process.pid, timestamp: Date.now() }),
+      );
+
+      expect(() => {
+        withFileLockSync(lockPath, () => 'should not run');
+      }).toThrow('Failed to acquire file lock');
+
+      // Cleanup
+      rmSync(lockPath, { force: true });
+    });
+  });
+
+  describe('acquireFileLock (async)', () => {
+    it('should acquire and release a lock successfully', async () => {
+      const lockPath = join(testDir, 'test-async.lock');
+      const handle = await acquireFileLock(lockPath);
+
+      expect(handle).not.toBeNull();
+      expect(existsSync(lockPath)).toBe(true);
+
+      releaseFileLock(handle!);
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    it('should retry with timeout and acquire when lock is released', async () => {
+      const lockPath = join(testDir, 'test-async.lock');
+      const handle1 = await acquireFileLock(lockPath);
+      expect(handle1).not.toBeNull();
+
+      // Release after a short delay
+      setTimeout(() => {
+        releaseFileLock(handle1!);
+      }, 100);
+
+      const handle2 = await acquireFileLock(lockPath, { timeoutMs: 1000, retryDelayMs: 50 });
+      expect(handle2).not.toBeNull();
+
+      releaseFileLock(handle2!);
+    });
+  });
+
+  describe('withFileLock (async)', () => {
+    it('should execute async function under lock and release', async () => {
+      const lockPath = join(testDir, 'test-async.lock');
+      const result = await withFileLock(lockPath, async () => {
+        expect(existsSync(lockPath)).toBe(true);
+        return 'async-result';
+      });
+
+      expect(result).toBe('async-result');
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    it('should release lock even on async error', async () => {
+      const lockPath = join(testDir, 'test-async.lock');
+
+      await expect(
+        withFileLock(lockPath, async () => {
+          throw new Error('async error');
+        }),
+      ).rejects.toThrow('async error');
+
+      expect(existsSync(lockPath)).toBe(false);
+    });
+  });
+
+  describe('concurrent writes with locking', () => {
+    it('should prevent data loss with concurrent notepad-style writes', () => {
+      const dataPath = join(testDir, 'data.txt');
+      const lockPath = lockPathFor(dataPath);
+      writeFileSync(dataPath, '');
+
+      // Simulate 10 concurrent writers, each appending a unique line
+      const results: boolean[] = [];
+      for (let i = 0; i < 10; i++) {
+        try {
+          withFileLockSync(lockPath, () => {
+            const current = readFileSync(dataPath, 'utf-8');
+            writeFileSync(dataPath, current + `line-${i}\n`);
+          }, { timeoutMs: 5000 });
+          results.push(true);
+        } catch {
+          results.push(false);
+        }
+      }
+
+      // All writes should succeed
+      expect(results.every(r => r)).toBe(true);
+
+      // All 10 lines should be present (no data loss)
+      const final = readFileSync(dataPath, 'utf-8');
+      const lines = final.trim().split('\n');
+      expect(lines).toHaveLength(10);
+      for (let i = 0; i < 10; i++) {
+        expect(lines).toContain(`line-${i}`);
+      }
+    });
+
+    it('should prevent data loss with concurrent async writes', async () => {
+      const dataPath = join(testDir, 'data-async.json');
+      const lockPath = lockPathFor(dataPath);
+      writeFileSync(dataPath, JSON.stringify({ items: [] }));
+
+      // Launch 10 concurrent async writers
+      const writers = Array.from({ length: 10 }, (_, i) =>
+        withFileLock(lockPath, async () => {
+          const content = JSON.parse(readFileSync(dataPath, 'utf-8'));
+          content.items.push(`item-${i}`);
+          writeFileSync(dataPath, JSON.stringify(content));
+        }, { timeoutMs: 5000 }),
+      );
+
+      await Promise.all(writers);
+
+      // All 10 items should be present
+      const final = JSON.parse(readFileSync(dataPath, 'utf-8'));
+      expect(final.items).toHaveLength(10);
+      for (let i = 0; i < 10; i++) {
+        expect(final.items).toContain(`item-${i}`);
+      }
+    });
+  });
+});

--- a/src/__tests__/shared-memory-concurrency.test.ts
+++ b/src/__tests__/shared-memory-concurrency.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for concurrent shared-memory access (issue #1160).
+ *
+ * Verifies that file-level locking prevents silent data loss when
+ * multiple agents write to notepad and project memory simultaneously.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  initNotepad,
+  addWorkingMemoryEntry,
+  addManualEntry,
+  setPriorityContext,
+  readNotepad,
+  getNotepadPath,
+  WORKING_MEMORY_HEADER,
+  MANUAL_HEADER,
+} from '../hooks/notepad/index.js';
+import {
+  loadProjectMemory,
+  saveProjectMemory,
+  withProjectMemoryLock,
+} from '../hooks/project-memory/index.js';
+
+describe('Shared Memory Concurrency (issue #1160)', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(
+      tmpdir(),
+      `concurrency-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Notepad concurrent writes', () => {
+    it('should not lose entries when multiple working memory writes happen concurrently', () => {
+      initNotepad(testDir);
+
+      // Simulate sequential writes (which previously raced without locking)
+      const count = 5;
+      for (let i = 0; i < count; i++) {
+        const result = addWorkingMemoryEntry(testDir, `Agent ${i} observation`);
+        expect(result).toBe(true);
+      }
+
+      // Verify all entries are present
+      const content = readNotepad(testDir)!;
+      for (let i = 0; i < count; i++) {
+        expect(content).toContain(`Agent ${i} observation`);
+      }
+    });
+
+    it('should not lose entries when manual and working memory writes interleave', () => {
+      initNotepad(testDir);
+
+      // Interleave different section writes
+      addWorkingMemoryEntry(testDir, 'Working entry 1');
+      addManualEntry(testDir, 'Manual entry 1');
+      addWorkingMemoryEntry(testDir, 'Working entry 2');
+      addManualEntry(testDir, 'Manual entry 2');
+
+      const content = readNotepad(testDir)!;
+      expect(content).toContain('Working entry 1');
+      expect(content).toContain('Working entry 2');
+      expect(content).toContain('Manual entry 1');
+      expect(content).toContain('Manual entry 2');
+    });
+
+    it('should not lose priority context when set concurrently with working memory', () => {
+      initNotepad(testDir);
+
+      setPriorityContext(testDir, 'Critical discovery');
+      addWorkingMemoryEntry(testDir, 'Working note');
+
+      const content = readNotepad(testDir)!;
+      expect(content).toContain('Critical discovery');
+      expect(content).toContain('Working note');
+    });
+
+    it('lock file should be cleaned up after notepad writes', () => {
+      initNotepad(testDir);
+
+      addWorkingMemoryEntry(testDir, 'Test entry');
+
+      const notepadPath = getNotepadPath(testDir);
+      const lockPath = notepadPath + '.lock';
+      expect(existsSync(lockPath)).toBe(false);
+    });
+  });
+
+  describe('Project memory concurrent writes', () => {
+    it('withProjectMemoryLock should serialize concurrent access', async () => {
+      // Set up initial memory
+      const omcDir = join(testDir, '.omc');
+      mkdirSync(omcDir, { recursive: true });
+
+      const initialMemory = {
+        version: '1.0.0',
+        projectRoot: testDir,
+        lastScanned: Date.now(),
+        techStack: { languages: [], frameworks: [], packageManagers: [] },
+        build: { buildCommand: null, testCommand: null, lintCommand: null },
+        conventions: { indentation: null, quoting: null, semicolons: null },
+        structure: { entryPoints: [], configFiles: [] },
+        customNotes: [] as Array<{ timestamp: number; source: string; category: string; content: string }>,
+        userDirectives: [],
+        hotPaths: { files: [], directories: [] },
+      };
+      await saveProjectMemory(testDir, initialMemory as any);
+
+      // Launch 5 concurrent note additions under lock
+      const writers = Array.from({ length: 5 }, (_, i) =>
+        withProjectMemoryLock(testDir, async () => {
+          const memory = await loadProjectMemory(testDir);
+          if (!memory) throw new Error('Memory not found');
+
+          memory.customNotes.push({
+            timestamp: Date.now(),
+            source: 'learned',
+            category: 'test',
+            content: `Note from agent ${i}`,
+          });
+
+          await saveProjectMemory(testDir, memory);
+        }),
+      );
+
+      await Promise.all(writers);
+
+      // Verify all 5 notes are present (no data loss)
+      const finalMemory = await loadProjectMemory(testDir);
+      expect(finalMemory).not.toBeNull();
+      expect(finalMemory!.customNotes).toHaveLength(5);
+      for (let i = 0; i < 5; i++) {
+        expect(
+          finalMemory!.customNotes.some(
+            (n: any) => n.content === `Note from agent ${i}`,
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it('lock file should be cleaned up after project memory writes', async () => {
+      const omcDir = join(testDir, '.omc');
+      mkdirSync(omcDir, { recursive: true });
+
+      const memoryPath = join(omcDir, 'project-memory.json');
+      writeFileSync(
+        memoryPath,
+        JSON.stringify({
+          version: '1.0.0',
+          projectRoot: testDir,
+          lastScanned: Date.now(),
+          techStack: { languages: [], frameworks: [], packageManagers: [] },
+          build: {},
+          conventions: {},
+          structure: {},
+          customNotes: [],
+          userDirectives: [],
+          hotPaths: { files: [], directories: [] },
+        }),
+      );
+
+      await withProjectMemoryLock(testDir, async () => {
+        // Do nothing -- just verify lock lifecycle
+      });
+
+      const lockPath = memoryPath + '.lock';
+      expect(existsSync(lockPath)).toBe(false);
+    });
+  });
+});

--- a/src/hooks/notepad/index.ts
+++ b/src/hooks/notepad/index.ts
@@ -27,6 +27,7 @@ import { existsSync, readFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { getOmcRoot } from "../../lib/worktree-paths.js";
 import { atomicWriteFileSync } from "../../lib/atomic-write.js";
+import { lockPathFor, withFileLockSync } from "../../lib/file-lock.js";
 
 // ============================================================================
 // Types
@@ -249,20 +250,23 @@ export function setPriorityContext(
   }
 
   const notepadPath = getNotepadPath(directory);
-  let notepadContent = readFileSync(notepadPath, "utf-8");
-
-  // Check size
-  const warning =
-    content.length > config.priorityMaxChars
-      ? `Priority Context exceeds ${config.priorityMaxChars} chars (${content.length} chars). Consider condensing.`
-      : undefined;
-
-  // Replace the section
-  notepadContent = replaceSection(notepadContent, PRIORITY_HEADER, content);
 
   try {
-    atomicWriteFileSync(notepadPath, notepadContent);
-    return { success: true, warning };
+    return withFileLockSync(lockPathFor(notepadPath), () => {
+      let notepadContent = readFileSync(notepadPath, "utf-8");
+
+      // Check size
+      const warning =
+        content.length > config.priorityMaxChars
+          ? `Priority Context exceeds ${config.priorityMaxChars} chars (${content.length} chars). Consider condensing.`
+          : undefined;
+
+      // Replace the section
+      notepadContent = replaceSection(notepadContent, PRIORITY_HEADER, content);
+
+      atomicWriteFileSync(notepadPath, notepadContent);
+      return { success: true, warning } as PriorityContextResult;
+    }, { timeoutMs: 5000 });
   } catch {
     return { success: false };
   }
@@ -283,32 +287,35 @@ export function addWorkingMemoryEntry(
   }
 
   const notepadPath = getNotepadPath(directory);
-  let notepadContent = readFileSync(notepadPath, "utf-8");
-
-  // Get current Working Memory content
-  const currentMemory =
-    extractSection(notepadContent, WORKING_MEMORY_HEADER) || "";
-
-  // Format timestamp
-  const now = new Date();
-  const timestamp = now.toISOString().slice(0, 16).replace("T", " "); // YYYY-MM-DD HH:MM
-
-  // Add new entry
-  const newEntry = `### ${timestamp}\n${content}\n`;
-  const updatedMemory = currentMemory
-    ? currentMemory + "\n" + newEntry
-    : newEntry;
-
-  // Replace the section
-  notepadContent = replaceSection(
-    notepadContent,
-    WORKING_MEMORY_HEADER,
-    updatedMemory,
-  );
 
   try {
-    atomicWriteFileSync(notepadPath, notepadContent);
-    return true;
+    return withFileLockSync(lockPathFor(notepadPath), () => {
+      let notepadContent = readFileSync(notepadPath, "utf-8");
+
+      // Get current Working Memory content
+      const currentMemory =
+        extractSection(notepadContent, WORKING_MEMORY_HEADER) || "";
+
+      // Format timestamp
+      const now = new Date();
+      const timestamp = now.toISOString().slice(0, 16).replace("T", " "); // YYYY-MM-DD HH:MM
+
+      // Add new entry
+      const newEntry = `### ${timestamp}\n${content}\n`;
+      const updatedMemory = currentMemory
+        ? currentMemory + "\n" + newEntry
+        : newEntry;
+
+      // Replace the section
+      notepadContent = replaceSection(
+        notepadContent,
+        WORKING_MEMORY_HEADER,
+        updatedMemory,
+      );
+
+      atomicWriteFileSync(notepadPath, notepadContent);
+      return true;
+    }, { timeoutMs: 5000 });
   } catch {
     return false;
   }
@@ -326,25 +333,28 @@ export function addManualEntry(directory: string, content: string): boolean {
   }
 
   const notepadPath = getNotepadPath(directory);
-  let notepadContent = readFileSync(notepadPath, "utf-8");
-
-  // Get current MANUAL content
-  const currentManual = extractSection(notepadContent, MANUAL_HEADER) || "";
-
-  // Add new entry with timestamp
-  const now = new Date();
-  const timestamp = now.toISOString().slice(0, 16).replace("T", " "); // YYYY-MM-DD HH:MM
-  const newEntry = `### ${timestamp}\n${content}\n`;
-  const updatedManual = currentManual
-    ? currentManual + "\n" + newEntry
-    : newEntry;
-
-  // Replace the section
-  notepadContent = replaceSection(notepadContent, MANUAL_HEADER, updatedManual);
 
   try {
-    atomicWriteFileSync(notepadPath, notepadContent);
-    return true;
+    return withFileLockSync(lockPathFor(notepadPath), () => {
+      let notepadContent = readFileSync(notepadPath, "utf-8");
+
+      // Get current MANUAL content
+      const currentManual = extractSection(notepadContent, MANUAL_HEADER) || "";
+
+      // Add new entry with timestamp
+      const now = new Date();
+      const timestamp = now.toISOString().slice(0, 16).replace("T", " "); // YYYY-MM-DD HH:MM
+      const newEntry = `### ${timestamp}\n${content}\n`;
+      const updatedManual = currentManual
+        ? currentManual + "\n" + newEntry
+        : newEntry;
+
+      // Replace the section
+      notepadContent = replaceSection(notepadContent, MANUAL_HEADER, updatedManual);
+
+      atomicWriteFileSync(notepadPath, notepadContent);
+      return true;
+    }, { timeoutMs: 5000 });
   } catch {
     return false;
   }
@@ -366,55 +376,57 @@ export function pruneOldEntries(
     return { pruned: 0, remaining: 0 };
   }
 
-  let notepadContent = readFileSync(notepadPath, "utf-8");
-  const workingMemory = extractSection(notepadContent, WORKING_MEMORY_HEADER);
-
-  if (!workingMemory) {
-    return { pruned: 0, remaining: 0 };
-  }
-
-  // Parse entries
-  const entryRegex =
-    /### (\d{4}-\d{2}-\d{2} \d{2}:\d{2})\n([\s\S]*?)(?=### |$)/g;
-  const entries: Array<{ timestamp: string; content: string }> = [];
-  let match: RegExpExecArray | null = entryRegex.exec(workingMemory);
-
-  while (match !== null) {
-    entries.push({
-      timestamp: match[1],
-      content: match[2].trim(),
-    });
-    match = entryRegex.exec(workingMemory);
-  }
-
-  // Calculate cutoff date
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - daysOld);
-
-  // Filter entries
-  const kept = entries.filter((entry) => {
-    const entryDate = new Date(entry.timestamp);
-    return entryDate >= cutoff;
-  });
-
-  const pruned = entries.length - kept.length;
-
-  // Rebuild Working Memory section
-  const newContent = kept
-    .map((entry) => `### ${entry.timestamp}\n${entry.content}`)
-    .join("\n\n");
-
-  notepadContent = replaceSection(
-    notepadContent,
-    WORKING_MEMORY_HEADER,
-    newContent,
-  );
-
   try {
-    atomicWriteFileSync(notepadPath, notepadContent);
-    return { pruned, remaining: kept.length };
+    return withFileLockSync(lockPathFor(notepadPath), () => {
+      let notepadContent = readFileSync(notepadPath, "utf-8");
+      const workingMemory = extractSection(notepadContent, WORKING_MEMORY_HEADER);
+
+      if (!workingMemory) {
+        return { pruned: 0, remaining: 0 } as PruneResult;
+      }
+
+      // Parse entries
+      const entryRegex =
+        /### (\d{4}-\d{2}-\d{2} \d{2}:\d{2})\n([\s\S]*?)(?=### |$)/g;
+      const entries: Array<{ timestamp: string; content: string }> = [];
+      let match: RegExpExecArray | null = entryRegex.exec(workingMemory);
+
+      while (match !== null) {
+        entries.push({
+          timestamp: match[1],
+          content: match[2].trim(),
+        });
+        match = entryRegex.exec(workingMemory);
+      }
+
+      // Calculate cutoff date
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - daysOld);
+
+      // Filter entries
+      const kept = entries.filter((entry) => {
+        const entryDate = new Date(entry.timestamp);
+        return entryDate >= cutoff;
+      });
+
+      const pruned = entries.length - kept.length;
+
+      // Rebuild Working Memory section
+      const newContent = kept
+        .map((entry) => `### ${entry.timestamp}\n${entry.content}`)
+        .join("\n\n");
+
+      notepadContent = replaceSection(
+        notepadContent,
+        WORKING_MEMORY_HEADER,
+        newContent,
+      );
+
+      atomicWriteFileSync(notepadPath, notepadContent);
+      return { pruned, remaining: kept.length } as PruneResult;
+    }, { timeoutMs: 5000 });
   } catch {
-    return { pruned: 0, remaining: entries.length };
+    return { pruned: 0, remaining: 0 };
   }
 }
 

--- a/src/hooks/project-memory/index.ts
+++ b/src/hooks/project-memory/index.ts
@@ -116,7 +116,7 @@ export async function rescanProjectEnvironment(projectRoot: string): Promise<voi
 }
 
 // Re-export utilities for use in other modules
-export { loadProjectMemory, saveProjectMemory } from './storage.js';
+export { loadProjectMemory, saveProjectMemory, withProjectMemoryLock } from './storage.js';
 export { detectProjectEnvironment } from './detector.js';
 export { formatContextSummary, formatFullContext } from './formatter.js';
 export { learnFromToolOutput, addCustomNote } from './learner.js';

--- a/src/lib/file-lock.ts
+++ b/src/lib/file-lock.ts
@@ -1,0 +1,309 @@
+/**
+ * Cross-process advisory file locking for shared-memory coordination.
+ *
+ * Uses O_CREAT|O_EXCL (exclusive-create) for atomic lock acquisition.
+ * The kernel guarantees at most one process succeeds in creating the file.
+ * Includes PID-based stale lock detection and automatic reaping.
+ *
+ * Provides both synchronous and asynchronous variants:
+ * - Sync: for notepad (readFileSync-based) and state operations
+ * - Async: for project-memory operations
+ */
+
+import {
+  openSync,
+  closeSync,
+  unlinkSync,
+  writeSync,
+  readFileSync,
+  statSync,
+  constants as fsConstants,
+} from "fs";
+import * as path from "path";
+import { ensureDirSync } from "./atomic-write.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Handle returned by lock acquisition; pass to release. */
+export interface FileLockHandle {
+  fd: number;
+  path: string;
+}
+
+/** Options for lock acquisition. */
+export interface FileLockOptions {
+  /** Maximum time (ms) to wait for lock acquisition. 0 = single attempt. Default: 0 */
+  timeoutMs?: number;
+  /** Delay (ms) between retry attempts. Default: 50 */
+  retryDelayMs?: number;
+  /** Age (ms) after which a lock held by a dead PID is considered stale. Default: 30000 */
+  staleLockMs?: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_STALE_LOCK_MS = 30_000;
+const DEFAULT_RETRY_DELAY_MS = 50;
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/**
+ * Check if a process with the given PID is alive.
+ * Returns false for invalid PIDs or if kill(pid, 0) throws ESRCH.
+ */
+function isPidAlive(pid: number): boolean {
+  if (pid <= 0 || !Number.isFinite(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: unknown) {
+    // EPERM means the process exists but we lack permission -- still alive
+    if (
+      e &&
+      typeof e === "object" &&
+      "code" in e &&
+      (e as { code: string }).code === "EPERM"
+    )
+      return true;
+    return false;
+  }
+}
+
+/**
+ * Check if an existing lock file is stale.
+ * A lock is stale if older than staleLockMs AND the owning PID is dead.
+ */
+function isLockStale(lockPath: string, staleLockMs: number): boolean {
+  try {
+    const stat = statSync(lockPath);
+    const ageMs = Date.now() - stat.mtimeMs;
+    if (ageMs < staleLockMs) return false;
+
+    // Try to read PID from the lock payload
+    try {
+      const raw = readFileSync(lockPath, "utf-8");
+      const payload = JSON.parse(raw) as { pid?: number };
+      if (payload.pid && isPidAlive(payload.pid)) return false;
+    } catch {
+      // Malformed or unreadable -- treat as stale if old enough
+    }
+    return true;
+  } catch {
+    // Lock file disappeared -- not stale, just gone
+    return false;
+  }
+}
+
+/**
+ * Derive the lock file path from a data file path.
+ * e.g. /path/to/data.json -> /path/to/data.json.lock
+ */
+export function lockPathFor(filePath: string): string {
+  return filePath + ".lock";
+}
+
+// ============================================================================
+// Synchronous API
+// ============================================================================
+
+/**
+ * Try to acquire an exclusive file lock (synchronous, single attempt).
+ *
+ * Creates a lock file adjacent to the target using O_CREAT|O_EXCL.
+ * On first failure due to EEXIST, checks for staleness and retries once.
+ *
+ * @returns LockHandle on success, null if lock is held
+ */
+function tryAcquireSync(
+  lockPath: string,
+  staleLockMs: number,
+): FileLockHandle | null {
+  ensureDirSync(path.dirname(lockPath));
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = openSync(
+        lockPath,
+        fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+        0o600,
+      );
+      const payload = JSON.stringify({
+        pid: process.pid,
+        timestamp: Date.now(),
+      });
+      writeSync(fd, payload, null, "utf-8");
+      return { fd, path: lockPath };
+    } catch (err: unknown) {
+      if (
+        err &&
+        typeof err === "object" &&
+        "code" in err &&
+        (err as { code: string }).code === "EEXIST"
+      ) {
+        if (attempt === 0 && isLockStale(lockPath, staleLockMs)) {
+          try {
+            unlinkSync(lockPath);
+          } catch {
+            /* another process reaped it */
+          }
+          continue;
+        }
+        return null;
+      }
+      throw err;
+    }
+  }
+  return null;
+}
+
+/**
+ * Acquire an exclusive file lock with optional retry/timeout (synchronous).
+ *
+ * @param lockPath Path for the lock file
+ * @param opts Lock options
+ * @returns FileLockHandle on success, null if lock could not be acquired
+ */
+export function acquireFileLockSync(
+  lockPath: string,
+  opts?: FileLockOptions,
+): FileLockHandle | null {
+  const staleLockMs = opts?.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
+  const timeoutMs = opts?.timeoutMs ?? 0;
+  const retryDelayMs = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+
+  const handle = tryAcquireSync(lockPath, staleLockMs);
+  if (handle || timeoutMs <= 0) return handle;
+
+  // Retry loop with busy-wait using Atomics (avoids blocking the event loop
+  // in a way that prevents signal handling, but is acceptable for short locks)
+  const deadline = Date.now() + timeoutMs;
+  const sharedBuf = new SharedArrayBuffer(4);
+  const sharedArr = new Int32Array(sharedBuf);
+
+  while (Date.now() < deadline) {
+    Atomics.wait(sharedArr, 0, 0, Math.min(retryDelayMs, deadline - Date.now()));
+    const retryHandle = tryAcquireSync(lockPath, staleLockMs);
+    if (retryHandle) return retryHandle;
+  }
+
+  return null;
+}
+
+/**
+ * Release a previously acquired file lock (synchronous).
+ */
+export function releaseFileLockSync(handle: FileLockHandle): void {
+  try {
+    closeSync(handle.fd);
+  } catch {
+    /* already closed */
+  }
+  try {
+    unlinkSync(handle.path);
+  } catch {
+    /* already removed */
+  }
+}
+
+/**
+ * Execute a function while holding an exclusive file lock (synchronous).
+ *
+ * @param lockPath Path for the lock file
+ * @param fn Function to execute under lock
+ * @param opts Lock options
+ * @returns The function's return value
+ * @throws Error if the lock cannot be acquired
+ */
+export function withFileLockSync<T>(
+  lockPath: string,
+  fn: () => T,
+  opts?: FileLockOptions,
+): T {
+  const handle = acquireFileLockSync(lockPath, opts);
+  if (!handle) {
+    throw new Error(`Failed to acquire file lock: ${lockPath}`);
+  }
+  try {
+    return fn();
+  } finally {
+    releaseFileLockSync(handle);
+  }
+}
+
+// ============================================================================
+// Asynchronous API
+// ============================================================================
+
+/**
+ * Sleep for a given number of milliseconds (async).
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Acquire an exclusive file lock with optional retry/timeout (asynchronous).
+ *
+ * @param lockPath Path for the lock file
+ * @param opts Lock options
+ * @returns FileLockHandle on success, null if lock could not be acquired
+ */
+export async function acquireFileLock(
+  lockPath: string,
+  opts?: FileLockOptions,
+): Promise<FileLockHandle | null> {
+  const staleLockMs = opts?.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
+  const timeoutMs = opts?.timeoutMs ?? 0;
+  const retryDelayMs = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+
+  const handle = tryAcquireSync(lockPath, staleLockMs);
+  if (handle || timeoutMs <= 0) return handle;
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    await sleep(Math.min(retryDelayMs, deadline - Date.now()));
+    const retryHandle = tryAcquireSync(lockPath, staleLockMs);
+    if (retryHandle) return retryHandle;
+  }
+
+  return null;
+}
+
+/**
+ * Release a previously acquired file lock (async-compatible, delegates to sync).
+ */
+export function releaseFileLock(handle: FileLockHandle): void {
+  releaseFileLockSync(handle);
+}
+
+/**
+ * Execute an async function while holding an exclusive file lock.
+ *
+ * @param lockPath Path for the lock file
+ * @param fn Async function to execute under lock
+ * @param opts Lock options
+ * @returns The function's return value
+ * @throws Error if the lock cannot be acquired
+ */
+export async function withFileLock<T>(
+  lockPath: string,
+  fn: () => T | Promise<T>,
+  opts?: FileLockOptions,
+): Promise<T> {
+  const handle = await acquireFileLock(lockPath, opts);
+  if (!handle) {
+    throw new Error(`Failed to acquire file lock: ${lockPath}`);
+  }
+  try {
+    return await fn();
+  } finally {
+    releaseFileLock(handle);
+  }
+}


### PR DESCRIPTION
## Summary

- Add generic cross-process file locking utility (`src/lib/file-lock.ts`) using `O_CREAT|O_EXCL` with PID-based stale lock detection
- Wrap all notepad read-modify-write operations (`setPriorityContext`, `addWorkingMemoryEntry`, `addManualEntry`, `pruneOldEntries`) with synchronous file locks
- Add `withProjectMemoryLock` to project memory storage for async file locking
- Protect `projectMemoryWriteTool` (merge mode) and `projectMemoryAddDirectiveTool` with file locks
- Add cross-process file lock to learner's `learnFromToolOutput` and `addCustomNote` (alongside existing in-process mutex)

Closes #1160

## Test plan

- [x] New `file-lock.test.ts` (16 tests): lock acquire/release, stale detection, retry timeout, error handling, concurrent write safety (sync + async)
- [x] New `shared-memory-concurrency.test.ts` (6 tests): notepad concurrent writes, interleaved section writes, project memory concurrent note additions, lock cleanup verification
- [x] Existing `notepad.test.ts` (40 tests): all pass unchanged
- [x] Full test suite (5129 tests): all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)