### PR TITLE
fix(shared-memory): add payload size validation on memory writes

### DIFF
--- a/src/lib/__tests__/payload-limits.test.ts
+++ b/src/lib/__tests__/payload-limits.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { validatePayload, DEFAULT_PAYLOAD_LIMITS } from '../payload-limits.js';
+
+describe('payload-limits', () => {
+  describe('validatePayload', () => {
+    it('should accept a small valid payload', () => {
+      const result = validatePayload({ key: 'value', count: 42 });
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should accept an empty object', () => {
+      const result = validatePayload({});
+      expect(result.valid).toBe(true);
+    });
+
+    it('should accept primitives', () => {
+      expect(validatePayload('hello').valid).toBe(true);
+      expect(validatePayload(42).valid).toBe(true);
+      expect(validatePayload(null).valid).toBe(true);
+      expect(validatePayload(true).valid).toBe(true);
+    });
+
+    describe('byte size limit', () => {
+      it('should reject payloads exceeding maxPayloadBytes', () => {
+        const largeString = 'x'.repeat(2_000_000);
+        const result = validatePayload({ data: largeString });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('exceeds maximum');
+        expect(result.error).toContain('MB');
+      });
+
+      it('should accept payloads just under the limit', () => {
+        // Create a payload close to but under 1MB
+        const str = 'a'.repeat(500_000);
+        const result = validatePayload({ data: str });
+        expect(result.valid).toBe(true);
+      });
+
+      it('should respect custom maxPayloadBytes', () => {
+        const result = validatePayload(
+          { data: 'x'.repeat(200) },
+          { maxPayloadBytes: 100 },
+        );
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('exceeds maximum');
+      });
+    });
+
+    describe('nesting depth limit', () => {
+      it('should reject deeply nested objects', () => {
+        let obj: Record<string, unknown> = { leaf: true };
+        for (let i = 0; i < 15; i++) {
+          obj = { nested: obj };
+        }
+        const result = validatePayload(obj);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('nesting depth');
+      });
+
+      it('should accept objects at max nesting depth', () => {
+        // Default max is 10
+        let obj: Record<string, unknown> = { leaf: true };
+        for (let i = 0; i < 9; i++) {
+          obj = { nested: obj };
+        }
+        const result = validatePayload(obj);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should reject deeply nested arrays', () => {
+        let arr: unknown[] = ['leaf'];
+        for (let i = 0; i < 15; i++) {
+          arr = [arr];
+        }
+        const result = validatePayload(arr);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('nesting depth');
+      });
+
+      it('should respect custom maxNestingDepth', () => {
+        const obj = { a: { b: { c: true } } }; // depth 3
+        const result = validatePayload(obj, { maxNestingDepth: 2 });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('nesting depth');
+      });
+    });
+
+    describe('top-level key count limit', () => {
+      it('should reject objects with too many top-level keys', () => {
+        const obj: Record<string, string> = {};
+        for (let i = 0; i < 150; i++) {
+          obj[`key_${i}`] = 'value';
+        }
+        const result = validatePayload(obj);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('top-level keys');
+        expect(result.error).toContain('150');
+      });
+
+      it('should accept objects at the key limit', () => {
+        const obj: Record<string, string> = {};
+        for (let i = 0; i < 100; i++) {
+          obj[`key_${i}`] = 'value';
+        }
+        const result = validatePayload(obj);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should respect custom maxTopLevelKeys', () => {
+        const result = validatePayload(
+          { a: 1, b: 2, c: 3, d: 4 },
+          { maxTopLevelKeys: 3 },
+        );
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('top-level keys');
+      });
+
+      it('should not count keys on arrays', () => {
+        const arr = Array.from({ length: 200 }, (_, i) => i);
+        const result = validatePayload(arr);
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('check ordering', () => {
+      it('should check key count before expensive serialization', () => {
+        const obj: Record<string, string> = {};
+        for (let i = 0; i < 150; i++) {
+          obj[`key_${i}`] = 'x'.repeat(10_000);
+        }
+        const result = validatePayload(obj);
+        expect(result.valid).toBe(false);
+        // Should fail on key count, not size
+        expect(result.error).toContain('top-level keys');
+      });
+    });
+
+    it('should expose sensible defaults', () => {
+      expect(DEFAULT_PAYLOAD_LIMITS.maxPayloadBytes).toBe(1_048_576);
+      expect(DEFAULT_PAYLOAD_LIMITS.maxNestingDepth).toBe(10);
+      expect(DEFAULT_PAYLOAD_LIMITS.maxTopLevelKeys).toBe(100);
+    });
+  });
+});

--- a/src/lib/payload-limits.ts
+++ b/src/lib/payload-limits.ts
@@ -1,0 +1,104 @@
+/**
+ * Payload Size Validation
+ *
+ * Configurable limits for memory/state write payloads to prevent
+ * OOM and disk exhaustion from oversized writes.
+ *
+ * @see https://github.com/anthropics/claude-code/issues/1169
+ */
+
+export interface PayloadLimits {
+  /** Maximum serialized JSON size in bytes (default: 1MB) */
+  maxPayloadBytes: number;
+  /** Maximum object nesting depth (default: 10) */
+  maxNestingDepth: number;
+  /** Maximum number of keys in the top-level object (default: 100) */
+  maxTopLevelKeys: number;
+}
+
+export const DEFAULT_PAYLOAD_LIMITS: PayloadLimits = {
+  maxPayloadBytes: 1_048_576, // 1MB
+  maxNestingDepth: 10,
+  maxTopLevelKeys: 100,
+};
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Measure the nesting depth of a value.
+ * Returns 0 for primitives, 1 for flat objects/arrays, etc.
+ */
+function measureDepth(value: unknown, current: number = 0, maxAllowed: number): number {
+  if (current > maxAllowed) return current; // short-circuit
+
+  if (value !== null && typeof value === 'object') {
+    const entries = Array.isArray(value) ? value : Object.values(value as Record<string, unknown>);
+    let max = current + 1;
+    for (const entry of entries) {
+      const d = measureDepth(entry, current + 1, maxAllowed);
+      if (d > max) max = d;
+      if (max > maxAllowed) return max; // short-circuit
+    }
+    return max;
+  }
+
+  return current;
+}
+
+/**
+ * Validate a payload against configurable size limits.
+ *
+ * Checks:
+ * 1. Serialized JSON byte size
+ * 2. Object nesting depth
+ * 3. Top-level key count
+ */
+export function validatePayload(
+  payload: unknown,
+  limits: Partial<PayloadLimits> = {},
+): ValidationResult {
+  const resolved: PayloadLimits = { ...DEFAULT_PAYLOAD_LIMITS, ...limits };
+
+  // 1. Top-level key count (only for objects)
+  if (payload !== null && typeof payload === 'object' && !Array.isArray(payload)) {
+    const keyCount = Object.keys(payload as Record<string, unknown>).length;
+    if (keyCount > resolved.maxTopLevelKeys) {
+      return {
+        valid: false,
+        error: `Payload has ${keyCount} top-level keys (max: ${resolved.maxTopLevelKeys})`,
+      };
+    }
+  }
+
+  // 2. Nesting depth
+  const depth = measureDepth(payload, 0, resolved.maxNestingDepth);
+  if (depth > resolved.maxNestingDepth) {
+    return {
+      valid: false,
+      error: `Payload nesting depth ${depth} exceeds maximum of ${resolved.maxNestingDepth}`,
+    };
+  }
+
+  // 3. Serialized byte size
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(payload);
+  } catch {
+    return { valid: false, error: 'Payload cannot be serialized to JSON' };
+  }
+
+  const byteSize = Buffer.byteLength(serialized, 'utf-8');
+  if (byteSize > resolved.maxPayloadBytes) {
+    const sizeMB = (byteSize / 1_048_576).toFixed(2);
+    const limitMB = (resolved.maxPayloadBytes / 1_048_576).toFixed(2);
+    return {
+      valid: false,
+      error: `Payload size ${sizeMB}MB exceeds maximum of ${limitMB}MB`,
+    };
+  }
+
+  return { valid: true };
+}

--- a/src/tools/__tests__/memory-tools.test.ts
+++ b/src/tools/__tests__/memory-tools.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { projectMemoryWriteTool } from '../memory-tools.js';
+
+const TEST_DIR = '/tmp/memory-tools-test';
+
+// Mock validateWorkingDirectory to allow test directory
+vi.mock('../../lib/worktree-paths.js', async () => {
+  const actual = await vi.importActual('../../lib/worktree-paths.js');
+  return {
+    ...actual,
+    validateWorkingDirectory: vi.fn((workingDirectory?: string) => {
+      return workingDirectory || process.cwd();
+    }),
+  };
+});
+
+describe('memory-tools payload validation', () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, '.omc'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('should reject oversized memory payloads', async () => {
+    const result = await projectMemoryWriteTool.handler({
+      memory: { huge: 'x'.repeat(2_000_000) },
+      workingDirectory: TEST_DIR,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('payload rejected');
+    expect(result.content[0].text).toContain('exceeds maximum');
+  });
+
+  it('should reject deeply nested memory payloads', async () => {
+    let obj: Record<string, unknown> = { leaf: true };
+    for (let i = 0; i < 15; i++) {
+      obj = { nested: obj };
+    }
+
+    const result = await projectMemoryWriteTool.handler({
+      memory: obj,
+      workingDirectory: TEST_DIR,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('nesting depth');
+  });
+
+  it('should reject memory with too many top-level keys', async () => {
+    const memory: Record<string, string> = {};
+    for (let i = 0; i < 150; i++) {
+      memory[`key_${i}`] = 'value';
+    }
+
+    const result = await projectMemoryWriteTool.handler({
+      memory,
+      workingDirectory: TEST_DIR,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('top-level keys');
+  });
+
+  it('should allow normal-sized memory writes', async () => {
+    const result = await projectMemoryWriteTool.handler({
+      memory: {
+        version: '1.0.0',
+        techStack: { language: 'TypeScript', framework: 'Node.js' },
+      },
+      workingDirectory: TEST_DIR,
+    });
+
+    expect(result.content[0].text).toContain('Successfully');
+  });
+});

--- a/src/tools/memory-tools.ts
+++ b/src/tools/memory-tools.ts
@@ -18,6 +18,7 @@ import {
   type ProjectMemory,
   type UserDirective,
 } from '../hooks/project-memory/index.js';
+import { validatePayload } from '../lib/payload-limits.js';
 import { ToolDefinition } from './types.js';
 
 // ============================================================================
@@ -113,6 +114,18 @@ export const projectMemoryWriteTool: ToolDefinition<{
 
     try {
       const root = validateWorkingDirectory(workingDirectory);
+
+      // Validate payload size before writing
+      const validation = validatePayload(memory);
+      if (!validation.valid) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error: payload rejected — ${validation.error}`
+          }],
+          isError: true
+        };
+      }
 
       // Ensure .omc directory exists
       ensureOmcDir('', root);


### PR DESCRIPTION
## Summary

- Add shared `payload-limits` utility (`src/lib/payload-limits.ts`) with configurable limits: max payload bytes (1MB), max nesting depth (10), max top-level keys (100)
- Validate payloads in `projectMemoryWriteTool` and `stateWriteTool` handlers before writing to disk
- Add `.max()` constraints to unbounded string fields in `stateWriteTool` schema (`task_description`, `current_phase`, `plan_path`, `error`, timestamps)
- Add 16 unit tests for the validation utility, 5 integration tests for state-tools, 4 integration tests for memory-tools

## Test plan

- [x] All 47 new + existing tests pass (`vitest run`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify oversized payloads are rejected with clear error messages
- [ ] Verify normal-sized payloads continue to work without regression

Closes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)