### PR TITLE
fix(hud): use async file I/O to prevent event loop blocking (#1273)

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -33,7 +33,8 @@ import type {
 import { getRuntimePackageVersion } from "../lib/version.js";
 import { compareVersions } from "../features/auto-update.js";
 import { resolveToWorktreeRoot, resolveTranscriptPath } from "../lib/worktree-paths.js";
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { writeFileSync, mkdirSync } from "fs";
+import { access, readFile } from "fs/promises";
 import { join, basename } from "path";
 import { homedir } from "os";
 import { getOmcRoot } from "../lib/worktree-paths.js";
@@ -158,13 +159,14 @@ async function main(watchMode = false): Promise<void> {
     } catch {
       // Ignore version detection errors
     }
+    // Async file read to avoid blocking event loop (Issue #1273)
     try {
       const updateCacheFile = join(homedir(), '.omc', 'update-check.json');
-      if (existsSync(updateCacheFile)) {
-        const cached = JSON.parse(readFileSync(updateCacheFile, 'utf-8'));
-        if (cached?.latestVersion && omcVersion && compareVersions(omcVersion, cached.latestVersion) < 0) {
-          updateAvailable = cached.latestVersion;
-        }
+      await access(updateCacheFile);
+      const content = await readFile(updateCacheFile, 'utf-8');
+      const cached = JSON.parse(content);
+      if (cached?.latestVersion && omcVersion && compareVersions(omcVersion, cached.latestVersion) < 0) {
+        updateAvailable = cached.latestVersion;
       }
     } catch {
       // Ignore update cache read errors
@@ -227,9 +229,7 @@ async function main(watchMode = false): Promise<void> {
     ) {
       try {
         const omcStateDir = join(getOmcRoot(cwd), 'state');
-        if (!existsSync(omcStateDir)) {
-          mkdirSync(omcStateDir, { recursive: true });
-        }
+        mkdirSync(omcStateDir, { recursive: true });
         const triggerFile = join(omcStateDir, 'compact-requested.json');
         writeFileSync(
           triggerFile,


### PR DESCRIPTION
## Summary
Fixes #1273 - Synchronous file I/O blocks event loop in HUD render hot path

## Changes
- Refactored src/hud/index.ts to use fs/promises:
  - Replaced `existsSync` + `readFileSync` with async `access` + `readFile`
  - Removed redundant `existsSync` check before `mkdirSync`
- Update cache reading is now non-blocking

## Impact
- Prevents event loop blocking during HUD rendering
- Better responsiveness for high-frequency HUD updates
- 274 HUD tests pass

Fixes #1273