### PR TITLE
fix: resolve Windows .cmd ask provider binaries

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -9,6 +9,7 @@ const PROVIDER_BINARIES = {
   codex: 'codex',
   gemini: 'gemini',
 };
+const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
 /**
  * Build CLI args for a given provider.
@@ -91,9 +92,20 @@ function ensureBinary(provider, binary) {
     stdio: 'ignore',
     encoding: 'utf8',
     env: buildProviderEnv(provider),
+    shell: SHOULD_USE_WINDOWS_SHELL,
   });
 
-  if (probe.error && probe.error.code === 'ENOENT') {
+  const isMissingOnWindowsShell = SHOULD_USE_WINDOWS_SHELL
+    && probe.status !== 0
+    && (() => {
+      const whereResult = spawnSync('where', [binary], {
+        encoding: 'utf8',
+        env: buildProviderEnv(provider),
+      });
+      return whereResult.status !== 0 || !whereResult.stdout?.trim();
+    })();
+
+  if ((probe.error && probe.error.code === 'ENOENT') || isMissingOnWindowsShell) {
     const verify = `${binary} --version`;
     console.error(`[ask-${binary}] Missing required local CLI binary: ${binary}`);
     console.error(`[ask-${binary}] Install/configure ${binary} CLI, then verify with: ${verify}`);
@@ -202,6 +214,7 @@ async function main() {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
     env: buildProviderEnv(provider),
+    shell: SHOULD_USE_WINDOWS_SHELL,
   });
 
   const stdout = run.stdout || '';

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -78,6 +78,27 @@ function runAdvisorScript(
   };
 }
 
+function runAdvisorScriptWithPrelude(
+  preludePath: string,
+  args: string[],
+  cwd: string,
+  envOverrides: Record<string, string> = {},
+  options: RunOptions = {},
+): CliRunResult {
+  const result = spawnSync(process.execPath, ['--import', preludePath, ADVISOR_SCRIPT, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: buildChildEnv(envOverrides, options),
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message,
+  };
+}
+
 function runWrapperScript(
   wrapperPath: string,
   args: string[],
@@ -133,6 +154,58 @@ function writeFakeProviderBinary(dir: string, provider: 'claude' | 'gemini'): st
   );
   chmodSync(binPath, 0o755);
   return binDir;
+}
+
+function writeSpawnSyncCapturePrelude(dir: string): string {
+  const preludePath = join(dir, 'spawn-sync-capture-prelude.mjs');
+  writeFileSync(
+    preludePath,
+    [
+      "import childProcess from 'node:child_process';",
+      "import { writeFileSync } from 'node:fs';",
+      "import { syncBuiltinESMExports } from 'node:module';",
+      '',
+      "Object.defineProperty(process, 'platform', { value: 'win32' });",
+      'const capturePath = process.env.SPAWN_CAPTURE_PATH;',
+      "const mode = process.env.SPAWN_CAPTURE_MODE || 'success';",
+      'const calls = [];',
+      'childProcess.spawnSync = (command, args = [], options = {}) => {',
+      '  calls.push({',
+      '    command,',
+      '    args,',
+      '    options: {',
+      "      shell: options.shell ?? false,",
+      "      encoding: options.encoding ?? null,",
+      "      stdio: options.stdio ?? null,",
+      '    },',
+      '  });',
+      "  if (mode === 'missing' && command === 'where') {",
+      "    return { status: 1, stdout: '', stderr: '', pid: 0, output: [], signal: null };",
+      '  }',
+      "  if (mode === 'missing' && (command === 'codex' || command === 'gemini') && Array.isArray(args) && args[0] === '--version') {",
+      "    return { status: 1, stdout: '', stderr: \"'\" + command + \"' is not recognized\", pid: 0, output: [], signal: null };",
+      '  }',
+      "  const isVersionProbe = Array.isArray(args) && args[0] === '--version';",
+      '  return {',
+      '    status: 0,',
+      "    stdout: isVersionProbe ? 'fake 1.0.0\\n' : 'FAKE_PROVIDER_OK',",
+      "    stderr: '',",
+      '    pid: 0,',
+      '    output: [],',
+      '    signal: null,',
+      '  };',
+      '};',
+      'syncBuiltinESMExports();',
+      'process.on(\'exit\', () => {',
+      '  if (capturePath) {',
+      "    writeFileSync(capturePath, JSON.stringify(calls), 'utf8');",
+      '  }',
+      '});',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  return preludePath;
 }
 
 
@@ -412,6 +485,85 @@ describe('run-provider-advisor script contract', () => {
       expect(artifact).toContain('CODEX_OK');
       expect(artifact).not.toContain('RUST_LEAK');
       expect(artifact).not.toContain('trace');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses shell:true for Windows codex binary probe and execution', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-win32-shell-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['codex', '--prompt', 'windows cmd support'],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+        options: { shell: boolean; encoding: string | null; stdio: string | null };
+      }>;
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]).toMatchObject({
+        command: 'codex',
+        args: ['--version'],
+        options: { shell: true, encoding: 'utf8', stdio: 'ignore' },
+      });
+      expect(calls[1]).toMatchObject({
+        command: 'codex',
+        args: ['exec', '--dangerously-bypass-approvals-and-sandbox', 'windows cmd support'],
+        options: { shell: true, encoding: 'utf8', stdio: null },
+      });
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('shows install guidance when a Windows codex binary is missing under shell:true', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-win32-missing-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['codex', '--prompt', 'windows missing binary'],
+        wd,
+        {
+          SPAWN_CAPTURE_PATH: capturePath,
+          SPAWN_CAPTURE_MODE: 'missing',
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Missing required local CLI binary: codex');
+      expect(result.stderr).toContain('codex --version');
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+        options: { shell: boolean; encoding: string | null; stdio: string | null };
+      }>;
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]).toMatchObject({
+        command: 'codex',
+        args: ['--version'],
+        options: { shell: true, encoding: 'utf8', stdio: 'ignore' },
+      });
+      expect(calls[1]).toMatchObject({
+        command: 'where',
+        args: ['codex'],
+      });
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/cli-detection.test.ts
+++ b/src/team/__tests__/cli-detection.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { spawnSync } from 'child_process';
+import { detectCli } from '../cli-detection.js';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawnSync: vi.fn(actual.spawnSync),
+  };
+});
+
+function setProcessPlatform(platform: NodeJS.Platform): () => void {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  return () => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  };
+}
+
+describe('cli-detection', () => {
+  it('uses shell:true for Windows provider version probes', () => {
+    const mockSpawnSync = vi.mocked(spawnSync);
+    const restorePlatform = setProcessPlatform('win32');
+
+    mockSpawnSync
+      .mockReturnValueOnce({ status: 0, stdout: 'codex 1.0.0', stderr: '', pid: 0, output: [], signal: null } as any)
+      .mockReturnValueOnce({ status: 0, stdout: 'C:\\Tools\\codex.cmd', stderr: '', pid: 0, output: [], signal: null } as any);
+
+    expect(detectCli('codex')).toEqual({
+      available: true,
+      version: 'codex 1.0.0',
+      path: 'C:\\Tools\\codex.cmd',
+    });
+
+    expect(mockSpawnSync).toHaveBeenNthCalledWith(1, 'codex', ['--version'], { timeout: 5000, shell: true });
+    expect(mockSpawnSync).toHaveBeenNthCalledWith(2, 'where', ['codex'], { timeout: 5000 });
+    restorePlatform();
+    mockSpawnSync.mockRestore();
+  });
+});

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -4,7 +4,6 @@ import {
   getContract,
   buildLaunchArgs,
   buildWorkerArgv,
-  buildWorkerCommand,
   getWorkerEnv,
   parseCliOutput,
   isPromptModeAgent,
@@ -24,6 +23,14 @@ vi.mock('child_process', async (importOriginal) => {
     spawnSync: vi.fn(actual.spawnSync),
   };
 });
+
+function setProcessPlatform(platform: NodeJS.Platform): () => void {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  return () => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  };
+}
 
 describe('model-contract', () => {
   describe('backward-compat API shims', () => {
@@ -215,6 +222,7 @@ describe('model-contract', () => {
   describe('isCliAvailable', () => {
     it('checks version without shell:true for standard binaries', () => {
       const mockSpawnSync = vi.mocked(spawnSync);
+      clearResolvedPathCache();
       mockSpawnSync
         .mockReturnValueOnce({ status: 1, stdout: '', stderr: '', pid: 0, output: [], signal: null } as any)
         .mockReturnValueOnce({ status: 0, stdout: '', stderr: '', pid: 0, output: [], signal: null } as any);
@@ -222,14 +230,16 @@ describe('model-contract', () => {
       isCliAvailable('codex');
 
       expect(mockSpawnSync).toHaveBeenNthCalledWith(1, 'which', ['codex'], { timeout: 5000, encoding: 'utf8' });
-      expect(mockSpawnSync).toHaveBeenNthCalledWith(2, 'codex', ['--version'], { timeout: 5000 });
+      expect(mockSpawnSync).toHaveBeenNthCalledWith(2, 'codex', ['--version'], { timeout: 5000, shell: false });
+      clearResolvedPathCache();
       mockSpawnSync.mockRestore();
     });
 
     it('uses COMSPEC for .cmd binaries on win32', () => {
       const mockSpawnSync = vi.mocked(spawnSync);
-      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+      const restorePlatform = setProcessPlatform('win32');
       vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+      clearResolvedPathCache();
 
       mockSpawnSync
         .mockReturnValueOnce({ status: 0, stdout: 'C:\\Tools\\codex.cmd\n', stderr: '', pid: 0, output: [], signal: null } as any)
@@ -244,8 +254,28 @@ describe('model-contract', () => {
         ['/d', '/s', '/c', '"C:\\Tools\\codex.cmd" --version'],
         { timeout: 5000 }
       );
+      restorePlatform();
+      clearResolvedPathCache();
       mockSpawnSync.mockRestore();
       vi.unstubAllEnvs();
+    });
+
+    it('uses shell:true for unresolved binaries on win32', () => {
+      const mockSpawnSync = vi.mocked(spawnSync);
+      const restorePlatform = setProcessPlatform('win32');
+      clearResolvedPathCache();
+
+      mockSpawnSync
+        .mockReturnValueOnce({ status: 1, stdout: '', stderr: '', pid: 0, output: [], signal: null } as any)
+        .mockReturnValueOnce({ status: 0, stdout: '', stderr: '', pid: 0, output: [], signal: null } as any);
+
+      isCliAvailable('gemini');
+
+      expect(mockSpawnSync).toHaveBeenNthCalledWith(1, 'where', ['gemini'], { timeout: 5000, encoding: 'utf8' });
+      expect(mockSpawnSync).toHaveBeenNthCalledWith(2, 'gemini', ['--version'], { timeout: 5000, shell: true });
+      restorePlatform();
+      clearResolvedPathCache();
+      mockSpawnSync.mockRestore();
     });
   });
 

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -11,7 +11,10 @@ export interface CliInfo {
 
 export function detectCli(binary: string): CliInfo {
   try {
-    const versionResult = spawnSync(binary, ['--version'], { timeout: 5000 });
+    const versionResult = spawnSync(binary, ['--version'], {
+      timeout: 5000,
+      shell: process.platform === 'win32',
+    });
     if (versionResult.status === 0) {
       const finder = process.platform === 'win32' ? 'where' : 'which';
       const pathResult = spawnSync(finder, [binary], { timeout: 5000 });

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -256,7 +256,10 @@ export function isCliAvailable(agentType: CliAgentType): boolean {
       return result.status === 0;
     }
 
-    const result = spawnSync(resolvedBinary, ['--version'], { timeout: 5000 });
+    const result = spawnSync(resolvedBinary, ['--version'], {
+      timeout: 5000,
+      shell: process.platform === 'win32',
+    });
     return result.status === 0;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- add Windows `shell: true` handling for ask provider binary probes and executions
- preserve missing-binary guidance on Windows by verifying resolution with `where` after a failed shell-based probe
- apply the same Windows shell handling to related codex/gemini CLI detection paths and add regression tests

## Testing
- `npm test -- --run src/cli/__tests__/ask.test.ts src/team/__tests__/model-contract.test.ts src/team/__tests__/cli-detection.test.ts`
- `npx eslint src/team/cli-detection.ts src/team/model-contract.ts src/team/__tests__/cli-detection.test.ts src/team/__tests__/model-contract.test.ts src/cli/__tests__/ask.test.ts`
- `npx tsc --noEmit`

Closes #1390
