### PR TITLE
test: harden regression coverage for #1322 #1323 #1324

### DIFF
--- a/src/__tests__/daemon-module-path.test.ts
+++ b/src/__tests__/daemon-module-path.test.ts
@@ -33,4 +33,20 @@ describe('resolveDaemonModulePath', () => {
     );
     expect(result).toBe('C:\\repo\\dist\\features\\rate-limit-wait\\daemon.js');
   });
+
+  it('converts windows-style TypeScript daemon module paths to .js siblings', () => {
+    const result = resolveDaemonModulePath(
+      'C:\\repo\\src\\features\\rate-limit-wait\\daemon.ts',
+      ['features', 'rate-limit-wait', 'daemon.js'],
+    );
+    expect(result).toBe('C:\\repo\\src\\features\\rate-limit-wait\\daemon.js');
+  });
+
+  it('does not rewrite cli.cjs outside bridge directory', () => {
+    const result = resolveDaemonModulePath(
+      '/repo/bin/cli.cjs',
+      ['features', 'rate-limit-wait', 'daemon.js'],
+    );
+    expect(result).toBe('/repo/bin/cli.cjs');
+  });
 });

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -9,6 +9,7 @@ import {
   isRunningAsPlugin,
   isProjectScopedPlugin,
 } from '../installer/index.js';
+import { getRuntimePackageVersion } from '../lib/version.js';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { readdirSync, readFileSync, existsSync } from 'fs';
@@ -299,6 +300,10 @@ describe('Installer Constants', () => {
       const __dirname = dirname(fileURLToPath(import.meta.url));
       const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'));
       expect(VERSION).toBe(pkg.version);
+    });
+
+    it('should stay in sync with runtime package version helper', () => {
+      expect(VERSION).toBe(getRuntimePackageVersion());
     });
   });
 

--- a/src/__tests__/package-dir-resolution-regression.test.ts
+++ b/src/__tests__/package-dir-resolution-regression.test.ts
@@ -1,24 +1,31 @@
-import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync, mkdtempSync } from 'fs';
 import { dirname, join } from 'path';
+import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
+import { loadAgentPrompt } from '../agents/utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const REPO_ROOT = join(__dirname, '..', '..');
 
