### PR TITLE
fix(team): support fish shell in worker pane launch commands

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -227,6 +227,15 @@ describe('buildWorkerStartCommand', () => {
     expect(cmd).toContain('exec $argv');
     expect(cmd).not.toContain('exec "$@"');
     expect(cmd).toContain("'--' 'codex' '--full-auto'");
+    // Fish uses separate -l -c flags (not combined -lc)
+    expect(cmd).toContain("'-l' '-c'");
+    expect(cmd).not.toContain("'-lc'");
+    // Fish sources ~/.config/fish/config.fish, not ~/.fishrc
+    expect(cmd).toContain('.config/fish/config.fish');
+    expect(cmd).not.toContain('.fishrc');
+    // Fish uses test/and syntax, not [ ] && .
+    expect(cmd).toContain('test -f');
+    expect(cmd).toContain('; and source');
   });
 
   it('rejects relative launchBinary containing spaces', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -149,17 +149,36 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
     });
 
     const shellName = shellNameFromPath(shell) || 'bash';
-    const execArgsCommand = shellName === 'fish' ? 'exec $argv' : 'exec "$@"';
-    const rcFile = process.env.HOME ? `${process.env.HOME}/.${shellName}rc` : '';
-    const script = shouldSourceRc && rcFile
-      ? `[ -f ${shellEscape(rcFile)} ] && . ${shellEscape(rcFile)}; ${execArgsCommand}`
-      : execArgsCommand;
+    const isFish = shellName === 'fish';
+    const execArgsCommand = isFish ? 'exec $argv' : 'exec "$@"';
+
+    let rcFile = '';
+    if (process.env.HOME) {
+      rcFile = isFish
+        ? `${process.env.HOME}/.config/fish/config.fish`
+        : `${process.env.HOME}/.${shellName}rc`;
+    }
+
+    let script: string;
+    if (isFish) {
+      // Fish uses different syntax for conditionals and sourcing
+      script = shouldSourceRc && rcFile
+        ? `test -f ${shellEscape(rcFile)}; and source ${shellEscape(rcFile)}; ${execArgsCommand}`
+        : execArgsCommand;
+    } else {
+      script = shouldSourceRc && rcFile
+        ? `[ -f ${shellEscape(rcFile)} ] && . ${shellEscape(rcFile)}; ${execArgsCommand}`
+        : execArgsCommand;
+    }
+
+    // Fish doesn't support combined -lc; use separate -l -c flags
+    const shellFlags = isFish ? ['-l', '-c'] : ['-lc'];
 
     return [
       'env',
       ...envAssignments,
       shell,
-      '-lc',
+      ...shellFlags,
       script,
       '--',
       ...launchWords,
@@ -174,9 +193,21 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
     .join(' ');
 
   const shellName = shellNameFromPath(shell) || 'bash';
-  const rcFile = process.env.HOME ? `${process.env.HOME}/.${shellName}rc` : '';
-  // Quote rcFile to prevent shell injection if HOME contains metacharacters
-  const sourceCmd = shouldSourceRc && rcFile ? `[ -f "${rcFile}" ] && source "${rcFile}"; ` : '';
+  const isFish = shellName === 'fish';
+
+  let rcFile = '';
+  if (process.env.HOME) {
+    rcFile = isFish
+      ? `${process.env.HOME}/.config/fish/config.fish`
+      : `${process.env.HOME}/.${shellName}rc`;
+  }
+
+  let sourceCmd = '';
+  if (shouldSourceRc && rcFile) {
+    sourceCmd = isFish
+      ? `test -f "${rcFile}"; and source "${rcFile}"; `
+      : `[ -f "${rcFile}" ] && source "${rcFile}"; `;
+  }
 
   return `env ${envString} ${shell} -c "${sourceCmd}exec ${launchWords[0]}"`;
 }


### PR DESCRIPTION
## Summary

`buildWorkerStartCommand` generates POSIX shell syntax that breaks when the user's `$SHELL` is fish. This PR fixes three issues:

- **Combined `-lc` flag** — fish requires separate `-l` `-c` flags
- **Wrong RC file path** — was using `~/.fishrc`, fish uses `~/.config/fish/config.fish`
- **POSIX conditional syntax** — `[ -f ... ] && . ...` is invalid in fish; replaced with `test -f ...; and source ...`

Both the `launchBinary` and legacy `launchCmd` code paths are fixed.

## Changes

- `src/team/tmux-session.ts`: Detect fish shell and generate compatible syntax for rc sourcing, flag separation, and rc file path
- `src/team/__tests__/tmux-session.test.ts`: Added assertions for fish-specific behavior (separate flags, correct rc path, fish conditional syntax)

## Test plan

- [x] All 30 existing `tmux-session.test.ts` tests pass
- [x] Fish shell test now validates `-l` `-c` separation, `.config/fish/config.fish` path, and `test -f; and source` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)