### PR TITLE
fix(team): parse comma-separated multi-type worker specs

### DIFF
--- a/src/cli/commands/__tests__/team.test.ts
+++ b/src/cli/commands/__tests__/team.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { teamCommand } from '../team.js';
+import { teamCommand, parseTeamArgs } from '../team.js';
 
 /** Helper: capture console.log output during a callback */
 async function captureLog(fn: () => Promise<void>): Promise<string[]> {
@@ -186,5 +186,62 @@ describe('teamCommand api operations', () => {
       process.env.OMC_TEAM_WORKER = previousWorker;
       process.exitCode = 0;
     }
+  });
+});
+
+describe('parseTeamArgs comma-separated multi-type specs', () => {
+  it('parses 1:codex,1:gemini into heterogeneous agentTypes', () => {
+    const parsed = parseTeamArgs(['1:codex,1:gemini', 'do the task']);
+    expect(parsed.workerCount).toBe(2);
+    expect(parsed.agentTypes).toEqual(['codex', 'gemini']);
+    expect(parsed.task).toBe('do the task');
+  });
+
+  it('parses 2:claude,1:codex:architect with mixed counts and roles', () => {
+    const parsed = parseTeamArgs(['2:claude,1:codex:architect', 'design system']);
+    expect(parsed.workerCount).toBe(3);
+    expect(parsed.agentTypes).toEqual(['claude', 'claude', 'codex']);
+    expect(parsed.role).toBeUndefined(); // mixed roles -> no single role
+    expect(parsed.task).toBe('design system');
+  });
+
+  it('sets role when all segments share the same role', () => {
+    const parsed = parseTeamArgs(['1:codex:executor,2:gemini:executor', 'run tasks']);
+    expect(parsed.workerCount).toBe(3);
+    expect(parsed.agentTypes).toEqual(['codex', 'gemini', 'gemini']);
+    expect(parsed.role).toBe('executor');
+  });
+
+  it('still parses single-type spec 3:codex into uniform agentTypes', () => {
+    const parsed = parseTeamArgs(['3:codex', 'fix tests']);
+    expect(parsed.workerCount).toBe(3);
+    expect(parsed.agentTypes).toEqual(['codex', 'codex', 'codex']);
+    expect(parsed.task).toBe('fix tests');
+  });
+
+  it('defaults to 3 claude workers when no spec is given', () => {
+    const parsed = parseTeamArgs(['run all tests']);
+    expect(parsed.workerCount).toBe(3);
+    expect(parsed.agentTypes).toEqual(['claude', 'claude', 'claude']);
+    expect(parsed.task).toBe('run all tests');
+  });
+
+  it('parses single spec with role correctly', () => {
+    const parsed = parseTeamArgs(['2:codex:architect', 'design auth']);
+    expect(parsed.workerCount).toBe(2);
+    expect(parsed.agentTypes).toEqual(['codex', 'codex']);
+    expect(parsed.role).toBe('architect');
+  });
+
+  it('supports --json flag with comma-separated specs', () => {
+    const parsed = parseTeamArgs(['1:codex,1:gemini', '--json', 'compare']);
+    expect(parsed.workerCount).toBe(2);
+    expect(parsed.agentTypes).toEqual(['codex', 'gemini']);
+    expect(parsed.json).toBe(true);
+    expect(parsed.task).toBe('compare');
+  });
+
+  it('throws on total count exceeding maximum', () => {
+    expect(() => parseTeamArgs(['15:codex,10:gemini', 'big task'])).toThrow('exceeds maximum');
   });
 });

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -30,6 +30,7 @@ Examples:
   omc team 3:claude "fix failing tests"
   omc team 2:codex:architect "design auth system"
   omc team 1:gemini:executor "implement feature"
+  omc team 1:codex,1:gemini "compare approaches"
   omc team status fix-failing-tests
   omc team shutdown fix-failing-tests
   omc team api send-message --input '{"team_name":"my-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json
@@ -113,9 +114,9 @@ function slugifyTask(task: string): string {
     .slice(0, 30) || 'team-task';
 }
 
