### PR TITLE
docs: fix Superpowers repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ MIT
 
 <div align="center">
 
-**Inspired by:** [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) • [claude-hud](https://github.com/ryanjoachim/claude-hud) • [Superpowers](https://github.com/NexTechFusion/Superpowers) • [everything-claude-code](https://github.com/affaan-m/everything-claude-code) • [Ouroboros](https://github.com/Q00/ouroboros)
+**Inspired by:** [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) • [claude-hud](https://github.com/ryanjoachim/claude-hud) • [Superpowers](https://github.com/obra/superpowers) • [everything-claude-code](https://github.com/affaan-m/everything-claude-code) • [Ouroboros](https://github.com/Q00/ouroboros)
 
 **Zero learning curve. Maximum power.**
 


### PR DESCRIPTION
## Summary

Fix Superpowers repo link in README.md

## Changes

- Changed: `NexTechFusion/Superpowers` → `obra/superpowers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)