### PR TITLE
fix(notifications): validate Slack WebSocket messages before session injection

### DIFF
--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -432,7 +432,7 @@ describe("reply-listener", () => {
       // The else blocks only increment error counters
       const successBlocks = source.match(/if \(success\) \{[\s\S]*?messagesInjected/g);
       expect(successBlocks).not.toBeNull();
-      expect(successBlocks!.length).toBe(2); // one for Discord, one for Telegram
+      expect(successBlocks!.length).toBe(3); // one for Discord, one for Telegram, one for Slack
     });
   });
 

--- a/src/notifications/__tests__/slack-socket.test.ts
+++ b/src/notifications/__tests__/slack-socket.test.ts
@@ -1,0 +1,587 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createHmac } from 'crypto';
+import {
+  verifySlackSignature,
+  isTimestampValid,
+  validateSlackEnvelope,
+  validateSlackMessage,
+  SlackConnectionStateTracker,
+} from '../slack-socket.js';
+
+// ============================================================================
+// Helper: generate a valid Slack v0 signature
+// ============================================================================
+
+function generateSlackSignature(
+  signingSecret: string,
+  timestamp: string,
+  body: string,
+): string {
+  const sigBasestring = `v0:${timestamp}:${body}`;
+  return (
+    'v0=' + createHmac('sha256', signingSecret).update(sigBasestring).digest('hex')
+  );
+}
+
+function currentTimestamp(): string {
+  return String(Math.floor(Date.now() / 1000));
+}
+
+// ============================================================================
+// verifySlackSignature
+// ============================================================================
+
+describe('verifySlackSignature', () => {
+  const signingSecret = 'test_signing_secret_abc123';
+  const body = '{"type":"event_callback","event":{"text":"hello"}}';
+
+  it('accepts a valid signature', () => {
+    const ts = currentTimestamp();
+    const sig = generateSlackSignature(signingSecret, ts, body);
+    expect(verifySlackSignature(signingSecret, sig, ts, body)).toBe(true);
+  });
+
+  it('rejects an invalid signature', () => {
+    const ts = currentTimestamp();
+    expect(
+      verifySlackSignature(signingSecret, 'v0=invalid_hex', ts, body),
+    ).toBe(false);
+  });
+
+  it('rejects a signature with wrong secret', () => {
+    const ts = currentTimestamp();
+    const sig = generateSlackSignature('wrong_secret', ts, body);
+    expect(verifySlackSignature(signingSecret, sig, ts, body)).toBe(false);
+  });
+
+  it('rejects a signature with tampered body', () => {
+    const ts = currentTimestamp();
+    const sig = generateSlackSignature(signingSecret, ts, body);
+    expect(
+      verifySlackSignature(signingSecret, sig, ts, body + 'tampered'),
+    ).toBe(false);
+  });
+
+  it('rejects when timestamp is too old (replay attack)', () => {
+    const staleTs = String(Math.floor(Date.now() / 1000) - 600); // 10 minutes ago
+    const sig = generateSlackSignature(signingSecret, staleTs, body);
+    expect(verifySlackSignature(signingSecret, sig, staleTs, body)).toBe(
+      false,
+    );
+  });
+
+  it('rejects empty signing secret', () => {
+    const ts = currentTimestamp();
+    expect(verifySlackSignature('', 'v0=abc', ts, body)).toBe(false);
+  });
+
+  it('rejects empty signature', () => {
+    const ts = currentTimestamp();
+    expect(verifySlackSignature(signingSecret, '', ts, body)).toBe(false);
+  });
+
+  it('rejects empty timestamp', () => {
+    expect(verifySlackSignature(signingSecret, 'v0=abc', '', body)).toBe(
+      false,
+    );
+  });
+
+  it('uses timing-safe comparison (different length signatures)', () => {
+    const ts = currentTimestamp();
+    // A signature with different length should not crash
+    expect(verifySlackSignature(signingSecret, 'v0=short', ts, body)).toBe(
+      false,
+    );
+  });
+});
+
+// ============================================================================
+// isTimestampValid
+// ============================================================================
+
+describe('isTimestampValid', () => {
+  it('accepts a current timestamp', () => {
+    expect(isTimestampValid(currentTimestamp())).toBe(true);
+  });
+
+  it('accepts a timestamp within the 5-minute window', () => {
+    const ts = String(Math.floor(Date.now() / 1000) - 200); // 200 seconds ago
+    expect(isTimestampValid(ts)).toBe(true);
+  });
+
+  it('rejects a timestamp older than 5 minutes', () => {
+    const ts = String(Math.floor(Date.now() / 1000) - 400); // 400 seconds ago
+    expect(isTimestampValid(ts)).toBe(false);
+  });
+
+  it('rejects a future timestamp beyond the window', () => {
+    const ts = String(Math.floor(Date.now() / 1000) + 400); // 400 seconds in future
+    expect(isTimestampValid(ts)).toBe(false);
+  });
+
+  it('rejects non-numeric timestamp', () => {
+    expect(isTimestampValid('not-a-number')).toBe(false);
+  });
+
+  it('rejects empty timestamp', () => {
+    expect(isTimestampValid('')).toBe(false);
+  });
+
+  it('respects custom maxAgeSeconds', () => {
+    const ts = String(Math.floor(Date.now() / 1000) - 50);
+    expect(isTimestampValid(ts, 30)).toBe(false); // 50s > 30s limit
+    expect(isTimestampValid(ts, 60)).toBe(true); // 50s < 60s limit
+  });
+});
+
+// ============================================================================
+// validateSlackEnvelope
+// ============================================================================
+
+describe('validateSlackEnvelope', () => {
+  it('accepts a valid events_api envelope', () => {
+    const envelope = {
+      envelope_id: 'abc-123',
+      type: 'events_api',
+      payload: { event: { text: 'hello' } },
+    };
+    expect(validateSlackEnvelope(envelope)).toEqual({ valid: true });
+  });
+
+  it('accepts a valid hello envelope', () => {
+    const envelope = {
+      envelope_id: 'hello-123',
+      type: 'hello',
+    };
+    expect(validateSlackEnvelope(envelope)).toEqual({ valid: true });
+  });
+
+  it('accepts a valid disconnect envelope', () => {
+    const envelope = {
+      envelope_id: 'disc-123',
+      type: 'disconnect',
+    };
+    expect(validateSlackEnvelope(envelope)).toEqual({ valid: true });
+  });
+
+  it('accepts slash_commands envelope', () => {
+    const envelope = {
+      envelope_id: 'cmd-123',
+      type: 'slash_commands',
+      payload: { command: '/test' },
+    };
+    expect(validateSlackEnvelope(envelope)).toEqual({ valid: true });
+  });
+
+  it('accepts interactive envelope', () => {
+    const envelope = {
+      envelope_id: 'int-123',
+      type: 'interactive',
+      payload: { action: 'click' },
+    };
+    expect(validateSlackEnvelope(envelope)).toEqual({ valid: true });
+  });
+
+  it('rejects null', () => {
+    const result = validateSlackEnvelope(null);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Message is not an object');
+  });
+
+  it('rejects non-object', () => {
+    const result = validateSlackEnvelope('not an object');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Message is not an object');
+  });
+
+  it('rejects missing envelope_id', () => {
+    const result = validateSlackEnvelope({ type: 'hello' });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Missing or empty envelope_id');
+  });
+
+  it('rejects empty envelope_id', () => {
+    const result = validateSlackEnvelope({ envelope_id: '  ', type: 'hello' });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Missing or empty envelope_id');
+  });
+
+  it('rejects missing type', () => {
+    const result = validateSlackEnvelope({ envelope_id: 'abc-123' });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Missing or empty message type');
+  });
+
+  it('rejects unknown envelope type', () => {
+    const result = validateSlackEnvelope({
+      envelope_id: 'abc-123',
+      type: 'unknown_type',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Unknown envelope type');
+  });
+
+  it('rejects events_api without payload', () => {
+    const result = validateSlackEnvelope({
+      envelope_id: 'abc-123',
+      type: 'events_api',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('events_api envelope missing payload');
+  });
+
+  it('rejects events_api with null payload', () => {
+    const result = validateSlackEnvelope({
+      envelope_id: 'abc-123',
+      type: 'events_api',
+      payload: null,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('events_api envelope missing payload');
+  });
+});
+
+// ============================================================================
+// SlackConnectionStateTracker
+// ============================================================================
+
+describe('SlackConnectionStateTracker', () => {
+  let tracker: SlackConnectionStateTracker;
+
+  beforeEach(() => {
+    tracker = new SlackConnectionStateTracker();
+  });
+
+  describe('state transitions', () => {
+    it('starts in disconnected state', () => {
+      expect(tracker.getState()).toBe('disconnected');
+      expect(tracker.canProcessMessages()).toBe(false);
+    });
+
+    it('transitions to connecting', () => {
+      tracker.onConnecting();
+      expect(tracker.getState()).toBe('connecting');
+      expect(tracker.canProcessMessages()).toBe(false);
+    });
+
+    it('transitions to authenticated', () => {
+      tracker.onConnecting();
+      tracker.onAuthenticated();
+      expect(tracker.getState()).toBe('authenticated');
+      expect(tracker.canProcessMessages()).toBe(true);
+      expect(tracker.getAuthenticatedAt()).not.toBeNull();
+    });
+
+    it('transitions to reconnecting', () => {
+      tracker.onConnecting();
+      tracker.onAuthenticated();
+      tracker.onReconnecting();
+      expect(tracker.getState()).toBe('reconnecting');
+      expect(tracker.canProcessMessages()).toBe(false);
+      expect(tracker.getAuthenticatedAt()).toBeNull();
+    });
+
+    it('transitions to disconnected and clears queue', () => {
+      tracker.onConnecting();
+      tracker.onAuthenticated();
+      tracker.onReconnecting();
+      tracker.queueMessage({
+        envelope_id: 'test',
+        type: 'events_api',
+        payload: {},
+      });
+      expect(tracker.getQueueSize()).toBe(1);
+
+      tracker.onDisconnected();
+      expect(tracker.getState()).toBe('disconnected');
+      expect(tracker.canProcessMessages()).toBe(false);
+      expect(tracker.getQueueSize()).toBe(0);
+    });
+  });
+
+  describe('reconnection tracking', () => {
+    it('increments reconnect count', () => {
+      expect(tracker.getReconnectCount()).toBe(0);
+      tracker.onReconnecting();
+      expect(tracker.getReconnectCount()).toBe(1);
+      tracker.onReconnecting();
+      expect(tracker.getReconnectCount()).toBe(2);
+    });
+
+    it('resets reconnect count on authentication', () => {
+      tracker.onReconnecting();
+      tracker.onReconnecting();
+      expect(tracker.getReconnectCount()).toBe(2);
+      tracker.onAuthenticated();
+      expect(tracker.getReconnectCount()).toBe(0);
+    });
+
+    it('detects exceeded max reconnects (default 5)', () => {
+      for (let i = 0; i < 5; i++) {
+        tracker.onReconnecting();
+      }
+      expect(tracker.hasExceededMaxReconnects()).toBe(true);
+    });
+
+    it('does not exceed before reaching max', () => {
+      for (let i = 0; i < 4; i++) {
+        tracker.onReconnecting();
+      }
+      expect(tracker.hasExceededMaxReconnects()).toBe(false);
+    });
+
+    it('respects custom maxReconnectAttempts', () => {
+      const custom = new SlackConnectionStateTracker({
+        maxReconnectAttempts: 2,
+      });
+      custom.onReconnecting();
+      expect(custom.hasExceededMaxReconnects()).toBe(false);
+      custom.onReconnecting();
+      expect(custom.hasExceededMaxReconnects()).toBe(true);
+    });
+  });
+
+  describe('message queue', () => {
+    it('queues messages during reconnection', () => {
+      tracker.onReconnecting();
+      const result = tracker.queueMessage({
+        envelope_id: 'msg-1',
+        type: 'events_api',
+        payload: {},
+      });
+      expect(result).toBe(true);
+      expect(tracker.getQueueSize()).toBe(1);
+    });
+
+    it('drains queue after re-authentication', () => {
+      tracker.onReconnecting();
+      tracker.queueMessage({
+        envelope_id: 'msg-1',
+        type: 'events_api',
+        payload: {},
+      });
+      tracker.queueMessage({
+        envelope_id: 'msg-2',
+        type: 'events_api',
+        payload: {},
+      });
+
+      const messages = tracker.drainQueue();
+      expect(messages).toHaveLength(2);
+      expect(messages[0].envelope_id).toBe('msg-1');
+      expect(messages[1].envelope_id).toBe('msg-2');
+      expect(tracker.getQueueSize()).toBe(0);
+    });
+
+    it('drops oldest when queue exceeds maxQueueSize', () => {
+      const small = new SlackConnectionStateTracker({ maxQueueSize: 2 });
+      small.onReconnecting();
+      small.queueMessage({ envelope_id: 'msg-1', type: 'hello' });
+      small.queueMessage({ envelope_id: 'msg-2', type: 'hello' });
+      const wasFull = !small.queueMessage({
+        envelope_id: 'msg-3',
+        type: 'hello',
+      });
+      expect(wasFull).toBe(true); // oldest was dropped
+      expect(small.getQueueSize()).toBe(2);
+
+      const messages = small.drainQueue();
+      expect(messages[0].envelope_id).toBe('msg-2');
+      expect(messages[1].envelope_id).toBe('msg-3');
+    });
+  });
+
+  describe('canProcessMessages', () => {
+    it('only returns true when authenticated', () => {
+      expect(tracker.canProcessMessages()).toBe(false); // disconnected
+      tracker.onConnecting();
+      expect(tracker.canProcessMessages()).toBe(false); // connecting
+      tracker.onAuthenticated();
+      expect(tracker.canProcessMessages()).toBe(true); // authenticated
+      tracker.onReconnecting();
+      expect(tracker.canProcessMessages()).toBe(false); // reconnecting
+      tracker.onAuthenticated();
+      expect(tracker.canProcessMessages()).toBe(true); // re-authenticated
+      tracker.onDisconnected();
+      expect(tracker.canProcessMessages()).toBe(false); // disconnected
+    });
+  });
+});
+
+// ============================================================================
+// validateSlackMessage (orchestrator)
+// ============================================================================
+
+describe('validateSlackMessage', () => {
+  let tracker: SlackConnectionStateTracker;
+  const signingSecret = 'test_secret_xyz';
+
+  beforeEach(() => {
+    tracker = new SlackConnectionStateTracker();
+    tracker.onConnecting();
+    tracker.onAuthenticated();
+  });
+
+  it('accepts a valid message without signing secret', () => {
+    const msg = JSON.stringify({
+      envelope_id: 'abc-123',
+      type: 'hello',
+    });
+    const result = validateSlackMessage(msg, tracker);
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts a valid message with valid signature', () => {
+    const msg = JSON.stringify({
+      envelope_id: 'abc-123',
+      type: 'hello',
+    });
+    const ts = currentTimestamp();
+    const sig = generateSlackSignature(signingSecret, ts, msg);
+    const result = validateSlackMessage(msg, tracker, signingSecret, sig, ts);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects when connection is not authenticated', () => {
+    const disconnected = new SlackConnectionStateTracker();
+    const msg = JSON.stringify({ envelope_id: 'abc', type: 'hello' });
+    const result = validateSlackMessage(msg, disconnected);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('not authenticated');
+  });
+
+  it('rejects during reconnection', () => {
+    tracker.onReconnecting();
+    const msg = JSON.stringify({ envelope_id: 'abc', type: 'hello' });
+    const result = validateSlackMessage(msg, tracker);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('reconnecting');
+  });
+
+  it('rejects invalid JSON', () => {
+    const result = validateSlackMessage('not json', tracker);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Invalid JSON message');
+  });
+
+  it('rejects invalid envelope structure', () => {
+    const msg = JSON.stringify({ not_an_envelope: true });
+    const result = validateSlackMessage(msg, tracker);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects when signature verification fails', () => {
+    const msg = JSON.stringify({
+      envelope_id: 'abc-123',
+      type: 'hello',
+    });
+    const ts = currentTimestamp();
+    const result = validateSlackMessage(
+      msg,
+      tracker,
+      signingSecret,
+      'v0=bad_signature',
+      ts,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Signature verification failed');
+  });
+
+  it('rejects when signing secret is set but signature is missing', () => {
+    const msg = JSON.stringify({
+      envelope_id: 'abc-123',
+      type: 'hello',
+    });
+    const result = validateSlackMessage(msg, tracker, signingSecret);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('signature/timestamp missing');
+  });
+
+  it('rejects when signing secret is set but timestamp is missing', () => {
+    const msg = JSON.stringify({
+      envelope_id: 'abc-123',
+      type: 'hello',
+    });
+    const result = validateSlackMessage(
+      msg,
+      tracker,
+      signingSecret,
+      'v0=abc',
+    );
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('signature/timestamp missing');
+  });
+});
+
+// ============================================================================
+// Slack message validation in reply-listener context
+// ============================================================================
+
+describe('Slack validation integration', () => {
+  it('source code imports slack-socket validation', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'reply-listener.ts'),
+      'utf-8',
+    );
+    expect(source).toContain("from './slack-socket.js'");
+    expect(source).toContain('validateSlackMessage');
+    expect(source).toContain('SlackConnectionStateTracker');
+  });
+
+  it('reply-listener exports processSlackSocketMessage', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'reply-listener.ts'),
+      'utf-8',
+    );
+    expect(source).toContain('export function processSlackSocketMessage');
+  });
+
+  it('reply-listener validates before injection', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'reply-listener.ts'),
+      'utf-8',
+    );
+    // processSlackSocketMessage calls validateSlackMessage before injectReply
+    expect(source).toContain('validateSlackMessage');
+    expect(source).toContain('REJECTED Slack message');
+  });
+
+  it('ReplyListenerDaemonConfig includes slackSigningSecret', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'reply-listener.ts'),
+      'utf-8',
+    );
+    expect(source).toContain('slackSigningSecret?: string');
+  });
+
+  it('SlackNotificationConfig includes signingSecret', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'types.ts'),
+      'utf-8',
+    );
+    expect(source).toContain('signingSecret?: string');
+  });
+
+  it('index.ts exports Slack validation functions', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'index.ts'),
+      'utf-8',
+    );
+    expect(source).toContain('verifySlackSignature');
+    expect(source).toContain('validateSlackEnvelope');
+    expect(source).toContain('validateSlackMessage');
+    expect(source).toContain('SlackConnectionStateTracker');
+  });
+});

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -75,6 +75,18 @@ export {
   validateTemplate,
   computeTemplateVariables,
 } from "./template-engine.js";