-interface ParsedTeamArgs {
+export interface ParsedTeamArgs {
   workerCount: number;
-  agentType: string;
+  agentTypes: string[];
   role?: string;
   task: string;
   teamName: string;
@@ -138,10 +139,14 @@ function assertTeamSpawnAllowed(env: NodeJS.ProcessEnv = process.env): void {
   );
 }
 
-function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
+/** Regex for a single worker spec segment: N[:type[:role]] */
+const SINGLE_SPEC_RE = /^(\d+)(?::([a-z][a-z0-9-]*)(?::([a-z][a-z0-9-]*))?)?$/i;
+
+/** @internal Exported for testing */
+export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   const args = [...tokens];
   let workerCount = 3;
-  let agentType = 'claude';
+  let agentTypes: string[] = [];
   let json = false;
 
   // Extract --json flag before parsing positional args
@@ -155,17 +160,65 @@ function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   }
 
   const first = filteredArgs[0] || '';
-  const match = first.match(/^(\d+)(?::([a-z][a-z0-9-]*)(?::([a-z][a-z0-9-]*))?)?$/i);
+
+  // Try comma-separated multi-type spec first (e.g. "1:codex,1:gemini" or "2:claude,1:codex:architect")
   let role: string | undefined;
-  if (match) {
-    const count = Number.parseInt(match[1], 10);
-    if (!Number.isFinite(count) || count < MIN_WORKER_COUNT || count > MAX_WORKER_COUNT) {
-      throw new Error(`Invalid worker count "${match[1]}". Expected ${MIN_WORKER_COUNT}-${MAX_WORKER_COUNT}.`);
+  let specMatched = false;
+
+  if (first.includes(',')) {
+    const segments = first.split(',');
+    const parsedSegments: Array<{ count: number; type: string; role?: string }> = [];
+    let allValid = true;
+
+    for (const seg of segments) {
+      const m = seg.match(SINGLE_SPEC_RE);
+      if (!m) { allValid = false; break; }
+      const count = Number.parseInt(m[1], 10);
+      if (!Number.isFinite(count) || count < MIN_WORKER_COUNT || count > MAX_WORKER_COUNT) {
+        throw new Error(`Invalid worker count "${m[1]}". Expected ${MIN_WORKER_COUNT}-${MAX_WORKER_COUNT}.`);
+      }
+      parsedSegments.push({ count, type: m[2] || 'claude', role: m[3] });
     }
-    workerCount = count;
-    if (match[2]) agentType = match[2];
-    if (match[3]) role = match[3];
-    filteredArgs.shift();
+
+    if (allValid && parsedSegments.length > 0) {
+      workerCount = 0;
+      for (const seg of parsedSegments) {
+        workerCount += seg.count;
+        for (let i = 0; i < seg.count; i++) {
+          agentTypes.push(seg.type);
+        }
+      }
+      if (workerCount > MAX_WORKER_COUNT) {
+        throw new Error(`Total worker count ${workerCount} exceeds maximum ${MAX_WORKER_COUNT}.`);
+      }
+      // If every segment specifies the same role, use it; otherwise leave undefined
+      const roles = parsedSegments.map(s => s.role);
+      const uniqueRoles = [...new Set(roles)];
+      if (uniqueRoles.length === 1 && uniqueRoles[0]) role = uniqueRoles[0];
+      specMatched = true;
+      filteredArgs.shift();
+    }
+  }
+
+  // Fall back to single spec (e.g. "3:codex" or "2:codex:architect")
+  if (!specMatched) {
+    const match = first.match(SINGLE_SPEC_RE);
+    if (match) {
+      const count = Number.parseInt(match[1], 10);
+      if (!Number.isFinite(count) || count < MIN_WORKER_COUNT || count > MAX_WORKER_COUNT) {
+        throw new Error(`Invalid worker count "${match[1]}". Expected ${MIN_WORKER_COUNT}-${MAX_WORKER_COUNT}.`);
+      }
+      workerCount = count;
+      const type = match[2] || 'claude';
+      if (match[3]) role = match[3];
+      agentTypes = Array.from({ length: workerCount }, () => type);
+      filteredArgs.shift();
+    }
+  }
+
+  // Default: 3 claude workers if no spec matched
+  if (agentTypes.length === 0) {
+    agentTypes = Array.from({ length: workerCount }, () => 'claude');
   }
 
   const task = filteredArgs.join(' ').trim();
@@ -174,7 +227,7 @@ function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   }
 
   const teamName = slugifyTask(task);
-  return { workerCount, agentType, role, task, teamName, json };
+  return { workerCount, agentTypes, role, task, teamName, json };
 }
 
 function sampleValueForField(field: string): unknown {
@@ -328,15 +381,16 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
   const { isRuntimeV2Enabled } = await import('../../team/runtime-v2.js');
   if (isRuntimeV2Enabled()) {
     const { startTeamV2, monitorTeamV2 } = await import('../../team/runtime-v2.js');
-    const agentTypes = Array.from({ length: parsed.workerCount }, () => parsed.agentType);
     const runtime = await startTeamV2({
       teamName: parsed.teamName,
       workerCount: parsed.workerCount,
-      agentTypes,
+      agentTypes: parsed.agentTypes,
       tasks,
       cwd,
       ...(rolePrompt ? { roleName: parsed.role, rolePrompt } : {}),
     });
+
+    const uniqueTypes = [...new Set(parsed.agentTypes)].join(',');
 
     if (parsed.json) {
       const snapshot = await monitorTeamV2(runtime.teamName, cwd);
@@ -344,7 +398,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
         teamName: runtime.teamName,
         sessionName: runtime.sessionName,
         workerCount: runtime.config.worker_count,
-        agentType: parsed.agentType,
+        agentType: uniqueTypes,
         tasks: snapshot ? snapshot.tasks : null,
       }));
       return;
