### PR TITLE
Add Ralph critic selection for verification

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -376,7 +376,7 @@ All installed skills are available as slash commands with the prefix `/oh-my-cla
 | `/oh-my-claudecode:ultrawork <task>`        | Maximum performance mode with parallel agents                                                 |
 | `/oh-my-claudecode:team <N>:<agent> <task>` | Coordinated native team workflow                                                              |
 | `/oh-my-claudecode:ralph-init <task>`       | Initialize PRD for structured task tracking                                                   |
-| `/oh-my-claudecode:ralph <task>`            | Self-referential loop until task completion                                                   |
+| `/oh-my-claudecode:ralph <task>`            | Self-referential loop until task completion (`--critic=architect|critic|codex`)               |
 | `/oh-my-claudecode:ultraqa <goal>`          | Autonomous QA cycling workflow                                                                |
 | `/oh-my-claudecode:omc-plan <description>`  | Start planning session (supports consensus structured deliberation)                           |
 | `/oh-my-claudecode:ralplan <description>`   | Iterative planning with consensus structured deliberation (`--deliberate` for high-risk mode) |

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralph
-description: Self-referential loop until task completion with architect verification
+description: Self-referential loop until task completion with configurable verification reviewer
 ---
 
 [RALPH + ULTRAWORK - ITERATION {{ITERATION}}/{{MAX}}]
@@ -8,14 +8,14 @@ description: Self-referential loop until task completion with architect verifica
 Your previous attempt did not output the completion promise. Continue working on the task.
 
 <Purpose>
-Ralph is a PRD-driven persistence loop that keeps working on a task until ALL user stories in prd.json have passes: true and are architect-verified. It wraps ultrawork's parallel execution with session persistence, automatic retry on failure, structured story tracking, and mandatory verification before completion.
+Ralph is a PRD-driven persistence loop that keeps working on a task until ALL user stories in prd.json have passes: true and are reviewer-verified. It wraps ultrawork's parallel execution with session persistence, automatic retry on failure, structured story tracking, and mandatory verification before completion.
 </Purpose>
 
 <Use_When>
 - Task requires guaranteed completion with verification (not just "do your best")
 - User says "ralph", "don't stop", "must complete", "finish this", or "keep going until done"
 - Work may span multiple iterations and needs persistence across retries
-- Task benefits from structured PRD-driven execution with architect sign-off
+- Task benefits from structured PRD-driven execution with reviewer sign-off
 </Use_When>
 
 <Do_Not_Use_When>
@@ -30,13 +30,15 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 1. Structuring work into discrete user stories with testable acceptance criteria (prd.json)
 2. Iterating story-by-story until each one passes
 3. Tracking progress and learnings across iterations (progress.txt)
-4. Requiring fresh architect verification against specific acceptance criteria before completion
+4. Requiring fresh reviewer verification against specific acceptance criteria before completion
 </Why_This_Exists>
 
 <PRD_Mode>
 By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated when ralph starts if none exists.
 
 **Opt-out:** If `{{PROMPT}}` contains `--no-prd`, skip PRD generation and work in legacy mode (no story tracking, generic verification). Use this for trivial quick fixes.
+
+**Reviewer selection:** Pass `--critic=architect`, `--critic=critic`, or `--critic=codex` in the Ralph prompt to choose the completion reviewer for that run. `architect` remains the default.
 </PRD_Mode>
 
 <Execution_Policy>
@@ -84,20 +86,24 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
    b. If NOT all complete, loop back to Step 2 (pick next story)
    c. If ALL complete, proceed to Step 7 (architect verification)
 
-7. **Architect verification** (tiered, against acceptance criteria):
+7. **Reviewer verification** (tiered, against acceptance criteria):
    - <5 files, <100 lines with full tests: STANDARD tier minimum (architect-medium / Sonnet)
    - Standard changes: STANDARD tier (architect-medium / Sonnet)
    - >20 files or security/architectural changes: THOROUGH tier (architect / Opus)
+   - If `--critic=critic`, use the Claude `critic` agent for the approval pass
+   - If `--critic=codex`, run `omc ask codex --agent-prompt critic "..."` for the approval pass
    - Ralph floor: always at least STANDARD, even for small changes
-   - The architect verifies against the SPECIFIC acceptance criteria from prd.json, not vague "is it done?"
+   - The selected reviewer verifies against the SPECIFIC acceptance criteria from prd.json, not vague "is it done?"
 
 8. **On approval**: Run `/oh-my-claudecode:cancel` to cleanly exit and clean up all state files
 
-9. **On rejection**: Fix the issues raised, re-verify at the same tier, then loop back to check if the story needs to be marked incomplete
+9. **On rejection**: Fix the issues raised, re-verify with the same reviewer, then loop back to check if the story needs to be marked incomplete
 </Steps>
 
 <Tool_Usage>
-- Use `Task(subagent_type="oh-my-claudecode:architect", ...)` for verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
+- Use `Task(subagent_type="oh-my-claudecode:architect", ...)` for architect verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
+- Use `Task(subagent_type="oh-my-claudecode:critic", ...)` when `--critic=critic`
+- Use `omc ask codex --agent-prompt critic "..."` when `--critic=codex`
 - Skip architect consultation for simple feature additions, well-tested changes, or time-critical verification
 - Proceed with architect agent verification alone -- never block on unavailable tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
@@ -171,7 +177,7 @@ Why bad: Did not refine scaffold criteria into task-specific ones. This is PRD t
 - Stop and report when a fundamental blocker requires user input (missing credentials, unclear requirements, external service down)
 - Stop when the user says "stop", "cancel", or "abort" -- run `/oh-my-claudecode:cancel`
 - Continue working when the hook system sends "The boulder never stops" -- this means the iteration continues
-- If architect rejects verification, fix the issues and re-verify (do not stop)
+- If the selected reviewer rejects verification, fix the issues and re-verify (do not stop)
 - If the same issue recurs across 3+ iterations, report it as a potential fundamental problem
 </Escalation_And_Stop_Conditions>
 
@@ -184,7 +190,7 @@ Why bad: Did not refine scaffold criteria into task-specific ones. This is PRD t
 - [ ] Fresh build output shows success
 - [ ] lsp_diagnostics shows 0 errors on affected files
 - [ ] progress.txt records implementation details and learnings
-- [ ] Architect verification passed (STANDARD tier minimum) against specific acceptance criteria
+- [ ] Selected reviewer verification passed against specific acceptance criteria
 - [ ] `/oh-my-claudecode:cancel` run for clean state cleanup
 </Final_Checklist>
 

--- a/src/__tests__/ralph-prd-mandatory.test.ts
+++ b/src/__tests__/ralph-prd-mandatory.test.ts
@@ -1,23 +1,26 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   detectNoPrdFlag,
   stripNoPrdFlag,
+  detectCriticModeFlag,
+  stripCriticModeFlag,
   createRalphLoopHook,
   readRalphState,
   findPrdPath,
   initPrd,
   readPrd,
   writePrd,
-  createSimplePrd,
   type PRD,
   type UserStory,
 } from '../hooks/ralph/index.js';
 import {
   getArchitectVerificationPrompt,
   startVerification,
+  detectArchitectApproval,
+  detectArchitectRejection,
   type VerificationState,
 } from '../hooks/ralph/verifier.js';
 
@@ -102,6 +105,30 @@ describe('Ralph PRD-Mandatory', () => {
 
     it('should handle empty string', () => {
       expect(stripNoPrdFlag('')).toBe('');
+    });
+  });
+
+  describe('detectCriticModeFlag', () => {
+    it('detects --critic=critic', () => {
+      expect(detectCriticModeFlag('ralph --critic=critic fix this')).toBe('critic');
+    });
+
+    it('detects --critic codex', () => {
+      expect(detectCriticModeFlag('ralph --critic codex fix this')).toBe('codex');
+    });
+
+    it('returns null for invalid critic mode', () => {
+      expect(detectCriticModeFlag('ralph --critic=gemini fix this')).toBeNull();
+    });
+  });
+
+  describe('stripCriticModeFlag', () => {
+    it('removes --critic=critic', () => {
+      expect(stripCriticModeFlag('ralph --critic=critic fix this')).toBe('ralph fix this');
+    });
+
+    it('removes --critic codex', () => {
+      expect(stripCriticModeFlag('ralph --critic codex fix this')).toBe('ralph fix this');
     });
   });
 
@@ -307,6 +334,38 @@ describe('Ralph PRD-Mandatory', () => {
       const prompt = getArchitectVerificationPrompt(state);
       expect(prompt).toContain('Missing error handling in auth module');
     });
+
+    it('should support critic verification prompts', () => {
+      const prompt = getArchitectVerificationPrompt({
+        ...baseVerificationState,
+        critic_mode: 'critic',
+      });
+
+      expect(prompt).toContain('[CRITIC VERIFICATION REQUIRED');
+      expect(prompt).toContain('Task(subagent_type="critic"');
+      expect(prompt).toContain('<ralph-approved critic="critic">VERIFIED_COMPLETE</ralph-approved>');
+    });
+
+    it('should support codex verification prompts', () => {
+      const prompt = getArchitectVerificationPrompt({
+        ...baseVerificationState,
+        critic_mode: 'codex',
+      });
+
+      expect(prompt).toContain('[CODEX CRITIC VERIFICATION REQUIRED');
+      expect(prompt).toContain('omc ask codex --agent-prompt critic');
+      expect(prompt).toContain('<ralph-approved critic="codex">VERIFIED_COMPLETE</ralph-approved>');
+    });
+
+    it('detects generic Ralph approval markers', () => {
+      expect(detectArchitectApproval('<ralph-approved critic="codex">VERIFIED_COMPLETE</ralph-approved>')).toBe(true);
+    });
+
+    it('detects codex-style rejection language', () => {
+      const result = detectArchitectRejection('Codex reviewer found issues: Missing tests.');
+      expect(result.rejected).toBe(true);
+      expect(result.feedback).toContain('Missing tests');
+    });
   });
 
   // ==========================================================================
@@ -369,6 +428,14 @@ describe('Ralph PRD-Mandatory', () => {
       expect(prompt).toContain('Implement caching');
       expect(prompt).toContain('US-001');
       expect(prompt).toContain('Verify EACH acceptance criterion');
+    });
+
+    it('stores selected critic mode in Ralph state', () => {
+      const hook = createRalphLoopHook(testDir);
+      hook.startLoop(undefined, 'Implement caching', { criticMode: 'codex' });
+
+      const state = readRalphState(testDir);
+      expect(state?.critic_mode).toBe('codex');
     });
 
     it('scaffold PRD creates valid structure that getPrdStatus can read', () => {

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -527,11 +527,13 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
     switch (keywordType) {
       case "ralph": {
         // Lazy-load ralph module
-        const { createRalphLoopHook, findPrdPath: findPrd, initPrd: initPrdFn, initProgress: initProgressFn, detectNoPrdFlag: detectNoPrd, stripNoPrdFlag: stripNoPrd } = await import("./ralph/index.js");
+        const { createRalphLoopHook, findPrdPath: findPrd, initPrd: initPrdFn, initProgress: initProgressFn, detectNoPrdFlag: detectNoPrd, stripNoPrdFlag: stripNoPrd, detectCriticModeFlag, stripCriticModeFlag } = await import("./ralph/index.js");
 
         // Handle --no-prd flag
         const noPrd = detectNoPrd(promptText);
-        const cleanPrompt = noPrd ? stripNoPrd(promptText) : promptText;
+        const criticMode = detectCriticModeFlag(promptText) ?? undefined;
+        const promptWithoutCriticFlag = stripCriticModeFlag(promptText);
+        const cleanPrompt = noPrd ? stripNoPrd(promptWithoutCriticFlag) : promptWithoutCriticFlag;
 
         // Auto-generate scaffold PRD if none exists and --no-prd not set
         const existingPrd = findPrd(directory);
@@ -551,7 +553,7 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
 
         // Activate ralph state which also auto-activates ultrawork
         const hook = createRalphLoopHook(directory);
-        hook.startLoop(sessionId, cleanPrompt);
+        hook.startLoop(sessionId, cleanPrompt, criticMode ? { criticMode } : undefined);
 
         messages.push(RALPH_MESSAGE);
         break;
@@ -1383,7 +1385,7 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
   if (toolName === "skill") {
     const skillName = getInvokedSkillName(input.toolInput);
     if (skillName === "ralph") {
-      const { createRalphLoopHook, findPrdPath: findPrd, initPrd: initPrdFn, initProgress: initProgressFn, detectNoPrdFlag: detectNoPrd, stripNoPrdFlag: stripNoPrd } = await import("./ralph/index.js");
+      const { createRalphLoopHook, findPrdPath: findPrd, initPrd: initPrdFn, initProgress: initProgressFn, detectNoPrdFlag: detectNoPrd, stripNoPrdFlag: stripNoPrd, detectCriticModeFlag, stripCriticModeFlag } = await import("./ralph/index.js");
       const rawPrompt =
         typeof input.prompt === "string" && input.prompt.trim().length > 0
           ? input.prompt
@@ -1391,7 +1393,9 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
 
       // Handle --no-prd flag
       const noPrd = detectNoPrd(rawPrompt);
-      const cleanPrompt = noPrd ? stripNoPrd(rawPrompt) : rawPrompt;
+      const criticMode = detectCriticModeFlag(rawPrompt) ?? undefined;
+      const promptWithoutCriticFlag = stripCriticModeFlag(rawPrompt);
+      const cleanPrompt = noPrd ? stripNoPrd(promptWithoutCriticFlag) : promptWithoutCriticFlag;
 
       // Auto-generate scaffold PRD if none exists and --no-prd not set
       const existingPrd = findPrd(directory);
@@ -1410,7 +1414,7 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
       }
 
       const hook = createRalphLoopHook(directory);
-      hook.startLoop(input.sessionId, cleanPrompt);
+      hook.startLoop(input.sessionId, cleanPrompt, criticMode ? { criticMode } : undefined);
     }
 
     // Clear skill-active state on skill completion to prevent false-blocking.

--- a/src/hooks/persistent-mode/__tests__/ralph-verification-flow.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ralph-verification-flow.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execSync } from 'child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { checkPersistentModes } from '../index.js';
+import { writePrd, type PRD } from '../../ralph/prd.js';
+
+describe('Ralph verification flow', () => {
+  let testDir: string;
+  let claudeConfigDir: string;
+  let originalClaudeConfigDir: string | undefined;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `ralph-verification-flow-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    claudeConfigDir = join(testDir, '.fake-claude');
+    mkdirSync(testDir, { recursive: true });
+    mkdirSync(claudeConfigDir, { recursive: true });
+    execSync('git init', { cwd: testDir });
+
+    originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+  });
+
+  afterEach(() => {
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    }
+
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  function writeRalphState(sessionId: string, extra: Record<string, unknown> = {}): void {
+    const sessionDir = join(testDir, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, 'ralph-state.json'), JSON.stringify({
+      active: true,
+      iteration: 4,
+      max_iterations: 10,
+      session_id: sessionId,
+      started_at: new Date().toISOString(),
+      prompt: 'Implement issue #1496',
+      ...extra,
+    }));
+  }
+
+  it('enters verification instead of completing immediately when PRD is done', async () => {
+    const sessionId = 'ralph-prd-complete';
+    const prd: PRD = {
+      project: 'Test',
+      branchName: 'ralph/test',
+      description: 'Test PRD',
+      userStories: [{
+        id: 'US-001',
+        title: 'Done',
+        description: 'All work complete',
+        acceptanceCriteria: ['Feature is implemented'],
+        priority: 1,
+        passes: true,
+      }],
+    };
+
+    writePrd(testDir, prd);
+    writeRalphState(sessionId, { critic_mode: 'codex' });
+
+    const result = await checkPersistentModes(sessionId, testDir);
+
+    expect(result.shouldBlock).toBe(true);
+    expect(result.mode).toBe('ralph');
+    expect(result.message).toContain('CODEX CRITIC VERIFICATION REQUIRED');
+    expect(result.message).toContain('omc ask codex --agent-prompt critic');
+  });
+
+  it('completes Ralph after generic approval marker is seen in transcript', async () => {
+    const sessionId = 'ralph-approved';
+    const sessionDir = join(testDir, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+
+    writeRalphState(sessionId);
+    writeFileSync(join(sessionDir, 'ralph-verification-state.json'), JSON.stringify({
+      pending: true,
+      completion_claim: 'All stories are complete',
+      verification_attempts: 0,
+      max_verification_attempts: 3,
+      requested_at: new Date().toISOString(),
+      original_task: 'Implement issue #1496',
+      critic_mode: 'critic',
+    }));
+
+    const transcriptDir = join(claudeConfigDir, 'sessions', sessionId);
+    mkdirSync(transcriptDir, { recursive: true });
+    writeFileSync(
+      join(transcriptDir, 'transcript.md'),
+      '<ralph-approved critic="critic">VERIFIED_COMPLETE</ralph-approved>'
+    );
+
+    const result = await checkPersistentModes(sessionId, testDir);
+
+    expect(result.shouldBlock).toBe(false);
+    expect(result.message).toContain('Critic verified task completion');
+  });
+});

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -23,7 +23,7 @@ import {
   getUltraworkPersistenceMessage,
   type UltraworkState
 } from '../ultrawork/index.js';