+export {
+  verifySlackSignature,
+  isTimestampValid,
+  validateSlackEnvelope,
+  validateSlackMessage,
+  SlackConnectionStateTracker,
+} from "./slack-socket.js";
+export type {
+  SlackConnectionState,
+  SlackValidationResult,
+  SlackSocketEnvelope,
+} from "./slack-socket.js";
 
 import type {
   NotificationEvent,

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -34,6 +34,11 @@ import {
 } from './session-registry.js';
 import type { ReplyConfig } from './types.js';
 import { parseMentionAllowedMentions } from './config.js';
+import {
+  validateSlackMessage,
+  SlackConnectionStateTracker,
+  type SlackValidationResult,
+} from './slack-socket.js';
 
 // ESM compatibility: __filename is not available in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -94,6 +99,8 @@ export interface ReplyListenerDaemonConfig extends ReplyConfig {
   discordChannelId?: string;
   /** Discord mention tag to include in injection feedback (e.g. "<@123456>") */
   discordMention?: string;
+  /** Slack signing secret for verifying incoming WebSocket messages */
+  slackSigningSecret?: string;
 }
 
 /** Response from daemon operations */
@@ -974,6 +981,118 @@ export function getReplyListenerStatus(): DaemonResponse {
     state: state ?? undefined,
   };
 }
