### PR TITLE
docs: update execution mode options to recommend Team first (#1221)

### DIFF
--- a/docs/shared/mode-selection-guide.md
+++ b/docs/shared/mode-selection-guide.md
@@ -4,79 +4,79 @@
 
 | If you want... | Use this | Keyword |
 |----------------|----------|---------|
+| Multi-agent coordinated execution (recommended) | `team` | "team", "coordinated team" |
 | Full autonomous build from idea | `autopilot` | "autopilot", "build me", "I want a" |
-| Parallel autonomous (3-5x faster) | `ultrapilot` | "ultrapilot", "parallel build" |
 | Persistence until verified done | `ralph` | "ralph", "don't stop" |
 | Parallel execution, manual oversight | `ultrawork` | "ulw", "ultrawork" |
-| Cost-efficient execution | `` (modifier) | "eco", "budget" |
-| Many similar independent tasks | `swarm` | "swarm N agents" |
+| Persistent team execution | `team ralph` | "team ralph" |
 
 ## If You're Confused
 
-**Start with `autopilot`** - it handles most scenarios and transitions to other modes automatically.
+**Start with `team`** — it is the canonical orchestration surface since v4.1.7. It handles most multi-agent scenarios with a staged pipeline (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`) and transitions between stages automatically.
+
+For single-deliverable autonomous builds, use `autopilot`.
 
 ## Detailed Decision Flowchart
 
 ```
-Want autonomous execution?
-├── YES: Is task parallelizable into 3+ independent components?
-│   ├── YES: ultrapilot (parallel autopilot with file ownership)
-│   └── NO: autopilot (sequential with ralph phases)
-└── NO: Want parallel execution with manual oversight?
-    ├── YES: Do you want cost optimization?
-    │   ├── YES:  + ultrawork
-    │   └── NO: ultrawork alone
+Want multi-agent execution?
+├── YES: team (canonical orchestration — staged pipeline with specialized agents)
+│   └── Need persistence until verified? team ralph (adds ralph retry loop)
+└── NO: Want autonomous end-to-end execution?
+    ├── YES: autopilot (sequential with ralph phases)
     └── NO: Want persistence until verified done?
         ├── YES: ralph (persistence + ultrawork + verification)
-        └── NO: Standard orchestration (delegate to agents directly)
-
-Have many similar independent tasks (e.g., "fix 47 errors")?
-└── YES: swarm (N agents claiming from task pool)
+        └── NO: Want parallel execution with manual oversight?
+            ├── YES: ultrawork
+            └── NO: Standard orchestration (delegate to agents directly)
 ```
 
 ## Examples
 
 | User Request | Best Mode | Why |
 |--------------|-----------|-----|
-| "Build me a REST API" | autopilot | Single coherent deliverable |
-| "Build frontend, backend, and database" | ultrapilot | Clear component boundaries |
-| "Fix all 47 TypeScript errors" | swarm | Many independent similar tasks |
-| "Refactor auth module thoroughly" | ralph | Need persistence + verification |
+| "Fix all 47 TypeScript errors" | team | Many subtasks, team decomposes and assigns to workers |
+| "Build frontend, backend, and database" | team | Clear component boundaries, parallel team agents |
+| "Build me a REST API" | autopilot | Single coherent deliverable, autonomous execution |
+| "Refactor auth module thoroughly" | ralph | Need persistence + verification for focused work |
 | "Quick parallel execution" | ultrawork | Manual oversight preferred |
-| "Save tokens while fixing errors" |  + ultrawork | Cost-conscious parallel |
 | "Don't stop until done" | ralph | Persistence keyword detected |
+| "Build complete app with tests and review" | team ralph | Team orchestration + ralph persistence loop |
 
-## Mode Types
+## Mode Categories
 
-### Standalone Modes
-These run independently:
-- **autopilot**: Autonomous end-to-end execution
-- **ultrapilot**: Parallel autonomous with file ownership
-- **swarm**: N-agent coordination with task pool
+### Canonical Orchestration
+- **team**: Multi-agent coordinated execution with staged pipeline. The recommended default for any task that benefits from parallelism or multiple specialized agents. Supports `team ralph` for persistence.
 
-### Wrapper Modes
-These wrap other modes:
-- **ralph**: Adds persistence + verification around ultrawork
+### Autonomous Execution
+- **autopilot**: Autonomous end-to-end execution from idea to working code. Best for single coherent deliverables.
+
+### Persistence + Verification
+- **ralph**: Self-referential loop with verification. Keeps working until the task is verified complete. Includes ultrawork for parallel execution.
 
 ### Component Modes
-These are used by other modes:
-- **ultrawork**: Parallel execution engine (used by ralph, autopilot)
+- **ultrawork**: Parallel execution engine (used by ralph, autopilot, and team internally).
 
-### Modifier Modes
-These modify how other modes work:
-- ****: Changes model routing to prefer cheaper tiers
+### Legacy Facades
+
+> **Note:** The following modes are retained for backward compatibility but route through `team` internally since v4.1.7. Prefer using `team` directly.
+
+- **ultrapilot**: Legacy parallel autonomous mode. Now a facade over `team` with autopilot-style decomposition. Use `team` instead for better control and visibility.
+- **swarm**: Legacy N-agent coordination with SQLite task pool. Now an alias for `team`. Use `team` directly for native Claude Code team tools, task dependencies, and inter-agent communication.
 
 ## Valid Combinations
 
 | Combination | Effect |
 |-------------|--------|
+| `team ralph` | Team orchestration with ralph persistence loop |
 | `eco ralph` | Ralph persistence with cheaper agents |
 | `eco ultrawork` | Parallel execution with cheaper agents |
 | `eco autopilot` | Autonomous execution with cost savings |
+| `eco team` | Team orchestration with cheaper agents |
 
 ## Invalid Combinations
 
 | Combination | Why Invalid |
 |-------------|-------------|
-| `autopilot ultrapilot` | Both are standalone - use one |
+| `autopilot team` | Both are standalone — use `team` for multi-agent, `autopilot` for autonomous |
 | `` alone | Needs an execution mode to modify |

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -91,16 +91,16 @@ Jumping into code without understanding requirements leads to rework, scope cree
    c. Update the plan file in `.omc/plans/` with the accepted improvements (add missing details, refine steps, strengthen acceptance criteria, ADR updates, etc.)
    d. Note which improvements were applied in a brief changelog section at the end of the plan
 7. On Critic approval (with improvements applied): *(--interactive only)* If running with `--interactive`, use `AskUserQuestion` to present the plan with these options:
-   - **Approve and execute** — proceed to implementation via ralph+ultrawork
-   - **Approve and implement via team** — proceed to implementation via coordinated parallel team agents
+   - **Approve and implement via team** (Recommended) — proceed to implementation via coordinated parallel team agents (`/team`). Team is the canonical orchestration surface since v4.1.7.
+   - **Approve and execute via ralph** — proceed to implementation via ralph+ultrawork (sequential execution with verification)
    - **Clear context and implement** — compact the context window first (recommended when context is large after planning), then start fresh implementation via ralph with the saved plan file
    - **Request changes** — return to step 1 with user feedback
    - **Reject** — discard the plan entirely
    If NOT running with `--interactive`, output the final approved plan and stop. Do NOT auto-execute.
 8. *(--interactive only)* User chooses via the structured `AskUserQuestion` UI (never ask for approval in plain text)
 9. On user approval (--interactive only):
-   - **Approve and execute**: **MUST** invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
-   - **Approve and implement via team**: **MUST** invoke `Skill("oh-my-claudecode:team")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. The team skill coordinates parallel agents across the staged pipeline for faster execution on large tasks.
+   - **Approve and implement via team**: **MUST** invoke `Skill("oh-my-claudecode:team")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. The team skill coordinates parallel agents across the staged pipeline for faster execution on large tasks. This is the recommended default execution path.
+   - **Approve and execute via ralph**: **MUST** invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
    - **Clear context and implement**: First invoke `Skill("compact")` to compress the context window (reduces token usage accumulated during planning), then invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/`. This path is recommended when the context window is 50%+ full after the planning session.
 
 ### Review Mode (`--review`)

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -49,9 +49,9 @@ The consensus workflow:
    d. Return to Critic evaluation
    e. Repeat this loop until Critic returns `APPROVE` or 5 iterations are reached
    f. If 5 iterations are reached without `APPROVE`, present the best version to the user
-6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and execute via ralph / Approve and implement via team / Clear context and implement / Request changes / Reject). Final plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups). Otherwise, output the final plan and stop.
-7. *(--interactive only)* User chooses: Approve (ralph or team), Request changes, or Reject
-8. *(--interactive only)* On approval: invoke `Skill("oh-my-claudecode:ralph")` for sequential execution or `Skill("oh-my-claudecode:team")` for parallel team execution -- never implement directly
+6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and implement via team (Recommended) / Approve and execute via ralph / Clear context and implement / Request changes / Reject). Final plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups). Otherwise, output the final plan and stop.
+7. *(--interactive only)* User chooses: Approve (team or ralph), Request changes, or Reject
+8. *(--interactive only)* On approval: invoke `Skill("oh-my-claudecode:team")` for parallel team execution (recommended) or `Skill("oh-my-claudecode:ralph")` for sequential execution -- never implement directly
 
 > **Important:** Steps 3 and 4 MUST run sequentially. Do NOT issue both agent Task calls in the same parallel batch. Always await the Architect result before issuing the Critic Task.
 
@@ -117,8 +117,8 @@ The gate auto-passes when it detects **any** concrete signal. You do not need al
    - **Architect** reviews for soundness
    - **Critic** validates quality and testability
 5. On consensus approval, user chooses execution path:
+   - **team**: parallel coordinated agents (recommended)
    - **ralph**: sequential execution with verification
-   - **team**: parallel coordinated agents
 6. Execution begins with a clear, bounded plan
 
 ### Troubleshooting


### PR DESCRIPTION
## Summary
- Reorder execution mode options in `skills/plan/SKILL.md` step 7 and step 9 to list Team as the first (recommended) option
- Sync option order in `skills/ralplan/SKILL.md` step 6-8 and end-to-end flow example to match
- Rewrite `docs/shared/mode-selection-guide.md` with Team as canonical orchestration mode, mark ultrapilot/swarm as legacy facades

Closes #1221

## Test plan
- [ ] Verify `skills/plan/SKILL.md` step 7 lists "Approve and implement via team (Recommended)" first
- [ ] Verify `skills/ralplan/SKILL.md` step 6 lists "Approve and implement via team (Recommended)" first
- [ ] Verify `docs/shared/mode-selection-guide.md` recommends Team as the default and marks ultrapilot/swarm as legacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)