### PR TITLE
fix(persistent-mode): check cancel signal before blocking stop hook

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -151,6 +151,41 @@ function isStaleState(state) {
 }
 
 /**
+ * Check if a cancel signal is in progress for the session.
+ * Cancel signals are written by state_clear and expire after 30 seconds.
+ * @param {string} stateDir - The .omc/state directory path
+ * @param {string} sessionId - Optional session ID
+ * @returns {boolean} true if cancel is in progress
+ */
+function isSessionCancelInProgress(stateDir, sessionId) {
+  const CANCEL_SIGNAL_TTL_MS = 30000; // 30 seconds
+
+  // Try session-scoped path first
+  if (sessionId) {
+    const sessionSignalPath = join(stateDir, 'sessions', sessionId, 'cancel-signal-state.json');
+    const signal = readJsonFile(sessionSignalPath);
+    if (signal && signal.expires_at) {
+      const expiresAt = new Date(signal.expires_at).getTime();
+      if (Date.now() < expiresAt) {
+        return true;
+      }
+    }
+  }
+
+  // Fall back to legacy path
+  const legacySignalPath = join(stateDir, 'cancel-signal-state.json');
+  const signal = readJsonFile(legacySignalPath);
+  if (signal && signal.expires_at) {
+    const expiresAt = new Date(signal.expires_at).getTime();
+    if (Date.now() < expiresAt) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Normalize a path for comparison.
  */
 function normalizePath(p) {
@@ -417,6 +452,12 @@ async function main() {
     const taskCount = countIncompleteTasks(sessionId);
     const todoCount = countIncompleteTodos(sessionId, directory);
     const totalIncomplete = taskCount + todoCount;
+
+    // Check if cancel is in progress - if so, allow stop immediately
+    if (isSessionCancelInProgress(stateDir, sessionId)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
 
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -176,6 +176,41 @@ function isStaleSkillState(state) {
 }
 
 /**
+ * Check if a cancel signal is in progress for the session.
+ * Cancel signals are written by state_clear and expire after 30 seconds.
+ * @param {string} stateDir - The .omc/state directory path
+ * @param {string} sessionId - Optional session ID
+ * @returns {boolean} true if cancel is in progress
+ */
+function isSessionCancelInProgress(stateDir, sessionId) {
+  const CANCEL_SIGNAL_TTL_MS = 30000; // 30 seconds
+
+  // Try session-scoped path first
+  if (sessionId) {
+    const sessionSignalPath = join(stateDir, 'sessions', sessionId, 'cancel-signal-state.json');
+    const signal = readJsonFile(sessionSignalPath);
+    if (signal && signal.expires_at) {
+      const expiresAt = new Date(signal.expires_at).getTime();
+      if (Date.now() < expiresAt) {
+        return true;
+      }
+    }
+  }
+
+  // Fall back to legacy path
+  const legacySignalPath = join(stateDir, 'cancel-signal-state.json');
+  const signal = readJsonFile(legacySignalPath);
+  if (signal && signal.expires_at) {
+    const expiresAt = new Date(signal.expires_at).getTime();
+    if (Date.now() < expiresAt) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Normalize a path for comparison.
  * Uses path.resolve() + path.normalize() for proper handling of:
  * - Trailing slashes
@@ -505,6 +540,12 @@ async function main() {
     const taskCount = countIncompleteTasks(sessionId);
     const todoCount = countIncompleteTodos(sessionId, directory);
     const totalIncomplete = taskCount + todoCount;
+
+    // Check if cancel is in progress - if so, allow stop immediately
+    if (isSessionCancelInProgress(stateDir, sessionId)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
 
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions


### PR DESCRIPTION
## Summary

Fixes #1299 - `/oh-my-claudecode:cancel` not working because the stop hook continued blocking session stops even after the cancel command was issued.

## Root Cause

The stop hook (`persistent-mode.cjs`) checked `state.active === true` to decide whether to block, but it didn't check for the cancel signal (`cancel-signal-state.json`) that gets written when `state_clear` is called during cancellation.

## Changes

Added `isSessionCancelInProgress()` function to both:
- `scripts/persistent-mode.cjs`
- `templates/hooks/persistent-mode.mjs`

This function:
1. Checks session-scoped cancel signal first (`.omc/state/sessions/{id}/cancel-signal-state.json`)
2. Falls back to legacy path (`.omc/state/cancel-signal-state.json`)
3. Validates the 30-second TTL on the signal
4. Allows stop immediately if cancel is in progress

## Impact

This fixes the issue for **all persistent modes** (ralph, autopilot, ultrawork, ultraqa, pipeline, team, omc-teams) since they all rely on the same persistent-mode hook.

## Testing

- All 5750 existing tests pass
- Manual verification confirmed:
  - Without cancel signal: blocks correctly (mode continues)
  - With valid cancel signal: allows stop immediately
  - With expired cancel signal: blocks correctly (TTL validation works)

## Related

- Issue #1299