### PR TITLE
fix(doctor): add missing knownFields for team, nodeBinary, hudEnabled, notificationProfiles (#1499)

### DIFF
--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -278,6 +278,10 @@ export function checkConfigIssues(): ConflictReport['configIssues'] {
       'stopHookCallbacks',
       'notifications',
       'autoUpgradePrompt',
+      'team',
+      'nodeBinary',
+      'hudEnabled',
+      'notificationProfiles',
     ]);
 
     for (const field of Object.keys(config)) {


### PR DESCRIPTION
## Summary

Add 4 missing fields to the `knownFields` set in `checkConfigIssues()` (`src/cli/commands/doctor-conflicts.ts`).

## Problem

`omc doctor conflicts` reports false positive warnings:
```
⚠ Unknown fields in .omc-config.json:
  - team
  - nodeBinary
```

Both are legitimate fields:
- **`team`** — written by setup wizard Phase 3
- **`nodeBinary`** — defined in `OMCConfig` interface (`src/features/auto-update.ts:168`)
- **`hudEnabled`** — defined in `OMCConfig` interface
- **`notificationProfiles`** — defined in `OMCConfig` interface

## Fix

Add `'team'`, `'nodeBinary'`, `'hudEnabled'`, `'notificationProfiles'` to the `knownFields` set (line 259-281).

Regression of #359.

Closes #1499