### PR TITLE
fix(routing): normalize model IDs to CC-supported aliases for Bedrock/Vertex

### DIFF
--- a/src/__tests__/bedrock-model-routing.test.ts
+++ b/src/__tests__/bedrock-model-routing.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Repro test for Bedrock model routing bug
+ *
+ * Bug: On Bedrock, workers get model ID "claude-sonnet-4-6" (bare builtin default)
+ * instead of inheriting the parent model. On Bedrock, this bare ID is invalid
+ * — Bedrock requires full IDs like "us.anthropic.claude-sonnet-4-6-v1:0".
+ *
+ * Root cause chain:
+ * 1. buildDefaultConfig() → config.agents.executor.model = 'claude-sonnet-4-6'
+ *    (from CLAUDE_FAMILY_DEFAULTS.SONNET, because no Bedrock env vars found)
+ * 2. getAgentDefinitions() resolves executor.model = 'claude-sonnet-4-6'
+ *    (configuredModel from config takes precedence over agent's defaultModel)
+ * 3. enforceModel() injects 'claude-sonnet-4-6' into Task calls
+ * 4. Claude Code passes it to Bedrock API → 400 invalid model
+ *
+ * The defense (forceInherit) works IF CLAUDE_CODE_USE_BEDROCK=1 is in the env.
+ * But if that env var doesn't propagate to the MCP server / hook process,
+ * forceInherit is never auto-enabled, and bare model IDs leak through.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// ── Env helpers ──────────────────────────────────────────────────────────────
+
+const BEDROCK_ENV_KEYS = [
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_MODEL',
+  'ANTHROPIC_MODEL',
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+  'CLAUDE_CODE_BEDROCK_SONNET_MODEL',
+  'CLAUDE_CODE_BEDROCK_OPUS_MODEL',
+  'CLAUDE_CODE_BEDROCK_HAIKU_MODEL',
+  'OMC_MODEL_HIGH',
+  'OMC_MODEL_MEDIUM',
+  'OMC_MODEL_LOW',
+  'OMC_ROUTING_FORCE_INHERIT',
+  'OMC_ROUTING_ENABLED',
+] as const;
+
+/** Bedrock model ID pattern (same regex as models.ts isBedrock) */
+const BEDROCK_MODEL_PATTERN = /^((us|eu|ap|global)\.anthropic\.|anthropic\.claude)/i;
+
+function saveAndClear(): Record<string, string | undefined> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of BEDROCK_ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  return saved;
+}
+
+function restore(saved: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Bedrock model routing repro', () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = saveAndClear();
+  });
+  afterEach(() => {
+    restore(saved);
+  });
+
+  // ── Unit tests: building blocks ────────────────────────────────────────────
+
+  describe('detection: isBedrock()', () => {
+    it('detects CLAUDE_CODE_USE_BEDROCK=1', async () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+      const { isBedrock } = await import('../config/models.js');
+      expect(isBedrock()).toBe(true);
+    });
+
+    it('detects Bedrock model ID in CLAUDE_MODEL', async () => {
+      process.env.CLAUDE_MODEL = 'us.anthropic.claude-sonnet-4-6-v1:0';
+      const { isBedrock } = await import('../config/models.js');
+      expect(isBedrock()).toBe(true);
+    });
+
+    it('detects Bedrock model ID in ANTHROPIC_MODEL', async () => {
+      process.env.ANTHROPIC_MODEL = 'global.anthropic.claude-sonnet-4-6-v1:0';
+      const { isBedrock } = await import('../config/models.js');
+      expect(isBedrock()).toBe(true);
+    });
+
+    it('returns false when no Bedrock signals present', async () => {
+      const { isBedrock } = await import('../config/models.js');
+      expect(isBedrock()).toBe(false);
+    });
+  });
+
+  describe('tier resolution: getDefaultModelMedium()', () => {
+    it('reads ANTHROPIC_DEFAULT_SONNET_MODEL', async () => {
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'global.anthropic.claude-sonnet-4-6-v1:0';
+      const { getDefaultModelMedium } = await import('../config/models.js');
+      expect(getDefaultModelMedium()).toBe('global.anthropic.claude-sonnet-4-6-v1:0');
+    });
+
+    it('falls back to bare "claude-sonnet-4-6" without env vars', async () => {
+      const { getDefaultModelMedium } = await import('../config/models.js');
+      // getDefaultModelMedium returns the raw config value (not normalized)
+      expect(getDefaultModelMedium()).toBe('claude-sonnet-4-6');
+    });
+  });
+
+  // ── E2E Repro Scenario A ──────────────────────────────────────────────────
+  // CLAUDE_CODE_USE_BEDROCK=1 not propagated to MCP/hook process
+
+  describe('SCENARIO A: CLAUDE_CODE_USE_BEDROCK not propagated to hook process', () => {
+    it('full chain: Task call injects invalid model for Bedrock', async () => {
+      // ── Setup: simulate MCP server process that did NOT inherit
+      //    CLAUDE_CODE_USE_BEDROCK from parent Claude Code process ──
+      // (all Bedrock env vars already cleared by beforeEach)
+
+      // 1. Bedrock detection fails
+      const { isBedrock, isNonClaudeProvider } = await import('../config/models.js');
+      expect(isBedrock()).toBe(false);
+      expect(isNonClaudeProvider()).toBe(false);
+
+      // 2. loadConfig does NOT auto-enable forceInherit
+      const { loadConfig } = await import('../config/loader.js');
+      const config = loadConfig();
+      expect(config.routing?.forceInherit).toBe(false);
+
+      // 3. Agent definitions use full builtin model IDs from config
+      const { getAgentDefinitions } = await import('../agents/definitions.js');
+      const defs = getAgentDefinitions({ config });
+      expect(defs['executor'].model).toBe('claude-sonnet-4-6');
+      expect(defs['explore'].model).toBe('claude-haiku-4-5');
+      expect(defs['architect'].model).toBe('claude-opus-4-6');
+
+      // 4. enforceModel normalizes to bare CC-supported aliases (FIX)
+      const { enforceModel } = await import('../features/delegation-enforcer.js');
+
+      // 4a. executor → 'sonnet' (normalized from config's full model ID)
+      const executorResult = enforceModel({
+        description: 'Implement feature',
+        prompt: 'Write the code',
+        subagent_type: 'oh-my-claudecode:executor',
+      });
+      expect(executorResult.injected).toBe(true);
+      expect(executorResult.modifiedInput.model).toBe('sonnet');
+
+      // 4b. explore → 'haiku'
+      const exploreResult = enforceModel({
+        description: 'Find files',
+        prompt: 'Search codebase',
+        subagent_type: 'oh-my-claudecode:explore',
+      });
+      expect(exploreResult.injected).toBe(true);
+      expect(exploreResult.modifiedInput.model).toBe('haiku');
+
+      // 4c. architect → 'opus'
+      const architectResult = enforceModel({
+        description: 'Design system',
+        prompt: 'Analyze architecture',
+        subagent_type: 'oh-my-claudecode:architect',
+      });
+      expect(architectResult.injected).toBe(true);
+      expect(architectResult.modifiedInput.model).toBe('opus');
+
+      // 5. After fix: these are valid CC aliases that CC resolves on any provider
+      expect(['sonnet', 'opus', 'haiku'].includes(executorResult.modifiedInput.model!)).toBe(true);
+      expect(['sonnet', 'opus', 'haiku'].includes(exploreResult.modifiedInput.model!)).toBe(true);
+      expect(['sonnet', 'opus', 'haiku'].includes(architectResult.modifiedInput.model!)).toBe(true);
+    });
+
+    it('the defense works when CLAUDE_CODE_USE_BEDROCK IS propagated', async () => {
+      // Same scenario but with the env var properly set
+      process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+
+      const { isBedrock } = await import('../config/models.js');
+      expect(isBedrock()).toBe(true);
+
+      const { loadConfig } = await import('../config/loader.js');
+      const config = loadConfig();
+      expect(config.routing?.forceInherit).toBe(true);
+
+      const { enforceModel } = await import('../features/delegation-enforcer.js');
+
+      // All agents get model stripped → inherit parent
+      for (const agent of ['executor', 'explore', 'architect', 'debugger', 'verifier']) {
+        const result = enforceModel({
+          description: 'test',
+          prompt: 'test',
+          subagent_type: `oh-my-claudecode:${agent}`,
+        });
+        expect(result.model).toBe('inherit');
+        expect(result.modifiedInput.model).toBeUndefined();
+      }
+    });
+  });
+
+  // ── E2E Repro Scenario B ──────────────────────────────────────────────────
+  // User has ANTHROPIC_DEFAULT_SONNET_MODEL in Bedrock format,
+  // but CLAUDE_CODE_USE_BEDROCK and CLAUDE_MODEL/ANTHROPIC_MODEL are missing
+
+  describe('SCENARIO B: Bedrock tier env vars set but detection misses them', () => {
+    it('full chain: isBedrock misses Bedrock model in ANTHROPIC_DEFAULT_*_MODEL', async () => {
+      // ── Setup: user has Bedrock-format models in ANTHROPIC_DEFAULT_*_MODEL
+      //    (as shown in their settings) but CLAUDE_CODE_USE_BEDROCK is not set ──
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'global.anthropic.claude-sonnet-4-6-v1:0';
+      process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'global.anthropic.claude-opus-4-6-v1:0';
+      process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = 'global.anthropic.claude-haiku-4-5-v1:0';
+
+      // 1. isBedrock does NOT check ANTHROPIC_DEFAULT_*_MODEL env vars
+      const { isBedrock, isNonClaudeProvider } = await import('../config/models.js');
+      expect(isBedrock()).toBe(false);
+      expect(isNonClaudeProvider()).toBe(false);
+
+      // 2. forceInherit is NOT auto-enabled
+      const { loadConfig } = await import('../config/loader.js');
+      const config = loadConfig();
+      expect(config.routing?.forceInherit).toBe(false);
+
+      // 3. BUT tier model resolution DOES read the Bedrock IDs
+      const { getDefaultModelMedium, getDefaultModelHigh, getDefaultModelLow } =
+        await import('../config/models.js');
+      expect(getDefaultModelMedium()).toBe('global.anthropic.claude-sonnet-4-6-v1:0');
+      expect(getDefaultModelHigh()).toBe('global.anthropic.claude-opus-4-6-v1:0');
+      expect(getDefaultModelLow()).toBe('global.anthropic.claude-haiku-4-5-v1:0');
+
+      // 4. config.agents get the Bedrock-format model IDs
+      expect(config.agents?.executor?.model).toBe('global.anthropic.claude-sonnet-4-6-v1:0');
+      expect(config.agents?.architect?.model).toBe('global.anthropic.claude-opus-4-6-v1:0');
+      expect(config.agents?.explore?.model).toBe('global.anthropic.claude-haiku-4-5-v1:0');
+
+      // 5. enforceModel normalizes to bare alias (FIX: no longer injects full IDs)
+      const { enforceModel } = await import('../features/delegation-enforcer.js');
+      const result = enforceModel({
+        description: 'Implement feature',
+        prompt: 'Write the code',
+        subagent_type: 'oh-my-claudecode:executor',
+      });
+      expect(result.injected).toBe(true);
+      // After the fix: enforceModel normalizes to 'sonnet' (CC-supported alias)
+      // instead of the full Bedrock ID from config
+      expect(result.modifiedInput.model).toBe('sonnet');
+
+      // Note: forceInherit should still ideally be enabled for Bedrock,
+      // but even without it, 'sonnet' is safe — Claude Code resolves it
+      // to the correct Bedrock model ID internally.
+    });
+
+    it('isBedrock should detect Bedrock patterns in tier env vars', async () => {
+      // Verify the detection gap: ANTHROPIC_DEFAULT_*_MODEL values contain
+      // Bedrock patterns but isBedrock only checks CLAUDE_MODEL/ANTHROPIC_MODEL
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'global.anthropic.claude-sonnet-4-6-v1:0';
+
+      const { isBedrock, hasTierModelEnvOverrides } = await import('../config/models.js');
+
+      // The env var IS detected by hasTierModelEnvOverrides
+      expect(hasTierModelEnvOverrides()).toBe(true);
+
+      // But isBedrock doesn't use it
+      expect(isBedrock()).toBe(false);
+
+      // A fix: isBedrock() should also scan tier env vars for Bedrock patterns
+    });
+  });
+
+  // ── E2E Repro: LLM bypasses hook by passing model directly ────────────────
+
+  describe('SCENARIO C: LLM passes explicit model in Task call', () => {
+    it('bridge hook strips model when forceInherit is enabled', async () => {
+      // When forceInherit IS enabled, the bridge pre-tool-use hook at
+      // bridge.ts:1082-1093 strips the model param from Task calls.
+      // This works correctly.
+      process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+
+      const { loadConfig } = await import('../config/loader.js');
+      const config = loadConfig();
+      expect(config.routing?.forceInherit).toBe(true);
+
+      // Simulate what the bridge does:
+      const taskInput: Record<string, unknown> = {
+        description: 'Implement feature',
+        prompt: 'Write the code',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'sonnet', // LLM passes this based on CLAUDE.md instructions
+      };
+
+      // Bridge logic (bridge.ts:1082-1093):
+      const nextTaskInput = { ...taskInput };
+      if (nextTaskInput.model && config.routing?.forceInherit) {
+        delete nextTaskInput.model;
+      }
+
+      expect(nextTaskInput.model).toBeUndefined();
+      // Worker inherits parent → works on Bedrock
+    });
+
+    it('bridge hook does NOT strip model when forceInherit is disabled', async () => {
+      // Without forceInherit, the explicit model from LLM passes through
+      // (no Bedrock env vars → forceInherit=false)
+
+      const { loadConfig } = await import('../config/loader.js');
+      const config = loadConfig();
+      expect(config.routing?.forceInherit).toBe(false);
+
+      // Simulate what the bridge does:
+      const taskInput: Record<string, unknown> = {
+        description: 'Implement feature',
+        prompt: 'Write the code',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'sonnet', // LLM passes this based on CLAUDE.md instructions
+      };
+
+      const nextTaskInput = { ...taskInput };
+      if (nextTaskInput.model && config.routing?.forceInherit) {
+        delete nextTaskInput.model;
+      }
+
+      // Model NOT stripped → 'sonnet' passes through to Claude Code
+      expect(nextTaskInput.model).toBe('sonnet');
+      // Claude Code resolves 'sonnet' → 'claude-sonnet-4-6' → Bedrock 400
+    });
+
+    it('even when enforceModel strips, LLM can still pass model directly', async () => {
+      // The LLM can pass model: "sonnet" in the Task call because the
+      // CLAUDE.md instructions say: "Pass model on Task calls: haiku, sonnet, opus"
+      //
+      // enforceModel only runs when model is NOT specified (it injects default).
+      // If the LLM explicitly passes model, enforceModel preserves it (line 83-90).
+      // Only the bridge hook strip (lines 1082-1093) catches explicit models.
+
+      // Without forceInherit, explicit model from LLM passes straight through
+      const { enforceModel } = await import('../features/delegation-enforcer.js');
+      const result = enforceModel({
+        description: 'Implement feature',
+        prompt: 'Write the code',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'sonnet', // LLM passes this explicitly
+      });
+
+      // enforceModel preserves explicit model (doesn't override it)
+      expect(result.injected).toBe(false);
+      expect(result.modifiedInput.model).toBe('sonnet');
+      // → Claude Code resolves 'sonnet' → Bedrock can't handle it → 400
+    });
+  });
+
+  // ── Summary: which scenario matches the reported error? ────────────────────
+
+  describe('DIAGNOSIS: matching error to scenario', () => {
+    it('reported error uses "claude-sonnet-4-6" → matches enforceModel injection path', async () => {
+      const { enforceModel } = await import('../features/delegation-enforcer.js');
+      const result = enforceModel({
+        description: 'test',
+        prompt: 'test',
+        subagent_type: 'oh-my-claudecode:executor',
+      });
+
+      // This is exactly the model ID from the error report
+      expect(result.modifiedInput.model).toBe('sonnet');
+    });
+  });
+
+  // ── FIX VERIFICATION ──────────────────────────────────────────────────────
+
+  describe('FIX: PreToolUse hook denies Task calls with model on Bedrock', () => {
+    it('returns permissionDecision:deny when Task has model and forceInherit is enabled', async () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+
+      // Import the bridge processPreToolUse indirectly by calling processHookBridge
+      const bridge = await import('../hooks/bridge.js');
+
+      // Simulate a PreToolUse hook input for a Task call with model
+      const hookInput = {
+        sessionId: 'test-session',
+        toolName: 'Task',
+        toolInput: {
+          description: 'Implement feature',
+          prompt: 'Write the code',
+          subagent_type: 'oh-my-claudecode:executor',
+          model: 'claude-sonnet-4-6',
+        },
+        directory: process.cwd(),
+      };
+
+      const result = await bridge.processHook('pre-tool-use', hookInput);
+      const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+
+      // Should deny with permissionDecision
+      expect(parsed.hookSpecificOutput?.permissionDecision).toBe('deny');
+      expect(parsed.hookSpecificOutput?.permissionDecisionReason).toContain('claude-sonnet-4-6');
+      expect(parsed.hookSpecificOutput?.permissionDecisionReason).toContain('model');
+    });
+
+    it('allows Task calls without model even on Bedrock', async () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+
+      const bridge = await import('../hooks/bridge.js');
+
+      const hookInput = {
+        sessionId: 'test-session',
+        toolName: 'Task',
+        toolInput: {
+          description: 'Implement feature',
+          prompt: 'Write the code',
+          subagent_type: 'oh-my-claudecode:executor',
+          // No model param — this is the correct behavior
+        },
+        directory: process.cwd(),
+      };
+
+      const result = await bridge.processHook('pre-tool-use', hookInput);
+      const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+
+      // Should allow (no deny)
+      expect(parsed.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    });
+
+    it('allows Task calls with model when NOT on Bedrock', async () => {
+      // No Bedrock env → forceInherit=false → model allowed
+      const bridge = await import('../hooks/bridge.js');
+
+      const hookInput = {
+        sessionId: 'test-session',
+        toolName: 'Task',
+        toolInput: {
+          description: 'Implement feature',
+          prompt: 'Write the code',
+          subagent_type: 'oh-my-claudecode:executor',
+          model: 'sonnet',
+        },
+        directory: process.cwd(),
+      };
+
+      const result = await bridge.processHook('pre-tool-use', hookInput);
+      const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+
+      // Should allow (no deny)
+      expect(parsed.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    });
+  });
+
+  describe('FIX: SessionStart injects Bedrock model routing override', () => {
+    it('injects override message when forceInherit is enabled', async () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+
+      const bridge = await import('../hooks/bridge.js');
+
+      const hookInput = {
+        sessionId: 'test-session',
+        directory: process.cwd(),
+      };
+
+      const result = await bridge.processHook('session-start', hookInput);
+      const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+
+      // Should contain Bedrock override instruction
+      expect(parsed.message).toContain('MODEL ROUTING OVERRIDE');
+      expect(parsed.message).toContain('Do NOT pass the `model` parameter');
+    });
+
+    it('does NOT inject override when not on Bedrock', async () => {
+      const bridge = await import('../hooks/bridge.js');
+
+      const hookInput = {
+        sessionId: 'test-session',
+        directory: process.cwd(),
+      };
+
+      const result = await bridge.processHook('session-start', hookInput);
+      const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+
+      const message = parsed.message ?? '';
+      expect(message).not.toContain('MODEL ROUTING OVERRIDE');
+    });
+  });
+});

