### PR TITLE
feat: harden native clawhip event emission for OMC sessions

### DIFF
--- a/docs/OPENCLAW-ROUTING.md
+++ b/docs/OPENCLAW-ROUTING.md
@@ -1,0 +1,102 @@
+# OpenClaw / Clawhip Routing Contract
+
+This document defines the normalized event contract OMC emits through the OpenClaw bridge for native Clawhip-style consumers.
+
+## Goals
+
+- Keep the raw hook event (`event`) for backward compatibility.
+- Add a normalized `signal` object for routing and dedupe-friendly filtering.
+- Make command/native gateways receive the same logical payload shape as HTTP gateways.
+
+## Payload shape
+
+HTTP gateways receive JSON with this structure:
+
+```json
+{
+  "event": "post-tool-use",
+  "instruction": "...",
+  "timestamp": "2026-03-09T00:00:00.000Z",
+  "sessionId": "...",
+  "projectPath": "...",
+  "projectName": "...",
+  "tmuxSession": "...",
+  "tmuxTail": "...",
+  "signal": {
+    "kind": "test",
+    "name": "test-run",
+    "phase": "failed",
+    "routeKey": "test.failed",
+    "priority": "high",
+    "toolName": "Bash",
+    "command": "pnpm test",
+    "testRunner": "package-test",
+    "summary": "FAIL src/example.test.ts | ..."
+  },
+  "context": {
+    "sessionId": "...",
+    "projectPath": "...",
+    "toolName": "Bash"
+  }
+}
+```
+
+## `signal` contract
+
+| Field      | Meaning                                                                           |
+| ---------- | --------------------------------------------------------------------------------- |
+| `kind`     | Routing family: `session`, `tool`, `test`, `pull-request`, `question`, `keyword`  |
+| `name`     | Stable logical signal name                                                        |
+| `phase`    | Lifecycle phase: `started`, `finished`, `failed`, `idle`, `detected`, `requested` |
+| `routeKey` | Canonical routing key for downstream consumers                                    |
+| `priority` | `high` for operational signals, `low` for generic tool noise                      |
+
+Additional fields may appear when applicable:
+
+- `toolName`
+- `command`
+- `testRunner`
+- `prUrl`
+- `summary`
+
+## Native command gateway contract
+
+Command gateways now get the same normalized payload through both:
+
+- template variable: `{{payloadJson}}`
+- env var: `OPENCLAW_PAYLOAD_JSON`
+
+They also receive convenience env vars:
+
+- `OPENCLAW_SIGNAL_ROUTE_KEY`
+- `OPENCLAW_SIGNAL_PHASE`
+- `OPENCLAW_SIGNAL_KIND`
+
+That lets native Clawhip routing consume one contract whether the transport is HTTP or shell-command based.
+
+## Current high-priority route keys
+
+- `session.started`
+- `session.finished`
+- `session.idle`
+- `question.requested`
+- `test.started`
+- `test.finished`
+- `test.failed`
+- `pull-request.started`
+- `pull-request.created`
+- `pull-request.failed`
+- `tool.failed`
+
+Generic `tool.started` / `tool.finished` remain available as low-priority fallback signals.
+
+## Noise reduction
+
+- `AskUserQuestion` now emits only the dedicated `question.requested` signal instead of also emitting generic tool lifecycle events.
+- Consumers should prefer `signal.priority === "high"` or explicit `signal.routeKey` filters instead of routing directly on raw hook names.
+
+## Stability notes
+
+- Raw `event` names are preserved for backward compatibility.
+- `signal` is the preferred routing surface for new native Clawhip integrations.
+- `context` remains a whitelisted subset; internal raw tool input/output are used only to derive normalized signals and are not forwarded in `payload.context`.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -333,6 +333,7 @@ Includes **33 canonical skills + 1 deprecated alias** (`psm`).
 | `ccg`                     | Tri-model workflow via `ask-codex` + `ask-gemini`, then Claude synthesis | `/oh-my-claudecode:ccg`                     |
 | `configure-notifications` | Configure notifications (Discord/Telegram/Slack/OpenClaw)        | `/oh-my-claudecode:configure-notifications` |
 | `configure-openclaw`      | Configure OpenClaw gateway (deprecated, use configure-notifications) | `/oh-my-claudecode:configure-openclaw`      |
