### PR TITLE
fix(skills): use CLAUDE_PLUGIN_ROOT for ask skill wrapper paths

### DIFF
--- a/skills/ask-codex/SKILL.md
+++ b/skills/ask-codex/SKILL.md
@@ -24,9 +24,7 @@ omc ask codex "{{ARGUMENTS}}"
 Wrapper alias (compatibility):
 
 ```bash
-npm run ask:codex -- "{{ARGUMENTS}}"
-# or
-./scripts/ask-codex.sh "{{ARGUMENTS}}"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/ask-codex.sh" "{{ARGUMENTS}}"
 ```
 
 ## Requirements

--- a/skills/ask-gemini/SKILL.md
+++ b/skills/ask-gemini/SKILL.md
@@ -24,9 +24,7 @@ omc ask gemini "{{ARGUMENTS}}"
 Wrapper alias (compatibility):
 
 ```bash
-npm run ask:gemini -- "{{ARGUMENTS}}"
-# or
-./scripts/ask-gemini.sh "{{ARGUMENTS}}"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/ask-gemini.sh" "{{ARGUMENTS}}"
 ```
 
 ## Requirements


### PR DESCRIPTION
## Summary
- Fix ask-codex and ask-gemini SKILL.md wrapper paths to use `${CLAUDE_PLUGIN_ROOT}/scripts/` instead of relative `./scripts/` paths
- Ensures skills work in production where the plugin is installed at `~/.claude/plugins/cache/omc/oh-my-claudecode/<version>/`
- Consistent with how team and cancel skills reference plugin scripts

## Test plan
- [x] Verified `omc ask codex` works (primary path, uses global `omc` CLI)
- [x] Confirmed `${CLAUDE_PLUGIN_ROOT}` is set by Claude Code plugin system at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)