### PR TITLE
fix(team): PATH manipulation could influence CLI binary resolution (#1173)

### DIFF
--- a/src/team/__tests__/cli-path-resolution.test.ts
+++ b/src/team/__tests__/cli-path-resolution.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  resolvedEnv: vi.fn<() => NodeJS.ProcessEnv>(() => ({ PATH: '/usr/local/bin:/usr/bin' })),
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('../shell-path.js', () => ({
+  resolvedEnv: mocks.resolvedEnv,
+}));
+
+vi.mock('child_process', () => ({
+  spawnSync: mocks.spawnSync,
+}));
+
+import { resolveCliBinaryPath, clearResolvedPathCache, _testInternals } from '../model-contract.js';
+
+describe('resolveCliBinaryPath', () => {
+  beforeEach(() => {
+    clearResolvedPathCache();
+    mocks.spawnSync.mockReset();
+    mocks.resolvedEnv.mockReset();
+    mocks.resolvedEnv.mockReturnValue({ PATH: '/usr/local/bin:/usr/bin' });
+  });
+
+  it('resolves a binary to its absolute path via which', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/usr/local/bin/claude\n',
+      stderr: '',
+      pid: 0,
+      output: [],
+      signal: null,
+    });
+
+    const result = resolveCliBinaryPath('claude');
+    expect(result).toBe('/usr/local/bin/claude');
+    expect(mocks.spawnSync).toHaveBeenCalledWith(
+      'which',
+      ['claude'],
+      expect.objectContaining({ timeout: 5000, env: expect.any(Object) }),
+    );
+  });
+
+  it('uses resolvedEnv() for PATH resolution', () => {
+    const customEnv = { PATH: '/custom/bin:/usr/bin' };
+    mocks.resolvedEnv.mockReturnValue(customEnv);
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/custom/bin/claude\n',
+      stderr: '',
+    });
+
+    resolveCliBinaryPath('claude');
+    expect(mocks.spawnSync).toHaveBeenCalledWith(
+      'which',
+      ['claude'],
+      expect.objectContaining({ env: customEnv }),
+    );
+  });
+
+  it('caches resolved paths for subsequent calls', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/usr/local/bin/claude\n',
+      stderr: '',
+    });
+
+    resolveCliBinaryPath('claude');
+    resolveCliBinaryPath('claude');
+
+    expect(mocks.spawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects binary names with path separators', () => {
+    expect(() => resolveCliBinaryPath('../evil')).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath('foo/bar')).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath('foo\\bar')).toThrow('Invalid CLI binary name');
+  });
+
+  it('rejects binary names with shell metacharacters', () => {
+    expect(() => resolveCliBinaryPath('claude;rm -rf /')).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath('claude|cat')).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath('claude&bg')).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath('$(whoami)')).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath('`whoami`')).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath("claude'inject")).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath('claude"inject')).toThrow('Invalid CLI binary name');
+  });
+
+  it('rejects binary names with whitespace', () => {
+    expect(() => resolveCliBinaryPath('claude code')).toThrow('Invalid CLI binary name');
+    expect(() => resolveCliBinaryPath('claude\tcode')).toThrow('Invalid CLI binary name');
+  });
+
+  it('throws when binary is not found in PATH', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: 'not found',
+    });
+
+    expect(() => resolveCliBinaryPath('nonexistent')).toThrow('not found in PATH');
+  });
+
+  it('throws when which returns empty stdout', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '  \n',
+      stderr: '',
+    });
+
+    expect(() => resolveCliBinaryPath('empty')).toThrow('not found in PATH');
+  });
+
+  it('rejects paths in /tmp', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/tmp/evil/claude\n',
+      stderr: '',
+    });
+
+    expect(() => resolveCliBinaryPath('claude')).toThrow('untrusted location');
+  });
+
+  it('rejects paths in /var/tmp', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/var/tmp/malicious/codex\n',
+      stderr: '',
+    });
+
+    expect(() => resolveCliBinaryPath('codex')).toThrow('untrusted location');
+  });
+
+  it('rejects paths in /dev/shm', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/dev/shm/codex\n',
+      stderr: '',
+    });
+
+    expect(() => resolveCliBinaryPath('codex')).toThrow('untrusted location');
+  });
+
+  it('rejects non-absolute resolved paths', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: 'relative/path/claude\n',
+      stderr: '',
+    });
+
+    expect(() => resolveCliBinaryPath('claude')).toThrow('relative path');
+  });
+
+  it('accepts paths in /usr/local/bin without warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/usr/local/bin/claude\n',
+      stderr: '',
+    });
+
+    const result = resolveCliBinaryPath('claude');
+    expect(result).toBe('/usr/local/bin/claude');
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('accepts paths in /usr/bin without warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/usr/bin/codex\n',
+      stderr: '',
+    });
+
+    const result = resolveCliBinaryPath('codex');
+    expect(result).toBe('/usr/bin/codex');
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('accepts paths in user nvm directory without warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const home = process.env.HOME || '/home/test';
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: `${home}/.nvm/versions/node/v20/bin/codex\n`,
+      stderr: '',
+    });
+
+    const result = resolveCliBinaryPath('codex');
+    expect(result).toBe(`${home}/.nvm/versions/node/v20/bin/codex`);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('accepts paths in /opt/homebrew without warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/opt/homebrew/bin/claude\n',
+      stderr: '',
+    });
+
+    const result = resolveCliBinaryPath('claude');
+    expect(result).toBe('/opt/homebrew/bin/claude');
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('warns for paths outside standard directories but still resolves', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/unusual/location/claude\n',
+      stderr: '',
+    });
+
+    const result = resolveCliBinaryPath('claude');
+    expect(result).toBe('/unusual/location/claude');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[omc:cli-security]'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('respects OMC_TRUSTED_CLI_DIRS for custom trusted directories', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const origEnv = process.env.OMC_TRUSTED_CLI_DIRS;
+    process.env.OMC_TRUSTED_CLI_DIRS = '/custom/tools/bin';
+
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/custom/tools/bin/claude\n',
+      stderr: '',
+    });
+
+    try {
+      const result = resolveCliBinaryPath('claude');
+      expect(result).toBe('/custom/tools/bin/claude');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      if (origEnv === undefined) delete process.env.OMC_TRUSTED_CLI_DIRS;
+      else process.env.OMC_TRUSTED_CLI_DIRS = origEnv;
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('ignores relative paths in OMC_TRUSTED_CLI_DIRS', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const origEnv = process.env.OMC_TRUSTED_CLI_DIRS;
+    process.env.OMC_TRUSTED_CLI_DIRS = 'relative/path';
+
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/unusual/location/claude\n',
+      stderr: '',
+    });
+
+    try {
+      resolveCliBinaryPath('claude');
+      // Should still warn since the relative trusted dir is ignored
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      if (origEnv === undefined) delete process.env.OMC_TRUSTED_CLI_DIRS;
+      else process.env.OMC_TRUSTED_CLI_DIRS = origEnv;
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('clearResolvedPathCache resets the cache', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/usr/local/bin/claude\n',
+      stderr: '',
+    });
+
+    resolveCliBinaryPath('claude');
+    clearResolvedPathCache();
+    resolveCliBinaryPath('claude');
+
+    expect(mocks.spawnSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('takes first result when which returns multiple lines', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/usr/local/bin/claude\n/usr/bin/claude\n',
+      stderr: '',
+    });
+
+    expect(resolveCliBinaryPath('claude')).toBe('/usr/local/bin/claude');
+  });
+
+  it('normalizes paths with redundant separators', () => {
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: '/usr/local//bin/claude\n',
+      stderr: '',
+    });
+
+    expect(resolveCliBinaryPath('claude')).toBe('/usr/local/bin/claude');
+  });
+
+  it('handles spawnSync throwing an exception', () => {
+    mocks.spawnSync.mockImplementation(() => { throw new Error('spawn failed'); });
+
+    expect(() => resolveCliBinaryPath('claude')).toThrow();
+  });
+});
+
+describe('_testInternals', () => {
+  it('UNTRUSTED_PATH_PATTERNS reject expected directories', () => {
+    const { UNTRUSTED_PATH_PATTERNS } = _testInternals;
+    expect(UNTRUSTED_PATH_PATTERNS.some(p => p.test('/tmp/evil'))).toBe(true);
+    expect(UNTRUSTED_PATH_PATTERNS.some(p => p.test('/var/tmp/evil'))).toBe(true);
+    expect(UNTRUSTED_PATH_PATTERNS.some(p => p.test('/dev/shm/evil'))).toBe(true);
+    expect(UNTRUSTED_PATH_PATTERNS.some(p => p.test('/usr/local/bin/claude'))).toBe(false);
+  });
+
+  it('getTrustedPrefixes includes system directories', () => {
+    const prefixes = _testInternals.getTrustedPrefixes();
+    expect(prefixes).toContain('/usr/local/bin');
+    expect(prefixes).toContain('/usr/bin');
+    expect(prefixes).toContain('/opt/homebrew/');
+  });
+
+  it('getTrustedPrefixes includes user-local directories when HOME is set', () => {
+    const home = process.env.HOME;
+    if (!home) return; // Skip if HOME is not set
+
+    const prefixes = _testInternals.getTrustedPrefixes();
+    expect(prefixes).toContain(`${home}/.local/bin`);
+    expect(prefixes).toContain(`${home}/.nvm/`);
+    expect(prefixes).toContain(`${home}/.cargo/bin`);
+  });
+});

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -1,8 +1,8 @@
 // Re-exports from model-contract.ts for backward compatibility
 // and additional CLI detection utilities
