### PR TITLE
fix(team): parse --new-window CLI flag in parseTeamArgs

### DIFF
--- a/src/cli/commands/__tests__/team.test.ts
+++ b/src/cli/commands/__tests__/team.test.ts
@@ -233,11 +233,12 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     expect(parsed.role).toBe('architect');
   });
 
-  it('supports --json flag with comma-separated specs', () => {
-    const parsed = parseTeamArgs(['1:codex,1:gemini', '--json', 'compare']);
+  it('supports --json and --new-window flags with comma-separated specs', () => {
+    const parsed = parseTeamArgs(['1:codex,1:gemini', '--new-window', '--json', 'compare']);
     expect(parsed.workerCount).toBe(2);
     expect(parsed.agentTypes).toEqual(['codex', 'gemini']);
     expect(parsed.json).toBe(true);
+    expect(parsed.newWindow).toBe(true);
     expect(parsed.task).toBe('compare');
   });
 

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -20,7 +20,7 @@ const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
 
 const TEAM_HELP = `
-Usage: omc team [N:agent-type[:role]] "<task description>"
+Usage: omc team [N:agent-type[:role]] [--new-window] "<task description>"
        omc team status <team-name>
        omc team shutdown <team-name> [--force]
        omc team api <operation> [--input <json>] [--json]
@@ -31,6 +31,7 @@ Examples:
   omc team 2:codex:architect "design auth system"
   omc team 1:gemini:executor "implement feature"
   omc team 1:codex,1:gemini "compare approaches"
+  omc team 2:codex "review auth flow" --new-window
   omc team status fix-failing-tests
   omc team shutdown fix-failing-tests
   omc team api send-message --input '{"team_name":"my-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json
@@ -121,6 +122,7 @@ export interface ParsedTeamArgs {
   task: string;
   teamName: string;
   json: boolean;
+  newWindow: boolean;
 }
 
 function getTeamWorkerIdentityFromEnv(env: NodeJS.ProcessEnv = process.env): string | null {
@@ -148,12 +150,15 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   let workerCount = 3;
   let agentTypes: string[] = [];
   let json = false;
+  let newWindow = false;
 
-  // Extract --json flag before parsing positional args
+  // Extract supported flags before parsing positional args
   const filteredArgs: string[] = [];
   for (const arg of args) {
     if (arg === '--json') {
       json = true;
+    } else if (arg === '--new-window') {
+      newWindow = true;
     } else {
       filteredArgs.push(arg);
     }
@@ -227,7 +232,7 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   }
 
   const teamName = slugifyTask(task);
-  return { workerCount, agentTypes, role, task, teamName, json };
+  return { workerCount, agentTypes, role, task, teamName, json, newWindow };
 }
 
 function sampleValueForField(field: string): unknown {
@@ -387,6 +392,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
       agentTypes: parsed.agentTypes,
       tasks,
       cwd,
+      newWindow: parsed.newWindow,
       ...(rolePrompt ? { roleName: parsed.role, rolePrompt } : {}),
     });
 
@@ -424,6 +430,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
     agentTypes: parsed.agentTypes as any,
     tasks,
     cwd,
+    newWindow: parsed.newWindow,
   });
 
   const uniqueTypesV1 = [...new Set(parsed.agentTypes)].join(',');


### PR DESCRIPTION
## Summary
- parse `--new-window` in `parseTeamArgs` instead of leaving it in the task string
- return `newWindow` from parsed team args and pass it into both runtime start paths
- add a regression test covering `--new-window` parsing

## Testing
- npm exec vitest run src/cli/commands/__tests__/team.test.ts
- npm exec vitest run src/cli/__tests__/team.test.ts
- npm exec tsc -- --noEmit
- npm run build:cli

Closes #1483