### PR TITLE
fix(team): disable prompt-mode for codex to fix WebSocket fallback (#1204)

### DIFF
--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -112,10 +112,10 @@ describe('model-contract', () => {
       expect(isPromptModeAgent('claude')).toBe(false);
     });
 
-    it('codex supports prompt mode (positional argument, no flag)', () => {
-      expect(isPromptModeAgent('codex')).toBe(true);
+    it('codex does not support prompt mode (uses interactive inbox trigger)', () => {
+      expect(isPromptModeAgent('codex')).toBe(false);
       const c = getContract('codex');
-      expect(c.supportsPromptMode).toBe(true);
+      expect(c.supportsPromptMode).toBe(false);
       expect(c.promptModeFlag).toBeUndefined();
     });
 
@@ -124,9 +124,9 @@ describe('model-contract', () => {
       expect(args).toEqual(['-p', 'Read inbox']);
     });
 
-    it('getPromptModeArgs returns instruction only (positional) for codex', () => {
+    it('getPromptModeArgs returns empty array for codex', () => {
       const args = getPromptModeArgs('codex', 'Read inbox');
-      expect(args).toEqual(['Read inbox']);
+      expect(args).toEqual([]);
     });
 
     it('getPromptModeArgs returns empty array for non-prompt-mode agents', () => {

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -41,9 +41,9 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     agentType: 'codex',
     binary: 'codex',
     installInstructions: 'Install Codex CLI: npm install -g @openai/codex',
-    supportsPromptMode: true,
-    // Codex accepts prompt as a positional argument (no flag needed):
-    //   codex [OPTIONS] [PROMPT]
+    // Keep Codex on interactive inbox-trigger path (no prompt-mode injection).
+    // See: #1204
+    supportsPromptMode: false,
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
       const args = ['--dangerously-bypass-approvals-and-sandbox'];
       if (model) args.push('--model', model);


### PR DESCRIPTION
## Summary
- Disable prompt-mode injection for Codex workers in team runtime by setting `supportsPromptMode` to `false`
- Keep Gemini prompt-mode behavior unchanged
- Update tests to reflect Codex interactive inbox-trigger path

## Root cause analysis
Issue #1204 reports Codex showing:

> Falling back from WebSockets to HTTPS transport. stream disconnected before completion

This fallback log is emitted by Codex CLI transport layer (not OMC transport code).
However, OMC recently routed Codex through prompt-mode argument injection (`Read and execute your task from: .../inbox.md`) via `supportsPromptMode: true`, which bypassed the prior interactive inbox trigger path and correlated with the reported disconnect/reconnect behavior.

This patch restores Codex to the interactive inbox trigger path while preserving Gemini prompt-mode, reducing behavioral mismatch with Codex TUI/network flow.

## Validation
- Updated model-contract prompt-mode expectations
- Updated runtime prompt-mode tests for Codex interactive notification behavior

## Issue
- Closes #1204
