### PR TITLE
fix(hud): resolve 429 rate limit on /api/oauth/usage polling

### DIFF
--- a/src/__tests__/hud/render.test.ts
+++ b/src/__tests__/hud/render.test.ts
@@ -224,6 +224,7 @@ describe('gitInfoPosition configuration', () => {
     thresholds: DEFAULT_HUD_CONFIG.thresholds,
     staleTaskThresholdMinutes: 30,
     contextLimitWarning: DEFAULT_HUD_CONFIG.contextLimitWarning,
+    usageApiPollIntervalMs: DEFAULT_HUD_CONFIG.usageApiPollIntervalMs,
   });
 
   beforeEach(() => {
@@ -410,6 +411,7 @@ describe('maxWidth wrapMode behavior', () => {
       ...DEFAULT_HUD_CONFIG.contextLimitWarning,
       threshold: 101,
     },
+    usageApiPollIntervalMs: DEFAULT_HUD_CONFIG.usageApiPollIntervalMs,
     maxWidth,
     wrapMode,
   });

--- a/src/__tests__/hud/state.test.ts
+++ b/src/__tests__/hud/state.test.ts
@@ -203,5 +203,22 @@ describe('readHudConfig', () => {
       expect(config.maxWidth).toBe(80);
       expect(config.wrapMode).toBe('wrap');
     });
+
+    it('merges usageApiPollIntervalMs from settings', () => {
+      mockExistsSync.mockImplementation((path) => {
+        const s = String(path);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        omcHud: {
+          usageApiPollIntervalMs: 180_000,
+        }
+      }));
+
+      const config = readHudConfig();
+
+      expect(config.usageApiPollIntervalMs).toBe(180_000);
+      expect(config.maxWidth).toBe(DEFAULT_HUD_CONFIG.maxWidth);
+    });
   });
 });

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import { EventEmitter } from 'events';
 import { isZaiHost, parseZaiResponse, getUsage } from '../../hud/usage-api.js';
 
 // Mock file-lock so withFileLock always executes the callback (tests focus on routing, not locking)
