### PR TITLE
feat(mission): add opt-in mission board for multi-agent progress tracking

### DIFF
--- a/src/__tests__/hud/defaults.test.ts
+++ b/src/__tests__/hud/defaults.test.ts
@@ -23,6 +23,11 @@ describe('HUD Default Configuration', () => {
       expect(DEFAULT_HUD_CONFIG.elements.thinkingFormat).toBe('text');
     });
 
+    it('should keep mission board disabled by default', () => {
+      expect(DEFAULT_HUD_CONFIG.elements.missionBoard).toBe(false);
+      expect(DEFAULT_HUD_CONFIG.missionBoard?.enabled).toBe(false);
+    });
+
     it('should default wrapMode to truncate', () => {
       expect(DEFAULT_HUD_CONFIG.wrapMode).toBe('truncate');
     });

--- a/src/__tests__/hud/mission-board-state.test.ts
+++ b/src/__tests__/hud/mission-board-state.test.ts
@@ -1,0 +1,200 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  readMissionBoardState,
+  recordMissionAgentStart,
+  recordMissionAgentStop,
+  refreshMissionBoardState,
+} from '../../hud/mission-board.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'omc-mission-board-'));
+  tempDirs.push(dir);
+  mkdirSync(join(dir, '.omc', 'state'), { recursive: true });
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('mission board state tracking', () => {
+  it('records session-scoped agent starts and completions', () => {
+    const cwd = makeTempDir();
+
+    recordMissionAgentStart(cwd, {
+      sessionId: 'sess-1234',
+      agentId: 'agent-1',
+      agentType: 'oh-my-claudecode:executor',
+      parentMode: 'ultrawork',
+      taskDescription: 'Implement mission board renderer',
+      at: '2026-03-09T07:00:00.000Z',
+    });
+    recordMissionAgentStop(cwd, {
+      sessionId: 'sess-1234',
+      agentId: 'agent-1',
+      success: true,
+      outputSummary: 'Rendered mission and timeline lines',
+      at: '2026-03-09T07:05:00.000Z',
+    });
+
+    const state = readMissionBoardState(cwd);
+    expect(state).not.toBeNull();
+    expect(state?.missions).toHaveLength(1);
+
+    const mission = state!.missions[0]!;
+    expect(mission.source).toBe('session');
+    expect(mission.name).toBe('ultrawork');
+    expect(mission.status).toBe('done');
+    expect(mission.taskCounts.completed).toBe(1);
+    expect(mission.agents[0]?.status).toBe('done');
+    expect(mission.agents[0]?.completedSummary).toContain('Rendered mission');
+    expect(mission.timeline.map((entry) => entry.kind)).toEqual(['update', 'completion']);
+  });
+
+  it('syncs team missions from existing team state files and preserves session missions', () => {
+    const cwd = makeTempDir();
+
+    recordMissionAgentStart(cwd, {
+      sessionId: 'sess-merge',
+      agentId: 'agent-9',
+      agentType: 'oh-my-claudecode:architect',
+      parentMode: 'ralph',
+      taskDescription: 'Review mission board architecture',
+      at: '2026-03-09T07:00:00.000Z',
+    });
+
+    const teamRoot = join(cwd, '.omc', 'state', 'team', 'demo');
+    mkdirSync(join(teamRoot, 'tasks'), { recursive: true });
+    mkdirSync(join(teamRoot, 'workers', 'worker-1'), { recursive: true });
+    mkdirSync(join(teamRoot, 'workers', 'worker-2'), { recursive: true });
+    mkdirSync(join(teamRoot, 'mailbox'), { recursive: true });
+
+    writeFileSync(join(teamRoot, 'config.json'), JSON.stringify({
+      name: 'demo',
+      task: 'Implement mission board',
+      created_at: '2026-03-09T06:55:00.000Z',
+      worker_count: 2,
+      workers: [
+        { name: 'worker-1', role: 'executor', assigned_tasks: ['1'] },
+        { name: 'worker-2', role: 'test-engineer', assigned_tasks: ['2'] },
+      ],
+    }, null, 2));
+
+    writeFileSync(join(teamRoot, 'tasks', '1.json'), JSON.stringify({
+      id: '1',
+      subject: 'Implement renderer',
+      status: 'in_progress',
+      owner: 'worker-1',
+    }, null, 2));
+    writeFileSync(join(teamRoot, 'tasks', '2.json'), JSON.stringify({
+      id: '2',
+      subject: 'Add tests',
+      status: 'completed',
+      owner: 'worker-2',
+      completed_at: '2026-03-09T07:03:00.000Z',
+      result: 'Added mission board tests',
+    }, null, 2));
+
+    writeFileSync(join(teamRoot, 'workers', 'worker-1', 'status.json'), JSON.stringify({
+      state: 'working',
+      current_task_id: '1',
+      updated_at: '2026-03-09T07:04:00.000Z',
+      reason: 'implementing renderer',
+    }, null, 2));
+    writeFileSync(join(teamRoot, 'workers', 'worker-1', 'heartbeat.json'), JSON.stringify({
+      last_turn_at: '2026-03-09T07:04:30.000Z',
+      alive: true,
+    }, null, 2));
+    writeFileSync(join(teamRoot, 'workers', 'worker-2', 'status.json'), JSON.stringify({
+      state: 'done',
+      updated_at: '2026-03-09T07:03:30.000Z',
+    }, null, 2));
+
+    writeFileSync(join(teamRoot, 'events.jsonl'), [
+      JSON.stringify({ type: 'task_completed', worker: 'worker-2', task_id: '2', created_at: '2026-03-09T07:03:00.000Z' }),
+      JSON.stringify({ type: 'team_leader_nudge', worker: 'worker-1', reason: 'continue working', created_at: '2026-03-09T07:04:00.000Z' }),
+    ].join('\n'));
+
+    writeFileSync(join(teamRoot, 'mailbox', 'worker-1.json'), JSON.stringify({
+      messages: [
+        {
+          message_id: 'm1',
+          from_worker: 'leader-fixed',
+          to_worker: 'worker-1',
+          body: 'Take task 1',
+          created_at: '2026-03-09T07:01:00.000Z',
+        },
+      ],
+    }, null, 2));
+
+    const state = refreshMissionBoardState(cwd, {
+      enabled: true,
+      maxMissions: 5,
+      maxAgentsPerMission: 5,
+      maxTimelineEvents: 5,
+      persistCompletedForMinutes: 30,
+    });
+
+    expect(state.missions).toHaveLength(2);
+
+    const teamMission = state.missions.find((mission) => mission.source === 'team');
+    expect(teamMission?.name).toBe('demo');
+    expect(teamMission?.status).toBe('running');
+    expect(teamMission?.taskCounts.inProgress).toBe(1);
+    expect(teamMission?.agents[0]?.currentStep).toContain('implementing renderer');
+    expect(teamMission?.agents[1]?.completedSummary).toContain('Added mission board tests');
+    expect(teamMission?.timeline.some((entry) => entry.kind === 'handoff')).toBe(true);
+    expect(teamMission?.timeline.some((entry) => entry.kind === 'completion')).toBe(true);
+
+    const persisted = JSON.parse(readFileSync(join(cwd, '.omc', 'state', 'mission-state.json'), 'utf-8')) as {
+      missions: Array<{ source: string }>;
+    };
+    expect(persisted.missions.some((mission) => mission.source === 'session')).toBe(true);
+    expect(persisted.missions.some((mission) => mission.source === 'team')).toBe(true);
+  });
+
+  it('marks team missions blocked when failures or blocked workers are present', () => {
+    const cwd = makeTempDir();
+    const teamRoot = join(cwd, '.omc', 'state', 'team', 'blocked-demo');
+    mkdirSync(join(teamRoot, 'tasks'), { recursive: true });
+    mkdirSync(join(teamRoot, 'workers', 'worker-1'), { recursive: true });
+
+    writeFileSync(join(teamRoot, 'config.json'), JSON.stringify({
+      name: 'blocked-demo',
+      task: 'Wait for approval',
+      created_at: '2026-03-09T08:00:00.000Z',
+      worker_count: 1,
+      workers: [{ name: 'worker-1', role: 'executor', assigned_tasks: ['1'] }],
+    }, null, 2));
+
+    writeFileSync(join(teamRoot, 'tasks', '1.json'), JSON.stringify({
+      id: '1',
+      subject: 'Wait for approval',
+      status: 'failed',
+      owner: 'worker-1',
+      error: 'approval required',
+    }, null, 2));
+
+    writeFileSync(join(teamRoot, 'workers', 'worker-1', 'status.json'), JSON.stringify({
+      state: 'blocked',
+      current_task_id: '1',
+      reason: 'waiting for approval',
+      updated_at: '2026-03-09T08:05:00.000Z',
+    }, null, 2));
+
+    const state = refreshMissionBoardState(cwd);
+    const mission = state.missions.find((entry) => entry.source === 'team');
+
+    expect(mission?.status).toBe('blocked');
+    expect(mission?.agents[0]?.status).toBe('blocked');
+    expect(mission?.agents[0]?.latestUpdate).toContain('waiting for approval');
+  });
+});

