### PR TITLE
fix(hooks): add skill-active-state lifecycle to plugin scripts

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -14,6 +14,7 @@ const {
   writeFileSync,
   readdirSync,
   mkdirSync,
+  unlinkSync,
 } = require("fs");
 const { join, dirname, resolve, normalize } = require("path");
 const { homedir } = require("os");
@@ -777,6 +778,43 @@ async function main() {
 
       console.log(JSON.stringify({ decision: "block", reason }));
       return;
+    }
+
+    // Priority 9: Skill Active State (issue #1033)
+    // Skills like code-review, plan, ralplan, tdd, etc. write skill-active-state.json
+    // when invoked via the Skill tool. This prevents premature stops mid-skill.
+    {
+      const skillState = readStateFileWithSession(stateDir, "skill-active-state.json", sessionId);
+      if (skillState.state?.active) {
+        // Staleness check (per-skill TTL)
+        const sLastChecked = skillState.state.last_checked_at ? new Date(skillState.state.last_checked_at).getTime() : 0;
+        const sStartedAt = skillState.state.started_at ? new Date(skillState.state.started_at).getTime() : 0;
+        const sMostRecent = Math.max(sLastChecked, sStartedAt);
+        const sTtl = skillState.state.stale_ttl_ms || 5 * 60 * 1000;
+        const sAge = sMostRecent > 0 ? Date.now() - sMostRecent : Infinity;
+        const isStale = sMostRecent === 0 || sAge > sTtl;
+
+        if (!isStale && isSessionMatch(skillState.state, sessionId)) {
+          const count = skillState.state.reinforcement_count || 0;
+          const maxReinforcements = skillState.state.max_reinforcements || 3;
+
+          if (count < maxReinforcements) {
+            skillState.state.reinforcement_count = count + 1;
+            skillState.state.last_checked_at = new Date().toISOString();
+            writeJsonFile(skillState.path, skillState.state);
+
+            const skillName = skillState.state.skill_name || "unknown";
+            console.log(JSON.stringify({
+              decision: "block",
+              reason: `[SKILL ACTIVE: ${skillName}] The "${skillName}" skill is still executing (reinforcement ${count + 1}/${maxReinforcements}). Continue working on the skill's instructions. Do not stop until the skill completes its workflow.`,
+            }));
+            return;
+          } else {
+            // Reinforcement limit reached - clear state and allow stop
+            try { if (skillState.path && existsSync(skillState.path)) unlinkSync(skillState.path); } catch {}
+          }
+        }
+      }
     }
 
     // No blocking needed — Claude is truly idle.

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -6,7 +6,7 @@
  * Cross-platform: Windows, macOS, Linux
  */
 
-import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from 'fs';
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, renameSync, statSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { execSync } from 'child_process';
 import { homedir } from 'os';
@@ -315,6 +315,85 @@ function generateMessage(toolName, todoStatus, modeActive = false) {
   return '';
 }
 
