### PR TITLE
feat: integrate omx ask-team into omc launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,15 @@ Enable Claude Code native teams in `~/.claude/settings.json`:
 
 ### tmux CLI Workers — Codex & Gemini (v4.4.0+)
 
-**v4.4.0 removes the Codex/Gemini MCP servers** (`x`, `g` providers). Use `/omc-teams` to spawn real CLI processes in tmux split-panes instead:
+**v4.4.0 removes the Codex/Gemini MCP servers** (`x`, `g` providers). Use the CLI-first Team runtime (`omc team ...`) to spawn real tmux worker panes:
 
 ```bash
-/omc-teams 2:codex   "review auth module for security issues"
-/omc-teams 2:gemini  "redesign UI components for accessibility"
-/omc-teams 1:claude  "implement the payment flow"
+omc team start --agent codex --count 2 --task "review auth module for security issues"
+omc team start --agent gemini --count 2 --task "redesign UI components for accessibility"
+omc team start --agent claude --count 1 --task "implement the payment flow"
 ```
+
+`/omc-teams` remains as a legacy compatibility skill and now routes to `omc team ...`.
 
 For mixed Codex + Gemini work in one command, use the **`/ccg`** skill:
 
@@ -88,11 +90,11 @@ For mixed Codex + Gemini work in one command, use the **`/ccg`** skill:
 /ccg Review this PR — architecture (Codex) and UI components (Gemini)
 ```
 
-| Skill | Workers | Best For |
+| Surface | Workers | Best For |
 |-------|---------|----------|
-| `/omc-teams N:codex` | N Codex CLI panes | Code review, security analysis, architecture |
-| `/omc-teams N:gemini` | N Gemini CLI panes | UI/UX design, docs, large-context tasks |
-| `/omc-teams N:claude` | N Claude CLI panes | General tasks via Claude CLI in tmux |
+| `omc team start --agent codex --count N ...` | N Codex CLI panes | Code review, security analysis, architecture |
+| `omc team start --agent gemini --count N ...` | N Gemini CLI panes | UI/UX design, docs, large-context tasks |
+| `omc team start --agent claude --count N ...` | N Claude CLI panes | General tasks via Claude CLI in tmux |
 | `/ccg` | 1 Codex + 1 Gemini | Parallel tri-model orchestration |
 
 Workers spawn on-demand and die when their task completes — no idle resource usage. Requires `codex` / `gemini` CLIs installed and an active tmux session.
@@ -146,7 +148,7 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 | Mode | What it is | Use For |
 |------|------------|---------|
 | **Team (recommended)** | Canonical staged pipeline (`team-plan → team-prd → team-exec → team-verify → team-fix`) | Coordinated Claude agents on a shared task list |
-| **omc-teams** | tmux CLI workers — real `claude`/`codex`/`gemini` processes in split-panes | Codex/Gemini CLI tasks; on-demand spawn, die when done |
+| **omc team (CLI)** | tmux CLI workers — real `claude`/`codex`/`gemini` processes in split-panes | Codex/Gemini CLI tasks; on-demand spawn, die when done |
 | **ccg** | Tri-model: Codex (analytical) + Gemini (design) in parallel, Claude synthesizes | Mixed backend+UI work needing both Codex and Gemini |
 | **Autopilot** | Autonomous execution (single lead agent) | End-to-end feature work with minimal ceremony |
 | **Ultrawork** | Maximum parallelism (non-team) | Burst parallel fixes/refactors where Team isn't needed |
@@ -178,7 +180,7 @@ Optional shortcuts for power users. Natural language works fine without them.
 | Keyword | Effect | Example |
 |---------|--------|---------|
 | `team` | Canonical Team orchestration | `/team 3:executor "fix all TypeScript errors"` |
-| `omc-teams` | tmux CLI workers (codex/gemini/claude) | `/omc-teams 2:codex "security review"` |
+| `omc team` | tmux CLI workers (codex/gemini/claude) | `omc team start --agent codex --count 2 --task "security review"` |
 | `ccg` | Tri-model Codex+Gemini orchestration | `/ccg review this PR` |
 | `autopilot` | Full autonomous execution | `autopilot: build a todo app` |
 | `ralph` | Persistence mode | `ralph: refactor auth` |
@@ -194,6 +196,22 @@ Optional shortcuts for power users. Natural language works fine without them.
 - `swarm N agents` syntax is still recognized for agent count extraction, but the runtime is Team-backed in v4.1.7+.
 
 ## Utilities
+
+### Provider Advisor (`omc ask`)
+
+Run local provider CLIs and save a markdown artifact under `.omc/artifacts/ask/`:
+
+```bash
+omc ask claude "review this migration plan"
+omc ask gemini --prompt "propose UI polish ideas"
+omc ask claude --agent-prompt executor --prompt "draft implementation steps"
+```
+
+Canonical env vars:
+- `OMC_ASK_ADVISOR_SCRIPT`
+- `OMC_ASK_ORIGINAL_TASK`
+
+Phase-1 aliases `OMX_ASK_ADVISOR_SCRIPT` and `OMX_ASK_ORIGINAL_TASK` are accepted with deprecation warnings.
 
 ### Rate Limit Wait
 
@@ -309,4 +327,3 @@ If Oh-My-ClaudeCode helps your workflow, consider sponsoring:
 - 🐛 Report bugs
 - 💡 Suggest features
 - 📝 Contribute code
-

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -62,8 +62,9 @@ Coordination:
 <tools>
 External AI (tmux CLI workers):
 - Claude agents: `/team N:executor "task"` via `TeamCreate`/`Task`
-- Codex/Gemini workers: `/omc-teams N:codex "task"` via tmux panes
-- MCP tools: `omc_run_team_start`, `omc_run_team_wait`, `omc_run_team_status`, `omc_run_team_cleanup`
+- Codex/Gemini workers: `omc team start --agent codex|gemini --count N --task "..."`
+- Provider advisor CLI: `omc ask <claude|gemini> ...` (writes artifacts to `.omc/artifacts/ask/`)
+- Legacy MCP runtime tools (`omc_run_team_*`) are deprecated with `deprecated_cli_only` and should not be used for execution.
 
 OMC State: `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
 - Stored at `{worktree}/.omc/state/{mode}-state.json`; session-scoped under `.omc/state/sessions/{sessionId}/`
@@ -88,7 +89,7 @@ Workflow:
 - `ralph` ("ralph", "don't stop", "must complete"): self-referential loop with verifier verification; includes ultrawork
 - `ultrawork` ("ulw", "ultrawork"): maximum parallelism with parallel agent orchestration
 - `team` ("team", "coordinated team", "team ralph"): N coordinated Claude agents with stage-aware routing; `team ralph` for persistent team execution
-- `omc-teams` ("omc-teams", "codex", "gemini"): spawn CLI workers in tmux panes
+- `omc-teams` ("omc-teams", "codex", "gemini"): legacy alias that routes to CLI-first `omc team ...` worker execution
 - `ccg` ("ccg", "tri-model", "claude codex gemini"): fan out to Codex + Gemini, Claude synthesizes
 - `ultraqa` (activated by autopilot): QA cycling -- test, verify, fix, repeat
 - `omc-plan` ("plan this", "plan the"): strategic planning; supports `--consensus` and `--review`
@@ -108,7 +109,7 @@ Agent Shortcuts (thin wrappers):
 Notifications: `configure-notifications` ("configure discord", "setup telegram", "configure slack")
 Utilities: `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `learn-about-omc`
 
-Disambiguation: bare "codex"/"gemini" -> omc-teams; "claude codex gemini" -> ccg. Ralph includes ultrawork.
+Disambiguation: bare "codex"/"gemini" -> omc-teams (legacy alias to `omc team`); "claude codex gemini" -> ccg. Ralph includes ultrawork.
 </skills>
 
 <team_pipeline>

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -6,7 +6,7 @@ This guide covers all migration paths for oh-my-claudecode. Find your current ve
 
 ## Table of Contents
 
-- [Unreleased: Team MCP timeoutSeconds Removal](#unreleased-team-mcp-timeoutseconds-removal)
+- [Unreleased: Team MCP Runtime Deprecation (CLI-Only)](#unreleased-team-mcp-runtime-deprecation-cli-only)
 - [v3.5.3 → v3.5.5: Test Fixes & Cleanup](#v353--v355-test-fixes--cleanup)
 - [v3.5.2 → v3.5.3: Skill Consolidation](#v352--v353-skill-consolidation)
 - [v2.x → v3.0: Package Rename & Auto-Activation](#v2x--v30-package-rename--auto-activation)
@@ -15,115 +15,50 @@ This guide covers all migration paths for oh-my-claudecode. Find your current ve
 
 ---
 
-## Unreleased: Team MCP timeoutSeconds Removal
+## Unreleased: Team MCP Runtime Deprecation (CLI-Only)
 
 ### TL;DR
 
-`omc_run_team_start` no longer accepts `timeoutSeconds`. Passing it now returns an API error. Use `omc_run_team_wait` with `timeout_ms` to limit how long you block (workers keep running), and call `omc_run_team_cleanup` only when you explicitly want to stop worker panes.
+`omc_run_team_start/status/wait/cleanup` are now hard-deprecated at runtime. Calls return:
 
-### What `timeoutSeconds` Did Before
-
-In earlier versions, `omc_run_team_start` accepted a `timeoutSeconds` parameter that would automatically kill all worker panes if the team had not completed within that duration. Example of the old pattern:
-
-```js
-// OLD — no longer works
-mcp__team__omc_run_team_start({
-  teamName: "my-team",
-  agentTypes: ["claude", "codex"],
-  tasks: [...],
-  cwd: "/path/to/project",
-  timeoutSeconds: 120   // <-- would silently kill workers after 2 minutes
-})
+```json
+{
+  "code": "deprecated_cli_only",
+  "message": "Legacy team MCP runtime tools are deprecated. Use the omc team CLI instead."
+}
 ```
 
-### Why It Was Removed
+Use CLI commands instead:
 
-`timeoutSeconds` was a footgun: it silently killed worker panes mid-task whenever the wall-clock limit was reached, with no way for the caller to distinguish "timed out and killed" from "completed normally". This caused data loss (workers writing files when killed), confusing error states, and made it impossible to resume or inspect stalled teams. Callers who set a conservative timeout often lost work that was 90% done.
+- `omc team start`
+- `omc team status <job_id>`
+- `omc team wait <job_id>`
+- `omc team cleanup <job_id>`
 
-The fix separates concerns cleanly:
-- **Wait timeout** (`omc_run_team_wait timeout_ms`) — limits how long *your call* blocks. Workers keep running.
-- **Explicit cleanup** (`omc_run_team_cleanup`) — kills worker panes only when you decide to cancel.
+### `omc ask` env alias sunset (Phase-1 compatibility)
+
+`OMC_ASK_*` is now canonical for advisor execution. Phase-1 accepts `OMX_ASK_ADVISOR_SCRIPT` and `OMX_ASK_ORIGINAL_TASK` with deprecation warnings. Planned hard sunset for alias removal: **2026-06-30**.
 
 ### How to Migrate
 
-**Step 1** — Remove `timeoutSeconds` from every `omc_run_team_start` call.
+1. Replace MCP runtime tool calls with CLI equivalents.
+2. Update skills/prompts from `/omc-teams ...` to `omc team ...` syntax.
+3. Keep legacy MCP registration only for compatibility checks; do not rely on runtime execution.
 
-**Step 2** — Use `omc_run_team_wait` with `timeout_ms` to bound the blocking call. If it times out, workers are still alive; call `omc_run_team_wait` again to keep waiting:
+### Example mapping
 
-```js
-// NEW — start (no timeoutSeconds)
-const { jobId } = await mcp__team__omc_run_team_start({
-  teamName: "my-team",
-  agentTypes: ["claude", "codex"],
-  tasks: [...],
-  cwd: "/path/to/project",
-})
+```bash
+# Old (deprecated runtime path)
+mcp__team__omc_run_team_start(...)
+mcp__team__omc_run_team_status({ job_id: ... })
+mcp__team__omc_run_team_wait({ job_id: ... })
+mcp__team__omc_run_team_cleanup({ job_id: ... })
 
