### PR TITLE
fix(config): auto-detect non-Claude providers and enable forceInherit (#1201)

### DIFF
--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -14,9 +14,17 @@ import { resolveDelegation } from '../features/delegation-routing/resolver.js';
 
 describe('delegation-enforcer', () => {
   let originalDebugEnv: string | undefined;
+  // Save/restore env vars that trigger non-Claude provider detection (issue #1201)
+  // so existing tests run in a standard Claude environment
+  const providerEnvKeys = ['ANTHROPIC_BASE_URL', 'CLAUDE_MODEL', 'ANTHROPIC_MODEL', 'OMC_ROUTING_FORCE_INHERIT'];
+  const savedProviderEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
     originalDebugEnv = process.env.OMC_DEBUG;
+    for (const key of providerEnvKeys) {
+      savedProviderEnv[key] = process.env[key];
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
@@ -24,6 +32,13 @@ describe('delegation-enforcer', () => {
       delete process.env.OMC_DEBUG;
     } else {
       process.env.OMC_DEBUG = originalDebugEnv;
+    }
+    for (const key of providerEnvKeys) {
+      if (savedProviderEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedProviderEnv[key];
+      }
     }
   });
 
@@ -286,6 +301,67 @@ describe('delegation-enforcer', () => {
       expect(result.provider).toBe('claude');
       expect(result.tool).toBe('Task');
       expect(result.agentOrModel).toBe('document-specialist');
+    });
+  });
+
+  describe('non-Claude provider support (issue #1201)', () => {
+    const savedEnv: Record<string, string | undefined> = {};
+    const envKeys = ['CLAUDE_MODEL', 'ANTHROPIC_BASE_URL', 'OMC_ROUTING_FORCE_INHERIT'];
+
+    beforeEach(() => {
+      for (const key of envKeys) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of envKeys) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = savedEnv[key];
+        }
+      }
+    });
+
+    it('strips model when non-Claude provider auto-enables forceInherit', () => {
+      process.env.CLAUDE_MODEL = 'glm-5';
+      // forceInherit is auto-enabled by loadConfig for non-Claude providers
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'sonnet'
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('inherit');
+      expect(result.modifiedInput.model).toBeUndefined();
+    });
+
+    it('strips model when custom ANTHROPIC_BASE_URL auto-enables forceInherit', () => {
+      process.env.ANTHROPIC_BASE_URL = 'https://my-proxy.example.com/v1';
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:architect',
+        model: 'opus'
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('inherit');
+      expect(result.modifiedInput.model).toBeUndefined();
+    });
+
+    it('does not strip model for standard Claude setup', () => {
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'haiku'
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('haiku');
+      expect(result.modifiedInput.model).toBe('haiku');
     });
   });
 });

