### PR TITLE
fix(cli): source shell rc files in tmux launch sessions

### DIFF
--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -85,6 +85,47 @@ describe('wrapWithLoginShell', () => {
     expect(result).toContain('/usr/local/bin/fish');
     expect(result).toContain('-lc');
   });
+
+  it('sources ~/.zshrc for zsh shells', () => {
+    vi.stubEnv('SHELL', '/bin/zsh');
+    vi.stubEnv('HOME', '/home/testuser');
+    const result = wrapWithLoginShell('claude');
+    expect(result).toContain('.zshrc');
+    expect(result).toContain('/home/testuser/.zshrc');
+  });
+
+  it('sources ~/.bashrc for bash shells', () => {
+    vi.stubEnv('SHELL', '/bin/bash');
+    vi.stubEnv('HOME', '/home/testuser');
+    const result = wrapWithLoginShell('claude');
+    expect(result).toContain('.bashrc');
+    expect(result).toContain('/home/testuser/.bashrc');
+  });
+
+  it('sources ~/.fishrc for fish shells', () => {
+    vi.stubEnv('SHELL', '/usr/local/bin/fish');
+    vi.stubEnv('HOME', '/home/testuser');
+    const result = wrapWithLoginShell('codex');
+    expect(result).toContain('.fishrc');
+    expect(result).toContain('/home/testuser/.fishrc');
+  });
+
+  it('skips rc sourcing when HOME is not set', () => {
+    vi.stubEnv('SHELL', '/bin/zsh');
+    vi.stubEnv('HOME', '');
+    const result = wrapWithLoginShell('claude');
+    expect(result).not.toContain('.zshrc');
+    expect(result).toContain('claude');
+  });
+
+  it('uses conditional test before sourcing rc file', () => {
+    vi.stubEnv('SHELL', '/bin/zsh');
+    vi.stubEnv('HOME', '/home/testuser');
+    const result = wrapWithLoginShell('claude');
+    // Should guard with [ -f ... ] to avoid errors if rc file doesn't exist
+    expect(result).toContain('[ -f');
+    expect(result).toContain('] && .');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `wrapWithLoginShell()` used `$SHELL -lc` which starts a login+non-interactive shell, sourcing `.zprofile`/`.bash_profile` but **not** `.zshrc`/`.bashrc`
- Most users put PATH and environment setup in rc files, so tmux sessions launched by `omc` CLI were missing user environment
- Now explicitly sources the shell rc file (e.g. `~/.zshrc`, `~/.bashrc`) before running the command, matching the pattern already used by `buildWorkerStartCommand()` in `tmux-session.ts`

## Test plan
- [x] 25/25 unit tests pass (`vitest run src/cli/__tests__/tmux-utils.test.ts`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] New tests verify rc sourcing for zsh, bash, fish, missing HOME, and conditional guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)