### PR TITLE
fix(team): remove -i flag from gemini worker launch args

### DIFF
--- a/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
+++ b/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
@@ -11,10 +11,10 @@ describe('mcp-team-bridge spawn args', () => {
     expect(source).toContain('"--skip-git-repo-check"');
   });
 
-  it('keeps Gemini bridge spawn args with --approval-mode yolo -i', () => {
+  it('keeps Gemini bridge spawn args with --approval-mode yolo', () => {
     expect(source).toContain('"--approval-mode"');
     expect(source).toContain('"yolo"');
-    expect(source).toContain('"-i"');
+    expect(source).not.toContain('"-i"');
     expect(source).toMatch(/cmd = "gemini";/);
   });
 });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -113,11 +113,11 @@ describe('model-contract', () => {
       expect(args).not.toContain('--full-auto');
       expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
     });
-    it('gemini includes --approval-mode yolo -i', () => {
+    it('gemini includes --approval-mode yolo', () => {
       const args = buildLaunchArgs('gemini', { teamName: 't', workerName: 'w', cwd: '/tmp' });
       expect(args).toContain('--approval-mode');
       expect(args).toContain('yolo');
-      expect(args).toContain('-i');
+      expect(args).not.toContain('-i');
     });
     it('passes model flag when specified', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'gpt-4' });

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -527,7 +527,7 @@ function spawnCliProcess(
     ];
   } else {
     cmd = "gemini";
-    args = ["--approval-mode", "yolo", "-i"];
+    args = ["--approval-mode", "yolo"];
     if (model) args.push("--model", model);
   }
 

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -200,7 +200,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     supportsPromptMode: true,
     promptModeFlag: '-p',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
-      const args = ['--approval-mode', 'yolo', '-i'];
+      const args = ['--approval-mode', 'yolo'];
       if (model) args.push('--model', model);
       return [...args, ...extraFlags];
     },


### PR DESCRIPTION
## Summary
Fixes #1360

Gemini CLI's `-i` (`--prompt-interactive`) requires a **string argument** — passing it without one causes the next argument (`--model`) to be consumed as the prompt, breaking model selection.

The MCP team bridge writes prompts via **stdin pipe**, so the `-i` flag is not needed.

## Changes
- `src/team/model-contract.ts`: `['--approval-mode', 'yolo', '-i']` → `['--approval-mode', 'yolo']`
- `src/team/mcp-team-bridge.ts`: same change
- Updated test assertions in both test files

## Test plan
- [x] `npx vitest run` — 283 files, 5972 tests all passing