### PR TITLE
fix: keep HUD rate limits visible on transient usage API failures

### DIFF
--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -111,6 +111,21 @@ describe('render: rate limits display priority', () => {
     expect(output).toContain('[API err]');
   });
 
+  it('shows stale cached data instead of [API err] when transient failures still have usage data', async () => {
+    const context = makeContext({
+      rateLimitsResult: {
+        rateLimits: { fiveHourPercent: 61, weeklyPercent: 22 },
+        error: 'network',
+        stale: true,
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).toContain('61%');
+    expect(output).toContain('*');
+    expect(output).not.toContain('[API err]');
+  });
+
   it('shows [API auth] when error=auth and rateLimits is null', async () => {
     const context = makeContext({
       rateLimitsResult: {

--- a/src/__tests__/hud/usage-api-stale.test.ts
+++ b/src/__tests__/hud/usage-api-stale.test.ts
@@ -244,4 +244,71 @@ describe('usage API stale data handling', () => {
     expect(result.rateLimits).toBeNull();
     expect(result.error).toBe('rate_limited');
   });
+
+  it('preserves last-known-good usage on transient network failures and marks it stale', async () => {
+    const lastSuccess = Date.now() - 5 * 60_000;
+    const expiredCache = JSON.stringify({
+      timestamp: Date.now() - 91_000,
+      source: 'zai',
+      lastSuccessAt: lastSuccess,
+      data: {
+        fiveHourPercent: 11,
+        fiveHourResetsAt: null,
+      },
+    });
+
+    const { files, fsModule } = createFsMock({ [CACHE_PATH]: expiredCache });
+    setupMocks(fsModule, 500, '');
+
+    const { getUsage } = await import('../../hud/usage-api.js');
+    const result = await getUsage();
+
+    expect(result).toEqual({
+      rateLimits: {
+        fiveHourPercent: 11,
+        fiveHourResetsAt: null,
+      },
+      error: 'network',
+      stale: true,
+    });
+
+    const written = JSON.parse(files.get(CACHE_PATH)!);
+    expect(written.data).toEqual({
+      fiveHourPercent: 11,
+      fiveHourResetsAt: null,
+    });
+    expect(written.error).toBe(true);
+    expect(written.errorReason).toBe('network');
+    expect(written.lastSuccessAt).toBe(lastSuccess);
+  });
+
+  it('does not preserve stale fallback data past the max stale window on transient failures', async () => {
+    const sixteenMinutesAgo = Date.now() - 16 * 60_000;
+    const expiredCache = JSON.stringify({
+      timestamp: Date.now() - 91_000,
+      source: 'zai',
+      lastSuccessAt: sixteenMinutesAgo,
+      data: {
+        fiveHourPercent: 11,
+        fiveHourResetsAt: null,
+      },
+    });
+
+    const { files, fsModule } = createFsMock({ [CACHE_PATH]: expiredCache });
+    setupMocks(fsModule, 500, '');
+
+    const { getUsage } = await import('../../hud/usage-api.js');
+    const result = await getUsage();
+
+    expect(result).toEqual({
+      rateLimits: null,
+      error: 'network',
+    });
+
+    const written = JSON.parse(files.get(CACHE_PATH)!);
+    expect(written.data).toBeNull();
+    expect(written.error).toBe(true);
+    expect(written.errorReason).toBe('network');
+    expect(written.lastSuccessAt).toBe(sixteenMinutesAgo);
+  });
 });

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -231,19 +231,35 @@ function isCacheValid(cache: UsageCache, pollIntervalMs: number): boolean {
   return Date.now() - cache.timestamp < ttl;
 }
 
+function hasUsableStaleData(cache: UsageCache | null | undefined): cache is UsageCache & { data: RateLimits } {
+  if (!cache?.data) {
+    return false;
+  }
+
+  if (cache.lastSuccessAt && Date.now() - cache.lastSuccessAt > MAX_STALE_DATA_MS) {
+    return false;
+  }
+
+  return true;
+}
+
 function getCachedUsageResult(cache: UsageCache): UsageResult {
   if (cache.rateLimited) {
-    // Discard stale data if lastSuccessAt is older than MAX_STALE_DATA_MS
-    if (cache.lastSuccessAt && Date.now() - cache.lastSuccessAt > MAX_STALE_DATA_MS) {
+    if (!hasUsableStaleData(cache) && cache.data) {
       return { rateLimits: null, error: 'rate_limited' };
     }
     return { rateLimits: cache.data, error: 'rate_limited', stale: cache.data ? true : undefined };
   }
 
-  const cachedError = cache.error && !cache.data
-    ? (cache.errorReason || 'network')
-    : undefined;
-  return { rateLimits: cache.data, error: cachedError };
+  if (cache.error) {
+    const errorReason = cache.errorReason || 'network';
+    if (hasUsableStaleData(cache)) {
+      return { rateLimits: cache.data, error: errorReason, stale: true };
+    }
+    return { rateLimits: null, error: errorReason };
+  }
+
+  return { rateLimits: cache.data };
 }
 
 function createRateLimitedCacheEntry(
@@ -764,7 +780,17 @@ export async function getUsage(): Promise<UsageResult> {
         }
 
         if (!result.data) {
-          writeCache({ data: null, error: true, source: 'zai', errorReason: 'network' });
+          const fallbackData = hasUsableStaleData(cachedZai) ? cachedZai.data : null;
+          writeCache({
+            data: fallbackData,
+            error: true,
+            source: 'zai',
+            errorReason: 'network',
+            lastSuccessAt: cachedZai?.lastSuccessAt,
+          });
+          if (fallbackData) {
+            return { rateLimits: fallbackData, error: 'network', stale: true };
+          }
           return { rateLimits: null, error: 'network' };
         }
 
@@ -818,7 +844,17 @@ export async function getUsage(): Promise<UsageResult> {
         }
 
         if (!result.data) {
-          writeCache({ data: null, error: true, source: 'anthropic', errorReason: 'network' });
+          const fallbackData = hasUsableStaleData(cachedAnthropic) ? cachedAnthropic.data : null;
+          writeCache({
+            data: fallbackData,
+            error: true,
+            source: 'anthropic',
+            errorReason: 'network',
+            lastSuccessAt: cachedAnthropic?.lastSuccessAt,
+          });
+          if (fallbackData) {
+            return { rateLimits: fallbackData, error: 'network', stale: true };
+          }
           return { rateLimits: null, error: 'network' };
         }
 


### PR DESCRIPTION
## Summary
- preserve last-known-good HUD usage data when the built-in usage API has transient failures
- keep stale fallbacks bounded and marked stale so limits do not vanish during 429/network degradation
- add focused HUD regression tests for stale cache preservation and stale rendering priority

Closes #1507