-function getFunctionSnippet(source: string, functionName: string): string {
-  const marker = `function ${functionName}(): string {`;
+function getSnippetByMarker(source: string, marker: string): string {
   const start = source.indexOf(marker);
   if (start === -1) return '';
-  // The function is small; a bounded snippet is enough for ordering assertions.
+  // A bounded snippet is enough for ordering assertions.
   return source.slice(start, start + 1400);
 }
 
 describe('package dir resolution regression (#1322, #1324)', () => {
+  const originalCwd = process.cwd();
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+  });
+
   it('src/agents/utils.ts checks __dirname before import.meta.url', () => {
     const source = readFileSync(join(REPO_ROOT, 'src', 'agents', 'utils.ts'), 'utf-8');
-    const snippet = getFunctionSnippet(source, 'getPackageDir');
+    const snippet = getSnippetByMarker(source, 'function getPackageDir(): string {');
 
     expect(snippet).toContain("typeof __dirname !== 'undefined'");
     expect(snippet).toContain("currentDirName === 'bridge'");
@@ -30,7 +37,7 @@ describe('package dir resolution regression (#1322, #1324)', () => {
 
   it('src/agents/prompt-helpers.ts checks __dirname before import.meta.url', () => {
     const source = readFileSync(join(REPO_ROOT, 'src', 'agents', 'prompt-helpers.ts'), 'utf-8');
-    const snippet = getFunctionSnippet(source, 'getPackageDir');
+    const snippet = getSnippetByMarker(source, 'function getPackageDir(): string {');
 
     expect(snippet).toContain("typeof __dirname !== 'undefined'");
     expect(snippet).toContain("currentDirName === 'bridge'");
@@ -38,5 +45,38 @@ describe('package dir resolution regression (#1322, #1324)', () => {
     expect(snippet.indexOf("typeof __dirname !== 'undefined'")).toBeLessThan(
       snippet.indexOf('fileURLToPath(import.meta.url)'),
     );
+  });
+
+  it('bridge/runtime-cli.cjs keeps __dirname branch ahead of fileURLToPath(import_meta.url)', () => {
+    const source = readFileSync(join(REPO_ROOT, 'bridge', 'runtime-cli.cjs'), 'utf-8');
+    const snippet = getSnippetByMarker(source, 'function getPackageDir() {');
+
+    expect(snippet).toContain('typeof __dirname !== "undefined"');
+    expect(snippet).toContain('currentDirName === "bridge"');
+    expect(snippet).toContain('fileURLToPath)(import_meta.url)');
+    expect(snippet.indexOf('typeof __dirname !== "undefined"')).toBeLessThan(
+      snippet.indexOf('fileURLToPath)(import_meta.url)'),
+    );
+  });
+
+  it('loadAgentPrompt resolves prompts even when cwd is unrelated', () => {
+    const sandboxDir = mkdtempSync(join(tmpdir(), 'omc-agents-path-resolution-'));
+    process.chdir(sandboxDir);
+
+    const prompt = loadAgentPrompt('architect');
+    expect(prompt).not.toContain('Prompt unavailable');
+    expect(prompt.length).toBeGreaterThan(100);
+  });
+
+  it('getValidAgentRoles resolves agents directory even when cwd is unrelated', async () => {
+    const sandboxDir = mkdtempSync(join(tmpdir(), 'omc-agent-roles-path-resolution-'));
+    process.chdir(sandboxDir);
+
+    const { getValidAgentRoles } = await import('../agents/prompt-helpers.js');
+    const roles = getValidAgentRoles();
+
+    expect(roles).toContain('architect');
+    expect(roles).toContain('executor');
+    expect(roles).toContain('planner');
   });
 });

--- a/src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts
+++ b/src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { DaemonConfig } from '../../features/rate-limit-wait/types.js';
+
+const { mockSpawn, mockResolveDaemonModulePath, mockIsTmuxAvailable } = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+  mockResolveDaemonModulePath: vi.fn(),
+  mockIsTmuxAvailable: vi.fn(() => true),
+}));
+
+vi.mock('child_process', () => ({
+  spawn: mockSpawn,
+}));
+
+vi.mock('../../utils/daemon-module-path.js', () => ({
+  resolveDaemonModulePath: mockResolveDaemonModulePath,
+}));
+
+vi.mock('../../features/rate-limit-wait/tmux-detector.js', async () => {
+  const actual = await vi.importActual<typeof import('../../features/rate-limit-wait/tmux-detector.js')>(
+    '../../features/rate-limit-wait/tmux-detector.js',
+  );
+  return {
+    ...actual,
+    isTmuxAvailable: mockIsTmuxAvailable,
+  };
+});
+
+describe('daemon bootstrap', () => {
+  const originalEnv = { ...process.env };
+  const testDir = join(tmpdir(), `omc-daemon-bootstrap-test-${Date.now()}`);
+  let startDaemon: typeof import('../../features/rate-limit-wait/daemon.js').startDaemon;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockSpawn.mockReset();
+    mockResolveDaemonModulePath.mockReset();
+    mockIsTmuxAvailable.mockReset();
+    mockIsTmuxAvailable.mockReturnValue(true);
+    mockResolveDaemonModulePath.mockReturnValue('/repo/dist/features/rate-limit-wait/daemon.js');
+
+    ({ startDaemon } = await import('../../features/rate-limit-wait/daemon.js'));
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('uses resolved daemon module path and sanitized child env when starting', () => {
+    const unref = vi.fn();
+    mockSpawn.mockReturnValue({ pid: 4242, unref } as any);
+
+    process.env.PATH = '/usr/bin:/bin';
+    process.env.TMUX = '/tmp/tmux-1000/default,100,0';
+    process.env.ANTHROPIC_API_KEY = 'super-secret';
+    process.env.GITHUB_TOKEN = 'token-should-not-leak';
+
+    const config: DaemonConfig = {
+      stateFilePath: join(testDir, 'state.json'),
+      pidFilePath: join(testDir, 'daemon.pid'),
+      logFilePath: join(testDir, 'daemon.log'),
+      pollIntervalMs: 1234,
+      verbose: true,
+    };
+
+    const result = startDaemon(config);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Daemon started with PID 4242');
+    expect(unref).toHaveBeenCalledTimes(1);
+
+    expect(mockResolveDaemonModulePath).toHaveBeenCalledTimes(1);
+    expect(mockResolveDaemonModulePath).toHaveBeenCalledWith(
+      expect.any(String),
+      ['features', 'rate-limit-wait', 'daemon.js'],
+    );
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [command, args, spawnOptions] = mockSpawn.mock.calls[0]!;
+    expect(command).toBe('node');
+    expect(args[0]).toBe('-e');
+    expect(args[1]).toContain("import('/repo/dist/features/rate-limit-wait/daemon.js')");
+    expect(spawnOptions?.detached).toBe(true);
+    expect(spawnOptions?.stdio).toBe('ignore');
+
+    const childEnv = spawnOptions?.env as Record<string, string | undefined>;
+    expect(childEnv.PATH).toBe('/usr/bin:/bin');
+    expect(childEnv.TMUX).toBe('/tmp/tmux-1000/default,100,0');
+    expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(childEnv.GITHUB_TOKEN).toBeUndefined();
+
+    const configPath = childEnv.OMC_DAEMON_CONFIG_FILE;
+    expect(configPath).toBeTruthy();
+    expect(existsSync(configPath!)).toBe(true);
+    const persistedConfig = JSON.parse(readFileSync(configPath!, 'utf-8')) as Record<string, unknown>;
+    expect(persistedConfig.pollIntervalMs).toBe(1234);
+    expect(persistedConfig.verbose).toBe(true);
+  });
+
+  it('returns already running when config pid file points to a live process', () => {
+    const config: DaemonConfig = {
+      stateFilePath: join(testDir, 'state.json'),
+      pidFilePath: join(testDir, 'daemon.pid'),
+      logFilePath: join(testDir, 'daemon.log'),
+    };
+
+    // Use current process PID so isDaemonRunning() reports true.
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(config.pidFilePath!, String(process.pid));
+
+    const result = startDaemon(config);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Daemon is already running');
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -18,6 +18,7 @@ import {
   HookInput,
   HookType,
 } from '../bridge.js';
+import { flushPendingWrites } from '../subagent-tracker/index.js';
 
 // ============================================================================
 // Hook Routing Tests
@@ -766,6 +767,101 @@ describe('processHook - Routing Matrix', () => {
       } finally {
         rmSync(tempDir, { recursive: true, force: true });
       }
+    });
+
+    it('setup-maintenance: hook type routing overrides conflicting trigger input', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-858-setup-maint-'));
+      try {
+        const rawInput = {
+          session_id: 'test-session-858',
+          cwd: tempDir,
+          transcript_path: join(tempDir, 'transcript.jsonl'),
+          permission_mode: 'default',
+          hook_event_name: 'Setup',
+          trigger: 'init',
+        } as unknown as HookInput;
+
+        const result = await processHook('setup-maintenance', rawInput);
+        expect(result.continue).toBe(true);
+        const out = result as unknown as Record<string, unknown>;
+        const specific = out.hookSpecificOutput as Record<string, unknown>;
+        expect(specific.hookEventName).toBe('Setup');
+        const context = String(specific.additionalContext ?? '');
+        expect(context).toContain('OMC maintenance completed:');
+        expect(context).not.toContain('OMC initialized:');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('subagent start/stop: normalized optional fields survive routing lifecycle', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-858-subagent-'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const startInput = {
+          session_id: 'test-session-858-subagent',
+          cwd: tempDir,
+          agent_id: 'agent-858',
+          agent_type: 'executor',
+          prompt: 'Investigate normalization edge regression in bridge routing',
+          model: 'gpt-5.3-codex-spark',
+        } as unknown as HookInput;
+
+        const start = await processHook('subagent-start', startInput);
+        expect(start.continue).toBe(true);
+
+        const stopInput = {
+          sessionId: 'test-session-858-subagent',
+          directory: tempDir,
+          agent_id: 'agent-858',
+          agent_type: 'executor',
+          output: 'routing complete with normalized fields',
+          success: false,
+        } as unknown as HookInput;
+
+        const stop = await processHook('subagent-stop', stopInput);
+        expect(stop.continue).toBe(true);
+
+        flushPendingWrites();
+
+        const trackingPath = join(tempDir, '.omc', 'state', 'subagent-tracking.json');
+        expect(existsSync(trackingPath)).toBe(true);
+
+        const tracking = JSON.parse(readFileSync(trackingPath, 'utf-8')) as {
+          agents: Array<Record<string, unknown>>;
+          total_failed: number;
+          total_completed: number;
+        };
+
+        const agent = tracking.agents.find((a) => a.agent_id === 'agent-858');
+        expect(agent).toBeDefined();
+        expect(agent?.task_description).toBe('Investigate normalization edge regression in bridge routing');
+        expect(agent?.model).toBe('gpt-5.3-codex-spark');
+        expect(agent?.status).toBe('failed');
+        expect(String(agent?.output_summary ?? '')).toContain('routing complete with normalized fields');
+        expect(tracking.total_failed).toBeGreaterThanOrEqual(1);
+        expect(tracking.total_completed).toBe(0);
+      } finally {
+        flushPendingWrites();
+        errorSpy.mockRestore();
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('permission-request: canonical hookEventName wins over conflicting raw hook_event_name', async () => {
+      const rawInput = {
+        session_id: 'test-session-858',
+        cwd: '/tmp/test-routing',
+        tool_name: 'Bash',
+        tool_input: { command: 'git status' },
+        hook_event_name: 'NotPermissionRequest',
+      } as unknown as HookInput;
+
+      const result = await processHook('permission-request', rawInput);
+      expect(result.continue).toBe(true);
+      const out = result as unknown as Record<string, unknown>;
+      const specific = out.hookSpecificOutput as Record<string, unknown>;
+      expect(specific.hookEventName).toBe('PermissionRequest');
     });
   });
 });

--- a/src/installer/__tests__/claude-md-merge.test.ts
+++ b/src/installer/__tests__/claude-md-merge.test.ts
@@ -262,4 +262,41 @@ New OMC content v2
       expect(result).toContain('My custom stuff');
     });
   });
