### PR TITLE
docs: deprecate ultrapilot and swarm modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ Optional shortcuts for power users. Natural language works fine without them.
 | `plan` | Planning interview | `plan the API` |
 | `ralplan` | Iterative planning consensus | `ralplan this feature` |
 | `deep-interview` | Socratic requirements clarification | `deep-interview "vague idea"` |
-| `swarm` | Legacy keyword (routes to Team) | `swarm 5 agents: fix lint errors` |
-| `ultrapilot` | Legacy keyword (routes to Team) | `ultrapilot: build a fullstack app` |
+| `swarm` | **Deprecated** — use `team` instead | `swarm 5 agents: fix lint errors` |
+| `ultrapilot` | **Deprecated** — use `team` instead | `ultrapilot: build a fullstack app` |
 
 **Notes:**
 - **ralph includes ultrawork**: when you activate ralph mode, it automatically includes ultrawork's parallel execution.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -495,8 +495,8 @@ analyze why the tests are failing
 # Autonomous execution
 autopilot: build a todo app with React
 
-# Parallel autopilot
-ultrapilot: build a fullstack todo app
+# Parallel autonomous execution (use team instead of deprecated ultrapilot)
+team 3:deep-executor "build a fullstack todo app"
 
 # Persistence mode
 ralph: refactor the authentication module

--- a/docs/partials/mode-selection-guide.md
+++ b/docs/partials/mode-selection-guide.md
@@ -6,11 +6,13 @@
 |----------------|----------|---------|
 | Clarify vague requirements first | `deep-interview` | "deep interview", "ouroboros", "don't assume" |
 | Full autonomous build from idea | `autopilot` | "autopilot", "build me", "I want a" |
-| Parallel autonomous (3-5x faster) | `ultrapilot` | "ultrapilot", "parallel build" |
+| Parallel autonomous (3-5x faster) | `team` (replaces `ultrapilot`) | `/team N:executor "task"` |
 | Persistence until verified done | `ralph` | "ralph", "don't stop" |
 | Parallel execution, manual oversight | `ultrawork` | "ulw", "ultrawork" |
 | Cost-efficient execution | `` (modifier) | "eco", "budget" |
-| Many similar independent tasks | `swarm` | "swarm N agents" |
+| Many similar independent tasks | `team` (replaces `swarm`) | `/team N:executor "task"` |
+
+> **Note:** `ultrapilot` and `swarm` are **deprecated** — they now route to `team` mode.
 
 ## If You're Confused or Uncertain
 
@@ -21,20 +23,24 @@
 ## Detailed Decision Flowchart
 
 ```
+Uncertain about requirements or have a vague idea?
+├── YES: Use deep-interview to clarify before execution
+└── NO: Continue below
+
 Want autonomous execution?
 ├── YES: Is task parallelizable into 3+ independent components?
-│   ├── YES: ultrapilot (parallel autopilot with file ownership)
+│   ├── YES: team N:deep-executor (parallel autonomous with file ownership)
 │   └── NO: autopilot (sequential with ralph phases)
 └── NO: Want parallel execution with manual oversight?
     ├── YES: Do you want cost optimization?
-    │   ├── YES:  + ultrawork
+    │   ├── YES: eco + ultrawork
     │   └── NO: ultrawork alone
     └── NO: Want persistence until verified done?
         ├── YES: ralph (persistence + ultrawork + verification)
         └── NO: Standard orchestration (delegate to agents directly)
 
 Have many similar independent tasks (e.g., "fix 47 errors")?
-└── YES: swarm (N agents claiming from task pool)
+└── YES: team N:executor (N agents claiming from task pool)
 ```
 
 ## Examples
@@ -42,8 +48,8 @@ Have many similar independent tasks (e.g., "fix 47 errors")?
 | User Request | Best Mode | Why |
 |--------------|-----------|-----|
 | "Build me a REST API" | autopilot | Single coherent deliverable |
-| "Build frontend, backend, and database" | ultrapilot | Clear component boundaries |
-| "Fix all 47 TypeScript errors" | swarm | Many independent similar tasks |
+| "Build frontend, backend, and database" | team 3:deep-executor | Clear component boundaries |
+| "Fix all 47 TypeScript errors" | team 5:executor | Many independent similar tasks |
 | "Refactor auth module thoroughly" | ralph | Need persistence + verification |
 | "Quick parallel execution" | ultrawork | Manual oversight preferred |
 | "Save tokens while fixing errors" |  + ultrawork | Cost-conscious parallel |
@@ -54,8 +60,9 @@ Have many similar independent tasks (e.g., "fix 47 errors")?
 ### Standalone Modes
 These run independently:
 - **autopilot**: Autonomous end-to-end execution
-- **ultrapilot**: Parallel autonomous with file ownership
-- **swarm**: N-agent coordination with task pool
+- **team**: Canonical orchestration with coordinated agents (replaces `ultrapilot` and `swarm`)
+
+> **Deprecated:** `ultrapilot` and `swarm` now route to `team` mode.
 
 ### Wrapper Modes
 These wrap other modes:
@@ -81,5 +88,5 @@ These modify how other modes work:
 
 | Combination | Why Invalid |
 |-------------|-------------|
