### PR TITLE
fix(team): add configurable timeout to shell-readiness wait (#1171)

### DIFF
--- a/src/team/__tests__/wait-for-shell-ready.test.ts
+++ b/src/team/__tests__/wait-for-shell-ready.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
 
@@ -189,5 +189,136 @@ describe('spawnWorkerInPane with waitForShell', () => {
       (args) => args[0] === 'send-keys' && args.includes('-l')
     );
     expect(sendKeysCalls).toHaveLength(1);
+  });
+
+  it('logs a warning when shell ready times out', async () => {
+    mockedState.captureResults = Array(100).fill('loading...');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await spawnWorkerInPane('session:0', '%2', {
+      teamName: 'safe-team',
+      workerName: 'worker-1',
+      envVars: { OMC_TEAM_NAME: 'safe-team' },
+      launchBinary: 'codex',
+      launchArgs: ['--full-auto'],
+      cwd: '/tmp',
+    }, { shellReadyOpts: { timeoutMs: 50, intervalMs: 10 } });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('spawnWorkerInPane: shell in pane %2 did not become ready')
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('OMC_SHELL_READY_TIMEOUT_MS')
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+describe('waitForShellReady timeout configuration', () => {
+  const originalEnv = process.env.OMC_SHELL_READY_TIMEOUT_MS;
+
+  beforeEach(() => {
+    resetMock();
+    delete process.env.OMC_SHELL_READY_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.OMC_SHELL_READY_TIMEOUT_MS = originalEnv;
+    } else {
+      delete process.env.OMC_SHELL_READY_TIMEOUT_MS;
+    }
+  });
+
+  it('uses OMC_SHELL_READY_TIMEOUT_MS env var when opts.timeoutMs is not set', async () => {
+    process.env.OMC_SHELL_READY_TIMEOUT_MS = '50';
+    mockedState.captureResults = Array(100).fill('loading...');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await waitForShellReady('%5', { intervalMs: 10 });
+
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('timed out after 50ms')
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('opts.timeoutMs takes precedence over env var', async () => {
+    process.env.OMC_SHELL_READY_TIMEOUT_MS = '5000';
+    mockedState.captureResults = Array(100).fill('loading...');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await waitForShellReady('%5', { intervalMs: 10, timeoutMs: 50 });
+
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('timed out after 50ms')
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('ignores invalid env var values', async () => {
+    process.env.OMC_SHELL_READY_TIMEOUT_MS = 'not-a-number';
+    mockedState.captureResults = ['user@host:~$ '];
+
+    const result = await waitForShellReady('%5', { intervalMs: 10 });
+
+    // Falls back to 10_000 default; prompt found immediately
+    expect(result).toBe(true);
+  });
+
+  it('ignores non-positive env var values', async () => {
+    process.env.OMC_SHELL_READY_TIMEOUT_MS = '-100';
+    mockedState.captureResults = ['user@host:~$ '];
+
+    const result = await waitForShellReady('%5', { intervalMs: 10 });
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('waitForShellReady progressive backoff', () => {
+  beforeEach(resetMock);
+
+  it('polls fewer times with backoff than fixed interval for same timeout', async () => {
+    // With 200ms initial interval and 1000ms timeout, fixed interval would do ~5 polls.
+    // With 1.5x backoff (200, 300, 450, 675), fewer polls are needed.
+    mockedState.captureResults = Array(100).fill('loading...');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await waitForShellReady('%5', { intervalMs: 200, timeoutMs: 1000 });
+
+    // With backoff: 200 + 300 + 450 = 950ms (3 polls before timeout)
+    // Without backoff: 200*5 = 1000ms (5 polls)
+    expect(mockedState.captureCallCount).toBeLessThanOrEqual(4);
+    expect(mockedState.captureCallCount).toBeGreaterThanOrEqual(2);
+    warnSpy.mockRestore();
+  });
+
+  it('logs a warning with pane ID on timeout', async () => {
+    mockedState.captureResults = Array(100).fill('loading...');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await waitForShellReady('%42', { intervalMs: 10, timeoutMs: 50 });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('pane %42')
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('timed out after 50ms')
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('does not log warning when prompt is found before timeout', async () => {
+    mockedState.captureResults = ['', 'user@host:~$ '];
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await waitForShellReady('%5', { intervalMs: 10, timeoutMs: 500 });
+
+    expect(result).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- Add progressive backoff (1.5x multiplier, 2s ceiling) to `waitForShellReady` polling loop to reduce unnecessary polling
- Add `OMC_SHELL_READY_TIMEOUT_MS` environment variable for runtime timeout override (priority: opts > env > 10s default)
- Log clear warnings on timeout in both `waitForShellReady` and `spawnWorkerInPane` with actionable guidance
- `spawnWorkerInPane` now checks the return value and proceeds fail-open with visibility

## Test plan

- [x] Existing tests pass (17 tests in `wait-for-shell-ready.test.ts`)
- [x] New tests: warning logging on timeout, env var override, env var precedence, invalid env var handling, progressive backoff poll count, no warning when prompt found
- [x] `npm run lint` passes (0 errors)
- [x] All tmux-session related tests pass (65 tests across 4 files)

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)