-// Wait up to 5 minutes (workers keep running if this times out)
-const result = await mcp__team__omc_run_team_wait({
-  job_id: jobId,
-  timeout_ms: 300000,
-})
-
-// If result.status === 'running' the wait timed out; call wait again or inspect progress:
-// await mcp__team__omc_run_team_status({ job_id: jobId })
-// await mcp__team__omc_run_team_wait({ job_id: jobId, timeout_ms: 600000 })
-```
-
-**Step 3** — Call `omc_run_team_cleanup` only when you *intentionally* want to cancel and stop worker panes:
-
-```js
-// Explicit cancel — only when you want to stop the workers
-await mcp__team__omc_run_team_cleanup({ job_id: jobId })
-```
-
-### Common Patterns with `/omc-teams`
-
-**Pattern A — Wait with re-try on timeout (recommended)**
-
-```js
-// Start
-const { jobId } = await mcp__team__omc_run_team_start({ ... })
-
-// Wait loop: keep waiting until terminal state
-let result
-do {
-  result = await mcp__team__omc_run_team_wait({ job_id: jobId, timeout_ms: 300000 })
-} while (result.status === 'running')
-```
-
-**Pattern B — Non-blocking progress check**
-
-```js
-const { jobId } = await mcp__team__omc_run_team_start({ ... })
-
-// Do other work, then check progress
-const status = await mcp__team__omc_run_team_status({ job_id: jobId })
-if (status.status === 'running') {
-  // Not done yet; wait or come back later
-}
-```
-
-**Pattern C — Explicit cancel when you give up**
-
-```js
-const { jobId } = await mcp__team__omc_run_team_start({ ... })
-
-const result = await mcp__team__omc_run_team_wait({ job_id: jobId, timeout_ms: 60000 })
-if (result.status === 'running') {
-  // Decided to cancel — explicitly stop worker panes
-  await mcp__team__omc_run_team_cleanup({ job_id: jobId })
-}
-```
-
-### Breaking Change
-
-Passing `timeoutSeconds` to `omc_run_team_start` now returns an API error immediately:
-
-```
-Error: omc_run_team_start no longer accepts timeoutSeconds. Remove timeoutSeconds
-and use omc_run_team_wait timeout_ms to limit the wait call only (workers keep running
-until completion or explicit omc_run_team_cleanup).
+# New (CLI-first)
+omc team start ...
+omc team status <job_id>
+omc team wait <job_id>
+omc team cleanup <job_id>
 ```
 
 ---

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -8,7 +8,8 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 
 - [Installation](#installation)
 - [Configuration](#configuration)
-- [MCP Team Runtime Tools](#mcp-team-runtime-tools)
+- [CLI Commands: ask/team](#cli-commands-askteam)
+- [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated)
 - [Agents (28 Total)](#agents-28-total)
 - [Skills (38 Total)](#skills-38-total)
 - [Slash Commands](#slash-commands)
@@ -187,16 +188,53 @@ Tag behavior:
 
 ---
 
-## MCP Team Runtime Tools
+## CLI Commands: ask/team
 
-When using the Team MCP server (`bridge/team-mcp.cjs`), these tools are available:
+### `omc ask`
+
+```bash
+omc ask claude "review this patch"
+omc ask gemini --prompt "suggest UX improvements"
+omc ask claude --agent-prompt executor --prompt "create an implementation plan"
+```
+
+- Provider matrix: `claude | gemini`
+- Artifacts: `.omc/artifacts/ask/{provider}-{slug}-{timestamp}.md`
+- Canonical env vars: `OMC_ASK_ADVISOR_SCRIPT`, `OMC_ASK_ORIGINAL_TASK`
+- Phase-1 aliases (deprecated warning): `OMX_ASK_ADVISOR_SCRIPT`, `OMX_ASK_ORIGINAL_TASK`
+
+### `omc team` (MVP runtime surface)
+
+```bash
+omc team start --agent codex --count 2 --task "review auth flow"
+omc team status <job_id>
+omc team wait <job_id> --timeout-ms 300000
+omc team cleanup <job_id> --grace-ms 5000
+```
+
+Supported subcommands in this integration phase: `start`, `status`, `wait`, `cleanup`.
+
+---
+
+## Legacy MCP Team Runtime Tools (Deprecated)
+
+The Team MCP server remains registered for compatibility, but runtime tools are now **CLI-only deprecated** and return a deterministic error envelope:
+
+```json
+{
+  "code": "deprecated_cli_only",
+  "message": "Legacy team MCP runtime tools are deprecated. Use the omc team CLI instead."
+}
+```
+
+Use `omc team ...` replacements instead:
 
 | Tool | Purpose |
 |------|---------|
-| `omc_run_team_start` | Start tmux workers in background and return `jobId` immediately |
-| `omc_run_team_status` | Non-blocking status check for a background team job |
-| `omc_run_team_wait` | Blocking wait with internal polling, backoff, and idle nudge support |
-| `omc_run_team_cleanup` | Explicitly stop worker panes and clear scoped team state directory |
+| `omc_run_team_start` | **Deprecated** → `omc team start` |
+| `omc_run_team_status` | **Deprecated** → `omc team status <job_id>` |
+| `omc_run_team_wait` | **Deprecated** → `omc team wait <job_id>` |
+| `omc_run_team_cleanup` | **Deprecated** → `omc team cleanup <job_id>` |
 
 ### Runtime status semantics
 

--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+import { spawnSync } from 'child_process';
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import process from 'process';
+
+const PROVIDER_BINARIES = {
+  claude: 'claude',
+  gemini: 'gemini',
+};
+
+const ASK_ORIGINAL_TASK_ENV = 'OMC_ASK_ORIGINAL_TASK';
+const ASK_ORIGINAL_TASK_ENV_ALIAS = 'OMX_ASK_ORIGINAL_TASK';
+
+function usage() {
+  console.error('Usage: omc ask <claude|gemini> "<prompt>"');
+  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini> <prompt...>');
+  console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
+  console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'task';
+}
+
+function timestampToken(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+function parseArgs(argv) {
+  const [providerRaw, ...rest] = argv;
+  const provider = (providerRaw || '').toLowerCase();
+
+  if (!provider || !(provider in PROVIDER_BINARIES)) {
+    usage();
+    process.exit(1);
+  }
+
+  if (rest.length === 0) {
+    usage();
+    process.exit(1);
+  }
+
+  if (rest[0] === '-p' || rest[0] === '--print' || rest[0] === '--prompt') {
+    const prompt = rest.slice(1).join(' ').trim();
+    if (!prompt) {
+      usage();
+      process.exit(1);
+    }
+    return { provider, prompt };
+  }
+
+  return { provider, prompt: rest.join(' ').trim() };
+}
+
+function ensureBinary(binary) {
+  const probe = spawnSync(binary, ['--version'], {
+    stdio: 'ignore',
+    encoding: 'utf8',
+  });
+
+  if (probe.error && probe.error.code === 'ENOENT') {
+    const verify = `${binary} --version`;
+    console.error(`[ask-${binary}] Missing required local CLI binary: ${binary}`);
+    console.error(`[ask-${binary}] Install/configure ${binary} CLI, then verify with: ${verify}`);
+    process.exit(1);
+  }
+}
+
+function buildSummary(exitCode, output) {
+  if (exitCode === 0) {
+    return 'Provider completed successfully. Review the raw output for details.';
+  }
+
+  const firstLine = output
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  return firstLine
+    ? `Provider command failed (exit ${exitCode}): ${firstLine}`
+    : `Provider command failed with exit code ${exitCode}.`;
+}
+
+function buildActionItems(exitCode) {
+  if (exitCode === 0) {
+    return [
+      'Review the response and extract decisions you want to apply.',
+      'Capture follow-up implementation tasks if needed.',
+    ];
+  }
+
+  return [
+    'Inspect the raw output error details.',
+    'Fix CLI/auth/environment issues and rerun the command.',
+  ];
+}
+
+function resolveOriginalTask(prompt) {
+  const canonical = process.env[ASK_ORIGINAL_TASK_ENV];
+  if (canonical && canonical.trim()) {
+    return canonical;
+  }
+
+  const alias = process.env[ASK_ORIGINAL_TASK_ENV_ALIAS];
+  if (alias && alias.trim()) {
+    console.error(`[ask] DEPRECATED: ${ASK_ORIGINAL_TASK_ENV_ALIAS} is deprecated; use ${ASK_ORIGINAL_TASK_ENV} instead.`);
+    return alias;
+  }
+
+  return prompt;
+}
+
+async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, exitCode }) {
+  const root = process.cwd();
+  const artifactDir = join(root, '.omc', 'artifacts', 'ask');
+  const slug = slugify(originalTask);
+  const timestamp = timestampToken();
+  const artifactPath = join(artifactDir, `${provider}-${slug}-${timestamp}.md`);
+
+  const summary = buildSummary(exitCode, rawOutput);
+  const actionItems = buildActionItems(exitCode);
+
+  const body = [
+    `# ${provider} advisor artifact`,
+    '',
+    `- Provider: ${provider}`,
+    `- Exit code: ${exitCode}`,
+    `- Created at: ${new Date().toISOString()}`,
+    '',
+    '## Original task',
+    '',
+    originalTask,
+    '',
+    '## Final prompt',
+    '',
+    finalPrompt,
+    '',
+    '## Raw output',
+    '',
+    '```text',
+    rawOutput || '(no output)',
+    '```',
+    '',
+    '## Concise summary',
+    '',
+    summary,
+    '',
+    '## Action items',
+    '',
+    ...actionItems.map((item) => `- ${item}`),
+    '',
+  ].join('\n');
+
+  await mkdir(artifactDir, { recursive: true });
+  await writeFile(artifactPath, body, 'utf8');
+  return artifactPath;
+}
+
+async function main() {
+  const { provider, prompt } = parseArgs(process.argv.slice(2));
+  const binary = PROVIDER_BINARIES[provider];
+
+  ensureBinary(binary);
+
+  const run = spawnSync(binary, ['-p', prompt], {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  const stdout = run.stdout || '';
+  const stderr = run.stderr || '';
+  const rawOutput = [stdout, stderr].filter(Boolean).join(stdout && stderr ? '\n\n' : '');
+  const exitCode = typeof run.status === 'number' ? run.status : 1;
+
+  const artifactPath = await writeArtifact({
+    provider,
+    originalTask: resolveOriginalTask(prompt),
+    finalPrompt: prompt,
+    rawOutput,
+    exitCode,
+  });
+
+  console.log(artifactPath);
+
+  if (run.error) {
+    console.error(`[ask-${provider}] ${run.error.message}`);
+  }
+
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+}
+
+main().catch((error) => {
+  console.error(`[run-provider-advisor] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -28,7 +28,7 @@ CCG spawns a tmux team with Codex and Gemini CLI workers running in parallel pan
    - Backend/analytical tasks → Codex worker
    - Frontend/UI/design tasks → Gemini worker
 
-2. mcp__team__omc_run_team_start creates a tmux session with 2 workers:
+2. `omc team start` creates a tmux session with 2 workers:
    omc-team-{name}
    ├── Leader pane (Claude orchestrates)
    ├── Worker pane 1: codex CLI (analytical tasks)
@@ -36,7 +36,7 @@ CCG spawns a tmux team with Codex and Gemini CLI workers running in parallel pan
 
 3. Workers read tasks from inbox files and write done.json on completion
 
-4. mcp__team__omc_run_team_wait blocks until all workers finish
+4. `omc team wait` blocks until all workers finish
 
 5. Claude reads taskResults and synthesizes into final output
 ```
@@ -55,36 +55,26 @@ Choose a short `teamName` slug (e.g., `ccg-auth-review`).
 
 ### 2. Start the team (non-blocking)
 
-Call `mcp__team__omc_run_team_start` — spawns workers in the background and returns a `jobId` immediately:
+Run `omc team start` — spawns workers in the background and returns a `jobId` immediately:
 
 ```
-mcp__team__omc_run_team_start({
-  "teamName": "ccg-{slug}",
-  "agentTypes": ["codex", "gemini"],
-  "tasks": [
-    {"subject": "Codex task: ...", "description": "Full description of analytical work..."},
-    {"subject": "Gemini task: ...", "description": "Full description of design/UI work..."}
-  ],
-  "cwd": "{cwd}"
-})
+omc team start --name "ccg-{slug}" --agent codex --count 1 --cwd "{cwd}" --task "Codex task: ..."
+omc team start --name "ccg-{slug}" --agent gemini --count 1 --cwd "{cwd}" --task "Gemini task: ..."
 ```
 
 Returns: `{ "jobId": "omc-...", "pid": 12345, "message": "Team started in background..." }`
 
 ### 3. Wait for completion
 
-Call `mcp__team__omc_run_team_wait` — blocks internally until done:
+Run `omc team wait <job_id>` — blocks internally until done:
 
 ```
-mcp__team__omc_run_team_wait({
-  "job_id": "{jobId}",
-  "timeout_ms": 60000
-})
+omc team wait "{jobId}"
 ```
 
 > **Timeout guidance:** `timeout_ms` is optional; the default wait timeout is fine.
-> If wait times out, workers/panes keep running. Call `omc_run_team_wait` again to keep
-> waiting. Use `omc_run_team_cleanup` only for explicit cancel intent.
+> If wait times out, workers/panes keep running. Call `omc team wait <job_id>` again to keep
+> waiting. Use `omc team cleanup <job_id>` only for explicit cancel intent.
 
 Returns when done:
 ```json

--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -6,7 +6,9 @@ aliases: []
 
 # OMC Teams Skill
 
-Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Supports `claude`, `codex`, and `gemini` agent types. Unlike `/team` (which uses Claude Code's native `TeamCreate`/`Task` tools), this skill uses the tmux runtime to launch actual CLI processes in visible tmux panes.
+Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Supports `claude`, `codex`, and `gemini` agent types. Unlike `/team` (which uses Claude Code's native `TeamCreate`/`Task` tools), this skill uses the CLI-first tmux runtime (`omc team ...`) to launch actual CLI processes in visible tmux panes.
+
+> Legacy MCP runtime tool calls (`omc_run_team_*`) are deprecated and return `code: "deprecated_cli_only"`.
 
 ## Usage
 
@@ -41,7 +43,7 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 ## How It Works
 
 1. Claude decomposes the task into N independent subtasks (one per worker)
-2. Calls `mcp__team__omc_run_team_start` then `mcp__team__omc_run_team_wait`
+2. Runs `omc team start` then `omc team wait`
 3. The OMC MCP server spawns `runtime-cli.cjs` (co-located in the same install directory)
 4. The runtime creates tmux split-panes and launches the CLI processes
 5. Each worker reads its task from an inbox file and writes `done.json` on completion
@@ -78,45 +80,33 @@ stopping prematurely after MCP tool calls return. The persistent-mode Stop hook 
 state_write(mode="team", current_phase="team-exec", active=true)
 ```
 
-Then call `mcp__team__omc_run_team_start` — it spawns workers in the background and returns a
-`jobId` immediately. No Bash, no path resolution; the MCP server finds `runtime-cli.cjs`
-from its own install directory automatically.
+Then run `omc team start` — it spawns workers in the background and returns a
+`jobId` immediately.
 
 ```
-mcp__team__omc_run_team_start({
-  "teamName": "{teamName}",
-  "agentTypes": ["{agentType}", "{agentType}", ...],
-  "tasks": [
-    {"subject": "Subtask 1 title", "description": "Full description..."},
-    {"subject": "Subtask 2 title", "description": "Full description..."}
-  ],
-  "cwd": "{cwd}"
-})
+omc team start --name "{teamName}" --agent "{agentType}" --count {N} --cwd "{cwd}" --task "<task from user message>"
 ```
 
 Returns: `{ "jobId": "omc-...", "pid": 12345, "message": "Team started in background..." }`
 
 ### Phase 4: Wait for completion, then report
 
-Call `mcp__team__omc_run_team_wait` — a single blocking call that polls internally
+Run `omc team wait <job_id>` — a single blocking call that polls internally
 (500ms → 2000ms exponential backoff) and returns only when the job reaches a terminal
 state. No repeated polling needed; one call instead of N.
 
 ```
-mcp__team__omc_run_team_wait({
-  "job_id": "{jobId}",
-  "timeout_ms": 60000
-})
+omc team wait "{jobId}"
 ```
 
 > **Timeout guidance:** `timeout_ms` is optional; the default wait timeout is fine.
 > If a wait call times out, **workers are left running** — wait timeout does NOT kill
 > worker processes or panes. You have two options:
-> - Call `omc_run_team_wait` again with the same `job_id` to keep waiting (workers continue)
-> - Call `omc_run_team_cleanup` only when you explicitly want to cancel and stop panes
+> - Call `omc team wait <job_id>` again to keep waiting (workers continue)
+> - Call `omc team cleanup <job_id>` only when you explicitly want to cancel and stop panes
 >
 > Teams can silently stall due to stuck workers or tmux session issues. Use
-> `mcp__team__omc_run_team_status` to inspect live progress before deciding to cancel.
+> `omc team status <job_id>` to inspect live progress before deciding to cancel.
 
 Returns when done:
 ```json
@@ -137,14 +127,14 @@ Returns when done:
 }
 ```
 
-> **Why no deadlock?** `omc_run_team_wait` uses `async/await` with `setTimeout`,
+> **Why no deadlock?** `omc team wait` uses `async/await` with `setTimeout`,
 > which yields the Node.js event loop between polls. The `child.on('close', ...)`
 > callback that updates job status fires during those yields. The background
 > `runtime-cli.cjs` child process is completely independent — it never calls back
 > into this MCP server.
 >
 > If you need non-blocking checks (e.g. to do other work while waiting), use
-> `mcp__team__omc_run_team_status` instead.
+> `omc team status <job_id>` instead.
 
 Report results to the user. For `failed` or wait-timeout errors, explain what happened and suggest next steps (reduce scope, check CLI installation, verify tmux is running).
 
@@ -162,7 +152,7 @@ state_write(mode="team", current_phase="completed", active=false)
 | `not inside tmux` | Shell not running inside a tmux session | Start tmux and rerun |
 | `codex: command not found` | Codex CLI not installed | `npm install -g @openai/codex` |
 | `gemini: command not found` | Gemini CLI not installed | `npm install -g @google/gemini-cli` |
-| wait timeout error | `omc_run_team_wait` hit `timeout_ms` before completion | Call `omc_run_team_wait` again to keep waiting, or call `omc_run_team_cleanup` to explicitly stop worker panes |
+| wait timeout error | `omc team wait` hit timeout before completion | Call `omc team wait <job_id>` again to keep waiting, or call `omc team cleanup <job_id>` to explicitly stop worker panes |
 | `status: failed` | All workers exited with work remaining | Check stderr for crash details |
 
 ---
@@ -172,7 +162,7 @@ state_write(mode="team", current_phase="completed", active=false)
 | Aspect | `/team` | `/omc-teams` |
 |--------|---------|-------------|
 | Worker type | Claude Code agents (`Task(subagent_type=...)`) | claude / codex / gemini CLI processes |
-| Invocation | `TeamCreate` / `SendMessage` / `TeamDelete` | `mcp__team__omc_run_team_start` + `omc_run_team_wait` |
+| Invocation | `TeamCreate` / `SendMessage` / `TeamDelete` | `omc team start` + `omc team wait` |
 | Coordination | Native Claude Code team messaging | tmux panes + inbox files + `done.json` sentinels |
 | Communication | Native Claude Code team messaging | File-based (inbox.md → done.json) |
 | Use when | You want Claude agents with full tool access | You want CLI autonomy (codex/gemini) at scale |

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { parseAskArgs, resolveAskAdvisorScriptPath } from '../ask.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const CLI_ENTRY = join(REPO_ROOT, 'src', 'cli', 'index.ts');
+const TSX_LOADER = join(REPO_ROOT, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+const ADVISOR_SCRIPT = join(REPO_ROOT, 'scripts', 'run-provider-advisor.js');
+
+interface CliRunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+function runCli(
+  args: string[],
+  cwd: string,
+  envOverrides: Record<string, string> = {},
+): CliRunResult {
+  const result = spawnSync(process.execPath, ['--import', TSX_LOADER, CLI_ENTRY, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message,
+  };
+}
+
+function runAdvisorScript(
+  args: string[],
+  cwd: string,
+  envOverrides: Record<string, string> = {},
+): CliRunResult {
+  const result = spawnSync(process.execPath, [ADVISOR_SCRIPT, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message,
+  };
+}
+
+function writeAdvisorStub(dir: string): string {
+  const stubPath = join(dir, 'advisor-stub.js');
+  writeFileSync(
+    stubPath,
+    [
+      '#!/usr/bin/env node',
+      'const payload = {',
+      '  provider: process.argv[2],',
+      '  prompt: process.argv[3],',
+      '  originalTask: process.env.OMC_ASK_ORIGINAL_TASK ?? null,',
+      '};',
+      'process.stdout.write(JSON.stringify(payload));',
+      'if (process.env.ASK_STUB_STDERR) process.stderr.write(process.env.ASK_STUB_STDERR);',
+      'process.exit(Number(process.env.ASK_STUB_EXIT_CODE || 0));',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  chmodSync(stubPath, 0o755);
+  return stubPath;
+}
+
+function writeFakeProviderBinary(dir: string, provider: 'claude' | 'gemini'): string {
+  const binDir = join(dir, 'bin');
+  mkdirSync(binDir, { recursive: true });
+  const binPath = join(binDir, provider);
+  writeFileSync(
+    binPath,
+    '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "fake"; exit 0; fi\nif [ "$1" = "-p" ]; then echo "FAKE_PROVIDER_OK:$2"; exit 0; fi\necho "unexpected" 1>&2\nexit 9\n',
+    'utf8',
+  );
+  chmodSync(binPath, 0o755);
+  return binDir;
+}
+
+describe('parseAskArgs', () => {
+  it('supports positional and print/prompt flag forms', () => {
+    expect(parseAskArgs(['claude', 'review', 'this'])).toEqual({ provider: 'claude', prompt: 'review this' });
+    expect(parseAskArgs(['gemini', '-p', 'brainstorm'])).toEqual({ provider: 'gemini', prompt: 'brainstorm' });
+    expect(parseAskArgs(['claude', '--print', 'draft', 'summary'])).toEqual({ provider: 'claude', prompt: 'draft summary' });
+    expect(parseAskArgs(['gemini', '--prompt=ship safely'])).toEqual({ provider: 'gemini', prompt: 'ship safely' });
+  });
+
+  it('supports --agent-prompt flag and equals syntax', () => {
+    expect(parseAskArgs(['claude', '--agent-prompt', 'executor', 'do', 'it'])).toEqual({
+      provider: 'claude',
+      prompt: 'do it',
+      agentPromptRole: 'executor',
+    });
+
+    expect(parseAskArgs(['gemini', '--agent-prompt=planner', '--prompt', 'plan', 'it'])).toEqual({
+      provider: 'gemini',
+      prompt: 'plan it',
+      agentPromptRole: 'planner',
+    });
+  });
+
+  it('rejects unsupported provider matrix', () => {
+    expect(() => parseAskArgs(['codex', 'hi'])).toThrow(/Invalid provider/i);
+  });
+});
+
+describe('omc ask command', () => {
+  it('accepts canonical advisor env and forwards prompt/task to advisor', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-canonical-'));
+    try {
+      const stubPath = writeAdvisorStub(wd);
+      const result = runCli(
+        ['ask', 'claude', '--print', 'hello world'],
+        wd,
+        { OMC_ASK_ADVISOR_SCRIPT: stubPath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+
+      const payload = JSON.parse(result.stdout);
+      expect(payload).toEqual({
+        provider: 'claude',
+        prompt: 'hello world',
+        originalTask: 'hello world',
+      });
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts OMX advisor env alias in Phase-1 and emits deprecation warning', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-alias-'));
+    try {
+      const stubPath = writeAdvisorStub(wd);
+      const result = runCli(
+        ['ask', 'gemini', 'legacy', 'path'],
+        wd,
+        { OMX_ASK_ADVISOR_SCRIPT: stubPath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain('DEPRECATED');
+      expect(result.stderr).toContain('OMX_ASK_ADVISOR_SCRIPT');
+
+      const payload = JSON.parse(result.stdout);
+      expect(payload.provider).toBe('gemini');
+      expect(payload.prompt).toBe('legacy path');
+      expect(payload.originalTask).toBe('legacy path');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('loads --agent-prompt role from resolved prompts dir and prepends role content', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-agent-prompt-'));
+    try {
+      const stubPath = writeAdvisorStub(wd);
+      mkdirSync(join(wd, '.omx'), { recursive: true });
+      mkdirSync(join(wd, '.codex', 'prompts'), { recursive: true });
+      writeFileSync(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }), 'utf8');
+      writeFileSync(join(wd, '.codex', 'prompts', 'executor.md'), 'ROLE HEADER\nFollow checks.', 'utf8');
+
+      const result = runCli(
+        ['ask', 'claude', '--agent-prompt=executor', '--prompt', 'ship feature'],
+        wd,
+        { OMC_ASK_ADVISOR_SCRIPT: stubPath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const payload = JSON.parse(result.stdout);
+      expect(payload.originalTask).toBe('ship feature');
+      expect(payload.prompt).toContain('ROLE HEADER');
+      expect(payload.prompt).toContain('ship feature');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('run-provider-advisor script contract', () => {
+  it('writes artifact to .omc/artifacts/ask/{provider}-{slug}-{timestamp}.md', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-artifact-'));
+    try {
+      const binDir = writeFakeProviderBinary(wd, 'claude');
+      const result = runAdvisorScript(
+        ['claude', '--print', 'artifact path contract'],
+        wd,
+        { PATH: `${binDir}:${process.env.PATH || ''}` },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const artifactPath = result.stdout.trim();
+      expect(artifactPath).toContain(join('.omc', 'artifacts', 'ask', 'claude-artifact-path-contract-'));
+      expect(existsSync(artifactPath)).toBe(true);
+
+      const artifact = readFileSync(artifactPath, 'utf8');
+      expect(artifact).toContain('FAKE_PROVIDER_OK:artifact path contract');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts OMX original-task alias in Phase-1 with deprecation warning', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-original-alias-'));
+    try {
+      const binDir = writeFakeProviderBinary(wd, 'gemini');
+      const result = runAdvisorScript(
+        ['gemini', '--prompt', 'fallback task'],
+        wd,
+        {
+          PATH: `${binDir}:${process.env.PATH || ''}`,
+          OMX_ASK_ORIGINAL_TASK: 'legacy original task',
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain('DEPRECATED');
+      expect(result.stderr).toContain('OMX_ASK_ORIGINAL_TASK');
+
+      const artifactPath = result.stdout.trim();
+      const artifact = readFileSync(artifactPath, 'utf8');
+      expect(artifact).toContain('## Original task\n\nlegacy original task');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('resolveAskAdvisorScriptPath', () => {
+  it('resolves canonical env and supports package-root relative paths', () => {
+    const packageRoot = '/tmp/pkg-root';
+    expect(resolveAskAdvisorScriptPath(packageRoot, { OMC_ASK_ADVISOR_SCRIPT: 'scripts/custom.js' } as NodeJS.ProcessEnv))
+      .toBe('/tmp/pkg-root/scripts/custom.js');
+    expect(resolveAskAdvisorScriptPath(packageRoot, { OMC_ASK_ADVISOR_SCRIPT: '/opt/custom.js' } as NodeJS.ProcessEnv))
+      .toBe('/opt/custom.js');
+  });
+});

--- a/src/cli/__tests__/team-help.test.ts
+++ b/src/cli/__tests__/team-help.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('team cli help text surfaces', () => {
+  it('team.ts usage includes legacy and api surfaces', () => {
+    const source = readFileSync(join(__dirname, '..', 'team.ts'), 'utf-8');
+    expect(source).toContain('omc team resume <team_name>');
+    expect(source).toContain('omc team shutdown <team_name>');
+    expect(source).toContain('omc team api <operation>');
+    expect(source).toContain('omc team [ralph] <N:agent-type>');
+  });
+
+  it('index.ts help text includes team api/resume/shutdown', () => {
+    const source = readFileSync(join(__dirname, '..', 'index.ts'), 'utf-8');
+    expect(source).toContain('omc team resume <team_name>');
+    expect(source).toContain('omc team shutdown <team_name>');
+    expect(source).toContain('omc team api <operation>');
+  });
+});

--- a/src/cli/__tests__/team-runtime-boundary.test.ts
+++ b/src/cli/__tests__/team-runtime-boundary.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('team cli runtime boundary', () => {
+  it('does not import or reference src/mcp/team-server.ts', () => {
+    const source = readFileSync(join(__dirname, '..', 'team.ts'), 'utf-8');
+
+    expect(source).not.toMatch(/mcp\/team-server/i);
+    expect(source).not.toMatch(/team-server\.ts/i);
+  });
+});

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  killWorkerPanes: vi.fn(),
+  resumeTeam: vi.fn(),
+  monitorTeam: vi.fn(),
+  shutdownTeam: vi.fn(),
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawn: mocks.spawn,
+  };
+});
+
+vi.mock('../../team/tmux-session.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../team/tmux-session.js')>();
+  return {
+    ...actual,
+    killWorkerPanes: mocks.killWorkerPanes,
+  };
+});
+
+vi.mock('../../team/runtime.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../team/runtime.js')>();
+  return {
+    ...actual,
+    resumeTeam: mocks.resumeTeam,
+    monitorTeam: mocks.monitorTeam,
+    shutdownTeam: mocks.shutdownTeam,
+  };
+});
+
+describe('team cli', () => {
+  let jobsDir: string;
+
+  beforeEach(() => {
+    jobsDir = mkdtempSync(join(tmpdir(), 'omc-team-cli-jobs-'));
+    process.env.OMC_JOBS_DIR = jobsDir;
+    process.env.OMC_RUNTIME_CLI_PATH = '/tmp/runtime-cli.cjs';
+    mocks.spawn.mockReset();
+    mocks.killWorkerPanes.mockReset();
+    mocks.resumeTeam.mockReset();
+    mocks.monitorTeam.mockReset();
+    mocks.shutdownTeam.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.OMC_JOBS_DIR;
+    delete process.env.OMC_RUNTIME_CLI_PATH;
+    rmSync(jobsDir, { recursive: true, force: true });
+  });
+
+  it('startTeamJob starts runtime-cli and persists running job', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    mocks.spawn.mockReturnValue({
+      pid: 4242,
+      stdin: { write, end },
+      unref,
+    });
+
+    const { startTeamJob } = await import('../team.js');
+
+    const result = await startTeamJob({
+      teamName: 'mvp-team',
+      agentTypes: ['codex'],
+      tasks: [{ subject: 'one', description: 'desc' }],
+      cwd: '/tmp/project',
+    });
+
+    expect(result.status).toBe('running');
+    expect(result.jobId).toMatch(/^omc-[a-z0-9]{1,12}$/);
+    expect(result.pid).toBe(4242);
+
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      'node',
+      ['/tmp/runtime-cli.cjs'],
+      expect.objectContaining({
+        detached: true,
+        stdio: ['pipe', 'ignore', 'ignore'],
+      }),
+    );
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(unref).toHaveBeenCalledTimes(1);
+
+    const savedJob = JSON.parse(readFileSync(join(jobsDir, `${result.jobId}.json`), 'utf-8')) as { status: string; pid: number };
+    expect(savedJob.status).toBe('running');
+    expect(savedJob.pid).toBe(4242);
+  });
+
+  it('getTeamJobStatus converges to result artifact state', async () => {
+    const { getTeamJobStatus } = await import('../team.js');
+
+    const jobId = 'omc-abc123';
+    writeFileSync(join(jobsDir, `${jobId}.json`), JSON.stringify({
+      status: 'running',
+      startedAt: Date.now() - 2_000,
+      teamName: 'demo',
+      cwd: '/tmp/demo',
+    }));
+    writeFileSync(join(jobsDir, `${jobId}-result.json`), JSON.stringify({
+      status: 'completed',
+      teamName: 'demo',
+      taskResults: [],
+    }));
+
+    const status = await getTeamJobStatus(jobId);
+    expect(status.status).toBe('completed');
+    expect(status.result).toEqual(expect.objectContaining({ status: 'completed' }));
+
+    const persisted = JSON.parse(readFileSync(join(jobsDir, `${jobId}.json`), 'utf-8')) as { status: string };
+    expect(persisted.status).toBe('completed');
+  });
+
+  it('waitForTeamJob times out with running status', async () => {
+    const { waitForTeamJob } = await import('../team.js');
+
+    const jobId = 'omc-timeout1';
+    writeFileSync(join(jobsDir, `${jobId}.json`), JSON.stringify({
+      status: 'running',
+      startedAt: Date.now(),
+      teamName: 'demo',
+      cwd: '/tmp/demo',
+    }));
+
+    const result = await waitForTeamJob(jobId, { timeoutMs: 10 });
+    expect(result.status).toBe('running');
+    expect(result.timedOut).toBe(true);
+    expect(result.error).toContain('Timed out waiting for job');
+  });
+
+  it('cleanupTeamJob kills worker panes and clears team state root', async () => {
+    const { cleanupTeamJob } = await import('../team.js');
+
+    const jobId = 'omc-cleanup1';
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-cleanup-'));
+    const stateRoot = join(cwd, '.omc', 'state', 'team', 'demo-team');
+    mkdirSync(stateRoot, { recursive: true });
+
+    writeFileSync(join(jobsDir, `${jobId}.json`), JSON.stringify({
+      status: 'running',
+      startedAt: Date.now(),
+      teamName: 'demo-team',
+      cwd,
+    }));
+
+    writeFileSync(join(jobsDir, `${jobId}-panes.json`), JSON.stringify({
+      paneIds: ['%11', '%12'],
+      leaderPaneId: '%10',
+    }));
+
+    const result = await cleanupTeamJob(jobId, 1234);
+
+    expect(result.message).toContain('Cleaned up 2 worker pane(s)');
+    expect(mocks.killWorkerPanes).toHaveBeenCalledWith({
+      paneIds: ['%11', '%12'],
+      leaderPaneId: '%10',
+      teamName: 'demo-team',
+      cwd,
+      graceMs: 1234,
+    });
+    expect(existsSync(stateRoot)).toBe(false);
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('team status supports team-name target via runtime snapshot', async () => {
+    const { teamCommand } = await import('../team.js');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    mocks.resumeTeam.mockResolvedValue({
+      teamName: 'demo-team',
+      sessionName: 'omc-team-demo:0',
+      leaderPaneId: '%0',
+      config: { teamName: 'demo-team', workerCount: 1, agentTypes: ['codex'], tasks: [], cwd: '/tmp/demo' },
+      workerNames: ['worker-1'],
+      workerPaneIds: ['%1'],
+      activeWorkers: new Map(),
+      cwd: '/tmp/demo',
+    });
+    mocks.monitorTeam.mockResolvedValue({
+      teamName: 'demo-team',
+      phase: 'executing',
+      workers: [],
+      taskCounts: { pending: 0, inProgress: 1, completed: 0, failed: 0 },
+      deadWorkers: [],
+      monitorPerformance: { listTasksMs: 0, workerScanMs: 0, totalMs: 0 },
+    });
+
+    await teamCommand(['status', 'demo-team', '--json']);
+
+    expect(mocks.resumeTeam).toHaveBeenCalledWith('demo-team', process.cwd());
+    expect(mocks.monitorTeam).toHaveBeenCalled();
+    const payload = JSON.parse(logSpy.mock.calls[0][0] as string) as { running: boolean; snapshot: { phase: string } };
+    expect(payload.running).toBe(true);
+    expect(payload.snapshot.phase).toBe('executing');
+
+    logSpy.mockRestore();
+  });
+
+  it('team resume invokes runtime resumeTeam', async () => {
+    const { teamCommand } = await import('../team.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    mocks.resumeTeam.mockResolvedValue({
+      teamName: 'alpha-team',
+      sessionName: 'omc-team-alpha:0',
+      leaderPaneId: '%0',
+      config: { teamName: 'alpha-team', workerCount: 1, agentTypes: ['codex'], tasks: [], cwd: '/tmp/demo' },
+      workerNames: ['worker-1'],
+      workerPaneIds: ['%1'],
+      activeWorkers: new Map([['worker-1', { paneId: '%1', taskId: '1', spawnedAt: Date.now() }]]),
+      cwd: '/tmp/demo',
+    });
+
+    await teamCommand(['resume', 'alpha-team', '--json']);
+
+    expect(mocks.resumeTeam).toHaveBeenCalledWith('alpha-team', process.cwd());
+    const payload = JSON.parse(logSpy.mock.calls[0][0] as string) as { resumed: boolean; activeWorkers: number };
+    expect(payload.resumed).toBe(true);
+    expect(payload.activeWorkers).toBe(1);
+
+    logSpy.mockRestore();
+  });
+
+  it('team shutdown supports --force and calls runtime shutdown', async () => {
+    const { teamCommand } = await import('../team.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    mocks.resumeTeam.mockResolvedValue({
+      teamName: 'beta-team',
+      sessionName: 'omc-team-beta:0',
+      leaderPaneId: '%0',
+      config: { teamName: 'beta-team', workerCount: 1, agentTypes: ['codex'], tasks: [], cwd: '/tmp/demo' },
+      workerNames: ['worker-1'],
+      workerPaneIds: ['%1'],
+      activeWorkers: new Map(),
+      cwd: '/tmp/demo',
+    });
+
+    await teamCommand(['shutdown', 'beta-team', '--force', '--json']);
+
+    expect(mocks.shutdownTeam).toHaveBeenCalledWith('beta-team', 'omc-team-beta:0', '/tmp/demo', 0, ['%1'], '%0');
+    const payload = JSON.parse(logSpy.mock.calls[0][0] as string) as { shutdown: boolean; forced: boolean };
+    expect(payload.shutdown).toBe(true);
+    expect(payload.forced).toBe(true);
+
+    logSpy.mockRestore();
+  });
+
+  it('legacy shorthand start alias supports optional ralph token', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    mocks.spawn.mockReturnValue({
+      pid: 5151,
+      stdin: { write, end },
+      unref,
+    });
+
+    const { teamCommand } = await import('../team.js');
+    await teamCommand(['ralph', '2:codex', 'ship', 'feature', '--json']);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(write.mock.calls[0][0] as string) as { agentTypes: string[]; tasks: Array<{ subject: string; description: string }> };
+    expect(payload.agentTypes).toEqual(['codex', 'codex']);
+    expect(payload.tasks[0].subject).toContain('Ralph');
+    expect(payload.tasks[0].description).toBe('ship feature');
+
+    const out = JSON.parse(logSpy.mock.calls[0][0] as string) as { status: string; pid: number };
+    expect(out.status).toBe('running');
+    expect(out.pid).toBe(5151);
+
+    logSpy.mockRestore();
+  });
+
+  it('team api supports list-tasks and read-config', async () => {
+    const { teamCommand } = await import('../team.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-api-'));
+    const root = join(cwd, '.omc', 'state', 'team', 'api-team');
+    mkdirSync(join(root, 'tasks'), { recursive: true });
+    writeFileSync(join(root, 'tasks', '1.json'), JSON.stringify({ id: '1', status: 'pending' }));
+    writeFileSync(join(root, 'config.json'), JSON.stringify({ teamName: 'api-team', workerCount: 1 }));
+
+    await teamCommand(['api', 'list-tasks', '--input', JSON.stringify({ teamName: 'api-team' }), '--json', '--cwd', cwd]);
+    const listPayload = JSON.parse(logSpy.mock.calls[0][0] as string) as { ok: boolean; data: { tasks: Array<{ id: string }> } };
+    expect(listPayload.ok).toBe(true);
+    expect(listPayload.data.tasks[0].id).toBe('1');
+
+    await teamCommand(['api', 'read-config', '--input', JSON.stringify({ teamName: 'api-team' }), '--json', '--cwd', cwd]);
+    const configPayload = JSON.parse(logSpy.mock.calls[1][0] as string) as { ok: boolean; data: { config: { workerCount: number } } };
+    expect(configPayload.ok).toBe(true);
+    expect(configPayload.data.config.workerCount).toBe(1);
+
+    rmSync(cwd, { recursive: true, force: true });
+    logSpy.mockRestore();
+  });
+
+  it('team api returns structured JSON envelope for unsupported operation', async () => {
+    const { teamCommand } = await import('../team.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await teamCommand(['api', 'unknown-op', '--json', '--input', JSON.stringify({ teamName: 'demo-team' })]);
+
+    const payload = JSON.parse(logSpy.mock.calls[0][0] as string) as { ok: boolean; error: { code: string } };
+    expect(payload.ok).toBe(false);
+    expect(payload.error.code).toBe('UNSUPPORTED_OPERATION');
+
+    logSpy.mockRestore();
+  });
+});

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -1,0 +1,258 @@
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { readFile, readdir } from 'fs/promises';
+import { constants as osConstants } from 'os';
+import { basename, dirname, isAbsolute, join } from 'path';
+import { fileURLToPath } from 'url';
+
+export const ASK_USAGE = [
+  'Usage: omc ask <claude|gemini> <question or task>',
+  '   or: omc ask <claude|gemini> -p "<prompt>"',
+  '   or: omc ask <claude|gemini> --print "<prompt>"',
+  '   or: omc ask <claude|gemini> --prompt "<prompt>"',
+  '   or: omc ask <claude|gemini> --agent-prompt <role> "<prompt>"',
+  '   or: omc ask <claude|gemini> --agent-prompt=<role> --prompt "<prompt>"',
+].join('\n');
+
+const ASK_PROVIDERS = ['claude', 'gemini'] as const;
+export type AskProvider = (typeof ASK_PROVIDERS)[number];
+const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
+
+const ASK_AGENT_PROMPT_FLAG = '--agent-prompt';
+const SAFE_ROLE_PATTERN = /^[a-z][a-z0-9-]*$/;
+const ASK_ADVISOR_SCRIPT_ENV = 'OMC_ASK_ADVISOR_SCRIPT';
+const ASK_ADVISOR_SCRIPT_ENV_ALIAS = 'OMX_ASK_ADVISOR_SCRIPT';
+const ASK_ORIGINAL_TASK_ENV = 'OMC_ASK_ORIGINAL_TASK';
+
+export interface ParsedAskArgs {
+  provider: AskProvider;
+  prompt: string;
+  agentPromptRole?: string;
+}
+
+function askUsageError(reason: string): Error {
+  return new Error(`${reason}\n${ASK_USAGE}`);
+}
+
+function warnDeprecatedAlias(alias: string, canonical: string): void {
+  process.stderr.write(`[ask] DEPRECATED: ${alias} is deprecated; use ${canonical} instead.\n`);
+}
+
+function getPackageRoot(): string {
+  if (typeof __dirname !== 'undefined' && __dirname) {
+    const currentDirName = basename(__dirname);
+    const parentDirName = basename(dirname(__dirname));
+
+    if (currentDirName === 'bridge') {
+      return join(__dirname, '..');
+    }
+
+    if (currentDirName === 'cli' && (parentDirName === 'src' || parentDirName === 'dist')) {
+      return join(__dirname, '..', '..');
+    }
+  }
+
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    return join(__dirname, '..', '..');
+  } catch {
+    return process.cwd();
+  }
+}
+
+function resolveAskPromptsDir(
+  cwd: string,
+  packageRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const codexHomeOverride = env.CODEX_HOME?.trim();
+  if (codexHomeOverride) {
+    return join(codexHomeOverride, 'prompts');
+  }
+
+  try {
+    const scopePath = join(cwd, '.omx', 'setup-scope.json');
+    if (existsSync(scopePath)) {
+      const parsed = JSON.parse(readFileSync(scopePath, 'utf-8')) as Partial<{ scope: string }>;
+      if (parsed.scope === 'project' || parsed.scope === 'project-local') {
+        return join(cwd, '.codex', 'prompts');
+      }
+    }
+  } catch {
+    // Ignore malformed persisted scope and fall back to package agents.
+  }
+
+  return join(packageRoot, 'agents');
+}
+
+async function resolveAgentPromptContent(role: string, promptsDir: string): Promise<string> {
+  const normalizedRole = role.trim().toLowerCase();
+  if (!SAFE_ROLE_PATTERN.test(normalizedRole)) {
+    throw new Error(`[ask] invalid --agent-prompt role "${role}". Expected lowercase role names like "executor" or "test-engineer".`);
+  }
+
+  if (!existsSync(promptsDir)) {
+    throw new Error(`[ask] prompts directory not found: ${promptsDir}.`);
+  }
+
+  const promptPath = join(promptsDir, `${normalizedRole}.md`);
+  if (!existsSync(promptPath)) {
+    const files = await readdir(promptsDir).catch(() => [] as string[]);
+    const availableRoles = files
+      .filter((file) => file.endsWith('.md'))
+      .map((file) => file.slice(0, -3))
+      .sort();
+    const availableSuffix = availableRoles.length > 0
+      ? ` Available roles: ${availableRoles.join(', ')}.`
+      : '';
+    throw new Error(`[ask] --agent-prompt role "${normalizedRole}" not found in ${promptsDir}.${availableSuffix}`);
+  }
+
+  const content = (await readFile(promptPath, 'utf-8')).trim();
+  if (!content) {
+    throw new Error(`[ask] --agent-prompt role "${normalizedRole}" is empty: ${promptPath}`);
+  }
+
+  return content;
+}
+
+export function parseAskArgs(args: readonly string[]): ParsedAskArgs {
+  const [providerRaw, ...rest] = args;
+  const provider = (providerRaw || '').toLowerCase();
+
+  if (!provider || !ASK_PROVIDER_SET.has(provider)) {
+    throw askUsageError(`Invalid provider "${providerRaw || ''}". Expected one of: ${ASK_PROVIDERS.join(', ')}.`);
+  }
+
+  if (rest.length === 0) {
+    throw askUsageError('Missing prompt text.');
+  }
+
+  let agentPromptRole: string | undefined;
+  let prompt = '';
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (token === ASK_AGENT_PROMPT_FLAG) {
+      const role = rest[i + 1]?.trim();
+      if (!role || role.startsWith('-')) {
+        throw askUsageError('Missing role after --agent-prompt.');
+      }
+      agentPromptRole = role;
+      i += 1;
+      continue;
+    }
+
+    if (token.startsWith(`${ASK_AGENT_PROMPT_FLAG}=`)) {
+      const role = token.slice(`${ASK_AGENT_PROMPT_FLAG}=`.length).trim();
+      if (!role) {
+        throw askUsageError('Missing role after --agent-prompt=');
+      }
+      agentPromptRole = role;
+      continue;
+    }
+
+    if (token === '-p' || token === '--print' || token === '--prompt') {
+      prompt = rest.slice(i + 1).join(' ').trim();
+      break;
+    }
+
+    if (token.startsWith('-p=') || token.startsWith('--print=') || token.startsWith('--prompt=')) {
+      const inlinePrompt = token.split('=').slice(1).join('=').trim();
+      const remainder = rest.slice(i + 1).join(' ').trim();
+      prompt = [inlinePrompt, remainder].filter(Boolean).join(' ').trim();
+      break;
+    }
+
+    prompt = [prompt, token].filter(Boolean).join(' ').trim();
+  }
+
+  if (!prompt) {
+    throw askUsageError('Missing prompt text.');
+  }
+
+  return {
+    provider: provider as AskProvider,
+    prompt,
+    ...(agentPromptRole ? { agentPromptRole } : {}),
+  };
+}
+
+export function resolveAskAdvisorScriptPath(
+  packageRoot = getPackageRoot(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const canonical = env[ASK_ADVISOR_SCRIPT_ENV]?.trim();
+  if (canonical) {
+    return isAbsolute(canonical) ? canonical : join(packageRoot, canonical);
+  }
+
+  const alias = env[ASK_ADVISOR_SCRIPT_ENV_ALIAS]?.trim();
+  if (alias) {
+    warnDeprecatedAlias(ASK_ADVISOR_SCRIPT_ENV_ALIAS, ASK_ADVISOR_SCRIPT_ENV);
+    return isAbsolute(alias) ? alias : join(packageRoot, alias);
+  }
+
+  return join(packageRoot, 'scripts', 'run-provider-advisor.js');
+}
+
+function resolveSignalExitCode(signal: NodeJS.Signals | null): number {
+  if (!signal) return 1;
+
+  const signalNumber = osConstants.signals[signal];
+  if (typeof signalNumber === 'number' && Number.isFinite(signalNumber)) {
+    return 128 + signalNumber;
+  }
+
+  return 1;
+}
+
+export async function askCommand(args: string[]): Promise<void> {
+  const parsed = parseAskArgs(args);
+  const packageRoot = getPackageRoot();
+  const advisorScriptPath = resolveAskAdvisorScriptPath(packageRoot);
+  const promptsDir = resolveAskPromptsDir(process.cwd(), packageRoot, process.env);
+
+  if (!existsSync(advisorScriptPath)) {
+    throw new Error(`[ask] advisor script not found: ${advisorScriptPath}`);
+  }
+
+  let finalPrompt = parsed.prompt;
+  if (parsed.agentPromptRole) {
+    const agentPromptContent = await resolveAgentPromptContent(parsed.agentPromptRole, promptsDir);
+    finalPrompt = `${agentPromptContent}\n\n${parsed.prompt}`;
+  }
+
+  const child = spawnSync(
+    process.execPath,
+    [advisorScriptPath, parsed.provider, finalPrompt],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        [ASK_ORIGINAL_TASK_ENV]: parsed.prompt,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+
+  if (child.stdout && child.stdout.length > 0) {
+    process.stdout.write(child.stdout);
+  }
+  if (child.stderr && child.stderr.length > 0) {
+    process.stderr.write(child.stderr);
+  }
+
+  if (child.error) {
+    throw new Error(`[ask] failed to launch advisor script: ${child.error.message}`);
+  }
+
+  const status = typeof child.status === 'number'
+    ? child.status
+    : resolveSignalExitCode(child.signal);
+
+  if (status !== 0) {
+    process.exitCode = status;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -59,6 +59,7 @@ import {
 import { getRuntimePackageVersion } from '../lib/version.js';
 import { launchCommand } from './launch.js';
 import { interopCommand } from './interop.js';
+import { askCommand, ASK_USAGE } from './ask.js';
 import { warnIfWin32 } from './win32-warning.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -77,6 +78,34 @@ async function defaultAction() {
   const args = process.argv.slice(2);
   await launchCommand(args);
 }
+
+async function runTeamCommand(args: string[]): Promise<void> {
+  const teamModuleUrl = new URL('./team.js', import.meta.url).href;
+  const teamModule = await import(teamModuleUrl) as {
+    teamCommand?: (argv: string[]) => Promise<void> | void;
+    main?: (argv: string[]) => Promise<void> | void;
+    default?: (argv: string[]) => Promise<void> | void;
+  };
+
+  const runner = teamModule.teamCommand ?? teamModule.main ?? teamModule.default;
+  if (!runner) {
+    throw new Error('Team CLI command module loaded but no runnable export found (expected teamCommand, main, or default).');
+  }
+
+  await runner(args);
+}
+
+const TEAM_COMMAND_USAGE = `
+Usage:
+  omc team start --agent <claude|codex|gemini>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--json]
+  omc team status <job_id|team_name> [--json] [--cwd DIR]
+  omc team wait <job_id> [--timeout-ms MS] [--json]
+  omc team cleanup <job_id> [--grace-ms MS] [--json]
+  omc team resume <team_name> [--json] [--cwd DIR]
+  omc team shutdown <team_name> [--force] [--json] [--cwd DIR]
+  omc team api <operation> [--input '<json>'] [--json] [--cwd DIR]
+  omc team [ralph] <N:agent-type> "task" [--json] [--cwd DIR]
+`.trim();
 
 program
   .name('omc')
@@ -126,6 +155,18 @@ Requirements:
   - Codex CLI recommended (graceful fallback if missing)`)
   .action(() => {
     interopCommand();
+  });
+
+/**
+ * Ask command - Run provider advisor prompt (claude|gemini)
+ */
+program
+  .command('ask [args...]')
+  .description('Run provider advisor prompt and write an ask artifact')
+  .allowUnknownOption()
+  .addHelpText('after', `\n${ASK_USAGE}`)
+  .action(async (args: string[]) => {
+    await askCommand(args || []);
   });
 
 /**
@@ -1174,6 +1215,15 @@ waitCmd
       json: options.json,
       lines: parseInt(options.lines),
     });
+  });
+
+program
+  .command('team [args...]')
+  .description('Team CLI runtime + legacy commands (start/status/wait/cleanup/resume/shutdown/api)')
+  .allowUnknownOption()
+  .addHelpText('after', `\n${TEAM_COMMAND_USAGE}`)
+  .action(async (args: string[]) => {
+    await runTeamCommand(args);
   });
 
 /**

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,0 +1,1359 @@
+import { spawn } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { appendFile, readFile, readdir, rm } from 'fs/promises';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { killWorkerPanes } from '../team/tmux-session.js';
+import { validateTeamName } from '../team/team-name.js';
+import { monitorTeam, resumeTeam, shutdownTeam } from '../team/runtime.js';
+
+const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,12}$/;
+const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini']);
+const SUBCOMMANDS = new Set(['start', 'status', 'wait', 'cleanup', 'resume', 'shutdown', 'api', 'help', '--help', '-h']);
+
+const SUPPORTED_API_OPERATIONS = new Set([
+  'send-message',
+  'broadcast',
+  'mailbox-list',
+  'mailbox-mark-delivered',
+  'list-tasks',
+  'read-task',
+  'read-config',
+  'get-summary',
+] as const);
+const TEAM_API_USAGE = `
+Usage:
+  omc team api <operation> --input '<json>' [--json] [--cwd DIR]
+
+Supported operations:
+  ${Array.from(SUPPORTED_API_OPERATIONS).join(', ')}
+`.trim();
+
+type SupportedApiOperation =
+  | 'send-message'
+  | 'broadcast'
+  | 'mailbox-list'
+  | 'mailbox-mark-delivered'
+  | 'list-tasks'
+  | 'read-task'
+  | 'read-config'
+  | 'get-summary';
+
+interface TeamApiEnvelope {
+  ok: boolean;
+  operation: string;
+  data?: Record<string, unknown>;
+  error?: {
+    code: string;
+    message: string;
+  };
+}
+
+interface TeamLegacyStartArgs {
+  workerCount: number;
+  agentType: string;
+  task: string;
+  teamName: string;
+  ralph: boolean;
+  json: boolean;
+  cwd: string;
+}
+
+export interface TeamTaskInput {
+  subject: string;
+  description: string;
+}
+
+export interface TeamStartInput {
+  teamName: string;
+  agentTypes: string[];
+  tasks: TeamTaskInput[];
+  cwd: string;
+  workerCount?: number;
+  pollIntervalMs?: number;
+  sentinelGateTimeoutMs?: number;
+  sentinelGatePollIntervalMs?: number;
+}
+
+export interface TeamStartResult {
+  jobId: string;
+  status: 'running';
+  pid?: number;
+}
+
+export interface TeamJobStatus {
+  jobId: string;
+  status: 'running' | 'completed' | 'failed';
+  elapsedSeconds: string;
+  result?: unknown;
+  stderr?: string;
+}
+
+export interface TeamWaitOptions {
+  timeoutMs?: number;
+}
+
+export interface TeamWaitResult extends TeamJobStatus {
+  timedOut?: boolean;
+  error?: string;
+}
+
+export interface TeamCleanupResult {
+  jobId: string;
+  message: string;
+}
+
+interface TeamJobRecord {
+  status: 'running' | 'completed' | 'failed';
+  startedAt: number;
+  teamName: string;
+  cwd: string;
+  pid?: number;
+  result?: string;
+  stderr?: string;
+  cleanedUpAt?: string;
+}
+
+interface TeamPanesFile {
+  paneIds: string[];
+  leaderPaneId: string;
+}
+
+function resolveJobsDir(env: NodeJS.ProcessEnv = process.env): string {
+  return env.OMC_JOBS_DIR || join(homedir(), '.omc', 'team-jobs');
+}
+
+function resolveRuntimeCliPath(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.OMC_RUNTIME_CLI_PATH) {
+    return env.OMC_RUNTIME_CLI_PATH;
+  }
+
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return join(moduleDir, '../../bridge/runtime-cli.cjs');
+}
+
+function ensureJobsDir(jobsDir: string): void {
+  if (!existsSync(jobsDir)) {
+    mkdirSync(jobsDir, { recursive: true });
+  }
+}
+
+function jobPath(jobsDir: string, jobId: string): string {
+  return join(jobsDir, `${jobId}.json`);
+}
+
+function resultArtifactPath(jobsDir: string, jobId: string): string {
+  return join(jobsDir, `${jobId}-result.json`);
+}
+
+function panesArtifactPath(jobsDir: string, jobId: string): string {
+  return join(jobsDir, `${jobId}-panes.json`);
+}
+
+function teamStateRoot(cwd: string, teamName: string): string {
+  return join(cwd, '.omc', 'state', 'team', teamName);
+}
+
+function validateJobId(jobId: string): void {
+  if (!JOB_ID_PATTERN.test(jobId)) {
+    throw new Error(`Invalid job id: ${jobId}`);
+  }
+}
+
+function parseJsonSafe<T>(content: string): T | null {
+  try {
+    return JSON.parse(content) as T;
+  } catch {
+    return null;
+  }
+}
+
+function readJobFromDisk(jobId: string, jobsDir: string): TeamJobRecord | null {
+  try {
+    const content = readFileSync(jobPath(jobsDir, jobId), 'utf-8');
+    return parseJsonSafe<TeamJobRecord>(content);
+  } catch {
+    return null;
+  }
+}
+
+function writeJobToDisk(jobId: string, job: TeamJobRecord, jobsDir: string): void {
+  ensureJobsDir(jobsDir);
+  writeFileSync(jobPath(jobsDir, jobId), JSON.stringify(job), 'utf-8');
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseJobResult(raw?: string): unknown {
+  if (!raw) return undefined;
+  const parsed = parseJsonSafe<unknown>(raw);
+  return parsed ?? raw;
+}
+
+function buildStatus(jobId: string, job: TeamJobRecord): TeamJobStatus {
+  return {
+    jobId,
+    status: job.status,
+    elapsedSeconds: ((Date.now() - job.startedAt) / 1000).toFixed(1),
+    result: parseJobResult(job.result),
+    stderr: job.stderr,
+  };
+}
+
+function generateJobId(now = Date.now()): string {
+  return `omc-${now.toString(36)}`;
+}
+
+function convergeWithResultArtifact(jobId: string, job: TeamJobRecord, jobsDir: string): TeamJobRecord {
+  try {
+    const artifactRaw = readFileSync(resultArtifactPath(jobsDir, jobId), 'utf-8');
+    const artifactParsed = parseJsonSafe<{ status?: string }>(artifactRaw);
+    if (artifactParsed?.status === 'completed' || artifactParsed?.status === 'failed') {
+      return {
+        ...job,
+        status: artifactParsed.status,
+        result: artifactRaw,
+      };
+    }
+  } catch {
+    // no artifact yet
+  }
+
+  if (job.status === 'running' && job.pid != null && !isPidAlive(job.pid)) {
+    return {
+      ...job,
+      status: 'failed',
+      result: job.result ?? JSON.stringify({ error: 'Process no longer alive' }),
+    };
+  }
+
+  return job;
+}
+
+function output(value: unknown, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(value, null, 2));
+    return;
+  }
+  console.log(value);
+}
+
+function toInt(value: string, flag: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid ${flag} value: ${value}`);
+  }
+  return parsed;
+}
+
+function normalizeAgentType(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) throw new Error('Agent type cannot be empty');
+  if (!VALID_CLI_AGENT_TYPES.has(normalized)) {
+    throw new Error(`Unsupported agent type: ${value}`);
+  }
+  return normalized;
+}
+
+function autoTeamName(task: string): string {
+  const slug = task
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 24) || 'task';
+  return `omc-${slug}-${Date.now().toString(36).slice(-4)}`;
+}
+
+function parseJsonInput(inputRaw: string | undefined): Record<string, unknown> {
+  if (!inputRaw || !inputRaw.trim()) return {};
+  const parsed = parseJsonSafe<Record<string, unknown>>(inputRaw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid --input JSON payload');
+  }
+  return parsed;
+}
+
+function readInputString(input: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return '';
+}
+
+function mailboxPath(cwd: string, teamName: string, workerName: string): string {
+  return join(teamStateRoot(cwd, teamName), 'mailbox', `${workerName}.jsonl`);
+}
+
+async function readTaskFiles(cwd: string, teamName: string): Promise<Array<Record<string, unknown>>> {
+  const tasksDir = join(teamStateRoot(cwd, teamName), 'tasks');
+  let files: string[] = [];
+  try {
+    files = (await readdir(tasksDir)).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+
+  const loaded = await Promise.all(
+    files.map(async (file) => {
+      try {
+        const raw = await readFile(join(tasksDir, file), 'utf-8');
+        const parsed = parseJsonSafe<Record<string, unknown>>(raw);
+        return parsed ?? null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return loaded.filter((v): v is Record<string, unknown> => v !== null);
+}
+
+export async function startTeamJob(input: TeamStartInput): Promise<TeamStartResult> {
+  validateTeamName(input.teamName);
+  if (!Array.isArray(input.agentTypes) || input.agentTypes.length === 0) {
+    throw new Error('agentTypes must be a non-empty array');
+  }
+  if (!Array.isArray(input.tasks) || input.tasks.length === 0) {
+    throw new Error('tasks must be a non-empty array');
+  }
+
+  const jobsDir = resolveJobsDir();
+  const runtimeCliPath = resolveRuntimeCliPath();
+  const jobId = generateJobId();
+
+  const job: TeamJobRecord = {
+    status: 'running',
+    startedAt: Date.now(),
+    teamName: input.teamName,
+    cwd: input.cwd,
+  };
+
+  const child = spawn('node', [runtimeCliPath], {
+    env: {
+      ...process.env,
+      OMC_JOB_ID: jobId,
+      OMC_JOBS_DIR: jobsDir,
+    },
+    detached: true,
+    stdio: ['pipe', 'ignore', 'ignore'],
+  });
+
+  const payload = {
+    teamName: input.teamName,
+    workerCount: input.workerCount,
+    agentTypes: input.agentTypes,
+    tasks: input.tasks,
+    cwd: input.cwd,
+    pollIntervalMs: input.pollIntervalMs,
+    sentinelGateTimeoutMs: input.sentinelGateTimeoutMs,
+    sentinelGatePollIntervalMs: input.sentinelGatePollIntervalMs,
+  };
+
+  child.stdin.write(JSON.stringify(payload));
+  child.stdin.end();
+  child.unref();
+
+  if (child.pid != null) {
+    job.pid = child.pid;
+  }
+  writeJobToDisk(jobId, job, jobsDir);
+
+  return {
+    jobId,
+    status: 'running',
+    pid: child.pid,
+  };
+}
+
+export async function getTeamJobStatus(jobId: string): Promise<TeamJobStatus> {
+  validateJobId(jobId);
+
+  const jobsDir = resolveJobsDir();
+  const job = readJobFromDisk(jobId, jobsDir);
+  if (!job) {
+    throw new Error(`No job found: ${jobId}`);
+  }
+
+  const converged = convergeWithResultArtifact(jobId, job, jobsDir);
+  if (JSON.stringify(converged) !== JSON.stringify(job)) {
+    writeJobToDisk(jobId, converged, jobsDir);
+  }
+
+  return buildStatus(jobId, converged);
+}
+
+export async function waitForTeamJob(jobId: string, options: TeamWaitOptions = {}): Promise<TeamWaitResult> {
+  const timeoutMs = Math.min(options.timeoutMs ?? 300_000, 3_600_000);
+  const deadline = Date.now() + timeoutMs;
+  let delayMs = 500;
+
+  while (Date.now() < deadline) {
+    const status = await getTeamJobStatus(jobId);
+    if (status.status !== 'running') {
+      return status;
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    delayMs = Math.min(Math.floor(delayMs * 1.5), 2000);
+  }
+
+  const status = await getTeamJobStatus(jobId);
+  return {
+    ...status,
+    timedOut: true,
+    error: `Timed out waiting for job ${jobId} after ${(timeoutMs / 1000).toFixed(0)}s`,
+  };
+}
+
+export async function cleanupTeamJob(jobId: string, graceMs = 10_000): Promise<TeamCleanupResult> {
+  validateJobId(jobId);
+
+  const jobsDir = resolveJobsDir();
+  const job = readJobFromDisk(jobId, jobsDir);
+  if (!job) {
+    throw new Error(`No job found: ${jobId}`);
+  }
+
+  const paneArtifact = await readFile(panesArtifactPath(jobsDir, jobId), 'utf-8')
+    .then((content) => parseJsonSafe<TeamPanesFile>(content))
+    .catch(() => null);
+
+  if (paneArtifact?.paneIds?.length) {
+    await killWorkerPanes({
+      paneIds: paneArtifact.paneIds,
+      leaderPaneId: paneArtifact.leaderPaneId,
+      teamName: job.teamName,
+      cwd: job.cwd,
+      graceMs,
+    });
+  }
+
+  await rm(teamStateRoot(job.cwd, job.teamName), {
+    recursive: true,
+    force: true,
+  }).catch(() => undefined);
+
+  writeJobToDisk(jobId, {
+    ...job,
+    cleanedUpAt: new Date().toISOString(),
+  }, jobsDir);
+
+  return {
+    jobId,
+    message: paneArtifact?.paneIds?.length
+      ? `Cleaned up ${paneArtifact.paneIds.length} worker pane(s)`
+      : 'No worker pane ids found for this job',
+  };
+}
+
+export async function teamStatusByTeamName(teamName: string, cwd = process.cwd()): Promise<Record<string, unknown>> {
+  validateTeamName(teamName);
+  const runtime = await resumeTeam(teamName, cwd);
+  if (!runtime) {
+    return {
+      teamName,
+      running: false,
+      error: 'Team session is not currently resumable',
+    };
+  }
+
+  const snapshot = await monitorTeam(teamName, cwd, runtime.workerPaneIds);
+  return {
+    teamName,
+    running: true,
+    sessionName: runtime.sessionName,
+    leaderPaneId: runtime.leaderPaneId,
+    workerPaneIds: runtime.workerPaneIds,
+    snapshot,
+  };
+}
+
+export async function teamResumeByName(teamName: string, cwd = process.cwd()): Promise<Record<string, unknown>> {
+  validateTeamName(teamName);
+  const runtime = await resumeTeam(teamName, cwd);
+  if (!runtime) {
+    return {
+      teamName,
+      resumed: false,
+      error: 'Team session is not currently resumable',
+    };
+  }
+
+  return {
+    teamName,
+    resumed: true,
+    sessionName: runtime.sessionName,
+    leaderPaneId: runtime.leaderPaneId,
+    workerPaneIds: runtime.workerPaneIds,
+    activeWorkers: runtime.activeWorkers.size,
+  };
+}
+
+export async function teamShutdownByName(teamName: string, options: { cwd?: string; force?: boolean } = {}): Promise<Record<string, unknown>> {
+  validateTeamName(teamName);
+  const cwd = options.cwd ?? process.cwd();
+  const runtime = await resumeTeam(teamName, cwd);
+
+  if (!runtime) {
+    if (options.force) {
+      await rm(teamStateRoot(cwd, teamName), { recursive: true, force: true }).catch(() => undefined);
+      return {
+        teamName,
+        shutdown: true,
+        forced: true,
+        sessionFound: false,
+      };
+    }
+
+    throw new Error(`Team ${teamName} is not running. Use --force to clear stale state.`);
+  }
+
+  await shutdownTeam(
+    runtime.teamName,
+    runtime.sessionName,
+    runtime.cwd,
+    options.force ? 0 : 30_000,
+    runtime.workerPaneIds,
+    runtime.leaderPaneId,
+  );
+
+  return {
+    teamName,
+    shutdown: true,
+    forced: Boolean(options.force),
+    sessionFound: true,
+  };
+}
+
+export async function executeTeamApiOperation(
+  operation: string,
+  input: Record<string, unknown>,
+  cwd = process.cwd(),
+): Promise<TeamApiEnvelope> {
+  if (!SUPPORTED_API_OPERATIONS.has(operation as SupportedApiOperation)) {
+    return {
+      ok: false,
+      operation,
+      error: {
+        code: 'UNSUPPORTED_OPERATION',
+        message: `Unsupported omc team api operation: ${operation}`,
+      },
+    };
+  }
+
+  const teamName = readInputString(input, 'teamName', 'team_name');
+  if (!teamName) {
+    return {
+      ok: false,
+      operation,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'teamName is required in --input payload',
+      },
+    };
+  }
+
+  validateTeamName(teamName);
+
+  if (operation === 'send-message') {
+    const toWorker = readInputString(input, 'toWorker', 'to_worker');
+    const body = readInputString(input, 'body');
+    const fromWorker = readInputString(input, 'fromWorker', 'from_worker') || 'leader';
+
+    if (!toWorker || !body) {
+      return {
+        ok: false,
+        operation,
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'send-message requires toWorker and body',
+        },
+      };
+    }
+
+    mkdirSync(dirname(mailboxPath(cwd, teamName, toWorker)), { recursive: true });
+    await appendFile(mailboxPath(cwd, teamName, toWorker), `${JSON.stringify({
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      from: fromWorker,
+      to: toWorker,
+      body,
+      createdAt: new Date().toISOString(),
+      notifiedAt: null,
+    })}\n`, 'utf-8');
+
+    return {
+      ok: true,
+      operation,
+      data: { teamName, toWorker },
+    };
+  }
+
+  if (operation === 'broadcast') {
+    const body = readInputString(input, 'body');
+    const fromWorker = readInputString(input, 'fromWorker', 'from_worker') || 'leader';
+    if (!body) {
+      return {
+        ok: false,
+        operation,
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'broadcast requires body',
+        },
+      };
+    }
+
+    const mailboxDir = join(teamStateRoot(cwd, teamName), 'mailbox');
+    let workers: string[] = [];
+    try {
+      workers = (await readdir(mailboxDir))
+        .filter((f) => f.endsWith('.jsonl'))
+        .map((f) => f.replace(/\.jsonl$/, ''));
+    } catch {
+      workers = [];
+    }
+
+    if (workers.length === 0) {
+      const configRaw = await readFile(join(teamStateRoot(cwd, teamName), 'config.json'), 'utf-8').catch(() => '');
+      const config = parseJsonSafe<{ workerCount?: number }>(configRaw);
+      const workerCount = Number.isFinite(config?.workerCount) && (config?.workerCount ?? 0) > 0
+        ? Number(config?.workerCount)
+        : 0;
+      workers = Array.from({ length: workerCount }, (_, i) => `worker-${i + 1}`);
+    }
+
+    await Promise.all(workers.map(async (worker) => {
+      mkdirSync(dirname(mailboxPath(cwd, teamName, worker)), { recursive: true });
+      await appendFile(mailboxPath(cwd, teamName, worker), `${JSON.stringify({
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        from: fromWorker,
+        to: worker,
+        body,
+        createdAt: new Date().toISOString(),
+        broadcast: true,
+      })}\n`, 'utf-8');
+    }));
+
+    return {
+      ok: true,
+      operation,
+      data: { teamName, recipients: workers },
+    };
+  }
+
+  if (operation === 'mailbox-list') {
+    const mailboxDir = join(teamStateRoot(cwd, teamName), 'mailbox');
+    const workerFilter = readInputString(input, 'workerName', 'worker');
+
+    let files: string[] = [];
+    try {
+      files = (await readdir(mailboxDir)).filter((f) => f.endsWith('.jsonl'));
+    } catch {
+      files = [];
+    }
+
+    const selected = workerFilter
+      ? files.filter((f) => f === `${workerFilter}.jsonl`)
+      : files;
+
+    const mailboxes = await Promise.all(selected.map(async (file) => {
+      const workerName = file.replace(/\.jsonl$/, '');
+      const raw = await readFile(join(mailboxDir, file), 'utf-8').catch(() => '');
+      const lines = raw.split('\n').filter((line) => line.trim().length > 0);
+      return { workerName, count: lines.length };
+    }));
+
+    return {
+      ok: true,
+      operation,
+      data: { teamName, mailboxes },
+    };
+  }
+
+  if (operation === 'mailbox-mark-delivered') {
+    const workerName = readInputString(input, 'workerName', 'worker');
+    const messageId = readInputString(input, 'messageId', 'message_id');
+    if (!workerName || !messageId) {
+      return {
+        ok: false,
+        operation,
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'mailbox-mark-delivered requires workerName and messageId',
+        },
+      };
+    }
+
+    mkdirSync(dirname(mailboxPath(cwd, teamName, workerName)), { recursive: true });
+    await appendFile(mailboxPath(cwd, teamName, workerName), `${JSON.stringify({
+      id: messageId,
+      type: 'delivered',
+      deliveredAt: new Date().toISOString(),
+    })}\n`, 'utf-8');
+
+    return {
+      ok: true,
+      operation,
+      data: { teamName, workerName, messageId },
+    };
+  }
+
+  if (operation === 'list-tasks') {
+    const tasks = await readTaskFiles(cwd, teamName);
+    return {
+      ok: true,
+      operation,
+      data: { teamName, tasks },
+    };
+  }
+
+  if (operation === 'read-task') {
+    const taskId = readInputString(input, 'taskId', 'task_id');
+    if (!taskId) {
+      return {
+        ok: false,
+        operation,
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'read-task requires taskId',
+        },
+      };
+    }
+
+    const raw = await readFile(join(teamStateRoot(cwd, teamName), 'tasks', `${taskId}.json`), 'utf-8').catch(() => '');
+    const task = raw ? parseJsonSafe<Record<string, unknown>>(raw) : null;
+
+    return {
+      ok: true,
+      operation,
+      data: { teamName, taskId, task },
+    };
+  }
+
+  if (operation === 'read-config') {
+    const raw = await readFile(join(teamStateRoot(cwd, teamName), 'config.json'), 'utf-8').catch(() => '');
+    return {
+      ok: true,
+      operation,
+      data: { teamName, config: raw ? parseJsonSafe<Record<string, unknown>>(raw) : null },
+    };
+  }
+
+  const tasks = await readTaskFiles(cwd, teamName);
+  const taskCounts = tasks.reduce<{ pending: number; inProgress: number; completed: number; failed: number }>(
+    (acc, task) => {
+      const status = String(task.status ?? 'unknown');
+      if (status === 'pending') acc.pending += 1;
+      else if (status === 'in_progress') acc.inProgress += 1;
+      else if (status === 'completed') acc.completed += 1;
+      else if (status === 'failed') acc.failed += 1;
+      return acc;
+    },
+    { pending: 0, inProgress: 0, completed: 0, failed: 0 },
+  );
+
+  const runtime = await resumeTeam(teamName, cwd);
+  const snapshot = runtime ? await monitorTeam(teamName, cwd, runtime.workerPaneIds) : null;
+
+  return {
+    ok: true,
+    operation,
+    data: {
+      teamName,
+      taskCounts,
+      workerCount: runtime?.workerPaneIds.length ?? 0,
+      phase: snapshot?.phase ?? null,
+    },
+  };
+}
+
+export async function teamStartCommand(input: TeamStartInput, options: { json?: boolean } = {}): Promise<TeamStartResult> {
+  const result = await startTeamJob(input);
+  output(result, Boolean(options.json));
+  return result;
+}
+
+export async function teamStatusCommand(jobId: string, options: { json?: boolean } = {}): Promise<TeamJobStatus> {
+  const result = await getTeamJobStatus(jobId);
+  output(result, Boolean(options.json));
+  return result;
+}
+
+export async function teamWaitCommand(
+  jobId: string,
+  waitOptions: TeamWaitOptions = {},
+  options: { json?: boolean } = {},
+): Promise<TeamWaitResult> {
+  const result = await waitForTeamJob(jobId, waitOptions);
+  output(result, Boolean(options.json));
+  return result;
+}
+
+export async function teamCleanupCommand(
+  jobId: string,
+  cleanupOptions: { graceMs?: number } = {},
+  options: { json?: boolean } = {},
+): Promise<TeamCleanupResult> {
+  const result = await cleanupTeamJob(jobId, cleanupOptions.graceMs);
+  output(result, Boolean(options.json));
+  return result;
+}
+
+export const TEAM_USAGE = `
+Usage:
+  omc team start --agent <claude|codex|gemini>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--json]
+  omc team status <job_id|team_name> [--json] [--cwd DIR]
+  omc team wait <job_id> [--timeout-ms MS] [--json]
+  omc team cleanup <job_id> [--grace-ms MS] [--json]
+  omc team resume <team_name> [--json] [--cwd DIR]
+  omc team shutdown <team_name> [--force] [--json] [--cwd DIR]
+  omc team api <operation> [--input '<json>'] [--json] [--cwd DIR]
+  omc team [ralph] <N:agent-type> "task" [--json] [--cwd DIR]
+
+Examples:
+  omc team start --agent codex --count 2 --task "review auth flow"
+  omc team status omc-abc123
+  omc team status auth-review
+  omc team resume auth-review
+  omc team shutdown auth-review --force
+  omc team api list-tasks --input '{"teamName":"auth-review"}' --json
+  omc team 3:codex "refactor launch command"
+`.trim();
+
+interface StartArgsParsed {
+  input: TeamStartInput;
+  json: boolean;
+}
+
+function parseStartArgs(args: string[]): StartArgsParsed {
+  const agentValues: string[] = [];
+  const taskValues: string[] = [];
+  let teamName: string | undefined;
+  let cwd = process.cwd();
+  let count = 1;
+  let json = false;
+  let subjectPrefix = 'Task';
+  let pollIntervalMs: number | undefined;
+  let sentinelGateTimeoutMs: number | undefined;
+  let sentinelGatePollIntervalMs: number | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    const next = args[i + 1];
+
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+
+    if (token === '--agent') {
+      if (!next) throw new Error('Missing value after --agent');
+      agentValues.push(...next.split(',').map(normalizeAgentType));
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--agent=')) {
+      agentValues.push(...token.slice('--agent='.length).split(',').map(normalizeAgentType));
+      continue;
+    }
+
+    if (token === '--task') {
+      if (!next) throw new Error('Missing value after --task');
+      taskValues.push(next);
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--task=')) {
+      taskValues.push(token.slice('--task='.length));
+      continue;
+    }
+
+    if (token === '--count') {
+      if (!next) throw new Error('Missing value after --count');
+      count = toInt(next, '--count');
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--count=')) {
+      count = toInt(token.slice('--count='.length), '--count');
+      continue;
+    }
+
+    if (token === '--name') {
+      if (!next) throw new Error('Missing value after --name');
+      teamName = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--name=')) {
+      teamName = token.slice('--name='.length);
+      continue;
+    }
+
+    if (token === '--cwd') {
+      if (!next) throw new Error('Missing value after --cwd');
+      cwd = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--cwd=')) {
+      cwd = token.slice('--cwd='.length);
+      continue;
+    }
+
+    if (token === '--subject') {
+      if (!next) throw new Error('Missing value after --subject');
+      subjectPrefix = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--subject=')) {
+      subjectPrefix = token.slice('--subject='.length);
+      continue;
+    }
+
+    if (token === '--poll-interval-ms') {
+      if (!next) throw new Error('Missing value after --poll-interval-ms');
+      pollIntervalMs = toInt(next, '--poll-interval-ms');
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--poll-interval-ms=')) {
+      pollIntervalMs = toInt(token.slice('--poll-interval-ms='.length), '--poll-interval-ms');
+      continue;
+    }
+
+    if (token === '--sentinel-gate-timeout-ms') {
+      if (!next) throw new Error('Missing value after --sentinel-gate-timeout-ms');
+      sentinelGateTimeoutMs = toInt(next, '--sentinel-gate-timeout-ms');
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--sentinel-gate-timeout-ms=')) {
+      sentinelGateTimeoutMs = toInt(token.slice('--sentinel-gate-timeout-ms='.length), '--sentinel-gate-timeout-ms');
+      continue;
+    }
+
+    if (token === '--sentinel-gate-poll-interval-ms') {
+      if (!next) throw new Error('Missing value after --sentinel-gate-poll-interval-ms');
+      sentinelGatePollIntervalMs = toInt(next, '--sentinel-gate-poll-interval-ms');
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--sentinel-gate-poll-interval-ms=')) {
+      sentinelGatePollIntervalMs = toInt(token.slice('--sentinel-gate-poll-interval-ms='.length), '--sentinel-gate-poll-interval-ms');
+      continue;
+    }
+
+    throw new Error(`Unknown argument for "omc team start": ${token}`);
+  }
+
+  if (count < 1) throw new Error('--count must be >= 1');
+  if (agentValues.length === 0) throw new Error('Missing required --agent');
+  if (taskValues.length === 0) throw new Error('Missing required --task');
+
+  const agentTypes = agentValues.length === 1
+    ? Array.from({ length: count }, () => agentValues[0])
+    : [...agentValues];
+
+  if (agentValues.length > 1 && count !== 1) {
+    throw new Error('Do not combine --count with multiple --agent values; either use one agent+count or explicit agent list.');
+  }
+
+  const taskDescriptions = taskValues.length === 1
+    ? Array.from({ length: agentTypes.length }, () => taskValues[0])
+    : [...taskValues];
+
+  if (taskDescriptions.length !== agentTypes.length) {
+    throw new Error(`Task count (${taskDescriptions.length}) must match worker count (${agentTypes.length}).`);
+  }
+
+  const resolvedTeamName = (teamName && teamName.trim()) ? teamName.trim() : autoTeamName(taskDescriptions[0]);
+  const tasks: TeamTaskInput[] = taskDescriptions.map((description, index) => ({
+    subject: `${subjectPrefix} ${index + 1}`,
+    description,
+  }));
+
+  return {
+    input: {
+      teamName: resolvedTeamName,
+      agentTypes,
+      tasks,
+      cwd,
+      ...(pollIntervalMs != null ? { pollIntervalMs } : {}),
+      ...(sentinelGateTimeoutMs != null ? { sentinelGateTimeoutMs } : {}),
+      ...(sentinelGatePollIntervalMs != null ? { sentinelGatePollIntervalMs } : {}),
+    },
+    json,
+  };
+}
+
+function parseCommonJobArgs(args: string[], command: 'status' | 'wait' | 'cleanup'): {
+  target: string;
+  json: boolean;
+  cwd?: string;
+  timeoutMs?: number;
+  graceMs?: number;
+} {
+  let json = false;
+  let target: string | undefined;
+  let cwd: string | undefined;
+  let timeoutMs: number | undefined;
+  let graceMs: number | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    const next = args[i + 1];
+
+    if (!token.startsWith('-') && !target) {
+      target = token;
+      continue;
+    }
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    if (token === '--cwd') {
+      if (!next) throw new Error('Missing value after --cwd');
+      cwd = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--cwd=')) {
+      cwd = token.slice('--cwd='.length);
+      continue;
+    }
+
+    if (token === '--job-id') {
+      if (!next) throw new Error('Missing value after --job-id');
+      target = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--job-id=')) {
+      target = token.slice('--job-id='.length);
+      continue;
+    }
+
+    if (command === 'wait') {
+      if (token === '--timeout-ms') {
+        if (!next) throw new Error('Missing value after --timeout-ms');
+        timeoutMs = toInt(next, '--timeout-ms');
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--timeout-ms=')) {
+        timeoutMs = toInt(token.slice('--timeout-ms='.length), '--timeout-ms');
+        continue;
+      }
+    }
+
+    if (command === 'cleanup') {
+      if (token === '--grace-ms') {
+        if (!next) throw new Error('Missing value after --grace-ms');
+        graceMs = toInt(next, '--grace-ms');
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--grace-ms=')) {
+        graceMs = toInt(token.slice('--grace-ms='.length), '--grace-ms');
+        continue;
+      }
+    }
+
+    throw new Error(`Unknown argument for "omc team ${command}": ${token}`);
+  }
+
+  if (!target) {
+    throw new Error(`Missing required target for "omc team ${command}".`);
+  }
+
+  return {
+    target,
+    json,
+    ...(cwd ? { cwd } : {}),
+    ...(timeoutMs != null ? { timeoutMs } : {}),
+    ...(graceMs != null ? { graceMs } : {}),
+  };
+}
+
+function parseTeamTargetArgs(args: string[], command: 'resume' | 'shutdown'): {
+  teamName: string;
+  json: boolean;
+  cwd?: string;
+  force?: boolean;
+} {
+  let teamName: string | undefined;
+  let json = false;
+  let cwd: string | undefined;
+  let force = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    const next = args[i + 1];
+
+    if (!token.startsWith('-') && !teamName) {
+      teamName = token;
+      continue;
+    }
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    if (token === '--cwd') {
+      if (!next) throw new Error('Missing value after --cwd');
+      cwd = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--cwd=')) {
+      cwd = token.slice('--cwd='.length);
+      continue;
+    }
+    if (command === 'shutdown' && token === '--force') {
+      force = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument for "omc team ${command}": ${token}`);
+  }
+
+  if (!teamName) {
+    throw new Error(`Missing required <team_name> for "omc team ${command}".`);
+  }
+
+  return {
+    teamName,
+    json,
+    ...(cwd ? { cwd } : {}),
+    ...(command === 'shutdown' ? { force } : {}),
+  };
+}
+
+function parseApiArgs(args: string[]): {
+  operation: string;
+  input: Record<string, unknown>;
+  json: boolean;
+  cwd?: string;
+} {
+  let operation: string | undefined;
+  let inputRaw: string | undefined;
+  let json = false;
+  let cwd: string | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    const next = args[i + 1];
+
+    if (!token.startsWith('-') && !operation) {
+      operation = token;
+      continue;
+    }
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    if (token === '--input') {
+      if (!next) throw new Error('Missing value after --input');
+      inputRaw = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--input=')) {
+      inputRaw = token.slice('--input='.length);
+      continue;
+    }
+    if (token === '--cwd') {
+      if (!next) throw new Error('Missing value after --cwd');
+      cwd = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--cwd=')) {
+      cwd = token.slice('--cwd='.length);
+      continue;
+    }
+
+    throw new Error(`Unknown argument for "omc team api": ${token}`);
+  }
+
+  if (!operation) {
+    throw new Error(`Missing required <operation> for "omc team api"\n\n${TEAM_API_USAGE}`);
+  }
+
+  return {
+    operation,
+    input: parseJsonInput(inputRaw),
+    json,
+    ...(cwd ? { cwd } : {}),
+  };
+}
+
+function parseLegacyStartAlias(args: string[]): TeamLegacyStartArgs | null {
+  if (args.length < 2) return null;
+
+  let index = 0;
+  let ralph = false;
+  if (args[index]?.toLowerCase() === 'ralph') {
+    ralph = true;
+    index += 1;
+  }
+
+  const spec = args[index];
+  if (!spec) return null;
+  const match = spec.match(/^(\d+):([a-zA-Z0-9_-]+)$/);
+  if (!match) return null;
+
+  const workerCount = toInt(match[1], 'worker-count');
+  if (workerCount < 1) throw new Error('worker-count must be >= 1');
+
+  const agentType = normalizeAgentType(match[2]);
+  index += 1;
+
+  let json = false;
+  let cwd = process.cwd();
+  const taskParts: string[] = [];
+  for (let i = index; i < args.length; i += 1) {
+    const token = args[i];
+    const next = args[i + 1];
+
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    if (token === '--cwd') {
+      if (!next) throw new Error('Missing value after --cwd');
+      cwd = next;
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--cwd=')) {
+      cwd = token.slice('--cwd='.length);
+      continue;
+    }
+
+    taskParts.push(token);
+  }
+
+  const task = taskParts.join(' ').trim();
+  if (!task) throw new Error('Legacy start alias requires a task string');
+
+  return {
+    workerCount,
+    agentType,
+    task,
+    teamName: autoTeamName(task),
+    ralph,
+    json,
+    cwd,
+  };
+}
+
+export async function teamCommand(argv: string[]): Promise<void> {
+  const [commandRaw, ...rest] = argv;
+  const command = (commandRaw || '').toLowerCase();
+
+  if (!command || command === 'help' || command === '--help' || command === '-h') {
+    console.log(TEAM_USAGE);
+    return;
+  }
+
+  if (command === 'start') {
+    const parsed = parseStartArgs(rest);
+    await teamStartCommand(parsed.input, { json: parsed.json });
+    return;
+  }
+
+  if (command === 'status') {
+    const parsed = parseCommonJobArgs(rest, 'status');
+    if (JOB_ID_PATTERN.test(parsed.target)) {
+      await teamStatusCommand(parsed.target, { json: parsed.json });
+      return;
+    }
+
+    const byTeam = await teamStatusByTeamName(parsed.target, parsed.cwd ?? process.cwd());
+    output(byTeam, parsed.json);
+    return;
+  }
+
+  if (command === 'wait') {
+    const parsed = parseCommonJobArgs(rest, 'wait');
+    await teamWaitCommand(parsed.target, { ...(parsed.timeoutMs != null ? { timeoutMs: parsed.timeoutMs } : {}) }, { json: parsed.json });
+    return;
+  }
+
+  if (command === 'cleanup') {
+    const parsed = parseCommonJobArgs(rest, 'cleanup');
+    await teamCleanupCommand(parsed.target, { ...(parsed.graceMs != null ? { graceMs: parsed.graceMs } : {}) }, { json: parsed.json });
+    return;
+  }
+
+  if (command === 'resume') {
+    const parsed = parseTeamTargetArgs(rest, 'resume');
+    const result = await teamResumeByName(parsed.teamName, parsed.cwd ?? process.cwd());
+    output(result, parsed.json);
+    return;
+  }
+
+  if (command === 'shutdown') {
+    const parsed = parseTeamTargetArgs(rest, 'shutdown');
+    const result = await teamShutdownByName(parsed.teamName, {
+      cwd: parsed.cwd ?? process.cwd(),
+      force: Boolean(parsed.force),
+    });
+    output(result, parsed.json);
+    return;
+  }
+
+  if (command === 'api') {
+    if (rest.length === 0 || rest[0] === 'help' || rest[0] === '--help' || rest[0] === '-h') {
+      console.log(TEAM_API_USAGE);
+      return;
+    }
+
+    const parsed = parseApiArgs(rest);
+    const result = await executeTeamApiOperation(parsed.operation, parsed.input, parsed.cwd ?? process.cwd());
+    if (!result.ok && !parsed.json) {
+      throw new Error(result.error?.message ?? 'Team API operation failed');
+    }
+    output(result, parsed.json);
+    return;
+  }
+
+  if (!SUBCOMMANDS.has(command)) {
+    const legacy = parseLegacyStartAlias(argv);
+    if (legacy) {
+      const tasks = Array.from({ length: legacy.workerCount }, (_, idx) => ({
+        subject: legacy.ralph ? `Ralph Task ${idx + 1}` : `Task ${idx + 1}`,
+        description: legacy.task,
+      }));
+
+      const result = await startTeamJob({
+        teamName: legacy.teamName,
+        workerCount: legacy.workerCount,
+        agentTypes: Array.from({ length: legacy.workerCount }, () => legacy.agentType),
+        tasks,
+        cwd: legacy.cwd,
+      });
+
+      output(result, legacy.json);
+      return;
+    }
+  }
+
+  throw new Error(`Unknown team command: ${command}\n\n${TEAM_USAGE}`);
+}
+
+export async function main(argv: string[]): Promise<void> {
+  await teamCommand(argv);
+}

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -456,10 +456,10 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
       case "codex":
       case "gemini": {
         messages.push(
-          `[MAGIC KEYWORD: omc-teams]\n` +
-          `User intent: delegate to ${keywordType} CLI workers via omc-teams.\n` +
+          `[MAGIC KEYWORD: team]\n` +
+          `User intent: delegate to ${keywordType} CLI workers via omc team CLI.\n` +
           `Agent type: ${keywordType}. Parse N from user message (default 1).\n` +
-          `Invoke: /omc-teams N:${keywordType} "<task from user message>"`
+          `Invoke: omc team start --agent ${keywordType} --count N --task "<task from user message>"`
         );
         break;
       }

--- a/src/mcp/__tests__/team-server-deprecation.test.ts
+++ b/src/mcp/__tests__/team-server-deprecation.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { createDeprecatedCliOnlyEnvelope, createDeprecatedCliOnlyEnvelopeWithArgs } from '../team-server.js';
+
+describe('team-server MCP runtime tool deprecation envelopes', () => {
+  it.each([
+    ['omc_run_team_start', 'omc team start'],
+    ['omc_run_team_status', 'omc team status <job_id>'],
+    ['omc_run_team_wait', 'omc team wait <job_id>'],
+    ['omc_run_team_cleanup', 'omc team cleanup <job_id>'],
+  ] as const)('returns stable deprecated_cli_only envelope for %s', (toolName, cliReplacement) => {
+    const first = createDeprecatedCliOnlyEnvelope(toolName);
+    const second = createDeprecatedCliOnlyEnvelope(toolName);
+
+    expect(first).toEqual(second);
+    expect(first.isError).toBe(true);
+
+    const payload = JSON.parse(first.content[0].text) as Record<string, string>;
+    expect(payload).toMatchObject({
+      code: 'deprecated_cli_only',
+      tool: toolName,
+      message: 'Legacy team MCP runtime tools are deprecated. Use the omc team CLI instead.',
+      cli_replacement: cliReplacement,
+    });
+  });
+});
+
+describe('team-server MCP deprecation envelope CLI argument mapping', () => {
+  it('maps start tool args to omc team start command flags', () => {
+    const envelope = createDeprecatedCliOnlyEnvelopeWithArgs('omc_run_team_start', {
+      teamName: 'alpha-team',
+      agentTypes: ['codex', 'codex'],
+      tasks: [{ subject: 'S1', description: 'review auth flow' }],
+      cwd: '/tmp/project',
+    });
+    const payload = JSON.parse(envelope.content[0].text) as Record<string, string>;
+    expect(payload.cli_replacement).toContain('omc team start');
+    expect(payload.cli_replacement).toContain('--name "alpha-team"');
+    expect(payload.cli_replacement).toContain('--cwd "/tmp/project"');
+    expect(payload.cli_replacement).toContain('--agent "codex"');
+    expect(payload.cli_replacement).toContain('--count 2');
+    expect(payload.cli_replacement).toContain('--task "review auth flow"');
+  });
+
+  it('maps wait/cleanup tool args to timeout/grace flags', () => {
+    const waitEnvelope = createDeprecatedCliOnlyEnvelopeWithArgs('omc_run_team_wait', {
+      job_id: 'omc-abc123',
+      timeout_ms: 120000,
+    });
+    const cleanupEnvelope = createDeprecatedCliOnlyEnvelopeWithArgs('omc_run_team_cleanup', {
+      job_id: 'omc-abc123',
+      grace_ms: 5000,
+    });
+
+    const waitPayload = JSON.parse(waitEnvelope.content[0].text) as Record<string, string>;
+    const cleanupPayload = JSON.parse(cleanupEnvelope.content[0].text) as Record<string, string>;
+
+    expect(waitPayload.cli_replacement).toBe('omc team wait --job-id "omc-abc123" --timeout-ms 120000');
+    expect(cleanupPayload.cli_replacement).toBe('omc team cleanup --job-id "omc-abc123" --grace-ms 5000');
+  });
+});

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -28,6 +28,129 @@ import type { OmcTeamJob } from './team-job-convergence.js';
 
 const omcTeamJobs = new Map<string, OmcTeamJob>();
 const OMC_JOBS_DIR = process.env.OMC_JOBS_DIR || join(homedir(), '.omc', 'team-jobs');
+const DEPRECATION_CODE = 'deprecated_cli_only' as const;
+
+type DeprecatedTeamToolName =
+  | 'omc_run_team_start'
+  | 'omc_run_team_status'
+  | 'omc_run_team_wait'
+  | 'omc_run_team_cleanup';
+
+const TEAM_CLI_REPLACEMENT_HINTS: Record<DeprecatedTeamToolName, string> = {
+  omc_run_team_start: 'omc team start',
+  omc_run_team_status: 'omc team status <job_id>',
+  omc_run_team_wait: 'omc team wait <job_id>',
+  omc_run_team_cleanup: 'omc team cleanup <job_id>',
+};
+
+function isDeprecatedTeamToolName(name: string): name is DeprecatedTeamToolName {
+  return Object.prototype.hasOwnProperty.call(TEAM_CLI_REPLACEMENT_HINTS, name);
+}
+
+export function createDeprecatedCliOnlyEnvelope(toolName: DeprecatedTeamToolName): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  return createDeprecatedCliOnlyEnvelopeWithArgs(toolName);
+}
+
+function quoteCliValue(value: string): string {
+  return JSON.stringify(value);
+}
+
+function buildCliReplacement(toolName: DeprecatedTeamToolName, args: unknown): string {
+  const hasArgsObject = typeof args === 'object' && args !== null;
+  if (!hasArgsObject) {
+    return TEAM_CLI_REPLACEMENT_HINTS[toolName];
+  }
+
+  const parsed = (typeof args === 'object' && args !== null) ? args as Record<string, unknown> : {};
+
+  if (toolName === 'omc_run_team_start') {
+    const teamName = typeof parsed.teamName === 'string' ? parsed.teamName.trim() : '';
+    const cwd = typeof parsed.cwd === 'string' ? parsed.cwd.trim() : '';
+    const agentTypes = Array.isArray(parsed.agentTypes)
+      ? parsed.agentTypes.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+      : [];
+    const tasks = Array.isArray(parsed.tasks)
+      ? parsed.tasks
+        .map((task) => (typeof task === 'object' && task !== null && typeof (task as { description?: unknown }).description === 'string')
+          ? (task as { description: string }).description.trim()
+          : '',
+        )
+        .filter(Boolean)
+      : [];
+
+    const flags: string[] = ['omc', 'team', 'start'];
+    if (teamName) flags.push('--name', quoteCliValue(teamName));
+    if (cwd) flags.push('--cwd', quoteCliValue(cwd));
+
+    if (agentTypes.length > 0) {
+      const uniqueAgentTypes = new Set(agentTypes);
+      if (uniqueAgentTypes.size === 1) {
+        flags.push('--agent', quoteCliValue(agentTypes[0]), '--count', String(agentTypes.length));
+      } else {
+        flags.push('--agent', quoteCliValue(agentTypes.join(',')));
+      }
+    } else {
+      flags.push('--agent', '"claude"');
+    }
+
+    if (tasks.length > 0) {
+      for (const task of tasks) {
+        flags.push('--task', quoteCliValue(task));
+      }
+    } else {
+      flags.push('--task', '"<task>"');
+    }
+
+    return flags.join(' ');
+  }
+
+  const jobId = typeof parsed.job_id === 'string' ? parsed.job_id.trim() : '<job_id>';
+  if (toolName === 'omc_run_team_status') {
+    return `omc team status --job-id ${quoteCliValue(jobId)}`;
+  }
+
+  if (toolName === 'omc_run_team_wait') {
+    const timeoutMs = typeof parsed.timeout_ms === 'number' && Number.isFinite(parsed.timeout_ms)
+      ? ` --timeout-ms ${Math.floor(parsed.timeout_ms)}`
+      : '';
+    return `omc team wait --job-id ${quoteCliValue(jobId)}${timeoutMs}`;
+  }
+
+  if (toolName === 'omc_run_team_cleanup') {
+    const graceMs = typeof parsed.grace_ms === 'number' && Number.isFinite(parsed.grace_ms)
+      ? ` --grace-ms ${Math.floor(parsed.grace_ms)}`
+      : '';
+    return `omc team cleanup --job-id ${quoteCliValue(jobId)}${graceMs}`;
+  }
+
+  return TEAM_CLI_REPLACEMENT_HINTS[toolName];
+}
+
+export function createDeprecatedCliOnlyEnvelopeWithArgs(
+  toolName: DeprecatedTeamToolName,
+  args?: unknown,
+): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  const cliReplacement = buildCliReplacement(toolName, args);
+
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify({
+        code: DEPRECATION_CODE,
+        tool: toolName,
+        message: 'Legacy team MCP runtime tools are deprecated. Use the omc team CLI instead.',
+        cli_replacement: cliReplacement,
+      }),
+    }],
+    isError: true,
+  };
+}
 
 function persistJob(jobId: string, job: OmcTeamJob): void {
   try {
@@ -310,7 +433,7 @@ export async function handleCleanup(args: unknown): Promise<{ content: Array<{ t
 const TOOLS = [
   {
     name: 'omc_run_team_start',
-    description: 'Spawn tmux CLI workers (claude/codex/gemini) in the background. Returns jobId immediately. Poll with omc_run_team_status.',
+    description: '[DEPRECATED] CLI-only migration required. This tool no longer executes; use `omc team start`.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -335,7 +458,7 @@ const TOOLS = [
   },
   {
     name: 'omc_run_team_status',
-    description: 'Non-blocking status check for a background omc_run_team job. Returns status and result when done.',
+    description: '[DEPRECATED] CLI-only migration required. This tool no longer executes; use `omc team status <job_id>`.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -346,7 +469,7 @@ const TOOLS = [
   },
   {
     name: 'omc_run_team_wait',
-    description: 'Block (poll internally) until a background omc_run_team job reaches a terminal state (completed or failed). Returns the result when done. One call instead of N polling calls. Uses exponential backoff (500ms → 2000ms). Auto-nudges idle teammate panes via tmux send-keys. If this wait call times out, workers are left running — call omc_run_team_wait again to keep waiting, or omc_run_team_cleanup to stop them explicitly.',
+    description: '[DEPRECATED] CLI-only migration required. This tool no longer executes; use `omc team wait <job_id>`.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -361,7 +484,7 @@ const TOOLS = [
   },
   {
     name: 'omc_run_team_cleanup',
-    description: 'Explicitly clean up worker panes when you want to stop workers. Kills all worker panes recorded for the job without touching the leader pane or the user session.',
+    description: '[DEPRECATED] CLI-only migration required. This tool no longer executes; use `omc team cleanup <job_id>`.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -382,6 +505,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
+  if (isDeprecatedTeamToolName(name)) {
+    return createDeprecatedCliOnlyEnvelopeWithArgs(name, args);
+  }
+
   try {
     if (name === 'omc_run_team_start') return await handleStart(args ?? {});
     if (name === 'omc_run_team_status') return await handleStatus(args ?? {});


### PR DESCRIPTION
## Summary
- integrate `omc ask` as first-class CLI command with provider parsing, `--agent-prompt`, and advisor-script execution wiring
- integrate `omc team` as first-class CLI command with `start/status/wait/cleanup/resume/shutdown/api` + legacy shorthand compatibility
- hard-deprecate legacy MCP runtime tools (`omc_run_team_start/status/wait/cleanup`) with deterministic `deprecated_cli_only` error envelopes and CLI replacement hints
- update bridge keyword routing and docs/skills to CLI-first `omc team ...` semantics

## Migration impact
- legacy Team MCP runtime calls now return deprecation envelopes instead of executing runtime flows
- canonical runtime path is now `omc team ...`
- canonical ask env vars are `OMC_ASK_*`; `OMX_ASK_*` aliases remain accepted in Phase-1 with deprecation warnings

## Validation
- `npx eslint src/cli/team.ts src/cli/ask.ts src/cli/index.ts src/mcp/team-server.ts src/hooks/bridge.ts src/cli/__tests__/team.test.ts src/cli/__tests__/team-help.test.ts src/cli/__tests__/team-runtime-boundary.test.ts src/cli/__tests__/ask.test.ts src/mcp/__tests__/team-server-deprecation.test.ts`
- `npx vitest run src/cli/__tests__/ask.test.ts src/cli/__tests__/team.test.ts src/cli/__tests__/team-help.test.ts src/cli/__tests__/team-runtime-boundary.test.ts src/mcp/__tests__/team-server-deprecation.test.ts`
- `npm run test:run -- src/cli/__tests__ src/mcp/__tests__/team-server-deprecation.test.ts`
- `npx tsc --noEmit --pretty false`
