### PR TITLE
fix(routing): add modelAliases config to override agent definition defaults

### DIFF
--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -304,6 +304,115 @@ describe('delegation-enforcer', () => {
     });
   });
 
+  describe('modelAliases config override (issue #1211)', () => {
+    const savedEnv: Record<string, string | undefined> = {};
+    const aliasEnvKeys = ['OMC_MODEL_ALIAS_HAIKU', 'OMC_MODEL_ALIAS_SONNET', 'OMC_MODEL_ALIAS_OPUS'];
+
+    beforeEach(() => {
+      for (const key of aliasEnvKeys) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of aliasEnvKeys) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = savedEnv[key];
+        }
+      }
+    });
+
+    it('remaps haiku agents to inherit via env var', () => {
+      process.env.OMC_MODEL_ALIAS_HAIKU = 'inherit';
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'explore' // explore defaults to haiku
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('inherit');
+      expect(result.modifiedInput.model).toBeUndefined();
+    });
+
+    it('remaps haiku agents to sonnet via env var', () => {
+      process.env.OMC_MODEL_ALIAS_HAIKU = 'sonnet';
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'explore' // explore defaults to haiku
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('sonnet');
+      expect(result.modifiedInput.model).toBe('sonnet');
+    });
+
+    it('does not remap when no alias configured for the tier', () => {
+      process.env.OMC_MODEL_ALIAS_HAIKU = 'sonnet';
+      // executor defaults to sonnet — no alias for sonnet
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'executor'
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('sonnet');
+      expect(result.modifiedInput.model).toBe('sonnet');
+    });
+
+    it('explicit model param takes priority over alias', () => {
+      process.env.OMC_MODEL_ALIAS_HAIKU = 'sonnet';
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'explore',
+        model: 'opus' // explicit param wins
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('opus');
+      expect(result.modifiedInput.model).toBe('opus');
+    });
+
+    it('forceInherit takes priority over alias', () => {
+      process.env.OMC_ROUTING_FORCE_INHERIT = 'true';
+      process.env.OMC_MODEL_ALIAS_HAIKU = 'sonnet';
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'explore'
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('inherit');
+      expect(result.modifiedInput.model).toBeUndefined();
+    });
+
+    it('remaps opus agents to inherit via env var', () => {
+      process.env.OMC_MODEL_ALIAS_OPUS = 'inherit';
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'architect' // architect defaults to opus
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('inherit');
+      expect(result.modifiedInput.model).toBeUndefined();
+    });
+
+    it('includes alias note in debug warning', () => {
+      process.env.OMC_MODEL_ALIAS_HAIKU = 'sonnet';
+      process.env.OMC_DEBUG = 'true';
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'explore'
+      };
+      const result = enforceModel(input);
+      expect(result.warning).toContain('aliased from haiku');
+    });
+  });
+
   describe('non-Claude provider support (issue #1201)', () => {
     const savedEnv: Record<string, string | undefined> = {};
     const envKeys = ['CLAUDE_MODEL', 'ANTHROPIC_BASE_URL', 'OMC_ROUTING_FORCE_INHERIT'];

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -265,6 +265,23 @@ export function loadEnvConfig(): Partial<PluginConfig> {
     }
   }
 
+  // Model alias overrides from environment (issue #1211)
+  const aliasKeys = ['HAIKU', 'SONNET', 'OPUS'] as const;
+  const modelAliases: Record<string, string> = {};
+  for (const key of aliasKeys) {
+    const envVal = process.env[`OMC_MODEL_ALIAS_${key}`];
+    if (envVal) {
+      const lower = key.toLowerCase();
+      modelAliases[lower] = envVal.toLowerCase();
+    }
+  }
+  if (Object.keys(modelAliases).length > 0) {
+    config.routing = {
+      ...config.routing,
+      modelAliases: modelAliases as Record<string, 'haiku' | 'sonnet' | 'opus' | 'inherit'>,
+    };
+  }
+
   if (process.env.OMC_ESCALATION_ENABLED !== undefined) {
     config.routing = {
       ...config.routing,

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -99,10 +99,22 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
     throw new Error(`No default model defined for agent: ${agentType}`);
   }
 
-  // If the agent's default model is 'inherit', don't inject any model parameter.
+  // Apply modelAliases from config (issue #1211).
+  // Priority: explicit param (already handled above) > modelAliases > agent default.
+  // This lets users remap tier names without the nuclear forceInherit option.
+  let resolvedModel: ModelType = agentDef.model;
+  const aliases = config.routing?.modelAliases;
+  if (aliases && agentDef.model !== 'inherit') {
+    const alias = aliases[agentDef.model as keyof typeof aliases];
+    if (alias) {
+      resolvedModel = alias;
+    }
+  }
+
+  // If the resolved model is 'inherit', don't inject any model parameter.
   // This lets the agent inherit the parent session's model, which is essential
   // for non-Claude providers where tier names like 'sonnet' cause 400 errors.
-  if (agentDef.model === 'inherit') {
+  if (resolvedModel === 'inherit') {
     const { model: _existing, ...rest } = agentInput;
     const cleanedInput: AgentInput = rest as AgentInput;
     return {
@@ -114,7 +126,7 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
   }
 
   // Convert ModelType to SDK model type
-  const sdkModel = convertToSdkModel(agentDef.model);
+  const sdkModel = convertToSdkModel(resolvedModel);
 
   // Create modified input with model injected
   const modifiedInput: AgentInput = {
@@ -125,14 +137,17 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
   // Create warning message (only shown if OMC_DEBUG=true)
   let warning: string | undefined;
   if (process.env.OMC_DEBUG === 'true') {
-    warning = `[OMC] Auto-injecting model: ${sdkModel} for ${agentType}`;
+    const aliasNote = resolvedModel !== agentDef.model
+      ? ` (aliased from ${agentDef.model})`
+      : '';
+    warning = `[OMC] Auto-injecting model: ${sdkModel} for ${agentType}${aliasNote}`;
   }
 
   return {
     originalInput: agentInput,
     modifiedInput,
     injected: true,
-    model: agentDef.model,
+    model: resolvedModel,
     warning,
   };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -94,6 +94,21 @@ export interface PluginConfig {
       tier: 'LOW' | 'MEDIUM' | 'HIGH';
       reason: string;
     }>;
+    /**
+     * Model alias overrides.
+     *
+     * Maps agent-definition model tier names to replacement values.
+     * Checked AFTER explicit model params (highest priority) but BEFORE
+     * agent-definition defaults (lowest priority).
+     *
+     * Use cases:
+     * - `{ haiku: 'inherit' }` — haiku agents inherit the parent model
+     *   (useful on non-Anthropic backends without the nuclear forceInherit)
+     * - `{ haiku: 'sonnet' }` — promote all haiku agents to sonnet tier
+     *
+     * Env: OMC_MODEL_ALIAS_HAIKU, OMC_MODEL_ALIAS_SONNET, OMC_MODEL_ALIAS_OPUS
+     */
+    modelAliases?: Partial<Record<'haiku' | 'sonnet' | 'opus', ModelType>>;
     /** Keywords that force escalation to higher tier */
     escalationKeywords?: string[];
     /** Keywords that suggest lower tier */


### PR DESCRIPTION
## Summary

- Adds `routing.modelAliases` config option that lets users remap agent model tier names (haiku/sonnet/opus) to other tiers or `inherit`
- Applies aliases in `enforceModel()` after explicit model params (highest priority) but before agent definition defaults (lowest priority)
- Supports env vars: `OMC_MODEL_ALIAS_HAIKU`, `OMC_MODEL_ALIAS_SONNET`, `OMC_MODEL_ALIAS_OPUS`

**Problem:** Agent definitions hardcode model tier names (e.g., `haiku` for explore). On non-Anthropic backends, these cause API errors. The only workaround was `forceInherit` which strips ALL model params — no fine-grained control.

**Fix:** Users can now selectively remap tiers:
```jsonc
// .claude/omc.jsonc
{
  "routing": {
    "modelAliases": {
      "haiku": "inherit",   // haiku agents inherit parent model
      "opus": "sonnet"      // demote opus agents to sonnet tier
    }
  }
}
```

Or via environment variables:
```bash
export OMC_MODEL_ALIAS_HAIKU=inherit
```

**Priority order:**
1. Explicit `model` param when calling agent (highest)
2. `routing.modelAliases` config mappings
3. Agent definition file default model (lowest)

Closes #1211

## Test plan

- [x] Existing delegation-enforcer tests still pass (26 tests)
- [x] New modelAliases tests cover all scenarios (7 tests):
  - Remap haiku → inherit via env var
  - Remap haiku → sonnet via env var
  - No remap when alias not configured for tier
  - Explicit model param takes priority over alias
  - forceInherit takes priority over alias
  - Remap opus → inherit via env var
  - Debug warning includes alias note
- [x] Related test suites pass: routing-force-inherit (13), config-force-inherit-env (3), delegation-enforcement-levels (63), non-claude-provider-detection (14), pre-tool-enforcer (10), consolidation-contracts (7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)