### PR TITLE
docs: add deep-interview workflow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ autopilot: build a REST API for managing tasks
 
 That's it. Everything else is automatic.
 
+### Not Sure Where to Start?
+
+If you're uncertain about requirements, have a vague idea, or want to micromanage the design:
+
+```
+/deep-interview "I want to build a task management app"
+```
+
+The deep interview uses Socratic questioning to clarify your thinking before any code is written. It exposes hidden assumptions and measures clarity across weighted dimensions, ensuring you know exactly what to build before execution begins.
+
 ## Team Mode (Recommended)
 
 Starting in **v4.1.7**, **Team** is the canonical orchestration surface in OMC. Legacy entrypoints like **swarm** and **ultrapilot** are still supported, but they now **route to Team under the hood**.
@@ -175,6 +185,7 @@ Optional shortcuts for power users. Natural language works fine without them.
 | `ulw` | Maximum parallelism | `ulw fix all errors` |
 | `plan` | Planning interview | `plan the API` |
 | `ralplan` | Iterative planning consensus | `ralplan this feature` |
+| `deep-interview` | Socratic requirements clarification | `deep-interview "vague idea"` |
 | `swarm` | Legacy keyword (routes to Team) | `swarm 5 agents: fix lint errors` |
 | `ultrapilot` | Legacy keyword (routes to Team) | `ultrapilot: build a fullstack app` |
 

--- a/docs/partials/mode-selection-guide.md
+++ b/docs/partials/mode-selection-guide.md
@@ -4,6 +4,7 @@
 
 | If you want... | Use this | Keyword |
 |----------------|----------|---------|
+| Clarify vague requirements first | `deep-interview` | "deep interview", "ouroboros", "don't assume" |
 | Full autonomous build from idea | `autopilot` | "autopilot", "build me", "I want a" |
 | Parallel autonomous (3-5x faster) | `ultrapilot` | "ultrapilot", "parallel build" |
 | Persistence until verified done | `ralph` | "ralph", "don't stop" |
@@ -11,9 +12,11 @@
 | Cost-efficient execution | `` (modifier) | "eco", "budget" |
 | Many similar independent tasks | `swarm` | "swarm N agents" |
 
-## If You're Confused
+## If You're Confused or Uncertain
 
-**Start with `autopilot`** - it handles most scenarios and transitions to other modes automatically.
+**Don't know what you don't know?** Start with `/deep-interview` - it uses Socratic questioning to clarify vague ideas, expose hidden assumptions, and measure clarity before any code is written.
+
+**Already have a clear idea?** Start with `autopilot` - it handles most scenarios and transitions to other modes automatically.
 
 ## Detailed Decision Flowchart
 


### PR DESCRIPTION
## Summary

Add workflow guidance recommending `/deep-interview` when users are uncertain about requirements.

## Changes

- README.md: Added "Not Sure Where to Start?" section after Quick Start
- README.md: Added `deep-interview` to Magic Keywords table
- docs/partials/mode-selection-guide.md: Added deep-interview as primary option for uncertain requirements
- docs/partials/mode-selection-guide.md: Clarified "If You're Confused or Uncertain" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)