+
+  describe('version marker sync', () => {
+    it('injects the provided version marker on fresh install', () => {
+      const result = mergeClaudeMd(null, omcContent, '4.6.7');
+
+      expect(result).toContain('<!-- OMC:VERSION:4.6.7 -->');
+      expect(result).toContain(START_MARKER);
+      expect(result).toContain(END_MARKER);
+    });
+
+    it('replaces stale version marker when updating existing marker block', () => {
+      const existingContent = `${START_MARKER}
+<!-- OMC:VERSION:4.5.0 -->
+Old content
+${END_MARKER}
+
+${USER_CUSTOMIZATIONS}
+my notes`;
+
+      const result = mergeClaudeMd(existingContent, omcContent, '4.6.7');
+
+      expect(result).toContain('<!-- OMC:VERSION:4.6.7 -->');
+      expect(result).not.toContain('<!-- OMC:VERSION:4.5.0 -->');
+      expect((result.match(/<!-- OMC:VERSION:/g) || []).length).toBe(1);
+      expect(result).toContain('my notes');
+    });
+
+    it('strips embedded version marker from omc content before inserting current version', () => {
+      const omcWithVersion = `<!-- OMC:VERSION:4.0.0 -->\n${omcContent}`;
+
+      const result = mergeClaudeMd(null, omcWithVersion, '4.6.7');
+
+      expect(result).toContain('<!-- OMC:VERSION:4.6.7 -->');
+      expect(result).not.toContain('<!-- OMC:VERSION:4.0.0 -->');
+      expect((result.match(/<!-- OMC:VERSION:/g) || []).length).toBe(1);
+    });
+  });
 });

