### PR TITLE
fix: add cancel-signal check to persistent-mode.cjs to prevent infinite loop

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -14,6 +14,7 @@ const {
   writeFileSync,
   readdirSync,
   mkdirSync,
+  unlinkSync,
 } = require("fs");
 const { join, dirname, resolve, normalize } = require("path");
 const { homedir } = require("os");
@@ -121,6 +122,40 @@ async function sendStopNotification(modeName, stateData, sessionId, directory) {
   } catch {
     // Notification module not available, skip silently
   }
+}
+
+/**
+ * TTL for cancel signals (30 seconds, matching index.ts CANCEL_SIGNAL_TTL_MS).
+ */
+const CANCEL_SIGNAL_TTL_MS = 30_000;
+
+/**
+ * Check whether this session is in an explicit cancel window.
+ * Used to prevent stop-hook re-enforcement races during /cancel.
+ * Mirrors isSessionCancelInProgress() from src/hooks/persistent-mode/index.ts.
+ */
+function isSessionCancelInProgress(stateDir, sessionId) {
+  if (!sessionId) return false;
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) return false;
+
+  const sessionsDir = join(stateDir, 'sessions', sessionId);
+  const signalPath = join(sessionsDir, 'cancel-signal-state.json');
+  const signal = readJsonFile(signalPath);
+  if (!signal) return false;
+
+  const now = Date.now();
+  const expiresAt = signal.expires_at ? new Date(signal.expires_at).getTime() : NaN;
+  const requestedAt = signal.requested_at ? new Date(signal.requested_at).getTime() : NaN;
+  const fallbackExpiry = Number.isFinite(requestedAt) ? requestedAt + CANCEL_SIGNAL_TTL_MS : NaN;
+  const effectiveExpiry = Number.isFinite(expiresAt) ? expiresAt : fallbackExpiry;
+
+  if (!Number.isFinite(effectiveExpiry) || effectiveExpiry <= now) {
+    // Expired — clean up and return false
+    try { unlinkSync(signalPath); } catch {}
+    return false;
+  }
+
+  return true;
 }
 
 /**
@@ -395,6 +430,13 @@ async function main() {
 
     // Respect user abort (Ctrl+C, cancel)
     if (isUserAbort(data)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    // Check for cancel signal from /cancel flow (issue #1058)
+    // Prevents infinite loop when persistent modes are active during cancellation.
+    if (isSessionCancelInProgress(stateDir, sessionId)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }

--- a/src/hooks/persistent-mode/__tests__/cancel-race.test.ts
+++ b/src/hooks/persistent-mode/__tests__/cancel-race.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
 import { checkPersistentModes } from '../index.js';
+
+const CJS_SCRIPT = resolve(__dirname, '../../../../scripts/persistent-mode.cjs');
 
 function makeRalphSession(tempDir: string, sessionId: string): string {
   const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
@@ -96,6 +98,200 @@ describe('persistent-mode cancel race guard (issue #921)', () => {
       expect(ralphState.max_iterations).toBe(10);
 
       expect(existsSync(join(stateDir, 'ultrawork-state.json'))).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('persistent-mode.cjs cancel-signal check (issue #1058)', () => {
+  function runCjsHook(input: Record<string, unknown>): Record<string, unknown> {
+    const stdout = execFileSync(process.execPath, [CJS_SCRIPT], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    // Parse the last JSON line (the script may emit multiple lines)
+    const lines = stdout.trim().split('\n');
+    return JSON.parse(lines[lines.length - 1]) as Record<string, unknown>;
+  }
+
+  it('should return continue:true when cancel-signal-state.json is active (ultrawork)', () => {
+    const sessionId = 'session-1058-cjs-ultrawork';
+    const tempDir = mkdtempSync(join(tmpdir(), 'cjs-cancel-signal-uw-'));
+
+    try {
+      const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(stateDir, { recursive: true });
+
+      // Write active ultrawork state
+      writeFileSync(
+        join(stateDir, 'ultrawork-state.json'),
+        JSON.stringify({
+          active: true,
+          started_at: new Date().toISOString(),
+          original_prompt: 'test task',
+          session_id: sessionId,
+          project_path: tempDir,
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString(),
+        })
+      );
+
+      // Write active cancel signal
+      writeFileSync(
+        join(stateDir, 'cancel-signal-state.json'),
+        JSON.stringify({
+          requested_at: new Date().toISOString(),
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+          source: 'test',
+        })
+      );
+
+      const result = runCjsHook({
+        cwd: tempDir,
+        sessionId,
+        stop_reason: 'end_turn',
+      });
+
+      expect(result.continue).toBe(true);
+
+      // Ultrawork state should NOT have been incremented
+      const uwState = JSON.parse(readFileSync(join(stateDir, 'ultrawork-state.json'), 'utf-8'));
+      expect(uwState.reinforcement_count).toBe(0);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return continue:true when cancel-signal-state.json is active (ralph)', () => {
+    const sessionId = 'session-1058-cjs-ralph';
+    const tempDir = mkdtempSync(join(tmpdir(), 'cjs-cancel-signal-ralph-'));
+
+    try {
+      const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(stateDir, { recursive: true });
+
+      // Write active ralph state at max iteration
+      writeFileSync(
+        join(stateDir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          iteration: 10,
+          max_iterations: 10,
+          started_at: new Date().toISOString(),
+          prompt: 'Finish all work',
+          session_id: sessionId,
+          project_path: tempDir,
+          linked_ultrawork: true,
+        })
+      );
+
+      // Write active cancel signal
+      writeFileSync(
+        join(stateDir, 'cancel-signal-state.json'),
+        JSON.stringify({
+          requested_at: new Date().toISOString(),
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+          source: 'test',
+        })
+      );
+
+      const result = runCjsHook({
+        cwd: tempDir,
+        sessionId,
+        stop_reason: 'end_turn',
+      });
+
+      expect(result.continue).toBe(true);
+
+      // Ralph state should NOT have been modified
+      const ralphState = JSON.parse(readFileSync(join(stateDir, 'ralph-state.json'), 'utf-8'));
+      expect(ralphState.iteration).toBe(10);
+      expect(ralphState.max_iterations).toBe(10);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should block when ultrawork is active but NO cancel signal exists', () => {
+    const sessionId = 'session-1058-cjs-no-cancel';
+    const tempDir = mkdtempSync(join(tmpdir(), 'cjs-no-cancel-signal-'));
+
+    try {
+      const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(stateDir, { recursive: true });
+
+      // Write active ultrawork state (no cancel signal)
+      writeFileSync(
+        join(stateDir, 'ultrawork-state.json'),
+        JSON.stringify({
+          active: true,
+          started_at: new Date().toISOString(),
+          original_prompt: 'test task',
+          session_id: sessionId,
+          project_path: tempDir,
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString(),
+        })
+      );
+
+      const result = runCjsHook({
+        cwd: tempDir,
+        sessionId,
+        stop_reason: 'end_turn',
+      });
+
+      // Should block (decision: "block") because ultrawork is active and no cancel signal
+      expect(result.decision).toBe('block');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should NOT honor expired cancel signals', () => {
+    const sessionId = 'session-1058-cjs-expired';
+    const tempDir = mkdtempSync(join(tmpdir(), 'cjs-expired-cancel-'));
+
+    try {
+      const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(stateDir, { recursive: true });
+
+      // Write active ultrawork state
+      writeFileSync(
+        join(stateDir, 'ultrawork-state.json'),
+        JSON.stringify({
+          active: true,
+          started_at: new Date().toISOString(),
+          original_prompt: 'test task',
+          session_id: sessionId,
+          project_path: tempDir,
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString(),
+        })
+      );
+
+      // Write EXPIRED cancel signal (expired 10 seconds ago)
+      writeFileSync(
+        join(stateDir, 'cancel-signal-state.json'),
+        JSON.stringify({
+          requested_at: new Date(Date.now() - 40_000).toISOString(),
+          expires_at: new Date(Date.now() - 10_000).toISOString(),
+          source: 'test',
+        })
+      );
+
+      const result = runCjsHook({
+        cwd: tempDir,
+        sessionId,
+        stop_reason: 'end_turn',
+      });
+
+      // Should block because cancel signal is expired — ultrawork still active
+      expect(result.decision).toBe('block');
+
+      // Expired signal file should have been cleaned up
+      expect(existsSync(join(stateDir, 'cancel-signal-state.json'))).toBe(false);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `scripts/persistent-mode.cjs` (the Stop hook) lacked the `isSessionCancelInProgress()` check that exists in the TypeScript version (`src/hooks/persistent-mode/index.ts`). When ultrawork/ralph mode was active and the user invoked `/cancel`, the CJS hook entered an infinite blocking loop (up to 50 iterations) because it never read `cancel-signal-state.json`.
- **Fix**: Added `isSessionCancelInProgress()` to `persistent-mode.cjs` mirroring the TypeScript implementation (TTL expiration + cleanup of expired signals), inserted right after the `isUserAbort` check in `main()`.
- **Tests**: Added 4 CJS integration tests validating: ultrawork + active cancel signal, ralph + active cancel signal, ultrawork without cancel signal (should block), and expired cancel signal (should block + cleanup).

## Test plan

- [x] All 7 tests pass (`npx vitest run src/hooks/persistent-mode/__tests__/cancel-race.test.ts`)
  - 3 existing TypeScript-level tests still pass
  - 4 new CJS integration tests pass (invoke `persistent-mode.cjs` via `execFileSync`)
- [ ] Manual: Start ultrawork → invoke `/oh-my-claudecode:cancel` → verify hook returns immediately without looping

Fixes #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)