@@ -294,6 +295,170 @@ describe('getUsage routing', () => {
       error: undefined,
     });
     expect(httpsModule.default.request).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it('respects configured usageApiPollIntervalMs for successful cache reuse', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-07T00:00:00Z'));
+
+    const mockedExistsSync = vi.mocked(fs.existsSync);
+    const mockedReadFileSync = vi.mocked(fs.readFileSync);
+
+    mockedExistsSync.mockImplementation((path) => {
+      const file = String(path);
+      return file.endsWith('settings.json') || file.endsWith('.usage-cache.json');
+    });
+    mockedReadFileSync.mockImplementation((path) => {
+      const file = String(path);
+      if (file.endsWith('settings.json')) {
+        return JSON.stringify({
+          omcHud: {
+            usageApiPollIntervalMs: 180_000,
+          },
+        });
+      }
+      if (file.endsWith('.usage-cache.json')) {
+        return JSON.stringify({
+          timestamp: Date.now() - 120_000,
+          source: 'anthropic',
+          data: {
+            fiveHourPercent: 42,
+            weeklyPercent: 17,
+            fiveHourResetsAt: null,
+            weeklyResetsAt: null,
+          },
+        });
+      }
+      return '{}';
+    });
+
+    const result = await getUsage();
+
+    expect(result).toEqual({
+      rateLimits: {
+        fiveHourPercent: 42,
+        weeklyPercent: 17,
+        fiveHourResetsAt: null,
+        weeklyResetsAt: null,
+      },
+      error: undefined,
+    });
+    expect(httpsModule.default.request).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it('returns rate_limited and persists exponential backoff metadata even without stale data', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-07T00:00:00Z'));
+
+    process.env.ANTHROPIC_BASE_URL = 'https://api.z.ai/v1';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
+
+    const mockedExistsSync = vi.mocked(fs.existsSync);
+    const mockedReadFileSync = vi.mocked(fs.readFileSync);
+    const mockedWriteFileSync = vi.mocked(fs.writeFileSync);
+
+    mockedExistsSync.mockImplementation((path) => String(path).endsWith('settings.json'));
+    mockedReadFileSync.mockImplementation((path) => {
+      const file = String(path);
+      if (file.endsWith('settings.json')) {
+        return JSON.stringify({
+          omcHud: {
+            usageApiPollIntervalMs: 60_000,
+          },
+        });
+      }
+      return '{}';
+    });
+
+    httpsModule.default.request.mockImplementationOnce((_options, callback) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void; on: typeof EventEmitter.prototype.on };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 429;
+        callback(res);
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result).toEqual({
+      rateLimits: null,
+      error: 'rate_limited',
+    });
+    expect(mockedWriteFileSync).toHaveBeenCalled();
+
+    const writtenCache = JSON.parse(String(mockedWriteFileSync.mock.calls.at(-1)?.[1] ?? '{}'));
+    expect(writtenCache.rateLimited).toBe(true);
+    expect(writtenCache.rateLimitedCount).toBe(1);
+    expect(writtenCache.error).toBe(false);
+    expect(writtenCache.errorReason).toBe('rate_limited');
+    expect(writtenCache.rateLimitedUntil - writtenCache.timestamp).toBe(60_000);
+
+    vi.useRealTimers();
+  });
+
+  it('increases 429 backoff exponentially up to the configured ceiling', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-07T00:00:00Z'));
+
+    process.env.ANTHROPIC_BASE_URL = 'https://api.z.ai/v1';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
+
+    const mockedExistsSync = vi.mocked(fs.existsSync);
+    const mockedReadFileSync = vi.mocked(fs.readFileSync);
+    const mockedWriteFileSync = vi.mocked(fs.writeFileSync);
+
+    mockedExistsSync.mockImplementation((path) => {
+      const file = String(path);
+      return file.endsWith('settings.json') || file.endsWith('.usage-cache.json');
+    });
+    mockedReadFileSync.mockImplementation((path) => {
+      const file = String(path);
+      if (file.endsWith('settings.json')) {
+        return JSON.stringify({
+          omcHud: {
+            usageApiPollIntervalMs: 60_000,
+          },
+        });
+      }
+      if (file.endsWith('.usage-cache.json')) {
+        return JSON.stringify({
+          timestamp: Date.now() - 300_000,
+          rateLimitedUntil: Date.now() - 1,
+          rateLimited: true,
+          rateLimitedCount: 4,
+          source: 'zai',
+          data: null,
+        });
+      }
+      return '{}';
+    });
+
+    httpsModule.default.request.mockImplementationOnce((_options, callback) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void; on: typeof EventEmitter.prototype.on };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 429;
+        callback(res);
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result.error).toBe('rate_limited');
+    const writtenCache = JSON.parse(String(mockedWriteFileSync.mock.calls.at(-1)?.[1] ?? '{}'));
+    expect(writtenCache.rateLimitedCount).toBe(5);
+    expect(writtenCache.rateLimitedUntil - writtenCache.timestamp).toBe(300_000);
 
     vi.useRealTimers();
   });

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -208,6 +208,7 @@ function mergeWithDefaults(config: Partial<HudConfig>): HudConfig {
       ...DEFAULT_HUD_CONFIG.contextLimitWarning,
       ...config.contextLimitWarning,
     },