--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -320,6 +320,19 @@ describe("reply-listener", () => {
       expect(allowlist.includes('PATH')).toBe(true);
       expect(allowlist.includes('ANTHROPIC_API_KEY')).toBe(false);
     });
+
+    it("resolves daemon module path through helper for bootstrap compatibility", () => {
+      const fs = require("fs");
+      const path = require("path");
+      const source = fs.readFileSync(
+        path.join(__dirname, "..", "reply-listener.ts"),
+        "utf-8",
+      );
+
+      expect(source).toContain("resolveDaemonModulePath");
+      expect(source).toContain("['notifications', 'reply-listener.js']");
+    });
+
   });
 
   describe("Injection feedback", () => {

--- a/src/team/__tests__/runtime-prompt-mode.test.ts
+++ b/src/team/__tests__/runtime-prompt-mode.test.ts
@@ -235,6 +235,29 @@ describe('spawnWorkerForTask – prompt mode (Gemini & Codex)', () => {
 
     rmSync(cwd, { recursive: true, force: true });
   });
+
+  it('returns empty and skips spawn when task is already in_progress (claim already taken)', async () => {
+    const taskPath = join(cwd, '.omc/state/team/test-team/tasks/1.json');
+    writeFileSync(taskPath, JSON.stringify({
+      id: '1',
+      subject: 'Test task',
+      description: 'Do something',
+      status: 'in_progress',
+      owner: 'worker-2',
+    }), 'utf-8');
+
+    const runtime = makeRuntime(cwd, 'codex');
+    const paneId = await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    expect(paneId).toBe('');
+    expect(tmuxCalls.args.some(args => args[0] === 'split-window')).toBe(false);
+    expect(tmuxCalls.args.some(args => args[0] === 'send-keys')).toBe(false);
+    expect(runtime.activeWorkers.size).toBe(0);
+
+    const task = JSON.parse(readFileSync(taskPath, 'utf-8')) as { status: string; owner: string | null };
+    expect(task.status).toBe('in_progress');
+    expect(task.owner).toBe('worker-2');
+  });
 });
 
 describe('spawnWorkerForTask – model passthrough from environment variables', () => {

--- a/src/team/__tests__/runtime-watchdog-retry.test.ts
+++ b/src/team/__tests__/runtime-watchdog-retry.test.ts
@@ -460,4 +460,42 @@ describe('watchdogCliWorkers dead-pane retry behavior', { timeout: 15000 }, () =
       warnSpy.mock.calls.some(([msg]: [unknown]) => String(msg).includes('dead pane — requeuing task'))
     ).toBe(false);
   });