-| `autopilot ultrapilot` | Both are standalone - use one |
+| `autopilot team` | Both are standalone - use one |
 | `` alone | Needs an execution mode to modify |

--- a/docs/shared/mode-selection-guide.md
+++ b/docs/shared/mode-selection-guide.md
@@ -4,34 +4,43 @@
 
 | If you want... | Use this | Keyword |
 |----------------|----------|---------|
+| Clarify vague requirements first | `deep-interview` | "deep interview", "ouroboros", "don't assume" |
 | Full autonomous build from idea | `autopilot` | "autopilot", "build me", "I want a" |
-| Parallel autonomous (3-5x faster) | `ultrapilot` | "ultrapilot", "parallel build" |
+| Parallel autonomous (3-5x faster) | `team` (replaces `ultrapilot`) | `/team N:executor "task"` |
 | Persistence until verified done | `ralph` | "ralph", "don't stop" |
 | Parallel execution, manual oversight | `ultrawork` | "ulw", "ultrawork" |
 | Cost-efficient execution | `` (modifier) | "eco", "budget" |
-| Many similar independent tasks | `swarm` | "swarm N agents" |
+| Many similar independent tasks | `team` (replaces `swarm`) | `/team N:executor "task"` |
 
-## If You're Confused
+> **Note:** `ultrapilot` and `swarm` are **deprecated** — they now route to `team` mode.
 
-**Start with `autopilot`** - it handles most scenarios and transitions to other modes automatically.
+## If You're Confused or Uncertain
+
+**Don't know what you don't know?** Start with `/deep-interview` - it uses Socratic questioning to clarify vague ideas, expose hidden assumptions, and measure clarity before any code is written.
+
+**Already have a clear idea?** Start with `autopilot` - it handles most scenarios and transitions to other modes automatically.
 
 ## Detailed Decision Flowchart
 
 ```
+Uncertain about requirements or have a vague idea?
+├── YES: Use deep-interview to clarify before execution
+└── NO: Continue below
+
 Want autonomous execution?
 ├── YES: Is task parallelizable into 3+ independent components?
-│   ├── YES: ultrapilot (parallel autopilot with file ownership)
+│   ├── YES: team N:deep-executor (parallel autonomous with file ownership)
 │   └── NO: autopilot (sequential with ralph phases)
 └── NO: Want parallel execution with manual oversight?
     ├── YES: Do you want cost optimization?
-    │   ├── YES:  + ultrawork
+    │   ├── YES: eco + ultrawork
     │   └── NO: ultrawork alone
     └── NO: Want persistence until verified done?
         ├── YES: ralph (persistence + ultrawork + verification)
         └── NO: Standard orchestration (delegate to agents directly)
 
 Have many similar independent tasks (e.g., "fix 47 errors")?
-└── YES: swarm (N agents claiming from task pool)
+└── YES: team N:executor (N agents claiming from task pool)
 ```
 
 ## Examples
@@ -39,8 +48,8 @@ Have many similar independent tasks (e.g., "fix 47 errors")?
 | User Request | Best Mode | Why |
 |--------------|-----------|-----|
 | "Build me a REST API" | autopilot | Single coherent deliverable |
-| "Build frontend, backend, and database" | ultrapilot | Clear component boundaries |
-| "Fix all 47 TypeScript errors" | swarm | Many independent similar tasks |
+| "Build frontend, backend, and database" | team 3:deep-executor | Clear component boundaries |
+| "Fix all 47 TypeScript errors" | team 5:executor | Many independent similar tasks |
 | "Refactor auth module thoroughly" | ralph | Need persistence + verification |
 | "Quick parallel execution" | ultrawork | Manual oversight preferred |
 | "Save tokens while fixing errors" |  + ultrawork | Cost-conscious parallel |
@@ -51,8 +60,9 @@ Have many similar independent tasks (e.g., "fix 47 errors")?
 ### Standalone Modes
 These run independently:
 - **autopilot**: Autonomous end-to-end execution
-- **ultrapilot**: Parallel autonomous with file ownership
-- **swarm**: N-agent coordination with task pool
+- **team**: Canonical orchestration with coordinated agents (replaces `ultrapilot` and `swarm`)
+
+> **Deprecated:** `ultrapilot` and `swarm` now route to `team` mode.
 
 ### Wrapper Modes
 These wrap other modes:
@@ -78,5 +88,5 @@ These modify how other modes work:
 
 | Combination | Why Invalid |
 |-------------|-------------|
-| `autopilot ultrapilot` | Both are standalone - use one |
+| `autopilot team` | Both are standalone - use one |
 | `` alone | Needs an execution mode to modify |


### PR DESCRIPTION
## Summary

Deprecate `ultrapilot` and `swarm` modes in documentation, replacing with `team` mode recommendations.

## Changes

- mode-selection-guide.md (both partials and shared):
  - Add deprecation notice to Quick Decision table
  - Recommend `team` instead of `ultrapilot`/`swarm`
  - Update flowchart to start with deep-interview for uncertain requirements
  - Update examples to use team mode
  - Update Mode Types section

- README.md:
  - Mark `swarm` and `ultrapilot` as deprecated in Magic Keywords table

- REFERENCE.md:
  - Update Magic Keywords examples to use team mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)