### PR TITLE
fix(team): enable prompt mode for Claude and auto-write done.json on exit

### DIFF
--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -52,8 +52,11 @@ var CONTRACTS = {
     agentType: "claude",
     binary: "claude",
     installInstructions: "Install Claude CLI: https://claude.ai/download",
+    supportsPromptMode: true,
+    // -p in buildLaunchArgs activates print mode (a mode switch, not a prompt flag).
+    // The instruction itself is passed as a trailing positional argument via getPromptModeArgs.
     buildLaunchArgs(model, extraFlags = []) {
-      const args = ["--dangerously-skip-permissions"];
+      const args = ["--dangerously-skip-permissions", "-p"];
       if (model) args.push("--model", model);
       return [...args, ...extraFlags];
     },
@@ -228,7 +231,8 @@ function buildWorkerStartCommand(config) {
     });
     const shellName2 = shellNameFromPath(shell) || "bash";
     const rcFile2 = process.env.HOME ? `${process.env.HOME}/.${shellName2}rc` : "";
-    const script = rcFile2 ? `[ -f ${shellEscape(rcFile2)} ] && . ${shellEscape(rcFile2)}; exec "$@"` : 'exec "$@"';
+    const runCmd = config.postExitCmd ? `"$@"; ${config.postExitCmd}` : 'exec "$@"';
+    const script = rcFile2 ? `[ -f ${shellEscape(rcFile2)} ] && . ${shellEscape(rcFile2)}; ${runCmd}` : runCmd;
     return [
       "env",
       ...envAssignments,
@@ -1281,6 +1285,18 @@ async function spawnWorkerForTask(runtime, workerNameValue, taskIndex) {
     launchArgs,
     cwd: runtime.cwd
   };
+  if (usePromptMode) {
+    const absDonePath = (0, import_path9.join)(runtime.cwd, `.omc/state/team/${runtime.teamName}/workers/${workerNameValue}/done.json`);
+    const escapedDonePath = absDonePath.replace(/'/g, `'\\''`);
+    paneConfig.postExitCmd = [
+      `_omc_rc=$?; _omc_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ);`,
+      `if [ "$_omc_rc" -eq 0 ]; then`,
+      `  printf '{"taskId":"${taskId}","status":"completed","summary":"prompt-mode auto-completion","completedAt":"%s"}' "$_omc_ts" > '${escapedDonePath}';`,
+      `else`,
+      `  printf '{"taskId":"${taskId}","status":"failed","summary":"agent exited with code %s","completedAt":"%s"}' "$_omc_rc" "$_omc_ts" > '${escapedDonePath}';`,
+      `fi`
+    ].join(" ");
+  }
   await spawnWorkerInPane(runtime.sessionName, paneId, paneConfig);
   runtime.workerPaneIds.push(paneId);
   runtime.activeWorkers.set(workerNameValue, { paneId, taskId, spawnedAt: Date.now() });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -33,9 +33,10 @@ describe('model-contract', () => {
   });
 
   describe('buildLaunchArgs', () => {
-    it('claude includes --dangerously-skip-permissions', () => {
+    it('claude includes --dangerously-skip-permissions and -p', () => {
       const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp' });
       expect(args).toContain('--dangerously-skip-permissions');
+      expect(args).toContain('-p');
     });
     it('codex includes --dangerously-bypass-approvals-and-sandbox', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp' });
@@ -108,8 +109,11 @@ describe('model-contract', () => {
       expect(c.promptModeFlag).toBe('-p');
     });
 
-    it('claude does not support prompt mode', () => {
-      expect(isPromptModeAgent('claude')).toBe(false);
+    it('claude supports prompt mode (positional argument, no flag)', () => {
+      expect(isPromptModeAgent('claude')).toBe(true);
+      const c = getContract('claude');
+      expect(c.supportsPromptMode).toBe(true);
+      expect(c.promptModeFlag).toBeUndefined();
     });
 
     it('codex supports prompt mode (positional argument, no flag)', () => {
@@ -129,8 +133,8 @@ describe('model-contract', () => {
       expect(args).toEqual(['Read inbox']);
     });
 
-    it('getPromptModeArgs returns empty array for non-prompt-mode agents', () => {
-      expect(getPromptModeArgs('claude', 'Read inbox')).toEqual([]);
+    it('getPromptModeArgs returns instruction only (positional) for claude', () => {
+      expect(getPromptModeArgs('claude', 'Read inbox')).toEqual(['Read inbox']);
     });
   });
 });

--- a/src/team/__tests__/runtime-prompt-mode.test.ts
+++ b/src/team/__tests__/runtime-prompt-mode.test.ts
@@ -99,7 +99,7 @@ function setupTaskDir(cwd: string): void {
   mkdirSync(workerDir, { recursive: true });
 }
 
-describe('spawnWorkerForTask – prompt mode (Gemini & Codex)', () => {
+describe('spawnWorkerForTask – prompt mode (Gemini, Codex & Claude)', () => {
   let cwd: string;
 
   beforeEach(() => {
@@ -192,6 +192,68 @@ describe('spawnWorkerForTask – prompt mode (Gemini & Codex)', () => {
     );
     // Only one send-keys call: the launch command itself
     expect(sendKeysCalls.length).toBe(1);
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('claude worker launch args include -p flag and positional prompt', async () => {
+    const runtime = makeRuntime(cwd, 'claude');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    // Find the send-keys call that launches the worker (contains -l flag)
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    // Should contain -p flag in buildLaunchArgs (not via promptModeFlag)
+    expect(launchCmd).toContain("'-p'");
+    // Should contain the inbox path as a positional argument
+    expect(launchCmd).toContain('.omc/state/team/test-team/workers/worker-1/inbox.md');
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('claude worker skips interactive send-keys notification (uses prompt mode)', async () => {
+    const runtime = makeRuntime(cwd, 'claude');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    // After the initial launch send-keys, there should be NO follow-up
+    // send-keys with "Read and execute" text (prompt-mode agents skip the
+    // interactive notification path).
+    const sendKeysCalls = tmuxCalls.args.filter(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    // Only one send-keys call: the launch command itself
+    expect(sendKeysCalls.length).toBe(1);
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('prompt-mode agents get postExitCmd in launch command (done.json auto-write)', async () => {
+    const runtime = makeRuntime(cwd, 'gemini');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    // Find the send-keys call that launches the worker (contains -l flag)
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    // Should contain done.json write (postExitCmd) — no 'exec "$@"' since
+    // postExitCmd needs the shell to survive the agent process exit.
+    expect(launchCmd).toContain('done.json');
+    expect(launchCmd).toContain('prompt-mode auto-completion');
+    // Should check exit code to distinguish success vs crash
+    expect(launchCmd).toContain('_omc_rc=$?');
+    expect(launchCmd).toContain('status":"failed"');
+    // Should NOT contain 'exec "$@"' (replaced with "$@"; postExitCmd)
+    expect(launchCmd).not.toContain('exec "$@"');
 
     rmSync(cwd, { recursive: true, force: true });
   });

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -28,8 +28,11 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     agentType: 'claude',
     binary: 'claude',
     installInstructions: 'Install Claude CLI: https://claude.ai/download',
+    supportsPromptMode: true,
+    // -p in buildLaunchArgs activates print mode (a mode switch, not a prompt flag).
+    // The instruction itself is passed as a trailing positional argument via getPromptModeArgs.
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
-      const args = ['--dangerously-skip-permissions'];
+      const args = ['--dangerously-skip-permissions', '-p'];
       if (model) args.push('--model', model);
       return [...args, ...extraFlags];
     },

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -613,6 +613,22 @@ export async function spawnWorkerForTask(
     cwd: runtime.cwd,
   };
 
+  // Auto-write done.json when a prompt-mode agent process exits.
+  // The shell wrapper runs the agent, waits for it to finish, then writes done.json.
+  // Uses exit code to distinguish success vs crash.
+  if (usePromptMode) {
+    const absDonePath = join(runtime.cwd, `.omc/state/team/${runtime.teamName}/workers/${workerNameValue}/done.json`);
+    const escapedDonePath = absDonePath.replace(/'/g, `'\\''`);
+    paneConfig.postExitCmd = [
+      `_omc_rc=$?; _omc_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ);`,
+      `if [ "$_omc_rc" -eq 0 ]; then`,
+      `  printf '{"taskId":"${taskId}","status":"completed","summary":"prompt-mode auto-completion","completedAt":"%s"}' "$_omc_ts" > '${escapedDonePath}';`,
+      `else`,
+      `  printf '{"taskId":"${taskId}","status":"failed","summary":"agent exited with code %s","completedAt":"%s"}' "$_omc_rc" "$_omc_ts" > '${escapedDonePath}';`,
+      `fi`,
+    ].join(' ');
+  }
+
   await spawnWorkerInPane(runtime.sessionName, paneId, paneConfig);
 
   runtime.workerPaneIds.push(paneId);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -57,6 +57,8 @@ export interface WorkerPaneConfig {
   /** @deprecated Prefer launchBinary + launchArgs for safe argv handling */
   launchCmd?: string;
   cwd: string;
+  /** Shell command to run after the main process exits (prompt-mode done.json write) */
+  postExitCmd?: string;
 }
 
 export function getDefaultShell(): string {
@@ -120,9 +122,10 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
 
     const shellName = shellNameFromPath(shell) || 'bash';
     const rcFile = process.env.HOME ? `${process.env.HOME}/.${shellName}rc` : '';
+    const runCmd = config.postExitCmd ? `"$@"; ${config.postExitCmd}` : 'exec "$@"';
     const script = rcFile
-      ? `[ -f ${shellEscape(rcFile)} ] && . ${shellEscape(rcFile)}; exec "$@"`
-      : 'exec "$@"';
+      ? `[ -f ${shellEscape(rcFile)} ] && . ${shellEscape(rcFile)}; ${runCmd}`
+      : runCmd;
 
     return [
       'env',


### PR DESCRIPTION
## Summary

- **Fix Claude task delivery race**: Enable prompt mode (`supportsPromptMode: true`, `-p` flag) for Claude so the task instruction is passed as a CLI argument at launch time, eliminating the 4-second `send-keys` race where Claude would pick up session context before the inbox instruction arrived
- **Fix false task failures for prompt-mode agents**: Add `postExitCmd` to `WorkerPaneConfig` that auto-writes `done.json` after the agent process exits, preventing the watchdog from calling `markTaskFailedDeadPane()` on agents that completed successfully
- **Exit-code awareness**: `postExitCmd` captures `$?` and writes `status: "failed"` with the exit code when an agent crashes (non-zero exit), rather than unconditionally marking as completed
- **Shell safety**: Escape single quotes in `absDonePath` to prevent shell injection if `cwd` contains `'` characters

## Files Changed (6)

| File | Change |
|------|--------|
| `src/team/model-contract.ts` | Add `supportsPromptMode: true`, `-p` to Claude's `buildLaunchArgs` |
| `src/team/tmux-session.ts` | Add `postExitCmd` to `WorkerPaneConfig`, use `"$@"` instead of `exec "$@"` when set |
| `src/team/runtime.ts` | Set `paneConfig.postExitCmd` for prompt-mode agents with exit-code handling |
| `src/team/__tests__/model-contract.test.ts` | Update Claude prompt-mode assertions (3 tests) |
| `src/team/__tests__/runtime-prompt-mode.test.ts` | Add Claude prompt-mode + postExitCmd tests (3 new tests) |
| `bridge/runtime-cli.cjs` | Rebuilt CJS bundle |

## Test plan

- [x] `model-contract.test.ts` — 21/21 passing (Claude now supports prompt mode, `-p` in launch args, positional prompt args)
- [x] `runtime-prompt-mode.test.ts` — 8/8 passing (Claude launch, Claude skip send-keys, postExitCmd with exit-code check)
- [x] Integration: 3-worker health check (1 claude, 1 codex, 1 gemini) — all 3 completed successfully, run twice
- [x] Integration: 3-worker hello-world task — all 3 created output files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)