### PR TITLE
fix(release): clarify npm package name in upgrade notes

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,0 +1,7 @@
+## Install / Upgrade
+
+```bash
+npm i -g oh-my-claude-sisyphus@{{VERSION}}
+```
+
+> **Package naming note:** the repo, plugin, and commands are branded **oh-my-claudecode**, but the published npm package name remains [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Build release note preamble
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed "s/{{VERSION}}/$VERSION/g" .github/release-notes.md > release-notes.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
+          body_path: release-notes.md
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}

--- a/README.md
+++ b/README.md
@@ -104,9 +104,19 @@ For mixed Codex + Gemini work in one command, use the **`/ccg`** skill (routes v
 
 Workers spawn on-demand and die when their task completes — no idle resource usage. Requires `codex` / `gemini` CLIs installed and an active tmux session.
 
-> **Note: Package naming** — The project is branded as **oh-my-claudecode** (repo, plugin, commands), but the npm package is published as [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus). If you install the CLI tools via npm/bun, use `npm install -g oh-my-claude-sisyphus`.
+> **Note: Package naming** — The project is branded as **oh-my-claudecode** (repo, plugin, commands), but the npm package is published as [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus). If you install or upgrade the CLI tools via npm/bun, use `npm i -g oh-my-claude-sisyphus@latest`.
 
 ### Updating
+
+If you installed OMC via npm, upgrade with the published package name:
+
+```bash
+npm i -g oh-my-claude-sisyphus@latest
+```
+
+> **Package naming note:** the repo, plugin, and commands are branded **oh-my-claudecode**, but the published npm package name remains `oh-my-claude-sisyphus`.
+
+If you installed OMC via the Claude Code marketplace/plugin flow, update with:
 
 ```bash
 # 1. Update the marketplace clone

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -176,14 +176,14 @@ Your old commands still work! But now you don't need them.
 The project was rebranded to better reflect its purpose and improve discoverability.
 
 - **Project/brand name**: `oh-my-claudecode` (GitHub repo, plugin name, commands)
-- **npm package name**: `oh-my-claudecode` (unchanged)
+- **npm package name**: `oh-my-claude-sisyphus` (unchanged)
 
-> **Why the difference?** The npm package name `oh-my-claudecode` was kept for backward compatibility with existing installations. The project, GitHub repository, plugin, and all commands use `oh-my-claudecode`.
+> **Why the difference?** The npm package name `oh-my-claude-sisyphus` was kept for backward compatibility with existing installations. The project, GitHub repository, plugin, and all commands use `oh-my-claudecode`.
 
 #### NPM Install Command (unchanged)
 
 ```bash
-npm install -g oh-my-claudecode
+npm i -g oh-my-claude-sisyphus@latest
 ```
 
 ### What Changed

--- a/scripts/sync-metadata.ts
+++ b/scripts/sync-metadata.ts
@@ -71,7 +71,7 @@ function loadMetadata(): Metadata {
     keywords: packageJson.keywords || [],
     repository: packageJson.repository?.url?.replace(/^git\+/, '').replace(/\.git$/, '') || '',
     homepage: packageJson.homepage || '',
-    npmPackage: packageJson.name || 'oh-my-claudecode',
+    npmPackage: packageJson.name || 'oh-my-claude-sisyphus',
   };
 }
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -4,10 +4,10 @@ Command-line interface for Oh-My-ClaudeCode analytics, token tracking, cost repo
 
 ## Installation
 
-Install via npm (note: the npm package name is `oh-my-claudecode`):
+Install via npm (note: the repo/command branding is `oh-my-claudecode`, but the published npm package name is `oh-my-claude-sisyphus`):
 
 ```bash
-npm install -g oh-my-claudecode
+npm i -g oh-my-claude-sisyphus@latest
 ```
 
 The `omc-analytics` command will be available globally.

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -200,7 +200,7 @@ async function main() {
     for (let i = 1; i <= 4; i++) {
       const candidate = join(__dirname, ...Array(i).fill('..'), 'package.json');
       const pkg = readJsonFile(candidate);
-      if (pkg?.name === 'oh-my-claudecode' && pkg?.version) {
+      if ((pkg?.name === 'oh-my-claude-sisyphus' || pkg?.name === 'oh-my-claudecode') && pkg?.version) {
         currentVersion = pkg.version;
         break;
       }


### PR DESCRIPTION
## Summary
- add a reusable GitHub release-note preamble with the explicit npm upgrade command
- prepend that preamble to auto-generated GitHub Releases via the release workflow
- update upgrade/install docs and session-start package detection to consistently use the published npm package name `oh-my-claude-sisyphus`

## Testing
- `npm run test -- --run`
- `npm run build`
- `npm run lint` *(passes with pre-existing warnings only)*
- `node` preview check for `.github/release-notes.md` version substitution and session-start package detection
- `git diff --check`
- `npx tsc --noEmit --pretty false --project tsconfig.json` via LSP diagnostics on `scripts/sync-metadata.ts`

## Notes
- `npm run sync-metadata:verify` still reports a pre-existing mismatch in `.github/CLAUDE.md` (slash command count), unrelated to this issue.

Closes #1439.
