### PR TITLE
fix(security): add SSRF protection for ANTHROPIC_BASE_URL (#1298)

### DIFF
--- a/src/__tests__/ssrf-guard.test.ts
+++ b/src/__tests__/ssrf-guard.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { validateUrlForSSRF, validateAnthropicBaseUrl } from '../utils/ssrf-guard.js';
+
+describe('SSRF Guard', () => {
+  describe('validateUrlForSSRF', () => {
+    describe('blocks private/internal IPs', () => {
+      it('blocks localhost', () => {
+        expect(validateUrlForSSRF('http://localhost/api')).toEqual({
+          allowed: false,
+          reason: "Hostname 'localhost' resolves to a blocked internal/private address",
+        });
+      });
+
+      it('blocks 127.0.0.1', () => {
+        expect(validateUrlForSSRF('http://127.0.0.1/api')).toEqual({
+          allowed: false,
+          reason: "Hostname '127.0.0.1' resolves to a blocked internal/private address",
+        });
+      });
+
+      it('blocks 10.x.x.x', () => {
+        expect(validateUrlForSSRF('http://10.0.0.1/api').allowed).toBe(false);
+        expect(validateUrlForSSRF('http://10.255.255.255/api').allowed).toBe(false);
+      });
+
+      it('blocks 172.16-31.x.x', () => {
+        expect(validateUrlForSSRF('http://172.16.0.1/api').allowed).toBe(false);
+        expect(validateUrlForSSRF('http://172.31.255.255/api').allowed).toBe(false);
+        expect(validateUrlForSSRF('http://172.15.0.1/api').allowed).toBe(true);
+        expect(validateUrlForSSRF('http://172.32.0.1/api').allowed).toBe(true);
+      });
+
+      it('blocks 192.168.x.x', () => {
+        expect(validateUrlForSSRF('http://192.168.0.1/api').allowed).toBe(false);
+        expect(validateUrlForSSRF('http://192.168.255.255/api').allowed).toBe(false);
+      });
+
+      it('blocks 169.254.x.x (link-local)', () => {
+        expect(validateUrlForSSRF('http://169.254.0.1/api').allowed).toBe(false);
+      });
+
+      it('blocks IPv6 loopback', () => {
+        expect(validateUrlForSSRF('http://[::1]/api').allowed).toBe(false);
+      });
+
+      it('blocks IPv6 link-local', () => {
+        expect(validateUrlForSSRF('http://[fe80::1]/api').allowed).toBe(false);
+      });
+    });
+
+    describe('blocks dangerous protocols', () => {
+      it('blocks file://', () => {
+        expect(validateUrlForSSRF('file:///etc/passwd').allowed).toBe(false);
+      });
+
+      it('blocks ftp://', () => {
+        expect(validateUrlForSSRF('ftp://example.com/file').allowed).toBe(false);
+      });
+
+      it('blocks gopher://', () => {
+        expect(validateUrlForSSRF('gopher://example.com').allowed).toBe(false);
+      });
+    });
+
+    describe('blocks credentials in URL', () => {
+      it('blocks user:pass@host', () => {
+        expect(validateUrlForSSRF('https://user:pass@example.com').allowed).toBe(false);
+      });
+    });
+
+    describe('blocks cloud metadata endpoints', () => {
+      it('blocks AWS metadata', () => {
+        expect(validateUrlForSSRF('http://169.254.169.254/latest/meta-data/').allowed).toBe(false);
+      });
+    });
+
+    describe('allows valid URLs', () => {
+      it('allows https://api.anthropic.com', () => {
+        expect(validateUrlForSSRF('https://api.anthropic.com/v1').allowed).toBe(true);
+      });
+
+      it('allows https://custom-proxy.example.com', () => {
+        expect(validateUrlForSSRF('https://custom-proxy.example.com/v1').allowed).toBe(true);
+      });
+
+      it('allows http:// for non-production (with warning)', () => {
+        expect(validateUrlForSSRF('http://example.com').allowed).toBe(true);
+      });
+    });
+
+    describe('handles invalid inputs', () => {
+      it('rejects empty string', () => {
+        expect(validateUrlForSSRF('').allowed).toBe(false);
+      });
+
+      it('rejects non-string input', () => {
+        expect(validateUrlForSSRF(null as any).allowed).toBe(false);
+        expect(validateUrlForSSRF(undefined as any).allowed).toBe(false);
+      });
+
+      it('rejects malformed URLs', () => {
+        expect(validateUrlForSSRF('not-a-url').allowed).toBe(false);
+      });
+    });
+  });
+
+  describe('validateAnthropicBaseUrl', () => {
+    it('blocks internal IPs', () => {
+      expect(validateAnthropicBaseUrl('http://127.0.0.1:8080').allowed).toBe(false);
+    });
+
+    it('allows valid external URLs', () => {
+      expect(validateAnthropicBaseUrl('https://api.anthropic.com').allowed).toBe(true);
+    });
+  });
+});

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,3 +1,5 @@
+import { validateAnthropicBaseUrl } from '../utils/ssrf-guard.js';
+
 /**
  * Centralized Model ID Constants
  *
@@ -77,8 +79,17 @@ export function isNonClaudeProvider(): boolean {
 
   // Custom base URL suggests a proxy/gateway (CC Switch, LiteLLM, OneAPI, etc.)
   const baseUrl = process.env.ANTHROPIC_BASE_URL || '';
-  if (baseUrl && !baseUrl.includes('anthropic.com')) {
-    return true;
+  if (baseUrl) {
+    // Validate URL for SSRF protection
+    const validation = validateAnthropicBaseUrl(baseUrl);
+    if (!validation.allowed) {
+      console.error(`[SSRF Guard] Rejecting ANTHROPIC_BASE_URL: ${validation.reason}`);
+      // Treat invalid URLs as non-Claude to prevent potential SSRF
+      return true;
+    }
+    if (!baseUrl.includes('anthropic.com')) {
+      return true;
+    }
   }
 
   return false;

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -18,6 +18,7 @@ import { join, dirname } from 'path';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 import https from 'https';
+import { validateAnthropicBaseUrl } from '../utils/ssrf-guard.js';
 import type { RateLimits, UsageResult } from './types.js';
 
 // Cache configuration
@@ -379,6 +380,14 @@ function fetchUsageFromZai(): Promise<ZaiQuotaResponse | null> {
     const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
 
     if (!baseUrl || !authToken) {
+      resolve(null);
+      return;
+    }
+
+    // Validate baseUrl for SSRF protection
+    const validation = validateAnthropicBaseUrl(baseUrl);
+    if (!validation.allowed) {
+      console.error(`[SSRF Guard] Blocking usage API call: ${validation.reason}`);
       resolve(null);
       return;
     }

--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -1,0 +1,119 @@
+/**
+ * SSRF Guard - URL validation to prevent Server-Side Request Forgery
+ *
+ * Validates URLs to ensure they don't point to:
+ * - Private IP ranges (10.x.x.x, 172.16-31.x.x, 192.168.x.x)
+ * - Loopback (127.x.x.x, localhost)
+ * - Link-local (169.254.x.x)
+ * - Multicast (224-239.x.x.x)
+ * - Reserved/documentations ranges
+ */
+
+export interface SSRFValidationResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+// Private/internal IP patterns
+const BLOCKED_HOST_PATTERNS = [
+  // Exact matches
+  /^localhost$/i,
+  /^127\.[0-9]+\.[0-9]+\.[0-9]+$/, // Loopback
+  /^10\.[0-9]+\.[0-9]+\.[0-9]+$/, // Class A private
+  /^172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]+\.[0-9]+$/, // Class B private
+  /^192\.168\.[0-9]+\.[0-9]+$/, // Class C private
+  /^169\.254\.[0-9]+\.[0-9]+$/, // Link-local
+  /^(0|22[4-9]|23[0-9])\.[0-9]+\.[0-9]+\.[0-9]+$/, // Multicast, reserved
+  /^\[?::1\]?$/, // IPv6 loopback
+  /^\[?fc00:/i, // IPv6 unique local
+  /^\[?fe80:/i, // IPv6 link-local
+];
+
+// Blocked URL schemes
+const ALLOWED_SCHEMES = ['https:', 'http:'];
+
+/**
+ * Validate a URL to prevent SSRF attacks
+ * @param urlString The URL to validate
+ * @returns SSRFValidationResult indicating if URL is safe
+ */
+export function validateUrlForSSRF(urlString: string): SSRFValidationResult {
+  if (!urlString || typeof urlString !== 'string') {
+    return { allowed: false, reason: 'URL is empty or invalid' };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return { allowed: false, reason: 'Invalid URL format' };
+  }
+
+  // Only allow http/https
+  if (!ALLOWED_SCHEMES.includes(parsed.protocol)) {
+    return { allowed: false, reason: `Protocol '${parsed.protocol}' is not allowed` };
+  }
+
+  // Get hostname (remove port if present)
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Check against blocked patterns
+  for (const pattern of BLOCKED_HOST_PATTERNS) {
+    if (pattern.test(hostname)) {
+      return {
+        allowed: false,
+        reason: `Hostname '${hostname}' resolves to a blocked internal/private address`,
+      };
+    }
+  }
+
+  // Block URLs with credentials (user:pass@host)
+  if (parsed.username || parsed.password) {
+    return { allowed: false, reason: 'URLs with embedded credentials are not allowed' };
+  }
+
+  // Block specific dangerous paths that could access cloud metadata
+  const dangerousPaths = [
+    '/metadata',
+    '/meta-data',
+    '/latest/meta-data',
+    '/computeMetadata',
+  ];
+  const pathLower = parsed.pathname.toLowerCase();
+  for (const dangerous of dangerousPaths) {
+    if (pathLower.startsWith(dangerous)) {
+      return {
+        allowed: false,
+        reason: `Path '${parsed.pathname}' is blocked (cloud metadata access)`,
+      };
+    }
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Validate ANTHROPIC_BASE_URL for safe usage
+ * This is a convenience function that also enforces HTTPS preference
+ */
+export function validateAnthropicBaseUrl(urlString: string): SSRFValidationResult {
+  const result = validateUrlForSSRF(urlString);
+  if (!result.allowed) {
+    return result;
+  }
+
+  // Prefer HTTPS but don't block HTTP for local development
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return { allowed: false, reason: 'Invalid URL' };
+  }
+
+  // Log warning for HTTP (non-HTTPS) in production contexts
+  if (parsed.protocol === 'http:') {
+    console.warn('[SSRF Guard] Warning: Using HTTP instead of HTTPS for ANTHROPIC_BASE_URL');
+  }
+
+  return { allowed: true };
+}


### PR DESCRIPTION
## Summary
Fixes #1298 - ANTHROPIC_BASE_URL enables SSRF attacks

## Changes
- Added SSRF guard utility (`src/utils/ssrf-guard.ts`):
  - Blocks private IP ranges (10.x, 172.16-31.x, 192.168.x)
  - Blocks loopback (127.x, localhost, ::1)  
  - Blocks link-local addresses (169.254.x)
  - Blocks IPv6 loopback and link-local
  - Blocks cloud metadata endpoints (/meta-data, /metadata)
  - Blocks URLs with embedded credentials
  - Only allows http/https protocols

- Integrated into `src/config/models.ts`:
  - `isNonClaudeProvider()` validates ANTHROPIC_BASE_URL
  - Rejects unsafe URLs with console.error logging

- Integrated into `src/hud/usage-api.ts`:
  - `fetchUsageFromZai()` validates baseUrl before API calls

## Tests
- Added 21 comprehensive tests in `src/__tests__/ssrf-guard.test.ts`
- All existing tests pass

## Security Impact
- Prevents SSRF attacks via ANTHROPIC_BASE_URL
- Prevents access to internal cloud metadata services
- Maintains backward compatibility for valid external URLs

Fixes #1298