### PR TITLE
fix(team): add path validation to prevent traversal in worker inbox/outbox

### DIFF
--- a/src/team/__tests__/heartbeat.test.ts
+++ b/src/team/__tests__/heartbeat.test.ts
@@ -109,3 +109,31 @@ describe('cleanupTeamHeartbeats', () => {
     cleanupTeamHeartbeats(TEST_DIR, 'nonexistent-team');
   });
 });
+
+describe('path traversal guard (issue #1170)', () => {
+  it('sanitizeName prevents traversal in team name', () => {
+    // Path traversal characters are stripped by sanitizeName
+    const hb = makeHeartbeat({ teamName: '../../../etc' });
+    writeHeartbeat(TEST_DIR, hb);
+    // Should write under sanitized name 'etc', not escape
+    const read = readHeartbeat(TEST_DIR, '../../../etc', 'w1');
+    expect(read?.teamName).toBe('../../../etc'); // data preserved, path sanitized
+  });
+
+  it('sanitizeName prevents traversal in worker name', () => {
+    const hb = makeHeartbeat({ workerName: '../../../tmp/evil' });
+    writeHeartbeat(TEST_DIR, hb);
+    // Should write under sanitized name, not escape to /tmp/evil
+    const read = readHeartbeat(TEST_DIR, TEST_TEAM, '../../../tmp/evil');
+    expect(read?.workerName).toBe('../../../tmp/evil'); // data preserved, path sanitized
+  });
+
+  it('deleteHeartbeat with traversal worker name does not escape', () => {
+    // Should not throw or affect files outside the heartbeat directory
+    deleteHeartbeat(TEST_DIR, TEST_TEAM, '../../../tmp/evil');
+  });
+
+  it('isWorkerAlive with traversal name does not escape', () => {
+    expect(isWorkerAlive(TEST_DIR, '../../../etc', '../../../tmp/evil', 60_000)).toBe(false);
+  });
+});

--- a/src/team/__tests__/inbox-outbox.test.ts
+++ b/src/team/__tests__/inbox-outbox.test.ts
@@ -260,3 +260,51 @@ describe('path traversal guard on teamsDir', () => {
       .toThrow();
   });
 });
+
+describe('path traversal guard on worker inbox paths (issue #1170)', () => {
+  it('rejects traversal in worker name for readNewInboxMessages', () => {
+    // sanitizeName strips traversal chars, so '../../../etc/passwd' becomes 'etcpasswd'
+    // This prevents writing/reading outside the expected inbox directory
+    const msgs = readNewInboxMessages(TEST_TEAM, '../../../etc/passwd');
+    expect(msgs).toEqual([]); // no file at sanitized path, returns empty
+  });
+
+  it('rejects traversal in worker name for appendOutbox', () => {
+    // Should not throw — sanitizeName cleans the name
+    const msg: OutboxMessage = { type: 'idle', timestamp: '2026-01-01T00:00:00Z' };
+    appendOutbox(TEST_TEAM, '../../../tmp/evil', msg);
+    // The file should be created under the team outbox dir with sanitized name, not at /tmp/evil
+    expect(existsSync(join(TEAMS_DIR, 'outbox', 'tmpevil.jsonl'))).toBe(true);
+    expect(existsSync('/tmp/evil.jsonl')).toBe(false);
+  });
+
+  it('rejects traversal in worker name for writeShutdownSignal', () => {
+    writeShutdownSignal(TEST_TEAM, '../signals/../../../tmp/evil', 'req-1', 'test');
+    // Should write to sanitized path, not escape
+    expect(existsSync('/tmp/evil.shutdown')).toBe(false);
+  });
+
+  it('rejects traversal in worker name for writeDrainSignal', () => {
+    writeDrainSignal(TEST_TEAM, '../../tmp/evil', 'req-1', 'test');
+    expect(existsSync('/tmp/evil.drain')).toBe(false);
+  });
+
+  it('rejects traversal in team name for readNewInboxMessages', () => {
+    const msgs = readNewInboxMessages('../../tmp', 'worker1');
+    expect(msgs).toEqual([]);
+  });
+
+  it('all-special-char worker name throws from sanitizeName', () => {
+    expect(() => readNewInboxMessages(TEST_TEAM, '...///...'))
+      .toThrow();
+  });
+
+  it('clearInbox with traversal worker name does not escape', () => {
+    // Should not throw or affect files outside team dir
+    clearInbox(TEST_TEAM, '../../../tmp/evil');
+  });
+
+  it('cleanupWorkerFiles with traversal worker name does not escape', () => {
+    cleanupWorkerFiles(TEST_TEAM, '../../../tmp/evil');
+  });
+});

