### PR TITLE
fix: restore keyword route for code-review after skill removal

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -16,9 +16,11 @@
  * 7. deep interview: Socratic interview workflow
  * 8. ai-slop-cleaner: Cleanup/deslop anti-slop workflow
  * 9. tdd: Test-driven development
- * 10. ultrathink: Extended reasoning
- * 11. deepsearch: Codebase search (restricted patterns)
- * 12. analyze: Analysis mode (restricted patterns)
+ * 10. code review: Comprehensive review mode
+ * 11. security review: Security-focused review mode
+ * 12. ultrathink: Extended reasoning
+ * 13. deepsearch: Codebase search (restricted patterns)
+ * 14. analyze: Analysis mode (restricted patterns)
  */
 
 import { writeFileSync, readFileSync, mkdirSync, existsSync, unlinkSync } from 'fs';
@@ -57,6 +59,22 @@ const TDD_MESSAGE = `<tdd-mode>
 [TDD MODE ACTIVATED]
 Write or update tests first when practical, confirm they fail for the right reason, then implement the minimal fix and re-run verification.
 </tdd-mode>
+
+---
+`;
+
+const CODE_REVIEW_MESSAGE = `<code-review-mode>
+[CODE REVIEW MODE ACTIVATED]
+Perform a comprehensive code review of the relevant changes or target area. Focus on correctness, maintainability, edge cases, regressions, and test adequacy before recommending changes.
+</code-review-mode>
+
+---
+`;
+
+const SECURITY_REVIEW_MESSAGE = `<security-review-mode>
+[SECURITY REVIEW MODE ACTIVATED]
+Perform a focused security review of the relevant changes or target area. Check trust boundaries, auth/authz, data exposure, input validation, command/file access, secrets handling, and escalation risks before recommending changes.
+</security-review-mode>
 
 ---
 `;
@@ -288,7 +306,7 @@ function resolveConflicts(matches) {
 
   // Sort by priority order
   const priorityOrder = ['cancel','ralph','autopilot','ultrawork',
-    'ccg','ralplan','deep-interview','ai-slop-cleaner','tdd','ultrathink','deepsearch','analyze'];
+    'ccg','ralplan','deep-interview','ai-slop-cleaner','tdd','code-review','security-review','ultrathink','deepsearch','analyze'];
   resolved.sort((a, b) => priorityOrder.indexOf(a.name) - priorityOrder.indexOf(b.name));
 
   return resolved;
@@ -407,6 +425,16 @@ async function main() {
       matches.push({ name: 'tdd', args: '' });
     }
 