-import { resolveToWorktreeRoot, resolveSessionStatePath, getOmcRoot, ensureSessionStateDir } from '../../lib/worktree-paths.js';
+import { resolveToWorktreeRoot, resolveSessionStatePath, getOmcRoot } from '../../lib/worktree-paths.js';
 import { readModeState } from '../../lib/mode-state-io.js';
 import {
   readRalphState,
@@ -33,6 +33,7 @@ import {
   getPrdCompletionStatus,
   getRalphContext,
   readVerificationState,
+  startVerification,
   recordArchitectFeedback,
   getArchitectVerificationPrompt,
   getArchitectRejectionContinuationPrompt,
@@ -464,20 +465,6 @@ async function checkRalphLoop(
     }
   }
 
-  // Check for PRD-based completion (all stories have passes: true)
-  const prdStatus = getPrdCompletionStatus(workingDir);
-  if (prdStatus.hasPrd && prdStatus.allComplete) {
-    // All PRD stories complete - allow completion
-    clearRalphState(workingDir, sessionId);
-    clearVerificationState(workingDir, sessionId);
-    deactivateUltrawork(workingDir, sessionId);
-    return {
-      shouldBlock: false,
-      message: `[RALPH LOOP COMPLETE - PRD] All ${prdStatus.status?.total || 0} stories are complete! Great work!`,
-      mode: 'none'
-    };
-  }
-
   // Check for existing verification state (architect verification in progress)
   const verificationState = readVerificationState(workingDir, sessionId);
 
@@ -491,9 +478,14 @@ async function checkRalphLoop(
         clearVerificationState(workingDir, sessionId);
         clearRalphState(workingDir, sessionId);
         deactivateUltrawork(workingDir, sessionId);
+        const criticLabel = verificationState.critic_mode === 'codex'
+          ? 'Codex critic'
+          : verificationState.critic_mode === 'critic'
+            ? 'Critic'
+            : 'Architect';
         return {
           shouldBlock: false,
-          message: `[RALPH LOOP VERIFIED COMPLETE] Architect verified task completion after ${state.iteration} iteration(s). Excellent work!`,
+          message: `[RALPH LOOP VERIFIED COMPLETE] ${criticLabel} verified task completion after ${state.iteration} iteration(s). Excellent work!`,
           mode: 'none'
         };
       }
@@ -520,7 +512,7 @@ async function checkRalphLoop(
       }
     }
 
