### PR TITLE
fix: prevent Rust debug env from bloating Codex ask artifacts

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -74,10 +74,23 @@ function parseArgs(argv) {
   return { provider, prompt: rest.join(' ').trim() };
 }
 
-function ensureBinary(binary) {
+const CODEX_STRIPPED_ENV_VARS = new Set(['RUST_LOG', 'RUST_BACKTRACE', 'RUST_LIB_BACKTRACE']);
+
+function buildProviderEnv(provider, env = process.env) {
+  if (provider !== 'codex') {
+    return env;
+  }
+
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !CODEX_STRIPPED_ENV_VARS.has(key)),
+  );
+}
+
+function ensureBinary(provider, binary) {
   const probe = spawnSync(binary, ['--version'], {
     stdio: 'ignore',
     encoding: 'utf8',
+    env: buildProviderEnv(provider),
   });
 
   if (probe.error && probe.error.code === 'ENOENT') {
@@ -182,12 +195,13 @@ async function main() {
   const { provider, prompt } = parseArgs(process.argv.slice(2));
   const binary = PROVIDER_BINARIES[provider];
 
-  ensureBinary(binary);
+  ensureBinary(provider, binary);
 
   const providerArgs = buildProviderArgs(provider, prompt);
   const run = spawnSync(binary, providerArgs, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
+    env: buildProviderEnv(provider),
   });
 
   const stdout = run.stdout || '';

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -119,6 +119,31 @@ function writeFakeProviderBinary(dir: string, provider: 'claude' | 'gemini'): st
   return binDir;
 }
 
+
+function writeFakeCodexBinary(dir: string): string {
+  const binDir = join(dir, 'bin');
+  mkdirSync(binDir, { recursive: true });
+  const binPath = join(binDir, 'codex');
+  writeFileSync(
+    binPath,
+    `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "fake"; exit 0; fi
+if [ "$1" = "exec" ]; then
+  echo "CODEX_OK"
+  if [ -n "\${RUST_LOG:-}" ] || [ -n "\${RUST_BACKTRACE:-}" ]; then
+    echo "RUST_LEAK:\${RUST_LOG:-}:\${RUST_BACKTRACE:-}" 1>&2
+  fi
+  exit 0
+fi
+echo "unexpected" 1>&2
+exit 9
+`,
+    'utf8',
+  );
+  chmodSync(binPath, 0o755);
+  return binDir;
+}
+
 function writeFakeOmcBinary(dir: string): string {
   const binDir = join(dir, 'bin');
   mkdirSync(binDir, { recursive: true });
@@ -285,6 +310,34 @@ describe('run-provider-advisor script contract', () => {
       const artifactPath = result.stdout.trim();
       const artifact = readFileSync(artifactPath, 'utf8');
       expect(artifact).toContain('## Original task\n\nlegacy original task');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('sanitizes Rust env vars for codex so artifacts do not capture Rust stderr logs', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-rust-env-'));
+    try {
+      const binDir = writeFakeCodexBinary(wd);
+      const result = runAdvisorScript(
+        ['codex', '--prompt', 'keep artifact small'],
+        wd,
+        {
+          PATH: `${binDir}:${process.env.PATH || ''}`,
+          RUST_LOG: 'trace',
+          RUST_BACKTRACE: '1',
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+
+      const artifactPath = result.stdout.trim();
+      const artifact = readFileSync(artifactPath, 'utf8');
+      expect(artifact).toContain('CODEX_OK');
+      expect(artifact).not.toContain('RUST_LEAK');
+      expect(artifact).not.toContain('trace');
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- strip Rust debug env vars before launching `codex` from `run-provider-advisor.js`
- keep the change scoped to the Codex advisor path for issue #1412
- add a regression test proving Codex artifacts stay free of leaked Rust stderr when `RUST_LOG`/`RUST_BACKTRACE` are set

## Testing
- npx vitest run src/cli/__tests__/ask.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json
- node --check scripts/run-provider-advisor.js
- manual shell repro with fake `codex` + `RUST_LOG=trace`/`RUST_BACKTRACE=1`

Fixes #1412