--- a/src/__tests__/non-claude-provider-detection.test.ts
+++ b/src/__tests__/non-claude-provider-detection.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for non-Claude provider auto-detection (issue #1201)
+ *
+ * When CC Switch or similar tools route requests to non-Claude providers,
+ * OMC should auto-enable forceInherit to avoid passing Claude-specific
+ * model tier names (sonnet/opus/haiku) that cause 400 errors.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isNonClaudeProvider } from '../config/models.js';
+import { loadConfig } from '../config/loader.js';
+
+describe('isNonClaudeProvider (issue #1201)', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = [
+    'CLAUDE_MODEL',
+    'ANTHROPIC_MODEL',
+    'ANTHROPIC_BASE_URL',
+    'OMC_ROUTING_FORCE_INHERIT',
+  ];
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  it('returns false when no env vars are set (default Claude provider)', () => {
+    expect(isNonClaudeProvider()).toBe(false);
+  });
+
+  it('returns true when CLAUDE_MODEL is a non-Claude model', () => {
+    process.env.CLAUDE_MODEL = 'glm-5';
+    expect(isNonClaudeProvider()).toBe(true);
+  });
+
+  it('returns true when ANTHROPIC_MODEL is a non-Claude model', () => {
+    process.env.ANTHROPIC_MODEL = 'MiniMax-Text-01';
+    expect(isNonClaudeProvider()).toBe(true);
+  });
+
+  it('returns false when CLAUDE_MODEL contains "claude"', () => {
+    process.env.CLAUDE_MODEL = 'claude-sonnet-4-6';
+    expect(isNonClaudeProvider()).toBe(false);
+  });
+
+  it('returns true when ANTHROPIC_BASE_URL is a non-Anthropic URL', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://my-proxy.example.com/v1';
+    expect(isNonClaudeProvider()).toBe(true);
+  });
+
+  it('returns false when ANTHROPIC_BASE_URL is anthropic.com', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1';
+    expect(isNonClaudeProvider()).toBe(false);
+  });
+
+  it('returns true when OMC_ROUTING_FORCE_INHERIT is already true', () => {
+    process.env.OMC_ROUTING_FORCE_INHERIT = 'true';
+    expect(isNonClaudeProvider()).toBe(true);
+  });
+
+  it('detects kimi model as non-Claude', () => {
+    process.env.CLAUDE_MODEL = 'kimi-k2';
+    expect(isNonClaudeProvider()).toBe(true);
+  });
+
+  it('is case-insensitive for Claude detection in model name', () => {
+    process.env.CLAUDE_MODEL = 'Claude-Sonnet-4-6';
+    expect(isNonClaudeProvider()).toBe(false);
+  });
+});
+
+describe('loadConfig auto-enables forceInherit for non-Claude providers (issue #1201)', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = [
+    'CLAUDE_MODEL',
+    'ANTHROPIC_MODEL',
+    'ANTHROPIC_BASE_URL',
+    'OMC_ROUTING_FORCE_INHERIT',
+  ];
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  it('auto-enables forceInherit when CLAUDE_MODEL is non-Claude', () => {
+    process.env.CLAUDE_MODEL = 'glm-5';
+    const config = loadConfig();
+    expect(config.routing?.forceInherit).toBe(true);
+  });
+
+  it('auto-enables forceInherit when ANTHROPIC_BASE_URL is non-Anthropic', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://litellm.example.com/v1';
+    const config = loadConfig();
+    expect(config.routing?.forceInherit).toBe(true);
+  });
+
+  it('does NOT auto-enable forceInherit for default Claude setup', () => {
+    const config = loadConfig();
+    expect(config.routing?.forceInherit).toBe(false);
+  });
+
+  it('respects explicit OMC_ROUTING_FORCE_INHERIT=false even with non-Claude model', () => {
+    process.env.CLAUDE_MODEL = 'glm-5';
+    process.env.OMC_ROUTING_FORCE_INHERIT = 'false';
+    const config = loadConfig();
+    // User explicitly set forceInherit=false, but our auto-detection
+    // checks OMC_ROUTING_FORCE_INHERIT === undefined, so explicit false
+    // means the env config sets it to false, then auto-detect skips
+    // because env var is defined.
+    expect(config.routing?.forceInherit).toBe(false);
+  });
+
+  it('does not double-enable when OMC_ROUTING_FORCE_INHERIT=true is already set', () => {
+    process.env.OMC_ROUTING_FORCE_INHERIT = 'true';
+    const config = loadConfig();
+    expect(config.routing?.forceInherit).toBe(true);
+  });
+});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -16,6 +16,7 @@ import {
   getDefaultModelHigh,
   getDefaultModelMedium,
   getDefaultModelLow,
+  isNonClaudeProvider,
 } from './models.js';
 
 /**
@@ -360,6 +361,22 @@ export function loadConfig(): PluginConfig {
   const envConfig = loadEnvConfig();
   config = deepMerge(config, envConfig);
 
+  // Auto-enable forceInherit for non-Claude providers (issue #1201)
+  // Only auto-enable if user hasn't explicitly set it via config or env var.
+  // When a non-Claude model is detected (CC Switch, LiteLLM, etc.), passing
+  // Claude-specific tier names (sonnet/opus/haiku) to the Agent tool causes
+  // 400 errors because the provider doesn't recognize them.
+  if (
+    config.routing?.forceInherit !== true &&
+    process.env.OMC_ROUTING_FORCE_INHERIT === undefined &&
+    isNonClaudeProvider()
+  ) {
+    config.routing = {
+      ...config.routing,
+      forceInherit: true,
+    };
+  }
+
   return config;
 }
 
@@ -529,7 +546,7 @@ export function generateConfigSchema(): object {
         properties: {
           enabled: { type: 'boolean', default: true, description: 'Enable intelligent model routing' },
           defaultTier: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH'], default: 'MEDIUM', description: 'Default tier when no rules match' },
-          forceInherit: { type: 'boolean', default: false, description: 'Force all agents to inherit the parent model, bypassing OMC model routing. When true, no model parameter is passed to Task calls, so agents use the user\'s Claude Code model setting.' },
+          forceInherit: { type: 'boolean', default: false, description: 'Force all agents to inherit the parent model, bypassing OMC model routing. When true, no model parameter is passed to Task calls, so agents use the user\'s Claude Code model setting. Auto-enabled when a non-Claude provider is detected (CC Switch, custom ANTHROPIC_BASE_URL, etc.).' },
         }
       },
       externalModels: {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -51,3 +51,35 @@ export function getDefaultTierModels(): Record<'LOW' | 'MEDIUM' | 'HIGH', string
     HIGH: getDefaultModelHigh(),
   };
 }
+
+/**
+ * Detect whether the user is running a non-Claude model provider.
+ *
+ * CC Switch and similar tools set CLAUDE_MODEL or ANTHROPIC_MODEL to a
+ * non-Claude model ID (e.g. "glm-5", "MiniMax-Text-01", "kimi-k2").
+ * When a custom ANTHROPIC_BASE_URL is set, the provider is likely not
+ * Anthropic's native API.
+ *
+ * Returns true when OMC should avoid passing Claude-specific model tier
+ * names (sonnet/opus/haiku) to the Agent tool.
+ */
+export function isNonClaudeProvider(): boolean {
+  // Explicit opt-in: user has already set forceInherit via env var
+  if (process.env.OMC_ROUTING_FORCE_INHERIT === 'true') {
+    return true;
+  }
+
+  // Check CLAUDE_MODEL / ANTHROPIC_MODEL for non-Claude model IDs
+  const modelId = process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || '';
+  if (modelId && !modelId.toLowerCase().includes('claude')) {
+    return true;
+  }
+
+  // Custom base URL suggests a proxy/gateway (CC Switch, LiteLLM, OneAPI, etc.)
+  const baseUrl = process.env.ANTHROPIC_BASE_URL || '';
+  if (baseUrl && !baseUrl.includes('anthropic.com')) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Fixes #1201. Adds non-Claude provider detection to auto-enable forceInherit when using third-party models, preventing hardcoded Claude model name issues.