+    // Code review keywords
+    if (/\b(code\s+review|review\s+code)\b/i.test(cleanPrompt)) {
+      matches.push({ name: 'code-review', args: '' });
+    }
+
+    // Security review keywords
+    if (/\b(security\s+review|review\s+security)\b/i.test(cleanPrompt)) {
+      matches.push({ name: 'security-review', args: '' });
+    }
+
     // Ultrathink keywords
     if (/\b(ultrathink|think hard|think deeply)\b/i.test(cleanPrompt)) {
       matches.push({ name: 'ultrathink', args: '' });
@@ -486,6 +514,8 @@ async function main() {
       ['ultrathink', ULTRATHINK_MESSAGE],
       ['analyze', ANALYZE_MESSAGE],
       ['tdd', TDD_MESSAGE],
+      ['code-review', CODE_REVIEW_MESSAGE],
+      ['security-review', SECURITY_REVIEW_MESSAGE],
     ]) {
       const index = resolved.findIndex(m => m.name === keywordName);
       if (index !== -1) {

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -101,6 +101,30 @@ describe('processHook - Routing Matrix', () => {
       expect(typeof result.message).toBe('string');
     });
 
+    it('should route code review keyword to the review mode message', async () => {
+      const input: HookInput = {
+        sessionId: 'test-session',
+        prompt: 'code review this change',
+        directory: '/tmp/test-routing',
+      };
+
+      const result = await processHook('keyword-detector', input);
+      expect(result.continue).toBe(true);
+      expect(result.message).toContain('[CODE REVIEW MODE ACTIVATED]');
+    });
+
+    it('should route security review keyword to the security mode message', async () => {
+      const input: HookInput = {
+        sessionId: 'test-session',
+        prompt: 'security review this change',
+        directory: '/tmp/test-routing',
+      };
+
+      const result = await processHook('keyword-detector', input);
+      expect(result.continue).toBe(true);
+      expect(result.message).toContain('[SECURITY REVIEW MODE ACTIVATED]');
+    });
+
     it('should handle keyword-detector with no keyword prompt', async () => {
       const input: HookInput = {
         sessionId: 'test-session',

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -35,6 +35,8 @@ import {
   SEARCH_MESSAGE,
   ANALYZE_MESSAGE,
   TDD_MESSAGE,
+  CODE_REVIEW_MESSAGE,
+  SECURITY_REVIEW_MESSAGE,
   RALPH_MESSAGE,
   PROMPT_TRANSLATION_MESSAGE,
 } from "../installer/hooks.js";
@@ -578,6 +580,14 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
 
       case "tdd":
         messages.push(TDD_MESSAGE);
+        break;
+
+      case "code-review":
+        messages.push(CODE_REVIEW_MESSAGE);
+        break;
+
+      case "security-review":
+        messages.push(SECURITY_REVIEW_MESSAGE);
         break;
 
       // For modes without dedicated message constants, return generic activation message

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -324,6 +324,34 @@ World`);
       });
     });
 
+    describe('code-review keyword', () => {
+      it('should detect code review phrase', () => {
+        const result = detectKeywordsWithType('please do a code review');
+        const match = result.find((r) => r.type === 'code-review');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect review code phrase', () => {
+        const result = detectKeywordsWithType('review code for this change');
+        const match = result.find((r) => r.type === 'code-review');
+        expect(match).toBeDefined();
+      });
+    });
+
+    describe('security-review keyword', () => {
+      it('should detect security review phrase', () => {
+        const result = detectKeywordsWithType('run a security review');
+        const match = result.find((r) => r.type === 'security-review');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect review security phrase', () => {
+        const result = detectKeywordsWithType('review security for this change');
+        const match = result.find((r) => r.type === 'security-review');
+        expect(match).toBeDefined();
+      });
+    });
+
     describe('ultrathink keyword', () => {
       it('should detect ultrathink keyword', () => {
         const result = detectKeywordsWithType('ultrathink about this problem');
@@ -728,6 +756,16 @@ World`);
         expect(result?.type).toBe('ultrawork');
       });
 
+      it('should return code-review over ultrathink', () => {
+        const result = getPrimaryKeyword('code review and ultrathink');
+        expect(result?.type).toBe('code-review');
+      });
+
+      it('should return security-review over ultrathink', () => {
+        const result = getPrimaryKeyword('security review and ultrathink');
+        expect(result?.type).toBe('security-review');
+      });
+
       it('should return ultrathink over deepsearch', () => {
         const result = getPrimaryKeyword('ultrathink and search the codebase');
         expect(result?.type).toBe('ultrathink');
@@ -887,6 +925,11 @@ World`);
       const result = getAllKeywords('ralph tdd fix');
       expect(result).toContain('ralph');
       expect(result).toContain('tdd');
+    });
+
+    it('should include code-review and security-review in priority order', () => {
+      const result = getAllKeywords('security review code review ultrathink');
+      expect(result).toEqual(['code-review', 'security-review', 'ultrathink']);
     });
 
     // Team keyword detection disabled — team is now explicit-only via /team skill

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -7,7 +7,6 @@
  * Ported from oh-my-opencode's keyword-detector hook.
  */
 
-import { isTeamEnabled } from '../../features/auto-update.js';
 import {
   classifyTaskSize,
   isHeavyMode,
@@ -23,12 +22,14 @@ export type KeywordType =
   | 'ultrawork'   // Priority 5
   | 'ralplan'     // Priority 8
   | 'tdd'         // Priority 9
+  | 'code-review' // Priority 10
+  | 'security-review' // Priority 10.5
   | 'ultrathink'  // Priority 11
   | 'deepsearch'  // Priority 12
   | 'deep-interview' // Priority 13.5
   | 'analyze'     // Priority 13
-  | 'codex'       // Priority 14
-  | 'gemini'      // Priority 15
+  | 'codex'       // Priority 15
+  | 'gemini'      // Priority 16
   | 'ccg';        // Priority 8.5 (Claude-Codex-Gemini orchestration)
 
 export interface DetectedKeyword {
@@ -51,6 +52,8 @@ const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   team: /(?!x)x/,  // never-match placeholder (type system requires the key)
   ralplan: /\b(ralplan)\b/i,
   tdd: /\b(tdd)\b|\btest\s+first\b/i,
+  'code-review': /\b(code\s+review|review\s+code)\b/i,
+  'security-review': /\b(security\s+review|review\s+security)\b/i,
   ultrathink: /\b(ultrathink)\b/i,
   deepsearch: /\b(deepsearch)\b|\bsearch\s+the\s+codebase\b|\bfind\s+in\s+(the\s+)?codebase\b/i,
   analyze: /\b(deep[\s-]?analyze|deepanalyze)\b/i,
@@ -65,7 +68,7 @@ const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
  */
 const KEYWORD_PRIORITY: KeywordType[] = [
   'cancel', 'ralph', 'autopilot', 'team', 'ultrawork',
-  'ccg', 'ralplan', 'tdd',
+  'ccg', 'ralplan', 'tdd', 'code-review', 'security-review',
   'ultrathink', 'deepsearch', 'analyze', 'deep-interview', 'codex', 'gemini'
 ];
 

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -252,6 +252,32 @@ SYNTHESIZE findings before proceeding.
 `;
 
 /**
+ * Code review mode message
+ * Replaces skills/code-review/SKILL.md after skill deletion
+ */
+export const CODE_REVIEW_MESSAGE = `<code-review-mode>
+[CODE REVIEW MODE ACTIVATED]
+Perform a comprehensive code review of the relevant changes or target area. Focus on correctness, maintainability, edge cases, regressions, and test adequacy before recommending changes.
+</code-review-mode>
+
+---
+
+`;
+
+/**
+ * Security review mode message
+ * Replaces skills/security-review/SKILL.md after skill deletion
+ */
+export const SECURITY_REVIEW_MESSAGE = `<security-review-mode>
+[SECURITY REVIEW MODE ACTIVATED]
+Perform a focused security review of the relevant changes or target area. Check trust boundaries, auth/authz, data exposure, input validation, command/file access, secrets handling, and escalation risks before recommending changes.
+</security-review-mode>
+
+---
+
+`;
+
+/**
  * TDD mode message
  * Replaces skills/tdd/SKILL.md after skill deletion
  */

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -11,14 +11,16 @@
  * 3. autopilot: Full autonomous execution
  * 4. team: Explicit-only via /team (not auto-triggered)
  * 5. ultrawork/ulw: Maximum parallel execution
- * 5. ccg: Claude-Codex-Gemini tri-model orchestration
- * 6. ralplan: Iterative planning with consensus
- * 7. deep interview: Socratic interview workflow
- * 8. ai-slop-cleaner: Cleanup/deslop anti-slop workflow
- * 9. tdd: Test-driven development
- * 10. ultrathink: Extended reasoning
- * 11. deepsearch: Codebase search (restricted patterns)
- * 12. analyze: Analysis mode (restricted patterns)
+ * 6. ccg: Claude-Codex-Gemini tri-model orchestration
+ * 7. ralplan: Iterative planning with consensus
+ * 8. deep interview: Socratic interview workflow
+ * 9. ai-slop-cleaner: Cleanup/deslop anti-slop workflow
+ * 10. tdd: Test-driven development
+ * 11. code review: Comprehensive review mode
+ * 12. security review: Security-focused review mode
+ * 13. ultrathink: Extended reasoning
+ * 14. deepsearch: Codebase search (restricted patterns)
+ * 15. analyze: Analysis mode (restricted patterns)
  */
 
 import { writeFileSync, mkdirSync, existsSync, unlinkSync, readFileSync } from 'fs';
@@ -63,6 +65,22 @@ const TDD_MESSAGE = `<tdd-mode>
 [TDD MODE ACTIVATED]
 Write or update tests first when practical, confirm they fail for the right reason, then implement the minimal fix and re-run verification.
 </tdd-mode>
+
+---
+`;
+
+const CODE_REVIEW_MESSAGE = `<code-review-mode>
+[CODE REVIEW MODE ACTIVATED]
+Perform a comprehensive code review of the relevant changes or target area. Focus on correctness, maintainability, edge cases, regressions, and test adequacy before recommending changes.
+</code-review-mode>
+
+---
+`;
+
+const SECURITY_REVIEW_MESSAGE = `<security-review-mode>
+[SECURITY REVIEW MODE ACTIVATED]
+Perform a focused security review of the relevant changes or target area. Check trust boundaries, auth/authz, data exposure, input validation, command/file access, secrets handling, and escalation risks before recommending changes.
+</security-review-mode>
 
 ---
 `;
@@ -256,8 +274,8 @@ function resolveConflicts(matches) {
   // Team keyword detection removed — team is now explicit-only via /team skill.
 
   // Sort by priority order
-const priorityOrder = ['cancel','ralph','autopilot','ultrawork',
-    'ccg','ralplan','deep-interview','ai-slop-cleaner','tdd','ultrathink','deepsearch','analyze'];
+  const priorityOrder = ['cancel','ralph','autopilot','ultrawork',
+    'ccg','ralplan','deep-interview','ai-slop-cleaner','tdd','code-review','security-review','ultrathink','deepsearch','analyze'];
   resolved.sort((a, b) => priorityOrder.indexOf(a.name) - priorityOrder.indexOf(b.name));
 
   return resolved;
@@ -392,6 +410,16 @@ async function main() {
       matches.push({ name: 'tdd', args: '' });
     }
 
+    // Code review keywords
+    if (/\b(code\s+review|review\s+code)\b/i.test(cleanPrompt)) {
+      matches.push({ name: 'code-review', args: '' });
+    }
+
+    // Security review keywords
+    if (/\b(security\s+review|review\s+security)\b/i.test(cleanPrompt)) {
+      matches.push({ name: 'security-review', args: '' });
+    }
+
     // Ultrathink keywords
     if (/\b(ultrathink)\b/i.test(cleanPrompt)) {
       matches.push({ name: 'ultrathink', args: '' });
@@ -454,6 +482,8 @@ async function main() {
       ['ultrathink', ULTRATHINK_MESSAGE],
       ['analyze', ANALYZE_MESSAGE],
       ['tdd', TDD_MESSAGE],
+      ['code-review', CODE_REVIEW_MESSAGE],
+      ['security-review', SECURITY_REVIEW_MESSAGE],
     ]) {
       const index = resolved.findIndex(m => m.name === keywordName);
       if (index !== -1) {


### PR DESCRIPTION
Fixes #1469

Restores the missing keyword route for `code-review` that was dropped during the thin wrapper skill removal.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*