### PR TITLE
feat(hud): display active profile name for multi-profile users

### DIFF
--- a/src/__tests__/hud/version-display.test.ts
+++ b/src/__tests__/hud/version-display.test.ts
@@ -28,6 +28,7 @@ function createMinimalContext(overrides: Partial<HudRenderContext> = {}): HudRen
     skillCallCount: 0,
     promptTime: null,
     apiKeySource: null,
+    profileName: null,
     ...overrides,
   };
 }

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -34,7 +34,7 @@ import { getRuntimePackageVersion } from "../lib/version.js";
 import { compareVersions } from "../features/auto-update.js";
 import { resolveToWorktreeRoot, resolveTranscriptPath } from "../lib/worktree-paths.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
-import { join } from "path";
+import { join, basename } from "path";
 import { homedir } from "os";
 import { getOmcRoot } from "../lib/worktree-paths.js";
 
@@ -201,6 +201,9 @@ async function main(watchMode = false): Promise<void> {
         : null,
       apiKeySource: config.elements.apiKeySource
         ? detectApiKeySource(cwd)
+        : null,
+      profileName: process.env.CLAUDE_CONFIG_DIR
+        ? basename(process.env.CLAUDE_CONFIG_DIR).replace(/^\./, '')
         : null,
     };
 

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -145,6 +145,11 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
     if (keySource) gitElements.push(keySource);
   }
 
+  // Profile name (from CLAUDE_CONFIG_DIR)
+  if (enabledElements.profile && context.profileName) {
+    gitElements.push(bold(`profile:${context.profileName}`));
+  }
+
   // [OMC#X.Y.Z] label with optional update notification
   if (enabledElements.omcLabel) {
     const versionTag = context.omcVersion ? `#${context.omcVersion}` : '';

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -312,6 +312,9 @@ export interface HudRenderContext {
 
   /** API key source: 'project', 'global', or 'env' */
   apiKeySource: ApiKeySource | null;
+
+  /** Active profile name (derived from CLAUDE_CONFIG_DIR), null if default */
+  profileName: string | null;
 }
 
 // ============================================================================
@@ -381,6 +384,7 @@ export interface HudElementConfig {
   thinking: boolean;          // Show extended thinking indicator
   thinkingFormat: ThinkingFormat;  // Thinking indicator format
   apiKeySource: boolean;       // Show API key source (project/global/env)
+  profile: boolean;            // Show active profile name (from CLAUDE_CONFIG_DIR)
   promptTime: boolean;        // Show last prompt submission time (HH:MM:SS)
   sessionHealth: boolean;     // Show session health/duration
   showSessionDuration?: boolean;  // Show session:19m duration display (default: true if sessionHealth is true)
@@ -449,6 +453,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     thinking: true,
     thinkingFormat: 'text',   // Text format for backward compatibility
     apiKeySource: false, // Disabled by default
+    profile: true,  // Show profile name when CLAUDE_CONFIG_DIR is set
     promptTime: true,  // Show last prompt time by default
     sessionHealth: true,
     useBars: false,  // Disabled by default for backwards compatibility
@@ -494,6 +499,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: false,
     thinkingFormat: 'text',
     apiKeySource: false,
+    profile: true,
     promptTime: false,
     sessionHealth: false,
     useBars: false,
@@ -525,6 +531,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     thinkingFormat: 'text',
     apiKeySource: false,
+    profile: true,
     promptTime: true,
     sessionHealth: true,
     useBars: true,
@@ -556,6 +563,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     thinkingFormat: 'text',
     apiKeySource: true,
+    profile: true,
     promptTime: true,
     sessionHealth: true,
     useBars: true,
@@ -587,6 +595,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     thinkingFormat: 'text',
     apiKeySource: false,
+    profile: true,
     promptTime: true,
     sessionHealth: true,
     useBars: false,
@@ -618,6 +627,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     thinkingFormat: 'text',
     apiKeySource: true,
+    profile: true,
     promptTime: true,
     sessionHealth: true,
     useBars: true,


### PR DESCRIPTION
## Summary

- When `CLAUDE_CONFIG_DIR` is set, the HUD now displays the active profile name (e.g., `profile:claude-personal`) in the git info line
- Helps users quickly identify which profile is active when running multiple Claude Code profiles simultaneously
- Profile name is derived from the `CLAUDE_CONFIG_DIR` basename with leading dot stripped (e.g., `~/.claude-personal` → `claude-personal`)

## Changes

| File | Change |
|------|--------|
| `src/hud/types.ts` | Add `profileName` to `HudRenderContext`, `profile` toggle to `HudElementConfig`, enabled in all presets |
| `src/hud/index.ts` | Compute `profileName` from `CLAUDE_CONFIG_DIR` env var |
| `src/hud/render.ts` | Render profile name in bold in the git info line |
| `src/__tests__/hud/version-display.test.ts` | Add `profileName: null` to test context |

## Motivation

Users who configure multiple Claude Code profiles via `CLAUDE_CONFIG_DIR` (e.g., separate work/personal accounts) have no visual indicator in the HUD showing which profile is active. This makes it easy to confuse sessions, especially when running both profiles simultaneously.

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All HUD tests pass (261/261, 2 pre-existing network failures in usage-api unrelated)
- [x] Manual: `CLAUDE_CONFIG_DIR=~/.claude-personal` → `profile:claude-personal` shown in git info line
- [x] Manual: no `CLAUDE_CONFIG_DIR` → no profile element displayed
- [x] Manual: `settings.json` with `"profile": false` → profile element hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)