+
+// ============================================================================
+// Slack WebSocket Message Validation Gate
+// ============================================================================
+
+/**
+ * Validate and process an incoming Slack WebSocket message before session injection.
+ *
+ * This function is the security gate for Slack Socket Mode messages.
+ * All Slack messages MUST pass through this function before reaching injectReply().
+ *
+ * Validation steps:
+ * 1. Slack message validation (envelope, signing secret, connection state)
+ * 2. Rate limiting
+ * 3. Session registry lookup
+ * 4. Pane verification and injection
+ *
+ * @param rawMessage - Raw WebSocket message string
+ * @param connectionState - Slack connection state tracker
+ * @param paneId - Target tmux pane ID (from session registry lookup by caller)
+ * @param config - Daemon configuration
+ * @param state - Daemon state (mutated: errors/messagesInjected counters)
+ * @param rateLimiter - Rate limiter instance
+ * @param signature - Slack request signature header (x-slack-signature)
+ * @param timestamp - Slack request timestamp header (x-slack-request-timestamp)
+ * @returns Object with injection result and validation details
+ */
+export function processSlackSocketMessage(
+  rawMessage: string,
+  connectionState: SlackConnectionStateTracker,
+  paneId: string | null,
+  config: ReplyListenerDaemonConfig,
+  state: ReplyListenerState,
+  rateLimiter: RateLimiter,
+  signature?: string,
+  timestamp?: string,
+): { injected: boolean; validation: SlackValidationResult } {
+  // 1. Validate the Slack message
+  const validation = validateSlackMessage(
+    rawMessage,
+    connectionState,
+    config.slackSigningSecret,
+    signature,
+    timestamp,
+  );
+
+  if (!validation.valid) {
+    log(`REJECTED Slack message: ${validation.reason}`);
+    state.errors++;
+    return { injected: false, validation };
+  }
+
+  // 2. Must have a target pane
+  if (!paneId) {
+    log('REJECTED Slack message: no target pane ID');
+    state.errors++;
+    return {
+      injected: false,
+      validation: { valid: false, reason: 'No target pane ID' },
+    };
+  }
+
+  // 3. Rate limiting
+  if (!rateLimiter.canProceed()) {
+    log('WARN: Rate limit exceeded, dropping Slack message');
+    state.errors++;
+    return {
+      injected: false,
+      validation: { valid: false, reason: 'Rate limit exceeded' },
+    };
+  }
+
+  // 4. Extract text from the validated message
+  let text: string;
+  try {
+    const parsed = JSON.parse(rawMessage);
+    const payload = parsed.payload;
+    text = payload?.event?.text || payload?.text || '';
+  } catch {
+    log('REJECTED Slack message: failed to extract text from validated message');
+    state.errors++;
+    return {
+      injected: false,
+      validation: { valid: false, reason: 'Failed to extract message text' },
+    };
+  }
+
+  if (!text) {
+    log('REJECTED Slack message: empty message text');
+    return {
+      injected: false,
+      validation: { valid: false, reason: 'Empty message text' },
+    };
+  }
+
+  // 5. Inject reply (applies sanitization + pane verification)
+  const success = injectReply(paneId, text, 'slack', config);
+  if (success) {
+    state.messagesInjected++;
+  } else {
+    state.errors++;
+  }
+
+  return { injected: success, validation };
+}
+
+// Re-export for Slack integration
+export { SlackConnectionStateTracker } from './slack-socket.js';
+export type { SlackValidationResult } from './slack-socket.js';
+
+// Export RateLimiter for external use (e.g., Slack Socket Mode handler)
+export { RateLimiter };
 
 // Export pollLoop for use by the daemon subprocess
 export { pollLoop };

