### PR TITLE
fix(hooks): resolve transcript path in native git worktrees

### DIFF
--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -20,8 +20,9 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { execSync } from 'node:child_process';
 import { readStdin } from './lib/stdin.mjs';
 
 const THRESHOLD = parseInt(process.env.OMC_CONTEXT_GUARD_THRESHOLD || '75', 10);
@@ -74,7 +75,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
     if (existsSync(transcriptPath)) return transcriptPath;
   } catch { /* fallthrough */ }
 
-  // Strip worktree segment from encoded project directory
+  // Strategy 1: Strip Claude worktree segment from encoded project directory
   const worktreePattern = /--claude-worktrees-[^/\\]+/;
   if (worktreePattern.test(transcriptPath)) {
     const resolved = transcriptPath.replace(worktreePattern, '');
@@ -82,6 +83,44 @@ function resolveTranscriptPath(transcriptPath, cwd) {
       if (existsSync(resolved)) return resolved;
     } catch { /* fallthrough */ }
   }
+
+  // Strategy 2: Detect native git worktree via git-common-dir.
+  // When CWD is a linked worktree (created by `git worktree add`), the
+  // transcript path encodes the worktree CWD, but the file lives under
+  // the main repo's encoded path.
+  const effectiveCwd = cwd || process.cwd();
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: effectiveCwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    const absoluteCommonDir = resolve(effectiveCwd, gitCommonDir);
+    const mainRepoRoot = dirname(absoluteCommonDir);
+
+    const worktreeTop = execSync('git rev-parse --show-toplevel', {
+      cwd: effectiveCwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    if (mainRepoRoot !== worktreeTop) {
+      const lastSep = transcriptPath.lastIndexOf('/');
+      const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
+      if (sessionFile) {
+        const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+        const projectsDir = join(configDir, 'projects');
+        if (existsSync(projectsDir)) {
+          const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
+          const resolvedPath = join(projectsDir, encodedMain, sessionFile);
+          try {
+            if (existsSync(resolvedPath)) return resolvedPath;
+          } catch { /* fallthrough */ }
+        }
+      }
+    }
+  } catch { /* not in a git repo or git not available — skip */ }
 
   return transcriptPath;
 }

--- a/src/__tests__/resolve-transcript-path.test.ts
+++ b/src/__tests__/resolve-transcript-path.test.ts
@@ -1,12 +1,17 @@
 /**
- * Tests for resolveTranscriptPath (issue #1094)
+ * Tests for resolveTranscriptPath (issues #1094, #1191)
  *
  * Verifies that worktree-mismatched transcript paths are correctly
  * resolved to the original project's transcript path.
+ *
+ * Covers:
+ *   - Claude internal worktrees (.claude/worktrees/X) — issue #1094
+ *   - Native git worktrees (git worktree add) — issue #1191
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { execSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { resolveTranscriptPath } from '../lib/worktree-paths.js';
@@ -113,5 +118,96 @@ describe('resolveTranscriptPath', () => {
   it('does not modify paths without worktree pattern even if file missing', () => {
     const normalPath = join(tempDir, 'projects', '-Users-user-project', 'missing.jsonl');
     expect(resolveTranscriptPath(normalPath)).toBe(normalPath);
+  });
+
+  // --- Native git worktree tests (issue #1191) ---
+
+  describe('native git worktree fallback', () => {
+    let mainRepoDir: string;
+    let worktreeDir: string;
+    let fakeClaudeDir: string;
+    let origClaudeConfigDir: string | undefined;
+
+    beforeEach(() => {
+      // Save and override CLAUDE_CONFIG_DIR so Strategy 3 finds our fake projects dir
+      origClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+      // Create a real git repo with a linked worktree
+      mainRepoDir = join(tempDir, 'main-repo');
+      mkdirSync(mainRepoDir, { recursive: true });
+      execSync('git init', { cwd: mainRepoDir, stdio: 'pipe' });
+      execSync('git commit --allow-empty -m "init"', {
+        cwd: mainRepoDir,
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: 'test', GIT_AUTHOR_EMAIL: 'test@test.com',
+          GIT_COMMITTER_NAME: 'test', GIT_COMMITTER_EMAIL: 'test@test.com',
+        },
+      });
+
+      worktreeDir = join(tempDir, 'linked-worktree');
+      execSync(`git worktree add "${worktreeDir}" -b test-branch`, {
+        cwd: mainRepoDir,
+        stdio: 'pipe',
+      });
+
+      // Simulate ~/.claude/projects/ with a transcript at the main repo's encoded path
+      fakeClaudeDir = join(tempDir, 'fake-claude');
+      process.env.CLAUDE_CONFIG_DIR = fakeClaudeDir;
+      const encodedMain = mainRepoDir.replace(/[/\\]/g, '-');
+      const projectDir = join(fakeClaudeDir, 'projects', encodedMain);
+      mkdirSync(projectDir, { recursive: true });
+      writeFileSync(join(projectDir, 'session-abc.jsonl'), '{}');
+    });
+
+    afterEach(() => {
+      // Restore CLAUDE_CONFIG_DIR
+      if (origClaudeConfigDir === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = origClaudeConfigDir;
+      }
+
+      // Clean up worktree before the main afterEach removes tempDir
+      try {
+        execSync(`git worktree remove "${worktreeDir}" --force`, {
+          cwd: mainRepoDir,
+          stdio: 'pipe',
+        });
+      } catch {
+        // ignore
+      }
+    });
+
+    it('resolves transcript path from native git worktree to main repo (issue #1191)', () => {
+      // The worktree-encoded transcript path (does not exist)
+      const encodedWorktree = worktreeDir.replace(/[/\\]/g, '-');
+      const worktreePath = join(fakeClaudeDir, 'projects', encodedWorktree, 'session-abc.jsonl');
+
+      const resolved = resolveTranscriptPath(worktreePath, worktreeDir);
+      const encodedMain = mainRepoDir.replace(/[/\\]/g, '-');
+      const expectedPath = join(fakeClaudeDir, 'projects', encodedMain, 'session-abc.jsonl');
+
+      expect(resolved).toBe(expectedPath);
+    });
+
+    it('does not alter path when CWD is the main repo (not a worktree)', () => {
+      const encodedMain = mainRepoDir.replace(/[/\\]/g, '-');
+      const mainPath = join(fakeClaudeDir, 'projects', encodedMain, 'session-abc.jsonl');
+
+      // Path exists and CWD is the main repo — should return as-is
+      const resolved = resolveTranscriptPath(mainPath, mainRepoDir);
+      expect(resolved).toBe(mainPath);
+    });
+
+    it('returns original path when main repo transcript also missing', () => {
+      const encodedWorktree = worktreeDir.replace(/[/\\]/g, '-');
+      // Use a session file that doesn't exist at the main repo path either
+      const worktreePath = join(fakeClaudeDir, 'projects', encodedWorktree, 'nonexistent.jsonl');
+
+      const resolved = resolveTranscriptPath(worktreePath, worktreeDir);
+      expect(resolved).toBe(worktreePath);
+    });
   });
 });

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -13,7 +13,7 @@ import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync, realpathSync, readdirSync } from 'fs';
 import { homedir } from 'os';
-import { resolve, normalize, relative, sep, join, isAbsolute, basename } from 'path';
+import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
 
 /** Standard .omc subdirectories */
 export const OmcPaths = {
@@ -554,6 +554,44 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
         if (existsSync(resolvedPath)) return resolvedPath;
       }
     }