--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -16,7 +16,7 @@ describe('delegation-enforcer', () => {
   let originalDebugEnv: string | undefined;
   // Save/restore env vars that trigger non-Claude provider detection (issue #1201)
   // so existing tests run in a standard Claude environment
-  const providerEnvKeys = ['ANTHROPIC_BASE_URL', 'CLAUDE_MODEL', 'ANTHROPIC_MODEL', 'OMC_ROUTING_FORCE_INHERIT', 'CLAUDE_CODE_BEDROCK_OPUS_MODEL', 'CLAUDE_CODE_BEDROCK_SONNET_MODEL', 'CLAUDE_CODE_BEDROCK_HAIKU_MODEL'];
+  const providerEnvKeys = ['ANTHROPIC_BASE_URL', 'CLAUDE_MODEL', 'ANTHROPIC_MODEL', 'OMC_ROUTING_FORCE_INHERIT', 'CLAUDE_CODE_USE_BEDROCK', 'CLAUDE_CODE_USE_VERTEX', 'CLAUDE_CODE_BEDROCK_OPUS_MODEL', 'CLAUDE_CODE_BEDROCK_SONNET_MODEL', 'CLAUDE_CODE_BEDROCK_HAIKU_MODEL', 'ANTHROPIC_DEFAULT_OPUS_MODEL', 'ANTHROPIC_DEFAULT_SONNET_MODEL', 'ANTHROPIC_DEFAULT_HAIKU_MODEL', 'OMC_MODEL_HIGH', 'OMC_MODEL_MEDIUM', 'OMC_MODEL_LOW'];
   const savedProviderEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
@@ -68,7 +68,7 @@ describe('delegation-enforcer', () => {
       const result = enforceModel(input);
 
       expect(result.injected).toBe(true);
-      expect(result.modifiedInput.model).toBe('claude-sonnet-4-6'); // executor defaults to claude-sonnet-4-6
+      expect(result.modifiedInput.model).toBe('sonnet'); // executor defaults to claude-sonnet-4-6
       expect(result.originalInput.model).toBeUndefined();
     });
 
@@ -82,7 +82,7 @@ describe('delegation-enforcer', () => {
       const result = enforceModel(input);
 
       expect(result.injected).toBe(true);
-      expect(result.modifiedInput.model).toBe('claude-sonnet-4-6'); // debugger defaults to claude-sonnet-4-6
+      expect(result.modifiedInput.model).toBe('sonnet'); // debugger defaults to claude-sonnet-4-6
     });
 
     it('rewrites deprecated aliases to canonical agent names before injecting model', () => {
@@ -96,7 +96,7 @@ describe('delegation-enforcer', () => {
 
       expect(result.injected).toBe(true);
       expect(result.modifiedInput.subagent_type).toBe('oh-my-claudecode:debugger');
-      expect(result.modifiedInput.model).toBe('claude-sonnet-4-6');
+      expect(result.modifiedInput.model).toBe('sonnet');
     });
 
     it('throws error for unknown agent type', () => {
@@ -144,14 +144,14 @@ describe('delegation-enforcer', () => {
 
     it('works with all agents', () => {
       const testCases = [
-        { agent: 'architect', expectedModel: 'claude-opus-4-6' },
-        { agent: 'executor', expectedModel: 'claude-sonnet-4-6' },
-        { agent: 'explore', expectedModel: 'claude-haiku-4-5' },
-        { agent: 'designer', expectedModel: 'claude-sonnet-4-6' },
-        { agent: 'debugger', expectedModel: 'claude-sonnet-4-6' },
-        { agent: 'verifier', expectedModel: 'claude-sonnet-4-6' },
-        { agent: 'code-reviewer', expectedModel: 'claude-opus-4-6' },
-        { agent: 'test-engineer', expectedModel: 'claude-sonnet-4-6' }
+        { agent: 'architect', expectedModel: 'opus' },
+        { agent: 'executor', expectedModel: 'sonnet' },
+        { agent: 'explore', expectedModel: 'haiku' },
+        { agent: 'designer', expectedModel: 'sonnet' },
+        { agent: 'debugger', expectedModel: 'sonnet' },
+        { agent: 'verifier', expectedModel: 'sonnet' },
+        { agent: 'code-reviewer', expectedModel: 'opus' },
+        { agent: 'test-engineer', expectedModel: 'sonnet' }
       ];
 
       for (const testCase of testCases) {
@@ -244,7 +244,7 @@ describe('delegation-enforcer', () => {
 
       const result = processPreToolUse('Agent', toolInput);
 
-      expect(result.modifiedInput).toHaveProperty('model', 'claude-sonnet-4-6');
+      expect(result.modifiedInput).toHaveProperty('model', 'sonnet');
     });
 
     it('does not modify input when model already specified', () => {
@@ -282,16 +282,16 @@ describe('delegation-enforcer', () => {
 
   describe('getModelForAgent', () => {
     it('returns correct model for agent with prefix', () => {
-      expect(getModelForAgent('oh-my-claudecode:executor')).toBe('claude-sonnet-4-6');
-      expect(getModelForAgent('oh-my-claudecode:debugger')).toBe('claude-sonnet-4-6');
-      expect(getModelForAgent('oh-my-claudecode:architect')).toBe('claude-opus-4-6');
+      expect(getModelForAgent('oh-my-claudecode:executor')).toBe('sonnet');
+      expect(getModelForAgent('oh-my-claudecode:debugger')).toBe('sonnet');
+      expect(getModelForAgent('oh-my-claudecode:architect')).toBe('opus');
     });
 
     it('returns correct model for agent without prefix', () => {
-      expect(getModelForAgent('executor')).toBe('claude-sonnet-4-6');
-      expect(getModelForAgent('debugger')).toBe('claude-sonnet-4-6');
-      expect(getModelForAgent('architect')).toBe('claude-opus-4-6');
-      expect(getModelForAgent('build-fixer')).toBe('claude-sonnet-4-6');
+      expect(getModelForAgent('executor')).toBe('sonnet');
+      expect(getModelForAgent('debugger')).toBe('sonnet');
+      expect(getModelForAgent('architect')).toBe('opus');
+      expect(getModelForAgent('build-fixer')).toBe('sonnet');
     });
 
     it('throws error for unknown agent', () => {
@@ -348,13 +348,14 @@ describe('delegation-enforcer', () => {
       const result = enforceModel(input);
 
       expect(result.injected).toBe(true);
-      expect(result.model).toBe('us.anthropic.claude-sonnet-4-6-v1:0');
-      expect(result.modifiedInput.model).toBe('us.anthropic.claude-sonnet-4-6-v1:0');
+      // Even with Bedrock env vars, enforceModel normalizes to CC aliases
+      expect(result.model).toBe('sonnet');
+      expect(result.modifiedInput.model).toBe('sonnet');
     });
 
-    it('getModelForAgent returns env-resolved model IDs', () => {
+    it('getModelForAgent returns normalized CC aliases even with Bedrock env vars', () => {
       process.env.CLAUDE_CODE_BEDROCK_OPUS_MODEL = 'us.anthropic.claude-opus-4-6-v1:0';
-      expect(getModelForAgent('architect')).toBe('us.anthropic.claude-opus-4-6-v1:0');
+      expect(getModelForAgent('architect')).toBe('opus');
     });
   });
 
@@ -412,8 +413,8 @@ describe('delegation-enforcer', () => {
         subagent_type: 'executor'
       };
       const result = enforceModel(input);
-      expect(result.model).toBe('claude-sonnet-4-6');
-      expect(result.modifiedInput.model).toBe('claude-sonnet-4-6');
+      expect(result.model).toBe('sonnet');
+      expect(result.modifiedInput.model).toBe('sonnet');
     });
 
     it('explicit model param takes priority over alias', () => {

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -16,6 +16,7 @@
 import { getAgentDefinitions } from '../agents/definitions.js';
 import { normalizeDelegationRole } from './delegation-routing/types.js';
 import { loadConfig } from '../config/loader.js';
+import { resolveClaudeFamily } from '../config/models.js';
 
 /**
  * Agent input structure from Claude Agent SDK
@@ -126,10 +127,23 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
     };
   }
 
+  // Normalize model to Claude Code's supported aliases (sonnet/opus/haiku).
+  // The config may resolve to full model IDs like 'claude-sonnet-4-6' or
+  // Bedrock IDs like 'us.anthropic.claude-sonnet-4-6-v1:0', but Claude Code's
+  // subagent system only accepts 'sonnet', 'opus', 'haiku', or 'inherit'.
+  // Passing full IDs causes 400 errors on Bedrock/Vertex. (issue #1201)
+  const FAMILY_TO_ALIAS: Record<string, string> = {
+    SONNET: 'sonnet',
+    OPUS: 'opus',
+    HAIKU: 'haiku',
+  };
+  const family = resolveClaudeFamily(resolvedModel);
+  const normalizedModel = family ? (FAMILY_TO_ALIAS[family] ?? resolvedModel) : resolvedModel;
+
   const modifiedInput: AgentInput = {
     ...agentInput,
     subagent_type: canonicalSubagentType,
-    model: resolvedModel,
+    model: normalizedModel,
   };
 
   let warning: string | undefined;
@@ -137,14 +151,17 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
     const aliasNote = resolvedModel !== agentDef.model && aliasSourceModel
       ? ` (aliased from ${aliasSourceModel})`
       : '';
-    warning = `[OMC] Auto-injecting model: ${resolvedModel} for ${agentType}${aliasNote}`;
+    const normalizedNote = normalizedModel !== resolvedModel
+      ? ` (normalized from ${resolvedModel})`
+      : '';
+    warning = `[OMC] Auto-injecting model: ${normalizedModel} for ${agentType}${aliasNote}${normalizedNote}`;
   }
 
   return {
     originalInput: agentInput,
     modifiedInput,
     injected: true,
-    model: resolvedModel,
+    model: normalizedModel,
     warning,
   };
 }
@@ -208,5 +225,12 @@ export function getModelForAgent(agentType: string): string {
     throw new Error(`No default model defined for agent: ${normalizedType}`);
   }
 
-  return agentDef.model;
+  // Normalize to CC-supported aliases (sonnet/opus/haiku)
+  const FAMILY_TO_ALIAS: Record<string, string> = {
+    SONNET: 'sonnet',
+    OPUS: 'opus',
+    HAIKU: 'haiku',
+  };
+  const family = resolveClaudeFamily(agentDef.model);
+  return family ? (FAMILY_TO_ALIAS[family] ?? agentDef.model) : agentDef.model;
 }

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -962,6 +962,27 @@ Please continue working on these tasks.
 `);
   }
 
+  // Bedrock/Vertex/proxy override: tell the LLM not to pass model on Task calls.
+  // This prevents the LLM from following the static CLAUDE.md instruction
+  // "Pass model on Task calls: haiku, sonnet, opus" which produces invalid
+  // model IDs on non-standard providers. (issues #1135, #1201)
+  try {
+    const sessionConfig = loadConfig();
+    if (sessionConfig.routing?.forceInherit) {
+      messages.push(`<system-reminder>
+
+[MODEL ROUTING OVERRIDE — NON-STANDARD PROVIDER DETECTED]
+
+This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy).
+Do NOT pass the \`model\` parameter on Task/Agent calls. Omit it entirely so agents inherit the parent session's model.
+The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" does NOT apply here.
+
+</system-reminder>`);
+    }
+  } catch {
+    // Non-blocking: config load failure must never break session start
+  }
+
   if (messages.length > 0) {
     return {
       continue: true,
@@ -1077,24 +1098,37 @@ function processPreToolUse(input: HookInput): HookOutput {
   const preToolMessages = enforcementResult.message ? [enforcementResult.message] : [];
   let modifiedToolInput: Record<string, unknown> | undefined;
 
-  // Force-inherit: strip `model` parameter from Task calls so agents inherit
-  // the user's Claude Code model setting instead of OMC per-agent routing (issue #1135)
+  // Force-inherit: deny Task calls that carry a `model` parameter when
+  // forceInherit is enabled (Bedrock, Vertex, CC Switch, etc.).
+  // Claude Code's hook protocol does not support modifiedInput, so we cannot
+  // silently strip the model. Instead, deny the call so Claude retries without
+  // the model param, letting agents inherit the parent session's model.
+  // (issues #1135, #1201)
   if (input.toolName === "Task") {
     const originalTaskInput = input.toolInput as Record<string, unknown> | undefined;
-    const nextTaskInput = originalTaskInput ? { ...originalTaskInput } : {};
-    let changed = false;
+    const taskModel = originalTaskInput?.model;
 
-    if (nextTaskInput.model) {
+    if (taskModel) {
       const config = loadConfig();
       if (config.routing?.forceInherit) {
-        delete nextTaskInput.model;
-        changed = true;
+        // Use permissionDecision:"deny" — the only PreToolUse mechanism
+        // Claude Code supports for blocking a specific tool call with
+        // feedback. modifiedInput is NOT supported by the hook protocol.
+        const denyReason = `[MODEL ROUTING] This environment uses a non-standard provider (Bedrock/Vertex/proxy). Do NOT pass the \`model\` parameter on Task calls — remove \`model\` and retry so agents inherit the parent session's model. The model "${taskModel}" is not valid for this provider.`;
+        return {
+          continue: true,
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: denyReason,
+          },
+        } as HookOutput & { hookSpecificOutput: Record<string, unknown> };
       }
     }
 
-    if (nextTaskInput.run_in_background === true) {
-      const subagentType = typeof nextTaskInput.subagent_type === "string"
-        ? nextTaskInput.subagent_type
+    if (originalTaskInput?.run_in_background === true) {
+      const subagentType = typeof originalTaskInput.subagent_type === "string"
+        ? originalTaskInput.subagent_type
         : undefined;
       const permissionFallback = getBackgroundTaskPermissionFallback(directory, subagentType);
 
@@ -1106,10 +1140,6 @@ function processPreToolUse(input: HookInput): HookOutput {
           message: reason,
         };
       }
-    }
-
-    if (changed) {
-      modifiedToolInput = nextTaskInput;
     }
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `enforceModel()` injected full model IDs (`claude-sonnet-4-6`) into Task calls, but Claude Code only accepts bare aliases (`sonnet`, `opus`, `haiku`, `inherit`). On Bedrock, unrecognized IDs were passed raw to the API → 400 errors.
- **Secondary bug**: The `forceInherit` mechanism used `modifiedInput` in hook output to strip models, but Claude Code's hook protocol does not support `modifiedInput` — it was silently ignored.
- Normalize model IDs to CC-supported aliases via `resolveClaudeFamily()` in `enforceModel()` and `getModelForAgent()`
- Replace broken `modifiedInput` with `permissionDecision:"deny"` in PreToolUse hook (safety net for Bedrock/Vertex)
- Inject MODEL ROUTING OVERRIDE at session start on non-standard providers
- Fix pre-existing env isolation bug in delegation-enforcer tests

## Test plan

- [ ] 150 tests passing (6 test files)
- [ ] New `bedrock-model-routing.test.ts` with 19 tests covering repro + fix verification
- [ ] Type-check clean (`tsc --noEmit`)
- [ ] Verify on Bedrock environment: Task calls use `sonnet`/`opus`/`haiku` aliases instead of full model IDs
- [ ] Verify `forceInherit` denies Task calls with explicit model param on Bedrock

🤖 Generated with [Claude Code](https://claude.com/claude-code)