### PR TITLE
fix(hud): prevent usage API thundering herd

### DIFF
--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for render.ts rate limits display priority.
+ *
+ * When both error and rateLimits data exist (e.g., 429 with stale data),
+ * data should be displayed instead of error indicator.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock git-related modules to avoid filesystem access during render
+vi.mock('../../hud/elements/git.js', () => ({
+  renderGitRepo: () => null,
+  renderGitBranch: () => null,
+}));
+
+vi.mock('../../hud/elements/cwd.js', () => ({
+  renderCwd: () => null,
+}));
+
+import { render } from '../../hud/render.js';
+import type { HudRenderContext, HudConfig } from '../../hud/types.js';
+import { DEFAULT_HUD_CONFIG } from '../../hud/types.js';
+
+function makeContext(overrides: Partial<HudRenderContext> = {}): HudRenderContext {
+  return {
+    contextPercent: 50,
+    modelName: 'opus',
+    ralph: null,
+    ultrawork: null,
+    prd: null,
+    autopilot: null,
+    activeAgents: [],
+    todos: [],
+    backgroundTasks: [],
+    cwd: '/tmp/test',
+    lastSkill: null,
+    rateLimitsResult: null,
+    customBuckets: null,
+    pendingPermission: null,
+    thinkingState: null,
+    sessionHealth: null,
+    omcVersion: '4.7.0',
+    updateAvailable: null,
+    toolCallCount: 0,
+    agentCallCount: 0,
+    skillCallCount: 0,
+    promptTime: null,
+    apiKeySource: null,
+    profileName: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<HudConfig> = {}): HudConfig {
+  return {
+    ...DEFAULT_HUD_CONFIG,
+    elements: {
+      ...DEFAULT_HUD_CONFIG.elements,
+      rateLimits: true,
+      omcLabel: false,
+      contextBar: false,
+      agents: false,
+      backgroundTasks: false,
+      todos: false,
+      activeSkills: false,
+      lastSkill: false,
+      sessionHealth: false,
+      promptTime: false,
+      showCallCounts: false,
+    },
+    ...overrides,
+  };
+}
+
+describe('render: rate limits display priority', () => {
+  it('shows data when error=rate_limited but rateLimits data exists', async () => {
+    const context = makeContext({
+      rateLimitsResult: {
+        rateLimits: { fiveHourPercent: 45, weeklyPercent: 20 },
+        error: 'rate_limited',
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    // Should show percentage data, NOT [API 429]
+    expect(output).toContain('45%');
+    expect(output).not.toContain('[API 429]');
+  });
+
+  it('shows [API 429] when error=rate_limited and rateLimits is null', async () => {
+    const context = makeContext({
+      rateLimitsResult: {
+        rateLimits: null,
+        error: 'rate_limited',
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).toContain('[API 429]');
+  });
+
+  it('shows [API err] when error=network and rateLimits is null', async () => {
+    const context = makeContext({
+      rateLimitsResult: {
+        rateLimits: null,
+        error: 'network',
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).toContain('[API err]');
+  });
+
+  it('shows [API auth] when error=auth and rateLimits is null', async () => {
+    const context = makeContext({
+      rateLimitsResult: {
+        rateLimits: null,
+        error: 'auth',
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).toContain('[API auth]');
+  });
+
+  it('shows data normally when no error', async () => {
+    const context = makeContext({
+      rateLimitsResult: {
+        rateLimits: { fiveHourPercent: 30, weeklyPercent: 10 },
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).toContain('30%');
+    expect(output).not.toContain('[API');
+  });
+
+  it('shows nothing when error=no_credentials', async () => {
+    const context = makeContext({
+      rateLimitsResult: {
+        rateLimits: null,
+        error: 'no_credentials',
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).not.toContain('[API');
+    expect(output).not.toContain('%');
+  });
+});

--- a/src/__tests__/hud/usage-api-lock.test.ts
+++ b/src/__tests__/hud/usage-api-lock.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for usage-api file lock (thundering herd prevention).
+ *
+ * When multiple sessions share the same cache file, only one session
+ * should fetch from the API at a time. Others should return stale cache.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Use vi.hoisted() so mock fns are available in vi.mock() factories
+const {
+  mockWithFileLock,
+  mockLockPathFor,
+  mockExistsSync,
+  mockReadFileSync,
+  mockWriteFileSync,
+  mockMkdirSync,
+  mockHttpsRequest,
+} = vi.hoisted(() => ({
+  mockWithFileLock: vi.fn(),
+  mockLockPathFor: vi.fn((p: string) => p + '.lock'),
+  mockExistsSync: vi.fn().mockReturnValue(false),
+  mockReadFileSync: vi.fn().mockReturnValue('{}'),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockHttpsRequest: vi.fn(),
+}));
+
+vi.mock('../../lib/file-lock.js', () => ({
+  withFileLock: mockWithFileLock,
+  lockPathFor: mockLockPathFor,
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+    readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+    writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+    mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+    renameSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    lstatSync: vi.fn(),
+  };
+});
+
+vi.mock('../../utils/paths.js', () => ({
+  getClaudeConfigDir: () => '/tmp/test-claude',
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn().mockImplementation(() => { throw new Error('mock: no keychain'); }),
+}));
+
+vi.mock('https', () => ({
+  default: {
+    request: (...args: unknown[]) => mockHttpsRequest(...args),
+  },
+}));
+
+vi.mock('../../utils/ssrf-guard.js', () => ({
+  validateAnthropicBaseUrl: () => ({ allowed: true }),
+}));
+
+import { getUsage } from '../../hud/usage-api.js';
+
+describe('getUsage with file lock (thundering herd prevention)', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    // Default: withFileLock executes the callback (lock acquired successfully)
+    mockWithFileLock.mockImplementation((_path: string, fn: () => unknown) => fn());
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('does not attempt lock when cache is valid', async () => {
+    // Set up valid cache
+    const validCache = JSON.stringify({
+      timestamp: Date.now(),
+      data: { fiveHourPercent: 50, weeklyPercent: 30 },
+      source: 'anthropic',
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(validCache);
+
+    const result = await getUsage();
+    // Should return cached data without acquiring lock
+    expect(mockWithFileLock).not.toHaveBeenCalled();
+    expect(result.rateLimits).not.toBeNull();
+  });
+
+  it('acquires lock before API call when cache is expired', async () => {
+    // Set up expired cache
+    const expiredCache = JSON.stringify({
+      timestamp: Date.now() - 60_000, // 60 seconds ago (TTL is 30s)
+      data: { fiveHourPercent: 50, weeklyPercent: 30 },
+      source: 'anthropic',
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(expiredCache);
+
+    await getUsage();
+
+    // Should have attempted to acquire lock via withFileLock
+    expect(mockWithFileLock).toHaveBeenCalled();
+  });
+
+  it('returns stale cache without error when lock not acquired and stale data exists', async () => {
+    // Set up expired cache with data
+    const staleCache = JSON.stringify({
+      timestamp: Date.now() - 60_000,
+      data: { fiveHourPercent: 42, weeklyPercent: 20 },
+      source: 'anthropic',
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(staleCache);
+
+    // withFileLock throws when lock acquisition fails
+    mockWithFileLock.mockRejectedValue(new Error('Failed to acquire file lock'));
+
+    const result = await getUsage();
+
+    // Should return stale data WITHOUT error
+    expect(result.rateLimits).not.toBeNull();
+    expect(result.rateLimits!.fiveHourPercent).toBe(42);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns error when lock not acquired and no stale data', async () => {
+    // No cache at all
+    mockExistsSync.mockReturnValue(false);
+    mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+
+    // Lock acquisition fails
+    mockWithFileLock.mockRejectedValue(new Error('Failed to acquire file lock'));
+
+    const result = await getUsage();
+
+    // No stale data → should return error
+    expect(result.rateLimits).toBeNull();
+    expect(result.error).toBeDefined();
+  });
+
+  it('withFileLock guarantees lock release via its finally block', async () => {
+    // Expired cache
+    const expiredCache = JSON.stringify({
+      timestamp: Date.now() - 60_000,
+      data: null,
+      source: 'anthropic',
+      error: true,
+      errorReason: 'no_credentials',
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(expiredCache);
+
+    await getUsage();
+
+    // withFileLock was called (it internally handles acquire/release)
+    expect(mockWithFileLock).toHaveBeenCalledTimes(1);
+    // Verify the lock path is derived from cache path
+    expect(mockLockPathFor).toHaveBeenCalled();
+  });
+
+  it('passes staleLockMs option of API_TIMEOUT + 5s', async () => {
+    // Expired cache
+    const expiredCache = JSON.stringify({
+      timestamp: Date.now() - 60_000,
+      data: null,
+      source: 'anthropic',
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(expiredCache);
+
+    await getUsage();
+
+    // Verify lock options include staleLockMs = 15000 (10s timeout + 5s)
+    if (mockWithFileLock.mock.calls.length > 0) {
+      const opts = mockWithFileLock.mock.calls[0][2];
+      expect(opts?.staleLockMs).toBe(15000);
+    }
+  });
+
+  it('handles API errors gracefully while holding lock', async () => {
+    // Set up z.ai env to trigger API path
+    process.env.ANTHROPIC_BASE_URL = 'https://api.z.ai/v1';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
+
+    // Expired cache
+    const expiredCache = JSON.stringify({
+      timestamp: Date.now() - 60_000,
+      data: null,
+      source: 'zai',
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(expiredCache);
+
+    // withFileLock executes callback; API call inside will fail
+    mockWithFileLock.mockImplementation((_path: string, fn: () => unknown) => fn());
+
+    // Mock https.request to simulate error
+    mockHttpsRequest.mockImplementation((_opts: unknown, _cb: unknown) => {
+      return {
+        on: (event: string, cb: (err?: Error) => void) => {
+          if (event === 'error') setTimeout(() => cb(new Error('network')), 0);
+          return { on: vi.fn().mockReturnThis(), end: vi.fn() };
+        },
+        end: vi.fn(),
+      };
+    });
+
+    // Should not throw — errors handled inside withFileLock callback
+    const result = await getUsage();
+    expect(result).toBeDefined();
+  });
+});

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -5,6 +5,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { isZaiHost, parseZaiResponse, getUsage } from '../../hud/usage-api.js';
 
+// Mock file-lock so withFileLock always executes the callback (tests focus on routing, not locking)
+vi.mock('../../lib/file-lock.js', () => ({
+  withFileLock: vi.fn((_lockPath: string, fn: () => unknown) => fn()),
+  lockPathFor: vi.fn((p: string) => p + '.lock'),
+}));
+
 // Mock dependencies that touch filesystem / keychain / network
 vi.mock('../../utils/paths.js', () => ({
   getClaudeConfigDir: () => '/tmp/test-claude',

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -238,16 +238,18 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
     }
   }
 
-  // Rate limits (5h and weekly) - show error indicator or data
+  // Rate limits (5h and weekly) - data takes priority over error indicator
   if (enabledElements.rateLimits && context.rateLimitsResult) {
-    const errorIndicator = renderRateLimitsError(context.rateLimitsResult);
-    if (errorIndicator) {
-      elements.push(errorIndicator);
-    } else if (context.rateLimitsResult.rateLimits) {
+    if (context.rateLimitsResult.rateLimits) {
+      // Data available (possibly stale from 429) → always show data
       const limits = enabledElements.useBars
         ? renderRateLimitsWithBar(context.rateLimitsResult.rateLimits)
         : renderRateLimits(context.rateLimitsResult.rateLimits);
       if (limits) elements.push(limits);
+    } else {
+      // No data → show error indicator
+      const errorIndicator = renderRateLimitsError(context.rateLimitsResult);
+      if (errorIndicator) elements.push(errorIndicator);
     }
   }
 

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -19,6 +19,7 @@ import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 import https from 'https';
 import { validateAnthropicBaseUrl } from '../utils/ssrf-guard.js';
+import { withFileLock, lockPathFor } from '../lib/file-lock.js';
 import type { RateLimits, UsageResult, UsageErrorReason } from './types.js';
 
 // Cache configuration
@@ -27,6 +28,7 @@ const CACHE_TTL_FAILURE_MS = 15 * 1000; // 15 seconds for failures
 const CACHE_TTL_RATE_LIMITED_MS = 120 * 1000; // 2 minutes base for 429
 const MAX_RATE_LIMITED_BACKOFF_MS = 600 * 1000; // 10 minutes max
 const API_TIMEOUT_MS = 10000;
+const LOCK_STALE_MS = API_TIMEOUT_MS + 5000; // 15s: API timeout + margin
 const TOKEN_REFRESH_URL_HOSTNAME = 'platform.claude.com';
 const TOKEN_REFRESH_URL_PATH = '/v1/oauth/token';
 
@@ -655,6 +657,39 @@ export async function getUsage(): Promise<UsageResult> {
     return { rateLimits: cache.data, error: cachedError };
   }
 
+  // Cache expired → try to acquire lock (thundering herd prevention)
+  // Only one session fetches at a time; others return stale cache.
+  // Deliberately no timeoutMs: fail immediately and serve stale cache
+  // rather than blocking HUD render.
+  try {
+    return await withFileLock(
+      lockPathFor(getCachePath()),
+      () => fetchUsageWithLock(isZai, authToken),
+      { staleLockMs: LOCK_STALE_MS },
+    );
+  } catch (err) {
+    // Only fall back to stale cache for lock contention
+    if (err instanceof Error && err.message.startsWith('Failed to acquire file lock')) {
+      if (cache?.data) {
+        return { rateLimits: cache.data };
+      }
+      return { rateLimits: null, error: 'network' };
+    }
+    // Callback threw unexpectedly — report as network error
+    return { rateLimits: null, error: 'network' };
+  }
+}
+
+/**
+ * Perform the actual API fetch (called while holding the file lock).
+ * Re-reads cache under lock to get fresh rateLimitedCount for accurate backoff.
+ */
+async function fetchUsageWithLock(
+  isZai: boolean,
+  authToken: string | undefined,
+): Promise<UsageResult> {
+  // Re-read cache under lock for accurate rateLimitedCount/stale data
+  const cache = readCache();
   // z.ai path (must precede OAuth check to avoid stale Anthropic credentials)
   if (isZai && authToken) {
     const result = await fetchUsageFromZai();


### PR DESCRIPTION
## Summary
- prevent multi-session HUD usage polling from stampeding the shared usage API
- return stale cache for lock losers instead of surfacing spurious 429/error states
- render stale rate-limit data ahead of `[API 429]` when data is available

## Testing
- npx vitest run src/__tests__/hud/usage-api.test.ts src/__tests__/hud/usage-api-lock.test.ts src/__tests__/hud/render-rate-limits-priority.test.ts src/__tests__/hud/limits-error.test.ts src/__tests__/hud/rate-limits-error.test.ts
- npm run build

Closes #1398