### PR TITLE
fix: increase failure cache TTL to prevent rate limit loops

### DIFF
--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -23,7 +23,7 @@ import type { RateLimits, UsageResult } from './types.js';
 
 // Cache configuration
 const CACHE_TTL_SUCCESS_MS = 30 * 1000; // 30 seconds for successful responses
-const CACHE_TTL_FAILURE_MS = 15 * 1000; // 15 seconds for failures
+const CACHE_TTL_FAILURE_MS = 5 * 60 * 1000; // 5 minutes for failures (avoid rate limit loops)
 const API_TIMEOUT_MS = 10000;
 const TOKEN_REFRESH_URL_HOSTNAME = 'platform.claude.com';
 const TOKEN_REFRESH_URL_PATH = '/v1/oauth/token';


### PR DESCRIPTION
## Summary

- When the usage API returns 429 (Rate Limited), the 15-second failure cache TTL causes HUD to retry on every render, creating a loop that permanently prevents usage display
- Increase `CACHE_TTL_FAILURE_MS` from 15 seconds to 5 minutes to break the rate limit retry cycle
- Success cache TTL (30s) remains unchanged

## Test plan

- [ ] Clear cache and run HUD; on 429, verify no retry for 5 minutes
- [ ] Verify normal responses still cache for 30 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)