### PR TITLE
docs: fix Ouroboros project links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This release delivers 48 commits of team runtime stability improvements, securit
 
 ### New Features
 
-- **Deep Interview Skill** (#1215): Ouroboros-inspired Socratic questioning skill for requirements elicitation and problem decomposition.
+- **Deep Interview Skill** (#1215): [Ouroboros](https://github.com/Q00/ouroboros)-inspired Socratic questioning skill for requirements elicitation and problem decomposition.
 - **Ralph PRD Mode Mandatory** (#1219): Ralph now auto-generates `prd.json` when none exists, making PRD-driven iteration the default behavior. Stories iterate until all acceptance criteria pass. Opt-out via `--no-prd`.
 - **Factcheck Sentinel Readiness Gate** (#1210): Wired factcheck sentinel readiness gate into team pipeline for improved verification reliability.
 - **Model Aliases Configuration** (#1211, #1213): Added `modelAliases` config to override agent definition defaults for flexible model routing.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -28,7 +28,7 @@ Deep Interview implements Ouroboros-inspired Socratic questioning with mathemati
 <Why_This_Exists>
 AI can build anything. The hard part is knowing what to build. OMC's autopilot Phase 0 expands ideas into specs via analyst + architect, but this single-pass approach struggles with genuinely vague inputs. It asks "what do you want?" instead of "what are you assuming?" Deep Interview applies Socratic methodology to iteratively expose assumptions and mathematically gate readiness, ensuring the AI has genuine clarity before spending execution cycles.
 
-Inspired by the Ouroboros project (github.com/Q00/ouroboros) which demonstrated that specification quality is the primary bottleneck in AI-assisted development.
+Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demonstrated that specification quality is the primary bottleneck in AI-assisted development.
 </Why_This_Exists>
 
 <Execution_Policy>


### PR DESCRIPTION
## Summary

Fix Ouroboros project links in documentation:
- CHANGELOG.md: Add proper markdown link to Q00/ouroboros repo  
- skills/deep-interview/SKILL.md: Convert plain text URL to markdown link

## Changes

- Fixed Ouroboros link format in v4.6.0 release notes
- Fixed Ouroboros reference in deep-interview skill documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)