### PR TITLE
fix(team): shell rc loading in worker context trust boundary (#1166)

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -10,6 +10,8 @@ import {
   getDefaultShell,
   buildWorkerStartCommand,
   isUnixLikeOnWindows,
+  shouldLoadShellRc,
+  validateCliBinaryPath,
 } from '../tmux-session.js';
 
 afterEach(() => {
@@ -158,6 +160,159 @@ describe('buildWorkerStartCommand', () => {
     });
 
     expect(cmd).toContain('/home/tester/.bashrc');
+  });
+});
+
+describe('shouldLoadShellRc', () => {
+  it('returns true by default (rc loading enabled)', () => {
+    delete process.env.OMC_TEAM_NO_RC;
+    expect(shouldLoadShellRc()).toBe(true);
+  });
+
+  it('returns false when OMC_TEAM_NO_RC=1', () => {
+    vi.stubEnv('OMC_TEAM_NO_RC', '1');
+    expect(shouldLoadShellRc()).toBe(false);
+  });
+
+  it('returns false when OMC_TEAM_NO_RC=true', () => {
+    vi.stubEnv('OMC_TEAM_NO_RC', 'true');
+    expect(shouldLoadShellRc()).toBe(false);
+  });
+
+  it('returns true for other OMC_TEAM_NO_RC values', () => {
+    vi.stubEnv('OMC_TEAM_NO_RC', '0');
+    expect(shouldLoadShellRc()).toBe(true);
+    vi.stubEnv('OMC_TEAM_NO_RC', 'false');
+    expect(shouldLoadShellRc()).toBe(true);
+    vi.stubEnv('OMC_TEAM_NO_RC', 'yes');
+    expect(shouldLoadShellRc()).toBe(true);
+  });
+});
+
+describe('validateCliBinaryPath', () => {
+  it('skips validation for unknown binaries', () => {
+    const result = validateCliBinaryPath('unknown-tool');
+    expect(result.isValid).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('validates known CLI binaries (node should be available in test env)', () => {
+    const result = validateCliBinaryPath('node');
+    expect(result.isValid).toBe(true);
+    expect(result.resolvedPath).toBeTruthy();
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('warns when binary is not found in PATH', () => {
+    const result = validateCliBinaryPath('gemini');
+    // gemini is unlikely to be installed in test env
+    if (!result.resolvedPath) {
+      expect(result.warnings).toContain("CLI binary 'gemini' not found in PATH");
+    }
+  });
+
+  it('returns binary name in result', () => {
+    const result = validateCliBinaryPath('node');
+    expect(result.binary).toBe('node');
+  });
+});
+
+describe('buildWorkerStartCommand with OMC_TEAM_NO_RC', () => {
+  it('skips rc sourcing when OMC_TEAM_NO_RC=1 (launchCmd path)', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    vi.stubEnv('SHELL', '/bin/zsh');
+    vi.stubEnv('HOME', '/home/tester');
+    vi.stubEnv('OMC_TEAM_NO_RC', '1');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 'tt',
+      workerName: 'ww',
+      envVars: { A: '1' },
+      launchCmd: 'node app.js',
+      cwd: '/tmp'
+    });
+
+    expect(cmd).not.toContain('.zshrc');
+    expect(cmd).not.toContain('source');
+  });
+
+  it('skips rc sourcing when OMC_TEAM_NO_RC=1 (launchBinary path)', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    vi.stubEnv('SHELL', '/bin/bash');
+    vi.stubEnv('HOME', '/home/tester');
+    vi.stubEnv('OMC_TEAM_NO_RC', '1');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 'tt',
+      workerName: 'ww',
+      envVars: { A: '1' },
+      launchBinary: 'codex',
+      launchArgs: ['--full-auto'],
+      cwd: '/tmp'
+    });
+
+    expect(cmd).not.toContain('.bashrc');
+    expect(cmd).toContain('exec "$@"');
+  });
+
+  it('includes binary resolution logging in launchBinary path', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    vi.stubEnv('SHELL', '/bin/bash');
+    vi.stubEnv('HOME', '/home/tester');
+    delete process.env.OMC_TEAM_NO_RC;
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 'tt',
+      workerName: 'ww',
+      envVars: {},
+      launchBinary: 'claude',
+      cwd: '/tmp'
+    });
+
+    expect(cmd).toContain('command -v');
+    expect(cmd).toContain('[omc-team]');
+  });
+
+  it('still sources rc when OMC_TEAM_NO_RC is not set', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    vi.stubEnv('SHELL', '/bin/zsh');
+    vi.stubEnv('HOME', '/home/tester');
+    delete process.env.OMC_TEAM_NO_RC;
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 'tt',
+      workerName: 'ww',
+      envVars: { A: '1' },
+      launchCmd: 'node app.js',
+      cwd: '/tmp'
+    });
+
+    expect(cmd).toContain('.zshrc');
+  });
+});
+
+describe('trust boundary source guards', () => {
+  const source = readFileSync(join(__dirname, '..', 'tmux-session.ts'), 'utf-8');
+
+  it('documents trust model in shouldLoadShellRc', () => {
+    expect(source).toContain('Trust boundary: shell rc loading in worker contexts');
+    expect(source).toContain('OMC_TEAM_NO_RC');
+  });
+
+  it('validates CLI binary path before spawning', () => {
+    expect(source).toContain('Trust boundary: validate CLI binary path before spawning');
+    expect(source).toContain('validateCliBinaryPath');
+  });
+
+  it('logs resolved binary path in generated shell script', () => {
+    expect(source).toContain('command -v "$1"');
+    expect(source).toContain('trust boundary audit trail');
+  });
+
+  it('checks for suspicious path prefixes', () => {
+    expect(source).toContain('/tmp/');
+    expect(source).toContain('/var/tmp/');
+    expect(source).toContain('SUSPICIOUS_PATH_PREFIXES');
   });
 });
 

--- a/src/team/index.ts
+++ b/src/team/index.ts
@@ -43,7 +43,11 @@ export {
   isSessionAlive,
   listActiveSessions,
   spawnBridgeInSession,
+  shouldLoadShellRc,
+  validateCliBinaryPath,
 } from './tmux-session.js';
+
+export type { CliBinaryValidation } from './tmux-session.js';
 
 export {
   appendOutbox,


### PR DESCRIPTION
## Summary

- Add `shouldLoadShellRc()` with `OMC_TEAM_NO_RC=1` env var to skip shell rc file loading in worker contexts
- Add `validateCliBinaryPath()` pre-spawn validation that rejects binaries in suspicious paths (`/tmp/`, `/var/tmp/`, `/dev/shm/`)
- Add binary resolution logging (`command -v`) in generated shell scripts for audit trail
- Document trust model: workers run with user's full shell environment by design, `exec "$@"` mitigates function/alias shadowing

## Test plan

- [x] `shouldLoadShellRc()` returns true by default, false for `OMC_TEAM_NO_RC=1` and `OMC_TEAM_NO_RC=true`
- [x] `validateCliBinaryPath()` validates known binaries, skips unknown, warns on not-found
- [x] `buildWorkerStartCommand` skips rc sourcing when `OMC_TEAM_NO_RC=1` (both launchCmd and launchBinary paths)
- [x] Generated script includes `command -v` binary logging
- [x] Source guards verify trust boundary documentation and suspicious path checks
- [x] All 43 tests pass, TypeScript compiles clean

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)