--- a/src/notifications/slack-socket.ts
+++ b/src/notifications/slack-socket.ts
@@ -1,0 +1,370 @@
+/**
+ * Slack WebSocket Message Validation
+ *
+ * Validates incoming Slack Socket Mode WebSocket messages before they can be
+ * injected into Claude Code sessions via the reply-listener.
+ *
+ * Security measures:
+ * - HMAC-SHA256 signing secret verification (Slack v0 signatures)
+ * - Timestamp-based replay attack prevention (5-minute window)
+ * - Message envelope structure validation
+ * - Connection state tracking (reject messages during reconnection windows)
+ *
+ * References:
+ * - https://api.slack.com/authentication/verifying-requests-from-slack
+ * - https://api.slack.com/apis/socket-mode
+ */
+
+import { createHmac, timingSafeEqual } from 'crypto';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Maximum age for request timestamps (5 minutes, per Slack docs) */
+const MAX_TIMESTAMP_AGE_SECONDS = 300;
+
+/** Valid Slack Socket Mode envelope types */
+const VALID_ENVELOPE_TYPES = new Set([
+  'events_api',
+  'slash_commands',
+  'interactive',
+  'hello',
+  'disconnect',
+]);
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Connection states for Slack Socket Mode */
+export type SlackConnectionState =
+  | 'disconnected'
+  | 'connecting'
+  | 'authenticated'
+  | 'reconnecting';
+
+/** Result of message validation */
+export interface SlackValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+/** Slack Socket Mode message envelope */
+export interface SlackSocketEnvelope {
+  envelope_id: string;
+  type: string;
+  payload?: Record<string, unknown>;
+  accepts_response_payload?: boolean;
+  retry_attempt?: number;
+  retry_reason?: string;
+}
+
+// ============================================================================
+// Signing Secret Verification
+// ============================================================================
+
+/**
+ * Verify Slack request signature using HMAC-SHA256.
+ *
+ * Implements Slack's v0 signing verification:
+ *   sig_basestring = 'v0:' + timestamp + ':' + body
+ *   signature = 'v0=' + HMAC-SHA256(signing_secret, sig_basestring)
+ *
+ * Uses timing-safe comparison to prevent timing attacks.
+ * Includes replay protection via timestamp validation.
+ */
+export function verifySlackSignature(
+  signingSecret: string,
+  signature: string,
+  timestamp: string,
+  body: string,
+): boolean {
+  if (!signingSecret || !signature || !timestamp) {
+    return false;
+  }
+
+  // Replay protection: reject stale timestamps
+  if (!isTimestampValid(timestamp)) {
+    return false;
+  }
+
+  const sigBasestring = `v0:${timestamp}:${body}`;
+  const expectedSignature =
+    'v0=' +
+    createHmac('sha256', signingSecret).update(sigBasestring).digest('hex');
+
+  // Timing-safe comparison to prevent timing attacks
+  try {
+    return timingSafeEqual(
+      Buffer.from(expectedSignature),
+      Buffer.from(signature),
+    );
+  } catch {
+    // Buffer length mismatch means signatures don't match
+    return false;
+  }
+}
+
+// ============================================================================
+// Timestamp Validation
+// ============================================================================
+
+/**
+ * Check if a request timestamp is within the acceptable window.
+ *
+ * Rejects timestamps older than maxAgeSeconds (default: 5 minutes)
+ * to prevent replay attacks.
+ */
+export function isTimestampValid(
+  timestamp: string,
+  maxAgeSeconds: number = MAX_TIMESTAMP_AGE_SECONDS,
+): boolean {
+  const requestTime = parseInt(timestamp, 10);
+  if (isNaN(requestTime)) {
+    return false;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  return Math.abs(now - requestTime) <= maxAgeSeconds;
+}
+
+// ============================================================================
+// Envelope Validation
+// ============================================================================
+
+/**
+ * Validate Slack Socket Mode message envelope structure.
+ *
+ * Ensures the message has required fields and a valid type
+ * before it can be processed for session injection.
+ */
+export function validateSlackEnvelope(
+  data: unknown,
+): SlackValidationResult {
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, reason: 'Message is not an object' };
+  }
+
+  const envelope = data as Record<string, unknown>;
+
+  // envelope_id is required for Socket Mode messages
+  if (
+    typeof envelope.envelope_id !== 'string' ||
+    !envelope.envelope_id.trim()
+  ) {
+    return { valid: false, reason: 'Missing or empty envelope_id' };
+  }
+
+  // type is required
+  if (typeof envelope.type !== 'string' || !envelope.type.trim()) {
+    return { valid: false, reason: 'Missing or empty message type' };
+  }
+
+  // Validate against known Slack Socket Mode types
+  if (!VALID_ENVELOPE_TYPES.has(envelope.type)) {
+    return {
+      valid: false,
+      reason: `Unknown envelope type: ${envelope.type}`,
+    };
+  }
+
+  // events_api type must have a payload
+  if (envelope.type === 'events_api') {
+    if (typeof envelope.payload !== 'object' || envelope.payload === null) {
+      return {
+        valid: false,
+        reason: 'events_api envelope missing payload',
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+// ============================================================================
+// Connection State Tracker
+// ============================================================================
+
+/**
+ * Connection state tracker for Slack Socket Mode.
+ *
+ * Tracks authentication status across the connection lifecycle:
+ * - disconnected: No WebSocket connection
+ * - connecting: WebSocket opening, not yet authenticated
+ * - authenticated: Hello message received, ready to process
+ * - reconnecting: Connection lost, attempting to re-establish
+ *
+ * Messages are ONLY processed in the 'authenticated' state.
+ * This prevents injection during reconnection windows where
+ * authentication has not been re-established.
+ */
+export class SlackConnectionStateTracker {
+  private state: SlackConnectionState = 'disconnected';
+  private authenticatedAt: number | null = null;
+  private reconnectCount = 0;
+  private readonly maxReconnectAttempts: number;
+  private messageQueue: SlackSocketEnvelope[] = [];
+  private readonly maxQueueSize: number;
+
+  constructor(options?: {
+    maxReconnectAttempts?: number;
+    maxQueueSize?: number;
+  }) {
+    this.maxReconnectAttempts = options?.maxReconnectAttempts ?? 5;
+    this.maxQueueSize = options?.maxQueueSize ?? 100;
+  }
+
+  getState(): SlackConnectionState {
+    return this.state;
+  }
+
+  getReconnectCount(): number {
+    return this.reconnectCount;
+  }
+
+  getAuthenticatedAt(): number | null {
+    return this.authenticatedAt;
+  }
+
+  /** Transition to connecting state. */
+  onConnecting(): void {
+    this.state = 'connecting';
+  }
+
+  /**
+   * Transition to authenticated state (received 'hello' message).
+   * Resets reconnect counter on successful authentication.
+   */
+  onAuthenticated(): void {
+    this.state = 'authenticated';
+    this.authenticatedAt = Date.now();
+    this.reconnectCount = 0;
+  }
+
+  /**
+   * Transition to reconnecting state.
+   * Increments reconnect counter and clears authentication timestamp.
+   */
+  onReconnecting(): void {
+    this.state = 'reconnecting';
+    this.reconnectCount++;
+    this.authenticatedAt = null;
+  }
+
+  /**
+   * Transition to disconnected state.
+   * Clears message queue to prevent processing stale messages.
+   */
+  onDisconnected(): void {
+    this.state = 'disconnected';
+    this.authenticatedAt = null;
+    this.messageQueue = [];
+  }
+
+  /** Check if maximum reconnection attempts have been exceeded. */
+  hasExceededMaxReconnects(): boolean {
+    return this.reconnectCount >= this.maxReconnectAttempts;
+  }
+
+  /**
+   * Check if messages can be safely processed in the current state.
+   * Only allows processing when the connection is authenticated.
+   */
+  canProcessMessages(): boolean {
+    return this.state === 'authenticated';
+  }
+
+  /**
+   * Queue a message for processing after reconnection.
+   * Drops oldest messages when queue exceeds maxQueueSize to
+   * prevent unbounded memory growth.
+   *
+   * Returns true if queued, false if queue is at capacity (oldest was dropped).
+   */
+  queueMessage(envelope: SlackSocketEnvelope): boolean {
+    const wasFull = this.messageQueue.length >= this.maxQueueSize;
+    if (wasFull) {
+      this.messageQueue.shift();
+    }
+    this.messageQueue.push(envelope);
+    return !wasFull;
+  }
+
+  /**
+   * Drain the message queue (called after re-authentication).
+   * Returns queued messages and clears the queue.
+   */
+  drainQueue(): SlackSocketEnvelope[] {
+    const messages = [...this.messageQueue];
+    this.messageQueue = [];
+    return messages;
+  }
+
+  /** Get current queue size. */
+  getQueueSize(): number {
+    return this.messageQueue.length;
+  }
+}
+
+// ============================================================================
+// Top-Level Validation
+// ============================================================================
+
+/**
+ * Validate a Slack WebSocket message before session injection.
+ *
+ * Performs all validation checks in order:
+ * 1. Connection state verification (must be authenticated)
+ * 2. JSON parsing
+ * 3. Message envelope structure validation
+ * 4. Signing secret verification (when signing material is provided)
+ *
+ * Returns validation result with reason on failure.
+ */
+export function validateSlackMessage(
+  rawMessage: string,
+  connectionState: SlackConnectionStateTracker,
+  signingSecret?: string,
+  signature?: string,
+  timestamp?: string,
+): SlackValidationResult {
+  // 1. Check connection state - reject during reconnection windows
+  if (!connectionState.canProcessMessages()) {
+    return {
+      valid: false,
+      reason: `Connection not authenticated (state: ${connectionState.getState()})`,
+    };
+  }
+
+  // 2. Parse message
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawMessage);
+  } catch {
+    return { valid: false, reason: 'Invalid JSON message' };
+  }
+
+  // 3. Validate envelope structure
+  const envelopeResult = validateSlackEnvelope(parsed);
+  if (!envelopeResult.valid) {
+    return envelopeResult;
+  }
+
+  // 4. Verify signing secret (when signing material is provided)
+  if (signingSecret && signature && timestamp) {
+    if (
+      !verifySlackSignature(signingSecret, signature, timestamp, rawMessage)
+    ) {
+      return { valid: false, reason: 'Signature verification failed' };
+    }
+  } else if (signingSecret && (!signature || !timestamp)) {
+    // Signing secret is configured but signing material is missing
+    return {
+      valid: false,
+      reason: 'Signing secret configured but signature/timestamp missing',
+    };
+  }
+
+  return { valid: true };
+}

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -70,6 +70,8 @@ export interface SlackNotificationConfig {
   username?: string;
   /** Optional mention to prepend to messages (e.g. "<@U12345678>" for user, "<!subteam^S12345>" for group, "<!channel>" / "<!here>" / "<!everyone>") */
   mention?: string;
+  /** Slack signing secret for verifying incoming WebSocket/Events API messages */
+  signingSecret?: string;
 }
 
 /** Generic webhook configuration */


### PR DESCRIPTION
Fixes #1161. Adds message validation, rate limiting, and schema checking for Slack WebSocket messages before they are injected into sessions.