+
+  it('does not requeue or increment retries when dead-pane worker no longer owns the task', async () => {
+    const teamName = 'dead-pane-owner-race-team';
+    const root = join(cwd, '.omc', 'state', 'team', teamName);
+    mkdirSync(join(root, 'tasks'), { recursive: true });
+    mkdirSync(join(root, 'workers', 'worker-1'), { recursive: true });
+
+    writeFileSync(join(root, 'tasks', '1.json'), JSON.stringify({
+      id: '1',
+      subject: 'Task 1',
+      description: 'Do work',
+      status: 'in_progress',
+      owner: 'worker-2',
+      assignedAt: new Date().toISOString(),
+    }), 'utf-8');
+
+    const runtime = makeRuntimeWithTask(cwd, teamName, '1');
+    const stop = watchdogCliWorkers(runtime, 20);
+    try {
+      await waitFor(() => runtime.activeWorkers.size === 0);
+    } finally {
+      await stopWatchdogAndSettle(stop);
+    }
+
+    const task = await readJsonFileWithRetry<{
+      status: string;
+      owner: string | null;
+    }>(join(root, 'tasks', '1.json'));
+    const failure = readTaskFailure(teamName, '1', { cwd });
+
+    expect(task.status).toBe('in_progress');
+    expect(task.owner).toBe('worker-2');
+    expect(failure).toBeNull();
+    expect(tmuxMocks.spawnWorkerInPane).not.toHaveBeenCalled();
+    expect(
+      warnSpy.mock.calls.some(([msg]: [unknown]) => String(msg).includes('dead pane — requeuing task'))
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary\n- add daemon bootstrap/path regression coverage, including Windows path conversion and sanitized child env assertions\n- add cwd-agnostic package-dir regression tests (including bridge runtime-cli ordering checks)\n- add hook routing normalization regressions and team runtime lifecycle race-condition regressions\n- add installer/version-marker sync regression tests plus notifications reply-listener daemon-path bootstrap assertions\n\n## Verification\n- 
> oh-my-claude-sisyphus@4.6.7 test:run
> vitest run src/__tests__/daemon-module-path.test.ts src/__tests__/installer.test.ts src/__tests__/package-dir-resolution-regression.test.ts src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts src/hooks/__tests__/bridge-routing.test.ts src/installer/__tests__/claude-md-merge.test.ts src/notifications/__tests__/reply-listener.test.ts src/team/__tests__/runtime-prompt-mode.test.ts src/team/__tests__/runtime-watchdog-retry.test.ts


 RUN  v4.0.18 /home/bellman/Workspace/oh-my-claudecode-dev

 ✓ src/__tests__/daemon-module-path.test.ts (6 tests) 3ms
 ✓ src/__tests__/package-dir-resolution-regression.test.ts (5 tests) 45ms
 ✓ src/installer/__tests__/claude-md-merge.test.ts (23 tests) 8ms
 ✓ src/__tests__/installer.test.ts (36 tests) 30ms
 ✓ src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts (2 tests) 162ms
 ✓ src/notifications/__tests__/reply-listener.test.ts (49 tests) 11ms
 ✓ src/team/__tests__/runtime-watchdog-retry.test.ts (6 tests) 776ms
 ✓ src/hooks/__tests__/bridge-routing.test.ts (68 tests) 708ms
 ✓ src/team/__tests__/runtime-prompt-mode.test.ts (16 tests) 1493ms
     ✓ non-prompt worker waits for pane readiness before sending inbox instruction  606ms
     ✓ claude worker does not pass model flag (not supported)  599ms

 Test Files  9 passed (9)
      Tests  211 passed (211)
   Start at  10:17:44
   Duration  2.00s (transform 2.52s, setup 0ms, import 2.44s, tests 3.24s, environment 1ms)\n- \n- \n\nCloses #1322\nCloses #1323\nCloses #1324