### PR TITLE
fix(team-runtime): restore robust done.json parsing recovery (#1231)

### DIFF
--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -882,12 +882,26 @@ async function writeJson(filePath, data) {
   await (0, import_promises3.writeFile)(filePath, JSON.stringify(data, null, 2), "utf-8");
 }
 async function readJsonSafe(filePath) {
-  try {
-    const content = await (0, import_promises3.readFile)(filePath, "utf-8");
-    return JSON.parse(content);
-  } catch {
-    return null;
+  const isDoneSignalPath = filePath.endsWith("done.json");
+  const maxAttempts = isDoneSignalPath ? 4 : 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const content = await (0, import_promises3.readFile)(filePath, "utf-8");
+      try {
+        return JSON.parse(content);
+      } catch {
+        if (!isDoneSignalPath || attempt === maxAttempts) {
+          return null;
+        }
+      }
+    } catch {
+      if (!isDoneSignalPath || attempt === maxAttempts) {
+        return null;
+      }
+    }
+    await new Promise((resolve3) => setTimeout(resolve3, 25));
   }
+  return null;
 }
 function parseWorkerIndex(workerNameValue) {
   const match = workerNameValue.match(/^worker-(\d+)$/);

--- a/src/team/__tests__/runtime-done-recovery.test.ts
+++ b/src/team/__tests__/runtime-done-recovery.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const mocks = vi.hoisted(() => ({
+  isWorkerAlive: vi.fn(),
+}));
+
+vi.mock('../tmux-session.js', async () => {
+  const actual = await vi.importActual<typeof import('../tmux-session.js')>('../tmux-session.js');
+  return {
+    ...actual,
+    isWorkerAlive: mocks.isWorkerAlive,
+  };
+});
+
+import { watchdogCliWorkers, type TeamRuntime } from '../runtime.js';
+
+describe('watchdog done.json parsing recovery', () => {
+  beforeEach(() => {
+    mocks.isWorkerAlive.mockReset();
+  });
+
+  it('marks task completed when done.json is briefly malformed before pane-dead check', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'team-runtime-done-recovery-'));
+    const teamName = 'done-recovery-team';
+    const root = join(cwd, '.omc', 'state', 'team', teamName);
+    const tasksDir = join(root, 'tasks');
+    const workerDir = join(root, 'workers', 'worker-1');
+    const donePath = join(workerDir, 'done.json');
+
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(workerDir, { recursive: true });
+
+    writeFileSync(join(tasksDir, '1.json'), JSON.stringify({
+      id: '1',
+      subject: 'Task 1',
+      description: 'desc',
+      status: 'in_progress',
+      owner: 'worker-1',
+      createdAt: new Date().toISOString(),
+      assignedAt: new Date().toISOString(),
+    }), 'utf-8');
+
+    writeFileSync(donePath, '{"taskId":"1","status":"completed","summary":"ok"', 'utf-8');
+
+    // Simulate worker pane already exited. Recovery must come from done.json re-parse.
+    mocks.isWorkerAlive.mockResolvedValue(false);
+
+    const runtime: TeamRuntime = {
+      teamName,
+      sessionName: 'omc-team-test',
+      leaderPaneId: '%0',
+      config: {
+        teamName,
+        workerCount: 1,
+        agentTypes: ['codex'],
+        tasks: [{ subject: 'Task 1', description: 'desc' }],
+        cwd,
+      },
+      workerNames: ['worker-1'],
+      workerPaneIds: ['%1'],
+      activeWorkers: new Map([
+        ['worker-1', { paneId: '%1', taskId: '1', spawnedAt: Date.now() }],
+      ]),
+      cwd,
+    };
+
+    const stop = watchdogCliWorkers(runtime, 20);
+
+    setTimeout(() => {
+      writeFileSync(donePath, JSON.stringify({
+        taskId: '1',
+        status: 'completed',
+        summary: 'done',
+        completedAt: new Date().toISOString(),
+      }), 'utf-8');
+    }, 40);
+
+    await new Promise(resolve => setTimeout(resolve, 220));
+    stop();
+
+    const task = JSON.parse(readFileSync(join(tasksDir, '1.json'), 'utf-8')) as {
+      status: string;
+      summary?: string;
+    };
+
+    expect(task.status).toBe('completed');
+    expect(task.summary).toBe('done');
+    expect(existsSync(donePath)).toBe(false);
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+});

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -105,12 +105,29 @@ async function writeJson(filePath: string, data: unknown): Promise<void> {
 }
 
 async function readJsonSafe<T>(filePath: string): Promise<T | null> {
-  try {
-    const content = await readFile(filePath, 'utf-8');
-    return JSON.parse(content) as T;
-  } catch {
-    return null;
+  const isDoneSignalPath = filePath.endsWith('done.json');
+  const maxAttempts = isDoneSignalPath ? 4 : 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const content = await readFile(filePath, 'utf-8');
+      try {
+        return JSON.parse(content) as T;
+      } catch {
+        if (!isDoneSignalPath || attempt === maxAttempts) {
+          return null;
+        }
+      }
+    } catch {
+      if (!isDoneSignalPath || attempt === maxAttempts) {
+        return null;
+      }
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 25));
   }
+
+  return null;
 }
 
 function parseWorkerIndex(workerNameValue: string): number {


### PR DESCRIPTION
## Summary
- restore robust done.json parsing recovery in the runtime `readJsonSafe` path by adding done-signal retries for transient partial/invalid reads
- keep non-`done.json` behavior unchanged (single-attempt read semantics)
- add a regression test covering malformed-then-valid `done.json` handling in watchdog completion flow

## Test plan
- [x] npm run test:run -- src/team/__tests__/runtime-done-recovery.test.ts
- [x] npm run test:run -- src/team/__tests__/runtime.test.ts src/team/__tests__/runtime-assign.test.ts src/team/__tests__/runtime-prompt-mode.test.ts src/team/__tests__/runtime-done-recovery.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)