### PR TITLE
fix: replace TOCTOU existsSync+readFileSync with atomic try/catch ENOENT

### DIFF
--- a/src/features/boulder-state/storage.ts
+++ b/src/features/boulder-state/storage.ts
@@ -6,11 +6,16 @@
  * Ported from oh-my-opencode's boulder-state.
  */
 
-import { existsSync, readFileSync, mkdirSync, readdirSync, statSync, unlinkSync } from 'fs';
-import { dirname, join, basename } from 'path';
-import type { BoulderState, PlanProgress, PlanSummary } from './types.js';
-import { BOULDER_DIR, BOULDER_FILE, PLANNER_PLANS_DIR, PLAN_EXTENSION } from './constants.js';
-import { atomicWriteSync } from '../../lib/atomic-write.js';
+import { readFileSync, mkdirSync, readdirSync, statSync, unlinkSync } from "fs";
+import { dirname, join, basename } from "path";
+import type { BoulderState, PlanProgress, PlanSummary } from "./types.js";
+import {
+  BOULDER_DIR,
+  BOULDER_FILE,
+  PLANNER_PLANS_DIR,
+  PLAN_EXTENSION,
+} from "./constants.js";
+import { atomicWriteSync } from "../../lib/atomic-write.js";
 
 /**
  * Get the full path to the boulder state file
@@ -25,14 +30,13 @@ export function getBoulderFilePath(directory: string): string {
 export function readBoulderState(directory: string): BoulderState | null {
   const filePath = getBoulderFilePath(directory);
 
-  if (!existsSync(filePath)) {
-    return null;
-  }
-
   try {
-    const content = readFileSync(filePath, 'utf-8');
+    const content = readFileSync(filePath, "utf-8");
     return JSON.parse(content) as BoulderState;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
     return null;
   }
 }
@@ -40,14 +44,15 @@ export function readBoulderState(directory: string): BoulderState | null {
 /**
  * Write boulder state to disk
  */
