### PR TITLE
docs: align team/ask guidance and route ccg via ask skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ English | [한국어](README.ko.md) | [中文](README.zh.md) | [日本語](READM
 
 **Multi-agent orchestration for Claude Code. Zero learning curve.**
 
-*Don't learn Claude Code. Just use OMC.*
+_Don't learn Claude Code. Just use OMC._
 
 [Get Started](#quick-start) • [Documentation](https://yeachan-heo.github.io/oh-my-claudecode-website) • [CLI Reference](https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#cli-reference) • [Workflows](https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#workflows) • [Migration Guide](docs/MIGRATION.md)
 
@@ -21,17 +21,20 @@ English | [한국어](README.ko.md) | [中文](README.zh.md) | [日本語](READM
 ## Quick Start
 
 **Step 1: Install**
+
 ```bash
 /plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
 /plugin install oh-my-claudecode
 ```
 
 **Step 2: Setup**
+
 ```bash
 /omc-setup
 ```
 
 **Step 3: Build something**
+
 ```
 autopilot: build a REST API for managing tasks
 ```
@@ -50,7 +53,7 @@ The deep interview uses Socratic questioning to clarify your thinking before any
 
 ## Team Mode (Recommended)
 
-Starting in **v4.1.7**, **Team** is the canonical orchestration surface in OMC. Legacy entrypoints like **swarm** and **ultrapilot** are still supported, but they now **route to Team under the hood**.
+Starting in **v4.1.7**, **Team** is the canonical orchestration surface in OMC. The legacy `swarm` keyword/skill has been removed; use `team` directly.
 
 ```bash
 /team 3:executor "fix all TypeScript errors"
@@ -77,25 +80,27 @@ Enable Claude Code native teams in `~/.claude/settings.json`:
 **v4.4.0 removes the Codex/Gemini MCP servers** (`x`, `g` providers). Use the CLI-first Team runtime (`omc team ...`) to spawn real tmux worker panes:
 
 ```bash
-omc team start --agent codex --count 2 --task "review auth module for security issues"
-omc team start --agent gemini --count 2 --task "redesign UI components for accessibility"
-omc team start --agent claude --count 1 --task "implement the payment flow"
+omc team 2:codex "review auth module for security issues"
+omc team 2:gemini "redesign UI components for accessibility"
+omc team 1:claude "implement the payment flow"
+omc team status auth-review
+omc team shutdown auth-review
 ```
 
 `/omc-teams` remains as a legacy compatibility skill and now routes to `omc team ...`.
 
-For mixed Codex + Gemini work in one command, use the **`/ccg`** skill:
+For mixed Codex + Gemini work in one command, use the **`/ccg`** skill (routes via `ask-codex` + `ask-gemini`, then Claude synthesizes):
 
 ```bash
 /ccg Review this PR — architecture (Codex) and UI components (Gemini)
 ```
 
-| Surface | Workers | Best For |
-|-------|---------|----------|
-| `omc team start --agent codex --count N ...` | N Codex CLI panes | Code review, security analysis, architecture |
-| `omc team start --agent gemini --count N ...` | N Gemini CLI panes | UI/UX design, docs, large-context tasks |
-| `omc team start --agent claude --count N ...` | N Claude CLI panes | General tasks via Claude CLI in tmux |
-| `/ccg` | 1 Codex + 1 Gemini | Parallel tri-model orchestration |
+| Surface                   | Workers            | Best For                                     |
+| ------------------------- | ------------------ | -------------------------------------------- |
+| `omc team N:codex "..."`  | N Codex CLI panes  | Code review, security analysis, architecture |
+| `omc team N:gemini "..."` | N Gemini CLI panes | UI/UX design, docs, large-context tasks      |
+| `omc team N:claude "..."` | N Claude CLI panes | General tasks via Claude CLI in tmux         |
+| `/ccg`                    | ask-codex + ask-gemini | Tri-model advisor synthesis             |
 
 Workers spawn on-demand and die when their task completes — no idle resource usage. Requires `codex` / `gemini` CLIs installed and an active tmux session.
 
@@ -130,7 +135,7 @@ If you experience issues after updating, clear the old plugin cache:
 ## Why oh-my-claudecode?
 
 - **Zero configuration required** - Works out of the box with intelligent defaults
-- **Team-first orchestration** - Team is the canonical multi-agent surface (swarm/ultrapilot are compatibility facades)
+- **Team-first orchestration** - Team is the canonical multi-agent surface
 - **Natural language interface** - No commands to memorize, just describe what you want
 - **Automatic parallelization** - Complex tasks distributed across specialized agents
 - **Persistent execution** - Won't give up until the job is verified complete
@@ -143,18 +148,19 @@ If you experience issues after updating, clear the old plugin cache:
 ## Features
 
 ### Orchestration Modes
+
 Multiple strategies for different use cases — from Team-backed orchestration to token-efficient refactoring. [Learn more →](https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html#execution-modes)
 
-| Mode | What it is | Use For |
-|------|------------|---------|
-| **Team (recommended)** | Canonical staged pipeline (`team-plan → team-prd → team-exec → team-verify → team-fix`) | Coordinated Claude agents on a shared task list |
-| **omc team (CLI)** | tmux CLI workers — real `claude`/`codex`/`gemini` processes in split-panes | Codex/Gemini CLI tasks; on-demand spawn, die when done |
-| **ccg** | Tri-model: Codex (analytical) + Gemini (design) in parallel, Claude synthesizes | Mixed backend+UI work needing both Codex and Gemini |
-| **Autopilot** | Autonomous execution (single lead agent) | End-to-end feature work with minimal ceremony |
-| **Ultrawork** | Maximum parallelism (non-team) | Burst parallel fixes/refactors where Team isn't needed |
-| **Ralph** | Persistent mode with verify/fix loops | Tasks that must complete fully (no silent partials) |
-| **Pipeline** | Sequential, staged processing | Multi-step transformations with strict ordering |
-| **Swarm / Ultrapilot (legacy)** | Compatibility facades that route to **Team** | Existing workflows and older docs |
+| Mode                    | What it is                                                                              | Use For                                                |
+| ----------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| **Team (recommended)**  | Canonical staged pipeline (`team-plan → team-prd → team-exec → team-verify → team-fix`) | Coordinated Claude agents on a shared task list        |
+| **omc team (CLI)**      | tmux CLI workers — real `claude`/`codex`/`gemini` processes in split-panes              | Codex/Gemini CLI tasks; on-demand spawn, die when done |
+| **ccg**                 | Tri-model advisors via ask-codex + ask-gemini, Claude synthesizes                         | Mixed backend+UI work needing both Codex and Gemini    |
+| **Autopilot**           | Autonomous execution (single lead agent)                                                | End-to-end feature work with minimal ceremony          |
+| **Ultrawork**           | Maximum parallelism (non-team)                                                          | Burst parallel fixes/refactors where Team isn't needed |
+| **Ralph**               | Persistent mode with verify/fix loops                                                   | Tasks that must complete fully (no silent partials)    |
+| **Pipeline**            | Sequential, staged processing                                                           | Multi-step transformations with strict ordering        |
+| **Ultrapilot (legacy)** | Deprecated compatibility mode (autopilot pipeline alias)                                | Existing workflows and older docs                      |
 
 ### Intelligent Orchestration
 
@@ -164,7 +170,7 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 
 ### Developer Experience
 
-- **Magic keywords** - `ralph`, `ulw`, `plan` for explicit control
+- **Magic keywords** - `ralph`, `ulw`, `team` for explicit control
 - **HUD statusline** - Real-time orchestration metrics in your status bar
 - **Skill learning** - Extract reusable patterns from your sessions
 - **Analytics & cost tracking** - Understand token usage across all sessions
@@ -177,23 +183,25 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 
 Optional shortcuts for power users. Natural language works fine without them.
 
-| Keyword | Effect | Example |
-|---------|--------|---------|
-| `team` | Canonical Team orchestration | `/team 3:executor "fix all TypeScript errors"` |
-| `omc team` | tmux CLI workers (codex/gemini/claude) | `omc team start --agent codex --count 2 --task "security review"` |
-| `ccg` | Tri-model Codex+Gemini orchestration | `/ccg review this PR` |
-| `autopilot` | Full autonomous execution | `autopilot: build a todo app` |
-| `ralph` | Persistence mode | `ralph: refactor auth` |
-| `ulw` | Maximum parallelism | `ulw fix all errors` |
-| `plan` | Planning interview | `plan the API` |
-| `ralplan` | Iterative planning consensus | `ralplan this feature` |
-| `deep-interview` | Socratic requirements clarification | `deep-interview "vague idea"` |
-| `swarm` | **Deprecated** — use `team` instead | `swarm 5 agents: fix lint errors` |
-| `ultrapilot` | **Deprecated** — use `team` instead | `ultrapilot: build a fullstack app` |
+| Keyword                | Effect                                 | Example                                        |
+| ---------------------- | -------------------------------------- | ---------------------------------------------- |
+| `team`                 | Canonical Team orchestration           | `/team 3:executor "fix all TypeScript errors"` |
+| `omc team`             | tmux CLI workers (codex/gemini/claude) | `omc team 2:codex "security review"`           |
+| `ccg`                  | ask-codex + ask-gemini synthesis       | `/ccg review this PR`                          |
+| `autopilot`            | Full autonomous execution              | `autopilot: build a todo app`                  |
+| `ralph`                | Persistence mode                       | `ralph: refactor auth`                         |
+| `ulw`                  | Maximum parallelism                    | `ulw fix all errors`                           |
+| `ralplan`              | Iterative planning consensus           | `ralplan this feature`                         |
+| `deep-interview`       | Socratic requirements clarification    | `deep-interview "vague idea"`                  |
+| `deepsearch`           | Codebase-focused search routing        | `deepsearch for auth middleware`               |
+| `ultrathink`           | Deep reasoning mode                    | `ultrathink about this architecture`           |
+| `cancelomc`, `stopomc` | Stop active OMC modes                  | `stopomc`                                      |
 
 **Notes:**
+
 - **ralph includes ultrawork**: when you activate ralph mode, it automatically includes ultrawork's parallel execution.
-- `swarm N agents` syntax is still recognized for agent count extraction, but the runtime is Team-backed in v4.1.7+.
+- `swarm` compatibility alias has been removed; migrate existing prompts to `/team` syntax.
+- `plan this` / `plan the` keyword triggers were removed; use `ralplan` or explicit `/oh-my-claudecode:omc-plan`.
 
 ## Utilities
 
@@ -203,11 +211,13 @@ Run local provider CLIs and save a markdown artifact under `.omc/artifacts/ask/`
 
 ```bash
 omc ask claude "review this migration plan"
+omc ask codex --prompt "identify architecture risks"
 omc ask gemini --prompt "propose UI polish ideas"
 omc ask claude --agent-prompt executor --prompt "draft implementation steps"
 ```
 
 Canonical env vars:
+
 - `OMC_ASK_ADVISOR_SCRIPT`
 - `OMC_ASK_ORIGINAL_TASK`
 
@@ -251,6 +261,7 @@ omc config-stop-callback discord --clear-tags
 ```
 
 Tag behavior:
+
 - Telegram: `alice` becomes `@alice`
 - Discord: supports `@here`, `@everyone`, numeric user IDs, and `role:<id>`
 - Slack: supports `<@MEMBER_ID>`, `<!channel>`, `<!here>`, `<!everyone>`, `<!subteam^GROUP_ID>`
@@ -281,10 +292,10 @@ Tag behavior:
 
 OMC can optionally orchestrate external AI providers for cross-validation and design consistency. These are **not required** — OMC works fully without them.
 
-| Provider | Install | What it enables |
-|----------|---------|-----------------|
+| Provider                                                  | Install                             | What it enables                                  |
+| --------------------------------------------------------- | ----------------------------------- | ------------------------------------------------ |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `npm install -g @google/gemini-cli` | Design review, UI consistency (1M token context) |
-| [Codex CLI](https://github.com/openai/codex) | `npm install -g @openai/codex` | Architecture validation, code review cross-check |
+| [Codex CLI](https://github.com/openai/codex)              | `npm install -g @openai/codex`      | Architecture validation, code review cross-check |
 
 **Cost:** 3 Pro plans (Claude + Gemini + ChatGPT) cover everything for ~$60/month.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,17 +1,19 @@
 <!-- OMC:START -->
 <!-- OMC:VERSION:4.6.0 -->
+
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
 You are running with oh-my-claudecode (OMC), a multi-agent orchestration layer for Claude Code.
 Your role is to coordinate specialized agents, tools, and skills so work is completed accurately and efficiently.
 
 <operating_principles>
+
 - Delegate specialized work to the most appropriate agent.
 - Keep users informed with concise progress updates.
 - Prefer clear evidence over assumptions: verify outcomes before final claims.
 - Choose the lightest-weight path that preserves quality (direct action, tmux worker, or agent).
 - Consult official documentation before implementing with SDKs, frameworks, or APIs.
-</operating_principles>
+  </operating_principles>
 
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification, specialist work.
@@ -30,6 +32,7 @@ For source-code edits, prefer delegation to implementation agents.
 Use `oh-my-claudecode:` prefix for Task subagent types.
 
 Build/Analysis:
+
 - `explore` (haiku): codebase discovery, symbol/file mapping
 - `analyst` (opus): requirements clarity, acceptance criteria
 - `planner` (opus): task sequencing, execution plans
@@ -40,11 +43,13 @@ Build/Analysis:
 - `verifier` (sonnet): completion evidence, claim validation
 
 Review:
+
 - `quality-reviewer` (sonnet): logic defects, maintainability, anti-patterns, performance
 - `security-reviewer` (sonnet): vulnerabilities, trust boundaries, authn/authz
 - `code-reviewer` (opus): comprehensive review, API contracts, backward compatibility
 
 Domain:
+
 - `test-engineer` (sonnet): test strategy, coverage, flaky-test hardening
 - `build-fixer` (sonnet): build/toolchain/type failures
 - `designer` (sonnet): UX/UI architecture, interaction design
@@ -56,18 +61,21 @@ Domain:
 - `code-simplifier` (opus): code clarity and simplification
 
 Coordination:
+
 - `critic` (opus): plan/design critical challenge
-</agent_catalog>
+  </agent_catalog>
 
 <tools>
 External AI (tmux CLI workers):
 - Claude agents: `/team N:executor "task"` via `TeamCreate`/`Task`
-- Codex/Gemini workers: `omc team start --agent codex|gemini --count N --task "..."`
-- Provider advisor CLI: `omc ask <claude|gemini> ...` (writes artifacts to `.omc/artifacts/ask/`)
+- Codex/Gemini workers: `omc team N:codex|gemini "..."` (plus `omc team status <team-name>` / `omc team shutdown <team-name>`)
+- Provider advisor CLI: `omc ask <claude|codex|gemini> ...` (writes artifacts to `.omc/artifacts/ask/`)
 - Ask shortcuts: `/oh-my-claudecode:ask-codex` and `/oh-my-claudecode:ask-gemini` route to the same `omc ask` flow
+- CCG skill route: `/oh-my-claudecode:ccg` fans out via `ask-codex` + `ask-gemini`, then Claude synthesizes
 - Legacy MCP runtime tools (`omc_run_team_*`) are deprecated with `deprecated_cli_only` and should not be used for execution.
 
 OMC State: `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
+
 - Stored at `{worktree}/.omc/state/{mode}-state.json`; session-scoped under `.omc/state/sessions/{sessionId}/`
 
 Team Coordination: `TeamCreate`, `TeamDelete`, `SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`
@@ -77,29 +85,32 @@ Notepad (`{worktree}/.omc/notepad.md`): `notepad_read`, `notepad_write_priority`
 Project Memory (`{worktree}/.omc/project-memory.json`): `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
 
 Code Intelligence:
+
 - LSP: `lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp_document_symbols`, `lsp_workspace_symbols`, `lsp_diagnostics`, `lsp_diagnostics_directory`, `lsp_prepare_rename`, `lsp_rename`, `lsp_code_actions`, `lsp_code_action_resolve`, `lsp_servers`
 - AST: `ast_grep_search`, `ast_grep_replace`
 - `python_repl`: persistent Python REPL for data analysis
-</tools>
+  </tools>
 
 <skills>
 Skills are user-invocable commands (`/oh-my-claudecode:<name>`). When you detect trigger patterns, invoke the corresponding skill.
 
 Workflow:
+
 - `autopilot` ("autopilot", "build me", "I want a"): full autonomous execution from idea to working code
 - `ralph` ("ralph", "don't stop", "must complete"): self-referential loop with verifier verification; includes ultrawork
 - `ultrawork` ("ulw", "ultrawork"): maximum parallelism with parallel agent orchestration
 - `team` ("team", "coordinated team", "team ralph"): N coordinated Claude agents with stage-aware routing; `team ralph` for persistent team execution
-- `omc-teams` ("omc-teams", "codex", "gemini"): legacy alias that routes to CLI-first `omc team ...` worker execution
-- `ccg` ("ccg", "tri-model", "claude codex gemini"): fan out to Codex + Gemini, Claude synthesizes
+- `omc-teams` ("omc-teams"): legacy alias that routes to CLI-first `omc team ...` worker execution
+- `ccg` ("ccg", "tri-model", "claude codex gemini"): fan out via `ask-codex` + `ask-gemini`, then Claude synthesizes
 - `ultraqa` (activated by autopilot): QA cycling -- test, verify, fix, repeat
-- `omc-plan` ("plan this", "plan the"): strategic planning; supports `--consensus` and `--review`
+- `omc-plan` (manual command): strategic planning; supports `--consensus` and `--review`
 - `ralplan` ("ralplan", "consensus plan"): alias for `/omc-plan --consensus` -- iterative planning with Planner, Architect, Critic until consensus; short deliberation by default, `--deliberate` for high-risk work (adds pre-mortem + expanded unit/integration/e2e/observability test planning)
 - `sciomc` ("sciomc"): parallel scientist agents for comprehensive analysis
 - `external-context`: parallel document-specialist agents for web searches
 - `deepinit` ("deepinit"): deep codebase init with hierarchical AGENTS.md
 
 Agent Shortcuts (thin wrappers):
+
 - `analyze` -> `debugger`: "analyze", "debug", "investigate"
 - `tdd` -> `test-engineer`: "tdd", "test first", "red green"
 - `build-fix` -> `build-fixer`: "fix build", "type errors"
@@ -110,13 +121,14 @@ Agent Shortcuts (thin wrappers):
 Notifications: `configure-notifications` ("configure discord", "setup telegram", "configure slack")
 Utilities: `ask-codex`, `ask-gemini`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `learn-about-omc`
 
-Disambiguation: bare "codex"/"gemini" -> omc-teams (legacy alias to `omc team`); "claude codex gemini" -> ccg. Ralph includes ultrawork.
+Disambiguation: prompts like "ask/use/delegate to codex|gemini" -> `ask-codex` / `ask-gemini`; "claude codex gemini" -> ccg. `omc-teams` remains available for explicit CLI-worker execution.
 </skills>
 
 <team_pipeline>
 Team is the default multi-agent orchestrator: `team-plan -> team-prd -> team-exec -> team-verify -> team-fix (loop)`
 
 Stage routing:
+
 - `team-plan`: `explore` + `planner`, optionally `analyst`/`architect`
 - `team-prd`: `analyst`, optionally `critic`
 - `team-exec`: `executor` + specialists (`designer`, `build-fixer`, `writer`, `test-engineer`, `deep-executor`)
@@ -140,6 +152,7 @@ Continuation: before concluding, confirm zero pending tasks, tests passing, zero
 
 <hooks_and_context>
 Hooks inject context via `<system-reminder>` tags:
+
 - `hook success: Success` -- proceed normally
 - `hook additional context: ...` -- read it; relevant to your task
 - `[MAGIC KEYWORD: ...]` -- invoke the indicated skill immediately
@@ -160,5 +173,7 @@ All OMC state lives under git worktree root: `.omc/state/` (mode state), `.omc/s
 </worktree_paths>
 
 ## Setup
+
 Say "setup omc" or run `/oh-my-claudecode:omc-setup`. Announce major behavior activations to keep users informed.
+
 <!-- OMC:END -->

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -30,10 +30,10 @@ This guide covers all migration paths for oh-my-claudecode. Find your current ve
 
 Use CLI commands instead:
 
-- `omc team start`
-- `omc team status <job_id>`
-- `omc team wait <job_id>`
-- `omc team cleanup <job_id>`
+- `omc team [N:agent-type] "<task>"`
+- `omc team status <team-name>`
+- `omc team shutdown <team-name> [--force]`
+- `omc team api <operation> --input '<json>' --json`
 
 ### `omc ask` env alias sunset (Phase-1 compatibility)
 
@@ -55,10 +55,10 @@ mcp__team__omc_run_team_wait({ job_id: ... })
 mcp__team__omc_run_team_cleanup({ job_id: ... })
 
 # New (CLI-first)
-omc team start ...
-omc team status <job_id>
-omc team wait <job_id>
-omc team cleanup <job_id>
+omc team 2:codex "review auth flow"
+omc team status review-auth-flow
+omc team shutdown review-auth-flow --force
+omc team api list-tasks --input '{"team_name":"review-auth-flow"}' --json
 ```
 
 ---
@@ -72,11 +72,13 @@ Maintenance release fixing test suite issues and continuing skill consolidation 
 ### What Changed
 
 **Test Fixes:**
+
 - Delegation-enforcer tests marked as skipped (implementation pending)
 - Analytics expectations corrected for agent attribution
 - All remaining tests now pass cleanly
 
 **Skill Consolidation:**
+
 - Continued cleanup from v3.5.3
 - Removed deprecated `cancel-*` skills (use `/cancel` instead)
 - Final skill count: 37 core skills
@@ -103,19 +105,20 @@ If you were depending on deprecated `cancel-*` skills, update to use the unified
 
 The following skills have been **completely removed** in v3.5.3:
 
-| Removed Skill | Replacement |
-|---------------|-------------|
-| `cancel-autopilot` | `/oh-my-claudecode:cancel` |
-| `cancel-ralph` | `/oh-my-claudecode:cancel` |
-| `cancel-ultrawork` | `/oh-my-claudecode:cancel` |
-| `cancel-ultraqa` | `/oh-my-claudecode:cancel` |
-| `omc-default` | `/oh-my-claudecode:omc-setup --local` |
+| Removed Skill        | Replacement                            |
+| -------------------- | -------------------------------------- |
+| `cancel-autopilot`   | `/oh-my-claudecode:cancel`             |
+| `cancel-ralph`       | `/oh-my-claudecode:cancel`             |
+| `cancel-ultrawork`   | `/oh-my-claudecode:cancel`             |
+| `cancel-ultraqa`     | `/oh-my-claudecode:cancel`             |
+| `omc-default`        | `/oh-my-claudecode:omc-setup --local`  |
 | `omc-default-global` | `/oh-my-claudecode:omc-setup --global` |
-| `planner` | `/oh-my-claudecode:plan` |
+| `planner`            | `/oh-my-claudecode:plan`               |
 
 ### What Changed
 
 **Before v3.5.3:**
+
 ```bash
 /oh-my-claudecode:cancel-ralph      # Cancel ralph specifically
 /oh-my-claudecode:omc-default       # Configure local project
@@ -123,6 +126,7 @@ The following skills have been **completely removed** in v3.5.3:
 ```
 
 **After v3.5.3:**
+
 ```bash
 /oh-my-claudecode:cancel            # Auto-detects and cancels any active mode
 /oh-my-claudecode:omc-setup --local # Configure local project
@@ -132,11 +136,13 @@ The following skills have been **completely removed** in v3.5.3:
 ### New Features
 
 **New skill: `/learn-about-omc`**
+
 - Analyzes your OMC usage patterns
 - Provides personalized recommendations
 - Identifies underutilized features
 
 **Plan skill now supports consensus mode:**
+
 ```bash
 /oh-my-claudecode:plan --consensus "task"  # Iterative planning with Critic review
 /oh-my-claudecode:ralplan "task"           # Alias for plan --consensus
@@ -222,18 +228,22 @@ Use canonical role names across prompts, commands, docs, and scripts. Avoid intr
 Directory structures have been renamed for consistency with the new package name:
 
 #### Local Project Directories
+
 - **Old**: `.omc/`
 - **New**: `.omc/`
 
 #### Global Directories
+
 - **Old**: `~/.omc/`
 - **New**: `~/.omc/`
 
 #### Skills Directory
+
 - **Old**: `~/.claude/skills/omc-learned/`
 - **New**: `~/.claude/skills/omc-learned/`
 
 #### Config Files
+
 - **Old**: `~/.claude/omc/mnemosyne.json`
 - **New**: `~/.claude/omc/learner.json`
 
@@ -241,52 +251,53 @@ Directory structures have been renamed for consistency with the new package name
 
 All environment variables have been renamed from `OMC_*` to `OMC_*`:
 
-| Old | New |
-|-----|-----|
-| OMC_USE_NODE_HOOKS | OMC_USE_NODE_HOOKS |
-| OMC_USE_BASH_HOOKS | OMC_USE_BASH_HOOKS |
-| OMC_PARALLEL_EXECUTION | OMC_PARALLEL_EXECUTION |
-| OMC_LSP_TOOLS | OMC_LSP_TOOLS |
+| Old                      | New                      |
+| ------------------------ | ------------------------ |
+| OMC_USE_NODE_HOOKS       | OMC_USE_NODE_HOOKS       |
+| OMC_USE_BASH_HOOKS       | OMC_USE_BASH_HOOKS       |
+| OMC_PARALLEL_EXECUTION   | OMC_PARALLEL_EXECUTION   |
+| OMC_LSP_TOOLS            | OMC_LSP_TOOLS            |
 | OMC_MAX_BACKGROUND_TASKS | OMC_MAX_BACKGROUND_TASKS |
-| OMC_ROUTING_ENABLED | OMC_ROUTING_ENABLED |
+| OMC_ROUTING_ENABLED      | OMC_ROUTING_ENABLED      |
 | OMC_ROUTING_DEFAULT_TIER | OMC_ROUTING_DEFAULT_TIER |
-| OMC_ESCALATION_ENABLED | OMC_ESCALATION_ENABLED |
-| OMC_DEBUG | OMC_DEBUG |
+| OMC_ESCALATION_ENABLED   | OMC_ESCALATION_ENABLED   |
+| OMC_DEBUG                | OMC_DEBUG                |
 
 ### Command Mapping
 
 All 2.x commands continue to work. Here's what changed:
 
-| 2.x Command | 3.0 Equivalent | Works? |
-|-------------|----------------|--------|
-| `/oh-my-claudecode:ralph "task"` | Say "don't stop until done" OR use `ralph` keyword | ✅ YES (both ways) |
-| `/oh-my-claudecode:ultrawork "task"` | Say "fast" or "parallel" OR use `ulw` keyword | ✅ YES (both ways) |
-| `/oh-my-claudecode:ultrawork-ralph` | Say "ralph ulw:" prefix | ✅ YES (keyword combo) |
-| `/oh-my-claudecode:planner "task"` | Say "plan this" OR use `plan` keyword | ✅ YES (both ways) |
-| `/oh-my-claudecode:plan "description"` | Start planning naturally | ✅ YES |
-| `/oh-my-claudecode:review [path]` | Invoke normally | ✅ YES (unchanged) |
-| `/oh-my-claudecode:deepsearch "query"` | Say "find" or "search" | ✅ YES (auto-detect) |
-| `/oh-my-claudecode:analyze "target"` | Say "analyze" or "investigate" | ✅ YES (auto-detect) |
-| `/oh-my-claudecode:deepinit [path]` | Invoke normally | ✅ YES (unchanged) |
-| `/oh-my-claudecode:git-master` | Say "git", "commit", "atomic commit" | ✅ YES (auto-detect) |
-| `/oh-my-claudecode:frontend-ui-ux` | Say "UI", "styling", "component", "design" | ✅ YES (auto-detect) |
-| `/oh-my-claudecode:note "content"` | Say "remember this" or "save this" | ✅ YES (auto-detect) |
-| `/oh-my-claudecode:cancel-ralph` | Say "stop", "cancel", or "abort" | ✅ YES (auto-detect) |
-| `/oh-my-claudecode:omc-doctor` | Invoke normally | ✅ YES (unchanged) |
-| All other commands | Work exactly as before | ✅ YES |
+| 2.x Command                            | 3.0 Equivalent                                     | Works?                 |
+| -------------------------------------- | -------------------------------------------------- | ---------------------- |
+| `/oh-my-claudecode:ralph "task"`       | Say "don't stop until done" OR use `ralph` keyword | ✅ YES (both ways)     |
+| `/oh-my-claudecode:ultrawork "task"`   | Say "fast" or "parallel" OR use `ulw` keyword      | ✅ YES (both ways)     |
+| `/oh-my-claudecode:ultrawork-ralph`    | Say "ralph ulw:" prefix                            | ✅ YES (keyword combo) |
+| `/oh-my-claudecode:planner "task"`     | Say "plan this" OR use `plan` keyword              | ✅ YES (both ways)     |
+| `/oh-my-claudecode:plan "description"` | Start planning naturally                           | ✅ YES                 |
+| `/oh-my-claudecode:review [path]`      | Invoke normally                                    | ✅ YES (unchanged)     |
+| `/oh-my-claudecode:deepsearch "query"` | Say "find" or "search"                             | ✅ YES (auto-detect)   |
+| `/oh-my-claudecode:analyze "target"`   | Say "analyze" or "investigate"                     | ✅ YES (auto-detect)   |
+| `/oh-my-claudecode:deepinit [path]`    | Invoke normally                                    | ✅ YES (unchanged)     |
+| `/oh-my-claudecode:git-master`         | Say "git", "commit", "atomic commit"               | ✅ YES (auto-detect)   |
+| `/oh-my-claudecode:frontend-ui-ux`     | Say "UI", "styling", "component", "design"         | ✅ YES (auto-detect)   |
+| `/oh-my-claudecode:note "content"`     | Say "remember this" or "save this"                 | ✅ YES (auto-detect)   |
+| `/oh-my-claudecode:cancel-ralph`       | Say "stop", "cancel", or "abort"                   | ✅ YES (auto-detect)   |
+| `/oh-my-claudecode:omc-doctor`         | Invoke normally                                    | ✅ YES (unchanged)     |
+| All other commands                     | Work exactly as before                             | ✅ YES                 |
 
 ### Magic Keywords
 
 Include these anywhere in your message to explicitly activate behaviors. Use keywords when you want explicit control (optional):
 
-| Keyword | Effect | Example |
-|---------|--------|---------|
-| `ralph` | Persistence mode - won't stop until done | "ralph: refactor the auth system" |
-| `ralplan` | Iterative planning with consensus | "ralplan: add OAuth support" |
-| `ulw` / `ultrawork` | Maximum parallel execution | "ulw: fix all type errors" |
-| `plan` | Planning interview | "plan: new API design" |
+| Keyword             | Effect                                   | Example                           |
+| ------------------- | ---------------------------------------- | --------------------------------- |
+| `ralph`             | Persistence mode - won't stop until done | "ralph: refactor the auth system" |
+| `ralplan`           | Iterative planning with consensus        | "ralplan: add OAuth support"      |
+| `ulw` / `ultrawork` | Maximum parallel execution               | "ulw: fix all type errors"        |
+| `plan`              | Planning interview                       | "plan: new API design"            |
 
 **ralph includes ultrawork:**
+
 ```
 ralph: migrate the entire database
     ↓
@@ -294,6 +305,7 @@ Persistence (won't stop) + Ultrawork (maximum parallelism) built-in
 ```
 
 **No keywords?** Claude still auto-detects:
+
 ```
 "don't stop until this works"      # Triggers ralph
 "fast, I'm in a hurry"             # Triggers ultrawork
@@ -303,6 +315,7 @@ Persistence (won't stop) + Ultrawork (maximum parallelism) built-in
 ### Natural Cancellation
 
 Say any of these to stop:
+
 - "stop"
 - "cancel"
 - "abort"
@@ -377,6 +390,7 @@ Update your shell configuration files (`.bashrc`, `.zshrc`, etc.):
 #### 6. Update Scripts and Configurations
 
 Search for and update any references to:
+
 - Package name: `oh-my-claudecode` → `oh-my-claudecode`
 - Agent names: Use the mapping table above
 - Commands: Use the new slash commands
@@ -387,6 +401,7 @@ Search for and update any references to:
 In Claude Code, just say "setup omc", "omc setup", or any natural language equivalent.
 
 This:
+
 - Downloads latest CLAUDE.md
 - Configures 32 agents
 - Enables auto-behavior detection
@@ -398,11 +413,13 @@ This:
 After migration, verify your setup:
 
 1. **Check installation**:
+
    ```bash
    npm list -g oh-my-claudecode
    ```
 
 2. **Verify directories exist**:
+
    ```bash
    ls -la .omc/  # In project directory
    ls -la ~/.omc/  # Global directory
@@ -454,6 +471,7 @@ Next time keywords match → Solution auto-injects
 ```
 
 Storage:
+
 - **Project-level**: `.omc/skills/` (version-controlled)
 - **User-level**: `~/.claude/skills/omc-learned/` (portable)
 
@@ -533,14 +551,15 @@ Plan-scoped wisdom capture for learnings, decisions, issues, and problems.
 
 **Location:** `.omc/notepads/{plan-name}/`
 
-| File | Purpose |
-|------|---------|
+| File           | Purpose                            |
+| -------------- | ---------------------------------- |
 | `learnings.md` | Technical discoveries and patterns |
 | `decisions.md` | Architectural and design decisions |
-| `issues.md` | Known issues and workarounds |
-| `problems.md` | Blockers and challenges |
+| `issues.md`    | Known issues and workarounds       |
+| `problems.md`  | Blockers and challenges            |
 
 **API:**
+
 - `initPlanNotepad()` - Initialize notepad for a plan
 - `addLearning()` - Record technical discoveries
 - `addDecision()` - Record architectural choices
@@ -553,13 +572,13 @@ Plan-scoped wisdom capture for learnings, decisions, issues, and problems.
 
 Semantic task categorization that auto-maps to model tier, temperature, and thinking budget.
 
-| Category | Tier | Temperature | Thinking | Use For |
-|----------|------|-------------|----------|---------|
-| `visual-engineering` | HIGH | 0.7 | high | UI/UX, frontend, design systems |
-| `ultrabrain` | HIGH | 0.3 | max | Complex reasoning, architecture, deep debugging |
-| `artistry` | MEDIUM | 0.9 | medium | Creative solutions, brainstorming |
-| `quick` | LOW | 0.1 | low | Simple lookups, basic operations |
-| `writing` | MEDIUM | 0.5 | medium | Documentation, technical writing |
+| Category             | Tier   | Temperature | Thinking | Use For                                         |
+| -------------------- | ------ | ----------- | -------- | ----------------------------------------------- |
+| `visual-engineering` | HIGH   | 0.7         | high     | UI/UX, frontend, design systems                 |
+| `ultrabrain`         | HIGH   | 0.3         | max      | Complex reasoning, architecture, deep debugging |
+| `artistry`           | MEDIUM | 0.9         | medium   | Creative solutions, brainstorming               |
+| `quick`              | LOW    | 0.1         | low      | Simple lookups, basic operations                |
+| `writing`            | MEDIUM | 0.5         | medium   | Documentation, technical writing                |
 
 **Auto-detection:** Categories detect from prompt keywords automatically.
 
@@ -568,6 +587,7 @@ Semantic task categorization that auto-maps to model tier, temperature, and thin
 Project-level type checking via `lsp_diagnostics_directory` tool.
 
 **Strategies:**
+
 - `auto` (default) - Auto-selects best strategy, prefers tsc when tsconfig.json exists
 - `tsc` - Fast, uses TypeScript compiler
 - `lsp` - Fallback, iterates files via Language Server
@@ -591,6 +611,7 @@ All existing configurations, plans, and workflows continue working unchanged.
 ### New Tools Available
 
 Once upgraded, agents automatically gain access to:
+
 - Notepad wisdom APIs (read/write wisdom during execution)
 - Delegation categories (automatic categorization)
 - Directory diagnostics (project-level type checking)
@@ -615,6 +636,7 @@ Execute complex tasks with up to 5 concurrent workers for 3-5x speedup:
 ```
 
 **Key Features:**
+
 - Automatic task decomposition into parallelizable subtasks
 - File ownership coordination to prevent conflicts
 - Parallel execution with intelligent coordination
@@ -631,6 +653,7 @@ N coordinated agents with atomic task claiming:
 ```
 
 **Key Features:**
+
 - Shared task pool with atomic claiming (prevents duplicate work)
 - 5-minute timeout per task with auto-release
 - Scales from 2 to 10 workers
@@ -645,6 +668,7 @@ Chain agents with data passing between stages:
 ```
 
 **Built-in Presets:**
+
 - `review` - explore → architect → critic → executor
 - `implement` - planner → executor → tdd-guide
 - `debug` - explore → architect → build-fixer
@@ -665,6 +689,7 @@ Smart cancellation that auto-detects active mode:
 
 **Deprecation Notice:**
 Individual cancel commands are deprecated but still work:
+
 - `/oh-my-claudecode:cancel-ralph` (deprecated)
 - `/oh-my-claudecode:cancel-ultraqa` (deprecated)
 - `/oh-my-claudecode:cancel-ultrawork` (deprecated)
@@ -677,9 +702,11 @@ Use `/oh-my-claudecode:cancel` instead.
 Opus-powered architectural search for complex codebase exploration:
 
 ```typescript
-Task(subagent_type="oh-my-claudecode:explore-high",
-     model="opus",
-     prompt="Find all authentication-related code patterns...")
+Task(
+  (subagent_type = "oh-my-claudecode:explore-high"),
+  (model = "opus"),
+  (prompt = "Find all authentication-related code patterns..."),
+);
 ```
 
 **Best for:** Architectural analysis, cross-cutting concerns, complex refactoring planning
@@ -689,6 +716,7 @@ Task(subagent_type="oh-my-claudecode:explore-high",
 State files now use standardized paths:
 
 **Standard paths:**
+
 - Local: `.omc/state/{name}.json`
 - Global: `~/.omc/state/{name}.json`
 
@@ -741,6 +769,7 @@ None. All v3.3.x features and commands continue to work in v3.4.0.
 ### New Tools Available
 
 Once upgraded, you automatically gain access to:
+
 - Ultrapilot (parallel autopilot)
 - Swarm coordination
 - Pipeline workflows
@@ -751,23 +780,25 @@ Once upgraded, you automatically gain access to:
 
 #### When to Use Each Mode
 
-| Scenario | Recommended Mode | Why |
-|----------|------------------|-----|
-| Multi-component systems | `ultrapilot` | Parallel workers handle independent components |
-| Many small fixes | `swarm` | Atomic task claiming prevents duplicate work |
-| Sequential dependencies | `pipeline` | Data passes between stages |
-| Single complex task | `autopilot` | Full autonomous execution |
-| Must complete | `ralph` | Persistence guarantee |
+| Scenario                | Recommended Mode | Why                                            |
+| ----------------------- | ---------------- | ---------------------------------------------- |
+| Multi-component systems | `ultrapilot`     | Parallel workers handle independent components |
+| Many small fixes        | `swarm`          | Atomic task claiming prevents duplicate work   |
+| Sequential dependencies | `pipeline`       | Data passes between stages                     |
+| Single complex task     | `autopilot`      | Full autonomous execution                      |
+| Must complete           | `ralph`          | Persistence guarantee                          |
 
 #### Keyword Usage
 
 **Explicit mode control (v3.4.0):**
+
 ```bash
 "ulw: fix all errors"           # ultrawork (explicit)
 "fast: implement feature"       # reads defaultExecutionMode config
 ```
 
 **Natural language (still works):**
+
 ```bash
 "don't stop until done"         # ralph
 "parallel execution"            # reads defaultExecutionMode
@@ -779,16 +810,19 @@ Once upgraded, you automatically gain access to:
 After upgrading, verify new features:
 
 1. **Check installation**:
+
    ```bash
    npm list -g oh-my-claudecode
    ```
 
 2. **Test ultrapilot**:
+
    ```bash
    /oh-my-claudecode:ultrapilot "create a simple React component"
    ```
 
 3. **Test unified cancel**:
+
    ```bash
    /oh-my-claudecode:cancel
    ```
@@ -850,11 +884,13 @@ Expected timeline: Q1 2026
 ### Scenario 1: Quick Implementation Task
 
 **2.x Workflow:**
+
 ```
 /oh-my-claudecode:ultrawork "implement the todo list feature"
 ```
 
 **3.0+ Workflow:**
+
 ```
 "implement the todo list feature quickly"
     ↓
@@ -866,11 +902,13 @@ Claude: "I'm activating ultrawork for maximum parallelism"
 ### Scenario 2: Complex Debugging
 
 **2.x Workflow:**
+
 ```
 /oh-my-claudecode:ralph "debug the memory leak"
 ```
 
 **3.0+ Workflow:**
+
 ```
 "there's a memory leak in the worker process - don't stop until we fix it"
     ↓
@@ -882,11 +920,13 @@ Claude: "I'm activating ralph-loop to ensure completion"
 ### Scenario 3: Strategic Planning
 
 **2.x Workflow:**
+
 ```
 /oh-my-claudecode:planner "design the new authentication system"
 ```
 
 **3.0+ Workflow:**
+
 ```
 "plan the new authentication system"
     ↓
@@ -900,11 +940,13 @@ Interview begins automatically
 ### Scenario 4: Stopping Work
 
 **2.x Workflow:**
+
 ```
 /oh-my-claudecode:cancel-ralph
 ```
 
 **3.0+ Workflow:**
+
 ```
 "stop"
 ```

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -78,13 +78,13 @@ Configure omc for all Claude Code sessions:
 
 ### What Configuration Enables
 
-| Feature | Without | With omc Config |
-|---------|---------|-----------------|
-| Agent delegation | Manual only | Automatic based on task |
-| Keyword detection | Disabled | ultrawork, search, analyze |
-| Todo continuation | Basic | Enforced completion |
-| Model routing | Default | Smart tier selection |
-| Skill composition | None | Auto-combines skills |
+| Feature           | Without     | With omc Config            |
+| ----------------- | ----------- | -------------------------- |
+| Agent delegation  | Manual only | Automatic based on task    |
+| Keyword detection | Disabled    | ultrawork, search, analyze |
+| Todo continuation | Basic       | Enforced completion        |
+| Model routing     | Default     | Smart tier selection       |
+| Skill composition | None        | Auto-combines skills       |
 
 ### Configuration Precedence
 
@@ -96,16 +96,16 @@ If both configurations exist, **project-scoped takes precedence** over global:
 
 ### Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `OMC_STATE_DIR` | _(unset)_ | Centralized state directory. When set, OMC stores state at `$OMC_STATE_DIR/{project-id}/` instead of `{worktree}/.omc/`. This preserves state across worktree deletions. The project identifier is derived from the git remote URL (or worktree path for local-only repos). |
-| `OMC_BRIDGE_SCRIPT` | _(auto-detected)_ | Path to the Python bridge script |
-| `OMC_PARALLEL_EXECUTION` | `true` | Enable/disable parallel agent execution |
-| `OMC_CODEX_DEFAULT_MODEL` | _(provider default)_ | Default model for Codex CLI workers |
-| `OMC_GEMINI_DEFAULT_MODEL` | _(provider default)_ | Default model for Gemini CLI workers |
-| `OMC_LSP_TIMEOUT_MS` | `15000` | Timeout (ms) for LSP requests. Increase for large repos or slow language servers |
-| `DISABLE_OMC` | _(unset)_ | Set to any value to disable all OMC hooks |
-| `OMC_SKIP_HOOKS` | _(unset)_ | Comma-separated list of hook names to skip |
+| Variable                   | Default              | Description                                                                                                                                                                                                                                                                 |
+| -------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OMC_STATE_DIR`            | _(unset)_            | Centralized state directory. When set, OMC stores state at `$OMC_STATE_DIR/{project-id}/` instead of `{worktree}/.omc/`. This preserves state across worktree deletions. The project identifier is derived from the git remote URL (or worktree path for local-only repos). |
+| `OMC_BRIDGE_SCRIPT`        | _(auto-detected)_    | Path to the Python bridge script                                                                                                                                                                                                                                            |
+| `OMC_PARALLEL_EXECUTION`   | `true`               | Enable/disable parallel agent execution                                                                                                                                                                                                                                     |
+| `OMC_CODEX_DEFAULT_MODEL`  | _(provider default)_ | Default model for Codex CLI workers                                                                                                                                                                                                                                         |
+| `OMC_GEMINI_DEFAULT_MODEL` | _(provider default)_ | Default model for Gemini CLI workers                                                                                                                                                                                                                                        |
+| `OMC_LSP_TIMEOUT_MS`       | `15000`              | Timeout (ms) for LSP requests. Increase for large repos or slow language servers                                                                                                                                                                                            |
+| `DISABLE_OMC`              | _(unset)_            | Set to any value to disable all OMC hooks                                                                                                                                                                                                                                   |
+| `OMC_SKIP_HOOKS`           | _(unset)_            | Comma-separated list of hook names to skip                                                                                                                                                                                                                                  |
 
 #### Centralized State with `OMC_STATE_DIR`
 
@@ -138,9 +138,8 @@ Edit agent files in `~/.claude/agents/` to customize behavior:
 name: architect
 description: Your custom description
 tools: Read, Grep, Glob, Bash, Edit
-model: opus  # or sonnet, haiku
+model: opus # or sonnet, haiku
 ---
-
 Your custom system prompt here...
 ```
 
@@ -152,11 +151,13 @@ Create `.claude/CLAUDE.md` in your project for project-specific instructions:
 # Project Context
 
 This is a TypeScript monorepo using:
+
 - Bun runtime
 - React for frontend
 - PostgreSQL database
 
 ## Conventions
+
 - Use functional components
 - All API routes in /src/api
 - Tests alongside source files
@@ -182,6 +183,7 @@ omc config-stop-callback discord --show
 ```
 
 Tag behavior:
+
 - Telegram: `alice` is normalized to `@alice`
 - Discord: supports `@here`, `@everyone`, numeric user IDs (`<@id>`), and role tags (`role:<id>` -> `<@&id>`)
 - `file` callbacks ignore tag options
@@ -194,26 +196,27 @@ Tag behavior:
 
 ```bash
 omc ask claude "review this patch"
+omc ask codex "review this patch from a security perspective"
 omc ask gemini --prompt "suggest UX improvements"
 omc ask claude --agent-prompt executor --prompt "create an implementation plan"
 ```
 
-- Provider matrix: `claude | gemini`
+- Provider matrix: `claude | codex | gemini`
 - Artifacts: `.omc/artifacts/ask/{provider}-{slug}-{timestamp}.md`
 - Canonical env vars: `OMC_ASK_ADVISOR_SCRIPT`, `OMC_ASK_ORIGINAL_TASK`
 - Phase-1 aliases (deprecated warning): `OMX_ASK_ADVISOR_SCRIPT`, `OMX_ASK_ORIGINAL_TASK`
 - Skill shortcuts: `/oh-my-claudecode:ask-codex` and `/oh-my-claudecode:ask-gemini` route to this command
 
-### `omc team` (MVP runtime surface)
+### `omc team` (CLI runtime surface)
 
 ```bash
-omc team start --agent codex --count 2 --task "review auth flow"
-omc team status <job_id>
-omc team wait <job_id> --timeout-ms 300000
-omc team cleanup <job_id> --grace-ms 5000
+omc team 2:codex "review auth flow"
+omc team status review-auth-flow
+omc team shutdown review-auth-flow --force
+omc team api claim-task --input '{"team_name":"auth-review","task_id":"1","worker":"worker-1"}' --json
 ```
 
-Supported subcommands in this integration phase: `start`, `status`, `wait`, `cleanup`.
+Supported entrypoints: direct start (`omc team [N:agent] "<task>"`), `status`, `shutdown`, and `api`.
 
 ---
 
@@ -230,18 +233,18 @@ The Team MCP server remains registered for compatibility, but runtime tools are 
 
 Use `omc team ...` replacements instead:
 
-| Tool | Purpose |
-|------|---------|
-| `omc_run_team_start` | **Deprecated** → `omc team start` |
-| `omc_run_team_status` | **Deprecated** → `omc team status <job_id>` |
-| `omc_run_team_wait` | **Deprecated** → `omc team wait <job_id>` |
-| `omc_run_team_cleanup` | **Deprecated** → `omc team cleanup <job_id>` |
+| Tool                   | Purpose                                                    |
+| ---------------------- | ---------------------------------------------------------- |
+| `omc_run_team_start`   | **Deprecated** → `omc team [N:agent-type] "<task>"`        |
+| `omc_run_team_status`  | **Deprecated** → `omc team status <team-name>`             |
+| `omc_run_team_wait`    | **Deprecated** → monitor via `omc team status <team-name>` |
+| `omc_run_team_cleanup` | **Deprecated** → `omc team shutdown <team-name> [--force]` |
 
 ### Runtime status semantics
 
-- **Artifact-first terminal convergence**: `status` and `wait` prefer `{jobId}-result.json` when present.
+- **Artifact-first terminal convergence**: team monitors prefer finalized state artifacts when present.
 - **Deterministic parse-failure handling**: malformed result artifacts are treated as terminal `failed`.
-- **Cleanup scope**: cleanup clears only `.omc/state/team/{teamName}` for the job (never sibling teams).
+- **Cleanup scope**: shutdown/cleanup only clears `.omc/state/team/{teamName}` for the target team (never sibling teams).
 
 ## Agents (28 Total)
 
@@ -249,114 +252,106 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
 ### By Domain and Tier
 
-| Domain | LOW (Haiku) | MEDIUM (Sonnet) | HIGH (Opus) |
-|--------|-------------|-----------------|-------------|
-| **Analysis** | `architect-low` | `architect-medium` | `architect` |
-| **Execution** | `executor-low` | `executor` | `executor-high` |
-| **Search** | `explore` | - | `explore-high` |
-| **Research** | - | `document-specialist` | - |
-| **Frontend** | `designer-low` | `designer` | `designer-high` |
-| **Docs** | `writer` | - | - |
-| **Visual** | - | `vision` | - |
-| **Planning** | - | - | `planner` |
-| **Critique** | - | - | `critic` |
-| **Pre-Planning** | - | - | `analyst` |
-| **Testing** | - | `qa-tester` | - |
-| **Security** | `security-reviewer-low` | - | `security-reviewer` |
-| **Build** | - | `build-fixer` | - |
-| **TDD** | - | `test-engineer` | - |
-| **Code Review** | - | - | `code-reviewer` |
-| **Data Science** | - | `scientist` | `scientist-high` |
+| Domain           | LOW (Haiku)             | MEDIUM (Sonnet)       | HIGH (Opus)         |
+| ---------------- | ----------------------- | --------------------- | ------------------- |
+| **Analysis**     | `architect-low`         | `architect-medium`    | `architect`         |
+| **Execution**    | `executor-low`          | `executor`            | `executor-high`     |
+| **Search**       | `explore`               | -                     | `explore-high`      |
+| **Research**     | -                       | `document-specialist` | -                   |
+| **Frontend**     | `designer-low`          | `designer`            | `designer-high`     |
+| **Docs**         | `writer`                | -                     | -                   |
+| **Visual**       | -                       | `vision`              | -                   |
+| **Planning**     | -                       | -                     | `planner`           |
+| **Critique**     | -                       | -                     | `critic`            |
+| **Pre-Planning** | -                       | -                     | `analyst`           |
+| **Testing**      | -                       | `qa-tester`           | -                   |
+| **Security**     | `security-reviewer-low` | -                     | `security-reviewer` |
+| **Build**        | -                       | `build-fixer`         | -                   |
+| **TDD**          | -                       | `test-engineer`       | -                   |
+| **Code Review**  | -                       | -                     | `code-reviewer`     |
+| **Data Science** | -                       | `scientist`           | `scientist-high`    |
 
 ### Agent Selection Guide
 
-| Task Type | Best Agent | Model |
-|-----------|------------|-------|
-| Quick code lookup | `explore` | haiku |
-| Find files/patterns | `explore` | haiku |
-| Complex architectural search | `explore-high` | opus |
-| Simple code change | `executor-low` | haiku |
-| Feature implementation | `executor` | sonnet |
-| Complex refactoring | `executor-high` | opus |
-| Debug simple issue | `architect-low` | haiku |
-| Debug complex issue | `architect` | opus |
-| UI component | `designer` | sonnet |
-| Complex UI system | `designer-high` | opus |
-| Write docs/comments | `writer` | haiku |
-| Research docs/APIs | `document-specialist` | sonnet |
-| Analyze images/diagrams | `vision` | sonnet |
-| Strategic planning | `planner` | opus |
-| Review/critique plan | `critic` | opus |
-| Pre-planning analysis | `analyst` | opus |
-| Test CLI interactively | `qa-tester` | sonnet |
-| Security review | `security-reviewer` | opus |
-| Quick security scan | `security-reviewer-low` | haiku |
-| Fix build errors | `build-fixer` | sonnet |
-| Simple build fix | `build-fixer` (model=haiku) | haiku |
-| TDD workflow | `test-engineer` | sonnet |
-| Quick test suggestions | `test-engineer` (model=haiku) | haiku |
-| Code review | `code-reviewer` | opus |
-| Quick code check | `code-reviewer` (model=haiku) | haiku |
-| Data analysis/stats | `scientist` | sonnet |
-| Quick data inspection | `scientist` (model=haiku) | haiku |
-| Complex ML/hypothesis | `scientist-high` | opus |
+| Task Type                    | Best Agent                    | Model  |
+| ---------------------------- | ----------------------------- | ------ |
+| Quick code lookup            | `explore`                     | haiku  |
+| Find files/patterns          | `explore`                     | haiku  |
+| Complex architectural search | `explore-high`                | opus   |
+| Simple code change           | `executor-low`                | haiku  |
+| Feature implementation       | `executor`                    | sonnet |
+| Complex refactoring          | `executor-high`               | opus   |
+| Debug simple issue           | `architect-low`               | haiku  |
+| Debug complex issue          | `architect`                   | opus   |
+| UI component                 | `designer`                    | sonnet |
+| Complex UI system            | `designer-high`               | opus   |
+| Write docs/comments          | `writer`                      | haiku  |
+| Research docs/APIs           | `document-specialist`         | sonnet |
+| Analyze images/diagrams      | `vision`                      | sonnet |
+| Strategic planning           | `planner`                     | opus   |
+| Review/critique plan         | `critic`                      | opus   |
+| Pre-planning analysis        | `analyst`                     | opus   |
+| Test CLI interactively       | `qa-tester`                   | sonnet |
+| Security review              | `security-reviewer`           | opus   |
+| Quick security scan          | `security-reviewer-low`       | haiku  |
+| Fix build errors             | `build-fixer`                 | sonnet |
+| Simple build fix             | `build-fixer` (model=haiku)   | haiku  |
+| TDD workflow                 | `test-engineer`               | sonnet |
+| Quick test suggestions       | `test-engineer` (model=haiku) | haiku  |
+| Code review                  | `code-reviewer`               | opus   |
+| Quick code check             | `code-reviewer` (model=haiku) | haiku  |
+| Data analysis/stats          | `scientist`                   | sonnet |
+| Quick data inspection        | `scientist` (model=haiku)     | haiku  |
+| Complex ML/hypothesis        | `scientist-high`              | opus   |
 
 ---
 
 ## Skills (38 Total)
 
-### Core Skills
+Includes **37 canonical skills + 1 deprecated alias** (`psm`).
 
-| Skill | Description | Manual Command |
-|-------|-------------|----------------|
-| `orchestrate` | Multi-agent orchestration mode | - |
-| `autopilot` | Full autonomous execution from idea to working code | `/oh-my-claudecode:autopilot` |
-| `ultrawork` | Maximum performance with parallel agents | `/oh-my-claudecode:ultrawork` |
-| `ultrapilot` | **Deprecated** — use `autopilot` or `team` instead | `/oh-my-claudecode:ultrapilot` |
-| `team` | N coordinated agents on shared task list using native teams | `/oh-my-claudecode:team` |
-| `pipeline` | **Deprecated** — use `autopilot` instead | `/oh-my-claudecode:pipeline` |
-| `ralph` | Self-referential development until completion | `/oh-my-claudecode:ralph` |
-| `ralph-init` | Initialize PRD for structured task tracking | `/oh-my-claudecode:ralph-init` |
-| `ultraqa` | Autonomous QA cycling workflow | `/oh-my-claudecode:ultraqa` |
-| `plan` | Start planning session (consensus mode uses RALPLAN-DR structured deliberation) | `/oh-my-claudecode:plan` |
-| `ralplan` | Iterative planning (Planner+Architect+Critic) with structured deliberation; short mode default, `--deliberate` for high-risk pre-mortem + expanded test plan | `/oh-my-claudecode:ralplan` |
-| `deep-interview` | Socratic deep interview with mathematical ambiguity gating (Ouroboros-inspired) | `/oh-my-claudecode:deep-interview` |
-| `review` | Review work plans with critic | `/oh-my-claudecode:review` |
+| Skill                     | Description                                                      | Manual Command                              |
+| ------------------------- | ---------------------------------------------------------------- | ------------------------------------------- |
+| `analyze`                 | Deep analysis and investigation                                  | `/oh-my-claudecode:analyze`                 |
+| `ask-codex`               | Ask Codex via `omc ask codex` and store an ask artifact          | `/oh-my-claudecode:ask-codex`               |
+| `ask-gemini`              | Ask Gemini via `omc ask gemini` and store an ask artifact        | `/oh-my-claudecode:ask-gemini`              |
+| `autopilot`               | Full autonomous execution from idea to working code              | `/oh-my-claudecode:autopilot`               |
+| `build-fix`               | Fix build and TypeScript errors                                  | `/oh-my-claudecode:build-fix`               |
+| `cancel`                  | Unified cancellation for active modes                            | `/oh-my-claudecode:cancel`                  |
+| `ccg`                     | Tri-model workflow via `ask-codex` + `ask-gemini`, then Claude synthesis | `/oh-my-claudecode:ccg`                     |
+| `code-review`             | Comprehensive code review                                        | `/oh-my-claudecode:code-review`             |
+| `configure-notifications` | Configure notifications (Discord/Telegram/Slack/OpenClaw)        | `/oh-my-claudecode:configure-notifications` |
+| `configure-openclaw`      | Configure OpenClaw notification bridge                           | `/oh-my-claudecode:configure-openclaw`      |
+| `deep-interview`          | Socratic deep interview with ambiguity gating                    | `/oh-my-claudecode:deep-interview`          |
+| `deepinit`                | Generate hierarchical AGENTS.md docs                             | `/oh-my-claudecode:deepinit`                |
+| `external-context`        | Parallel document-specialist research                            | `/oh-my-claudecode:external-context`        |
+| `hud`                     | Configure HUD/statusline                                         | `/oh-my-claudecode:hud`                     |
+| `learn-about-omc`         | Analyze OMC usage patterns                                       | `/oh-my-claudecode:learn-about-omc`         |
+| `learner`                 | Extract reusable skill from session                              | `/oh-my-claudecode:learner`                 |
+| `mcp-setup`               | Configure MCP servers                                            | `/oh-my-claudecode:mcp-setup`               |
+| `note`                    | Save notes to notepad                                            | `/oh-my-claudecode:note`                    |
+| `omc-doctor`              | Diagnose and fix installation issues                             | `/oh-my-claudecode:omc-doctor`              |
+| `omc-help`                | Show OMC usage guide                                             | `/oh-my-claudecode:omc-help`                |
+| `omc-plan`                | Planning workflow (`/plan` safe alias)                           | `/oh-my-claudecode:omc-plan`                |
+| `omc-security-review`     | Security review workflow (`/security-review` safe alias)         | `/oh-my-claudecode:omc-security-review`     |
+| `omc-setup`               | One-time setup wizard                                            | `/oh-my-claudecode:omc-setup`               |
+| `omc-teams`               | Legacy compatibility wrapper for `omc team` CLI                  | `/oh-my-claudecode:omc-teams`               |
+| `project-session-manager` | Manage isolated dev environments (git worktrees + tmux)          | `/oh-my-claudecode:project-session-manager` |
+| `psm`                     | **Deprecated** compatibility alias for `project-session-manager` | `/oh-my-claudecode:psm`                     |
+| `ralph`                   | Persistence loop until verified completion                       | `/oh-my-claudecode:ralph`                   |
+| `ralph-init`              | Initialize PRD for structured ralph execution                    | `/oh-my-claudecode:ralph-init`              |
+| `ralplan`                 | Consensus planning alias for `/omc-plan --consensus`             | `/oh-my-claudecode:ralplan`                 |
+| `release`                 | Automated release workflow                                       | `/oh-my-claudecode:release`                 |
+| `sciomc`                  | Parallel scientist orchestration                                 | `/oh-my-claudecode:sciomc`                  |
+| `skill`                   | Manage local skills (list/add/remove/search/edit)                | `/oh-my-claudecode:skill`                   |
+| `tdd`                     | Test-first workflow enforcement                                  | `/oh-my-claudecode:tdd`                     |
+| `team`                    | Coordinated multi-agent workflow                                 | `/oh-my-claudecode:team`                    |
+| `trace`                   | Show orchestration trace timeline                                | `/oh-my-claudecode:trace`                   |
+| `ultraqa`                 | QA cycle until goal is met                                       | `/oh-my-claudecode:ultraqa`                 |
+| `ultrawork`               | Maximum parallel throughput mode                                 | `/oh-my-claudecode:ultrawork`               |
+| `writer-memory`           | Agentic memory system for writing projects                       | `/oh-my-claudecode:writer-memory`           |
 
-### Enhancement Skills
-
-| Skill | Description | Manual Command |
-|-------|-------------|----------------|
-| `deepinit` | Hierarchical AGENTS.md codebase documentation | `/oh-my-claudecode:deepinit` |
-| `deepsearch` | Thorough multi-strategy codebase search | `/oh-my-claudecode:deepsearch` |
-| `analyze` | Deep analysis and investigation | `/oh-my-claudecode:analyze` |
-| `sciomc` | Parallel scientist orchestration | `/oh-my-claudecode:sciomc` |
-| `frontend-ui-ux` | Designer-turned-developer UI/UX expertise | (silent activation) |
-| `git-master` | Git expert for atomic commits and history | (silent activation) |
-| `tdd` | TDD enforcement: test-first development | `/oh-my-claudecode:tdd` |
-| `learner` | Extract reusable skill from session | `/oh-my-claudecode:learner` |
-| `build-fix` | Fix build and TypeScript errors | `/oh-my-claudecode:build-fix` |
-| `code-review` | Comprehensive code review | `/oh-my-claudecode:code-review` |
-| `security-review` | Security vulnerability detection | `/oh-my-claudecode:security-review` |
-
-### Utility Skills
-
-| Skill | Description | Manual Command |
-|-------|-------------|----------------|
-| `note` | Save notes to compaction-resilient notepad | `/oh-my-claudecode:note` |
-| `cancel` | Unified cancellation for all modes | `/oh-my-claudecode:cancel` |
-| `omc-setup` | One-time setup wizard | `/oh-my-claudecode:omc-setup` |
-| `omc-doctor` | Diagnose and fix installation issues | `/oh-my-claudecode:omc-doctor` |
-| `omc-help` | Show OMC usage guide | `/oh-my-claudecode:omc-help` |
-| `ask-codex` | Ask Codex via `omc ask codex` and store an ask artifact | `/oh-my-claudecode:ask-codex` |
-| `ask-gemini` | Ask Gemini via `omc ask gemini` and store an ask artifact | `/oh-my-claudecode:ask-gemini` |
-| `hud` | Configure HUD statusline | `/oh-my-claudecode:hud` |
-| `release` | Automated release workflow | `/oh-my-claudecode:release` |
-| `mcp-setup` | Configure MCP servers | `/oh-my-claudecode:mcp-setup` |
-| `writer-memory` | Agentic memory system for writers | `/oh-my-claudecode:writer-memory` |
-| `project-session-manager` | Manage isolated dev environments (git worktrees + tmux) | `/oh-my-claudecode:project-session-manager` |
-| `psm` | **Deprecated** compatibility alias for `project-session-manager` | `/oh-my-claudecode:psm` |
-| `skill` | Manage local skills (list, add, remove, search, edit) | `/oh-my-claudecode:skill` |
+`psm` | **Deprecated** compatibility alias for `project-session-manager`
 
 ---
 
@@ -364,36 +359,32 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
 All skills are available as slash commands with the prefix `/oh-my-claudecode:`.
 
-| Command | Description |
-|---------|-------------|
-| `/oh-my-claudecode:orchestrate <task>` | Activate multi-agent orchestration mode |
-| `/oh-my-claudecode:autopilot <task>` | Full autonomous execution |
-| `/oh-my-claudecode:ultrawork <task>` | Maximum performance mode with parallel agents |
-| `/oh-my-claudecode:ultrapilot <task>` | **Deprecated** — redirects to `autopilot` or `team` |
-| `/oh-my-claudecode:team <N>:<agent> <task>` | Coordinated native team workflow |
-| `/oh-my-claudecode:pipeline <stages>` | **Deprecated** — redirects to `autopilot` |
-| `/oh-my-claudecode:ralph-init <task>` | Initialize PRD for structured task tracking |
-| `/oh-my-claudecode:ralph <task>` | Self-referential loop until task completion |
-| `/oh-my-claudecode:ultraqa <goal>` | Autonomous QA cycling workflow |
-| `/oh-my-claudecode:plan <description>` | Start planning session (supports consensus structured deliberation) |
-| `/oh-my-claudecode:ralplan <description>` | Iterative planning with consensus structured deliberation (`--deliberate` for high-risk mode) |
-| `/oh-my-claudecode:deep-interview <idea>` | Socratic interview with ambiguity scoring before execution |
-| `/oh-my-claudecode:review [plan-path]` | Review a plan with critic |
-| `/oh-my-claudecode:deepsearch <query>` | Thorough multi-strategy codebase search |
-| `/oh-my-claudecode:deepinit [path]` | Index codebase with hierarchical AGENTS.md files |
-| `/oh-my-claudecode:analyze <target>` | Deep analysis and investigation |
-| `/oh-my-claudecode:sciomc <topic>` | Parallel research orchestration |
-| `/oh-my-claudecode:tdd <feature>` | TDD workflow enforcement |
-| `/oh-my-claudecode:learner` | Extract reusable skill from session |
-| `/oh-my-claudecode:note <content>` | Save notes to notepad.md |
-| `/oh-my-claudecode:cancel` | Unified cancellation |
-| `/oh-my-claudecode:omc-setup` | One-time setup wizard |
-| `/oh-my-claudecode:omc-doctor` | Diagnose and fix installation issues |
-| `/oh-my-claudecode:omc-help` | Show OMC usage guide |
-| `/oh-my-claudecode:hud` | Configure HUD statusline |
-| `/oh-my-claudecode:release` | Automated release workflow |
-| `/oh-my-claudecode:mcp-setup` | Configure MCP servers |
-| `/oh-my-claudecode:psm <arguments>` | Deprecated alias for project session manager |
+| Command                                     | Description                                                                                   |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `/oh-my-claudecode:autopilot <task>`        | Full autonomous execution                                                                     |
+| `/oh-my-claudecode:ultrawork <task>`        | Maximum performance mode with parallel agents                                                 |
+| `/oh-my-claudecode:team <N>:<agent> <task>` | Coordinated native team workflow                                                              |
+| `/oh-my-claudecode:ralph-init <task>`       | Initialize PRD for structured task tracking                                                   |
+| `/oh-my-claudecode:ralph <task>`            | Self-referential loop until task completion                                                   |
+| `/oh-my-claudecode:ultraqa <goal>`          | Autonomous QA cycling workflow                                                                |
+| `/oh-my-claudecode:omc-plan <description>`  | Start planning session (supports consensus structured deliberation)                           |
+| `/oh-my-claudecode:ralplan <description>`   | Iterative planning with consensus structured deliberation (`--deliberate` for high-risk mode) |
+| `/oh-my-claudecode:deep-interview <idea>`   | Socratic interview with ambiguity scoring before execution                                    |
+| `/oh-my-claudecode:deepinit [path]`         | Index codebase with hierarchical AGENTS.md files                                              |
+| `/oh-my-claudecode:analyze <target>`        | Deep analysis and investigation                                                               |
+| `/oh-my-claudecode:sciomc <topic>`          | Parallel research orchestration                                                               |
+| `/oh-my-claudecode:tdd <feature>`           | TDD workflow enforcement                                                                      |
+| `/oh-my-claudecode:learner`                 | Extract reusable skill from session                                                           |
+| `/oh-my-claudecode:note <content>`          | Save notes to notepad.md                                                                      |
+| `/oh-my-claudecode:cancel`                  | Unified cancellation                                                                          |
+| `/oh-my-claudecode:omc-setup`               | One-time setup wizard                                                                         |
+| `/oh-my-claudecode:omc-doctor`              | Diagnose and fix installation issues                                                          |
+| `/oh-my-claudecode:omc-help`                | Show OMC usage guide                                                                          |
+| `/oh-my-claudecode:hud`                     | Configure HUD statusline                                                                      |
+| `/oh-my-claudecode:release`                 | Automated release workflow                                                                    |
+| `/oh-my-claudecode:mcp-setup`               | Configure MCP servers                                                                         |
+| `/oh-my-claudecode:trace`                   | Show orchestration trace timeline                                                             |
+| `/oh-my-claudecode:psm <arguments>`         | Deprecated alias for project session manager                                                  |
 
 ---
 
@@ -403,47 +394,47 @@ Oh-my-claudecode includes 31 lifecycle hooks that enhance Claude Code's behavior
 
 ### Execution Mode Hooks
 
-| Hook | Description |
-|------|-------------|
-| `autopilot` | Full autonomous execution from idea to working code |
-| `ultrawork` | Maximum parallel agent execution |
-| `ralph` | Persistence until verified complete |
-| `team-pipeline` | Native team staged pipeline orchestration |
-| `ultraqa` | QA cycling until goal met |
-| `mode-registry` | Tracks active execution mode state (including team/ralph/ultrawork/ralplan) |
-| `persistent-mode` | Maintains mode state across sessions |
+| Hook              | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `autopilot`       | Full autonomous execution from idea to working code                         |
+| `ultrawork`       | Maximum parallel agent execution                                            |
+| `ralph`           | Persistence until verified complete                                         |
+| `team-pipeline`   | Native team staged pipeline orchestration                                   |
+| `ultraqa`         | QA cycling until goal met                                                   |
+| `mode-registry`   | Tracks active execution mode state (including team/ralph/ultrawork/ralplan) |
+| `persistent-mode` | Maintains mode state across sessions                                        |
 
 ### Core Hooks
 
-| Hook | Description |
-|------|-------------|
-| `rules-injector` | Dynamic rules injection with YAML frontmatter parsing |
-| `omc-orchestrator` | Enforces orchestrator behavior and delegation |
-| `auto-slash-command` | Automatic slash command detection and execution |
-| `keyword-detector` | Magic keyword detection (ultrawork, ralph, etc.) |
-| `todo-continuation` | Ensures todo list completion |
-| `notepad` | Compaction-resilient memory system |
-| `learner` | Skill extraction from conversations |
+| Hook                 | Description                                           |
+| -------------------- | ----------------------------------------------------- |
+| `rules-injector`     | Dynamic rules injection with YAML frontmatter parsing |
+| `omc-orchestrator`   | Enforces orchestrator behavior and delegation         |
+| `auto-slash-command` | Automatic slash command detection and execution       |
+| `keyword-detector`   | Magic keyword detection (ultrawork, ralph, etc.)      |
+| `todo-continuation`  | Ensures todo list completion                          |
+| `notepad`            | Compaction-resilient memory system                    |
+| `learner`            | Skill extraction from conversations                   |
 
 ### Context & Recovery
 
-| Hook | Description |
-|------|-------------|
-| `recovery` | Edit error, session, and context window recovery |
-| `preemptive-compaction` | Context usage monitoring to prevent limits |
-| `pre-compact` | Pre-compaction processing |
-| `directory-readme-injector` | README context injection |
+| Hook                        | Description                                      |
+| --------------------------- | ------------------------------------------------ |
+| `recovery`                  | Edit error, session, and context window recovery |
+| `preemptive-compaction`     | Context usage monitoring to prevent limits       |
+| `pre-compact`               | Pre-compaction processing                        |
+| `directory-readme-injector` | README context injection                         |
 
 ### Quality & Validation
 
-| Hook | Description |
-|------|-------------|
-| `comment-checker` | BDD detection and directive filtering |
-| `thinking-block-validator` | Extended thinking validation |
-| `empty-message-sanitizer` | Empty message handling |
-| `permission-handler` | Permission requests and validation |
-| `think-mode` | Extended thinking detection |
-| `code-simplifier` | Auto-simplify recently modified files on Stop (opt-in) |
+| Hook                       | Description                                            |
+| -------------------------- | ------------------------------------------------------ |
+| `comment-checker`          | BDD detection and directive filtering                  |
+| `thinking-block-validator` | Extended thinking validation                           |
+| `empty-message-sanitizer`  | Empty message handling                                 |
+| `permission-handler`       | Permission requests and validation                     |
+| `think-mode`               | Extended thinking detection                            |
+| `code-simplifier`          | Auto-simplify recently modified files on Stop (opt-in) |
 
 ### Code Simplifier Hook
 
@@ -452,6 +443,7 @@ The `code-simplifier` Stop hook automatically delegates recently modified source
 explicitly enabled via `~/.omc/config.json`.
 
 **Enable:**
+
 ```json
 {
   "codeSimplifier": {
@@ -461,6 +453,7 @@ explicitly enabled via `~/.omc/config.json`.
 ```
 
 **Full config options:**
+
 ```json
 {
   "codeSimplifier": {
@@ -471,13 +464,14 @@ explicitly enabled via `~/.omc/config.json`.
 }
 ```
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enabled` | `boolean` | `false` | Opt-in to automatic simplification |
-| `extensions` | `string[]` | `[".ts",".tsx",".js",".jsx",".py",".go",".rs"]` | File extensions to consider |
-| `maxFiles` | `number` | `10` | Maximum files simplified per turn |
+| Option       | Type       | Default                                         | Description                        |
+| ------------ | ---------- | ----------------------------------------------- | ---------------------------------- |
+| `enabled`    | `boolean`  | `false`                                         | Opt-in to automatic simplification |
+| `extensions` | `string[]` | `[".ts",".tsx",".js",".jsx",".py",".go",".rs"]` | File extensions to consider        |
+| `maxFiles`   | `number`   | `10`                                            | Maximum files simplified per turn  |
 
 **How it works:**
+
 1. When Claude stops, the hook runs `git diff HEAD --name-only` to find modified files
 2. If modified source files are found, the hook injects a message asking Claude to delegate to the `code-simplifier` agent
 3. The agent simplifies the files for clarity and consistency without changing behavior
@@ -485,36 +479,35 @@ explicitly enabled via `~/.omc/config.json`.
 
 ### Coordination & Environment
 
-| Hook | Description |
-|------|-------------|
-| `subagent-tracker` | Tracks spawned sub-agents |
-| `session-end` | Session termination handling |
-| `non-interactive-env` | CI/non-interactive environment handling |
-| `agent-usage-reminder` | Reminder to use specialized agents |
+| Hook                      | Description                              |
+| ------------------------- | ---------------------------------------- |
+| `subagent-tracker`        | Tracks spawned sub-agents                |
+| `session-end`             | Session termination handling             |
+| `non-interactive-env`     | CI/non-interactive environment handling  |
+| `agent-usage-reminder`    | Reminder to use specialized agents       |
 | `background-notification` | Background task completion notifications |
-| `plugin-patterns` | Plugin pattern detection |
-| `setup` | Initial setup and configuration |
+| `plugin-patterns`         | Plugin pattern detection                 |
+| `setup`                   | Initial setup and configuration          |
 
 ---
 
 ## Magic Keywords
 
-Just include these words anywhere in your prompt to activate enhanced modes:
+Use these trigger phrases in natural language prompts to activate enhanced modes:
 
-| Keyword | Effect |
-|---------|--------|
-| `ultrawork`, `ulw`, `uw` | Activates parallel agent orchestration |
-| `eco`, `efficient`, `save-tokens`, `budget` | Token-efficient parallel execution |
-| `autopilot`, `build me`, `I want a` | Full autonomous execution |
-| `ralph`, `don't stop`, `must complete` | Persistence until verified complete |
-| `plan this`, `plan the` | Planning interview workflow |
-| `ralplan` | Iterative planning consensus with structured deliberation (`--deliberate` for high-risk mode) |
-| `deep interview`, `ouroboros` | Deep Socratic interview with mathematical clarity gating |
-| `search`, `find`, `locate` | Enhanced search mode |
-| `analyze`, `investigate`, `debug` | Deep analysis mode |
-| `sciomc` | Parallel research orchestration |
-| `tdd`, `test first`, `red green` | TDD workflow enforcement |
-| `stop`, `cancel`, `abort` | Unified cancellation |
+| Keyword                                                 | Effect                                                                                        |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `ultrawork`, `ulw`                                      | Activates parallel agent orchestration                                                        |
+| `autopilot`, `build me`, `I want a`                     | Full autonomous execution                                                                     |
+| `ralph`, `don't stop`, `must complete`                  | Persistence until verified complete                                                           |
+| `team`, `coordinated team`                              | Team pipeline orchestration                                                                   |
+| `ralplan`                                               | Iterative planning consensus with structured deliberation (`--deliberate` for high-risk mode) |
+| `deep interview`, `ouroboros`                           | Deep Socratic interview with mathematical clarity gating                                      |
+| `deepsearch`, `search the codebase`, `find in codebase` | Codebase-focused search mode                                                                  |
+| `deepanalyze`, `deep-analyze`                           | Deep analysis mode                                                                            |
+| `ultrathink`                                            | Deep reasoning mode                                                                           |
+| `tdd`, `test first`, `red green`                        | TDD workflow enforcement                                                                      |
+| `cancelomc`, `stopomc`                                  | Unified cancellation                                                                          |
 
 ### Examples
 
@@ -524,32 +517,29 @@ Just include these words anywhere in your prompt to activate enhanced modes:
 # Maximum parallelism
 ultrawork implement user authentication with OAuth
 
-# Token-efficient parallelism
-eco fix all TypeScript errors
-
 # Enhanced search
-find all files that import the utils module
+deepsearch for files that import the utils module
 
 # Deep analysis
-analyze why the tests are failing
+deep-analyze why the tests are failing
 
 # Autonomous execution
 autopilot: build a todo app with React
 
-# Parallel autonomous execution (use team instead of deprecated ultrapilot)
-team 3:deep-executor "build a fullstack todo app"
+# Parallel autonomous execution
+team 3:executor "build a fullstack todo app"
 
 # Persistence mode
 ralph: refactor the authentication module
 
 # Planning session
-plan this feature
+ralplan this feature
 
 # TDD workflow
 tdd: implement password validation
 
-# Coordinated team agents
-team 5:executor fix all lint errors
+# Stop active orchestration
+stopomc
 ```
 
 ---
@@ -558,11 +548,11 @@ team 5:executor fix all lint errors
 
 ### Operating Systems
 
-| Platform | Install Method | Hook Type |
-|----------|---------------|-----------|
+| Platform    | Install Method              | Hook Type      |
+| ----------- | --------------------------- | -------------- |
 | **Windows** | WSL2 recommended (see note) | Node.js (.mjs) |
-| **macOS** | curl or npm | Bash (.sh) |
-| **Linux** | curl or npm | Bash (.sh) |
+| **macOS**   | curl or npm                 | Bash (.sh)     |
+| **Linux**   | curl or npm                 | Bash (.sh)     |
 
 > **Note**: Bash hooks are fully portable across macOS and Linux (no GNU-specific dependencies).
 
@@ -572,44 +562,44 @@ team 5:executor fix all lint errors
 
 ### Available Tools
 
-| Tool | Status | Description |
-|------|--------|-------------|
-| **Read** | ✅ Available | Read files |
-| **Write** | ✅ Available | Create files |
-| **Edit** | ✅ Available | Modify files |
-| **Bash** | ✅ Available | Run shell commands |
-| **Glob** | ✅ Available | Find files by pattern |
-| **Grep** | ✅ Available | Search file contents |
-| **WebSearch** | ✅ Available | Search the web |
-| **WebFetch** | ✅ Available | Fetch web pages |
-| **Task** | ✅ Available | Spawn subagents |
-| **TodoWrite** | ✅ Available | Track tasks |
+| Tool          | Status       | Description           |
+| ------------- | ------------ | --------------------- |
+| **Read**      | ✅ Available | Read files            |
+| **Write**     | ✅ Available | Create files          |
+| **Edit**      | ✅ Available | Modify files          |
+| **Bash**      | ✅ Available | Run shell commands    |
+| **Glob**      | ✅ Available | Find files by pattern |
+| **Grep**      | ✅ Available | Search file contents  |
+| **WebSearch** | ✅ Available | Search the web        |
+| **WebFetch**  | ✅ Available | Fetch web pages       |
+| **Task**      | ✅ Available | Spawn subagents       |
+| **TodoWrite** | ✅ Available | Track tasks           |
 
 ### LSP Tools (Real Implementation)
 
-| Tool | Status | Description |
-|------|--------|-------------|
-| `lsp_hover` | ✅ Implemented | Get type info and documentation at position |
-| `lsp_goto_definition` | ✅ Implemented | Jump to symbol definition |
-| `lsp_find_references` | ✅ Implemented | Find all usages of a symbol |
-| `lsp_document_symbols` | ✅ Implemented | Get file outline (functions, classes, etc.) |
-| `lsp_workspace_symbols` | ✅ Implemented | Search symbols across workspace |
-| `lsp_diagnostics` | ✅ Implemented | Get errors, warnings, hints |
-| `lsp_prepare_rename` | ✅ Implemented | Check if rename is valid |
-| `lsp_rename` | ✅ Implemented | Rename symbol across project |
-| `lsp_code_actions` | ✅ Implemented | Get available refactorings |
-| `lsp_code_action_resolve` | ✅ Implemented | Get details of a code action |
-| `lsp_servers` | ✅ Implemented | List available language servers |
-| `lsp_diagnostics_directory` | ✅ Implemented | Project-level type checking |
+| Tool                        | Status         | Description                                 |
+| --------------------------- | -------------- | ------------------------------------------- |
+| `lsp_hover`                 | ✅ Implemented | Get type info and documentation at position |
+| `lsp_goto_definition`       | ✅ Implemented | Jump to symbol definition                   |
+| `lsp_find_references`       | ✅ Implemented | Find all usages of a symbol                 |
+| `lsp_document_symbols`      | ✅ Implemented | Get file outline (functions, classes, etc.) |
+| `lsp_workspace_symbols`     | ✅ Implemented | Search symbols across workspace             |
+| `lsp_diagnostics`           | ✅ Implemented | Get errors, warnings, hints                 |
+| `lsp_prepare_rename`        | ✅ Implemented | Check if rename is valid                    |
+| `lsp_rename`                | ✅ Implemented | Rename symbol across project                |
+| `lsp_code_actions`          | ✅ Implemented | Get available refactorings                  |
+| `lsp_code_action_resolve`   | ✅ Implemented | Get details of a code action                |
+| `lsp_servers`               | ✅ Implemented | List available language servers             |
+| `lsp_diagnostics_directory` | ✅ Implemented | Project-level type checking                 |
 
 > **Note**: LSP tools require language servers to be installed (typescript-language-server, pylsp, rust-analyzer, gopls, etc.). Use `lsp_servers` to check installation status.
 
 ### AST Tools (ast-grep Integration)
 
-| Tool | Status | Description |
-|------|--------|-------------|
-| `ast_grep_search` | ✅ Implemented | Pattern-based code search using AST matching |
-| `ast_grep_replace` | ✅ Implemented | Pattern-based code transformation |
+| Tool               | Status         | Description                                  |
+| ------------------ | -------------- | -------------------------------------------- |
+| `ast_grep_search`  | ✅ Implemented | Pattern-based code search using AST matching |
+| `ast_grep_replace` | ✅ Implemented | Pattern-based code transformation            |
 
 > **Note**: AST tools use [@ast-grep/napi](https://ast-grep.github.io/) for structural code matching. Supports meta-variables like `$VAR` (single node) and `$$$` (multiple nodes).
 
@@ -623,12 +613,12 @@ For complete documentation, see **[Performance Monitoring Guide](./PERFORMANCE-M
 
 ### Quick Overview
 
-| Feature | Description | Access |
-|---------|-------------|--------|
-| **Agent Observatory** | Real-time agent status, efficiency, bottlenecks | HUD / API |
-| **Token Analytics** | Cost tracking, usage reports, budget warnings | HUD (`analytics` preset), `omc cost` |
-| **Session Replay** | Event timeline for post-session analysis | `.omc/state/agent-replay-*.jsonl` |
-| **Intervention System** | Auto-detection of stale agents, cost overruns | Automatic |
+| Feature                 | Description                                     | Access                               |
+| ----------------------- | ----------------------------------------------- | ------------------------------------ |
+| **Agent Observatory**   | Real-time agent status, efficiency, bottlenecks | HUD / API                            |
+| **Token Analytics**     | Cost tracking, usage reports, budget warnings   | HUD (`analytics` preset), `omc cost` |
+| **Session Replay**      | Event timeline for post-session analysis        | `.omc/state/agent-replay-*.jsonl`    |
+| **Intervention System** | Auto-detection of stale agents, cost overruns   | Automatic                            |
 
 ### CLI Commands
 
@@ -667,6 +657,7 @@ Enable detailed cost tracking in your status line:
 ```
 
 Checks for:
+
 - Missing dependencies
 - Configuration errors
 - Hook installation status
@@ -698,42 +689,43 @@ Configure HUD elements in `~/.claude/settings.json`:
 }
 ```
 
-| Element | Description | Default |
-|---------|-------------|---------|
-| `cwd` | Show current working directory | `false` |
-| `gitRepo` | Show git repository name | `false` |
-| `gitBranch` | Show current git branch | `false` |
-| `omcLabel` | Show [OMC] label | `true` |
-| `contextBar` | Show context window usage | `true` |
-| `agents` | Show active agents count | `true` |
-| `todos` | Show todo progress | `true` |
-| `ralph` | Show ralph loop status | `true` |
-| `autopilot` | Show autopilot status | `true` |
+| Element      | Description                    | Default |
+| ------------ | ------------------------------ | ------- |
+| `cwd`        | Show current working directory | `false` |
+| `gitRepo`    | Show git repository name       | `false` |
+| `gitBranch`  | Show current git branch        | `false` |
+| `omcLabel`   | Show [OMC] label               | `true`  |
+| `contextBar` | Show context window usage      | `true`  |
+| `agents`     | Show active agents count       | `true`  |
+| `todos`      | Show todo progress             | `true`  |
+| `ralph`      | Show ralph loop status         | `true`  |
+| `autopilot`  | Show autopilot status          | `true`  |
 
 Additional `omcHud` layout options (top-level):
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `maxWidth` | Maximum HUD line width (terminal columns) | unset |
-| `wrapMode` | `truncate` (ellipsis) or `wrap` (break at ` \| ` boundaries) when `maxWidth` is set | `truncate` |
+| Option     | Description                                                                       | Default    |
+| ---------- | --------------------------------------------------------------------------------- | ---------- |
+| `maxWidth` | Maximum HUD line width (terminal columns)                                         | unset      |
+| `wrapMode` | `truncate` (ellipsis) or `wrap` (break at `\|` boundaries) when `maxWidth` is set | `truncate` |
 
 Available presets: `minimal`, `focused`, `full`, `dense`, `analytics`, `opencode`
 
 ### Common Issues
 
-| Issue | Solution |
-|-------|----------|
-| Commands not found | Re-run `/oh-my-claudecode:omc-setup` |
-| Hooks not executing | Check hook permissions: `chmod +x ~/.claude/hooks/**/*.sh` |
+| Issue                 | Solution                                                                         |
+| --------------------- | -------------------------------------------------------------------------------- |
+| Commands not found    | Re-run `/oh-my-claudecode:omc-setup`                                             |
+| Hooks not executing   | Check hook permissions: `chmod +x ~/.claude/hooks/**/*.sh`                       |
 | Agents not delegating | Verify CLAUDE.md is loaded: check `./.claude/CLAUDE.md` or `~/.claude/CLAUDE.md` |
-| LSP tools not working | Install language servers: `npm install -g typescript-language-server` |
-| Token limit errors | Use `/oh-my-claudecode:` for token-efficient execution |
+| LSP tools not working | Install language servers: `npm install -g typescript-language-server`            |
+| Token limit errors    | Use `/oh-my-claudecode:` for token-efficient execution                           |
 
 ### Auto-Update
 
 Oh-my-claudecode includes a silent auto-update system that checks for updates in the background.
 
 Features:
+
 - **Rate-limited**: Checks at most once every 24 hours
 - **Concurrent-safe**: Lock file prevents simultaneous update attempts
 - **Cross-platform**: Works on both macOS and Linux

--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -1,44 +1,44 @@
 ---
 name: ccg
-description: Claude-Codex-Gemini tri-model orchestration - fans out backend tasks to Codex and frontend/UI tasks to Gemini in parallel, then Claude synthesizes results
+description: Claude-Codex-Gemini tri-model orchestration via ask-codex + ask-gemini, then Claude synthesizes results
 ---
 
 # CCG - Claude-Codex-Gemini Tri-Model Orchestration
 
-CCG spawns a tmux team with Codex and Gemini CLI workers running in parallel panes, then Claude synthesizes the results. Use this for tasks that benefit from multiple AI perspectives simultaneously.
+CCG routes through `ask-codex` and `ask-gemini` (CLI advisor flow), then Claude synthesizes both outputs into one answer.
+
+Use this when you want parallel external perspectives without launching tmux team workers.
 
 ## When to Use
 
-- Backend/analysis + frontend/UI work that can run truly in parallel
-- Code review from multiple perspectives (architecture + style simultaneously)
-- Research tasks where different models have complementary strengths
-- Any task you want to split across Codex (analytical) and Gemini (design/creative) workers
+- Backend/analysis + frontend/UI work in one request
+- Code review from multiple perspectives (architecture + design/UX)
+- Cross-validation where Codex and Gemini may disagree
+- Fast advisor-style parallel input without team runtime orchestration
 
 ## Requirements
 
 - **Codex CLI**: `npm install -g @openai/codex` (or `@openai/codex`)
 - **Gemini CLI**: `npm install -g @google/gemini-cli`
-- **tmux**: Must be running inside a tmux session
-- If either CLI is unavailable, CCG falls back to Claude-only execution
+- `omc ask` command available
+- If either CLI is unavailable, continue with whichever provider is available and note the limitation
 
 ## How It Works
 
-```
-1. Claude decomposes the request into:
-   - Backend/analytical tasks → Codex worker
-   - Frontend/UI/design tasks → Gemini worker
+```text
+1. Claude decomposes the request into two advisor prompts:
+   - Codex prompt (analysis/architecture/backend)
+   - Gemini prompt (UX/design/docs/alternatives)
 
-2. `omc team start` creates a tmux session with 2 workers:
-   omc-team-{name}
-   ├── Leader pane (Claude orchestrates)
-   ├── Worker pane 1: codex CLI (analytical tasks)
-   └── Worker pane 2: gemini CLI (design tasks)
+2. Claude runs:
+   - /oh-my-claudecode:ask-codex "<codex prompt>"
+   - /oh-my-claudecode:ask-gemini "<gemini prompt>"
 
-3. Workers read tasks from inbox files and write done.json on completion
+   (equivalent CLI path: `omc ask codex ...` + `omc ask gemini ...`)
 
-4. `omc team wait` blocks until all workers finish
+3. Artifacts are written under `.omc/artifacts/ask/`
 
-5. Claude reads taskResults and synthesizes into final output
+4. Claude synthesizes both outputs into one final response
 ```
 
 ## Execution Protocol
@@ -46,72 +46,65 @@ CCG spawns a tmux team with Codex and Gemini CLI workers running in parallel pan
 When invoked, Claude MUST follow this workflow:
 
 ### 1. Decompose Request
-Split the user's request into:
-- **Codex tasks**: code analysis, architecture review, backend logic, security review, test strategy
-- **Gemini tasks**: UI/UX design, documentation, visual analysis, large-context file review
-- **Synthesis task**: Claude combines results (always done by Claude, not delegated)
+Split the user request into:
 
-Choose a short `teamName` slug (e.g., `ccg-auth-review`).
+- **Codex prompt:** architecture, correctness, backend, risks, test strategy
+- **Gemini prompt:** UX/content clarity, alternatives, edge-case usability, docs polish
+- **Synthesis plan:** how to reconcile conflicts
 
-### 2. Start the team (non-blocking)
+### 2. Invoke ask skills
 
-Run `omc team start` — spawns workers in the background and returns a `jobId` immediately:
+Use skill routing first:
 
-```
-omc team start --name "ccg-{slug}" --agent codex --count 1 --cwd "{cwd}" --task "Codex task: ..."
-omc team start --name "ccg-{slug}" --agent gemini --count 1 --cwd "{cwd}" --task "Gemini task: ..."
-```
-
-Returns: `{ "jobId": "omc-...", "pid": 12345, "message": "Team started in background..." }`
-
-### 3. Wait for completion
-
-Run `omc team wait <job_id>` — blocks internally until done:
-
-```
-omc team wait "{jobId}"
+```bash
+/oh-my-claudecode:ask-codex <codex prompt>
+/oh-my-claudecode:ask-gemini <gemini prompt>
 ```
 
-> **Timeout guidance:** `timeout_ms` is optional; the default wait timeout is fine.
-> If wait times out, workers/panes keep running. Call `omc team wait <job_id>` again to keep
-> waiting. Use `omc team cleanup <job_id>` only for explicit cancel intent.
+Equivalent direct CLI:
 
-Returns when done:
-```json
-{
-  "status": "completed|failed",
-  "result": {
-    "taskResults": [
-      {"taskId": "1", "status": "completed", "summary": "..."},
-      {"taskId": "2", "status": "completed", "summary": "..."}
-    ]
-  }
-}
+```bash
+omc ask codex "<codex prompt>"
+omc ask gemini "<gemini prompt>"
 ```
 
-### 4. Synthesize Results
+### 3. Collect artifacts
 
-Parse `result.taskResults` and synthesize Codex + Gemini outputs into a unified response for the user.
+Read latest ask artifacts from:
 
-## Fallback (CLIs Not Available)
-
-CLI availability is checked by the MCP runtime automatically. If a CLI is not installed, the worker exits with `command not found`. In that case, fall back to Claude Task agents:
-
-```
-[CCG] Codex/Gemini CLI not found. Falling back to Claude-only execution.
+```text
+.omc/artifacts/ask/codex-*.md
+.omc/artifacts/ask/gemini-*.md
 ```
 
-Use standard Claude Task agents instead:
-- `Task(subagent_type="oh-my-claudecode:executor", model="sonnet", ...)` for analytical tasks
-- `Task(subagent_type="oh-my-claudecode:designer", model="sonnet", ...)` for design tasks
+### 4. Synthesize
+
+Return one unified answer with:
+
+- Agreed recommendations
+- Conflicting recommendations (explicitly called out)
+- Chosen final direction + rationale
+- Action checklist
+
+## Fallbacks
+
+If one provider is unavailable:
+
+- Continue with available provider + Claude synthesis
+- Clearly note missing perspective and risk
+
+If both unavailable:
+
+- Fall back to Claude-only answer and state CCG external advisors were unavailable
 
 ## Invocation
 
-```
-/oh-my-claudecode:ccg [task description]
+```bash
+/oh-my-claudecode:ccg <task description>
 ```
 
 Example:
-```
-/oh-my-claudecode:ccg Review this PR - check architecture and code quality (Codex) and UI components (Gemini)
+
+```bash
+/oh-my-claudecode:ccg Review this PR - architecture/security via Codex and UX/readability via Gemini
 ```

--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -6,11 +6,13 @@ aliases: []
 
 # OMC Teams Skill
 
-Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Supports `claude`, `codex`, and `gemini` agent types. Unlike `/team` (which uses Claude Code's native `TeamCreate`/`Task` tools), this skill uses the tmux runtime to launch actual CLI processes in visible tmux panes.
+Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Supports `claude`, `codex`, and `gemini` agent types.
+
+`/omc-teams` is a legacy compatibility skill for the CLI-first runtime: use `omc team ...` commands (not deprecated MCP runtime tools).
 
 ## Usage
 
-```
+```bash
 /oh-my-claudecode:omc-teams N:claude "task description"
 /oh-my-claudecode:omc-teams N:codex "task description"
 /oh-my-claudecode:omc-teams N:gemini "task description"
@@ -28,151 +30,97 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 /omc-teams 2:claude "implement auth module with tests"
 /omc-teams 2:codex "review the auth module for security issues"
 /omc-teams 3:gemini "redesign UI components for accessibility"
-/omc-teams 1:codex "write comprehensive tests for src/api/"
 ```
 
 ## Requirements
 
 - **tmux** must be running (`$TMUX` set in the current shell)
-- **claude** CLI: `npm install -g @anthropic-ai/claude-code` (for claude workers)
-- **codex** CLI: `npm install -g @openai/codex` (for codex workers)
-- **gemini** CLI: `npm install -g @google/gemini-cli` (for gemini workers)
-
-## How It Works
-
-1. Claude decomposes the task into N independent subtasks (one per worker)
-2. Calls `mcp__team__omc_run_team_start` then `mcp__team__omc_run_team_wait`
-3. The OMC MCP server spawns `runtime-cli.cjs` (co-located in the same install directory)
-4. The runtime creates tmux split-panes and launches the CLI processes
-5. Each worker reads its task from an inbox file and completes via CLI API lifecycle transitions (claim-task, transition-task-status) when OMC_RUNTIME_V2=1 is set, or writes `done.json` in legacy mode
-6. The runtime collects results, shuts down workers, returns structured JSON
-7. Claude parses the result and reports to the user
-
----
+- **claude** CLI: `npm install -g @anthropic-ai/claude-code`
+- **codex** CLI: `npm install -g @openai/codex`
+- **gemini** CLI: `npm install -g @google/gemini-cli`
 
 ## Workflow
 
 ### Phase 1: Parse input
 
-Extract from the user command:
-- `N` — number of workers (integer, 1–10)
-- `agent-type` — must be `claude`, `codex`, or `gemini`; reject anything else with an error
-- `task` — the task description
+Extract:
+
+- `N` — worker count (1–10)
+- `agent-type` — `claude|codex|gemini`
+- `task` — task description
 
 ### Phase 2: Decompose task
 
-Break the task into exactly N subtasks. Each subtask must be:
-- **Independent** — no conflicting writes between workers
-- **Scoped** — operates on a distinct subset of files or concerns
-- **Self-contained** — completable without inter-worker coordination
+Break work into N independent subtasks (file- or concern-scoped) to avoid write conflicts.
 
-Choose a `teamName` slug from the task (e.g., `auth-security-review`).
+### Phase 3: Start CLI team runtime
 
-### Phase 3: Activate team state & start the team
+Activate mode state (recommended):
 
-**CRITICAL: Activate team state BEFORE calling MCP tools.** This prevents the session from
-stopping prematurely after MCP tool calls return. The persistent-mode Stop hook checks
-`team-state.json` to know whether to block the stop or allow it.
-
-```
+```text
 state_write(mode="team", current_phase="team-exec", active=true)
 ```
 
-Then call `mcp__team__omc_run_team_start` — it spawns workers in the background and returns a
-`jobId` immediately. No Bash, no path resolution; the MCP server finds `runtime-cli.cjs`
-from its own install directory automatically.
+Start workers via CLI:
 
-```
-mcp__team__omc_run_team_start({
-  "teamName": "{teamName}",
-  "agentTypes": ["{agentType}", "{agentType}", ...],
-  "tasks": [
-    {"subject": "Subtask 1 title", "description": "Full description..."},
-    {"subject": "Subtask 2 title", "description": "Full description..."}
-  ],
-  "cwd": "{cwd}"
-})
+```bash
+omc team <N>:<claude|codex|gemini> "<task>"
 ```
 
-Returns: `{ "jobId": "omc-...", "pid": 12345, "message": "Team started in background..." }`
+Team name defaults to a slug from the task text (example: `review-auth-flow`).
 
-### Phase 4: Wait for completion, then report
+### Phase 4: Monitor + lifecycle API
 
-Call `mcp__team__omc_run_team_wait` — a single blocking call that polls internally
-(500ms → 2000ms exponential backoff) and returns only when the job reaches a terminal
-state. No repeated polling needed; one call instead of N.
-
-```
-mcp__team__omc_run_team_wait({
-  "job_id": "{jobId}",
-  "timeout_ms": 60000
-})
+```bash
+omc team status <team-name>
+omc team api list-tasks --input '{"team_name":"<team-name>"}' --json
 ```
 
-> **Timeout guidance:** `timeout_ms` is optional; the default wait timeout is fine.
-> If a wait call times out, **workers are left running** — wait timeout does NOT kill
-> worker processes or panes. You have two options:
-> - Call `omc_run_team_wait` again with the same `job_id` to keep waiting (workers continue)
-> - Call `omc_run_team_cleanup` only when you explicitly want to cancel and stop panes
->
-> Teams can silently stall due to stuck workers or tmux session issues. Use
-> `mcp__team__omc_run_team_status` to inspect live progress before deciding to cancel.
+Use `omc team api ...` for task claiming, task transitions, mailbox delivery, and worker state updates.
 
-Returns when done:
-```json
-{
-  "jobId": "omc-...",
-  "status": "completed|failed",
-  "elapsedSeconds": "95.3",
-  "result": {
-    "status": "completed",
-    "teamName": "...",
-    "taskResults": [
-      {"taskId": "1", "status": "completed", "summary": "Done: added 12 tests"},
-      {"taskId": "2", "status": "failed", "summary": "Worker exited early"}
-    ],
-    "duration": 95.1,
-    "workerCount": 2
-  }
-}
+### Phase 5: Shutdown (only when needed)
+
+```bash
+omc team shutdown <team-name>
+omc team shutdown <team-name> --force
 ```
 
-> **Why no deadlock?** `omc_run_team_wait` uses `async/await` with `setTimeout`,
-> which yields the Node.js event loop between polls. The `child.on('close', ...)`
-> callback that updates job status fires during those yields. The background
-> `runtime-cli.cjs` child process is completely independent — it never calls back
-> into this MCP server.
->
-> If you need non-blocking checks (e.g. to do other work while waiting), use
-> `mcp__team__omc_run_team_status` instead.
+Use shutdown for intentional cancellation or stale-state cleanup. Prefer non-force shutdown first.
 
-Report results to the user. For `failed` or wait-timeout errors, explain what happened and suggest next steps (reduce scope, check CLI installation, verify tmux is running).
+### Phase 6: Report + state close
 
-Update OMC state:
-```
-state_write(mode="team", current_phase="completed", active=false)
+Report task results with completion/failure summary and any remaining risks.
+
+```text
+state_write(mode="team", current_phase="complete", active=false)
 ```
 
----
+## Deprecated Runtime Note
+
+Legacy MCP runtime tools are deprecated for execution:
+
+- `omc_run_team_start`
+- `omc_run_team_status`
+- `omc_run_team_wait`
+- `omc_run_team_cleanup`
+
+If encountered, switch to `omc team ...` CLI commands.
 
 ## Error Reference
 
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `not inside tmux` | Shell not running inside a tmux session | Start tmux and rerun |
-| `codex: command not found` | Codex CLI not installed | `npm install -g @openai/codex` |
-| `gemini: command not found` | Gemini CLI not installed | `npm install -g @google/gemini-cli` |
-| wait timeout error | `omc_run_team_wait` hit `timeout_ms` before completion | Call `omc_run_team_wait` again to keep waiting, or call `omc_run_team_cleanup` to explicitly stop worker panes |
-| `status: failed` | All workers exited with work remaining | Check stderr for crash details |
-
----
+| Error                        | Cause                               | Fix                                                                                 |
+| ---------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `not inside tmux`            | Shell not running inside tmux       | Start tmux and rerun                                                                |
+| `codex: command not found`   | Codex CLI not installed             | `npm install -g @openai/codex`                                                      |
+| `gemini: command not found`  | Gemini CLI not installed            | `npm install -g @google/gemini-cli`                                                 |
+| `Team <name> is not running` | stale or missing runtime state      | `omc team status <team-name>` then `omc team shutdown <team-name> --force` if stale |
+| `status: failed`             | Workers exited with incomplete work | inspect runtime output, narrow scope, rerun                                         |
 
 ## Relationship to `/team`
 
-| Aspect | `/team` | `/omc-teams` |
-|--------|---------|-------------|
-| Worker type | Claude Code agents (`Task(subagent_type=...)`) | claude / codex / gemini CLI processes |
-| Invocation | `TeamCreate` / `SendMessage` / `TeamDelete` | `mcp__team__omc_run_team_start` + `omc_run_team_wait` |
-| Coordination | Native Claude Code team messaging | tmux panes + inbox files + CLI API lifecycle (v2) or done.json sentinels (v1) |
-| Communication | Native Claude Code team messaging | File-based inbox + CLI API interop (v2) or inbox.md + done.json (v1) |
-| Use when | You want Claude agents with full tool access | You want CLI autonomy (codex/gemini) at scale |
+| Aspect       | `/team`                                   | `/omc-teams`                                         |
+| ------------ | ----------------------------------------- | ---------------------------------------------------- |
+| Worker type  | Claude Code native team agents            | claude / codex / gemini CLI processes in tmux        |
+| Invocation   | `TeamCreate` / `Task` / `SendMessage`     | `omc team [N:agent]` + `status` + `shutdown` + `api` |
+| Coordination | Native team messaging and staged pipeline | tmux worker runtime + CLI API state files            |
+| Use when     | You want Claude-native team orchestration | You want external CLI worker execution               |


### PR DESCRIPTION
## Summary
- align user/docs guidance with current `omc team` CLI surface (`omc team N:agent`, `status`, `shutdown`, `api`)
- clarify `omc ask` provider matrix as `claude|codex|gemini`
- rewrite `skills/ccg/SKILL.md` to route via `/oh-my-claudecode:ask-codex` + `/oh-my-claudecode:ask-gemini` and synthesize outputs
- update `skills/omc-teams/SKILL.md` as a legacy compatibility wrapper over CLI-first `omc team ...`
- sync related docs (`README.md`, `docs/CLAUDE.md`, `docs/MIGRATION.md`, `docs/REFERENCE.md`)

## Why
Recent runtime/docs drift left old examples (`omc team start/wait/job_id`) in guidance, and CCG behavior needed to reflect ask-based routing instead of tmux worker orchestration.

## Files changed
- README.md
- docs/CLAUDE.md
- docs/MIGRATION.md
- docs/REFERENCE.md
- skills/ccg/SKILL.md
- skills/omc-teams/SKILL.md

## Verification
- compared docs against current CLI help surface:
  - `node bridge/cli.cjs team --help`
- grep checks for stale team-runtime syntax in updated docs/skills

## Notes
- this PR is docs/skills only
- repository currently has unrelated unstaged local changes outside this commit; they are intentionally excluded
