### PR TITLE
feat(hud): add API error indicator for rate limit fetch failures (issue #1253)

### DIFF
--- a/src/__tests__/hud/rate-limits-error.test.ts
+++ b/src/__tests__/hud/rate-limits-error.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for rate limits error indicator (Issue #1253)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderRateLimitsError } from '../../hud/elements/limits.js';
+import type { UsageResult } from '../../hud/types.js';
+
+describe('renderRateLimitsError', () => {
+  it('returns null when result is null', () => {
+    const result = renderRateLimitsError(null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when result has no error', () => {
+    const usageResult: UsageResult = {
+      rateLimits: {
+        fiveHourPercent: 50,
+        weeklyPercent: 30,
+        fiveHourResetsAt: null,
+        weeklyResetsAt: null,
+      },
+    };
+    const result = renderRateLimitsError(usageResult);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when rateLimits is null but no error', () => {
+    const usageResult: UsageResult = {
+      rateLimits: null,
+    };
+    const result = renderRateLimitsError(usageResult);
+    expect(result).toBeNull();
+  });
+
+  it('returns [API err] in yellow when network error', () => {
+    const usageResult: UsageResult = {
+      rateLimits: null,
+      error: 'network',
+    };
+    const result = renderRateLimitsError(usageResult);
+    expect(result).toContain('[API err]');
+    expect(result).toContain('\x1b[33m'); // Yellow ANSI code
+  });
+
+  it('returns [API err] in yellow when timeout error', () => {
+    const usageResult: UsageResult = {
+      rateLimits: null,
+      error: 'timeout',
+    };
+    const result = renderRateLimitsError(usageResult);
+    expect(result).toContain('[API err]');
+    expect(result).toContain('\x1b[33m'); // Yellow ANSI code
+  });
+
+  it('returns [API err] in yellow when http error', () => {
+    const usageResult: UsageResult = {
+      rateLimits: null,
+      error: 'http',
+    };
+    const result = renderRateLimitsError(usageResult);
+    expect(result).toContain('[API err]');
+    expect(result).toContain('\x1b[33m'); // Yellow ANSI code
+  });
+
+  it('includes reset code in output', () => {
+    const usageResult: UsageResult = {
+      rateLimits: null,
+      error: 'network',
+    };
+    const result = renderRateLimitsError(usageResult);
+    expect(result).toContain('\x1b[0m'); // Reset ANSI code
+  });
+});

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -194,9 +194,9 @@ describe('getUsage routing', () => {
     process.env = { ...originalEnv };
   });
 
-  it('returns null when no credentials and no z.ai env', async () => {
+  it('returns { rateLimits: null } when no credentials and no z.ai env', async () => {
     const result = await getUsage();
-    expect(result).toBeNull();
+    expect(result).toEqual({ rateLimits: null });
     // No network call should be made without credentials
     expect(httpsModule.default.request).not.toHaveBeenCalled();
   });
@@ -205,9 +205,10 @@ describe('getUsage routing', () => {
     process.env.ANTHROPIC_BASE_URL = 'https://api.z.ai/v1';
     process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
 
-    // https.request mock not wired, so fetchUsageFromZai resolves to null
+    // https.request mock not wired, so fetchUsageFromZai resolves to null (network error)
     const result = await getUsage();
-    expect(result).toBeNull();
+    expect(result.rateLimits).toBeNull();
+    expect(result.error).toBe('network');
 
     // Verify z.ai quota endpoint was called
     expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
@@ -221,11 +222,21 @@ describe('getUsage routing', () => {
     process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
 
     const result = await getUsage();
-    expect(result).toBeNull();
+    expect(result).toEqual({ rateLimits: null });
 
     // Should NOT call https.request with z.ai endpoint.
     // Falls through to OAuth path which has no credentials (mocked),
     // so no network call should be made at all.
     expect(httpsModule.default.request).not.toHaveBeenCalled();
+  });
+
+  it('returns error when API call fails', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.z.ai/v1';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
+
+    // Mock failed API response (network error)
+    const result = await getUsage();
+    expect(result.rateLimits).toBeNull();
+    expect(result.error).toBe('network');
   });
 });

--- a/src/__tests__/hud/version-display.test.ts
+++ b/src/__tests__/hud/version-display.test.ts
@@ -16,7 +16,7 @@ function createMinimalContext(overrides: Partial<HudRenderContext> = {}): HudRen
     backgroundTasks: [],
     cwd: '/tmp/test',
     lastSkill: null,
-    rateLimits: null,
+    rateLimitsResult: null,
     customBuckets: null,
     pendingPermission: null,
     thinkingState: null,

--- a/src/__tests__/rate-limit-wait/integration.test.ts
+++ b/src/__tests__/rate-limit-wait/integration.test.ts
@@ -51,12 +51,14 @@ describe('Rate Limit Wait Integration Tests', () => {
     it('should detect when 5-hour limit is reached', async () => {
       // Simulate rate limit API response
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 100,
-        weeklyPercent: 75,
-        fiveHourResetsAt: new Date(Date.now() + 3600000),
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        rateLimits: {
+          fiveHourPercent: 100,
+          weeklyPercent: 75,
+          fiveHourResetsAt: new Date(Date.now() + 3600000),
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const status = await checkRateLimitStatus();
@@ -71,12 +73,14 @@ describe('Rate Limit Wait Integration Tests', () => {
 
     it('should detect when weekly limit is reached', async () => {
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 50,
-        weeklyPercent: 100,
-        fiveHourResetsAt: null,
-        weeklyResetsAt: new Date(Date.now() + 86400000),
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        rateLimits: {
+          fiveHourPercent: 50,
+          weeklyPercent: 100,
+          fiveHourResetsAt: null,
+          weeklyResetsAt: new Date(Date.now() + 86400000),
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const status = await checkRateLimitStatus();
@@ -90,12 +94,14 @@ describe('Rate Limit Wait Integration Tests', () => {
     it('should handle transition from limited to not limited', async () => {
       // First call: limited
       vi.mocked(getUsage).mockResolvedValueOnce({
-        fiveHourPercent: 100,
-        weeklyPercent: 50,
-        fiveHourResetsAt: new Date(Date.now() + 1000),
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        rateLimits: {
+          fiveHourPercent: 100,
+          weeklyPercent: 50,
+          fiveHourResetsAt: new Date(Date.now() + 1000),
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const limitedStatus = await checkRateLimitStatus();
@@ -103,12 +109,14 @@ describe('Rate Limit Wait Integration Tests', () => {
 
       // Second call: no longer limited
       vi.mocked(getUsage).mockResolvedValueOnce({
-        fiveHourPercent: 0,
-        weeklyPercent: 50,
-        fiveHourResetsAt: null,
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        rateLimits: {
+          fiveHourPercent: 0,
+          weeklyPercent: 50,
+          fiveHourResetsAt: null,
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const clearedStatus = await checkRateLimitStatus();
@@ -316,7 +324,7 @@ Assistant: I can help with more tasks.
 
   describe('Scenario: Error handling and edge cases', () => {
     it('should handle OAuth credentials not available', async () => {
-      vi.mocked(getUsage).mockResolvedValue(null);
+      vi.mocked(getUsage).mockResolvedValue({ rateLimits: null });
 
       const status = await checkRateLimitStatus();
 

--- a/src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts
+++ b/src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts
@@ -23,8 +23,8 @@ describe('rate-limit-monitor', () => {
   });
 
   describe('checkRateLimitStatus', () => {
-    it('should return null when getUsage returns null', async () => {
-      vi.mocked(getUsage).mockResolvedValue(null);
+    it('should return null when getUsage returns null rateLimits', async () => {
+      vi.mocked(getUsage).mockResolvedValue({ rateLimits: null });
 
       const result = await checkRateLimitStatus();
 
@@ -34,12 +34,14 @@ describe('rate-limit-monitor', () => {
     it('should detect 5-hour rate limit', async () => {
       const resetTime = new Date(Date.now() + 3600000); // 1 hour from now
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 100,
-        weeklyPercent: 50,
-        fiveHourResetsAt: resetTime,
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        rateLimits: {
+          fiveHourPercent: 100,
+          weeklyPercent: 50,
+          fiveHourResetsAt: resetTime,
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const result = await checkRateLimitStatus();
@@ -54,12 +56,14 @@ describe('rate-limit-monitor', () => {
     it('should detect weekly rate limit', async () => {
       const resetTime = new Date(Date.now() + 86400000); // 1 day from now
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 50,
-        weeklyPercent: 100,
-        fiveHourResetsAt: null,
-        weeklyResetsAt: resetTime,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        rateLimits: {
+          fiveHourPercent: 50,
+          weeklyPercent: 100,
+          fiveHourResetsAt: null,
+          weeklyResetsAt: resetTime,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const result = await checkRateLimitStatus();
@@ -75,12 +79,14 @@ describe('rate-limit-monitor', () => {
       const fiveHourReset = new Date(Date.now() + 3600000); // 1 hour
       const weeklyReset = new Date(Date.now() + 86400000); // 1 day
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 100,
-        weeklyPercent: 100,
-        fiveHourResetsAt: fiveHourReset,
-        weeklyResetsAt: weeklyReset,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        rateLimits: {
+          fiveHourPercent: 100,
+          weeklyPercent: 100,
+          fiveHourResetsAt: fiveHourReset,
+          weeklyResetsAt: weeklyReset,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const result = await checkRateLimitStatus();
@@ -94,12 +100,14 @@ describe('rate-limit-monitor', () => {
 
     it('should return not limited when under thresholds', async () => {
       vi.mocked(getUsage).mockResolvedValue({
-        fiveHourPercent: 50,
-        weeklyPercent: 75,
-        fiveHourResetsAt: null,
-        weeklyResetsAt: null,
-        monthlyPercent: 0,
-        monthlyResetsAt: null,
+        rateLimits: {
+          fiveHourPercent: 50,
+          weeklyPercent: 75,
+          fiveHourResetsAt: null,
+          weeklyResetsAt: null,
+          monthlyPercent: 0,
+          monthlyResetsAt: null,
+        },
       });
 
       const result = await checkRateLimitStatus();

--- a/src/features/rate-limit-wait/rate-limit-monitor.ts
+++ b/src/features/rate-limit-wait/rate-limit-monitor.ts
@@ -18,13 +18,14 @@ const RATE_LIMIT_THRESHOLD = 100;
  */
 export async function checkRateLimitStatus(): Promise<RateLimitStatus | null> {
   try {
-    const usage = await getUsage();
+    const result = await getUsage();
 
-    if (!usage) {
+    if (!result.rateLimits) {
       // No OAuth credentials or API unavailable
       return null;
     }
 
+    const usage = result.rateLimits;
     const fiveHourLimited = (usage.fiveHourPercent ?? 0) >= RATE_LIMIT_THRESHOLD;
     const weeklyLimited = (usage.weeklyPercent ?? 0) >= RATE_LIMIT_THRESHOLD;
     const monthlyLimited = (usage.monthlyPercent ?? 0) >= RATE_LIMIT_THRESHOLD;

--- a/src/hud/elements/limits.ts
+++ b/src/hud/elements/limits.ts
@@ -5,7 +5,7 @@
  * and custom rate limit buckets from the rateLimitsProvider command.
  */
 
-import type { RateLimits, CustomProviderResult, CustomBucketUsage } from '../types.js';
+import type { RateLimits, CustomProviderResult, CustomBucketUsage, UsageResult } from '../types.js';
 import { RESET } from '../colors.js';
 
 const GREEN = '\x1b[32m';
@@ -254,4 +254,16 @@ export function renderCustomBuckets(
   });
 
   return parts.join(' ');
+}
+
+/**
+ * Render rate limits error indicator.
+ * Shows [API err] in yellow when API call fails.
+ *
+ * @param result - The UsageResult containing error information
+ * @returns Error indicator string or null if no error
+ */
+export function renderRateLimitsError(result: UsageResult | null): string | null {
+  if (!result?.error) return null;
+  return `${YELLOW}[API err]${RESET}`;
 }

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -140,7 +140,7 @@ async function main(watchMode = false): Promise<void> {
     }
 
     // Fetch rate limits from OAuth API (if available)
-    const rateLimits =
+    const rateLimitsResult =
       config.elements.rateLimits !== false ? await getUsage() : null;
 
     // Fetch custom rate limit buckets (if configured)
@@ -183,7 +183,7 @@ async function main(watchMode = false): Promise<void> {
       backgroundTasks: getRunningTasks(hudState),
       cwd,
       lastSkill: transcriptData.lastActivatedSkill || null,
-      rateLimits,
+      rateLimitsResult,
       customBuckets,
       pendingPermission: transcriptData.pendingPermission || null,
       thinkingState: transcriptData.thinkingState || null,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -15,7 +15,7 @@ import { renderSkills, renderLastSkill } from './elements/skills.js';
 import { renderContext, renderContextWithBar } from './elements/context.js';
 import { renderBackground } from './elements/background.js';
 import { renderPrd } from './elements/prd.js';
-import { renderRateLimits, renderRateLimitsWithBar, renderCustomBuckets } from './elements/limits.js';
+import { renderRateLimits, renderRateLimitsWithBar, renderCustomBuckets, renderRateLimitsError } from './elements/limits.js';
 import { renderPermission } from './elements/permission.js';
 import { renderThinking } from './elements/thinking.js';
 import { renderSession } from './elements/session.js';
@@ -155,12 +155,17 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
     }
   }
 
-  // Rate limits (5h and weekly)
-  if (enabledElements.rateLimits && context.rateLimits) {
-    const limits = enabledElements.useBars
-      ? renderRateLimitsWithBar(context.rateLimits)
-      : renderRateLimits(context.rateLimits);
-    if (limits) elements.push(limits);
+  // Rate limits (5h and weekly) - show error indicator or data
+  if (enabledElements.rateLimits && context.rateLimitsResult) {
+    const errorIndicator = renderRateLimitsError(context.rateLimitsResult);
+    if (errorIndicator) {
+      elements.push(errorIndicator);
+    } else if (context.rateLimitsResult.rateLimits) {
+      const limits = enabledElements.useBars
+        ? renderRateLimitsWithBar(context.rateLimitsResult.rateLimits)
+        : renderRateLimits(context.rateLimitsResult.rateLimits);
+      if (limits) elements.push(limits);
+    }
   }
 
   // Custom rate limit buckets

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -174,6 +174,16 @@ export interface RateLimits {
   monthlyResetsAt?: Date | null;
 }
 
+/**
+ * Result of fetching usage data from the API.
+ * - rateLimits: The rate limit data (null if no data available)
+ * - error: Set when the API call fails (network/timeout/HTTP error)
+ */
+export interface UsageResult {
+  rateLimits: RateLimits | null;
+  error?: 'network' | 'timeout' | 'http';
+}
+
 // ============================================================================
 // Custom Rate Limit Provider
 // ============================================================================
@@ -277,8 +287,8 @@ export interface HudRenderContext {
   /** Last activated skill from transcript */
   lastSkill: SkillInvocation | null;
 
-  /** Rate limits (5h and weekly) from built-in Anthropic/z.ai providers */
-  rateLimits: RateLimits | null;
+  /** Rate limits result from built-in Anthropic/z.ai providers (includes error state) */
+  rateLimitsResult: UsageResult | null;
 
   /** Custom rate limit buckets from rateLimitsProvider command (null when not configured) */
   customBuckets: CustomProviderResult | null;

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -18,7 +18,7 @@ import { join, dirname } from 'path';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 import https from 'https';
-import type { RateLimits } from './types.js';
+import type { RateLimits, UsageResult } from './types.js';
 
 // Cache configuration
 const CACHE_TTL_SUCCESS_MS = 30 * 1000; // 30 seconds for successful responses
@@ -577,12 +577,14 @@ export function parseZaiResponse(response: ZaiQuotaResponse): RateLimits | null 
 /**
  * Get usage data (with caching)
  *
- * Returns null if:
+ * Returns { rateLimits: null } if:
  * - No OAuth credentials available (API users)
  * - Credentials expired
- * - API call failed
+ *
+ * Returns { rateLimits: null, error: 'network' | 'timeout' | 'http' } if:
+ * - API call failed due to network/timeout/HTTP error
  */
-export async function getUsage(): Promise<RateLimits | null> {
+export async function getUsage(): Promise<UsageResult> {
   const baseUrl = process.env.ANTHROPIC_BASE_URL;
   const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
   const isZai = baseUrl != null && isZaiHost(baseUrl);
@@ -591,7 +593,7 @@ export async function getUsage(): Promise<RateLimits | null> {
   // Check cache first (source must match to avoid cross-provider stale data)
   const cache = readCache();
   if (cache && isCacheValid(cache) && cache.source === currentSource) {
-    return cache.data;
+    return { rateLimits: cache.data };
   }
 
   // z.ai path (must precede OAuth check to avoid stale Anthropic credentials)
@@ -599,12 +601,12 @@ export async function getUsage(): Promise<RateLimits | null> {
     const response = await fetchUsageFromZai();
     if (!response) {
       writeCache(null, true, 'zai');
-      return null;
+      return { rateLimits: null, error: 'network' };
     }
 
     const usage = parseZaiResponse(response);
     writeCache(usage, !usage, 'zai');
-    return usage;
+    return { rateLimits: usage };
   }
 
   // Anthropic OAuth path (official Claude Code support)
@@ -634,16 +636,16 @@ export async function getUsage(): Promise<RateLimits | null> {
       const response = await fetchUsageFromApi(creds.accessToken);
       if (!response) {
         writeCache(null, true, 'anthropic');
-        return null;
+        return { rateLimits: null, error: 'network' };
       }
 
       const usage = parseUsageResponse(response);
       writeCache(usage, !usage, 'anthropic');
-      return usage;
+      return { rateLimits: usage };
     }
   }
 
-  // No credentials available
+  // No credentials available - not an error, just no data
   writeCache(null, true, 'anthropic');
-  return null;
+  return { rateLimits: null };
 }


### PR DESCRIPTION
## Summary

Implements issue #1253: Show explicit error indicator in HUD when API rate limit fetch fails.

**Current behavior:**
- Rate limits section silently disappears on API errors

**Proposed behavior:**
- Show `[API err]` in yellow when API call fails (network/timeout/HTTP error)
- No change when no credentials configured (existing behavior preserved)

## Changes

1. **types.ts**: Added `UsageResult` interface with optional error reason
2. **usage-api.ts**: Changed `getUsage()` to return `UsageResult` instead of `RateLimits | null`
3. **elements/limits.ts**: Added `renderRateLimitsError()` function to display `[API err]` in yellow
4. **render.ts**: Updated to display error indicator when `rateLimitsResult.error` is present
5. **index.ts**: Adapted to use new `rateLimitsResult` field name
6. **Tests**: Updated existing tests and added new error state coverage in `rate-limits-error.test.ts`

## Test Plan

- [x] Build passes (`npm run build`)
- [x] All HUD tests pass (337 tests)
- [x] All rate-limit-wait tests pass
- [x] New error indicator tests added and passing

## Verification

```bash
# Run HUD-specific tests
npm test -- src/__tests__/hud/

# Run rate-limit tests
npm test -- src/__tests__/rate-limit-wait/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)