-export function writeBoulderState(directory: string, state: BoulderState): boolean {
+export function writeBoulderState(
+  directory: string,
+  state: BoulderState,
+): boolean {
   const filePath = getBoulderFilePath(directory);
 
   try {
     const dir = dirname(filePath);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-    }
+    mkdirSync(dir, { recursive: true });
 
     atomicWriteSync(filePath, JSON.stringify(state, null, 2));
     return true;
@@ -59,7 +64,10 @@ export function writeBoulderState(directory: string, state: BoulderState): boole
 /**
  * Append a session ID to the boulder state
  */
-export function appendSessionId(directory: string, sessionId: string): BoulderState | null {
+export function appendSessionId(
+  directory: string,
+  sessionId: string,
+): BoulderState | null {
   const state = readBoulderState(directory);
   if (!state) return null;
 
@@ -83,7 +91,7 @@ export function clearBoulderState(directory: string): boolean {
     unlinkSync(filePath);
     return true;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return true; // Already gone — success
     }
     return false;
@@ -97,10 +105,6 @@ export function clearBoulderState(directory: string): boolean {
 export function findPlannerPlans(directory: string): string[] {
   const plansDir = join(directory, PLANNER_PLANS_DIR);
 
-  if (!existsSync(plansDir)) {
-    return [];
-  }
-
   try {
     const files = readdirSync(plansDir);
     return files
@@ -112,7 +116,10 @@ export function findPlannerPlans(directory: string): string[] {
         const bStat = statSync(b);
         return bStat.mtimeMs - aStat.mtimeMs;
       });
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
     return [];
   }
 }
@@ -121,12 +128,8 @@ export function findPlannerPlans(directory: string): string[] {
  * Parse a plan file and count checkbox progress.
  */
 export function getPlanProgress(planPath: string): PlanProgress {
-  if (!existsSync(planPath)) {
-    return { total: 0, completed: 0, isComplete: true };
-  }
-
   try {
-    const content = readFileSync(planPath, 'utf-8');
+    const content = readFileSync(planPath, "utf-8");
 
     // Match markdown checkboxes: - [ ] or - [x] or - [X]
     const uncheckedMatches = content.match(/^[-*]\s*\[\s*\]/gm) || [];
@@ -140,7 +143,10 @@ export function getPlanProgress(planPath: string): PlanProgress {
       completed,
       isComplete: total === 0 || completed === total,
     };
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { total: 0, completed: 0, isComplete: true };
+    }
     return { total: 0, completed: 0, isComplete: true };
   }
 }
@@ -157,7 +163,7 @@ export function getPlanName(planPath: string): string {
  */
 export function createBoulderState(
   planPath: string,
-  sessionId: string
+  sessionId: string,
 ): BoulderState {
   const now = new Date().toISOString();
   return {

--- a/src/features/state-manager/index.ts
+++ b/src/features/state-manager/index.ts
@@ -16,7 +16,11 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { atomicWriteJsonSync } from "../../lib/atomic-write.js";
-import { OmcPaths, getWorktreeRoot, validateWorkingDirectory } from "../../lib/worktree-paths.js";
+import {
+  OmcPaths,
+  getWorktreeRoot,
+  validateWorkingDirectory,
+} from "../../lib/worktree-paths.js";
 import {
   StateLocation,
   StateConfig,
@@ -101,9 +105,7 @@ export function getLegacyPaths(name: string): string[] {
 export function ensureStateDir(location: StateLocation): void {
   const dir =
     location === StateLocation.LOCAL ? getLocalStateDir() : GLOBAL_STATE_DIR;
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  fs.mkdirSync(dir, { recursive: true });
 }
 
 /**
@@ -122,48 +124,56 @@ export function readState<T = StateData>(
   const legacyPaths = checkLegacy ? getLegacyPaths(name) : [];
 
   // Try standard location first
-  if (fs.existsSync(standardPath)) {
-    try {
-      // Get mtime BEFORE reading to prevent TOCTOU cache poisoning.
-      // Previously mtime was read AFTER readFileSync, so a concurrent write
-      // between the two could cache stale data under the new mtime.
-      const statBefore = fs.statSync(standardPath);
-      const mtimeBefore = statBefore.mtimeMs;
+  try {
+    // Get mtime BEFORE reading to prevent TOCTOU cache poisoning.
+    // Previously mtime was read AFTER readFileSync, so a concurrent write
+    // between the two could cache stale data under the new mtime.
+    const statBefore = fs.statSync(standardPath);
+    const mtimeBefore = statBefore.mtimeMs;
 
-      // Check cache: entry exists, mtime matches, TTL not expired
-      const cached = stateCache.get(standardPath);
-      if (cached && cached.mtime === mtimeBefore && (Date.now() - cached.cachedAt) < STATE_CACHE_TTL_MS) {
-        return {
-          exists: true,
-          data: structuredClone(cached.data) as T,
-          foundAt: standardPath,
-          legacyLocations: [],
-        };
-      }
-
-      // Cache miss or stale — read from disk
-      const content = fs.readFileSync(standardPath, "utf-8");
-      const data = JSON.parse(content) as T;
-
-      // Verify mtime unchanged during read to prevent caching inconsistent data.
-      // If the file was modified between our statBefore and readFileSync, we still
-      // return the data but do NOT cache it — the next read will re-read from disk.
-      try {
-        const statAfter = fs.statSync(standardPath);
-        if (statAfter.mtimeMs === mtimeBefore) {
-          stateCache.set(standardPath, { data: structuredClone(data), mtime: mtimeBefore, cachedAt: Date.now() });
-        }
-      } catch {
-        // statSync failed — skip caching, data is still returned
-      }
-
+    // Check cache: entry exists, mtime matches, TTL not expired
+    const cached = stateCache.get(standardPath);
+    if (
+      cached &&
+      cached.mtime === mtimeBefore &&
+      Date.now() - cached.cachedAt < STATE_CACHE_TTL_MS
+    ) {
       return {
         exists: true,
-        data: structuredClone(data) as T,
+        data: structuredClone(cached.data) as T,
         foundAt: standardPath,
         legacyLocations: [],
       };
-    } catch (error) {
+    }
+
+    // Cache miss or stale — read from disk
+    const content = fs.readFileSync(standardPath, "utf-8");
+    const data = JSON.parse(content) as T;
+
+    // Verify mtime unchanged during read to prevent caching inconsistent data.
+    // If the file was modified between our statBefore and readFileSync, we still
+    // return the data but do NOT cache it — the next read will re-read from disk.
+    try {
+      const statAfter = fs.statSync(standardPath);
+      if (statAfter.mtimeMs === mtimeBefore) {
+        stateCache.set(standardPath, {
+          data: structuredClone(data),
+          mtime: mtimeBefore,
+          cachedAt: Date.now(),
+        });
+      }
+    } catch {
+      // statSync failed — skip caching, data is still returned
+    }
+
+    return {
+      exists: true,
+      data: structuredClone(data) as T,
+      foundAt: standardPath,
+      legacyLocations: [],
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       // Invalid JSON or read error - treat as not found
       console.warn(`Failed to read state from ${standardPath}:`, error);
     }
@@ -177,17 +187,17 @@ export function readState<T = StateData>(
         ? legacyPath
         : path.join(getWorktreeRoot() || process.cwd(), legacyPath);
 
-      if (fs.existsSync(resolvedPath)) {
-        try {
-          const content = fs.readFileSync(resolvedPath, "utf-8");
-          const data = JSON.parse(content) as T;
-          return {
-            exists: true,
-            data: structuredClone(data) as T,
-            foundAt: resolvedPath,
-            legacyLocations: legacyPaths,
-          };
-        } catch (error) {
+      try {
+        const content = fs.readFileSync(resolvedPath, "utf-8");
+        const data = JSON.parse(content) as T;
+        return {
+          exists: true,
+          data: structuredClone(data) as T,
+          foundAt: resolvedPath,
+          legacyLocations: legacyPaths,
+        };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
           console.warn(
             `Failed to read legacy state from ${resolvedPath}:`,
             error,
@@ -275,17 +285,17 @@ export function clearState(
   for (const loc of locationsToCheck) {
     const standardPath = getStatePath(name, loc);
     try {
-      if (fs.existsSync(standardPath)) {
-        fs.unlinkSync(standardPath);
-        result.removed.push(standardPath);
-      } else {
-        result.notFound.push(standardPath);
-      }
+      fs.unlinkSync(standardPath);
+      result.removed.push(standardPath);
     } catch (error) {
-      result.errors.push({
-        path: standardPath,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        result.notFound.push(standardPath);
+      } else {
+        result.errors.push({
+          path: standardPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 
@@ -297,17 +307,17 @@ export function clearState(
       : path.join(getWorktreeRoot() || process.cwd(), legacyPath);
 
     try {
-      if (fs.existsSync(resolvedPath)) {
-        fs.unlinkSync(resolvedPath);
-        result.removed.push(resolvedPath);
-      } else {
-        result.notFound.push(resolvedPath);
-      }
+      fs.unlinkSync(resolvedPath);
+      result.removed.push(resolvedPath);
     } catch (error) {
-      result.errors.push({
-        path: resolvedPath,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        result.notFound.push(resolvedPath);
+      } else {
+        result.errors.push({
+          path: resolvedPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 
@@ -583,9 +593,16 @@ export function cleanupStaleStates(
 
           if (data.active !== true) continue;
 
-          const meta = (data._meta as Record<string, unknown> | undefined) ?? {};
+          const meta =
+            (data._meta as Record<string, unknown> | undefined) ?? {};
 
-          if (isStateStale(meta as { updatedAt?: string; heartbeatAt?: string }, now, maxAgeMs)) {
+          if (
+            isStateStale(
+              meta as { updatedAt?: string; heartbeatAt?: string },
+              now,
+              maxAgeMs,
+            )
+          ) {
             console.warn(
               `[state-manager] cleanupStaleStates: marking "${file}" inactive (last updated ${meta.updatedAt ?? "unknown"})`,
             );
@@ -595,7 +612,9 @@ export function cleanupStaleStates(
             try {
               atomicWriteJsonSync(filePath, data);
               cleaned++;
-            } catch { /* best-effort */ }
+            } catch {
+              /* best-effort */
+            }
           }
         } catch {
           // Skip files that can't be read/parsed
@@ -613,7 +632,9 @@ export function cleanupStaleStates(
   const sessionsDir = path.join(stateDir, "sessions");
   if (fs.existsSync(sessionsDir)) {
     try {
-      const sessionEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+      const sessionEntries = fs.readdirSync(sessionsDir, {
+        withFileTypes: true,
+      });
       for (const entry of sessionEntries) {
         if (entry.isDirectory()) {
           scanDir(path.join(sessionsDir, entry.name));
@@ -663,7 +684,11 @@ function withFileLock<R>(filePath: string, fn: () => R): R {
       try {
         const lockStat = fs.statSync(lockPath);
         if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
-          try { fs.unlinkSync(lockPath); } catch { /* race OK */ }
+          try {
+            fs.unlinkSync(lockPath);
+          } catch {
+            /* race OK */
+          }
           continue;
         }
       } catch {
@@ -677,14 +702,20 @@ function withFileLock<R>(filePath: string, fn: () => R): R {
 
       // Brief busy-wait before retry
       const waitEnd = Date.now() + LOCK_POLL_MS;
-      while (Date.now() < waitEnd) { /* spin */ }
+      while (Date.now() < waitEnd) {
+        /* spin */
+      }
     }
   }
 
   try {
     return fn();
   } finally {
-    try { fs.unlinkSync(lockPath); } catch { /* best-effort */ }
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      /* best-effort */
+    }
   }
 }
 

--- a/src/hooks/autopilot/state.ts
+++ b/src/hooks/autopilot/state.ts
@@ -7,26 +7,37 @@
  * - State machine operations
  */
 
-import { existsSync, mkdirSync, statSync } from 'fs';
-import { join } from 'path';
-import { writeModeState, readModeState, clearModeStateFile } from '../../lib/mode-state-io.js';
-import { resolveStatePath, resolveSessionStatePath } from '../../lib/worktree-paths.js';
-import type { AutopilotState, AutopilotPhase, AutopilotConfig } from './types.js';
-import { DEFAULT_CONFIG } from './types.js';
+import { mkdirSync, statSync } from "fs";
+import { join } from "path";
+import {
+  writeModeState,
+  readModeState,
+  clearModeStateFile,
+} from "../../lib/mode-state-io.js";
+import {
+  resolveStatePath,
+  resolveSessionStatePath,
+} from "../../lib/worktree-paths.js";
+import type {
+  AutopilotState,
+  AutopilotPhase,
+  AutopilotConfig,
+} from "./types.js";
+import { DEFAULT_CONFIG } from "./types.js";
 import {
   readRalphState,
   clearRalphState,
-  clearLinkedUltraworkState
-} from '../ralph/index.js';
+  clearLinkedUltraworkState,
+} from "../ralph/index.js";
 import {
   startUltraQA,
   clearUltraQAState,
-  readUltraQAState
-} from '../ultraqa/index.js';
-import { canStartMode } from '../mode-registry/index.js';
-import { getOmcRoot } from '../../lib/worktree-paths.js';
+  readUltraQAState,
+} from "../ultraqa/index.js";
+import { canStartMode } from "../mode-registry/index.js";
+import { getOmcRoot } from "../../lib/worktree-paths.js";
 
-const SPEC_DIR = 'autopilot';
+const SPEC_DIR = "autopilot";
 
 // ============================================================================
 // STATE MANAGEMENT
@@ -37,20 +48,30 @@ const SPEC_DIR = 'autopilot';
  */
 export function ensureAutopilotDir(directory: string): string {
   const autopilotDir = join(getOmcRoot(directory), SPEC_DIR);
-  if (!existsSync(autopilotDir)) {
-    mkdirSync(autopilotDir, { recursive: true });
-  }
+  mkdirSync(autopilotDir, { recursive: true });
   return autopilotDir;
 }
 
 /**
  * Read autopilot state from disk
  */
-export function readAutopilotState(directory: string, sessionId?: string): AutopilotState | null {
-  const state = readModeState<AutopilotState>('autopilot', directory, sessionId);
+export function readAutopilotState(
+  directory: string,
+  sessionId?: string,
+): AutopilotState | null {
+  const state = readModeState<AutopilotState>(
+    "autopilot",
+    directory,
+    sessionId,
+  );
 
   // Validate session identity
-  if (state && sessionId && state.session_id && state.session_id !== sessionId) {
+  if (
+    state &&
+    sessionId &&
+    state.session_id &&
+    state.session_id !== sessionId
+  ) {
     return null;
   }
 
@@ -60,30 +81,47 @@ export function readAutopilotState(directory: string, sessionId?: string): Autop
 /**
  * Write autopilot state to disk
  */
-export function writeAutopilotState(directory: string, state: AutopilotState, sessionId?: string): boolean {
-  return writeModeState('autopilot', state as unknown as Record<string, unknown>, directory, sessionId);
+export function writeAutopilotState(
+  directory: string,
+  state: AutopilotState,
+  sessionId?: string,
+): boolean {
+  return writeModeState(
+    "autopilot",
+    state as unknown as Record<string, unknown>,
+    directory,
+    sessionId,
+  );
 }
 
 /**
  * Clear autopilot state
  */
-export function clearAutopilotState(directory: string, sessionId?: string): boolean {
-  return clearModeStateFile('autopilot', directory, sessionId);
+export function clearAutopilotState(
+  directory: string,
+  sessionId?: string,
+): boolean {
+  return clearModeStateFile("autopilot", directory, sessionId);
 }
 
 /**
  * Get the age of the autopilot state file in milliseconds.
  * Returns null if no state file exists.
  */
-export function getAutopilotStateAge(directory: string, sessionId?: string): number | null {
+export function getAutopilotStateAge(
+  directory: string,
+  sessionId?: string,
+): number | null {
   const stateFile = sessionId
-    ? resolveSessionStatePath('autopilot', sessionId, directory)
-    : resolveStatePath('autopilot', directory);
-  if (!existsSync(stateFile)) return null;
+    ? resolveSessionStatePath("autopilot", sessionId, directory)
+    : resolveStatePath("autopilot", directory);
   try {
     const stats = statSync(stateFile);
     return Date.now() - stats.mtimeMs;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
     return null;
   }
 }
@@ -91,7 +129,10 @@ export function getAutopilotStateAge(directory: string, sessionId?: string): num
 /**
  * Check if autopilot is active
  */
-export function isAutopilotActive(directory: string, sessionId?: string): boolean {
+export function isAutopilotActive(
+  directory: string,
+  sessionId?: string,
+): boolean {
   const state = readAutopilotState(directory, sessionId);
   return state !== null && state.active === true;
 }
@@ -103,10 +144,10 @@ export function initAutopilot(
   directory: string,
   idea: string,
   sessionId?: string,
-  config?: Partial<AutopilotConfig>
+  config?: Partial<AutopilotConfig>,
 ): AutopilotState | null {
   // Mutual exclusion check via mode-registry
-  const canStart = canStartMode('autopilot', directory);
+  const canStart = canStartMode("autopilot", directory);
   if (!canStart.allowed) {
     console.error(canStart.message);
     return null;
@@ -117,7 +158,7 @@ export function initAutopilot(
 
   const state: AutopilotState = {
     active: true,
-    phase: 'expansion',
+    phase: "expansion",
     iteration: 1,
     max_iterations: mergedConfig.maxIterations ?? 10,
     originalIdea: idea,
@@ -126,14 +167,14 @@ export function initAutopilot(
       analyst_complete: false,
       architect_complete: false,
       spec_path: null,
-      requirements_summary: '',
-      tech_stack: []
+      requirements_summary: "",
+      tech_stack: [],
     },
 
     planning: {
       plan_path: null,
       architect_iterations: 0,
-      approved: false
+      approved: false,
     },
 
     execution: {
@@ -142,21 +183,21 @@ export function initAutopilot(
       tasks_completed: 0,
       tasks_total: 0,
       files_created: [],
-      files_modified: []
+      files_modified: [],
     },
 
     qa: {
       ultraqa_cycles: 0,
-      build_status: 'pending',
-      lint_status: 'pending',
-      test_status: 'pending'
+      build_status: "pending",
+      lint_status: "pending",
+      test_status: "pending",
     },
 
     validation: {
       architects_spawned: 0,
       verdicts: [],
       all_approved: false,
-      validation_rounds: 0
+      validation_rounds: 0,
     },
 
     started_at: now,
@@ -165,7 +206,7 @@ export function initAutopilot(
     total_agents_spawned: 0,
     wisdom_entries: 0,
     session_id: sessionId,
-    project_path: directory
+    project_path: directory,
   };
 
   ensureAutopilotDir(directory);
@@ -180,7 +221,7 @@ export function initAutopilot(
 export function transitionPhase(
   directory: string,
   newPhase: AutopilotPhase,
-  sessionId?: string
+  sessionId?: string,
 ): AutopilotState | null {
   const state = readAutopilotState(directory, sessionId);
 
@@ -202,7 +243,7 @@ export function transitionPhase(
   state.phase = newPhase;
   state.phase_durations[`${newPhase}_start_ms`] = Date.now();
 
-  if (newPhase === 'complete' || newPhase === 'failed') {
+  if (newPhase === "complete" || newPhase === "failed") {
     state.completed_at = now;
     state.active = false;
   }
@@ -214,7 +255,11 @@ export function transitionPhase(
 /**
  * Increment the agent spawn counter
  */
-export function incrementAgentCount(directory: string, count: number = 1, sessionId?: string): boolean {
+export function incrementAgentCount(
+  directory: string,
+  count: number = 1,
+  sessionId?: string,
+): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
 
@@ -227,8 +272,8 @@ export function incrementAgentCount(directory: string, count: number = 1, sessio
  */
 export function updateExpansion(
   directory: string,
-  updates: Partial<AutopilotState['expansion']>,
-  sessionId?: string
+  updates: Partial<AutopilotState["expansion"]>,
+  sessionId?: string,
 ): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
@@ -242,8 +287,8 @@ export function updateExpansion(
  */
 export function updatePlanning(
   directory: string,
-  updates: Partial<AutopilotState['planning']>,
-  sessionId?: string
+  updates: Partial<AutopilotState["planning"]>,
+  sessionId?: string,
 ): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
@@ -257,8 +302,8 @@ export function updatePlanning(
  */
 export function updateExecution(
   directory: string,
-  updates: Partial<AutopilotState['execution']>,
-  sessionId?: string
+  updates: Partial<AutopilotState["execution"]>,
+  sessionId?: string,
 ): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
@@ -272,8 +317,8 @@ export function updateExecution(
  */
 export function updateQA(
   directory: string,
-  updates: Partial<AutopilotState['qa']>,
-  sessionId?: string
+  updates: Partial<AutopilotState["qa"]>,
+  sessionId?: string,
 ): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
@@ -287,8 +332,8 @@ export function updateQA(
  */
 export function updateValidation(
   directory: string,
-  updates: Partial<AutopilotState['validation']>,
-  sessionId?: string
+  updates: Partial<AutopilotState["validation"]>,
+  sessionId?: string,
 ): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
@@ -301,14 +346,14 @@ export function updateValidation(
  * Get the spec file path
  */
 export function getSpecPath(directory: string): string {
-  return join(getOmcRoot(directory), SPEC_DIR, 'spec.md');
+  return join(getOmcRoot(directory), SPEC_DIR, "spec.md");
 }
 
 /**
  * Get the plan file path
  */
 export function getPlanPath(directory: string): string {
-  return join(getOmcRoot(directory), 'plans', 'autopilot-impl.md');
+  return join(getOmcRoot(directory), "plans", "autopilot-impl.md");
 }
 
 // ============================================================================
@@ -332,30 +377,35 @@ export interface TransitionResult {
  */
 export function transitionRalphToUltraQA(
   directory: string,
-  sessionId: string
+  sessionId: string,
 ): TransitionResult {
   const autopilotState = readAutopilotState(directory, sessionId);
 
-  if (!autopilotState || autopilotState.phase !== 'execution') {
+  if (!autopilotState || autopilotState.phase !== "execution") {
     return {
       success: false,
-      error: 'Not in execution phase - cannot transition to QA'
+      error: "Not in execution phase - cannot transition to QA",
     };
   }
 
   const ralphState = readRalphState(directory, sessionId);
 
   // Step 1: Preserve Ralph progress in autopilot state
-  const executionUpdated = updateExecution(directory, {
-    ralph_iterations: ralphState?.iteration ?? autopilotState.execution.ralph_iterations,
-    ralph_completed_at: new Date().toISOString(),
-    ultrawork_active: false
-  }, sessionId);
+  const executionUpdated = updateExecution(
+    directory,
+    {
+      ralph_iterations:
+        ralphState?.iteration ?? autopilotState.execution.ralph_iterations,
+      ralph_completed_at: new Date().toISOString(),
+      ultrawork_active: false,
+    },
+    sessionId,
+  );
 
   if (!executionUpdated) {
     return {
       success: false,
-      error: 'Failed to update execution state'
+      error: "Failed to update execution state",
     };
   }
 
@@ -368,36 +418,38 @@ export function transitionRalphToUltraQA(
   if (!ralphCleared) {
     return {
       success: false,
-      error: 'Failed to clear Ralph state'
+      error: "Failed to clear Ralph state",
     };
   }
 
   // Step 3: Transition to QA phase
-  const newState = transitionPhase(directory, 'qa', sessionId);
+  const newState = transitionPhase(directory, "qa", sessionId);
   if (!newState) {
     return {
       success: false,
-      error: 'Failed to transition to QA phase'
+      error: "Failed to transition to QA phase",
     };
   }
 
   // Step 4: Start UltraQA
-  const qaResult = startUltraQA(directory, 'tests', sessionId, { maxCycles: 5 });
+  const qaResult = startUltraQA(directory, "tests", sessionId, {
+    maxCycles: 5,
+  });
 
   if (!qaResult.success) {
     // Rollback on failure - restore execution phase
-    transitionPhase(directory, 'execution', sessionId);
+    transitionPhase(directory, "execution", sessionId);
     updateExecution(directory, { ralph_completed_at: undefined }, sessionId);
 
     return {
       success: false,
-      error: qaResult.error || 'Failed to start UltraQA'
+      error: qaResult.error || "Failed to start UltraQA",
     };
   }
 
   return {
     success: true,
-    state: newState
+    state: newState,
   };
 }
 
@@ -406,29 +458,33 @@ export function transitionRalphToUltraQA(
  */
 export function transitionUltraQAToValidation(
   directory: string,
-  sessionId?: string
+  sessionId?: string,
 ): TransitionResult {
   const autopilotState = readAutopilotState(directory, sessionId);
 
-  if (!autopilotState || autopilotState.phase !== 'qa') {
+  if (!autopilotState || autopilotState.phase !== "qa") {
     return {
       success: false,
-      error: 'Not in QA phase - cannot transition to validation'
+      error: "Not in QA phase - cannot transition to validation",
     };
   }
 
   const qaState = readUltraQAState(directory, sessionId);
 
   // Preserve QA progress
-  const qaUpdated = updateQA(directory, {
-    ultraqa_cycles: qaState?.cycle ?? autopilotState.qa.ultraqa_cycles,
-    qa_completed_at: new Date().toISOString()
-  }, sessionId);
+  const qaUpdated = updateQA(
+    directory,
+    {
+      ultraqa_cycles: qaState?.cycle ?? autopilotState.qa.ultraqa_cycles,
+      qa_completed_at: new Date().toISOString(),
+    },
+    sessionId,
+  );
 
   if (!qaUpdated) {
     return {
       success: false,
-      error: 'Failed to update QA state'
+      error: "Failed to update QA state",
     };
   }
 
@@ -436,30 +492,33 @@ export function transitionUltraQAToValidation(
   clearUltraQAState(directory, sessionId);
 
   // Transition to validation
-  const newState = transitionPhase(directory, 'validation', sessionId);
+  const newState = transitionPhase(directory, "validation", sessionId);
   if (!newState) {
     return {
       success: false,
-      error: 'Failed to transition to validation phase'
+      error: "Failed to transition to validation phase",
     };
   }
 
   return {
     success: true,
-    state: newState
+    state: newState,
   };
 }
 
 /**
  * Transition from Validation (Phase 4) to Complete
  */
-export function transitionToComplete(directory: string, sessionId?: string): TransitionResult {
-  const state = transitionPhase(directory, 'complete', sessionId);
+export function transitionToComplete(
+  directory: string,
+  sessionId?: string,
+): TransitionResult {
+  const state = transitionPhase(directory, "complete", sessionId);
 
   if (!state) {
     return {
       success: false,
-      error: 'Failed to transition to complete phase'
+      error: "Failed to transition to complete phase",
     };
   }
 
@@ -472,14 +531,14 @@ export function transitionToComplete(directory: string, sessionId?: string): Tra
 export function transitionToFailed(
   directory: string,
   error: string,
-  sessionId?: string
+  sessionId?: string,
 ): TransitionResult {
-  const state = transitionPhase(directory, 'failed', sessionId);
+  const state = transitionPhase(directory, "failed", sessionId);
 
   if (!state) {
     return {
       success: false,
-      error: 'Failed to transition to failed phase'
+      error: "Failed to transition to failed phase",
     };
   }
 
@@ -491,9 +550,9 @@ export function transitionToFailed(
  */
 export function getTransitionPrompt(
   fromPhase: string,
-  toPhase: string
+  toPhase: string,
 ): string {
-  if (fromPhase === 'execution' && toPhase === 'qa') {
+  if (fromPhase === "execution" && toPhase === "qa") {
     return `## PHASE TRANSITION: Execution → QA
 
 The execution phase is complete. Transitioning to QA phase.
@@ -516,7 +575,7 @@ Signal when QA passes: QA_COMPLETE
 `;
   }
 
-  if (fromPhase === 'qa' && toPhase === 'validation') {
+  if (fromPhase === "qa" && toPhase === "validation") {
     return `## PHASE TRANSITION: QA → Validation
 
 All QA checks have passed. Transitioning to validation phase.
@@ -546,7 +605,7 @@ Aggregate verdicts:
 `;
   }
 
-  if (fromPhase === 'expansion' && toPhase === 'planning') {
+  if (fromPhase === "expansion" && toPhase === "planning") {
     return `## PHASE TRANSITION: Expansion → Planning
 
 The idea has been expanded into a detailed specification.
@@ -557,7 +616,7 @@ Signal when Critic approves the plan: PLANNING_COMPLETE
 `;
   }
 
-  if (fromPhase === 'planning' && toPhase === 'execution') {
+  if (fromPhase === "planning" && toPhase === "execution") {
     return `## PHASE TRANSITION: Planning → Execution
 
 The plan has been approved. Starting execution phase with Ralph + Ultrawork.
@@ -568,5 +627,5 @@ Signal when all tasks complete: EXECUTION_COMPLETE
 `;
   }
 
-  return '';
+  return "";
 }

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -9,14 +9,38 @@
  * All modes store state in `.omc/state/` subdirectory for consistency.
  */
 
-import { existsSync, readFileSync, unlinkSync, mkdirSync, readdirSync, statSync, rmdirSync, rmSync } from 'fs';
-import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
-import { join, dirname } from 'path';
-import type { ExecutionMode, ModeConfig, ModeStatus, CanStartResult } from './types.js';
-import { listSessionIds, resolveSessionStatePath, getSessionStateDir, getOmcRoot } from '../../lib/worktree-paths.js';
-import { MODE_STATE_FILE_MAP, MODE_NAMES } from '../../lib/mode-names.js';
+import {
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  rmdirSync,
+  rmSync,
+} from "fs";
+import { atomicWriteJsonSync } from "../../lib/atomic-write.js";
+import { join, dirname } from "path";
+import type {
+  ExecutionMode,
+  ModeConfig,
+  ModeStatus,
+  CanStartResult,
+} from "./types.js";
+import {
+  listSessionIds,
+  resolveSessionStatePath,
+  getSessionStateDir,
+  getOmcRoot,
+} from "../../lib/worktree-paths.js";
+import { MODE_STATE_FILE_MAP, MODE_NAMES } from "../../lib/mode-names.js";
 
-export type { ExecutionMode, ModeConfig, ModeStatus, CanStartResult } from './types.js';
+export type {
+  ExecutionMode,
+  ModeConfig,
+  ModeStatus,
+  CanStartResult,
+} from "./types.js";
 
 /**
  * Mode configuration registry
@@ -26,34 +50,34 @@ export type { ExecutionMode, ModeConfig, ModeStatus, CanStartResult } from './ty
  */
 const MODE_CONFIGS: Record<ExecutionMode, ModeConfig> = {
   [MODE_NAMES.AUTOPILOT]: {
-    name: 'Autopilot',
+    name: "Autopilot",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.AUTOPILOT],
-    activeProperty: 'active'
+    activeProperty: "active",
   },
   [MODE_NAMES.TEAM]: {
-    name: 'Team',
+    name: "Team",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.TEAM],
-    activeProperty: 'active',
-    hasGlobalState: false
+    activeProperty: "active",
+    hasGlobalState: false,
   },
   [MODE_NAMES.RALPH]: {
-    name: 'Ralph',
+    name: "Ralph",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.RALPH],
-    markerFile: 'ralph-verification.json',
-    activeProperty: 'active',
-    hasGlobalState: false
+    markerFile: "ralph-verification.json",
+    activeProperty: "active",
+    hasGlobalState: false,
   },
   [MODE_NAMES.ULTRAWORK]: {
-    name: 'Ultrawork',
+    name: "Ultrawork",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAWORK],
-    activeProperty: 'active',
-    hasGlobalState: false
+    activeProperty: "active",
+    hasGlobalState: false,
   },
   [MODE_NAMES.ULTRAQA]: {
-    name: 'UltraQA',
+    name: "UltraQA",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAQA],
-    activeProperty: 'active'
-  }
+    activeProperty: "active",
+  },
 };
 
 // Export for use in other modules
@@ -68,7 +92,7 @@ const EXCLUSIVE_MODES: ExecutionMode[] = [MODE_NAMES.AUTOPILOT];
  * Get the state directory path
  */
 export function getStateDir(cwd: string): string {
-  return join(getOmcRoot(cwd), 'state');
+  return join(getOmcRoot(cwd), "state");
 }
 
 /**
@@ -76,15 +100,17 @@ export function getStateDir(cwd: string): string {
  */
 export function ensureStateDir(cwd: string): void {
   const stateDir = getStateDir(cwd);
-  if (!existsSync(stateDir)) {
-    mkdirSync(stateDir, { recursive: true });
-  }
+  mkdirSync(stateDir, { recursive: true });
 }
 
 /**
  * Get the full path to a mode's state file
  */
-export function getStateFilePath(cwd: string, mode: ExecutionMode, sessionId?: string): string {
+export function getStateFilePath(
+  cwd: string,
+  mode: ExecutionMode,
+  sessionId?: string,
+): string {
   const config = MODE_CONFIGS[mode];
   if (sessionId) {
     return resolveSessionStatePath(mode, sessionId, cwd);
@@ -95,7 +121,10 @@ export function getStateFilePath(cwd: string, mode: ExecutionMode, sessionId?: s
 /**
  * Get the full path to a mode's marker file
  */
-export function getMarkerFilePath(cwd: string, mode: ExecutionMode): string | null {
+export function getMarkerFilePath(
+  cwd: string,
+  mode: ExecutionMode,
+): string | null {
   const config = MODE_CONFIGS[mode];
   if (!config.markerFile) return null;
   return join(getStateDir(cwd), config.markerFile);
@@ -114,7 +143,11 @@ export function getGlobalStateFilePath(_mode: ExecutionMode): string | null {
 /**
  * Check if a JSON-based mode is active by reading its state file
  */
-function isJsonModeActive(cwd: string, mode: ExecutionMode, sessionId?: string): boolean {
+function isJsonModeActive(
+  cwd: string,
+  mode: ExecutionMode,
+  sessionId?: string,
+): boolean {
   const config = MODE_CONFIGS[mode];
 
   // When sessionId is provided, ONLY check session-scoped path — no legacy fallback.
@@ -122,12 +155,8 @@ function isJsonModeActive(cwd: string, mode: ExecutionMode, sessionId?: string):
   // could cause another session to see mode as active.
   if (sessionId) {
     const sessionStateFile = resolveSessionStatePath(mode, sessionId, cwd);
-    if (!existsSync(sessionStateFile)) {
-      return false;
-    }
-
     try {
-      const content = readFileSync(sessionStateFile, 'utf-8');
+      const content = readFileSync(sessionStateFile, "utf-8");
       const state = JSON.parse(content);
 
       // Validate session identity: state must belong to this session
@@ -140,19 +169,18 @@ function isJsonModeActive(cwd: string, mode: ExecutionMode, sessionId?: string):
       }
 
       return true;
-    } catch {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return false;
+      }
       return false;
     }
   }
 
   // No sessionId: check legacy shared path (backward compat)
   const stateFile = getStateFilePath(cwd, mode);
-  if (!existsSync(stateFile)) {
-    return false;
-  }
-
   try {
-    const content = readFileSync(stateFile, 'utf-8');
+    const content = readFileSync(stateFile, "utf-8");
     const state = JSON.parse(content);
 
     if (config.activeProperty) {
@@ -161,7 +189,10 @@ function isJsonModeActive(cwd: string, mode: ExecutionMode, sessionId?: string):
 
     // Default: file existence means active
     return true;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
     return false;
   }
 }
@@ -174,7 +205,11 @@ function isJsonModeActive(cwd: string, mode: ExecutionMode, sessionId?: string):
  * @param sessionId - Optional session ID to check session-scoped state
  * @returns true if the mode is active
  */
-export function isModeActive(mode: ExecutionMode, cwd: string, sessionId?: string): boolean {
+export function isModeActive(
+  mode: ExecutionMode,
+  cwd: string,
+  sessionId?: string,
+): boolean {
   return isJsonModeActive(cwd, mode, sessionId);
 }
 
@@ -182,7 +217,11 @@ export function isModeActive(mode: ExecutionMode, cwd: string, sessionId?: strin
  * Check if a mode has active state (file exists)
  * @param sessionId - When provided, checks session-scoped path only (no legacy fallback)
  */
-export function hasModeState(cwd: string, mode: ExecutionMode, sessionId?: string): boolean {
+export function hasModeState(
+  cwd: string,
+  mode: ExecutionMode,
+  sessionId?: string,
+): boolean {
   const stateFile = getStateFilePath(cwd, mode, sessionId);
   return existsSync(stateFile);
 }
@@ -190,7 +229,10 @@ export function hasModeState(cwd: string, mode: ExecutionMode, sessionId?: strin
 /**
  * Get all modes that currently have state files
  */
-export function getActiveModes(cwd: string, sessionId?: string): ExecutionMode[] {
+export function getActiveModes(
+  cwd: string,
+  sessionId?: string,
+): ExecutionMode[] {
   const modes: ExecutionMode[] = [];
 
   for (const mode of Object.keys(MODE_CONFIGS) as ExecutionMode[]) {
@@ -238,12 +280,15 @@ export function canStartMode(mode: ExecutionMode, cwd: string): CanStartResult {
   // Check for mutually exclusive modes across all sessions
   if (EXCLUSIVE_MODES.includes(mode)) {
     for (const exclusiveMode of EXCLUSIVE_MODES) {
-      if (exclusiveMode !== mode && isModeActiveInAnySession(exclusiveMode, cwd)) {
+      if (
+        exclusiveMode !== mode &&
+        isModeActiveInAnySession(exclusiveMode, cwd)
+      ) {
         const config = MODE_CONFIGS[exclusiveMode];
         return {
           allowed: false,
           blockedBy: exclusiveMode,
-          message: `Cannot start ${MODE_CONFIGS[mode].name} while ${config.name} is active. Cancel ${config.name} first with /oh-my-claudecode:cancel.`
+          message: `Cannot start ${MODE_CONFIGS[mode].name} while ${config.name} is active. Cancel ${config.name} first with /oh-my-claudecode:cancel.`,
         };
       }
     }
@@ -259,11 +304,14 @@ export function canStartMode(mode: ExecutionMode, cwd: string): CanStartResult {
  * @param sessionId - Optional session ID to check session-scoped state
  * @returns Array of mode statuses
  */
-export function getAllModeStatuses(cwd: string, sessionId?: string): ModeStatus[] {
-  return (Object.keys(MODE_CONFIGS) as ExecutionMode[]).map(mode => ({
+export function getAllModeStatuses(
+  cwd: string,
+  sessionId?: string,
+): ModeStatus[] {
+  return (Object.keys(MODE_CONFIGS) as ExecutionMode[]).map((mode) => ({
     mode,
     active: isModeActive(mode, cwd, sessionId),
-    stateFilePath: getStateFilePath(cwd, mode, sessionId)
+    stateFilePath: getStateFilePath(cwd, mode, sessionId),
   }));
 }
 
@@ -278,7 +326,11 @@ export function getAllModeStatuses(cwd: string, sessionId?: string): ModeStatus[
  *
  * @returns true if all files were deleted successfully (or didn't exist)
  */
-export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: string): boolean {
+export function clearModeState(
+  mode: ExecutionMode,
+  cwd: string,
+  sessionId?: string,
+): boolean {
   const config = MODE_CONFIGS[mode];
   let success = true;
   const markerFile = getMarkerFilePath(cwd, mode);
@@ -290,7 +342,7 @@ export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: str
     try {
       unlinkSync(sessionStateFile);
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         success = false;
       }
     }
@@ -298,12 +350,16 @@ export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: str
     // Clear session-scoped marker artifacts (e.g., ralph-verification-state.json).
     // Keep legacy/shared marker files untouched for isolation.
     if (config.markerFile) {
-      const markerStateName = config.markerFile.replace(/\.json$/i, '');
-      const sessionMarkerFile = resolveSessionStatePath(markerStateName, sessionId, cwd);
+      const markerStateName = config.markerFile.replace(/\.json$/i, "");
+      const sessionMarkerFile = resolveSessionStatePath(
+        markerStateName,
+        sessionId,
+        cwd,
+      );
       try {
         unlinkSync(sessionMarkerFile);
       } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
           success = false;
         }
       }
@@ -313,13 +369,16 @@ export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: str
     // Keep isolation by deleting only unowned markers or markers owned by this session.
     if (markerFile) {
       try {
-        const markerRaw = JSON.parse(readFileSync(markerFile, 'utf-8')) as { session_id?: string; sessionId?: string };
+        const markerRaw = JSON.parse(readFileSync(markerFile, "utf-8")) as {
+          session_id?: string;
+          sessionId?: string;
+        };
         const markerSessionId = markerRaw.session_id ?? markerRaw.sessionId;
         if (!markerSessionId || markerSessionId === sessionId) {
           try {
             unlinkSync(markerFile);
           } catch (err) {
-            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
               success = false;
             }
           }
@@ -329,7 +388,7 @@ export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: str
         try {
           unlinkSync(markerFile);
         } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
             success = false;
           }
         }
@@ -343,11 +402,10 @@ export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: str
     try {
       unlinkSync(stateFile);
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         success = false;
       }
     }
-
   }
 
   // Delete marker file if applicable, but respect ownership when session-scoped.
@@ -355,13 +413,16 @@ export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: str
     if (isSessionScopedClear) {
       // Only delete if the marker is unowned or owned by this session.
       try {
-        const markerRaw = JSON.parse(readFileSync(markerFile, 'utf-8')) as { session_id?: string; sessionId?: string };
+        const markerRaw = JSON.parse(readFileSync(markerFile, "utf-8")) as {
+          session_id?: string;
+          sessionId?: string;
+        };
         const markerSessionId = markerRaw.session_id ?? markerRaw.sessionId;
         if (!markerSessionId || markerSessionId === sessionId) {
           try {
             unlinkSync(markerFile);
           } catch (err) {
-            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
               success = false;
             }
           }
@@ -371,7 +432,7 @@ export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: str
         try {
           unlinkSync(markerFile);
         } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
             success = false;
           }
         }
@@ -380,7 +441,7 @@ export function clearModeState(mode: ExecutionMode, cwd: string, sessionId?: str
       try {
         unlinkSync(markerFile);
       } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
           success = false;
         }
       }
@@ -405,11 +466,11 @@ export function clearAllModeStates(cwd: string): boolean {
   }
 
   // Clear skill-active-state.json (issue #1033)
-  const skillStatePath = join(getStateDir(cwd), 'skill-active-state.json');
+  const skillStatePath = join(getStateDir(cwd), "skill-active-state.json");
   try {
     unlinkSync(skillStatePath);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
       success = false;
     }
   }
@@ -435,7 +496,10 @@ export function clearAllModeStates(cwd: string): boolean {
  * @param cwd - Working directory
  * @returns true if the mode is active in any session or legacy path
  */
-export function isModeActiveInAnySession(mode: ExecutionMode, cwd: string): boolean {
+export function isModeActiveInAnySession(
+  mode: ExecutionMode,
+  cwd: string,
+): boolean {
   // Check legacy path first
   if (isJsonModeActive(cwd, mode)) {
     return true;
@@ -459,9 +523,12 @@ export function isModeActiveInAnySession(mode: ExecutionMode, cwd: string): bool
  * @param cwd - Working directory
  * @returns Array of session IDs with this mode active
  */
-export function getActiveSessionsForMode(mode: ExecutionMode, cwd: string): string[] {
+export function getActiveSessionsForMode(
+  mode: ExecutionMode,
+  cwd: string,
+): string[] {
   const sessionIds = listSessionIds(cwd);
-  return sessionIds.filter(sid => isJsonModeActive(cwd, mode, sid));
+  return sessionIds.filter((sid) => isJsonModeActive(cwd, mode, sid));
 }
 
 /**
@@ -473,12 +540,10 @@ export function getActiveSessionsForMode(mode: ExecutionMode, cwd: string): stri
  * @param maxAgeMs - Maximum age in milliseconds (default: 24 hours)
  * @returns Array of removed session IDs
  */
-export function clearStaleSessionDirs(cwd: string, maxAgeMs: number = 24 * 60 * 60 * 1000): string[] {
-  const sessionsDir = join(getOmcRoot(cwd), 'state', 'sessions');
-  if (!existsSync(sessionsDir)) {
-    return [];
-  }
-
+export function clearStaleSessionDirs(
+  cwd: string,
+  maxAgeMs: number = 24 * 60 * 60 * 1000,
+): string[] {
   const removed: string[] = [];
   const sessionIds = listSessionIds(cwd);
 
@@ -530,7 +595,7 @@ export function clearStaleSessionDirs(cwd: string, maxAgeMs: number = 24 * 60 * 
 export function createModeMarker(
   mode: ExecutionMode,
   cwd: string,
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown>,
 ): boolean {
   const markerPath = getMarkerFilePath(cwd, mode);
   if (!markerPath) {
@@ -541,14 +606,12 @@ export function createModeMarker(
   try {
     // Ensure directory exists
     const dir = dirname(markerPath);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-    }
+    mkdirSync(dir, { recursive: true });
 
     atomicWriteJsonSync(markerPath, {
       mode,
       startedAt: new Date().toISOString(),
-      ...metadata
+      ...metadata,
     });
     return true;
   } catch (error) {
@@ -570,11 +633,12 @@ export function removeModeMarker(mode: ExecutionMode, cwd: string): boolean {
   }
 
   try {
-    if (existsSync(markerPath)) {
-      unlinkSync(markerPath);
-    }
+    unlinkSync(markerPath);
     return true;
   } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return true;
+    }
     console.error(`Failed to remove marker file for ${mode}:`, error);
     return false;
   }
@@ -588,17 +652,20 @@ export function removeModeMarker(mode: ExecutionMode, cwd: string): boolean {
  */
 export function readModeMarker(
   mode: ExecutionMode,
-  cwd: string
+  cwd: string,
 ): Record<string, unknown> | null {
   const markerPath = getMarkerFilePath(cwd, mode);
-  if (!markerPath || !existsSync(markerPath)) {
+  if (!markerPath) {
     return null;
   }
 
   try {
-    const content = readFileSync(markerPath, 'utf-8');
+    const content = readFileSync(markerPath, "utf-8");
     return JSON.parse(content);
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
     return null;
   }
 }
@@ -617,11 +684,12 @@ export function forceRemoveMarker(mode: ExecutionMode, cwd: string): boolean {
   }
 
   try {
-    if (existsSync(markerPath)) {
-      unlinkSync(markerPath);
-    }
+    unlinkSync(markerPath);
     return true;
   } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return true;
+    }
     console.error(`Failed to force remove marker file for ${mode}:`, error);
     return false;
   }

--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -10,12 +10,13 @@
  * Ported from oh-my-opencode's ralph hook.
  */
 
-import {
-  existsSync,
-  readFileSync,
-} from "fs";
+import { readFileSync } from "fs";
 import { join } from "path";
-import { writeModeState, readModeState, clearModeStateFile } from '../../lib/mode-state-io.js';
+import {
+  writeModeState,
+  readModeState,
+  clearModeStateFile,
+} from "../../lib/mode-state-io.js";
 import {
   readPrd,
   getPrdStatus,
@@ -35,23 +36,33 @@ import {
   readUltraworkState as readUltraworkStateFromModule,
   writeUltraworkState as writeUltraworkStateFromModule,
 } from "../ultrawork/index.js";
-import { resolveSessionStatePath, getOmcRoot } from "../../lib/worktree-paths.js";
+import {
+  resolveSessionStatePath,
+  getOmcRoot,
+} from "../../lib/worktree-paths.js";
 import { readTeamPipelineState } from "../team-pipeline/state.js";
 import type { TeamPipelinePhase } from "../team-pipeline/types.js";
 
 // Forward declaration to avoid circular import - check ultraqa state file directly
-export function isUltraQAActive(directory: string, sessionId?: string): boolean {
+export function isUltraQAActive(
+  directory: string,
+  sessionId?: string,
+): boolean {
   // When sessionId is provided, ONLY check session-scoped path — no legacy fallback
   if (sessionId) {
-    const sessionFile = resolveSessionStatePath('ultraqa', sessionId, directory);
-    if (!existsSync(sessionFile)) {
-      return false;
-    }
+    const sessionFile = resolveSessionStatePath(
+      "ultraqa",
+      sessionId,
+      directory,
+    );
     try {
       const content = readFileSync(sessionFile, "utf-8");
       const state = JSON.parse(content);
       return state && state.active === true;
-    } catch {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return false;
+      }
       return false; // NO legacy fallback
     }
   }
@@ -59,14 +70,14 @@ export function isUltraQAActive(directory: string, sessionId?: string): boolean 
   // No sessionId: legacy path (backward compat)
   const omcDir = getOmcRoot(directory);
   const stateFile = join(omcDir, "state", "ultraqa-state.json");
-  if (!existsSync(stateFile)) {
-    return false;
-  }
   try {
     const content = readFileSync(stateFile, "utf-8");
     const state = JSON.parse(content);
     return state && state.active === true;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
     return false;
   }
 }
@@ -116,11 +127,19 @@ const DEFAULT_MAX_ITERATIONS = 10;
 /**
  * Read Ralph Loop state from disk
  */
-export function readRalphState(directory: string, sessionId?: string): RalphLoopState | null {
-  const state = readModeState<RalphLoopState>('ralph', directory, sessionId);
+export function readRalphState(
+  directory: string,
+  sessionId?: string,
+): RalphLoopState | null {
+  const state = readModeState<RalphLoopState>("ralph", directory, sessionId);
 
   // Validate session identity
-  if (state && sessionId && state.session_id && state.session_id !== sessionId) {
+  if (
+    state &&
+    sessionId &&
+    state.session_id &&
+    state.session_id !== sessionId
+  ) {
     return null;
   }
 
@@ -133,22 +152,33 @@ export function readRalphState(directory: string, sessionId?: string): RalphLoop
 export function writeRalphState(
   directory: string,
   state: RalphLoopState,
-  sessionId?: string
+  sessionId?: string,
 ): boolean {
-  return writeModeState('ralph', state as unknown as Record<string, unknown>, directory, sessionId);
+  return writeModeState(
+    "ralph",
+    state as unknown as Record<string, unknown>,
+    directory,
+    sessionId,
+  );
 }
 
 /**
  * Clear Ralph Loop state (includes ghost-legacy cleanup)
  */
-export function clearRalphState(directory: string, sessionId?: string): boolean {
-  return clearModeStateFile('ralph', directory, sessionId);
+export function clearRalphState(
+  directory: string,
+  sessionId?: string,
+): boolean {
+  return clearModeStateFile("ralph", directory, sessionId);
 }
 
 /**
  * Clear ultrawork state (only if linked to ralph)
  */
-export function clearLinkedUltraworkState(directory: string, sessionId?: string): boolean {
+export function clearLinkedUltraworkState(
+  directory: string,
+  sessionId?: string,
+): boolean {
   const state = readUltraworkStateFromModule(directory, sessionId);
 
   // Only clear if it was linked to ralph (auto-activated)
@@ -156,7 +186,7 @@ export function clearLinkedUltraworkState(directory: string, sessionId?: string)
     return true;
   }
 
-  return clearModeStateFile('ultrawork', directory, sessionId);
+  return clearModeStateFile("ultrawork", directory, sessionId);
 }
 
 /**
@@ -164,7 +194,7 @@ export function clearLinkedUltraworkState(directory: string, sessionId?: string)
  */
 export function incrementRalphIteration(
   directory: string,
-  sessionId?: string
+  sessionId?: string,
 ): RalphLoopState | null {
   const state = readRalphState(directory, sessionId);
 
@@ -196,7 +226,10 @@ export function detectNoPrdFlag(prompt: string): boolean {
  * Strip --no-prd flag from prompt text and trim whitespace
  */
 export function stripNoPrdFlag(prompt: string): string {
-  return prompt.replace(/--no-prd/gi, '').replace(/\s+/g, ' ').trim();
+  return prompt
+    .replace(/--no-prd/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**
@@ -426,22 +459,28 @@ export function recordPattern(directory: string, pattern: string): boolean {
 export function getTeamPhaseDirective(
   directory: string,
   sessionId?: string,
-): 'continue' | 'complete' | null {
+): "continue" | "complete" | null {
   const teamState = readTeamPipelineState(directory, sessionId);
   if (!teamState || !teamState.active) {
     // Check terminal states even when active=false
     if (teamState) {
-      const terminalPhases: TeamPipelinePhase[] = ['complete', 'failed'];
+      const terminalPhases: TeamPipelinePhase[] = ["complete", "failed"];
       if (terminalPhases.includes(teamState.phase)) {
-        return 'complete';
+        return "complete";
       }
     }
     return null;
   }
 
-  const continuePhases: TeamPipelinePhase[] = ['team-verify', 'team-fix', 'team-exec', 'team-plan', 'team-prd'];
+  const continuePhases: TeamPipelinePhase[] = [
+    "team-verify",
+    "team-fix",
+    "team-exec",
+    "team-plan",
+    "team-prd",
+  ];
   if (continuePhases.includes(teamState.phase)) {
-    return 'continue';
+    return "continue";
   }
 
   return null;

--- a/src/hooks/ultrapilot/state.ts
+++ b/src/hooks/ultrapilot/state.ts
@@ -5,24 +5,33 @@
  * file ownership, and progress.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
-import { join } from 'path';
-import type { UltrapilotState, UltrapilotConfig, WorkerState, FileOwnership } from './types.js';
-import { DEFAULT_CONFIG } from './types.js';
-import { resolveSessionStatePath, ensureSessionStateDir, getOmcRoot } from '../../lib/worktree-paths.js';
-import { writeModeState, readModeState } from '../../lib/mode-state-io.js';
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from "fs";
+import { join } from "path";
+import type {
+  UltrapilotState,
+  UltrapilotConfig,
+  WorkerState,
+  FileOwnership,
+} from "./types.js";
+import { DEFAULT_CONFIG } from "./types.js";
+import {
+  resolveSessionStatePath,
+  ensureSessionStateDir,
+  getOmcRoot,
+} from "../../lib/worktree-paths.js";
+import { writeModeState, readModeState } from "../../lib/mode-state-io.js";
 
-const STATE_FILE = 'ultrapilot-state.json';
-const OWNERSHIP_FILE = 'ultrapilot-ownership.json';
+const STATE_FILE = "ultrapilot-state.json";
+const OWNERSHIP_FILE = "ultrapilot-ownership.json";
 
 /**
  * Get the state file path
  */
 function getStateFilePath(directory: string, sessionId?: string): string {
   if (sessionId) {
-    return resolveSessionStatePath('ultrapilot', sessionId, directory);
+    return resolveSessionStatePath("ultrapilot", sessionId, directory);
   }
-  const omcDir = join(getOmcRoot(directory), 'state');
+  const omcDir = join(getOmcRoot(directory), "state");
   return join(omcDir, STATE_FILE);
 }
 
@@ -32,10 +41,15 @@ function getStateFilePath(directory: string, sessionId?: string): string {
 function getOwnershipFilePath(directory: string, sessionId?: string): string {
   if (sessionId) {
     // Store ownership file next to state file in session directory
-    const sessionDir = join(getOmcRoot(directory), 'state', 'sessions', sessionId);
+    const sessionDir = join(
+      getOmcRoot(directory),
+      "state",
+      "sessions",
+      sessionId,
+    );
     return join(sessionDir, OWNERSHIP_FILE);
   }
-  const omcDir = join(getOmcRoot(directory), 'state');
+  const omcDir = join(getOmcRoot(directory), "state");
   return join(omcDir, OWNERSHIP_FILE);
 }
 
@@ -47,39 +61,60 @@ function ensureStateDir(directory: string, sessionId?: string): void {
     ensureSessionStateDir(sessionId, directory);
     return;
   }
-  const stateDir = join(getOmcRoot(directory), 'state');
-  if (!existsSync(stateDir)) {
-    mkdirSync(stateDir, { recursive: true });
-  }
+  const stateDir = join(getOmcRoot(directory), "state");
+  mkdirSync(stateDir, { recursive: true });
 }
 
 /**
  * Read ultrapilot state from disk
  */
-export function readUltrapilotState(directory: string, sessionId?: string): UltrapilotState | null {
-  return readModeState<UltrapilotState>('ultrapilot', directory, sessionId);
+export function readUltrapilotState(
+  directory: string,
+  sessionId?: string,
+): UltrapilotState | null {
+  return readModeState<UltrapilotState>("ultrapilot", directory, sessionId);
 }
 
 /**
  * Write ultrapilot state to disk
  */
-export function writeUltrapilotState(directory: string, state: UltrapilotState, sessionId?: string): boolean {
-  return writeModeState('ultrapilot', state as unknown as Record<string, unknown>, directory, sessionId);
+export function writeUltrapilotState(
+  directory: string,
+  state: UltrapilotState,
+  sessionId?: string,
+): boolean {
+  return writeModeState(
+    "ultrapilot",
+    state as unknown as Record<string, unknown>,
+    directory,
+    sessionId,
+  );
 }
 
 /**
  * Clear ultrapilot state
  */
-export function clearUltrapilotState(directory: string, sessionId?: string): boolean {
+export function clearUltrapilotState(
+  directory: string,
+  sessionId?: string,
+): boolean {
   const stateFile = getStateFilePath(directory, sessionId);
   const ownershipFile = getOwnershipFilePath(directory, sessionId);
 
   try {
-    if (existsSync(stateFile)) {
+    try {
       unlinkSync(stateFile);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
     }
-    if (existsSync(ownershipFile)) {
+    try {
       unlinkSync(ownershipFile);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
     }
     return true;
   } catch {
@@ -90,7 +125,10 @@ export function clearUltrapilotState(directory: string, sessionId?: string): boo
 /**
  * Check if ultrapilot is active
  */
-export function isUltrapilotActive(directory: string, sessionId?: string): boolean {
+export function isUltrapilotActive(
+  directory: string,
+  sessionId?: string,
+): boolean {
   const state = readUltrapilotState(directory, sessionId);
   return state !== null && state.active === true;
 }
@@ -103,7 +141,7 @@ export function initUltrapilot(
   task: string,
   subtasks: string[],
   sessionId?: string,
-  config?: Partial<UltrapilotConfig>
+  config?: Partial<UltrapilotConfig>,
 ): UltrapilotState | null {
   const mergedConfig = { ...DEFAULT_CONFIG, ...config };
   const now = new Date().toISOString();
@@ -118,7 +156,7 @@ export function initUltrapilot(
     ownership: {
       coordinator: mergedConfig.sharedFiles,
       workers: {},
-      conflicts: []
+      conflicts: [],
     },
     startedAt: now,
     completedAt: null,
@@ -126,7 +164,7 @@ export function initUltrapilot(
     successfulWorkers: 0,
     failedWorkers: 0,
     sessionId,
-    project_path: directory
+    project_path: directory,
   };
 
   writeUltrapilotState(directory, state, sessionId);
@@ -140,7 +178,7 @@ export function updateWorkerState(
   directory: string,
   workerId: string,
   updates: Partial<WorkerState>,
-  sessionId?: string
+  sessionId?: string,
 ): boolean {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return false;
@@ -155,7 +193,11 @@ export function updateWorkerState(
 /**
  * Add a new worker
  */
-export function addWorker(directory: string, worker: WorkerState, sessionId?: string): boolean {
+export function addWorker(
+  directory: string,
+  worker: WorkerState,
+  sessionId?: string,
+): boolean {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return false;
 
@@ -176,7 +218,7 @@ export function completeWorker(
   workerId: string,
   filesCreated: string[],
   filesModified: string[],
-  sessionId?: string
+  sessionId?: string,
 ): boolean {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return false;
@@ -184,7 +226,7 @@ export function completeWorker(
   const workerIndex = state.workers.findIndex((w) => w.id === workerId);
   if (workerIndex === -1) return false;
 
-  state.workers[workerIndex].status = 'complete';
+  state.workers[workerIndex].status = "complete";
   state.workers[workerIndex].completedAt = new Date().toISOString();
   state.workers[workerIndex].filesCreated = filesCreated;
   state.workers[workerIndex].filesModified = filesModified;
@@ -196,14 +238,19 @@ export function completeWorker(
 /**
  * Mark worker as failed
  */
-export function failWorker(directory: string, workerId: string, error: string, sessionId?: string): boolean {
+export function failWorker(
+  directory: string,
+  workerId: string,
+  error: string,
+  sessionId?: string,
+): boolean {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return false;
 
   const workerIndex = state.workers.findIndex((w) => w.id === workerId);
   if (workerIndex === -1) return false;
 
-  state.workers[workerIndex].status = 'failed';
+  state.workers[workerIndex].status = "failed";
   state.workers[workerIndex].completedAt = new Date().toISOString();
   state.workers[workerIndex].error = error;
   state.failedWorkers += 1;
@@ -214,7 +261,10 @@ export function failWorker(directory: string, workerId: string, error: string, s
 /**
  * Complete ultrapilot session
  */
-export function completeUltrapilot(directory: string, sessionId?: string): boolean {
+export function completeUltrapilot(
+  directory: string,
+  sessionId?: string,
+): boolean {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return false;
 
@@ -227,30 +277,30 @@ export function completeUltrapilot(directory: string, sessionId?: string): boole
 /**
  * Read file ownership mapping
  */
-export function readFileOwnership(directory: string, sessionId?: string): FileOwnership | null {
+export function readFileOwnership(
+  directory: string,
+  sessionId?: string,
+): FileOwnership | null {
   // Try session-scoped path first
   if (sessionId) {
     const sessionFile = getOwnershipFilePath(directory, sessionId);
-    if (existsSync(sessionFile)) {
-      try {
-        const content = readFileSync(sessionFile, 'utf-8');
-        return JSON.parse(content);
-      } catch {
-        // Fall through to legacy path
-      }
+    try {
+      const content = readFileSync(sessionFile, "utf-8");
+      return JSON.parse(content);
+    } catch {
+      // Fall through to legacy path
     }
   }
 
   // Fallback to legacy path
   const ownershipFile = getOwnershipFilePath(directory);
-  if (!existsSync(ownershipFile)) {
-    return null;
-  }
-
   try {
-    const content = readFileSync(ownershipFile, 'utf-8');
+    const content = readFileSync(ownershipFile, "utf-8");
     return JSON.parse(content);
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
     return null;
   }
 }
@@ -258,7 +308,11 @@ export function readFileOwnership(directory: string, sessionId?: string): FileOw
 /**
  * Write file ownership mapping
  */
-export function writeFileOwnership(directory: string, ownership: FileOwnership, sessionId?: string): boolean {
+export function writeFileOwnership(
+  directory: string,
+  ownership: FileOwnership,
+  sessionId?: string,
+): boolean {
   try {
     ensureStateDir(directory, sessionId);
     const ownershipFile = getOwnershipFilePath(directory, sessionId);
@@ -272,7 +326,11 @@ export function writeFileOwnership(directory: string, ownership: FileOwnership, 
 /**
  * Record a file conflict
  */
-export function recordConflict(directory: string, filePath: string, sessionId?: string): boolean {
+export function recordConflict(
+  directory: string,
+  filePath: string,
+  sessionId?: string,
+): boolean {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return false;
 
@@ -286,29 +344,38 @@ export function recordConflict(directory: string, filePath: string, sessionId?: 
 /**
  * Get all completed workers
  */
-export function getCompletedWorkers(directory: string, sessionId?: string): WorkerState[] {
+export function getCompletedWorkers(
+  directory: string,
+  sessionId?: string,
+): WorkerState[] {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return [];
 
-  return state.workers.filter((w) => w.status === 'complete');
+  return state.workers.filter((w) => w.status === "complete");
 }
 
 /**
  * Get all running workers
  */
-export function getRunningWorkers(directory: string, sessionId?: string): WorkerState[] {
+export function getRunningWorkers(
+  directory: string,
+  sessionId?: string,
+): WorkerState[] {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return [];
 
-  return state.workers.filter((w) => w.status === 'running');
+  return state.workers.filter((w) => w.status === "running");
 }
 
 /**
  * Get all failed workers
  */
-export function getFailedWorkers(directory: string, sessionId?: string): WorkerState[] {
+export function getFailedWorkers(
+  directory: string,
+  sessionId?: string,
+): WorkerState[] {
   const state = readUltrapilotState(directory, sessionId);
   if (!state) return [];
 
-  return state.workers.filter((w) => w.status === 'failed');
+  return state.workers.filter((w) => w.status === "failed");
 }

--- a/src/hooks/ultrawork/index.ts
+++ b/src/hooks/ultrawork/index.ts
@@ -6,9 +6,12 @@
  * this module ensures the mode persists until all work is done.
  */
 
-import { existsSync, readFileSync, unlinkSync } from 'fs';
-import { writeModeState, readModeState } from '../../lib/mode-state-io.js';
-import { resolveStatePath, resolveSessionStatePath } from '../../lib/worktree-paths.js';
+import { readFileSync, unlinkSync } from "fs";
+import { writeModeState, readModeState } from "../../lib/mode-state-io.js";
+import {
+  resolveStatePath,
+  resolveSessionStatePath,
+} from "../../lib/worktree-paths.js";
 
 export interface UltraworkState {
   /** Whether ultrawork mode is currently active */
@@ -31,10 +34,10 @@ export interface UltraworkState {
 
 const _DEFAULT_STATE: UltraworkState = {
   active: false,
-  started_at: '',
-  original_prompt: '',
+  started_at: "",
+  original_prompt: "",
   reinforcement_count: 0,
-  last_checked_at: ''
+  last_checked_at: "",
 };
 
 /**
@@ -43,11 +46,10 @@ const _DEFAULT_STATE: UltraworkState = {
 function getStateFilePath(directory?: string, sessionId?: string): string {
   const baseDir = directory || process.cwd();
   if (sessionId) {
-    return resolveSessionStatePath('ultrawork', sessionId, baseDir);
+    return resolveSessionStatePath("ultrawork", sessionId, baseDir);
   }
-  return resolveStatePath('ultrawork', baseDir);
+  return resolveStatePath("ultrawork", baseDir);
 }
-
 
 /**
  * Read Ultrawork state from disk (local only)
@@ -55,11 +57,23 @@ function getStateFilePath(directory?: string, sessionId?: string): string {
  * When sessionId is provided, ONLY reads session-scoped file — no legacy fallback.
  * This prevents cross-session state leakage.
  */
-export function readUltraworkState(directory?: string, sessionId?: string): UltraworkState | null {
-  const state = readModeState<UltraworkState>('ultrawork', directory, sessionId);
+export function readUltraworkState(
+  directory?: string,
+  sessionId?: string,
+): UltraworkState | null {
+  const state = readModeState<UltraworkState>(
+    "ultrawork",
+    directory,
+    sessionId,
+  );
 
   // Validate session identity: state must belong to this session
-  if (state && sessionId && state.session_id && state.session_id !== sessionId) {
+  if (
+    state &&
+    sessionId &&
+    state.session_id &&
+    state.session_id !== sessionId
+  ) {
     return null;
   }
 
@@ -69,8 +83,17 @@ export function readUltraworkState(directory?: string, sessionId?: string): Ultr
 /**
  * Write Ultrawork state to disk (local only)
  */
-export function writeUltraworkState(state: UltraworkState, directory?: string, sessionId?: string): boolean {
-  return writeModeState('ultrawork', state as unknown as Record<string, unknown>, directory, sessionId);
+export function writeUltraworkState(
+  state: UltraworkState,
+  directory?: string,
+  sessionId?: string,
+): boolean {
+  return writeModeState(
+    "ultrawork",
+    state as unknown as Record<string, unknown>,
+    directory,
+    sessionId,
+  );
 }
 
 /**
@@ -80,7 +103,7 @@ export function activateUltrawork(
   prompt: string,
   sessionId?: string,
   directory?: string,
-  linkedToRalph?: boolean
+  linkedToRalph?: boolean,
 ): boolean {
   const state: UltraworkState = {
     active: true,
@@ -90,7 +113,7 @@ export function activateUltrawork(
     project_path: directory || process.cwd(),
     reinforcement_count: 0,
     last_checked_at: new Date().toISOString(),
-    linked_to_ralph: linkedToRalph
+    linked_to_ralph: linkedToRalph,
   };
 
   return writeUltraworkState(state, directory, sessionId);
@@ -104,15 +127,18 @@ export function activateUltrawork(
  * 2. Cleans up ghost legacy files that belong to this session (or have no session_id)
  *    to prevent stale legacy files from leaking into other sessions.
  */
-export function deactivateUltrawork(directory?: string, sessionId?: string): boolean {
+export function deactivateUltrawork(
+  directory?: string,
+  sessionId?: string,
+): boolean {
   let success = true;
 
   // Delete session-scoped state file
   const stateFile = getStateFilePath(directory, sessionId);
-  if (existsSync(stateFile)) {
-    try {
-      unlinkSync(stateFile);
-    } catch {
+  try {
+    unlinkSync(stateFile);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       success = false;
     }
   }
@@ -121,19 +147,23 @@ export function deactivateUltrawork(directory?: string, sessionId?: string): boo
   // if it belongs to this session or has no session_id (orphaned)
   if (sessionId) {
     const legacyFile = getStateFilePath(directory); // no sessionId = legacy path
-    if (existsSync(legacyFile)) {
-      try {
-        const content = readFileSync(legacyFile, 'utf-8');
-        const legacyState = JSON.parse(content);
+    try {
+      const content = readFileSync(legacyFile, "utf-8");
+      const legacyState = JSON.parse(content);
 
-        // Only remove if it belongs to this session or is unowned (no session_id)
-        if (!legacyState.session_id || legacyState.session_id === sessionId) {
+      // Only remove if it belongs to this session or is unowned (no session_id)
+      if (!legacyState.session_id || legacyState.session_id === sessionId) {
+        try {
           unlinkSync(legacyFile);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
+          }
         }
-        // Do NOT delete another session's legacy data
-      } catch {
-        // If we can't read/parse, leave it alone
       }
+      // Do NOT delete another session's legacy data
+    } catch {
+      // If we can't read/parse, leave it alone
     }
   }
 
@@ -143,7 +173,10 @@ export function deactivateUltrawork(directory?: string, sessionId?: string): boo
 /**
  * Increment reinforcement count (called when mode is reinforced on stop)
  */
-export function incrementReinforcement(directory?: string, sessionId?: string): UltraworkState | null {
+export function incrementReinforcement(
+  directory?: string,
+  sessionId?: string,
+): UltraworkState | null {
   const state = readUltraworkState(directory, sessionId);
 
   if (!state || !state.active) {
@@ -165,7 +198,7 @@ export function incrementReinforcement(directory?: string, sessionId?: string): 
  */
 export function shouldReinforceUltrawork(
   sessionId?: string,
-  directory?: string
+  directory?: string,
 ): boolean {
   const state = readUltraworkState(directory, sessionId);
 
@@ -218,10 +251,12 @@ export function createUltraworkStateHook(directory: string) {
   return {
     activate: (prompt: string, sessionId?: string) =>
       activateUltrawork(prompt, sessionId, directory),
-    deactivate: (sessionId?: string) => deactivateUltrawork(directory, sessionId),
+    deactivate: (sessionId?: string) =>
+      deactivateUltrawork(directory, sessionId),
     getState: (sessionId?: string) => readUltraworkState(directory, sessionId),
     shouldReinforce: (sessionId?: string) =>
       shouldReinforceUltrawork(sessionId, directory),
-    incrementReinforcement: (sessionId?: string) => incrementReinforcement(directory, sessionId)
+    incrementReinforcement: (sessionId?: string) =>
+      incrementReinforcement(directory, sessionId),
   };
 }


### PR DESCRIPTION
## Summary

Replaces race-prone `existsSync()` guards followed by `readFileSync`/`statSync`/`unlinkSync` with atomic try/catch patterns checking `error.code === 'ENOENT'` across 7 files (26 sites total).

### Changes

| File | Sites Fixed |
|------|-------------|
| `src/features/boulder-state/storage.ts` | 3 |
| `src/features/state-manager/index.ts` | 4 |
| `src/hooks/autopilot/state.ts` | 3 |
| `src/hooks/mode-registry/index.ts` | 6 |
| `src/hooks/ralph/loop.ts` | 4 |
| `src/hooks/ultrapilot/state.ts` | 3 |
| `src/hooks/ultrawork/index.ts` | 3 |

### The TOCTOU Problem

```typescript
// BEFORE: Race condition — file can be deleted between check and read
if (existsSync(path)) {
  const data = readFileSync(path, 'utf-8'); // may throw ENOENT!
}

// AFTER: Atomic — single operation, no race window
try {
  const data = readFileSync(path, 'utf-8');
} catch (error) {
  if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
    return null; // file doesn't exist
  }
  throw error; // re-throw unexpected errors
}
```

The `existsSync()` + `readFileSync()` pattern has a race window where the file can be created, deleted, or modified between the two calls. This is especially problematic in the mode-registry and state-manager which handle concurrent session access.

### Verification

- `tsc --noEmit` passes (only pre-existing test dependency errors)
- `src/hooks/ultraqa/index.ts` was listed in the issue but has no remaining TOCTOU patterns on `dev`

Fixes #1279