--- a/src/__tests__/hud/mission-board.test.ts
+++ b/src/__tests__/hud/mission-board.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { renderMissionBoard } from '../../hud/elements/mission-board.js';
+import { render } from '../../hud/render.js';
+import { DEFAULT_HUD_CONFIG, type HudConfig, type HudRenderContext } from '../../hud/types.js';
+import type { MissionBoardState } from '../../hud/mission-board.js';
+
+function createMissionState(): MissionBoardState {
+  return {
+    updatedAt: '2026-03-09T07:12:00.000Z',
+    missions: [
+      {
+        id: 'team:demo',
+        source: 'team',
+        teamName: 'demo',
+        name: 'demo',
+        objective: 'Implement mission board',
+        createdAt: '2026-03-09T07:00:00.000Z',
+        updatedAt: '2026-03-09T07:12:00.000Z',
+        status: 'running',
+        workerCount: 2,
+        taskCounts: { total: 2, pending: 0, blocked: 0, inProgress: 1, completed: 1, failed: 0 },
+        agents: [
+          {
+            name: 'worker-1',
+            role: 'executor',
+            ownership: '#1',
+            status: 'running',
+            currentStep: '#1 Implement renderer',
+            latestUpdate: 'editing mission-board.ts',
+            completedSummary: null,
+            updatedAt: '2026-03-09T07:11:00.000Z',
+          },
+          {
+            name: 'worker-2',
+            role: 'test-engineer',
+            ownership: '#2',
+            status: 'done',
+            currentStep: null,
+            latestUpdate: 'Added mission board tests',
+            completedSummary: 'Added mission board tests',
+            updatedAt: '2026-03-09T07:10:00.000Z',
+          },
+        ],
+        timeline: [
+          {
+            id: 'handoff-1',
+            at: '2026-03-09T07:05:00.000Z',
+            kind: 'handoff',
+            agent: 'worker-1',
+            detail: 'picked up task 1 (Implement renderer)',
+            sourceKey: 'handoff:1',
+          },
+          {
+            id: 'completion-2',
+            at: '2026-03-09T07:10:00.000Z',
+            kind: 'completion',
+            agent: 'worker-2',
+            detail: 'completed task 2',
+            sourceKey: 'completion:2',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('mission board renderer', () => {
+  it('renders mission, agent, and timeline lines', () => {
+    const lines = renderMissionBoard(createMissionState(), {
+      enabled: true,
+      maxMissions: 2,
+      maxAgentsPerMission: 3,
+      maxTimelineEvents: 3,
+      persistCompletedForMinutes: 20,
+    });
+
+    expect(lines[0]).toContain('MISSION demo [running]');
+    expect(lines[1]).toContain('[run] worker-1 (executor)');
+    expect(lines[2]).toContain('[done] worker-2 (test-engineer)');
+    expect(lines[3]).toContain('timeline: 07:05 handoff worker-1');
+  });
+
+  it('inserts the mission board above existing HUD detail lines when enabled', async () => {
+    const context: HudRenderContext = {
+      contextPercent: 20,
+      modelName: 'claude-sonnet',
+      ralph: null,
+      ultrawork: null,
+      prd: null,
+      autopilot: null,
+      activeAgents: [],
+      todos: [{ content: 'keep shipping', status: 'in_progress' }],
+      backgroundTasks: [],
+      cwd: '/tmp/project',
+      missionBoard: createMissionState(),
+      lastSkill: null,
+      rateLimitsResult: null,
+      customBuckets: null,
+      pendingPermission: null,
+      thinkingState: null,
+      sessionHealth: null,
+      omcVersion: '4.7.8',
+      updateAvailable: null,
+      toolCallCount: 0,
+      agentCallCount: 0,
+      skillCallCount: 0,
+      promptTime: null,
+      apiKeySource: null,
+      profileName: null,
+    };
+
+    const config: HudConfig = {
+      ...DEFAULT_HUD_CONFIG,
+      missionBoard: {
+        enabled: true,
+        maxMissions: 2,
+        maxAgentsPerMission: 3,
+        maxTimelineEvents: 3,
+        persistCompletedForMinutes: 20,
+      },
+      elements: {
+        ...DEFAULT_HUD_CONFIG.elements,
+        omcLabel: true,
+        missionBoard: true,
+        rateLimits: false,
+        ralph: false,
+        autopilot: false,
+        prdStory: false,
+        activeSkills: false,
+        contextBar: false,
+        agents: false,
+        backgroundTasks: false,
+        sessionHealth: false,
+        promptTime: false,
+        todos: true,
+        maxOutputLines: 12,
+      },
+    };
+
+    const output = await render(context, config);
+    const lines = output.split('\n');
+
+    expect(lines[0]).toContain('[OMC#4.7.8]');
+    expect(lines[1]).toContain('MISSION demo [running]');
+    expect(lines[2]).toContain('[run] worker-1');
+    expect(lines[4]).toContain('timeline: 07:05 handoff worker-1');
+    expect(lines[5]).toContain('todos:');
+    expect(lines[5]).toContain('keep shipping');
+  });
+});

--- a/src/__tests__/hud/state.test.ts
+++ b/src/__tests__/hud/state.test.ts
@@ -144,6 +144,25 @@ describe('readHudConfig', () => {
   });
 
   describe('merging with defaults', () => {
+    it('allows mission board to be explicitly enabled from settings', () => {
+      mockExistsSync.mockImplementation((path) => {
+        const s = String(path);
+        return /[\/]Users[\/]testuser[\/]\.claude[\/]settings\.json$/.test(s);
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        omcHud: {
+          elements: {
+            missionBoard: true,
+          }
+        }
+      }));
+
+      const config = readHudConfig();
+
+      expect(config.elements.missionBoard).toBe(true);
+      expect(config.missionBoard?.enabled).toBe(true);
+    });
+
     it('merges partial config with defaults', () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1431,6 +1431,29 @@ program
     }
   });
 
+program
+  .command('mission-board')
+  .description('Render the opt-in mission board snapshot for the current workspace')
+  .option('--json', 'Print raw mission-board JSON')
+  .action(async (options) => {
+    const { refreshMissionBoardState, renderMissionBoard } = await import('../hud/mission-board.js');
+    const state = refreshMissionBoardState(process.cwd());
+    if (options.json) {
+      console.log(JSON.stringify(state, null, 2));
+      return;
+    }
+
+    const lines = renderMissionBoard(state, {
+      enabled: true,
+      maxMissions: 5,
+      maxAgentsPerMission: 8,
+      maxTimelineEvents: 8,
+      persistCompletedForMinutes: 20,
+    });
+
+    console.log(lines.length > 0 ? lines.join('\n') : '(no active missions)');
+  });
+
 /**
  * Team command - CLI API for team worker lifecycle operations
  * Exposes OMC's `omc team api` interface.

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -19,6 +19,7 @@ import {
 import { join } from "path";
 import { getOmcRoot } from '../../lib/worktree-paths.js';
 import { recordAgentStart, recordAgentStop } from './session-replay.js';
+import { recordMissionAgentStart, recordMissionAgentStop } from '../../hud/mission-board.js';
 
 // ============================================================================
 // Types
@@ -602,6 +603,17 @@ export function processSubagentStart(input: SubagentStartInput): HookOutput {
       recordAgentStart(input.cwd, input.session_id, input.agent_id, input.agent_type, input.prompt, parentMode, input.model);
     } catch { /* best-effort */ }
 
+    try {
+      recordMissionAgentStart(input.cwd, {
+        sessionId: input.session_id,
+        agentId: input.agent_id,
+        agentType: input.agent_type,
+        parentMode,
+        taskDescription: input.prompt,
+        at: agentInfo.started_at,
+      });
+    } catch { /* best-effort */ }
+
     // Check for stale agents
     const staleAgents = getStaleAgents(state);
 
@@ -688,6 +700,16 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
       const trackedAgent = agentIndex !== -1 ? state.agents[agentIndex] : undefined;
       const agentType = trackedAgent?.agent_type || input.agent_type || 'unknown';
       recordAgentStop(input.cwd, input.session_id, input.agent_id, agentType, succeeded, trackedAgent?.duration_ms);
+    } catch { /* best-effort */ }
+
+    try {
+      recordMissionAgentStop(input.cwd, {
+        sessionId: input.session_id,
+        agentId: input.agent_id,
+        success: succeeded,
+        outputSummary: agentIndex !== -1 ? state.agents[agentIndex]?.output_summary : input.output,
+        at: agentIndex !== -1 ? state.agents[agentIndex]?.completed_at : new Date().toISOString(),
+      });
     } catch { /* best-effort */ }
 
     const runningCount = state.agents.filter(

--- a/src/hud/elements/index.ts
+++ b/src/hud/elements/index.ts
@@ -21,3 +21,4 @@ export { renderGitRepo, renderGitBranch, getGitRepoName, getGitBranch } from './
 export { renderModel, formatModelName } from './model.js';
 export { renderPromptTime } from './prompt-time.js';
 export { detectApiKeySource, renderApiKeySource, type ApiKeySource } from './api-key-source.js';
+export { renderMissionBoard } from './mission-board.js';

--- a/src/hud/elements/mission-board.ts
+++ b/src/hud/elements/mission-board.ts
@@ -1,0 +1,1 @@
+export { renderMissionBoard } from '../mission-board.js';

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -25,6 +25,7 @@ import { getUsage } from "./usage-api.js";
 import { executeCustomProvider } from "./custom-rate-provider.js";
 import { render } from "./render.js";
 import { detectApiKeySource } from "./elements/api-key-source.js";
+import { refreshMissionBoardState } from "./mission-board.js";
 import { sanitizeOutput } from "./sanitize.js";
 import type {
   HudRenderContext,
@@ -178,6 +179,11 @@ async function main(watchMode = false): Promise<void> {
       }
     }
 
+    const missionBoardEnabled = config.missionBoard?.enabled ?? config.elements.missionBoard ?? false;
+    const missionBoard = missionBoardEnabled
+      ? await refreshMissionBoardState(cwd, config.missionBoard)
+      : null;
+
     // Build render context
     const context: HudRenderContext = {
       contextPercent: getContextPercent(stdin),
@@ -190,6 +196,7 @@ async function main(watchMode = false): Promise<void> {
       todos: transcriptData.todos,
       backgroundTasks: getRunningTasks(hudState),
       cwd,
+      missionBoard,
       lastSkill: transcriptData.lastActivatedSkill || null,
       rateLimitsResult,
       customBuckets,

--- a/src/hud/mission-board.ts
+++ b/src/hud/mission-board.ts
@@ -1,0 +1,579 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { atomicWriteJsonSync } from '../lib/atomic-write.js';
+import { getOmcRoot } from '../lib/worktree-paths.js';
+import { truncateToWidth } from '../utils/string-width.js';
+
+export type MissionBoardSource = 'session' | 'team';
+export type MissionBoardStatus = 'blocked' | 'waiting' | 'running' | 'done';
+export type MissionTimelineEventType = 'handoff' | 'completion' | 'failure' | 'update';
+
+export interface MissionBoardConfig {
+  enabled: boolean;
+  maxMissions?: number;
+  maxAgentsPerMission?: number;
+  maxTimelineEvents?: number;
+  persistCompletedForMinutes?: number;
+}
+
+export interface MissionBoardTimelineEvent {
+  id: string;
+  at: string;
+  kind: MissionTimelineEventType;
+  agent: string;
+  detail: string;
+  sourceKey: string;
+}
+
+export interface MissionBoardAgent {
+  name: string;
+  role?: string;
+  ownership?: string;
+  status: MissionBoardStatus;
+  currentStep?: string | null;
+  latestUpdate?: string | null;
+  completedSummary?: string | null;
+  updatedAt?: string;
+}
+
+export interface MissionBoardMission {
+  id: string;
+  source: MissionBoardSource;
+  teamName?: string;
+  name: string;
+  objective: string;
+  createdAt: string;
+  updatedAt: string;
+  status: MissionBoardStatus;
+  workerCount: number;
+  taskCounts: {
+    total: number;
+    pending: number;
+    blocked: number;
+    inProgress: number;
+    completed: number;
+    failed: number;
+  };
+  agents: MissionBoardAgent[];
+  timeline: MissionBoardTimelineEvent[];
+}
+
+export interface MissionBoardState {
+  updatedAt: string;
+  missions: MissionBoardMission[];
+}
+
+export interface MissionAgentStartInput {
+  sessionId: string;
+  agentId: string;
+  agentType: string;
+  parentMode: string;
+  taskDescription?: string;
+  at?: string;
+}
+
+export interface MissionAgentStopInput {
+  sessionId: string;
+  agentId: string;
+  success: boolean;
+  outputSummary?: string;
+  at?: string;
+}
+
+interface TeamConfigLike {
+  name?: string;
+  task?: string;
+  created_at?: string;
+  worker_count?: number;
+  workers?: Array<{
+    name?: string;
+    role?: string;
+    assigned_tasks?: string[];
+  }>;
+}
+
+interface TeamTaskLike {
+  id?: string;
+  subject?: string;
+  description?: string;
+  status?: string;
+  owner?: string;
+  completed_at?: string;
+  result?: string;
+  summary?: string;
+  error?: string;
+}
+
+interface WorkerStatusLike {
+  state?: string;
+  current_task_id?: string;
+  reason?: string;
+  updated_at?: string;
+}
+
+interface WorkerHeartbeatLike {
+  last_turn_at?: string;
+}
+
+interface TeamEventLike {
+  event_id?: string;
+  type?: string;
+  worker?: string;
+  task_id?: string;
+  reason?: string;
+  created_at?: string;
+}
+
+interface TeamMailboxLike {
+  messages?: Array<{
+    message_id?: string;
+    from_worker?: string;
+    to_worker?: string;
+    body?: string;
+    created_at?: string;
+  }>;
+}
+
+const DEFAULT_CONFIG: Required<MissionBoardConfig> = {
+  enabled: false,
+  maxMissions: 2,
+  maxAgentsPerMission: 3,
+  maxTimelineEvents: 3,
+  persistCompletedForMinutes: 20,
+};
+
+const STATUS_ORDER: Record<MissionBoardStatus, number> = {
+  running: 0,
+  blocked: 1,
+  waiting: 2,
+  done: 3,
+};
+
+export const DEFAULT_MISSION_BOARD_CONFIG: MissionBoardConfig = DEFAULT_CONFIG;
+
+function resolveConfig(config?: MissionBoardConfig): Required<MissionBoardConfig> {
+  return {
+    ...DEFAULT_CONFIG,
+    ...config,
+    enabled: config?.enabled ?? DEFAULT_CONFIG.enabled,
+  };
+}
+
+function stateFilePath(directory: string): string {
+  return join(getOmcRoot(directory), 'state', 'mission-state.json');
+}
+
+function readJsonSafe<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function readJsonLinesSafe<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  try {
+    return readFileSync(path, 'utf-8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as T);
+  } catch {
+    return [];
+  }
+}
+
+function writeState(directory: string, state: MissionBoardState): MissionBoardState {
+  const stateDir = join(getOmcRoot(directory), 'state');
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true });
+  }
+  atomicWriteJsonSync(stateFilePath(directory), state);
+  return state;
+}
+
+function parseTime(value: string | undefined | null): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function compactText(value: string | null | undefined, width = 64): string | null {
+  const trimmed = typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+  if (!trimmed) return null;
+  return truncateToWidth(trimmed, width);
+}
+
+function formatTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '--:--';
+  return date.toISOString().slice(11, 16);
+}
+
+function latest(...values: Array<string | undefined | null>): string | undefined {
+  return values
+    .filter((value): value is string => Boolean(value))
+    .sort((left, right) => parseTime(right) - parseTime(left))[0];
+}
+
+function shortAgentType(agentType: string): string {
+  return agentType.replace(/^oh-my-claudecode:/, '').trim() || 'agent';
+}
+
+function sessionAgentName(agentType: string, agentId: string): string {
+  return `${shortAgentType(agentType)}:${agentId.slice(0, 7)}`;
+}
+
+function summarizeTask(task?: TeamTaskLike | null): string | null {
+  if (!task) return null;
+  return compactText(task.result || task.summary || task.error || task.subject || task.description, 56);
+}
+
+function deriveSessionStatus(mission: MissionBoardMission): MissionBoardStatus {
+  if (mission.taskCounts.inProgress > 0) return 'running';
+  if (mission.taskCounts.blocked > 0 || mission.taskCounts.failed > 0) return 'blocked';
+  if (mission.taskCounts.completed === mission.taskCounts.total && mission.taskCounts.total > 0) return 'done';
+  return 'waiting';
+}
+
+function ensureSessionMission(state: MissionBoardState, input: MissionAgentStartInput): MissionBoardMission {
+  const missionId = `session:${input.sessionId}:${input.parentMode || 'session'}`;
+  let mission = state.missions.find((entry) => entry.id === missionId && entry.source === 'session');
+  if (!mission) {
+    mission = {
+      id: missionId,
+      source: 'session',
+      name: input.parentMode || 'session',
+      objective: compactText(input.taskDescription, 72) || 'Session mission',
+      createdAt: input.at || new Date().toISOString(),
+      updatedAt: input.at || new Date().toISOString(),
+      status: 'running',
+      workerCount: 0,
+      taskCounts: { total: 0, pending: 0, blocked: 0, inProgress: 0, completed: 0, failed: 0 },
+      agents: [],
+      timeline: [],
+    };
+    state.missions.push(mission);
+  }
+  return mission;
+}
+
+function recalcSessionMission(mission: MissionBoardMission): void {
+  mission.workerCount = mission.agents.length;
+  mission.taskCounts = {
+    total: mission.agents.length,
+    pending: mission.agents.filter((agent) => agent.status === 'waiting').length,
+    blocked: mission.agents.filter((agent) => agent.status === 'blocked').length,
+    inProgress: mission.agents.filter((agent) => agent.status === 'running').length,
+    completed: mission.agents.filter((agent) => agent.status === 'done').length,
+    failed: 0,
+  };
+  mission.status = deriveSessionStatus(mission);
+}
+
+export function readMissionBoardState(directory: string): MissionBoardState | null {
+  return readJsonSafe<MissionBoardState>(stateFilePath(directory));
+}
+
+export function recordMissionAgentStart(directory: string, input: MissionAgentStartInput): MissionBoardState {
+  const now = input.at || new Date().toISOString();
+  const state = readMissionBoardState(directory) || { updatedAt: now, missions: [] };
+  const mission = ensureSessionMission(state, input);
+  const agentName = sessionAgentName(input.agentType, input.agentId);
+  const agent = mission.agents.find((entry) => entry.ownership === input.agentId) || {
+    name: agentName,
+    role: shortAgentType(input.agentType),
+    ownership: input.agentId,
+    status: 'running' as MissionBoardStatus,
+    currentStep: null,
+    latestUpdate: null,
+    completedSummary: null,
+    updatedAt: now,
+  };
+
+  agent.status = 'running';
+  agent.currentStep = compactText(input.taskDescription, 56);
+  agent.latestUpdate = compactText(input.taskDescription, 64);
+  agent.completedSummary = null;
+  agent.updatedAt = now;
+  if (!mission.agents.includes(agent)) {
+    mission.agents.push(agent);
+  }
+
+  mission.updatedAt = now;
+  mission.timeline.push({
+    id: `session-start:${input.agentId}:${now}`,
+    at: now,
+    kind: 'update',
+    agent: agent.name,
+    detail: compactText(input.taskDescription || `started ${agent.name}`, 72) || `started ${agent.name}`,
+    sourceKey: `session-start:${input.agentId}`,
+  });
+  mission.timeline = mission.timeline.slice(-DEFAULT_CONFIG.maxTimelineEvents);
+  recalcSessionMission(mission);
+  state.updatedAt = now;
+  return writeState(directory, state);
+}
+
+export function recordMissionAgentStop(directory: string, input: MissionAgentStopInput): MissionBoardState {
+  const now = input.at || new Date().toISOString();
+  const state = readMissionBoardState(directory) || { updatedAt: now, missions: [] };
+  const mission = state.missions
+    .filter((entry) => entry.source === 'session' && entry.id.startsWith(`session:${input.sessionId}:`))
+    .sort((left, right) => parseTime(right.updatedAt) - parseTime(left.updatedAt))[0];
+  if (!mission) {
+    return state;
+  }
+
+  const agent = mission.agents.find((entry) => entry.ownership === input.agentId) || mission.agents[0];
+  if (!agent) {
+    return state;
+  }
+
+  agent.status = input.success ? 'done' : 'blocked';
+  agent.currentStep = null;
+  agent.latestUpdate = compactText(input.outputSummary, 64) || (input.success ? 'completed' : 'blocked');
+  agent.completedSummary = input.success ? compactText(input.outputSummary, 64) : null;
+  agent.updatedAt = now;
+  mission.updatedAt = now;
+  mission.timeline.push({
+    id: `session-stop:${input.agentId}:${now}`,
+    at: now,
+    kind: input.success ? 'completion' : 'failure',
+    agent: agent.name,
+    detail: compactText(input.outputSummary || (input.success ? 'completed' : 'blocked'), 72) || (input.success ? 'completed' : 'blocked'),
+    sourceKey: `session-stop:${input.agentId}`,
+  });
+  recalcSessionMission(mission);
+  state.updatedAt = now;
+  return writeState(directory, state);
+}
+
+function deriveTeamStatus(taskCounts: MissionBoardMission['taskCounts'], agents: MissionBoardAgent[]): MissionBoardStatus {
+  if (taskCounts.inProgress > 0 || agents.some((agent) => agent.status === 'running')) {
+    return 'running';
+  }
+  if (taskCounts.blocked > 0 || taskCounts.failed > 0 || agents.some((agent) => agent.status === 'blocked')) {
+    return 'blocked';
+  }
+  if (taskCounts.total > 0 && taskCounts.completed === taskCounts.total) {
+    return 'done';
+  }
+  return 'waiting';
+}
+
+function deriveWorkerStatus(workerStatus: WorkerStatusLike | null, task?: TeamTaskLike): MissionBoardStatus {
+  if (workerStatus?.state === 'blocked' || workerStatus?.state === 'failed' || task?.status === 'blocked' || task?.status === 'failed') return 'blocked';
+  if (workerStatus?.state === 'working' || task?.status === 'in_progress') return 'running';
+  if (workerStatus?.state === 'done' || task?.status === 'completed') return 'done';
+  return 'waiting';
+}
+
+function collectTeamMission(teamRoot: string, teamName: string, config: Required<MissionBoardConfig>): MissionBoardMission | null {
+  const teamConfig = readJsonSafe<TeamConfigLike>(join(teamRoot, 'config.json'));
+  if (!teamConfig) return null;
+
+  const workers = Array.isArray(teamConfig.workers) ? teamConfig.workers : [];
+  const tasksDir = join(teamRoot, 'tasks');
+  const tasks = existsSync(tasksDir)
+    ? readdirSync(tasksDir)
+      .filter((entry) => /^(?:task-)?\d+\.json$/i.test(entry))
+      .map((entry) => readJsonSafe<TeamTaskLike>(join(tasksDir, entry)))
+      .filter((task): task is TeamTaskLike => Boolean(task?.id))
+    : [];
+  const taskById = new Map(tasks.map((task) => [task.id!, task] as const));
+  const taskCounts = {
+    total: tasks.length,
+    pending: tasks.filter((task) => task.status === 'pending').length,
+    blocked: tasks.filter((task) => task.status === 'blocked').length,
+    inProgress: tasks.filter((task) => task.status === 'in_progress').length,
+    completed: tasks.filter((task) => task.status === 'completed').length,
+    failed: tasks.filter((task) => task.status === 'failed').length,
+  };
+
+  const timeline: MissionBoardTimelineEvent[] = [];
+  for (const event of readJsonLinesSafe<TeamEventLike>(join(teamRoot, 'events.jsonl'))) {
+    if (!event.created_at || !event.type) continue;
+    if (event.type === 'task_completed' || event.type === 'task_failed') {
+      timeline.push({
+        id: `event:${event.event_id || `${event.type}:${event.created_at}`}`,
+        at: event.created_at,
+        kind: event.type === 'task_completed' ? 'completion' : 'failure',
+        agent: event.worker || 'leader-fixed',
+        detail: compactText(`${event.type === 'task_completed' ? 'completed' : 'failed'} task ${event.task_id ?? '?'}`, 72) || event.type,
+        sourceKey: `event:${event.event_id || event.type}`,
+      });
+    } else if (event.type === 'team_leader_nudge' || event.type === 'worker_idle' || event.type === 'worker_stopped') {
+      timeline.push({
+        id: `event:${event.event_id || `${event.type}:${event.created_at}`}`,
+        at: event.created_at,
+        kind: 'update',
+        agent: event.worker || 'leader-fixed',
+        detail: compactText(event.reason || event.type.replace(/_/g, ' '), 72) || event.type,
+        sourceKey: `event:${event.event_id || event.type}`,
+      });
+    }
+  }
+
+  for (const worker of workers) {
+    const workerName = worker.name?.trim();
+    if (!workerName) continue;
+    const mailbox = readJsonSafe<TeamMailboxLike>(join(teamRoot, 'mailbox', `${workerName}.json`));
+    for (const message of mailbox?.messages ?? []) {
+      if (!message.created_at || !message.body) continue;
+      timeline.push({
+        id: `handoff:${message.message_id || `${workerName}:${message.created_at}`}`,
+        at: message.created_at,
+        kind: 'handoff',
+        agent: workerName,
+        detail: compactText(message.body, 72) || 'handoff',
+        sourceKey: `handoff:${message.message_id || workerName}`,
+      });
+    }
+  }
+
+  timeline.sort((left, right) => parseTime(left.at) - parseTime(right.at));
+
+  const agents = workers.slice(0, config.maxAgentsPerMission).map((worker) => {
+    const workerName = worker.name?.trim() || 'worker';
+    const workerStatus = readJsonSafe<WorkerStatusLike>(join(teamRoot, 'workers', workerName, 'status.json'));
+    const heartbeat = readJsonSafe<WorkerHeartbeatLike>(join(teamRoot, 'workers', workerName, 'heartbeat.json'));
+    const ownedTasks = tasks.filter((task) => task.owner === workerName);
+    const currentTask = (workerStatus?.current_task_id ? taskById.get(workerStatus.current_task_id) : undefined)
+      || ownedTasks.find((task) => task.status === 'in_progress')
+      || ownedTasks.find((task) => task.status === 'blocked')
+      || (worker.assigned_tasks || []).map((taskId) => taskById.get(taskId)).find(Boolean)
+      || undefined;
+    const completedTask = [...ownedTasks]
+      .filter((task) => task.status === 'completed' || task.status === 'failed')
+      .sort((left, right) => parseTime(right.completed_at) - parseTime(left.completed_at))[0];
+    const latestTimeline = [...timeline].reverse().find((entry) => entry.agent === workerName);
+    const ownership = Array.from(new Set([
+      ...(worker.assigned_tasks || []),
+      ...ownedTasks.map((task) => task.id || ''),
+    ].filter(Boolean)))
+      .map((taskId) => `#${taskId}`)
+      .join(',');
+
+    return {
+      name: workerName,
+      role: worker.role,
+      ownership: ownership || undefined,
+      status: deriveWorkerStatus(workerStatus ?? null, currentTask),
+      currentStep: compactText(
+        workerStatus?.reason
+        || (currentTask?.id && currentTask.subject ? `#${currentTask.id} ${currentTask.subject}` : currentTask?.subject)
+        || currentTask?.description,
+        56,
+      ),
+      latestUpdate: compactText(workerStatus?.reason || latestTimeline?.detail || summarizeTask(currentTask), 64),
+      completedSummary: summarizeTask(completedTask),
+      updatedAt: latest(workerStatus?.updated_at, heartbeat?.last_turn_at, latestTimeline?.at, completedTask?.completed_at),
+    } satisfies MissionBoardAgent;
+  });
+
+  const createdAt = teamConfig.created_at || latest(...timeline.map((entry) => entry.at)) || new Date().toISOString();
+  const updatedAt = latest(createdAt, ...timeline.map((entry) => entry.at), ...agents.map((agent) => agent.updatedAt)) || createdAt;
+
+  return {
+    id: `team:${teamName}`,
+    source: 'team',
+    teamName,
+    name: teamName,
+    objective: compactText(teamConfig.task, 72) || teamName,
+    createdAt,
+    updatedAt,
+    status: deriveTeamStatus(taskCounts, agents),
+    workerCount: teamConfig.worker_count || workers.length,
+    taskCounts,
+    agents,
+    timeline: timeline.slice(-config.maxTimelineEvents),
+  };
+}
+
+function mergeMissions(previous: MissionBoardState | null, teamMissions: MissionBoardMission[], config: Required<MissionBoardConfig>): MissionBoardMission[] {
+  const previousMissions = previous?.missions || [];
+  const sessionMissions = previousMissions.filter((mission) => mission.source === 'session');
+  const currentIds = new Set(teamMissions.map((mission) => mission.id));
+  const cutoff = Date.now() - (config.persistCompletedForMinutes * 60_000);
+  const preservedTeams = previousMissions.filter((mission) => (
+    mission.source === 'team'
+    && !currentIds.has(mission.id)
+    && mission.status === 'done'
+    && parseTime(mission.updatedAt) >= cutoff
+  ));
+
+  return [...teamMissions, ...sessionMissions, ...preservedTeams]
+    .sort((left, right) => {
+      const statusDelta = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
+      if (statusDelta !== 0) return statusDelta;
+      return parseTime(right.updatedAt) - parseTime(left.updatedAt);
+    })
+    .slice(0, config.maxMissions);
+}
+
+export function refreshMissionBoardState(directory: string, rawConfig: MissionBoardConfig = DEFAULT_CONFIG): MissionBoardState {
+  const config = resolveConfig(rawConfig);
+  const previous = readMissionBoardState(directory);
+  const teamsRoot = join(getOmcRoot(directory), 'state', 'team');
+  const teamMissions = existsSync(teamsRoot)
+    ? readdirSync(teamsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => collectTeamMission(join(teamsRoot, entry.name), entry.name, config))
+      .filter((mission): mission is MissionBoardMission => Boolean(mission))
+    : [];
+
+  const state: MissionBoardState = {
+    updatedAt: new Date().toISOString(),
+    missions: mergeMissions(previous, teamMissions, config),
+  };
+  return writeState(directory, state);
+}
+
+export function renderMissionBoard(
+  state: MissionBoardState | null,
+  rawConfig: MissionBoardConfig = DEFAULT_CONFIG,
+): string[] {
+  if (!state || !Array.isArray(state.missions) || state.missions.length === 0) return [];
+  const config = resolveConfig(rawConfig);
+  const lines: string[] = [];
+
+  for (const mission of state.missions.slice(0, config.maxMissions)) {
+    const summary = [
+      `${mission.taskCounts.completed}/${mission.taskCounts.total} done`,
+      ...(mission.taskCounts.inProgress > 0 ? [`${mission.taskCounts.inProgress} active`] : []),
+      ...(mission.taskCounts.blocked > 0 ? [`${mission.taskCounts.blocked} blocked`] : []),
+      ...(mission.taskCounts.pending > 0 ? [`${mission.taskCounts.pending} waiting`] : []),
+      ...(mission.taskCounts.failed > 0 ? [`${mission.taskCounts.failed} failed`] : []),
+    ].join(' · ');
+    lines.push(`MISSION ${mission.name} [${mission.status}] · ${summary} · ${mission.objective}`);
+    for (const agent of mission.agents.slice(0, config.maxAgentsPerMission)) {
+      const badge = agent.status === 'running'
+        ? 'run'
+        : agent.status === 'blocked'
+          ? 'blk'
+          : agent.status === 'done'
+            ? 'done'
+            : 'wait';
+      const detail = agent.status === 'done'
+        ? agent.completedSummary || agent.latestUpdate || agent.currentStep || 'done'
+        : agent.latestUpdate || agent.currentStep || 'no update';
+      lines.push(`  [${badge}] ${agent.name}${agent.role ? ` (${agent.role})` : ''}${agent.ownership ? ` · own:${agent.ownership}` : ''} · ${detail}`);
+    }
+    if (mission.timeline.length > 0) {
+      const timeline = mission.timeline.slice(-config.maxTimelineEvents).map((entry) => {
+        const label = entry.kind === 'completion'
+          ? 'done'
+          : entry.kind === 'failure'
+            ? 'fail'
+            : entry.kind;
+        return `${formatTime(entry.at)} ${label} ${entry.agent}: ${entry.detail}`;
+      }).join(' | ');
+      lines.push(`  timeline: ${timeline}`);
+    }
+  }
+
+  return lines;
+}

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -27,6 +27,7 @@ import { renderModel } from './elements/model.js';
 import { renderApiKeySource } from './elements/api-key-source.js';
 import { renderCallCounts } from './elements/call-counts.js';
 import { renderContextLimitWarning } from './elements/context-warning.js';
+import { renderMissionBoard } from './mission-board.js';
 
 /**
  * ANSI escape sequence regex (matches SGR and other CSI sequences).
@@ -377,7 +378,6 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
 
   // Compose output
   const outputLines: string[] = [];
-
   const gitInfoLine = gitElements.length > 0 ? gitElements.join(dim(PLAIN_SEPARATOR)) : null;
   const headerLine = elements.join(dim(PLAIN_SEPARATOR));
 
@@ -402,6 +402,10 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   if (enabledElements.todos) {
     const todos = renderTodosWithCurrent(context.todos);
     if (todos) detailLines.push(todos);
+  }
+
+  if (context.missionBoard && (config.missionBoard?.enabled ?? config.elements.missionBoard ?? false)) {
+    detailLines.unshift(...renderMissionBoard(context.missionBoard, config.missionBoard));
   }
 
   const widthAdjustedLines = applyMaxWidthByMode(

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -12,6 +12,7 @@ import { validateWorkingDirectory, getOmcRoot } from '../lib/worktree-paths.js';
 import { atomicWriteJsonSync } from '../lib/atomic-write.js';
 import type { OmcHudState, BackgroundTask, HudConfig } from './types.js';
 import { DEFAULT_HUD_CONFIG, PRESET_CONFIGS } from './types.js';
+import { DEFAULT_MISSION_BOARD_CONFIG } from './mission-board.js';
 import { cleanupStaleBackgroundTasks, markOrphanedTasksAsStale } from './background-cleanup.js';
 
 // ============================================================================
@@ -191,6 +192,17 @@ export function readHudConfig(): HudConfig {
 function mergeWithDefaults(config: Partial<HudConfig>): HudConfig {
   const preset = config.preset ?? DEFAULT_HUD_CONFIG.preset;
   const presetElements = PRESET_CONFIGS[preset] ?? {};
+  const missionBoardEnabled =
+    config.missionBoard?.enabled
+    ?? config.elements?.missionBoard
+    ?? DEFAULT_HUD_CONFIG.missionBoard?.enabled
+    ?? false;
+  const missionBoard = {
+    ...DEFAULT_MISSION_BOARD_CONFIG,
+    ...DEFAULT_HUD_CONFIG.missionBoard,
+    ...config.missionBoard,
+    enabled: missionBoardEnabled,
+  };
 
   return {
     preset,
@@ -208,6 +220,7 @@ function mergeWithDefaults(config: Partial<HudConfig>): HudConfig {
       ...DEFAULT_HUD_CONFIG.contextLimitWarning,
       ...config.contextLimitWarning,
     },
+    missionBoard,
     usageApiPollIntervalMs: config.usageApiPollIntervalMs ?? DEFAULT_HUD_CONFIG.usageApiPollIntervalMs,
     ...(config.rateLimitsProvider ? { rateLimitsProvider: config.rateLimitsProvider } : {}),
     ...(config.maxWidth != null ? { maxWidth: config.maxWidth } : {}),

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -6,6 +6,8 @@
 
 import type { AutopilotStateForHud } from './elements/autopilot.js';
 import type { ApiKeySource } from './elements/api-key-source.js';
+import type { MissionBoardConfig, MissionBoardState } from './mission-board.js';
+import { DEFAULT_MISSION_BOARD_CONFIG } from './mission-board.js';
 
 // Re-export for convenience
 export type { AutopilotStateForHud, ApiKeySource };
@@ -295,6 +297,9 @@ export interface HudRenderContext {
   /** Working directory */
   cwd: string;
 
+  /** Mission-board snapshot (opt-in) */
+  missionBoard?: MissionBoardState | null;
+
   /** Last activated skill from transcript */
   lastSkill: SkillInvocation | null;
 
@@ -410,6 +415,7 @@ export interface HudElementConfig {
   thinkingFormat: ThinkingFormat;  // Thinking indicator format
   apiKeySource: boolean;       // Show API key source (project/global/env)
   profile: boolean;            // Show active profile name (from CLAUDE_CONFIG_DIR)
+  missionBoard?: boolean;      // Show opt-in mission board above existing HUD detail lines
   promptTime: boolean;        // Show last prompt submission time (HH:MM:SS)
   sessionHealth: boolean;     // Show session health/duration
   showSessionDuration?: boolean;  // Show session:19m duration display (default: true if sessionHealth is true)
@@ -446,6 +452,8 @@ export interface HudConfig {
   thresholds: HudThresholds;
   staleTaskThresholdMinutes: number; // Default 30
   contextLimitWarning: ContextLimitWarningConfig;
+  /** Mission-board collection/rendering settings. */
+  missionBoard?: MissionBoardConfig;
   /** Built-in usage API polling interval / success-cache TTL in milliseconds. */
   usageApiPollIntervalMs: number;
   /** Optional custom rate limit provider; omit to use built-in Anthropic/z.ai */
@@ -486,6 +494,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     thinkingFormat: 'text',   // Text format for backward compatibility
     apiKeySource: false, // Disabled by default
     profile: true,  // Show profile name when CLAUDE_CONFIG_DIR is set
+    missionBoard: false,  // Opt-in mission board for whole-run progress tracking
     promptTime: true,  // Show last prompt time by default
     sessionHealth: true,
     useBars: false,  // Disabled by default for backwards compatibility
@@ -504,6 +513,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     threshold: 80,
     autoCompact: false,
   },
+  missionBoard: DEFAULT_MISSION_BOARD_CONFIG,
   usageApiPollIntervalMs: DEFAULT_HUD_USAGE_POLL_INTERVAL_MS,
   wrapMode: 'truncate',
 };
@@ -535,6 +545,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: false,
     profile: true,
+    missionBoard: false,
     promptTime: false,
     sessionHealth: false,
     useBars: false,
@@ -568,6 +579,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: false,
     profile: true,
+    missionBoard: false,
     promptTime: true,
     sessionHealth: true,
     useBars: true,
@@ -601,6 +613,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: true,
     profile: true,
+    missionBoard: false,
     promptTime: true,
     sessionHealth: true,
     useBars: true,
@@ -634,6 +647,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: false,
     profile: true,
+    missionBoard: false,
     promptTime: true,
     sessionHealth: true,
     useBars: false,
@@ -667,6 +681,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: true,
     profile: true,
+    missionBoard: false,
     promptTime: true,
     sessionHealth: true,
     useBars: true,


### PR DESCRIPTION
## Summary
- add an opt-in mission board snapshot above the existing HUD worker details
- persist lightweight mission-state from existing team/worker/subagent state instead of rebuilding tracing
- add renderer/config/CLI coverage and focused tests for state tracking + rendering

## Testing
- npx tsc --noEmit
- npm test -- --run src/__tests__/hud/mission-board.test.ts src/__tests__/hud/mission-board-state.test.ts src/__tests__/hud/state.test.ts
- npx eslint src/cli/index.ts src/hooks/subagent-tracker/index.ts src/hud/index.ts src/hud/render.ts src/hud/state.ts src/hud/types.ts src/hud/mission-board.ts src/hud/elements/index.ts src/hud/elements/mission-board.ts src/__tests__/hud/defaults.test.ts src/__tests__/hud/state.test.ts src/__tests__/hud/mission-board.test.ts src/__tests__/hud/mission-board-state.test.ts

Closes #1481