### PR TITLE
feat(benchmark): calibrate keyword matcher with deterministic thresholds

### DIFF
--- a/benchmarks/harsh-critic/SCORING_MATCH_CALIBRATION.md
+++ b/benchmarks/harsh-critic/SCORING_MATCH_CALIBRATION.md
@@ -1,0 +1,71 @@
+# Scoring Match Calibration Rationale
+
+## Why This Change Exists
+
+The benchmark matcher currently relies on strict substring overlap with a fixed threshold:
+
+- Match rule: `countKeywordMatches >= 2`
+- String check: raw lowercase `includes(...)`
+
+This is brittle for real model outputs where wording is semantically correct but formatted differently:
+
+- punctuation / separator variation: `new-hire` vs `new hire`
+- symbol variation: `processPayment():47-52` vs `processPayment 47 52`
+- phrase variation: keyword phrase appears with punctuation between tokens
+
+The failure mode is false negatives in benchmark scoring, not model quality regressions.
+
+## What This PR Changes
+
+1. Normalizes text for matching:
+- case-fold
+- unicode normalization (`NFKC`)
+- punctuation and separators collapsed to spaces
+
+2. Adds phrase fallback matching:
+- multi-token keywords match if all tokens are present in normalized text
+- preserves direct substring matching first (fast path)
+
+3. Uses dynamic threshold by keyword-set size:
+- base remains `MIN_KEYWORD_MATCHES = 2`
+- for 6-keyword findings, required matches become 3 (40% proportional floor)
+
+## Why This Method Is Better
+
+This method improves robustness without turning matching into fuzzy semantic search:
+
+- deterministic and auditable (no embeddings, no LLM-in-the-loop scorer)
+- still keyword-grounded (no synonym hallucination risk)
+- controls accidental matches on larger keyword sets via dynamic threshold
+- keeps existing behavior for 4-5 keyword findings (still requires 2)
+
+In short: it reduces formatting-induced false negatives while preserving precision guardrails.
+
+## Risk and Mitigations
+
+Risk: looser normalization could increase false positives.
+
+Mitigations:
+- keyword match threshold is not globally lowered
+- larger keyword sets now require more evidence (3/6 instead of 2/6)
+- added regression tests for both positive and negative threshold boundaries
+
+## Alternatives Considered
+
+1. Keep strict `includes` + fixed threshold:
+- rejected: too brittle to punctuation/format variants seen in real outputs
+
+2. Lower fixed threshold globally to 1:
+- rejected: large precision loss, especially for common terms
+
+3. Embedding-based semantic matcher:
+- rejected for now: higher complexity, less deterministic, harder to audit
+
+## Validation
+
+- Unit test suite passes with added calibration tests:
+  - punctuation/hyphen robustness
+  - 6-keyword threshold negative case (2/6 fails)
+  - 6-keyword threshold positive case (3/6 passes)
+
+- Live benchmark rerun is intentionally separate due to API cost/variance and should be done after merge for clean before/after reporting.

