### PR TITLE
fix(team-runtime): allow valid launchBinary paths with spaces (#1232)

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -159,6 +159,44 @@ describe('buildWorkerStartCommand', () => {
 
     expect(cmd).toContain('/home/tester/.bashrc');
   });
+
+  it('accepts absolute Windows launchBinary paths with spaces', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    expect(() => buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: { OMC_TEAM_WORKER: 't/w' },
+      launchBinary: 'C:\\Program Files\\OpenAI\\Codex\\codex.exe',
+      launchArgs: ['--full-auto'],
+      cwd: 'C:\\repo'
+    })).not.toThrow();
+  });
+
+  it('rejects relative launchBinary containing spaces', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+
+    expect(() => buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: {},
+      launchBinary: 'Program Files/codex',
+      cwd: '/tmp'
+    })).toThrow('Invalid launchBinary: paths with spaces must be absolute');
+  });
+
+  it('rejects dangerous shell metacharacters in launchBinary', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+
+    expect(() => buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: {},
+      launchBinary: '/usr/bin/codex;touch /tmp/pwn',
+      cwd: '/tmp'
+    })).toThrow('Invalid launchBinary: contains dangerous shell metacharacters');
+  });
 });
 
 describe('shouldAttemptAdaptiveRetry', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -8,7 +8,7 @@
  */
 
 import { exec, execFile, execSync, execFileSync } from 'child_process';
-import { join, basename } from 'path';
+import { join, basename, isAbsolute, win32 } from 'path';
 import { promisify } from 'util';
 import fs from 'fs/promises';
 import { validateTeamName } from './team-name.js';
@@ -84,10 +84,25 @@ function assertSafeEnvKey(key: string): void {
   }
 }
 
-function assertSafeLaunchBinary(binary: string): void {
-  if (/^[A-Za-z0-9._/-]+$/.test(binary)) return;
-  if (/^[A-Za-z]:[\\/][A-Za-z0-9._\\/-]+$/.test(binary)) return;
-  throw new Error(`Invalid launchBinary: "${binary}"`);
+const DANGEROUS_LAUNCH_BINARY_CHARS = /[;&|`$()<>\n\r\t\0]/;
+
+function isAbsoluteLaunchBinaryPath(value: string): boolean {
+  return isAbsolute(value) || win32.isAbsolute(value);
+}
+
+function assertSafeLaunchBinary(launchBinary: string): void {
+  if (launchBinary.trim().length === 0) {
+    throw new Error('Invalid launchBinary: value cannot be empty');
+  }
+  if (launchBinary !== launchBinary.trim()) {
+    throw new Error('Invalid launchBinary: value cannot have leading/trailing whitespace');
+  }
+  if (DANGEROUS_LAUNCH_BINARY_CHARS.test(launchBinary)) {
+    throw new Error('Invalid launchBinary: contains dangerous shell metacharacters');
+  }
+  if (/\s/.test(launchBinary) && !isAbsoluteLaunchBinaryPath(launchBinary)) {
+    throw new Error('Invalid launchBinary: paths with spaces must be absolute');
+  }
 }
 
 function getLaunchWords(config: WorkerPaneConfig): string[] {


### PR DESCRIPTION
## Summary
- allow absolute `launchBinary` paths that include spaces (Windows-style) in team runtime worker launch
- keep command-injection protections by rejecting dangerous shell metacharacters and trimming/empty edge cases
- add regression tests for accepted absolute Windows path with spaces and rejected unsafe/relative-with-spaces cases

## Test plan
- [x] npm run test:run -- src/team/__tests__/tmux-session.test.ts src/team/__tests__/tmux-session.spawn.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)