### PR TITLE
ci: add npm pack + install test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,60 @@ jobs:
           fi
           
           echo "✅ All versions match: $PKG_VERSION"
+
+  npm-pack-test:
+    name: npm pack + install test
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: npm pack test
+        run: |
+          echo "📦 Creating tarball..."
+          npm pack
+          
+          TARBALL=$(ls -t oh-my-claude-sisyphus-*.tgz | head -1)
+          echo "📦 Tarball: $TARBALL"
+          
+          echo "📦 Testing global install from tarball..."
+          npm install -g ./$TARBALL
+          
+          echo "🔍 Checking omc command..."
+          which omc
+          
+          echo "🔍 Testing omc --version..."
+          omc --version
+          
+          VERSION_OUTPUT=$(omc --version 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "❌ omc --version failed!"
+            echo "$VERSION_OUTPUT"
+            exit 1
+          fi
+          
+          echo "✅ omc --version: $VERSION_OUTPUT"
+          
+          echo "🔍 Testing omc --help..."
+          omc --help
+          
+          HELP_OUTPUT=$(omc --help 2>&1)
+          if [ $? -ne 0 ]; then
+            echo "❌ omc --help failed!"
+            echo "$HELP_OUTPUT"
+            exit 1
+          fi
+          
+          echo "✅ npm pack + install test passed!"


### PR DESCRIPTION
## Summary

Add npm-pack-test job to CI that verifies the package actually works when installed from npm registry.

## Problem

CI was green but publish failed:
- 4.6.2: Missing bridge/cli.cjs file
- 4.6.3: better-sqlite3 build failures

The gap: CI tests git clone → npm run build, but users run npm install -g.

## Solution

Add job that:
1. npm pack (creates tarball like npm publish)
2. npm install -g ./tarball
3. omc --version (must succeed)
4. omc --help (must succeed)

## Testing

This would have caught:
- Missing files in files[] array
- Build artifacts not included
- CLI entry point failures

## Related

- Issue #1315: npm package v4.6.2 missing bridge/cli.cjs
- User reports from @dorge and @sibainu