### PR TITLE
feat(hud): add wrap mode alternative to maxWidth truncation (#1319)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -669,6 +669,13 @@ Configure HUD elements in `~/.claude/settings.json`:
 | `ralph` | Show ralph loop status | `true` |
 | `autopilot` | Show autopilot status | `true` |
 
+Additional `omcHud` layout options (top-level):
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `maxWidth` | Maximum HUD line width (terminal columns) | unset |
+| `wrapMode` | `truncate` (ellipsis) or `wrap` (break at ` \| ` boundaries) when `maxWidth` is set | `truncate` |
+
 Available presets: `minimal`, `focused`, `full`, `dense`, `analytics`, `opencode`
 
 ### Common Issues

--- a/src/__tests__/hud/defaults.test.ts
+++ b/src/__tests__/hud/defaults.test.ts
@@ -22,6 +22,10 @@ describe('HUD Default Configuration', () => {
     it('should use text format for thinking indicator by default', () => {
       expect(DEFAULT_HUD_CONFIG.elements.thinkingFormat).toBe('text');
     });
+
+    it('should default wrapMode to truncate', () => {
+      expect(DEFAULT_HUD_CONFIG.wrapMode).toBe('truncate');
+    });
   });
 
   describe('PRESET_CONFIGS', () => {

--- a/src/__tests__/hud/render.test.ts
+++ b/src/__tests__/hud/render.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { limitOutputLines } from '../../hud/render.js';
 import { render } from '../../hud/render.js';
 import { DEFAULT_HUD_CONFIG, PRESET_CONFIGS, type HudRenderContext, type HudConfig } from '../../hud/types.js';
+import { stringWidth } from '../../utils/string-width.js';
 
 // Mock git elements
 vi.mock('../../hud/elements/git.js', () => ({
@@ -327,5 +328,118 @@ describe('gitInfoPosition configuration', () => {
       // Either git info is first, or if no git info, header is first
       expect(firstLineIsGitInfo || firstLineIsHeader).toBe(true);
     });
+  });
+});
+
+describe('maxWidth wrapMode behavior', () => {
+  const createMockContext = (): HudRenderContext => ({
+    contextPercent: 30,
+    modelName: '',
+    ralph: null,
+    ultrawork: null,
+    prd: null,
+    autopilot: null,
+    activeAgents: [],
+    todos: [],
+    backgroundTasks: [],
+    cwd: '/home/user/project',
+    lastSkill: null,
+    rateLimitsResult: null,
+    customBuckets: null,
+    pendingPermission: null,
+    thinkingState: null,
+    sessionHealth: null,
+    omcVersion: '4.5.4',
+    updateAvailable: null,
+    toolCallCount: 0,
+    agentCallCount: 0,
+    skillCallCount: 0,
+    promptTime: null,
+    apiKeySource: null,
+    profileName: null,
+  });
+
+  const createWrapConfig = (
+    wrapMode: 'truncate' | 'wrap',
+    maxWidth: number,
+    maxOutputLines = 6
+  ): HudConfig => ({
+    preset: 'focused',
+    elements: {
+      ...DEFAULT_HUD_CONFIG.elements,
+      omcLabel: true,
+      rateLimits: false,
+      ralph: false,
+      autopilot: false,
+      prdStory: false,
+      activeSkills: false,
+      contextBar: true,
+      agents: false,
+      backgroundTasks: false,
+      todos: false,
+      promptTime: false,
+      sessionHealth: false,
+      maxOutputLines,
+    },
+    thresholds: DEFAULT_HUD_CONFIG.thresholds,
+    staleTaskThresholdMinutes: 30,
+    contextLimitWarning: {
+      ...DEFAULT_HUD_CONFIG.contextLimitWarning,
+      threshold: 101,
+    },
+    maxWidth,
+    wrapMode,
+  });
+
+  it('uses truncate mode by default when wrapMode is not provided', async () => {
+    const context = createMockContext();
+    context.contextPercent = 88; // makes header longer
+    const config = createWrapConfig('truncate', 24);
+    delete (config as Partial<HudConfig>).wrapMode;
+
+    const result = await render(context, config);
+    const lines = result.split('\n');
+    expect(lines[0]).toMatch(/\.\.\.$/);
+  });
+
+  it('wraps long HUD lines at separator boundaries in wrap mode', async () => {
+    const context = createMockContext();
+    context.contextPercent = 88;
+    const config = createWrapConfig('wrap', 24);
+
+    const result = await render(context, config);
+    const lines = result.split('\n');
+
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0]).toContain('[OMC');
+    lines.forEach(line => {
+      expect(stringWidth(line)).toBeLessThanOrEqual(24);
+    });
+  });
+
+  it('respects maxOutputLines after wrap expansion', async () => {
+    const context = createMockContext();
+    context.contextPercent = 88;
+    const config = createWrapConfig('wrap', 14, 2);
+
+    const result = await render(context, config);
+    const lines = result.split('\n');
+
+    expect(lines).toHaveLength(2);
+    lines.forEach(line => {
+      expect(stringWidth(line)).toBeLessThanOrEqual(14);
+    });
+  });
+
+  it('keeps truncation indicator within maxWidth when maxOutputLines is hit', async () => {
+    const context = createMockContext();
+    context.contextPercent = 88;
+    const config = createWrapConfig('wrap', 8, 1);
+
+    const result = await render(context, config);
+    const lines = result.split('\n');
+
+    expect(lines).toHaveLength(1);
+    expect(stringWidth(lines[0] ?? '')).toBeLessThanOrEqual(8);
   });
 });

