### PR TITLE
feat(hud): show explicit error indicator when API rate limit fetch fails

### DIFF
--- a/src/__tests__/hud/limits-error.test.ts
+++ b/src/__tests__/hud/limits-error.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Tests for HUD rate limits error indicator rendering.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderRateLimitsError } from '../../hud/elements/limits.js';
+
+describe('renderRateLimitsError', () => {
+  it('returns null for no_credentials (expected for API key users)', () => {
+    expect(renderRateLimitsError('no_credentials')).toBeNull();
+  });
+
+  it('returns yellow [API err] for network errors', () => {
+    const result = renderRateLimitsError('network');
+    expect(result).not.toBeNull();
+    expect(result).toContain('[API err]');
+    // Verify yellow ANSI color code is present
+    expect(result).toContain('\x1b[33m');
+  });
+
+  it('returns yellow [API auth] for auth errors', () => {
+    const result = renderRateLimitsError('auth');
+    expect(result).not.toBeNull();
+    expect(result).toContain('[API auth]');
+    // Verify yellow ANSI color code is present
+    expect(result).toContain('\x1b[33m');
+  });
+});

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -21,6 +21,10 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 
+vi.mock('child_process', () => ({
+  execSync: vi.fn().mockImplementation(() => { throw new Error('mock: no keychain'); }),
+}));
+
 vi.mock('https', () => ({
   default: {
     request: vi.fn(),
@@ -194,9 +198,10 @@ describe('getUsage routing', () => {
     process.env = { ...originalEnv };
   });
 
-  it('returns null when no credentials and no z.ai env', async () => {
+  it('returns no_credentials error when no credentials and no z.ai env', async () => {
     const result = await getUsage();
-    expect(result).toBeNull();
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('no_credentials');
     // No network call should be made without credentials
     expect(httpsModule.default.request).not.toHaveBeenCalled();
   });
@@ -207,7 +212,8 @@ describe('getUsage routing', () => {
 
     // https.request mock not wired, so fetchUsageFromZai resolves to null
     const result = await getUsage();
-    expect(result).toBeNull();
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('network');
 
     // Verify z.ai quota endpoint was called
     expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
@@ -221,7 +227,8 @@ describe('getUsage routing', () => {
     process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
 
     const result = await getUsage();
-    expect(result).toBeNull();
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('no_credentials');
 
     // Should NOT call https.request with z.ai endpoint.
     // Falls through to OAuth path which has no credentials (mocked),

--- a/src/__tests__/rate-limit-wait/integration.test.ts
+++ b/src/__tests__/rate-limit-wait/integration.test.ts
@@ -51,12 +51,14 @@ describe('Rate Limit Wait Integration Tests', () => {
     it('should detect when 5-hour limit is reached', async () => {
       // Simulate rate limit API response
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 100,
-        weeklyPercent: 75,
-        fiveHourResetsAt: new Date(Date.now() + 3600000),
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        data: {
+          fiveHourPercent: 100,
+          weeklyPercent: 75,
+          fiveHourResetsAt: new Date(Date.now() + 3600000),
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const status = await checkRateLimitStatus();
@@ -71,12 +73,14 @@ describe('Rate Limit Wait Integration Tests', () => {
 
     it('should detect when weekly limit is reached', async () => {
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 50,
-        weeklyPercent: 100,
-        fiveHourResetsAt: null,
-        weeklyResetsAt: new Date(Date.now() + 86400000),
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        data: {
+          fiveHourPercent: 50,
+          weeklyPercent: 100,
+          fiveHourResetsAt: null,
+          weeklyResetsAt: new Date(Date.now() + 86400000),
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const status = await checkRateLimitStatus();
@@ -90,12 +94,14 @@ describe('Rate Limit Wait Integration Tests', () => {
     it('should handle transition from limited to not limited', async () => {
       // First call: limited
       vi.mocked(getUsage).mockResolvedValueOnce({
-        fiveHourPercent: 100,
-        weeklyPercent: 50,
-        fiveHourResetsAt: new Date(Date.now() + 1000),
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        data: {
+          fiveHourPercent: 100,
+          weeklyPercent: 50,
+          fiveHourResetsAt: new Date(Date.now() + 1000),
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const limitedStatus = await checkRateLimitStatus();
@@ -103,12 +109,14 @@ describe('Rate Limit Wait Integration Tests', () => {
 
       // Second call: no longer limited
       vi.mocked(getUsage).mockResolvedValueOnce({
-        fiveHourPercent: 0,
-        weeklyPercent: 50,
-        fiveHourResetsAt: null,
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        data: {
+          fiveHourPercent: 0,
+          weeklyPercent: 50,
+          fiveHourResetsAt: null,
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const clearedStatus = await checkRateLimitStatus();
@@ -316,7 +324,7 @@ Assistant: I can help with more tasks.
 
   describe('Scenario: Error handling and edge cases', () => {
     it('should handle OAuth credentials not available', async () => {
-      vi.mocked(getUsage).mockResolvedValue(null);
+      vi.mocked(getUsage).mockResolvedValue({ data: null, error: 'no_credentials' });
 
       const status = await checkRateLimitStatus();
 

--- a/src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts
+++ b/src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts
@@ -23,8 +23,8 @@ describe('rate-limit-monitor', () => {
   });
 
   describe('checkRateLimitStatus', () => {
-    it('should return null when getUsage returns null', async () => {
-      vi.mocked(getUsage).mockResolvedValue(null);
+    it('should return null when getUsage returns no data', async () => {
+      vi.mocked(getUsage).mockResolvedValue({ data: null, error: 'no_credentials' });
 
       const result = await checkRateLimitStatus();
 
@@ -34,12 +34,14 @@ describe('rate-limit-monitor', () => {
     it('should detect 5-hour rate limit', async () => {
       const resetTime = new Date(Date.now() + 3600000); // 1 hour from now
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 100,
-        weeklyPercent: 50,
-        fiveHourResetsAt: resetTime,
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        data: {
+          fiveHourPercent: 100,
+          weeklyPercent: 50,
+          fiveHourResetsAt: resetTime,
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const result = await checkRateLimitStatus();
@@ -54,12 +56,14 @@ describe('rate-limit-monitor', () => {
     it('should detect weekly rate limit', async () => {
       const resetTime = new Date(Date.now() + 86400000); // 1 day from now
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 50,
-        weeklyPercent: 100,
-        fiveHourResetsAt: null,
-        weeklyResetsAt: resetTime,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        data: {
+          fiveHourPercent: 50,
+          weeklyPercent: 100,
+          fiveHourResetsAt: null,
+          weeklyResetsAt: resetTime,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const result = await checkRateLimitStatus();
@@ -75,12 +79,14 @@ describe('rate-limit-monitor', () => {
       const fiveHourReset = new Date(Date.now() + 3600000); // 1 hour
       const weeklyReset = new Date(Date.now() + 86400000); // 1 day
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 100,
-        weeklyPercent: 100,
-        fiveHourResetsAt: fiveHourReset,
-        weeklyResetsAt: weeklyReset,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        data: {
+          fiveHourPercent: 100,
+          weeklyPercent: 100,
+          fiveHourResetsAt: fiveHourReset,
+          weeklyResetsAt: weeklyReset,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const result = await checkRateLimitStatus();
@@ -94,12 +100,14 @@ describe('rate-limit-monitor', () => {
 
     it('should return not limited when under thresholds', async () => {
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 50,
-        weeklyPercent: 75,
-        fiveHourResetsAt: null,
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        data: {
+          fiveHourPercent: 50,
+          weeklyPercent: 75,
+          fiveHourResetsAt: null,
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const result = await checkRateLimitStatus();

--- a/src/features/rate-limit-wait/rate-limit-monitor.ts
+++ b/src/features/rate-limit-wait/rate-limit-monitor.ts
@@ -18,7 +18,8 @@ const RATE_LIMIT_THRESHOLD = 100;
  */
 export async function checkRateLimitStatus(): Promise<RateLimitStatus | null> {
   try {
-    const usage = await getUsage();
+    const result = await getUsage();
+    const usage = result.data;
 
     if (!usage) {
       // No OAuth credentials or API unavailable

--- a/src/hud/elements/limits.ts
+++ b/src/hud/elements/limits.ts
@@ -5,7 +5,7 @@
  * and custom rate limit buckets from the rateLimitsProvider command.
  */
 
-import type { RateLimits, CustomProviderResult, CustomBucketUsage } from '../types.js';
+import type { RateLimits, CustomProviderResult, CustomBucketUsage, UsageErrorReason } from '../types.js';
 import { RESET } from '../colors.js';
 
 const GREEN = '\x1b[32m';
@@ -184,6 +184,19 @@ export function renderRateLimitsWithBar(
   }
 
   return parts.join(' ');
+}
+
+/**
+ * Render an error indicator when the built-in rate limit API call fails.
+ *
+ * - 'network': API timeout, HTTP error, or parse failure → [API err]
+ * - 'auth': credentials expired, refresh failed → [API auth]
+ * - 'no_credentials': no OAuth credentials (expected for API key users) → null (no display)
+ */
+export function renderRateLimitsError(error: UsageErrorReason): string | null {
+  if (error === 'no_credentials') return null;
+  if (error === 'auth') return `${YELLOW}[API auth]${RESET}`;
+  return `${YELLOW}[API err]${RESET}`;
 }
 
 // ============================================================================

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -140,8 +140,10 @@ async function main(watchMode = false): Promise<void> {
     }
 
     // Fetch rate limits from OAuth API (if available)
-    const rateLimits =
+    const usageResult =
       config.elements.rateLimits !== false ? await getUsage() : null;
+    const rateLimits = usageResult?.data ?? null;
+    const rateLimitsError = usageResult?.error;
 
     // Fetch custom rate limit buckets (if configured)
     const customBuckets =
@@ -184,6 +186,7 @@ async function main(watchMode = false): Promise<void> {
       cwd,
       lastSkill: transcriptData.lastActivatedSkill || null,
       rateLimits,
+      rateLimitsError,
       customBuckets,
       pendingPermission: transcriptData.pendingPermission || null,
       thinkingState: transcriptData.thinkingState || null,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -15,7 +15,7 @@ import { renderSkills, renderLastSkill } from './elements/skills.js';
 import { renderContext, renderContextWithBar } from './elements/context.js';
 import { renderBackground } from './elements/background.js';
 import { renderPrd } from './elements/prd.js';
-import { renderRateLimits, renderRateLimitsWithBar, renderCustomBuckets } from './elements/limits.js';
+import { renderRateLimits, renderRateLimitsWithBar, renderRateLimitsError, renderCustomBuckets } from './elements/limits.js';
 import { renderPermission } from './elements/permission.js';
 import { renderThinking } from './elements/thinking.js';
 import { renderSession } from './elements/session.js';
@@ -156,11 +156,16 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   }
 
   // Rate limits (5h and weekly)
-  if (enabledElements.rateLimits && context.rateLimits) {
-    const limits = enabledElements.useBars
-      ? renderRateLimitsWithBar(context.rateLimits)
-      : renderRateLimits(context.rateLimits);
-    if (limits) elements.push(limits);
+  if (enabledElements.rateLimits) {
+    if (context.rateLimits) {
+      const limits = enabledElements.useBars
+        ? renderRateLimitsWithBar(context.rateLimits)
+        : renderRateLimits(context.rateLimits);
+      if (limits) elements.push(limits);
+    } else if (context.rateLimitsError) {
+      const errorIndicator = renderRateLimitsError(context.rateLimitsError);
+      if (errorIndicator) elements.push(errorIndicator);
+    }
   }
 
   // Custom rate limit buckets

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -174,6 +174,25 @@ export interface RateLimits {
   monthlyResetsAt?: Date | null;
 }
 
+/**
+ * Categorized error reasons for API usage fetch failures.
+ * - 'network': Network error or timeout
+ * - 'auth': Authentication failure (token expired, refresh failed)
+ * - 'no_credentials': No OAuth credentials available (expected for API key users)
+ */
+export type UsageErrorReason = 'network' | 'auth' | 'no_credentials';
+
+/**
+ * Result of fetching usage data from the API.
+ * Wraps RateLimits with error information so the HUD can distinguish
+ * between "no data available" and "API call failed".
+ */
+export interface UsageResult {
+  data: RateLimits | null;
+  /** Error reason when API call fails (undefined on success) */
+  error?: UsageErrorReason;
+}
+
 // ============================================================================
 // Custom Rate Limit Provider
 // ============================================================================
@@ -279,6 +298,9 @@ export interface HudRenderContext {
 
   /** Rate limits (5h and weekly) from built-in Anthropic/z.ai providers */
   rateLimits: RateLimits | null;
+
+  /** Error reason when built-in rate limit API call fails (undefined on success or no credentials) */
+  rateLimitsError?: UsageErrorReason;
 
   /** Custom rate limit buckets from rateLimitsProvider command (null when not configured) */
   customBuckets: CustomProviderResult | null;

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -18,7 +18,7 @@ import { join, dirname } from 'path';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 import https from 'https';
-import type { RateLimits } from './types.js';
+import type { RateLimits, UsageResult } from './types.js';
 
 // Cache configuration
 const CACHE_TTL_SUCCESS_MS = 30 * 1000; // 30 seconds for successful responses
@@ -577,12 +577,14 @@ export function parseZaiResponse(response: ZaiQuotaResponse): RateLimits | null 
 /**
  * Get usage data (with caching)
  *
- * Returns null if:
- * - No OAuth credentials available (API users)
- * - Credentials expired
- * - API call failed
+ * Returns a UsageResult with:
+ * - data: RateLimits on success, null on failure
+ * - error: categorized reason when data is null
+ *   - 'network': API call failed (timeout, HTTP error, parse error)
+ *   - 'auth': credentials expired and refresh failed
+ *   - 'no_credentials': no OAuth credentials available (expected for API key users)
  */
-export async function getUsage(): Promise<RateLimits | null> {
+export async function getUsage(): Promise<UsageResult> {
   const baseUrl = process.env.ANTHROPIC_BASE_URL;
   const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
   const isZai = baseUrl != null && isZaiHost(baseUrl);
@@ -591,7 +593,7 @@ export async function getUsage(): Promise<RateLimits | null> {
   // Check cache first (source must match to avoid cross-provider stale data)
   const cache = readCache();
   if (cache && isCacheValid(cache) && cache.source === currentSource) {
-    return cache.data;
+    return { data: cache.data, error: cache.error && !cache.data ? 'network' : undefined };
   }
 
   // z.ai path (must precede OAuth check to avoid stale Anthropic credentials)
@@ -599,12 +601,12 @@ export async function getUsage(): Promise<RateLimits | null> {
     const response = await fetchUsageFromZai();
     if (!response) {
       writeCache(null, true, 'zai');
-      return null;
+      return { data: null, error: 'network' };
     }
 
     const usage = parseZaiResponse(response);
     writeCache(usage, !usage, 'zai');
-    return usage;
+    return { data: usage, error: usage ? undefined : 'network' };
   }
 
   // Anthropic OAuth path (official Claude Code support)
@@ -620,12 +622,14 @@ export async function getUsage(): Promise<RateLimits | null> {
           // Persist refreshed credentials back to store
           writeBackCredentials(creds);
         } else {
-          // Refresh failed - no credentials available
-          creds = null;
+          // Refresh failed - auth error
+          writeCache(null, true, 'anthropic');
+          return { data: null, error: 'auth' };
         }
       } else {
-        // No refresh token available
-        creds = null;
+        // No refresh token available - auth error
+        writeCache(null, true, 'anthropic');
+        return { data: null, error: 'auth' };
       }
     }
 
@@ -634,16 +638,16 @@ export async function getUsage(): Promise<RateLimits | null> {
       const response = await fetchUsageFromApi(creds.accessToken);
       if (!response) {
         writeCache(null, true, 'anthropic');
-        return null;
+        return { data: null, error: 'network' };
       }
 
       const usage = parseUsageResponse(response);
       writeCache(usage, !usage, 'anthropic');
-      return usage;
+      return { data: usage, error: usage ? undefined : 'network' };
     }
   }
 
-  // No credentials available
+  // No credentials available (expected for API key users)
   writeCache(null, true, 'anthropic');
-  return null;
+  return { data: null, error: 'no_credentials' };
 }


### PR DESCRIPTION
## Summary

When the Anthropic API is unstable (network timeout, HTTP 5xx, auth failure), the HUD rate limit section silently disappears. Users cannot tell if it's a configuration issue or a transient API error.

This PR makes `getUsage()` return a `UsageResult` with categorized error reasons and displays `[API err]` or `[API auth]` in yellow — following the existing `[cmd:err]` pattern from `renderCustomBuckets()`.

No display change when credentials aren't configured (API key users).

## Changes

| File | Change |
|------|--------|
| `src/hud/types.ts` | Add `UsageResult`, `UsageErrorReason` types; add `rateLimitsError` to `HudRenderContext` |
| `src/hud/usage-api.ts` | `getUsage()` returns `UsageResult` with categorized error reasons |
| `src/hud/elements/limits.ts` | Add `renderRateLimitsError()` function |
| `src/hud/render.ts` | Show error indicator when `rateLimitsError` is present |
| `src/hud/index.ts` | Adapt to new `getUsage()` return type |
| `src/features/rate-limit-wait/rate-limit-monitor.ts` | Unwrap `UsageResult.data` for rate limit monitoring |
| Tests (4 files) | Update mock return values; add new `limits-error.test.ts` |

## Before / After

```
# Before (API failure): rate limits section missing entirely
[OMC#4.6.0] | ctx:32%

# After (API failure): explicit yellow indicator
[OMC#4.6.0] | [API err] | ctx:32%

# After (auth failure): specific auth indicator
[OMC#4.6.0] | [API auth] | ctx:32%

# No credentials (unchanged): nothing shown
[OMC#4.6.0] | ctx:32%
```

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All affected tests pass (70/70): `usage-api`, `limits-error`, `render`, `rate-limit-monitor`, `integration`
- [x] New test file `limits-error.test.ts` covers all 3 error states
- [x] No new test failures introduced (verified against main branch baseline)

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)