### PR TITLE
fix(lint): replace unsafe Function type in layout-stabilizer tests

### DIFF
--- a/src/team/__tests__/layout-stabilizer.test.ts
+++ b/src/team/__tests__/layout-stabilizer.test.ts
@@ -25,7 +25,7 @@ vi.mock('child_process', () => {
     promisify: vi.fn((fn: unknown) => {
       return (...args: unknown[]) => {
         return new Promise((resolve, reject) => {
-          (fn as Function)(...args, (err: Error | null, result: unknown) => {
+          (fn as (...a: unknown[]) => void)(...args, (err: Error | null, result: unknown) => {
             if (err) reject(err);
             else resolve(result);
           });
@@ -43,7 +43,7 @@ vi.mock('util', async () => {
     promisify: vi.fn((fn: unknown) => {
       return (...args: unknown[]) => {
         return new Promise((resolve, reject) => {
-          (fn as Function)(...args, (err: Error | null, result: unknown) => {
+          (fn as (...a: unknown[]) => void)(...args, (err: Error | null, result: unknown) => {
             if (err) reject(err);
             else resolve(result);
           });


### PR DESCRIPTION
## Summary
- Replace `Function` type casts with `(...a: unknown[]) => void` in `src/team/__tests__/layout-stabilizer.test.ts` (lines 28 and 46)
- Fixes `@typescript-eslint/no-unsafe-function-type` lint errors — the last remaining CI issue on `dev`

## Test plan
- [x] `npm run lint` passes with 0 errors
- [x] Change is minimal (2 lines) and only affects test mock helper casts

🤖 Generated with [Claude Code](https://claude.com/claude-code)