+    usageApiPollIntervalMs: config.usageApiPollIntervalMs ?? DEFAULT_HUD_CONFIG.usageApiPollIntervalMs,
     ...(config.rateLimitsProvider ? { rateLimitsProvider: config.rateLimitsProvider } : {}),
     ...(config.maxWidth != null ? { maxWidth: config.maxWidth } : {}),
     ...(config.wrapMode != null ? { wrapMode: config.wrapMode } : {}),

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -444,6 +444,8 @@ export interface HudConfig {
   thresholds: HudThresholds;
   staleTaskThresholdMinutes: number; // Default 30
   contextLimitWarning: ContextLimitWarningConfig;
+  /** Built-in usage API polling interval / success-cache TTL in milliseconds. */
+  usageApiPollIntervalMs: number;
   /** Optional custom rate limit provider; omit to use built-in Anthropic/z.ai */
   rateLimitsProvider?: RateLimitsProviderConfig;
   /** Optional maximum width (columns) for statusline output. */
@@ -451,6 +453,8 @@ export interface HudConfig {
   /** Controls maxWidth behavior: truncate with ellipsis (default) or wrap at " | " HUD element boundaries. */
   wrapMode?: 'truncate' | 'wrap';
 }
+
+export const DEFAULT_HUD_USAGE_POLL_INTERVAL_MS = 90 * 1000;
 
 export const DEFAULT_HUD_CONFIG: HudConfig = {
   preset: 'focused',
@@ -498,6 +502,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     threshold: 80,
     autoCompact: false,
   },
+  usageApiPollIntervalMs: DEFAULT_HUD_USAGE_POLL_INTERVAL_MS,
   wrapMode: 'truncate',
 };
 

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -19,14 +19,18 @@ import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 import https from 'https';
 import { validateAnthropicBaseUrl } from '../utils/ssrf-guard.js';
-import type { RateLimits, UsageResult, UsageErrorReason } from './types.js';
+import {
+  DEFAULT_HUD_USAGE_POLL_INTERVAL_MS,
+  type RateLimits,
+  type UsageResult,
+  type UsageErrorReason,
+} from './types.js';
+import { readHudConfig } from './state.js';
 import { lockPathFor, withFileLock, type FileLockOptions } from '../lib/file-lock.js';
 
 // Cache configuration
-const CACHE_TTL_SUCCESS_MS = 90 * 1000; // 90 seconds for successful responses to reduce usage API polling
 const CACHE_TTL_FAILURE_MS = 15 * 1000; // 15 seconds for failures
-const CACHE_TTL_RATE_LIMITED_MS = 120 * 1000; // 2 minutes base for 429
-const MAX_RATE_LIMITED_BACKOFF_MS = 600 * 1000; // 10 minutes max
+const MAX_RATE_LIMITED_BACKOFF_MS = 5 * 60 * 1000; // 5 minutes max for sustained 429s
 const API_TIMEOUT_MS = 10000;
 const TOKEN_REFRESH_URL_HOSTNAME = 'platform.claude.com';
 const USAGE_CACHE_LOCK_OPTS: FileLockOptions = { timeoutMs: API_TIMEOUT_MS + 2000 };