-export { isCliAvailable, validateCliAvailable, getContract, type CliAgentType } from './model-contract.js';
+export { isCliAvailable, validateCliAvailable, getContract, resolveCliBinaryPath, clearResolvedPathCache, type CliAgentType } from './model-contract.js';
 import { spawnSync } from 'child_process';
-import { resolvedEnv } from './shell-path.js';
+import { resolveCliBinaryPath } from './model-contract.js';
 
 export interface CliInfo {
   available: boolean;
@@ -12,14 +12,13 @@ export interface CliInfo {
 
 export function detectCli(binary: string): CliInfo {
   try {
-    const env = resolvedEnv();
-    const versionResult = spawnSync(binary, ['--version'], { timeout: 5000, env });
+    const resolvedPath = resolveCliBinaryPath(binary);
+    const versionResult = spawnSync(resolvedPath, ['--version'], { timeout: 5000 });
     if (versionResult.status === 0) {
-      const pathResult = spawnSync('which', [binary], { timeout: 5000, env });
       return {
         available: true,
         version: versionResult.stdout?.toString().trim(),
-        path: pathResult.stdout?.toString().trim(),
+        path: resolvedPath,
       };
     }
     return { available: false };

--- a/src/team/index.ts
+++ b/src/team/index.ts
@@ -187,7 +187,7 @@ export {
 
 // cli-detection: only export symbols not already covered by model-contract
 export type { CliInfo } from './cli-detection.js';
-export { detectCli, detectAllClis } from './cli-detection.js';
+export { detectCli, detectAllClis, resolveCliBinaryPath, clearResolvedPathCache } from './cli-detection.js';
 
 // worker-bootstrap
 export type { WorkerBootstrapParams } from './worker-bootstrap.js';

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'child_process';
+import { isAbsolute, normalize } from 'path';
 import { resolvedEnv } from './shell-path.js';
 import { validateTeamName } from './team-name.js';
 
@@ -87,6 +88,139 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
   },
 };
 
+/**
+ * Patterns matching directories that must never contain trusted CLI binaries.
+ * These locations are world-writable and trivially exploitable for PATH hijacking.
+ */
+const UNTRUSTED_PATH_PATTERNS: RegExp[] = [
+  /^\/tmp\b/,
+  /^\/var\/tmp\b/,
+  /^\/dev\/shm\b/,
+];
+
+/**
+ * Well-known prefixes where CLI binaries are typically installed.
+ * Binaries outside these directories produce a warning but are not blocked,
+ * supporting custom user setups while maintaining audit visibility.
+ *
+ * Extend via `OMC_TRUSTED_CLI_DIRS` (colon-separated) for non-standard layouts.
+ */
+function getTrustedPrefixes(): string[] {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const prefixes = [
+    '/usr/local/bin',
+    '/usr/local/sbin',
+    '/usr/bin',
+    '/usr/sbin',
+    '/opt/',
+    '/snap/',
+    '/nix/',
+    '/opt/homebrew/',
+  ];
+  if (home) {
+    prefixes.push(
+      `${home}/.local/bin`,
+      `${home}/.npm-global/`,
+      `${home}/.nvm/`,
+      `${home}/.volta/`,
+      `${home}/.fnm/`,
+      `${home}/.cargo/bin`,
+      `${home}/.bun/bin`,
+      `${home}/n/bin`,
+    );
+  }
+  const extra = process.env.OMC_TRUSTED_CLI_DIRS;
+  if (extra) {
+    for (const dir of extra.split(':').filter(Boolean)) {
+      if (isAbsolute(dir)) prefixes.push(dir);
+    }
+  }
+  return prefixes;
+}
+
+/** Session-scoped cache of binary-name → resolved-absolute-path. */
+const resolvedPathCache = new Map<string, string>();
+
+/**
+ * Resolve a CLI binary name to its absolute filesystem path with security
+ * validation. The result is cached for the lifetime of this process so that
+ * subsequent calls are deterministic (PATH is only consulted once per binary).
+ *
+ * Security guarantees:
+ *  - Rejects binary names containing path separators or shell metacharacters.
+ *  - Rejects paths in world-writable temp directories (/tmp, /var/tmp, /dev/shm).
+ *  - Rejects non-absolute resolution results.
+ *  - Logs a warning for binaries outside well-known installation prefixes.
+ *
+ * @returns Absolute path to the binary.
+ * @throws  If the binary is not found, the name is invalid, or the resolved
+ *          path fails validation.
+ */
+export function resolveCliBinaryPath(binary: string): string {
+  const cached = resolvedPathCache.get(binary);
+  if (cached) return cached;
+
+  if (/[/\\;|&$`()"'\s]/.test(binary)) {
+    throw new Error(`Invalid CLI binary name: "${binary}"`);
+  }
+
+  const whichCmd =
+    process.platform === 'win32' && !process.env.MSYSTEM ? 'where' : 'which';
+  const result = spawnSync(whichCmd, [binary], {
+    timeout: 5000,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: resolvedEnv(),
+  });
+
+  if (result.status !== 0 || !result.stdout?.trim()) {
+    throw new Error(`CLI binary '${binary}' not found in PATH`);
+  }
+
+  const resolvedPath = normalize(result.stdout.trim().split('\n')[0].trim());
+
+  if (!isAbsolute(resolvedPath)) {
+    throw new Error(
+      `CLI binary '${binary}' resolved to a relative path: "${resolvedPath}". ` +
+        'Only absolute paths are accepted.',
+    );
+  }
+
+  for (const pattern of UNTRUSTED_PATH_PATTERNS) {
+    if (pattern.test(resolvedPath)) {
+      throw new Error(
+        `CLI binary '${binary}' resolved to an untrusted location: "${resolvedPath}". ` +
+          'Binaries in temporary directories are not allowed for security reasons.',
+      );
+    }
+  }
+
+  const trustedPrefixes = getTrustedPrefixes();
+  const inTrustedDir = trustedPrefixes.some((p) => resolvedPath.startsWith(p));
+  if (!inTrustedDir) {
+    console.warn(
+      `[omc:cli-security] CLI binary '${binary}' resolved to '${resolvedPath}' ` +
+        'which is not in a standard installation directory. ' +
+        'This may indicate PATH manipulation. ' +
+        `Expected prefixes include: ${trustedPrefixes.slice(0, 5).join(', ')}, ...`,
+    );
+  }
+
+  resolvedPathCache.set(binary, resolvedPath);
+  return resolvedPath;
+}
+
+/** Clear the resolved-path cache (for testing or session reset). */
+export function clearResolvedPathCache(): void {
+  resolvedPathCache.clear();
+}
+
+/** @internal Exposed for testing only. */
+export const _testInternals = {
+  UNTRUSTED_PATH_PATTERNS,
+  getTrustedPrefixes,
+};
+
 export function getContract(agentType: CliAgentType): CliAgentContract {
   const contract = CONTRACTS[agentType];
   if (!contract) {
@@ -98,11 +232,8 @@ export function getContract(agentType: CliAgentType): CliAgentContract {
 export function isCliAvailable(agentType: CliAgentType): boolean {
   const contract = getContract(agentType);
   try {
-    const result = spawnSync(contract.binary, ['--version'], {
-      timeout: 5000,
-      shell: true,
-      env: resolvedEnv(),
-    });
+    const resolvedBinary = resolveCliBinaryPath(contract.binary);
+    const result = spawnSync(resolvedBinary, ['--version'], { timeout: 5000 });
     return result.status === 0;
   } catch {
     return false;
@@ -125,8 +256,9 @@ export function buildLaunchArgs(agentType: CliAgentType, config: WorkerLaunchCon
 export function buildWorkerArgv(agentType: CliAgentType, config: WorkerLaunchConfig): string[] {
   validateTeamName(config.teamName);
   const contract = getContract(agentType);
+  const resolvedBinary = resolveCliBinaryPath(contract.binary);
   const args = buildLaunchArgs(agentType, config);
-  return [contract.binary, ...args];
+  return [resolvedBinary, ...args];
 }
 
 export function buildWorkerCommand(agentType: CliAgentType, config: WorkerLaunchConfig): string {


### PR DESCRIPTION
Fixes #1173. Adds validateCliBinaryPath() to verify CLI binaries before worker spawning.