-    // Verification still pending - remind to spawn architect
+    // Verification still pending - remind to run the selected reviewer
     // Get current story for story-aware verification
     const prdInfo = getPrdCompletionStatus(workingDir);
     const currentStory = prdInfo.nextStory ?? undefined;
@@ -528,6 +520,29 @@ async function checkRalphLoop(
     return {
       shouldBlock: true,
       message: verificationPrompt,
+      mode: 'ralph',
+      metadata: {
+        iteration: state.iteration,
+        maxIterations: state.max_iterations
+      }
+    };
+  }
+
+  // Check for PRD-based completion (all stories have passes: true).
+  // Enter a verification phase instead of clearing Ralph immediately.
+  const prdStatus = getPrdCompletionStatus(workingDir);
+  if (prdStatus.hasPrd && prdStatus.allComplete) {
+    const startedVerification = startVerification(
+      workingDir,
+      `All ${prdStatus.status?.total || 0} PRD stories are marked passes: true.`,
+      state.prompt,
+      state.critic_mode,
+      sessionId
+    );
+
+    return {
+      shouldBlock: true,
+      message: getArchitectVerificationPrompt(startedVerification),
       mode: 'ralph',
       metadata: {
         iteration: state.iteration,
@@ -571,7 +586,7 @@ CRITICAL INSTRUCTIONS:
 1. Review your progress and the original task
 ${prdInstruction}
 3. Continue from where you left off
-4. When FULLY complete (after Architect verification), run \`/oh-my-claudecode:cancel\` to cleanly exit and clean up state files. If cancel fails, retry with \`/oh-my-claudecode:cancel --force\`.
+4. When FULLY complete (after ${state.critic_mode === 'codex' ? 'Codex critic' : state.critic_mode === 'critic' ? 'Critic' : 'Architect'} verification), run \`/oh-my-claudecode:cancel\` to cleanly exit and clean up state files. If cancel fails, retry with \`/oh-my-claudecode:cancel --force\`.
 5. Do NOT stop until the task is truly done
 
 ${newState.prompt ? `Original task: ${newState.prompt}` : ''}

--- a/src/hooks/ralph/index.ts
+++ b/src/hooks/ralph/index.ts
@@ -24,6 +24,9 @@ export {
   // PRD flag helpers
   detectNoPrdFlag,
   stripNoPrdFlag,
+  detectCriticModeFlag,
+  stripCriticModeFlag,
+  normalizeRalphCriticMode,
 
   // Team coordination
   getTeamPhaseDirective,
@@ -40,6 +43,7 @@ export {
 
   // Types
   type RalphLoopState,
+  type RalphCriticMode,
   type RalphLoopOptions,
   type RalphLoopHook,
   type PRD,

--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -103,13 +103,20 @@ export interface RalphLoopState {
   current_story_id?: string;
   /** Whether ultrawork is linked/auto-activated with ralph */
   linked_ultrawork?: boolean;
+  /** Reviewer mode for Ralph completion verification */
+  critic_mode?: RalphCriticMode;
 }
+
+export const RALPH_CRITIC_MODES = ['architect', 'critic', 'codex'] as const;
+export type RalphCriticMode = typeof RALPH_CRITIC_MODES[number];
 
 export interface RalphLoopOptions {
   /** Maximum iterations (default: 10) */
   maxIterations?: number;
   /** Disable auto-activation of ultrawork (default: false - ultrawork is enabled) */
   disableUltrawork?: boolean;
+  /** Reviewer mode for Ralph completion verification */
+  criticMode?: RalphCriticMode;
 }
 
 export interface RalphLoopHook {
@@ -123,6 +130,7 @@ export interface RalphLoopHook {
 }
 
 const DEFAULT_MAX_ITERATIONS = 10;
+const DEFAULT_RALPH_CRITIC_MODE: RalphCriticMode = 'architect';
 
 /**
  * Read Ralph Loop state from disk
@@ -233,6 +241,38 @@ export function stripNoPrdFlag(prompt: string): string {
 }
 
 /**
+ * Normalize a Ralph critic mode flag value.
+ */
+export function normalizeRalphCriticMode(value: string | null | undefined): RalphCriticMode | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return (RALPH_CRITIC_MODES as readonly string[]).includes(normalized)
+    ? normalized as RalphCriticMode
+    : null;
+}
+
+/**
+ * Detect --critic=<mode> flag (case-insensitive).
+ */
+export function detectCriticModeFlag(prompt: string): RalphCriticMode | null {
+  const match = prompt.match(/--critic(?:=|\s+)([^\s]+)/i);
+  return normalizeRalphCriticMode(match?.[1]);
+}
+
+/**
+ * Strip --critic=<mode> flag from prompt text and trim whitespace.
+ */
+export function stripCriticModeFlag(prompt: string): string {
+  return prompt
+    .replace(/--critic(?:=|\s+)([^\s]+)/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
  * Create a Ralph Loop hook instance
  */
 export function createRalphLoopHook(directory: string): RalphLoopHook {
@@ -261,6 +301,7 @@ export function createRalphLoopHook(directory: string): RalphLoopHook {
       session_id: sessionId,
       project_path: directory,
       linked_ultrawork: enableUltrawork,
+      critic_mode: options?.criticMode ?? detectCriticModeFlag(prompt) ?? DEFAULT_RALPH_CRITIC_MODE,
     };
 
     const ralphSuccess = writeRalphState(directory, state, sessionId);

--- a/src/hooks/ralph/verifier.ts
+++ b/src/hooks/ralph/verifier.ts
@@ -16,6 +16,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from '
 import { join } from 'path';
 import { resolveSessionStatePath, ensureSessionStateDir, getOmcRoot } from '../../lib/worktree-paths.js';
 import type { UserStory } from './prd.js';
+import type { RalphCriticMode } from './loop.js';
 
 export interface VerificationState {
   /** Whether verification is pending */
@@ -34,9 +35,48 @@ export interface VerificationState {
   requested_at: string;
   /** Original ralph task */
   original_task: string;
+  /** Reviewer mode to use for verification */
+  critic_mode?: RalphCriticMode;
 }
 
 const DEFAULT_MAX_VERIFICATION_ATTEMPTS = 3;
+const DEFAULT_RALPH_CRITIC_MODE: RalphCriticMode = 'architect';
+
+function getCriticMode(mode?: RalphCriticMode): RalphCriticMode {
+  return mode ?? DEFAULT_RALPH_CRITIC_MODE;
+}
+
+function getCriticLabel(mode?: RalphCriticMode): string {
+  switch (getCriticMode(mode)) {
+    case 'critic':
+      return 'Critic';
+    case 'codex':
+      return 'Codex critic';
+    default:
+      return 'Architect';
+  }
+}
+
+function getVerificationAgentStep(mode?: RalphCriticMode): string {
+  switch (getCriticMode(mode)) {
+    case 'critic':
+      return `1. **Spawn Critic Agent** for verification:
+   \`\`\`
+   Task(subagent_type="critic", prompt="Critically review this task completion claim...")
+   \`\`\``;
+    case 'codex':
+      return `1. **Run an external Codex critic review**:
+   \`\`\`
+   omc ask codex --agent-prompt critic "<verification prompt covering the task, completion claim, and acceptance criteria>"
+   \`\`\`
+   Use the Codex output as the reviewer verdict before deciding pass/fix.`;
+    default:
+      return `1. **Spawn Architect Agent** for verification:
+   \`\`\`
+   Task(subagent_type="architect", prompt="Verify this task completion claim...")
+   \`\`\``;
+  }
+}
 
 /**
  * Get verification state file path
@@ -116,6 +156,7 @@ export function startVerification(
   directory: string,
   completionClaim: string,
   originalTask: string,
+  criticMode?: RalphCriticMode,
   sessionId?: string
 ): VerificationState {
   const state: VerificationState = {
@@ -124,7 +165,8 @@ export function startVerification(
     verification_attempts: 0,
     max_verification_attempts: DEFAULT_MAX_VERIFICATION_ATTEMPTS,
     requested_at: new Date().toISOString(),
-    original_task: originalTask
+    original_task: originalTask,
+    critic_mode: getCriticMode(criticMode)
   };
 
   writeVerificationState(directory, state, sessionId);
@@ -171,6 +213,8 @@ export function recordArchitectFeedback(
  * When a currentStory is provided, includes its specific acceptance criteria for targeted verification.
  */
 export function getArchitectVerificationPrompt(state: VerificationState, currentStory?: UserStory): string {
+  const criticLabel = getCriticLabel(state.critic_mode);
+  const approvalTag = `<ralph-approved critic="${getCriticMode(state.critic_mode)}">VERIFIED_COMPLETE</ralph-approved>`;
   const storySection = currentStory ? `
 **Current Story: ${currentStory.id} - ${currentStory.title}**
 ${currentStory.description}
@@ -183,9 +227,9 @@ IMPORTANT: Verify EACH acceptance criterion above is met. Do not verify based on
 
   return `<ralph-verification>
 
-[ARCHITECT VERIFICATION REQUIRED - Attempt ${state.verification_attempts + 1}/${state.max_verification_attempts}]
+[${criticLabel.toUpperCase()} VERIFICATION REQUIRED - Attempt ${state.verification_attempts + 1}/${state.max_verification_attempts}]
 
-The agent claims the task is complete. Before accepting, YOU MUST verify with Architect.
+The agent claims the task is complete. Before accepting, YOU MUST verify with ${criticLabel}.
 
 **Original Task:**
 ${state.original_task}
@@ -193,16 +237,13 @@ ${state.original_task}
 **Completion Claim:**
 ${state.completion_claim}
 
-${state.architect_feedback ? `**Previous Architect Feedback (rejected):**\n${state.architect_feedback}\n` : ''}
+${state.architect_feedback ? `**Previous ${criticLabel} Feedback (rejected):**\n${state.architect_feedback}\n` : ''}
 ${storySection}
 ## MANDATORY VERIFICATION STEPS
 
-1. **Spawn Architect Agent** for verification:
-   \`\`\`
-   Task(subagent_type="architect", prompt="Verify this task completion claim...")
-   \`\`\`
+${getVerificationAgentStep(state.critic_mode)}
 
-2. **Architect must check:**${currentStory ? `
+2. **${criticLabel} must check:**${currentStory ? `
    - Verify EACH acceptance criterion listed above is met with fresh evidence
    - Run the relevant tests/builds to confirm criteria pass` : `
    - Are ALL requirements from the original task met?
@@ -211,8 +252,8 @@ ${storySection}
    - Does the code compile/run without errors?
    - Are tests passing (if applicable)?
 
-3. **Based on Architect's response:**
-   - If APPROVED: Output \`<architect-approved>VERIFIED_COMPLETE</architect-approved>\`, then run \`/oh-my-claudecode:cancel\` to cleanly exit
+3. **Based on ${criticLabel}'s response:**
+   - If APPROVED: Output \`${approvalTag}\`, then run \`/oh-my-claudecode:cancel\` to cleanly exit
    - If REJECTED: Continue working on the identified issues
 
 </ralph-verification>
@@ -226,13 +267,14 @@ ${storySection}
  * Generate continuation prompt after architect rejection
  */
 export function getArchitectRejectionContinuationPrompt(state: VerificationState): string {
+  const criticLabel = getCriticLabel(state.critic_mode);
   return `<ralph-continuation-after-rejection>
 
-[ARCHITECT REJECTED - Continue Working]
+[${criticLabel.toUpperCase()} REJECTED - Continue Working]
 
-Architect found issues with your completion claim. You must address them.
+${criticLabel} found issues with your completion claim. You must address them.
 
-**Architect Feedback:**
+**${criticLabel} Feedback:**
 ${state.architect_feedback}
 
 **Original Task:**
@@ -240,10 +282,10 @@ ${state.original_task}
 
 ## INSTRUCTIONS
 
-1. Address ALL issues identified by Architect
+1. Address ALL issues identified by ${criticLabel}
 2. Do NOT claim completion again until issues are fixed
-3. When truly done, another Architect verification will be triggered
-4. After Architect approves, run \`/oh-my-claudecode:cancel\` to cleanly exit
+3. When truly done, another ${criticLabel} verification will be triggered
+4. After ${criticLabel} approves, run \`/oh-my-claudecode:cancel\` to cleanly exit
 
 Continue working now.
 
@@ -258,7 +300,7 @@ Continue working now.
  * Check if text contains architect approval
  */
 export function detectArchitectApproval(text: string): boolean {
-  return /<architect-approved>.*?VERIFIED_COMPLETE.*?<\/architect-approved>/is.test(text);
+  return /<(?:architect-approved|ralph-approved)(?:\s+[^>]*)?>.*?VERIFIED_COMPLETE.*?<\/(?:architect-approved|ralph-approved)>/is.test(text);
 }
 
 /**
@@ -267,7 +309,7 @@ export function detectArchitectApproval(text: string): boolean {
 export function detectArchitectRejection(text: string): { rejected: boolean; feedback: string } {
   // Look for explicit rejection patterns
   const rejectionPatterns = [
-    /architect.*?(rejected|found issues|not complete|incomplete)/i,
+    /(architect|critic|codex|reviewer).*?(rejected|found issues|not complete|incomplete)/i,
     /issues? (found|identified|detected)/i,
     /not yet complete/i,
     /missing.*?(implementation|feature|test)/i,
@@ -278,7 +320,7 @@ export function detectArchitectRejection(text: string): { rejected: boolean; fee
   for (const pattern of rejectionPatterns) {
     if (pattern.test(text)) {
       // Extract feedback (rough heuristic)
-      const feedbackMatch = text.match(/(?:architect|feedback|issue|problem|error|bug)[:\s]+([^.]+\.)/i);
+      const feedbackMatch = text.match(/(?:architect|critic|codex|reviewer|feedback|issue|problem|error|bug)[:\s]+([^.]+\.)/i);
       return {
         rejected: true,
         feedback: feedbackMatch ? feedbackMatch[1] : 'Architect found issues with the implementation.'


### PR DESCRIPTION
## Summary
- add a Ralph `--critic=` option with `architect`, `critic`, and `codex` reviewer modes
- enter the real Ralph verification phase when PRD stories are complete instead of exiting immediately
- add focused verification-flow tests and document the new reviewer selection option

## Testing
- npm test -- --run src/__tests__/ralph-prd-mandatory.test.ts src/hooks/persistent-mode/__tests__/ralph-verification-flow.test.ts
- npx eslint src/hooks/ralph/loop.ts src/hooks/ralph/verifier.ts src/hooks/persistent-mode/index.ts src/hooks/bridge.ts src/__tests__/ralph-prd-mandatory.test.ts src/hooks/persistent-mode/__tests__/ralph-verification-flow.test.ts
- npm run build

Closes #1496.