+| _OpenClaw routing_        | Normalized native/HTTP routing contract for clawhip consumers    | [`docs/OPENCLAW-ROUTING.md`](./OPENCLAW-ROUTING.md) |
 | `deep-interview`          | Socratic deep interview with ambiguity gating                    | `/oh-my-claudecode:deep-interview`          |
 | `deepinit`                | Generate hierarchical AGENTS.md docs                             | `/oh-my-claudecode:deepinit`                |
 | `external-context`        | Parallel document-specialist research                            | `/oh-my-claudecode:external-context`        |

--- a/src/hooks/__tests__/bridge-openclaw.test.ts
+++ b/src/hooks/__tests__/bridge-openclaw.test.ts
@@ -125,7 +125,7 @@ describe("bridge-level regression tests", () => {
     expect(msg).not.toContain("[PROMPT TRANSLATION]");
   });
 
-  it("pre-tool-use calls _openclaw.wake for AskUserQuestion", async () => {
+  it("pre-tool-use emits only the dedicated ask-user-question OpenClaw signal", async () => {
     process.env.OMC_OPENCLAW = "1";
     process.env.OMC_NOTIFY = "0"; // suppress real notifications
 
@@ -142,16 +142,31 @@ describe("bridge-level regression tests", () => {
 
     await processHook("pre-tool-use", input);
 
-    // Verify _openclaw.wake was called with ask-user-question event
-    const askCall = wakeSpy.mock.calls.find(
-      (call) => call[0] === "ask-user-question",
+    expect(wakeSpy).toHaveBeenCalledWith(
+      "ask-user-question",
+      expect.objectContaining({
+        sessionId: "test-session",
+        question: "What should I do next?",
+      }),
     );
-    expect(askCall).toBeDefined();
-    expect(askCall![1]).toMatchObject({
+    expect(wakeSpy.mock.calls.some((call) => call[0] === "pre-tool-use")).toBe(false);
+
+    wakeSpy.mockRestore();
+  });
+
+  it("post-tool-use skips generic OpenClaw emission for AskUserQuestion", async () => {
+    process.env.OMC_OPENCLAW = "1";
+    const wakeSpy = vi.spyOn(_openclaw, "wake");
+
+    await processHook("post-tool-use", {
       sessionId: "test-session",
-      question: "What should I do next?",
+      toolName: "AskUserQuestion",
+      toolInput: { questions: [{ question: "Need approval?" }] },
+      toolOutput: '{"answers":{"0":"yes"}}',
+      directory: "/tmp/test",
     });
 
+    expect(wakeSpy).not.toHaveBeenCalled();
     wakeSpy.mockRestore();
   });
 });

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1329,12 +1329,14 @@ function processPreToolUse(input: HookInput): HookOutput {
     }
   }
 
-  // Wake OpenClaw gateway for pre-tool-use (non-blocking, fires only for allowed tools)
-  if (input.sessionId) {
+  // Wake OpenClaw gateway for pre-tool-use (non-blocking, fires only for allowed tools).
+  // AskUserQuestion already has a dedicated high-signal OpenClaw event.
+  if (input.sessionId && input.toolName !== "AskUserQuestion") {
     _openclaw.wake("pre-tool-use", {
       sessionId: input.sessionId,
       projectPath: directory,
       toolName: input.toolName,
+      toolInput: input.toolInput,
     });
   }
 
@@ -1442,12 +1444,15 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
     }
   }
 
-  // Wake OpenClaw gateway for post-tool-use (non-blocking, fires for all tools)
-  if (input.sessionId) {
+  // Wake OpenClaw gateway for post-tool-use (non-blocking, fires for all tools).
+  // AskUserQuestion already emitted a dedicated question.requested signal.
+  if (input.sessionId && input.toolName !== "AskUserQuestion") {
     _openclaw.wake("post-tool-use", {
       sessionId: input.sessionId,
       projectPath: directory,
       toolName: input.toolName,
+      toolInput: input.toolInput,
+      toolOutput: input.toolOutput,
     });
   }
 

--- a/src/openclaw/__tests__/dispatcher.test.ts
+++ b/src/openclaw/__tests__/dispatcher.test.ts
@@ -16,6 +16,13 @@ const basePayload: OpenClawPayload = {
   event: "session-start",
   instruction: "Session started",
   timestamp: "2026-02-25T00:00:00.000Z",
+  signal: {
+    kind: "session",
+    name: "session",
+    phase: "started",
+    routeKey: "session.started",
+    priority: "high",
+  },
   context: {},
 };
 
@@ -407,6 +414,35 @@ describe("wakeCommandGateway", () => {
     await wakeCommandGateway("gw", config, {});
     expect(capturedCmd).toBe("sh");
     expect(capturedArgs[0]).toBe("-c");
+  });
+
+  it("exposes normalized payload and signal env vars to command gateways", async () => {
+    let capturedOpts: Record<string, unknown> = {};
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], opts: Record<string, unknown>, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedOpts = opts;
+        cb(null, { stdout: "", stderr: "" });
+      },
+    );
+
+    const config: OpenClawCommandGatewayConfig = { type: "command", command: "echo hello" };
+    await wakeCommandGateway(
+      "test",
+      config,
+      {
+        payloadJson: JSON.stringify(basePayload),
+        signalRouteKey: "session.started",
+        signalPhase: "started",
+        signalKind: "session",
+      },
+      basePayload,
+    );
+
+    const env = capturedOpts.env as Record<string, string>;
+    expect(env.OPENCLAW_PAYLOAD_JSON).toContain('"routeKey":"session.started"');
+    expect(env.OPENCLAW_SIGNAL_ROUTE_KEY).toBe("session.started");
+    expect(env.OPENCLAW_SIGNAL_PHASE).toBe("started");
+    expect(env.OPENCLAW_SIGNAL_KIND).toBe("session");
   });
 
   it("uses the default timeout of 10000ms when config.timeout is not specified", async () => {

--- a/src/openclaw/__tests__/index.test.ts
+++ b/src/openclaw/__tests__/index.test.ts
@@ -281,6 +281,54 @@ describe("wakeOpenClaw", () => {
     // The instruction variable should be the interpolated result
     expect(variables.instruction).toContain("myproject");
   });
+
+  it("adds a normalized test signal to the HTTP payload", async () => {
+    vi.mocked(resolveGateway).mockReturnValue({
+      gatewayName: "my-gateway",
+      gateway: { url: "https://example.com/wake", method: "POST" as const },
+      instruction: "test",
+    });
+
+    await wakeOpenClaw("post-tool-use", {
+      sessionId: "sid-1",
+      projectPath: "/home/user/myproject",
+      toolName: "Bash",
+      toolInput: { command: "pnpm test" },
+      toolOutput: "FAIL src/openclaw/signal.test.ts\nTest failed",
+    });
+
+    const payload = vi.mocked(wakeGateway).mock.calls[0][2];
+    expect(payload.signal).toMatchObject({
+      kind: "test",
+      phase: "failed",
+      routeKey: "test.failed",
+      priority: "high",
+      testRunner: "package-test",
+    });
+  });
+
+  it("passes payloadJson and signalRouteKey to command gateways for PR creation", async () => {
+    const commandGateway = { type: "command" as const, command: "notify {{signalRouteKey}} {{payloadJson}}" };
+    vi.mocked(resolveGateway).mockReturnValue({
+      gatewayName: "cmd-gw",
+      gateway: commandGateway,
+      instruction: "Create PR",
+    });
+    vi.mocked(wakeCommandGateway).mockResolvedValue({ gateway: "cmd-gw", success: true });
+
+    await wakeOpenClaw("post-tool-use", {
+      sessionId: "sid-1",
+      projectPath: "/home/user/myproject",
+      toolName: "Bash",
+      toolInput: { command: "gh pr create --base dev --fill" },
+      toolOutput: "https://github.com/example/repo/pull/1500",
+    });
+
+    const variables = vi.mocked(wakeCommandGateway).mock.calls[0][2];
+    expect(variables.signalRouteKey).toBe("pull-request.created");
+    expect(variables.payloadJson).toContain('"routeKey":"pull-request.created"');
+    expect(variables.payloadJson).toContain('"prUrl":"https://github.com/example/repo/pull/1500"');
+  });
 });
 
 describe("reply channel context", () => {

--- a/src/openclaw/__tests__/signal.test.ts
+++ b/src/openclaw/__tests__/signal.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenClawSignal } from "../signal.js";
+
+describe("buildOpenClawSignal", () => {
+  it("classifies session-start as a high-priority started session signal", () => {
+    const signal = buildOpenClawSignal("session-start", {
+      sessionId: "sess-1",
+    });
+
+    expect(signal).toMatchObject({
+      kind: "session",
+      phase: "started",
+      routeKey: "session.started",
+      priority: "high",
+    });
+  });
+
+  it("classifies bash test commands as high-priority test signals", () => {
+    const signal = buildOpenClawSignal("pre-tool-use", {
+      toolName: "Bash",
+      toolInput: { command: "npm test -- --runInBand" },
+    });
+
+    expect(signal).toMatchObject({
+      kind: "test",
+      name: "test-run",
+      phase: "started",
+      routeKey: "test.started",
+      testRunner: "package-test",
+      priority: "high",
+    });
+  });
+
+  it("classifies failed bash test output as a failed test signal", () => {
+    const signal = buildOpenClawSignal("post-tool-use", {
+      toolName: "Bash",
+      toolInput: { command: "pnpm test" },
+      toolOutput:
+        "FAIL src/openclaw/signal.test.ts\nTest failed: expected 1 to be 2",
+    });
+
+    expect(signal).toMatchObject({
+      kind: "test",
+      phase: "failed",
+      routeKey: "test.failed",
+      priority: "high",
+    });
+  });
+
+  it("extracts pull request URLs from gh pr create output", () => {
+    const signal = buildOpenClawSignal("post-tool-use", {
+      toolName: "Bash",
+      toolInput: { command: "gh pr create --base dev --fill" },
+      toolOutput: "https://github.com/example/oh-my-claudecode/pull/1501",
+    });
+
+    expect(signal).toMatchObject({
+      kind: "pull-request",
+      phase: "finished",
+      routeKey: "pull-request.created",
+      priority: "high",
+      prUrl: "https://github.com/example/oh-my-claudecode/pull/1501",
+    });
+  });
+
+  it("keeps generic tool completion low priority when no higher-level signal exists", () => {
+    const signal = buildOpenClawSignal("post-tool-use", {
+      toolName: "Read",
+      toolOutput: "file contents",
+    });
+
+    expect(signal).toMatchObject({
+      kind: "tool",
+      phase: "finished",
+      routeKey: "tool.finished",
+      priority: "low",
+    });
+  });
+});

--- a/src/openclaw/dispatcher.ts
+++ b/src/openclaw/dispatcher.ts
@@ -50,6 +50,10 @@ function validateGatewayUrl(url: string): boolean {
  * - {{question}} - question text (ask-user-question event)
  * - {{timestamp}} - ISO timestamp
  * - {{event}} - hook event name
+ * - {{signalKind}} / {{signalName}} / {{signalPhase}} / {{signalRouteKey}}
+ * - {{signalPriority}} / {{signalSummary}}
+ * - {{testRunner}} / {{prUrl}} / {{command}}
+ * - {{payloadJson}} - full normalized payload JSON for native command gateways
  *
  * Unresolved variables are left as-is (not replaced with empty string).
  */
@@ -140,6 +144,7 @@ export async function wakeCommandGateway(
   gatewayName: string,
   gatewayConfig: OpenClawCommandGatewayConfig,
   variables: Record<string, string | undefined>,
+  payload?: OpenClawPayload,
 ): Promise<OpenClawResult> {
   try {
     const { execFile } = await import("child_process");
@@ -158,9 +163,17 @@ export async function wakeCommandGateway(
 
     const timeout = gatewayConfig.timeout ?? DEFAULT_TIMEOUT_MS;
 
+    const payloadJson = payload ? JSON.stringify(payload) : variables.payloadJson;
+
     await execFileAsync("sh", ["-c", command], {
       timeout,
-      env: { ...process.env },
+      env: {
+        ...process.env,
+        ...(payloadJson ? { OPENCLAW_PAYLOAD_JSON: payloadJson } : {}),
+        ...(variables.signalRouteKey ? { OPENCLAW_SIGNAL_ROUTE_KEY: variables.signalRouteKey } : {}),
+        ...(variables.signalPhase ? { OPENCLAW_SIGNAL_PHASE: variables.signalPhase } : {}),
+        ...(variables.signalKind ? { OPENCLAW_SIGNAL_KIND: variables.signalKind } : {}),
+      },
     });
 
     return { gateway: gatewayName, success: true };

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -17,14 +17,20 @@ export type {
   OpenClawHttpGatewayConfig,
   OpenClawPayload,
   OpenClawResult,
+  OpenClawSignal,
+  OpenClawSignalKind,
+  OpenClawSignalPhase,
+  OpenClawSignalPriority,
 } from "./types.js";
 
 export { getOpenClawConfig, resolveGateway, resetOpenClawConfigCache } from "./config.js";
 export { wakeGateway, wakeCommandGateway, interpolateInstruction, isCommandGateway, shellEscapeArg } from "./dispatcher.js";
+export { buildOpenClawSignal } from "./signal.js";
 
-import type { OpenClawHookEvent, OpenClawContext, OpenClawResult } from "./types.js";
+import type { OpenClawHookEvent, OpenClawContext, OpenClawPayload, OpenClawResult } from "./types.js";
 import { getOpenClawConfig, resolveGateway } from "./config.js";
 import { wakeGateway, wakeCommandGateway, interpolateInstruction, isCommandGateway } from "./dispatcher.js";
+import { buildOpenClawSignal } from "./signal.js";
 import { basename } from "path";
 import { getCurrentTmuxSession } from "../notifications/tmux.js";
 
@@ -109,6 +115,8 @@ export async function wakeOpenClaw(
       ...(replyThread && { replyThread }),
     };
 
+    const signal = buildOpenClawSignal(event, enrichedContext);
+
     // Build template variables from whitelisted context fields
     const variables: Record<string, string | undefined> = {
       sessionId: context.sessionId,
@@ -126,33 +134,45 @@ export async function wakeOpenClaw(
       replyChannel,
       replyTarget,
       replyThread,
+      signalKind: signal.kind,
+      signalName: signal.name,
+      signalPhase: signal.phase,
+      signalRouteKey: signal.routeKey,
+      signalPriority: signal.priority,
+      signalSummary: signal.summary,
+      prUrl: signal.prUrl,
+      testRunner: signal.testRunner,
+      command: signal.command,
     };
 
     // Add interpolated instruction to variables for command gateway {{instruction}} placeholder
     const interpolatedInstruction = interpolateInstruction(instruction, variables);
+
+    const payload: OpenClawPayload = {
+      event,
+      instruction: interpolatedInstruction,
+      timestamp: now,
+      sessionId: context.sessionId,
+      projectPath: context.projectPath,
+      projectName: context.projectPath ? basename(context.projectPath) : undefined,
+      tmuxSession,
+      tmuxTail,
+      ...(replyChannel && { channel: replyChannel }),
+      ...(replyTarget && { to: replyTarget }),
+      ...(replyThread && { threadId: replyThread }),
+      signal,
+      context: buildWhitelistedContext(enrichedContext),
+    };
     variables.instruction = interpolatedInstruction;
+    variables.payloadJson = JSON.stringify(payload);
 
     let result: OpenClawResult;
 
     if (isCommandGateway(gateway)) {
       // Command gateway: execute shell command with shell-escaped variables
-      result = await wakeCommandGateway(gatewayName, gateway, variables);
+      result = await wakeCommandGateway(gatewayName, gateway, variables, payload);
     } else {
       // HTTP gateway: send JSON payload
-      const payload = {
-        event,
-        instruction: interpolatedInstruction,
-        timestamp: now,
-        sessionId: context.sessionId,
-        projectPath: context.projectPath,
-        projectName: context.projectPath ? basename(context.projectPath) : undefined,
-        tmuxSession,
-        tmuxTail,
-        ...(replyChannel && { channel: replyChannel }),
-        ...(replyTarget && { to: replyTarget }),
-        ...(replyThread && { threadId: replyThread }),
-        context: buildWhitelistedContext(enrichedContext),
-      };
       result = await wakeGateway(gatewayName, gateway, payload);
     }
 

--- a/src/openclaw/signal.ts
+++ b/src/openclaw/signal.ts
@@ -1,0 +1,232 @@
+import type { OpenClawContext, OpenClawHookEvent, OpenClawSignal } from "./types.js";
+
+const CLAUDE_TEMP_CWD_PATTERN = /zsh:\d+: permission denied:.*\/T\/claude-[a-z0-9]+-cwd/gi;
+const CLAUDE_EXIT_CODE_PREFIX = /^Error: Exit code \d+\s*$/gm;
+const PR_CREATE_PATTERN = /\bgh\s+pr\s+create\b/i;
+const PR_URL_PATTERN = /https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+/i;
+
+const TEST_COMMAND_PATTERNS: Array<{ pattern: RegExp; runner: string }> = [
+  { pattern: /\b(?:npm|pnpm|yarn|bun)\s+test\b/i, runner: "package-test" },
+  { pattern: /\bnpx\s+vitest\b|\bvitest\b/i, runner: "vitest" },
+  { pattern: /\bnpx\s+jest\b|\bjest\b/i, runner: "jest" },
+  { pattern: /\bpytest\b|\bpython\s+-m\s+pytest\b/i, runner: "pytest" },
+  { pattern: /\bcargo\s+test\b/i, runner: "cargo-test" },
+  { pattern: /\bgo\s+test\b/i, runner: "go-test" },
+  { pattern: /\bmake\s+test\b/i, runner: "make-test" },
+];
+
+function stripClaudeTempCwdErrors(output: string): string {
+  return output.replace(CLAUDE_TEMP_CWD_PATTERN, "");
+}
+
+function isNonZeroExitWithOutput(output: string): boolean {
+  const cleaned = stripClaudeTempCwdErrors(output);
+  if (!CLAUDE_EXIT_CODE_PREFIX.test(cleaned)) return false;
+  CLAUDE_EXIT_CODE_PREFIX.lastIndex = 0;
+
+  const remaining = cleaned.replace(CLAUDE_EXIT_CODE_PREFIX, "").trim();
+  CLAUDE_EXIT_CODE_PREFIX.lastIndex = 0;
+  if (!remaining) return false;
+
+  const contentErrorPatterns = [
+    /error:/i,
+    /failed/i,
+    /\bFAIL\b/,
+    /cannot/i,
+    /permission denied/i,
+    /command not found/i,
+    /no such file/i,
+    /fatal:/i,
+    /abort/i,
+  ];
+
+  return !contentErrorPatterns.some((pattern) => pattern.test(remaining));
+}
+
+function detectBashFailure(output: string): boolean {
+  const cleaned = stripClaudeTempCwdErrors(output);
+  const errorPatterns = [
+    /error:/i,
+    /failed/i,
+    /\bFAIL\b/,
+    /cannot/i,
+    /permission denied/i,
+    /command not found/i,
+    /no such file/i,
+    /exit code: [1-9]/i,
+    /exit status [1-9]/i,
+    /fatal:/i,
+    /abort/i,
+  ];
+
+  return errorPatterns.some((pattern) => pattern.test(cleaned));
+}
+
+function detectWriteFailure(output: string): boolean {
+  const cleaned = stripClaudeTempCwdErrors(output);
+  const errorPatterns = [
+    /\berror:/i,
+    /\bfailed to\b/i,
+    /\bwrite failed\b/i,
+    /\boperation failed\b/i,
+    /permission denied/i,
+    /read-only/i,
+    /\bno such file\b/i,
+    /\bdirectory not found\b/i,
+  ];
+
+  return errorPatterns.some((pattern) => pattern.test(cleaned));
+}
+
+function getCommand(toolInput: unknown): string | undefined {
+  if (!toolInput || typeof toolInput !== "object") return undefined;
+  const raw = (toolInput as Record<string, unknown>).command;
+  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : undefined;
+}
+
+function detectTestRunner(command?: string): string | undefined {
+  if (!command) return undefined;
+  return TEST_COMMAND_PATTERNS.find(({ pattern }) => pattern.test(command))?.runner;
+}
+
+function summarize(value: unknown, maxLength = 160): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 4)
+    .join(" | ");
+
+  if (!normalized) return undefined;
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 2)).trimEnd()}…`;
+}
+
+function getToolPhase(toolName: string | undefined, toolOutput: unknown): "finished" | "failed" {
+  if (typeof toolOutput !== "string" || toolOutput.trim().length === 0) {
+    return "finished";
+  }
+
+  if (toolName === "Bash") {
+    if (isNonZeroExitWithOutput(toolOutput)) return "finished";
+    return detectBashFailure(toolOutput) ? "failed" : "finished";
+  }
+
+  if (toolName === "Edit" || toolName === "Write") {
+    return detectWriteFailure(toolOutput) ? "failed" : "finished";
+  }
+
+  return "finished";
+}
+
+function buildToolSignal(event: "pre-tool-use" | "post-tool-use", context: OpenClawContext): OpenClawSignal {
+  const toolName = context.toolName || "unknown";
+  const command = getCommand(context.toolInput);
+  const testRunner = toolName === "Bash" ? detectTestRunner(command) : undefined;
+  const isPrCreate = toolName === "Bash" && !!command && PR_CREATE_PATTERN.test(command);
+  const phase = event === "pre-tool-use" ? "started" : getToolPhase(context.toolName, context.toolOutput);
+  const summary = summarize(context.toolOutput ?? command);
+
+  if (testRunner) {
+    return {
+      kind: "test",
+      name: "test-run",
+      phase,
+      routeKey: `test.${phase}`,
+      priority: "high",
+      toolName,
+      command,
+      testRunner,
+      summary,
+    };
+  }
+
+  if (isPrCreate) {
+    const output = typeof context.toolOutput === "string" ? context.toolOutput : "";
+    const prUrl = output.match(PR_URL_PATTERN)?.[0];
+    const routeKey =
+      phase === "started" ? "pull-request.started" : phase === "failed" ? "pull-request.failed" : "pull-request.created";
+    return {
+      kind: "pull-request",
+      name: "pull-request-create",
+      phase,
+      routeKey,
+      priority: "high",
+      toolName,
+      command,
+      prUrl,
+      summary: summarize(prUrl ? `${prUrl}${summary ? ` ${summary}` : ""}` : summary),
+    };
+  }
+
+  return {
+    kind: "tool",
+    name: "tool-use",
+    phase,
+    routeKey: `tool.${phase}`,
+    priority: phase === "failed" ? "high" : "low",
+    toolName,
+    summary,
+  };
+}
+
+export function buildOpenClawSignal(event: OpenClawHookEvent, context: OpenClawContext): OpenClawSignal {
+  switch (event) {
+    case "session-start":
+      return {
+        kind: "session",
+        name: "session",
+        phase: "started",
+        routeKey: "session.started",
+        priority: "high",
+      };
+    case "session-end":
+      return {
+        kind: "session",
+        name: "session",
+        phase: "finished",
+        routeKey: "session.finished",
+        priority: "high",
+        summary: summarize(context.reason),
+      };
+    case "stop":
+      return {
+        kind: "session",
+        name: "session-idle",
+        phase: "idle",
+        routeKey: "session.idle",
+        priority: "high",
+      };
+    case "keyword-detector":
+      return {
+        kind: "keyword",
+        name: "keyword-detected",
+        phase: "detected",
+        routeKey: "keyword.detected",
+        priority: "low",
+        summary: summarize(context.prompt),
+      };
+    case "ask-user-question":
+      return {
+        kind: "question",
+        name: "ask-user-question",
+        phase: "requested",
+        routeKey: "question.requested",
+        priority: "high",
+        summary: summarize(context.question),
+      };
+    case "pre-tool-use":
+    case "post-tool-use":
+      return buildToolSignal(event, context);
+    default:
+      return {
+        kind: "tool",
+        name: "tool-use",
+        phase: "finished",
+        routeKey: "tool.finished",
+        priority: "low",
+      };
+  }
+}

--- a/src/openclaw/types.ts
+++ b/src/openclaw/types.ts
@@ -63,6 +63,51 @@ export interface OpenClawConfig {
   hooks: Partial<Record<OpenClawHookEvent, OpenClawHookMapping>>;
 }
 
+/** Normalized signal kinds for downstream routing */
+export type OpenClawSignalKind =
+  | "session"
+  | "tool"
+  | "test"
+  | "pull-request"
+  | "question"
+  | "keyword";
+
+/** Supported lifecycle phases for normalized signals */
+export type OpenClawSignalPhase =
+  | "started"
+  | "finished"
+  | "failed"
+  | "idle"
+  | "detected"
+  | "requested";
+
+/** Relative priority for downstream routing */
+export type OpenClawSignalPriority = "high" | "low";
+
+/** Canonical normalized signal routed alongside the raw hook event */
+export interface OpenClawSignal {
+  /** Routing family */
+  kind: OpenClawSignalKind;
+  /** Stable logical signal name */
+  name: string;
+  /** Lifecycle phase */
+  phase: OpenClawSignalPhase;
+  /** Canonical route key for native/HTTP consumers */
+  routeKey: string;
+  /** High-priority signals are lifecycle/test/PR/question events */
+  priority: OpenClawSignalPriority;
+  /** Tool name when relevant */
+  toolName?: string;
+  /** Safe command string when routing depends on the invoked Bash command */
+  command?: string;
+  /** Normalized test runner when the signal represents a test command */
+  testRunner?: string;
+  /** PR URL extracted from gh pr create output */
+  prUrl?: string;
+  /** Short summary for routing/debugging */
+  summary?: string;
+}
+
 /** Payload sent to an OpenClaw gateway */
 export interface OpenClawPayload {
   /** The hook event that triggered this call */
@@ -87,6 +132,8 @@ export interface OpenClawPayload {
   to?: string;
   /** Reply thread ID from OPENCLAW_REPLY_THREAD env var */
   threadId?: string;
+  /** Normalized routing signal derived from the raw hook event */
+  signal: OpenClawSignal;
   /** Context data from the hook (whitelisted fields only) */
   context: OpenClawContext;
 }
@@ -102,6 +149,10 @@ export interface OpenClawContext {
   projectPath?: string;
   tmuxSession?: string;
   toolName?: string;
+  /** Internal-only raw tool input used to derive normalized signals; never forwarded in payload.context */
+  toolInput?: unknown;
+  /** Internal-only raw tool output used to derive normalized signals; never forwarded in payload.context */
+  toolOutput?: unknown;
   prompt?: string;
   contextSummary?: string;
   reason?: string;


### PR DESCRIPTION
## Summary
- add a normalized OpenClaw/clawhip signal contract on top of existing hook events
- emit higher-signal test and PR lifecycle metadata for native/http command gateways
- reduce AskUserQuestion duplicate noise and document the routing contract

## Testing
- npm test -- --run src/openclaw/__tests__/signal.test.ts src/openclaw/__tests__/index.test.ts src/openclaw/__tests__/dispatcher.test.ts src/hooks/__tests__/bridge-openclaw.test.ts src/hooks/session-end/__tests__/openclaw-session-end.test.ts
- npm run build
- npx eslint src/openclaw src/hooks/bridge.ts src/hooks/__tests__/bridge-openclaw.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json