--- a/src/team/__tests__/outbox-reader.test.ts
+++ b/src/team/__tests__/outbox-reader.test.ts
@@ -166,6 +166,34 @@ describe('readAllTeamOutboxMessages', () => {
   });
 });
 
+describe('readAllTeamOutboxMessages path traversal guard (issue #1170)', () => {
+  it('sanitizes worker names extracted from filenames', () => {
+    // Simulate a malicious filename in the outbox directory
+    // Even if someone created a file named '../../../etc/passwd.jsonl',
+    // sanitizeName would strip the traversal characters
+    const outbox = join(TEAMS_DIR, 'outbox', 'w1.jsonl');
+    const msg: OutboxMessage = { type: 'idle', timestamp: '2026-01-01T00:00:00Z' };
+    writeFileSync(outbox, JSON.stringify(msg) + '\n');
+
+    const results = readAllTeamOutboxMessages(TEST_TEAM);
+    // Worker names in results should be sanitized
+    for (const r of results) {
+      expect(r.workerName).toMatch(/^[a-zA-Z0-9-]+$/);
+    }
+  });
+
+  it('skips files with all-special-char names', () => {
+    // Create a file with a name that sanitizes to empty string
+    const maliciousFile = join(TEAMS_DIR, 'outbox', '....jsonl');
+    const msg: OutboxMessage = { type: 'idle', timestamp: '2026-01-01T00:00:00Z' };
+    writeFileSync(maliciousFile, JSON.stringify(msg) + '\n');
+
+    // Should skip the file (sanitizeName throws on empty result)
+    const results = readAllTeamOutboxMessages(TEST_TEAM);
+    expect(results).toEqual([]);
+  });
+});
+
 describe('resetOutboxCursor', () => {
   it('resets cursor to 0', () => {
     const outbox = join(TEAMS_DIR, 'outbox', 'w1.jsonl');

--- a/src/team/heartbeat.ts
+++ b/src/team/heartbeat.ts
@@ -12,7 +12,7 @@ import { readFileSync, existsSync, readdirSync, unlinkSync, rmdirSync } from 'fs
 import { join } from 'path';
 import type { HeartbeatData } from './types.js';
 import { sanitizeName } from './tmux-session.js';
-import { atomicWriteJson } from './fs-utils.js';
+import { atomicWriteJson, validateResolvedPath } from './fs-utils.js';
 
 /** Heartbeat file path */
 function heartbeatPath(workingDirectory: string, teamName: string, workerName: string): string {
@@ -62,9 +62,12 @@ export function listHeartbeats(
     const heartbeats: HeartbeatData[] = [];
     for (const file of files) {
       try {
-        const raw = readFileSync(join(dir, file), 'utf-8');
+        const filePath = join(dir, file);
+        // Validate file path stays within heartbeat directory
+        validateResolvedPath(filePath, dir);
+        const raw = readFileSync(filePath, 'utf-8');
         heartbeats.push(JSON.parse(raw) as HeartbeatData);
-      } catch { /* skip malformed */ }
+      } catch { /* skip malformed or invalid path */ }
     }
     return heartbeats;
   } catch {
@@ -118,7 +121,12 @@ export function cleanupTeamHeartbeats(
   try {
     const files = readdirSync(dir);
     for (const file of files) {
-      try { unlinkSync(join(dir, file)); } catch { /* ignore */ }
+      try {
+        const filePath = join(dir, file);
+        // Validate file path stays within heartbeat directory
+        validateResolvedPath(filePath, dir);
+        unlinkSync(filePath);
+      } catch { /* ignore invalid path or deletion failure */ }
     }
     // Try to remove the directory itself
     try {

--- a/src/team/inbox-outbox.ts
+++ b/src/team/inbox-outbox.ts
@@ -30,23 +30,38 @@ function teamsDir(teamName: string): string {
 }
 
 function inboxPath(teamName: string, workerName: string): string {
-  return join(teamsDir(teamName), 'inbox', `${sanitizeName(workerName)}.jsonl`);
+  const base = join(getClaudeConfigDir(), 'teams');
+  const result = join(teamsDir(teamName), 'inbox', `${sanitizeName(workerName)}.jsonl`);
+  validateResolvedPath(result, base);
+  return result;
 }
 
 function inboxCursorPath(teamName: string, workerName: string): string {
-  return join(teamsDir(teamName), 'inbox', `${sanitizeName(workerName)}.offset`);
+  const base = join(getClaudeConfigDir(), 'teams');
+  const result = join(teamsDir(teamName), 'inbox', `${sanitizeName(workerName)}.offset`);
+  validateResolvedPath(result, base);
+  return result;
 }
 
 function outboxPath(teamName: string, workerName: string): string {
-  return join(teamsDir(teamName), 'outbox', `${sanitizeName(workerName)}.jsonl`);
+  const base = join(getClaudeConfigDir(), 'teams');
+  const result = join(teamsDir(teamName), 'outbox', `${sanitizeName(workerName)}.jsonl`);
+  validateResolvedPath(result, base);
+  return result;
 }
 
 function signalPath(teamName: string, workerName: string): string {
-  return join(teamsDir(teamName), 'signals', `${sanitizeName(workerName)}.shutdown`);
+  const base = join(getClaudeConfigDir(), 'teams');
+  const result = join(teamsDir(teamName), 'signals', `${sanitizeName(workerName)}.shutdown`);
+  validateResolvedPath(result, base);
+  return result;
 }
 
 function drainSignalPath(teamName: string, workerName: string): string {
-  return join(teamsDir(teamName), 'signals', `${sanitizeName(workerName)}.drain`);
+  const base = join(getClaudeConfigDir(), 'teams');
+  const result = join(teamsDir(teamName), 'signals', `${sanitizeName(workerName)}.drain`);
+  validateResolvedPath(result, base);
+  return result;
 }
 
 /** Ensure directory exists for a file path */

--- a/src/team/outbox-reader.ts
+++ b/src/team/outbox-reader.ts
@@ -115,7 +115,15 @@ export function readAllTeamOutboxMessages(
   const results: { workerName: string; messages: OutboxMessage[] }[] = [];
 
   for (const file of files) {
-    const workerName = file.replace('.jsonl', '');
+    const rawName = file.replace('.jsonl', '');
+    // Sanitize worker name extracted from filesystem to prevent path traversal
+    let workerName: string;
+    try {
+      workerName = sanitizeName(rawName);
+    } catch {
+      // Invalid name (e.g., all special chars) — skip this file
+      continue;
+    }
     const messages = readNewOutboxMessages(teamName, workerName);
     if (messages.length > 0) {
       results.push({ workerName, messages });


### PR DESCRIPTION
## Summary

- Add `validateResolvedPath()` defense-in-depth validation to all inbox/outbox/signal path helpers in `inbox-outbox.ts`
- Sanitize worker names extracted from filesystem directory listings in `outbox-reader.ts` `readAllTeamOutboxMessages()`
- Add path validation to `heartbeat.ts` `listHeartbeats()` and `cleanupTeamHeartbeats()` for files enumerated via `readdirSync()`
- Add 14 new path traversal security tests across inbox-outbox, outbox-reader, and heartbeat test suites

## Details

The worker inbox/outbox path helpers in `inbox-outbox.ts` relied solely on `sanitizeName()` to strip traversal characters from team/worker names. While `sanitizeName()` is effective (strips all non-alphanumeric/hyphen chars), it was the **only** defense layer. This PR adds `validateResolvedPath()` as a second validation layer on all constructed file paths, ensuring they resolve within the expected `~/.claude/teams/` base directory.

Additionally, `readAllTeamOutboxMessages()` extracted worker names directly from filenames via `readdirSync()` without sanitization. A maliciously crafted filename could return an unsanitized worker name to callers. This is now sanitized with `sanitizeName()`, and files with invalid names are skipped.

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 125 existing + new tests pass (`vitest run`)
- [x] New tests verify traversal in worker names for inbox read/write/clear/cleanup
- [x] New tests verify traversal in team names
- [x] New tests verify all-special-char names are rejected
- [x] New tests verify sanitized filenames in outbox directory listing
- [x] New tests verify heartbeat path traversal protection

Closes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)