@@ -50,6 +54,8 @@ interface UsageCache {
   rateLimited?: boolean;
   /** Consecutive 429 count for exponential backoff */
   rateLimitedCount?: number;
+  /** Absolute timestamp when the next rate-limited retry is allowed */
+  rateLimitedUntil?: number;
 }
 
 interface OAuthCredentials {
@@ -147,6 +153,7 @@ function writeCache(
   source?: 'anthropic' | 'zai',
   rateLimited = false,
   rateLimitedCount = 0,
+  rateLimitedUntil?: number,
   errorReason?: UsageErrorReason,
 ): void {
   try {
@@ -165,6 +172,7 @@ function writeCache(
       source,
       rateLimited: rateLimited || undefined,
       rateLimitedCount: rateLimitedCount > 0 ? rateLimitedCount : undefined,
+      rateLimitedUntil,
     };
 
     writeFileSync(cachePath, JSON.stringify(cache, null, 2));
@@ -176,16 +184,40 @@ function writeCache(
 /**
  * Check if cache is still valid
  */
-function isCacheValid(cache: UsageCache): boolean {
-  if (cache.rateLimited) {
-    const count = cache.rateLimitedCount || 1;
-    const backoffMs = Math.min(
-      CACHE_TTL_RATE_LIMITED_MS * Math.pow(2, count - 1),
-      MAX_RATE_LIMITED_BACKOFF_MS,
-    );
-    return Date.now() - cache.timestamp < backoffMs;
+function sanitizePollIntervalMs(value: number | undefined): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_HUD_USAGE_POLL_INTERVAL_MS;
   }
-  const ttl = cache.error ? CACHE_TTL_FAILURE_MS : CACHE_TTL_SUCCESS_MS;
+
+  return Math.max(1000, Math.floor(value));
+}
+
+function getUsagePollIntervalMs(): number {
+  try {
+    return sanitizePollIntervalMs(readHudConfig().usageApiPollIntervalMs);
+  } catch {
+    return DEFAULT_HUD_USAGE_POLL_INTERVAL_MS;
+  }
+}
+
+function getRateLimitedBackoffMs(pollIntervalMs: number, count: number): number {
+  const normalizedPollIntervalMs = sanitizePollIntervalMs(pollIntervalMs);
+  return Math.min(
+    normalizedPollIntervalMs * Math.pow(2, Math.max(0, count - 1)),
+    Math.max(MAX_RATE_LIMITED_BACKOFF_MS, normalizedPollIntervalMs),
+  );
+}
+
+function isCacheValid(cache: UsageCache, pollIntervalMs: number): boolean {
+  if (cache.rateLimited) {
+    if (cache.rateLimitedUntil != null) {
+      return Date.now() < cache.rateLimitedUntil;
+    }
+
+    const count = cache.rateLimitedCount || 1;
+    return Date.now() - cache.timestamp < getRateLimitedBackoffMs(pollIntervalMs, count);
+  }
+  const ttl = cache.error ? CACHE_TTL_FAILURE_MS : sanitizePollIntervalMs(pollIntervalMs);
   return Date.now() - cache.timestamp < ttl;
 }
 
@@ -198,6 +230,27 @@ function getCachedUsageResult(cache: UsageCache): UsageResult {
     ? (cache.errorReason || 'network')
     : undefined;
   return { rateLimits: cache.data, error: cachedError };
+}
+
+function createRateLimitedCacheEntry(
+  source: 'anthropic' | 'zai',
+  data: RateLimits | null,
+  pollIntervalMs: number,
+  previousCount: number,
+): UsageCache {
+  const timestamp = Date.now();
+  const rateLimitedCount = previousCount + 1;
+
+  return {
+    timestamp,
+    data,
+    error: false,
+    errorReason: 'rate_limited',
+    source,
+    rateLimited: true,
+    rateLimitedCount,
+    rateLimitedUntil: timestamp + getRateLimitedBackoffMs(pollIntervalMs, rateLimitedCount),
+  };
 }
 
 /**
@@ -653,35 +706,40 @@ export async function getUsage(): Promise<UsageResult> {
   const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
   const isZai = baseUrl != null && isZaiHost(baseUrl);
   const currentSource: 'anthropic' | 'zai' = isZai && authToken ? 'zai' : 'anthropic';
+  const pollIntervalMs = getUsagePollIntervalMs();
 
   const initialCache = readCache();
-  if (initialCache && isCacheValid(initialCache) && initialCache.source === currentSource) {
+  if (initialCache && isCacheValid(initialCache, pollIntervalMs) && initialCache.source === currentSource) {
     return getCachedUsageResult(initialCache);
   }
 
   return withFileLock(lockPathFor(getCachePath()), async () => {
     const cache = readCache();
-    if (cache && isCacheValid(cache) && cache.source === currentSource) {
+    if (cache && isCacheValid(cache, pollIntervalMs) && cache.source === currentSource) {
       return getCachedUsageResult(cache);
     }
 
     // z.ai path (must precede OAuth check to avoid stale Anthropic credentials)
     if (isZai && authToken) {
       const result = await fetchUsageFromZai();
+      const cachedZai = cache?.source === 'zai' ? cache : null;
 
       if (result.rateLimited) {
-        const prevCount = cache?.rateLimitedCount || 0;
-        const newCount = prevCount + 1;
-        // Serve stale data if available
-        writeCache(cache?.data || null, !cache?.data, 'zai', true, newCount, 'rate_limited');
-        if (cache?.data) {
-          return { rateLimits: cache.data, error: 'rate_limited' };
-        }
-        return { rateLimits: null, error: 'rate_limited' };
+        const rateLimitedCache = createRateLimitedCacheEntry('zai', cachedZai?.data || null, pollIntervalMs, cachedZai?.rateLimitedCount || 0);
+        writeCache(
+          rateLimitedCache.data,
+          rateLimitedCache.error,
+          rateLimitedCache.source,
+          true,
+          rateLimitedCache.rateLimitedCount,
+          rateLimitedCache.rateLimitedUntil,
+          'rate_limited',
+        );
+        return getCachedUsageResult(rateLimitedCache);
       }
 
       if (!result.data) {
-        writeCache(null, true, 'zai', false, 0, 'network');
+        writeCache(null, true, 'zai', false, 0, undefined, 'network');
         return { rateLimits: null, error: 'network' };
       }
 
@@ -693,6 +751,7 @@ export async function getUsage(): Promise<UsageResult> {
     // Anthropic OAuth path (official Claude Code support)
     let creds = getCredentials();
     if (creds) {
+      const cachedAnthropic = cache?.source === 'anthropic' ? cache : null;
       if (!validateCredentials(creds)) {
         if (creds.refreshToken) {
           const refreshed = await refreshAccessToken(creds.refreshToken);
@@ -700,11 +759,11 @@ export async function getUsage(): Promise<UsageResult> {
             creds = { ...creds, ...refreshed };
             writeBackCredentials(creds);
           } else {
-            writeCache(null, true, 'anthropic', false, 0, 'auth');
+            writeCache(null, true, 'anthropic', false, 0, undefined, 'auth');
             return { rateLimits: null, error: 'auth' };
           }
         } else {
-          writeCache(null, true, 'anthropic', false, 0, 'auth');
+          writeCache(null, true, 'anthropic', false, 0, undefined, 'auth');
           return { rateLimits: null, error: 'auth' };
         }
       }
@@ -712,17 +771,21 @@ export async function getUsage(): Promise<UsageResult> {
       const result = await fetchUsageFromApi(creds.accessToken);
 
       if (result.rateLimited) {
-        const prevCount = cache?.rateLimitedCount || 0;
-        const newCount = prevCount + 1;
-        writeCache(cache?.data || null, !cache?.data, 'anthropic', true, newCount, 'rate_limited');
-        if (cache?.data) {
-          return { rateLimits: cache.data, error: 'rate_limited' };
-        }
-        return { rateLimits: null, error: 'rate_limited' };
+        const rateLimitedCache = createRateLimitedCacheEntry('anthropic', cachedAnthropic?.data || null, pollIntervalMs, cachedAnthropic?.rateLimitedCount || 0);
+        writeCache(
+          rateLimitedCache.data,
+          rateLimitedCache.error,
+          rateLimitedCache.source,
+          true,
+          rateLimitedCache.rateLimitedCount,
+          rateLimitedCache.rateLimitedUntil,
+          'rate_limited',
+        );
+        return getCachedUsageResult(rateLimitedCache);
       }
 
       if (!result.data) {
-        writeCache(null, true, 'anthropic', false, 0, 'network');
+        writeCache(null, true, 'anthropic', false, 0, undefined, 'network');
         return { rateLimits: null, error: 'network' };
       }
 
@@ -731,7 +794,7 @@ export async function getUsage(): Promise<UsageResult> {
       return { rateLimits: usage };
     }
 
-    writeCache(null, true, 'anthropic', false, 0, 'no_credentials');
+    writeCache(null, true, 'anthropic', false, 0, undefined, 'no_credentials');
     return { rateLimits: null, error: 'no_credentials' };
   }, USAGE_CACHE_LOCK_OPTS);
 }


### PR DESCRIPTION
Fixes #1470

Adds backoff logic for sustained 429 errors on the HUD usage polling endpoint.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*