--- a/benchmarks/harsh-critic/scoring/__tests__/scorer.test.ts
+++ b/benchmarks/harsh-critic/scoring/__tests__/scorer.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect } from 'vitest';
+import { matchFindings, scoreFixture, aggregateScores } from '../scorer.js';
+import type {
+  GroundTruth,
+  GroundTruthFinding,
+  ParsedAgentOutput,
+  FixtureResult,
+  BenchmarkScores,
+} from '../types.js';
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function makeGroundTruthFinding(overrides: Partial<GroundTruthFinding> = {}): GroundTruthFinding {
+  return {
+    id: 'F1',
+    severity: 'CRITICAL',
+    category: 'finding',
+    summary: 'Test finding',
+    keywords: ['stale', 'validateSession', 'auth'],
+    explanation: 'Test explanation',
+    ...overrides,
+  };
+}
+
+function makeGroundTruth(overrides: Partial<GroundTruth> = {}): GroundTruth {
+  return {
+    fixtureId: 'test-fixture',
+    fixturePath: 'fixtures/test.md',
+    domain: 'plan',
+    expectedVerdict: 'REJECT',
+    findings: [makeGroundTruthFinding()],
+    isCleanBaseline: false,
+    ...overrides,
+  };
+}
+
+function makeParsedOutput(overrides: Partial<ParsedAgentOutput> = {}): ParsedAgentOutput {
+  return {
+    verdict: 'REJECT',
+    criticalFindings: [],
+    majorFindings: [],
+    minorFindings: [],
+    missingItems: [],
+    perspectiveNotes: { security: [], newHire: [], ops: [] },
+    hasPreCommitment: true,
+    hasGapAnalysis: true,
+    hasMultiPerspective: true,
+    rawOutput: '',
+    ...overrides,
+  };
+}
+
+function makeFixtureResult(overrides: Partial<FixtureResult> = {}): FixtureResult {
+  return {
+    fixtureId: 'test-fixture',
+    domain: 'plan',
+    agentType: 'harsh-critic',
+    parsedOutput: makeParsedOutput(),
+    scores: {
+      truePositiveRate: 0.5,
+      falsePositiveRate: 0.2,
+      falseNegativeRate: 0.5,
+      severityAccuracy: 0.8,
+      missingCoverage: 0.6,
+      perspectiveCoverage: 0.5,
+      evidenceRate: 0.7,
+      hasPreCommitment: true,
+      hasMultiPerspective: true,
+      hasGapAnalysis: true,
+      compositeScore: 0.65,
+    },
+    matchedFindings: ['F1'],
+    missedFindings: [],
+    spuriousFindings: [],
+    ...overrides,
+  };
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('matchFindings', () => {
+  test('matches agent finding to ground truth by keyword overlap', () => {
+    const gt = makeGroundTruth();
+    const parsed = makeParsedOutput({
+      criticalFindings: [
+        {
+          text: 'Stale function reference: validateSession() at auth.ts:42',
+          severity: 'CRITICAL',
+          hasEvidence: true,
+        },
+      ],
+    });
+
+    const result = matchFindings(parsed, gt);
+    expect(result.matchedIds).toContain('F1');
+    expect(result.missedIds).toHaveLength(0);
+  });
+
+  test('reports missed findings when no keyword overlap', () => {
+    const gt = makeGroundTruth();
+    const parsed = makeParsedOutput({
+      criticalFindings: [
+        {
+          text: 'Completely unrelated finding about database indexing',
+          severity: 'CRITICAL',
+          hasEvidence: false,
+        },
+      ],
+    });
+
+    const result = matchFindings(parsed, gt);
+    expect(result.matchedIds).toHaveLength(0);
+    expect(result.missedIds).toContain('F1');
+  });
+
+  test('reports spurious findings that do not match ground truth', () => {
+    const gt = makeGroundTruth({ findings: [] });
+    const parsed = makeParsedOutput({
+      criticalFindings: [
+        {
+          text: 'Some spurious finding',
+          severity: 'CRITICAL',
+          hasEvidence: false,
+        },
+      ],
+    });
+
+    const result = matchFindings(parsed, gt);
+    expect(result.spuriousTexts).toHaveLength(1);
+  });
+
+  // --- PR #1300: scorer calibration tests ---
+
+  test('matching is robust to punctuation and hyphen variants', () => {
+    const gt = makeGroundTruth({
+      findings: [
+        makeGroundTruthFinding({
+          id: 'F1',
+          keywords: ['new-hire', 'sameSite', 'cookie', 'csrf'],
+        }),
+      ],
+    });
+
+    const parsed = makeParsedOutput({
+      criticalFindings: [
+        {
+          text: 'New hire note: session cookie is missing SameSite and enables CSRF risk.',
+          severity: 'CRITICAL',
+          hasEvidence: false,
+        },
+      ],
+    });
+
+    const result = matchFindings(parsed, gt);
+    expect(result.matchedIds).toContain('F1');
+  });
+
+  test('requires 3 keyword matches when ground truth has 6 keywords', () => {
+    const gt = makeGroundTruth({
+      findings: [
+        makeGroundTruthFinding({
+          id: 'F1',
+          keywords: ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot'],
+        }),
+      ],
+    });
+
+    const parsed = makeParsedOutput({
+      criticalFindings: [
+        {
+          text: 'alpha bravo issue only',
+          severity: 'CRITICAL',
+          hasEvidence: false,
+        },
+      ],
+    });
+
+    const result = matchFindings(parsed, gt);
+    expect(result.matchedIds).toHaveLength(0);
+    expect(result.missedIds).toContain('F1');
+  });
+
+  test('matches 6-keyword ground truth when 3 keywords overlap', () => {
+    const gt = makeGroundTruth({
+      findings: [
+        makeGroundTruthFinding({
+          id: 'F1',
+          keywords: ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot'],
+        }),
+      ],
+    });
+
+    const parsed = makeParsedOutput({
+      criticalFindings: [
+        {
+          text: 'alpha bravo charlie issue is confirmed',
+          severity: 'CRITICAL',
+          hasEvidence: false,
+        },
+      ],
+    });
+
+    const result = matchFindings(parsed, gt);
+    expect(result.matchedIds).toContain('F1');
+  });
+});
+
+describe('scoreFixture', () => {
+  test('computes all score fields', () => {
+    const gt = makeGroundTruth();
+    const parsed = makeParsedOutput({
+      criticalFindings: [
+        {
+          text: 'Stale function reference: validateSession() at auth.ts:42',
+          severity: 'CRITICAL',
+          hasEvidence: true,
+        },
+      ],
+    });
+
+    const scores = scoreFixture(parsed, gt);
+    expect(scores.truePositiveRate).toBe(1);
+    expect(scores.falseNegativeRate).toBe(0);
+    expect(scores.compositeScore).toBeGreaterThan(0);
+  });
+
+  test('returns zero scores for empty output vs ground truth', () => {
+    const gt = makeGroundTruth();
+    const parsed = makeParsedOutput();
+
+    const scores = scoreFixture(parsed, gt);
+    expect(scores.truePositiveRate).toBe(0);
+    expect(scores.falseNegativeRate).toBe(1);
+  });
+});
+
+describe('aggregateScores', () => {
+  test('averages numeric scores across fixture results', () => {
+    const r1 = makeFixtureResult({
+      scores: { ...makeFixtureResult().scores, truePositiveRate: 0.8 },
+    });
+    const r2 = makeFixtureResult({
+      scores: { ...makeFixtureResult().scores, truePositiveRate: 0.4 },
+    });
+
+    const agg = aggregateScores([r1, r2]);
+    expect(agg.truePositiveRate).toBeCloseTo(0.6);
+  });
+
+  test('returns zero scores for empty results array', () => {
+    const agg = aggregateScores([]);
+    expect(agg.compositeScore).toBe(0);
+    expect(agg.truePositiveRate).toBe(0);
+  });
+});

--- a/benchmarks/harsh-critic/vitest.config.ts
+++ b/benchmarks/harsh-critic/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    testTimeout: 30000,
+    include: ['scoring/__tests__/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
This PR adds tests and documentation for the keyword matcher calibration in benchmark scoring.

Rebased onto dev's modular scoring structure (`benchmarks/harsh-critic/scoring/`). The scorer calibration changes are already present on dev; this PR adds the missing test coverage and rationale documentation.

## What Changed
- Added `benchmarks/harsh-critic/scoring/__tests__/scorer.test.ts` (10 tests) covering:
  - Basic keyword matching (positive and negative cases)
  - Spurious finding detection
  - Punctuation/hyphen variant robustness (`new-hire` vs `New hire`)
  - Dynamic threshold: 6-keyword negative boundary (2/6 fails)
  - Dynamic threshold: 6-keyword positive boundary (3/6 passes)
  - Score computation and aggregation
- Added `benchmarks/harsh-critic/SCORING_MATCH_CALIBRATION.md` - rationale for calibration changes
- Added `benchmarks/harsh-critic/vitest.config.ts` for running benchmark tests independently

## Validation
- [x] `npx vitest run --config vitest.config.ts` in `benchmarks/harsh-critic/` - 10 tests passing
- [x] Full repo test suite - no regressions (same failure count as dev baseline)
- [x] Scorer changes verified present on dev branch

## Scope
- No scorer logic changes (already on dev)
- No parser changes
- No fixture or ground-truth changes