+  }
+
+  // Strategy 3: Detect native git worktree via git-common-dir.
+  // When CWD is a linked worktree (created by `git worktree add`), the
+  // transcript path encodes the worktree CWD, but the file lives under
+  // the main repo's encoded path. Use `git rev-parse --git-common-dir`
+  // to find the main repo root and re-encode.
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: effectiveCwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    const absoluteCommonDir = resolve(effectiveCwd, gitCommonDir);
+    const mainRepoRoot = dirname(absoluteCommonDir);
+
+    const worktreeTop = execSync('git rev-parse --show-toplevel', {
+      cwd: effectiveCwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    if (mainRepoRoot !== worktreeTop) {
+      const lastSep = transcriptPath.lastIndexOf('/');
+      const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
+      if (sessionFile) {
+        const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+        const projectsDir = join(configDir, 'projects');
+        if (existsSync(projectsDir)) {
+          const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
+          const resolvedPath = join(projectsDir, encodedMain, sessionFile);
+          if (existsSync(resolvedPath)) return resolvedPath;
+        }
+      }
+    }
+  } catch {
+    // Not in a git repo or git not available — skip
   }
 
   // No resolution found — return original path.


### PR DESCRIPTION
## Summary

- Fixes transcript path resolution when running inside native git worktrees (`git worktree add`)
- The stop hook (`context-guard-stop.mjs`) and context-safety hook (`context-safety.mjs`) failed to find the transcript `.jsonl` because the path was encoded using the worktree CWD, but the file lives under the main repo's encoded project directory
- Adds a new resolution strategy using `git rev-parse --git-common-dir` to detect linked worktrees and fall back to the main repo's encoded path

## Changes

- `src/lib/worktree-paths.ts`: Added Strategy 3 to `resolveTranscriptPath()` — detects native git worktrees via `git-common-dir` and resolves to main repo path
- `scripts/context-guard-stop.mjs`: Added the same git-common-dir fallback to the inline `resolveTranscriptPath()`
- `scripts/context-safety.mjs`: Added the same git-common-dir fallback to the inline `resolveTranscriptPath()`
- `src/__tests__/resolve-transcript-path.test.ts`: Added 3 test cases covering native git worktree scenarios (creates real git repos with linked worktrees)

Closes #1191

## Test plan

- [x] Existing transcript path tests pass (9 tests)
- [x] New native git worktree tests pass (3 tests) — creates real git repos with `git worktree add` to verify end-to-end resolution
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)