### PR TITLE
fix(team): use --approval-mode yolo -i for gemini worker launch

### DIFF
--- a/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
+++ b/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
@@ -11,8 +11,10 @@ describe('mcp-team-bridge spawn args', () => {
     expect(source).toContain('"--skip-git-repo-check"');
   });
 
-  it('keeps Gemini bridge spawn args with --yolo', () => {
-    expect(source).toContain('"--yolo"');
+  it('keeps Gemini bridge spawn args with --approval-mode yolo -i', () => {
+    expect(source).toContain('"--approval-mode"');
+    expect(source).toContain('"yolo"');
+    expect(source).toContain('"-i"');
     expect(source).toMatch(/cmd = "gemini";/);
   });
 });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -113,9 +113,11 @@ describe('model-contract', () => {
       expect(args).not.toContain('--full-auto');
       expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
     });
-    it('gemini includes --yolo', () => {
+    it('gemini includes --approval-mode yolo -i', () => {
       const args = buildLaunchArgs('gemini', { teamName: 't', workerName: 'w', cwd: '/tmp' });
-      expect(args).toContain('--yolo');
+      expect(args).toContain('--approval-mode');
+      expect(args).toContain('yolo');
+      expect(args).toContain('-i');
     });
     it('passes model flag when specified', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'gpt-4' });

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -527,7 +527,7 @@ function spawnCliProcess(
     ];
   } else {
     cmd = "gemini";
-    args = ["--yolo"];
+    args = ["--approval-mode", "yolo", "-i"];
     if (model) args.push("--model", model);
   }
 

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -200,7 +200,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     supportsPromptMode: true,
     promptModeFlag: '-p',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
-      const args = ['--yolo'];
+      const args = ['--approval-mode', 'yolo', '-i'];
       if (model) args.push('--model', model);
       return [...args, ...extraFlags];
     },


### PR DESCRIPTION
## Summary
- Gemini team workers in omc-teams are interactive, so the launch command should use `gemini --approval-mode yolo -i <prompt>` instead of `gemini --yolo <prompt>`
- Updated both the model-contract (runtime path) and mcp-team-bridge (bridge path)
- Updated corresponding tests to assert the new flags

## Changes
- `src/team/model-contract.ts`: `['--yolo']` → `['--approval-mode', 'yolo', '-i']`
- `src/team/mcp-team-bridge.ts`: same change for bridge spawn path
- `src/team/__tests__/model-contract.test.ts`: updated assertion
- `src/team/__tests__/mcp-team-bridge.spawn-args.test.ts`: updated assertion

## Test plan
- [x] `model-contract.test.ts` — 28 tests pass
- [x] `mcp-team-bridge.spawn-args.test.ts` — 2 tests pass
- [x] `runtime-prompt-mode.test.ts` — 16 tests pass (validates end-to-end spawn flow)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)