### PR TITLE
fix(doctor-conflicts): recognize supported .omc-config keys

### DIFF
--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -31,7 +31,13 @@ vi.mock('../features/builtin-skills/skills.js', () => ({
 }));
 
 // Import after mock setup
-import { checkHookConflicts, checkClaudeMdStatus, checkLegacySkills, runConflictCheck } from '../cli/commands/doctor-conflicts.js';
+import {
+  checkHookConflicts,
+  checkClaudeMdStatus,
+  checkConfigIssues,
+  checkLegacySkills,
+  runConflictCheck,
+} from '../cli/commands/doctor-conflicts.js';
 
 describe('doctor-conflicts: hook ownership classification', () => {
   let cwdSpy: ReturnType<typeof vi.spyOn>;
@@ -424,5 +430,73 @@ describe('doctor-conflicts: legacy skills collision check (issue #1101)', () => 
     const report = runConflictCheck();
     expect(report.legacySkills).toHaveLength(1);
     expect(report.hasConflicts).toBe(true);
+  });
+});
+
+describe('doctor-conflicts: config known fields (issue #1499)', () => {
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
+      if (existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+    mkdirSync(TEST_CLAUDE_DIR, { recursive: true });
+    mkdirSync(TEST_PROJECT_CLAUDE_DIR, { recursive: true });
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(TEST_PROJECT_DIR);
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
+      if (existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('does not flag legitimate config keys from current writers and readers', () => {
+    writeFileSync(join(TEST_CLAUDE_DIR, '.omc-config.json'), JSON.stringify({
+      silentAutoUpdate: false,
+      notificationProfiles: {
+        work: {
+          enabled: true,
+          discord: {
+            enabled: true,
+            webhookUrl: 'https://discord.example.test/webhook',
+          },
+        },
+      },
+      hudEnabled: true,
+      nodeBinary: '/opt/homebrew/bin/node',
+      delegationEnforcementLevel: 'strict',
+      autoInvoke: {
+        enabled: true,
+        confidenceThreshold: 85,
+      },
+      customIntegrations: {
+        enabled: true,
+        integrations: [],
+      },
+      team: {
+        maxAgents: 20,
+        defaultAgentType: 'executor',
+      },
+    }, null, 2));
+
+    expect(checkConfigIssues().unknownFields).toEqual([]);
+    expect(runConflictCheck().hasConflicts).toBe(false);
+  });
+
+  it('still reports genuinely unknown config keys', () => {
+    writeFileSync(join(TEST_CLAUDE_DIR, '.omc-config.json'), JSON.stringify({
+      silentAutoUpdate: false,
+      totallyMadeUpKey: true,
+      anotherUnknown: { nested: true },
+    }, null, 2));
+
+    expect(checkConfigIssues().unknownFields).toEqual(['totallyMadeUpKey', 'anotherUnknown']);
+    expect(runConflictCheck().hasConflicts).toBe(true);
   });
 });

--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -255,7 +255,12 @@ export function checkConfigIssues(): ConflictReport['configIssues'] {
   try {
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
 
-    // Known top-level fields from PluginConfig type
+    // Known top-level fields from the current config surfaces:
+    // - PluginConfig (src/shared/types.ts)
+    // - OMCConfig (src/features/auto-update.ts)
+    // - direct .omc-config.json readers/writers (notifications, auto-invoke,
+    //   delegation enforcement, omc-setup team config)
+    // - preserved legacy compatibility keys that still appear in user configs
     const knownFields = new Set([
       // PluginConfig fields
       'agents',
@@ -277,7 +282,16 @@ export function checkConfigIssues(): ConflictReport['configIssues'] {
       'setupVersion',
       'stopHookCallbacks',
       'notifications',
+      'notificationProfiles',
+      'hudEnabled',
       'autoUpgradePrompt',
+      'nodeBinary',
+      // Direct config readers / writers outside OMCConfig
+      'customIntegrations',
+      'delegationEnforcementLevel',
+      'enforcementLevel',
+      'autoInvoke',
+      'team',
     ]);
 
     for (const field of Object.keys(config)) {


### PR DESCRIPTION
## Summary
- add the missing supported `.omc-config.json` keys to `doctor-conflicts`
- cover the known-fields behavior with focused regression tests
- keep unknown-field reporting intact for genuinely unsupported keys

## Testing
- npx vitest run src/__tests__/doctor-conflicts.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json

Closes #1499