### PR TITLE
feat: add wrapMode config for auto-wrapping HUD at element boundaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "oh-my-claudecode": "dist/cli/index.js",
-        "omc": "dist/cli/index.js",
-        "omc-cli": "dist/cli/index.js"
+        "oh-my-claudecode": "bridge/cli.cjs",
+        "omc": "bridge/cli.cjs",
+        "omc-cli": "bridge/cli.cjs"
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
@@ -1763,7 +1763,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -2065,7 +2064,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -2115,7 +2113,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2709,7 +2706,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3023,7 +3019,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3400,7 +3395,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
       "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4029,7 +4023,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4779,7 +4772,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4839,7 +4831,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4918,7 +4909,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4994,7 +4984,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -5158,7 +5147,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/__tests__/hud/wrap-mode.test.ts
+++ b/src/__tests__/hud/wrap-mode.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { wrapLineAtElements } from '../../hud/render.js';
+import { stringWidth } from '../../utils/string-width.js';
+
+describe('wrapLineAtElements', () => {
+  describe('no wrapping needed', () => {
+    it('returns single-element array when line fits within maxWidth', () => {
+      const result = wrapLineAtElements('short line', 80);
+      expect(result).toEqual(['short line']);
+    });
+
+    it('returns empty string for maxWidth of 0', () => {
+      const result = wrapLineAtElements('something', 0);
+      expect(result).toEqual(['']);
+    });
+  });
+
+  describe('wrapping at element boundaries', () => {
+    it('wraps at pipe separators when line exceeds maxWidth', () => {
+      const line = '[OMC#4.4.4] | 5h:5%(3h31m) | session:9m | ctx:23% | ~$0.15 | 46.8k';
+      const result = wrapLineAtElements(line, 40);
+
+      // All lines should fit within maxWidth
+      for (const wrappedLine of result) {
+        expect(stringWidth(wrappedLine)).toBeLessThanOrEqual(40);
+      }
+
+      // Should produce multiple lines
+      expect(result.length).toBeGreaterThan(1);
+    });
+
+    it('preserves all elements across wrapped lines', () => {
+      const elements = ['[OMC#4.4.4]', '5h:5%', 'session:9m', 'ctx:23%', '~$0.15'];
+      const line = elements.join(' | ');
+      const result = wrapLineAtElements(line, 30);
+
+      // Every element should appear in some wrapped line
+      const allText = result.join(' | ');
+      for (const el of elements) {
+        expect(allText).toContain(el);
+      }
+    });
+
+    it('does not break mid-element', () => {
+      const line = 'element-one | element-two | element-three';
+      const result = wrapLineAtElements(line, 25);
+
+      for (const wrappedLine of result) {
+        // Each line should be a complete element or elements joined by separator
+        expect(wrappedLine).not.toMatch(/^[\s|]/);
+        expect(wrappedLine).not.toMatch(/[\s|]$/);
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('falls back to truncation when no separators exist', () => {
+      const line = 'a very long line without any pipe separators at all';
+      const result = wrapLineAtElements(line, 20);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatch(/\.\.\.$/);
+    });
+
+    it('handles single element that fits', () => {
+      const result = wrapLineAtElements('[OMC#4.4.4]', 80);
+      expect(result).toEqual(['[OMC#4.4.4]']);
+    });
+
+    it('handles single element that exceeds maxWidth', () => {
+      const result = wrapLineAtElements('a-very-long-single-element-without-separators', 10);
+      expect(result).toHaveLength(1);
+      expect(stringWidth(result[0])).toBeLessThanOrEqual(10);
+    });
+  });
+});

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -88,6 +88,62 @@ export function truncateLineToMaxWidth(line: string, maxWidth: number): string {
 }
 
 /**
+ * Wrap a single line at element boundaries (` | ` separators) to fit within maxWidth.
+ * Each element is treated as an atomic unit — never broken mid-element.
+ * Returns an array of wrapped lines, each fitting within maxWidth.
+ *
+ * @param line - The line to wrap (may contain ANSI codes and ` | ` separators)
+ * @param maxWidth - Maximum visual width in terminal columns
+ * @returns Array of wrapped lines
+ */
+export function wrapLineAtElements(line: string, maxWidth: number): string[] {
+  if (maxWidth <= 0) return [''];
+  if (stringWidth(line) <= maxWidth) return [line];
+
+  // Split by the dim(' | ') separator pattern.
+  // The separator includes ANSI dim codes: \x1b[2m | \x1b[22m
+  // We split on both plain and ANSI-wrapped separators.
+  const SEPARATOR_PATTERN = /(?:\x1b\[2m)? \| (?:\x1b\[22m)?/;
+  const parts = line.split(SEPARATOR_PATTERN);
+
+  if (parts.length <= 1) {
+    // No separators — fall back to truncation
+    return [truncateLineToMaxWidth(line, maxWidth)];
+  }
+
+  const separator = ' | ';
+  const separatorWidth = 3; // visual width of " | "
+  const wrappedLines: string[] = [];
+  let currentLine = '';
+  let currentWidth = 0;
+
+  for (const part of parts) {
+    const partWidth = stringWidth(part);
+
+    if (currentLine === '') {
+      // First element on this line
+      currentLine = part;
+      currentWidth = partWidth;
+    } else if (currentWidth + separatorWidth + partWidth <= maxWidth) {
+      // Fits on current line
+      currentLine += separator + part;
+      currentWidth += separatorWidth + partWidth;
+    } else {
+      // Doesn't fit — start a new line
+      wrappedLines.push(currentLine);
+      currentLine = part;
+      currentWidth = partWidth;
+    }
+  }
+
+  if (currentLine) {
+    wrappedLines.push(currentLine);
+  }
+
+  return wrappedLines;
+}
+
+/**
  * Limit output lines to prevent input field shrinkage (Issue #222).
  * Trims lines from the end while preserving the first (header) line.
  *
@@ -325,9 +381,15 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
 
   let finalLines = limitOutputLines([...outputLines, ...detailLines], config.elements.maxOutputLines);
 
-  // Apply maxWidth truncation if configured (Issue #1086)
+  // Apply maxWidth handling if configured (Issue #1086, #1319)
   if (config.maxWidth && config.maxWidth > 0) {
-    finalLines = finalLines.map(line => truncateLineToMaxWidth(line, config.maxWidth!));
+    if (config.wrapMode === 'wrap') {
+      // Wrap at element boundaries — no information loss
+      finalLines = finalLines.flatMap(line => wrapLineAtElements(line, config.maxWidth!));
+    } else {
+      // Default: truncate with ellipsis
+      finalLines = finalLines.map(line => truncateLineToMaxWidth(line, config.maxWidth!));
+    }
   }
 
   return finalLines.join('\n');

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -448,6 +448,8 @@ export interface HudConfig {
   rateLimitsProvider?: RateLimitsProviderConfig;
   /** Optional maximum width (columns) for statusline output. Lines exceeding this width are truncated with ellipsis. Useful when the terminal shares space with IDE panels or tabs. */
   maxWidth?: number;
+  /** Controls how lines exceeding maxWidth are handled. 'truncate' cuts with ellipsis (default), 'wrap' breaks at element boundaries onto next line. */
+  wrapMode?: 'truncate' | 'wrap';
 }
 
 export const DEFAULT_HUD_CONFIG: HudConfig = {


### PR DESCRIPTION
## Changes
Adds a `wrapMode` config option that controls how lines exceeding `maxWidth` are handled:

| Mode | Behavior |
|------|----------|
| `truncate` | Current behavior — cut with ellipsis (default) |
| `wrap` | Break at element boundaries onto next line |

### Config
```json
{ "maxWidth": 80, "wrapMode": "wrap" }
```

### Implementation
- `wrapLineAtElements()` — ANSI-aware wrapping at element boundaries
- `wrapMode` config in HudConfig
- Default: `truncate` (backward compatible)
- Unit tests included

Fixes #1319