--- a/src/__tests__/hud/state.test.ts
+++ b/src/__tests__/hud/state.test.ts
@@ -185,5 +185,23 @@ describe('readHudConfig', () => {
       expect(config.thresholds.contextWarning).toBe(80);
       expect(config.thresholds.contextCritical).toBe(DEFAULT_HUD_CONFIG.thresholds.contextCritical);
     });
+
+    it('merges maxWidth and wrapMode from settings', () => {
+      mockExistsSync.mockImplementation((path) => {
+        const s = String(path);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        omcHud: {
+          maxWidth: 80,
+          wrapMode: 'wrap',
+        }
+      }));
+
+      const config = readHudConfig();
+
+      expect(config.maxWidth).toBe(80);
+      expect(config.wrapMode).toBe('wrap');
+    });
   });
 });

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -34,6 +34,10 @@ import { renderContextLimitWarning } from './elements/context-warning.js';
  */
 const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07/;
 
+
+const PLAIN_SEPARATOR = ' | ';
+const DIM_SEPARATOR = dim(PLAIN_SEPARATOR);
+
 /**
  * Truncate a single line to a maximum visual width, preserving ANSI escape codes.
  * When the visible content exceeds maxWidth columns, it is truncated with an ellipsis.
@@ -85,6 +89,80 @@ export function truncateLineToMaxWidth(line: string, maxWidth: number): string {
   // to prevent color/style bleed into subsequent terminal output
   const reset = hasAnsi ? '\x1b[0m' : '';
   return result + reset + ELLIPSIS;
+}
+
+/**
+ * Wrap a single line at HUD separator boundaries so each wrapped line
+ * fits within maxWidth visible columns.
+ *
+ * Falls back to truncation when:
+ * - no separator is present
+ * - any single segment exceeds maxWidth
+ */
+function wrapLineToMaxWidth(line: string, maxWidth: number): string[] {
+  if (maxWidth <= 0) return [''];
+  if (stringWidth(line) <= maxWidth) return [line];
+
+  const separator = line.includes(DIM_SEPARATOR)
+    ? DIM_SEPARATOR
+    : line.includes(PLAIN_SEPARATOR)
+      ? PLAIN_SEPARATOR
+      : null;
+
+  if (!separator) {
+    return [truncateLineToMaxWidth(line, maxWidth)];
+  }
+
+  const segments = line.split(separator);
+  if (segments.length <= 1) {
+    return [truncateLineToMaxWidth(line, maxWidth)];
+  }
+
+  const wrapped: string[] = [];
+  let current = segments[0] ?? '';
+
+  for (let i = 1; i < segments.length; i += 1) {
+    const nextSegment = segments[i] ?? '';
+    const candidate = `${current}${separator}${nextSegment}`;
+
+    if (stringWidth(candidate) <= maxWidth) {
+      current = candidate;
+      continue;
+    }
+
+    if (stringWidth(current) > maxWidth) {
+      wrapped.push(truncateLineToMaxWidth(current, maxWidth));
+    } else {
+      wrapped.push(current);
+    }
+
+    current = nextSegment;
+  }
+
+  if (stringWidth(current) > maxWidth) {
+    wrapped.push(truncateLineToMaxWidth(current, maxWidth));
+  } else {
+    wrapped.push(current);
+  }
+
+  return wrapped;
+}
+
+/**
+ * Apply maxWidth behavior by mode.
+ */
+function applyMaxWidthByMode(
+  lines: string[],
+  maxWidth: number | undefined,
+  wrapMode: 'truncate' | 'wrap' | undefined
+): string[] {
+  if (!maxWidth || maxWidth <= 0) return lines;
+
+  if (wrapMode === 'wrap') {
+    return lines.flatMap(line => wrapLineToMaxWidth(line, maxWidth));
+  }
+
+  return lines.map(line => truncateLineToMaxWidth(line, maxWidth));
 }
 
 /**
@@ -297,8 +375,8 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   // Compose output
   const outputLines: string[] = [];
 
-  const gitInfoLine = gitElements.length > 0 ? gitElements.join(dim(' | ')) : null;
-  const headerLine = elements.join(dim(' | '));
+  const gitInfoLine = gitElements.length > 0 ? gitElements.join(dim(PLAIN_SEPARATOR)) : null;
+  const headerLine = elements.join(dim(PLAIN_SEPARATOR));
 
   // Position git info based on config (default: above for backward compatibility)
   const gitPosition = config.elements.gitInfoPosition ?? 'above';
@@ -323,12 +401,19 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
     if (todos) detailLines.push(todos);
   }
 
-  let finalLines = limitOutputLines([...outputLines, ...detailLines], config.elements.maxOutputLines);
+  const widthAdjustedLines = applyMaxWidthByMode(
+    [...outputLines, ...detailLines],
+    config.maxWidth,
+    config.wrapMode
+  );
 
-  // Apply maxWidth truncation if configured (Issue #1086)
-  if (config.maxWidth && config.maxWidth > 0) {
-    finalLines = finalLines.map(line => truncateLineToMaxWidth(line, config.maxWidth!));
-  }
+  // Apply max output line limit after wrapping so wrapped output still respects maxOutputLines.
+  const limitedLines = limitOutputLines(widthAdjustedLines, config.elements.maxOutputLines);
+
+  // Ensure line-limit indicator and all other lines still respect maxWidth.
+  const finalLines = config.maxWidth && config.maxWidth > 0
+    ? limitedLines.map(line => truncateLineToMaxWidth(line, config.maxWidth!))
+    : limitedLines;
 
   return finalLines.join('\n');
 }

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -205,6 +205,7 @@ function mergeWithDefaults(config: Partial<HudConfig>): HudConfig {
     },
     ...(config.rateLimitsProvider ? { rateLimitsProvider: config.rateLimitsProvider } : {}),
     ...(config.maxWidth != null ? { maxWidth: config.maxWidth } : {}),
+    ...(config.wrapMode != null ? { wrapMode: config.wrapMode } : {}),
   };
 }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -446,8 +446,10 @@ export interface HudConfig {
   contextLimitWarning: ContextLimitWarningConfig;
   /** Optional custom rate limit provider; omit to use built-in Anthropic/z.ai */
   rateLimitsProvider?: RateLimitsProviderConfig;