@@ -353,7 +407,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
     console.log(`Team started: ${runtime.teamName}`);
     console.log(`tmux session: ${runtime.sessionName}`);
     console.log(`workers: ${runtime.config.worker_count}`);
-    console.log(`agent_type: ${parsed.agentType}`);
+    console.log(`agent_type: ${uniqueTypes}`);
 
     const snapshot = await monitorTeamV2(runtime.teamName, cwd);
     if (snapshot) {
@@ -364,14 +418,15 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
 
   // v1 fallback
   const { startTeam, monitorTeam } = await import('../../team/runtime.js');
-  const agentTypes = Array.from({ length: parsed.workerCount }, () => parsed.agentType) as any;
   const runtime = await startTeam({
     teamName: parsed.teamName,
     workerCount: parsed.workerCount,
-    agentTypes,
+    agentTypes: parsed.agentTypes as any,
     tasks,
     cwd,
   });
+
+  const uniqueTypesV1 = [...new Set(parsed.agentTypes)].join(',');
 
   if (parsed.json) {
     const snapshot = await monitorTeam(runtime.teamName, cwd, runtime.workerPaneIds);
@@ -379,7 +434,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
       teamName: runtime.teamName,
       sessionName: runtime.sessionName,
       workerCount: runtime.workerNames.length,
-      agentType: parsed.agentType,
+      agentType: uniqueTypesV1,
       tasks: snapshot ? {
         total: snapshot.taskCounts.pending + snapshot.taskCounts.inProgress + snapshot.taskCounts.completed + snapshot.taskCounts.failed,
         pending: snapshot.taskCounts.pending,
@@ -394,7 +449,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
   console.log(`Team started: ${runtime.teamName}`);
   console.log(`tmux session: ${runtime.sessionName}`);
   console.log(`workers: ${runtime.workerNames.length}`);
-  console.log(`agent_type: ${parsed.agentType}`);
+  console.log(`agent_type: ${uniqueTypesV1}`);
 
   const snapshot = await monitorTeam(runtime.teamName, cwd, runtime.workerPaneIds);
   if (snapshot) {


### PR DESCRIPTION
## Summary

- Fixes `omc team 1:codex,1:gemini "task"` silently defaulting all workers to `claude`
- The comma-separated multi-type spec wasn't matched by the parser regex, causing it to be treated as part of the task description
- Changes `agentType: string` to `agentTypes: string[]` for per-worker type tracking
- Updates both v1 and v2 runtime callers to pass heterogeneous type arrays

## Test plan

- [x] `parseTeamArgs(['1:codex,1:gemini', 'task'])` → `{workerCount: 2, agentTypes: ['codex', 'gemini']}`
- [x] `parseTeamArgs(['2:claude,1:codex:architect', 'task'])` → `{workerCount: 3, agentTypes: ['claude', 'claude', 'codex']}`
- [x] Existing single-type specs unchanged: `3:codex` → `['codex', 'codex', 'codex']`
- [x] Default (no spec) unchanged: 3 claude workers
- [x] `--json` flag works with comma specs
- [x] Total count exceeding max throws error
- [x] Uniform role extraction when all segments share the same role
- [x] 17 tests passing (8 new + 9 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)