### PR TITLE
fix(python-repl): fix orphan process and session cleanup issues in windows

### DIFF
--- a/src/tools/python-repl/bridge-manager.ts
+++ b/src/tools/python-repl/bridge-manager.ts
@@ -8,7 +8,7 @@
  * - PID reuse detection via process identity verification
  */
 
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, ChildProcess, execSync } from 'child_process';
 import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
@@ -304,7 +304,7 @@ function killProcessGroup(pid: number, signal: NodeJS.Signals): boolean {
     try {
       const force = signal === 'SIGKILL';
       const args = force ? '/F /T' : '/T';
-      require('child_process').execSync(
+      execSync(
         `taskkill ${args} /PID ${pid}`,
         { stdio: 'ignore', timeout: 5000, windowsHide: true }
       );


### PR DESCRIPTION
bug fix related to python-repl process and session management.

## Orphan processes on Windows (bridge-manager.ts)

killProcessGroup was using an inline require('child_process').execSync to run taskkill.
In certain execution contexts, this inline require could fail silently, causing taskkill to never execute and leaving child processes alive as orphans.

Fixed by replacing the inline require with the named execSync import already declared at the top of the file.