-  /** Optional maximum width (columns) for statusline output. Lines exceeding this width are truncated with ellipsis. Useful when the terminal shares space with IDE panels or tabs. */
+  /** Optional maximum width (columns) for statusline output. */
   maxWidth?: number;
+  /** Controls maxWidth behavior: truncate with ellipsis (default) or wrap at " | " HUD element boundaries. */
+  wrapMode?: 'truncate' | 'wrap';
 }
 
 export const DEFAULT_HUD_CONFIG: HudConfig = {
@@ -496,6 +498,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     threshold: 80,
     autoCompact: false,
   },
+  wrapMode: 'truncate',
 };
 
 export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {


### PR DESCRIPTION
## Summary
- add `omcHud.wrapMode` with values `truncate` (default) and `wrap`
- keep existing maxWidth truncation behavior for `truncate`
- add ANSI-aware wrapping at ` | ` HUD element boundaries for `wrap`
- enforce `maxOutputLines` **after** width handling so wrapped output is still capped
- update HUD config merge and docs for new options
- add regression tests for wrap mode behavior

## Changes
- `src/hud/types.ts`
  - add `wrapMode?: 'truncate' | 'wrap'`
  - set `DEFAULT_HUD_CONFIG.wrapMode = 'truncate'`
- `src/hud/state.ts`
  - merge `wrapMode` from config sources
- `src/hud/render.ts`
  - extract shared separator constants
  - add ANSI-aware `wrapLineToMaxWidth()` at separator boundaries
  - add mode switch `applyMaxWidthByMode()`
  - apply `limitOutputLines()` after wrap/truncate processing
- `src/__tests__/hud/render.test.ts`
  - add tests for default truncate behavior, wrap behavior, and maxOutputLines interaction
- `src/__tests__/hud/state.test.ts`
  - add config merge test for `maxWidth` + `wrapMode`
- `src/__tests__/hud/defaults.test.ts`
  - add default `wrapMode` assertion
- `docs/REFERENCE.md`
  - document `omcHud.maxWidth` and `omcHud.wrapMode`

## Verification
- `npm run test:run -- src/__tests__/hud/max-width.test.ts src/__tests__/hud/render.test.ts src/__tests__/hud/state.test.ts src/__tests__/hud/defaults.test.ts`
  - 4 files passed, 76 tests passed
- `npm run build`
  - success
- `npx tsc --noEmit --pretty false`
  - success
- `lsp_diagnostics` on modified files
  - all clean (`diagnosticCount: 0`)
- `lsp_diagnostics_directory`
  - `totalErrors: 0`, `totalWarnings: 0`

Closes #1319
