### PR TITLE
fix: steer external literature lookup to document-specialist

### DIFF
--- a/agents/document-specialist.md
+++ b/agents/document-specialist.md
@@ -8,7 +8,7 @@ disallowedTools: Write, Edit
 <Agent_Prompt>
   <Role>
     You are Document Specialist. Your mission is to find and synthesize information from external sources: official docs, GitHub repos, package registries, and technical references.
-    You are responsible for external documentation lookup, API reference research, package evaluation, version compatibility checks, and source synthesis.
+    You are responsible for external documentation lookup, API reference research, package evaluation, version compatibility checks, source synthesis, and external literature/paper/reference-database research.
     You are not responsible for internal codebase search (use explore agent), code implementation, code review, or architecture decisions.
   </Role>
 
@@ -27,6 +27,7 @@ disallowedTools: Write, Edit
 
   <Constraints>
     - Search EXTERNAL resources only. For internal codebase, use explore agent.
+    - Treat academic papers, literature reviews, manuals, standards, external databases, and reference sites as your responsibility when the information is outside the current repository.
     - Always cite sources with URLs. An answer without a URL is unverifiable.
     - Prefer official documentation over third-party sources.
     - Evaluate source freshness: flag information older than 2 years or from deprecated docs.
@@ -35,7 +36,7 @@ disallowedTools: Write, Edit
 
   <Investigation_Protocol>
     1) Clarify what specific information is needed.
-    2) Identify the best sources: official docs first, then GitHub, then package registries, then community.
+    2) Identify the best sources: official docs first, then standards/manuals/reference databases, then GitHub, then package registries, then community.
     3) Search with WebSearch, fetch details with WebFetch when needed.
     4) Evaluate source quality: is it official? Current? For the right version?
     5) Synthesize findings with source citations.
@@ -43,7 +44,7 @@ disallowedTools: Write, Edit
   </Investigation_Protocol>
 
   <Tool_Usage>
-    - Use WebSearch for finding official documentation and references.
+    - Use WebSearch for finding official documentation, papers, manuals, and reference databases.
     - Use WebFetch for extracting details from specific documentation pages.
     - Use Read to examine local files if context is needed to formulate better queries.
   </Tool_Usage>

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -9,7 +9,7 @@ disallowedTools: Write, Edit
   <Role>
     You are Explorer. Your mission is to find files, code patterns, and relationships in the codebase and return actionable results.
     You are responsible for answering "where is X?", "which files contain Y?", and "how does Z connect to W?" questions.
-    You are not responsible for modifying code, implementing features, or making architectural decisions.
+    You are not responsible for modifying code, implementing features, architectural decisions, or external documentation/literature/reference search.
   </Role>
 
   <Why_This_Matters>
@@ -29,6 +29,7 @@ disallowedTools: Write, Edit
     - Never use relative paths.
     - Never store results in files; return them as message text.
     - For finding all usages of a symbol, escalate to explore-high which has lsp_find_references.
+    - If the request is about external docs, academic papers, literature reviews, manuals, package references, or database/reference lookups outside this repository, route to document-specialist instead.
   </Constraints>
 
   <Investigation_Protocol>
@@ -93,6 +94,7 @@ disallowedTools: Write, Edit
   <Failure_Modes_To_Avoid>
     - Single search: Running one query and returning. Always launch parallel searches from different angles.
     - Literal-only answers: Answering "where is auth?" with a file list but not explaining the auth flow. Address the underlying need.
+    - External research drift: Treating literature searches, paper lookups, official docs, or reference/manual/database research as codebase exploration. Those belong to document-specialist.
     - Relative paths: Any path not starting with / is a failure. Always use absolute paths.
     - Tunnel vision: Searching only one naming convention. Try camelCase, snake_case, PascalCase, and acronyms.
     - Unbounded exploration: Spending 10 rounds on diminishing returns. Cap depth and report what you found.