+// ---------------------------------------------------------------------------
+// Skill Active State (issue #1033)
+// Writes skill-active-state.json so the persistent-mode Stop hook can prevent
+// premature session termination while a skill is executing.
+// ---------------------------------------------------------------------------
+
+const SKILL_PROTECTION_CONFIGS = {
+  none:   { maxReinforcements: 0,  staleTtlMs: 0 },
+  light:  { maxReinforcements: 3,  staleTtlMs: 5 * 60 * 1000 },
+  medium: { maxReinforcements: 5,  staleTtlMs: 15 * 60 * 1000 },
+  heavy:  { maxReinforcements: 10, staleTtlMs: 30 * 60 * 1000 },
+};
+
+const SKILL_PROTECTION_MAP = {
+  autopilot: 'none', ralph: 'none', ultrawork: 'none', team: 'none',
+  'omc-teams': 'none', ultraqa: 'none', cancel: 'none',
+  trace: 'none', hud: 'none', 'omc-doctor': 'none', 'omc-help': 'none',
+  'learn-about-omc': 'none', note: 'none',
+  tdd: 'light', 'build-fix': 'light', analyze: 'light', skill: 'light',
+  'configure-notifications': 'light',
+  'code-review': 'medium', 'security-review': 'medium', plan: 'medium',
+  ralplan: 'medium', review: 'medium', 'external-context': 'medium',
+  sciomc: 'medium', learner: 'medium', 'omc-setup': 'medium',
+  'mcp-setup': 'medium', 'project-session-manager': 'medium',
+  'writer-memory': 'medium', 'ralph-init': 'medium', ccg: 'medium',
+  deepinit: 'heavy',
+};
+
+function getSkillProtectionLevel(skillName) {
+  const normalized = (skillName || '').toLowerCase().replace(/^oh-my-claudecode:/, '');
+  return SKILL_PROTECTION_MAP[normalized] || 'light';
+}
+
+function extractSkillName(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const rawSkill = toolInput.skill || toolInput.skill_name || toolInput.skillName || toolInput.command || null;
+  if (typeof rawSkill !== 'string' || !rawSkill.trim()) return null;
+  const normalized = rawSkill.trim();
+  return normalized.includes(':') ? normalized.split(':').at(-1).toLowerCase() : normalized.toLowerCase();
+}
+
+function writeSkillActiveState(directory, skillName, sessionId) {
+  const protection = getSkillProtectionLevel(skillName);
+  if (protection === 'none') return;
+
+  const config = SKILL_PROTECTION_CONFIGS[protection];
+  const now = new Date().toISOString();
+  const normalized = (skillName || '').toLowerCase().replace(/^oh-my-claudecode:/, '');
+
+  const state = {
+    active: true,
+    skill_name: normalized,
+    session_id: sessionId || undefined,
+    started_at: now,
+    last_checked_at: now,
+    reinforcement_count: 0,
+    max_reinforcements: config.maxReinforcements,
+    stale_ttl_ms: config.staleTtlMs,
+  };
+
+  const stateDir = join(directory, '.omc', 'state');
+  const safeSessionId = sessionId && SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
+  const targetDir = safeSessionId
+    ? join(stateDir, 'sessions', safeSessionId)
+    : stateDir;
+  const targetPath = join(targetDir, 'skill-active-state.json');
+
+  try {
+    if (!existsSync(targetDir)) {
+      mkdirSync(targetDir, { recursive: true });
+    }
+    const tmpPath = targetPath + '.tmp';
+    writeFileSync(tmpPath, JSON.stringify(state, null, 2), { mode: 0o600 });
+    renameSync(tmpPath, targetPath);
+  } catch {
+    // Best-effort; don't fail the hook
+  }
+}
+
 // Record Skill/Task invocations to flow trace (best-effort)
 async function recordToolInvocation(data, directory) {
   try {
@@ -350,6 +429,19 @@ async function main() {
     let data = {};
     try { data = JSON.parse(input); } catch {}
     recordToolInvocation(data, directory);
+
+    // Activate skill state when Skill tool is invoked (issue #1033)
+    // Writes skill-active-state.json so the persistent-mode Stop hook can
+    // prevent premature session termination while a skill is executing.
+    if (toolName === 'Skill') {
+      const toolInput = data.toolInput || data.tool_input || {};
+      const skillName = extractSkillName(toolInput);
+      if (skillName) {
+        const sid = typeof data.session_id === 'string' ? data.session_id
+          : typeof data.sessionId === 'string' ? data.sessionId : '';
+        writeSkillActiveState(directory, skillName, sid);
+      }
+    }
 
     const sessionId =
       typeof data.session_id === 'string'

--- a/templates/hooks/pre-tool-use.mjs
+++ b/templates/hooks/pre-tool-use.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
  * OMC Pre-Tool-Use Hook (Node.js)
- * Enforces delegation by warning when orchestrator attempts direct source file edits
+ * Enforces delegation by warning when orchestrator attempts direct source file edits.
+ * Also activates skill-active state for Stop hook protection (issue #1033).
  */
 
 import * as path from 'path';
 import { dirname } from 'path';
+import { existsSync, mkdirSync, writeFileSync, renameSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -13,6 +15,105 @@ const __dirname = dirname(__filename);
 
 // Dynamic import for the shared stdin module
 const { readStdin } = await import(pathToFileURL(path.join(__dirname, 'lib', 'stdin.mjs')).href);
+
+// ---------------------------------------------------------------------------
+// Skill Active State (issue #1033)
+// Writes skill-active-state.json so the persistent-mode Stop hook can prevent
+// premature session termination while a skill is executing.
+// ---------------------------------------------------------------------------
+
+/**
+ * Skill protection levels: none/light/medium/heavy.
+ * - 'none': Already has dedicated mode state (ralph, autopilot) or instant/read-only
+ * - 'light': Quick agent shortcuts (3 reinforcements, 5 min TTL)
+ * - 'medium': Review/planning skills that run multiple agents (5 reinforcements, 15 min TTL)
+ * - 'heavy': Long-running skills (10 reinforcements, 30 min TTL)
+ */
+const PROTECTION_CONFIGS = {
+  none:   { maxReinforcements: 0,  staleTtlMs: 0 },
+  light:  { maxReinforcements: 3,  staleTtlMs: 5 * 60 * 1000 },
+  medium: { maxReinforcements: 5,  staleTtlMs: 15 * 60 * 1000 },
+  heavy:  { maxReinforcements: 10, staleTtlMs: 30 * 60 * 1000 },
+};
+
+const SKILL_PROTECTION = {
+  // Already have mode state → no protection needed
+  autopilot: 'none', ralph: 'none', ultrawork: 'none', team: 'none',
+  'omc-teams': 'none', ultraqa: 'none', cancel: 'none',
+  // Instant / read-only → no protection needed
+  trace: 'none', hud: 'none', 'omc-doctor': 'none', 'omc-help': 'none',
+  'learn-about-omc': 'none', note: 'none',
+  // Light protection (3 reinforcements)
+  tdd: 'light', 'build-fix': 'light', analyze: 'light', skill: 'light',
+  'configure-notifications': 'light',
+  // Medium protection (5 reinforcements)
+  'code-review': 'medium', 'security-review': 'medium', plan: 'medium',
+  ralplan: 'medium', review: 'medium', 'external-context': 'medium',
+  sciomc: 'medium', learner: 'medium', 'omc-setup': 'medium',
+  'mcp-setup': 'medium', 'project-session-manager': 'medium',
+  'writer-memory': 'medium', 'ralph-init': 'medium', ccg: 'medium',
+  // Heavy protection (10 reinforcements)
+  deepinit: 'heavy',
+};
+
+function getSkillProtection(skillName) {
+  const normalized = (skillName || '').toLowerCase().replace(/^oh-my-claudecode:/, '');
+  return SKILL_PROTECTION[normalized] || 'light';
+}
+
+function getInvokedSkillName(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const rawSkill = toolInput.skill || toolInput.skill_name || toolInput.skillName || toolInput.command || null;
+  if (typeof rawSkill !== 'string' || !rawSkill.trim()) return null;
+  const normalized = rawSkill.trim();
+  return normalized.includes(':') ? normalized.split(':').at(-1).toLowerCase() : normalized.toLowerCase();
+}
+
+const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+
+function writeSkillActiveState(directory, skillName, sessionId) {
+  const protection = getSkillProtection(skillName);
+  if (protection === 'none') return;
+
+  const config = PROTECTION_CONFIGS[protection];
+  const now = new Date().toISOString();
+  const normalized = (skillName || '').toLowerCase().replace(/^oh-my-claudecode:/, '');
+
+  const state = {
+    active: true,
+    skill_name: normalized,
+    session_id: sessionId || undefined,
+    started_at: now,
+    last_checked_at: now,
+    reinforcement_count: 0,
+    max_reinforcements: config.maxReinforcements,
+    stale_ttl_ms: config.staleTtlMs,
+  };
+
+  const stateDir = path.join(directory, '.omc', 'state');
+
+  // Write to session-scoped path when sessionId is available (must match persistent-mode.mjs reads)
+  const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  const targetDir = safeSessionId
+    ? path.join(stateDir, 'sessions', safeSessionId)
+    : stateDir;
+  const targetPath = path.join(targetDir, 'skill-active-state.json');
+
+  try {
+    if (!existsSync(targetDir)) {
+      mkdirSync(targetDir, { recursive: true });
+    }
+    const tmpPath = targetPath + '.tmp';
+    writeFileSync(tmpPath, JSON.stringify(state, null, 2), { mode: 0o600 });
+    renameSync(tmpPath, targetPath);
+  } catch {
+    // Best-effort; don't fail the hook
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Delegation enforcement
+// ---------------------------------------------------------------------------
 
 // Allowed path patterns (no warning)
 // Paths are normalized to forward slashes before matching
@@ -165,6 +266,19 @@ async function main() {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     }
     return;
+  }
+
+  // Activate skill state when Skill tool is invoked (issue #1033)
+  // Writes skill-active-state.json so the persistent-mode Stop hook can
+  // prevent premature session termination while a skill is executing.
+  if (toolName === 'Skill' || toolName === 'skill') {
+    const directory = data.cwd || data.directory || process.cwd();
+    const sessionId = data.sessionId || data.session_id || data.sessionid || '';
+    const toolInput = data.tool_input || data.toolInput || {};
+    const skillName = getInvokedSkillName(toolInput);
+    if (skillName) {
+      writeSkillActiveState(directory, skillName, sessionId);
+    }
   }
 
   // Only check Edit and Write tools


### PR DESCRIPTION
## Summary

- Add skill-active-state writing to `scripts/pre-tool-enforcer.mjs` (PreToolUse hook)
- Add skill-active-state reading/blocking to `scripts/persistent-mode.cjs` (Stop hook)
- Sync legacy `templates/hooks/pre-tool-use.mjs` with the same logic

Fixes #1479

## Context

The original #1033 fix and subsequent enhancements (#1424, #1432) were applied only to `src/hooks/` (bridge code), which is not invoked at runtime. The actual plugin scripts routed via `hooks/hooks.json` were never updated, causing skills like `ralplan`, `code-review`, and `plan` to have zero stop protection.

See #1479 for full root cause analysis.

## What this covers

- Per-skill protection levels (none/light/medium/heavy) with configurable reinforcements and TTL
- Session-scoped state paths (`skill-active-state.json`)
- Staleness detection and reinforcement counting
- Atomic file writes (tmp + rename)

## What this does NOT cover

- First-class `checkRalplan()` (30 reinforcements, 45-min TTL) from `src/hooks/persistent-mode/index.ts`
- First-class `checkTeamPipeline()` (20 reinforcements, 5-min TTL)
- PostToolUse cleanup of skill-active-state

These require a design decision on the `src/hooks/` vs `scripts/` sync strategy (see #1479).

## Test plan

- [x] All 3 files pass Node.js syntax check
- [x] `SESSION_ID_PATTERN`, `readStateFileWithSession`, `isSessionMatch`, `writeJsonFile` verified to exist in their respective files
- [ ] Manual: run `/ralplan`, verify stop is blocked during consensus workflow
- [ ] Manual: run `/code-review`, verify stop is blocked during review

🤖 Generated with [Claude Code](https://claude.com/claude-code)