### PR TITLE
fix(team): use gemini -i flag instead of -p for interactive mode

### DIFF
--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -216,7 +216,7 @@ describe('model-contract', () => {
       expect(isPromptModeAgent('gemini')).toBe(true);
       const c = getContract('gemini');
       expect(c.supportsPromptMode).toBe(true);
-      expect(c.promptModeFlag).toBe('-p');
+      expect(c.promptModeFlag).toBe('-i');
     });
 
     it('claude does not support prompt mode', () => {
@@ -232,7 +232,7 @@ describe('model-contract', () => {
 
     it('getPromptModeArgs returns flag + instruction for gemini', () => {
       const args = getPromptModeArgs('gemini', 'Read inbox');
-      expect(args).toEqual(['-p', 'Read inbox']);
+      expect(args).toEqual(['-i', 'Read inbox']);
     });
 
     it('getPromptModeArgs returns instruction only (positional) for codex', () => {

--- a/src/team/__tests__/runtime-prompt-mode.test.ts
+++ b/src/team/__tests__/runtime-prompt-mode.test.ts
@@ -7,8 +7,8 @@ import { tmpdir } from 'os';
  * Tests for Gemini prompt-mode (headless) spawn flow.
  *
  * Gemini CLI v0.29.7+ uses an Ink-based TUI that does not receive keystrokes
- * via tmux send-keys. The fix passes the initial instruction via the `-p` flag
- * (prompt mode) so the TUI is bypassed entirely. Trust-confirm and send-keys
+ * via tmux send-keys. The fix passes the initial instruction via the `-i` flag
+ * (interactive mode) so the TUI is bypassed entirely. Trust-confirm and send-keys
  * notification are skipped for prompt-mode agents.
  *
  * See: https://github.com/anthropics/claude-code/issues/1000
@@ -117,7 +117,7 @@ describe('spawnWorkerForTask – prompt mode (Gemini & Codex)', () => {
     setupTaskDir(cwd);
   });
 
-  it('gemini worker launch args include -p flag with inbox path', async () => {
+  it('gemini worker launch args include -i flag with inbox path', async () => {
     const runtime = makeRuntime(cwd, 'gemini');
 
     await spawnWorkerForTask(runtime, 'worker-1', 0);
@@ -129,8 +129,8 @@ describe('spawnWorkerForTask – prompt mode (Gemini & Codex)', () => {
     expect(launchCall).toBeDefined();
     const launchCmd = launchCall![launchCall!.length - 1];
 
-    // Should contain -p flag for prompt mode
-    expect(launchCmd).toContain("'-p'");
+    // Should contain -i flag for interactive mode
+    expect(launchCmd).toContain("'-i'");
     // Should contain the inbox path reference
     expect(launchCmd).toContain('.omc/state/team/test-team/workers/worker-1/inbox.md');
 
@@ -180,8 +180,8 @@ describe('spawnWorkerForTask – prompt mode (Gemini & Codex)', () => {
     expect(launchCall).toBeDefined();
     const launchCmd = launchCall![launchCall!.length - 1];
 
-    // Should NOT contain -p flag (codex uses positional argument, not a flag)
-    expect(launchCmd).not.toContain("'-p'");
+    // Should NOT contain -i flag (codex uses positional argument, not a flag)
+    expect(launchCmd).not.toContain("'-i'");
     // Should contain the inbox path as a positional argument
     expect(launchCmd).toContain('.omc/state/team/test-team/workers/worker-1/inbox.md');
 

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -12,7 +12,7 @@ export interface CliAgentContract {
   parseOutput(rawOutput: string): string;
   /** Whether this agent supports a prompt/headless mode that bypasses TUI input */
   supportsPromptMode?: boolean;
-  /** CLI flag for prompt mode (e.g., '-p' for gemini) */
+  /** CLI flag for prompt mode (e.g., '-i' for gemini) */
   promptModeFlag?: string;
 }
 
@@ -198,7 +198,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     binary: 'gemini',
     installInstructions: 'Install Gemini CLI: npm install -g @google/gemini-cli',
     supportsPromptMode: true,
-    promptModeFlag: '-p',
+    promptModeFlag: '-i',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
       const args = ['--approval-mode', 'yolo'];
       if (model) args.push('--model', model);
@@ -330,7 +330,7 @@ export function getPromptModeArgs(agentType: CliAgentType, instruction: string):
   if (!contract.supportsPromptMode) {
     return [];
   }
-  // If a flag is defined (e.g. gemini's '-p'), prepend it; otherwise the
+  // If a flag is defined (e.g. gemini's '-i'), prepend it; otherwise the
   // instruction is passed as a positional argument (e.g. codex [PROMPT]).
   if (contract.promptModeFlag) {
     return [contract.promptModeFlag, instruction];


### PR DESCRIPTION
## Summary
- Changed gemini worker `promptModeFlag` from `-p` (non-interactive print mode) to `-i` (interactive mode)
- The previous PR #1362 removed `-i` from `buildLaunchArgs` but didn't address the `promptModeFlag` still using `-p`
- Updated all related tests and comments

## Test plan
- [x] `model-contract.test.ts` — 28 tests pass
- [x] `runtime-prompt-mode.test.ts` — 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)