### PR TITLE
fix(test): stub TMUX env for tmux-in-tmux test environments

### DIFF
--- a/src/team/__tests__/tmux-session.create-team.test.ts
+++ b/src/team/__tests__/tmux-session.create-team.test.ts
@@ -88,7 +88,8 @@ describe('createTeamSession context resolution', () => {
   });
 
   it('creates a detached session when running outside tmux', async () => {
-    vi.unstubAllEnvs();
+    vi.stubEnv('TMUX', '');
+    vi.stubEnv('TMUX_PANE', '');
 
     const session = await createTeamSession('race-team', 0, '/tmp');
 


### PR DESCRIPTION
## Fix
Stub TMUX and TMUX_PANE environment variables in create-team test to properly simulate outside-tmux conditions.

## Problem
- `vi.unstubAllEnvs()` only removes Vitest stubs, not actual env vars
- Test fails when running inside tmux (CI/dev workflows)

## Solution  
- Use `vi.stubEnv('TMUX', '')` and `vi.stubEnv('TMUX_PANE', '')`
- Test now passes regardless of tmux context

## CI Status
✅ All 5750 tests passing (268 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)