--- a/src/__tests__/agent-boundary-guidance.test.ts
+++ b/src/__tests__/agent-boundary-guidance.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { exploreAgent, EXPLORE_PROMPT_METADATA } from '../agents/explore.js';
+import {
+  documentSpecialistAgent,
+  DOCUMENT_SPECIALIST_PROMPT_METADATA,
+} from '../agents/document-specialist.js';
+
+describe('agent guidance boundary for external research', () => {
+  it('steers external literature and reference lookups away from explore', () => {
+    expect(exploreAgent.description).toMatch(/document-specialist/i);
+    expect(exploreAgent.description).toMatch(/literature|papers?|reference databases?/i);
+
+    expect(EXPLORE_PROMPT_METADATA.avoidWhen).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/external documentation, literature, or academic paper lookup/i),
+        expect.stringMatching(/database\/reference\/manual lookups outside the current project/i),
+      ]),
+    );
+
+    expect(exploreAgent.prompt).toMatch(/external documentation\/literature\/reference search/i);
+    expect(exploreAgent.prompt).toMatch(/academic papers, literature reviews, manuals, package references, or database\/reference lookups outside this repository/i);
+  });
+
+  it('steers external literature and reference research to document-specialist', () => {
+    expect(documentSpecialistAgent.description).toMatch(/literature, academic papers, and reference\/database lookups/i);
+
+    expect(DOCUMENT_SPECIALIST_PROMPT_METADATA.triggers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          domain: 'Literature and reference research',
+        }),
+      ]),
+    );
+
+    expect(DOCUMENT_SPECIALIST_PROMPT_METADATA.useWhen).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/external literature or academic papers/i),
+        expect.stringMatching(/manuals, databases, or reference material outside the current project/i),
+      ]),
+    );
+
+    expect(documentSpecialistAgent.prompt).toMatch(/external literature\/paper\/reference-database research/i);
+    expect(documentSpecialistAgent.prompt).toMatch(/academic papers, literature reviews, manuals, standards, external databases, and reference sites/i);
+  });
+});

--- a/src/agents/document-specialist.ts
+++ b/src/agents/document-specialist.ts
@@ -18,6 +18,7 @@ export const DOCUMENT_SPECIALIST_PROMPT_METADATA: AgentPromptMetadata = {
     { domain: 'External documentation', trigger: 'API references, official docs' },
     { domain: 'OSS implementations', trigger: 'GitHub examples, package source' },
     { domain: 'Best practices', trigger: 'Community patterns, recommendations' },
+    { domain: 'Literature and reference research', trigger: 'Academic papers, manuals, reference databases' },
   ],
   useWhen: [
     'Looking up official documentation',
@@ -25,6 +26,8 @@ export const DOCUMENT_SPECIALIST_PROMPT_METADATA: AgentPromptMetadata = {
     'Researching npm/pip packages',
     'Stack Overflow solutions',
     'External API references',
+    'Searching external literature or academic papers',
+    'Looking up manuals, databases, or reference material outside the current project',
   ],
   avoidWhen: [
     'Internal codebase search (use explore)',
@@ -36,7 +39,7 @@ export const DOCUMENT_SPECIALIST_PROMPT_METADATA: AgentPromptMetadata = {
 
 export const documentSpecialistAgent: AgentConfig = {
   name: 'document-specialist',
-  description: 'Document Specialist for documentation research and external reference finding. Use for official docs, GitHub examples, OSS implementations, API references. Searches EXTERNAL resources, not internal codebase.',
+  description: 'Document Specialist for documentation research and external reference finding. Use for official docs, GitHub examples, OSS implementations, API references, external literature, academic papers, and reference/database lookups. Searches EXTERNAL resources, not internal codebase.',
   prompt: loadAgentPrompt('document-specialist'),
   model: 'sonnet',
   defaultModel: 'sonnet',

--- a/src/agents/explore.ts
+++ b/src/agents/explore.ts
@@ -27,7 +27,8 @@ export const EXPLORE_PROMPT_METADATA: AgentPromptMetadata = {
     'Quick codebase exploration',
   ],
   avoidWhen: [
-    'External documentation lookup (use document-specialist)',
+    'External documentation, literature, or academic paper lookup (use document-specialist)',
+    'Database/reference/manual lookups outside the current project (use document-specialist)',
     'GitHub/npm package research (use document-specialist)',
     'Complex architectural analysis (use architect)',
     'When you already know the file location',
@@ -36,7 +37,7 @@ export const EXPLORE_PROMPT_METADATA: AgentPromptMetadata = {
 
 export const exploreAgent: AgentConfig = {
   name: 'explore',
-  description: 'Fast codebase exploration and pattern search. Use for finding files, understanding structure, locating implementations. Searches INTERNAL codebase.',
+  description: 'Fast codebase exploration and pattern search. Use for finding files, understanding structure, locating implementations. Searches INTERNAL codebase only; external docs, literature, papers, and reference databases belong to document-specialist.',
   prompt: loadAgentPrompt('explore'),
   model: 'haiku',
   defaultModel: 'haiku',


### PR DESCRIPTION
## Summary
- clarify the shipped explore/document-specialist boundary for external literature, docs, papers, and reference/database lookups
- expand document-specialist metadata/prompt ownership for external research tasks
- add regression coverage locking the boundary guidance

## Testing
- npx vitest run src/__tests__/agent-boundary-guidance.test.ts src/__tests__/delegation-enforcer.test.ts src/__tests__/consolidation-contracts.test.ts src/__tests__/agent-registry.test.ts
- npx vitest run src/features/delegation-routing/__tests__/resolver.test.ts

Fixes #1411