### PR TITLE
fix: clean up stale transient files on session end

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -132,6 +132,7 @@ function activateState(directory, prompt, stateName, sessionId) {
     started_at: new Date().toISOString(),
     original_prompt: prompt,
     session_id: sessionId || undefined,
+    project_path: directory,
     reinforcement_count: 0,
     last_checked_at: new Date().toISOString()
   };

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -342,7 +342,26 @@ function readStateFileWithSession(stateDir, filename, sessionId) {
     if (state) {
       return { state, path: sessionPath, isGlobal: false };
     }
-    // Session path not found — do NOT fall back to legacy
+    // Session path not found — fallback: scan ALL session dirs for a state
+    // whose session_id matches ours (handles path mismatches)
+    try {
+      const allSessionsDir = join(stateDir, 'sessions');
+      if (existsSync(allSessionsDir)) {
+        const dirs = readdirSync(allSessionsDir).filter(d => /^[a-zA-Z0-9]/.test(d));
+        for (const dir of dirs) {
+          const candidatePath = join(allSessionsDir, dir, filename);
+          const candidateState = readJsonFile(candidatePath);
+          if (candidateState && candidateState.session_id === sessionId) {
+            return { state: candidateState, path: candidatePath, isGlobal: false };
+          }
+        }
+      }
+    } catch { /* ignore scan errors */ }
+    // Also check legacy path if its session_id matches
+    const legacyResult = readStateFile(stateDir, filename);
+    if (legacyResult.state && legacyResult.state.session_id === sessionId) {
+      return legacyResult;
+    }
     return { state: null, path: null, isGlobal: false };
   }
   // No sessionId: fall back to legacy path (backward compat)

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -279,6 +279,73 @@ export function cleanupTransientState(directory: string): number {
 
   removeTmpFiles(omcDir);
 
+  // Remove transient state files that accumulate across sessions
+  const stateDir = path.join(omcDir, 'state');
+  if (fs.existsSync(stateDir)) {
+    const transientPatterns = [
+      /^agent-replay-.*\.jsonl$/,
+      /^last-tool-error\.json$/,
+      /^hud-state\.json$/,
+      /^hud-stdin-cache\.json$/,
+      /^idle-notif-cooldown\.json$/,
+      /^.*-stop-breaker\.json$/,
+    ];
+
+    try {
+      const stateFiles = fs.readdirSync(stateDir);
+      for (const file of stateFiles) {
+        if (transientPatterns.some(p => p.test(file))) {
+          try {
+            fs.unlinkSync(path.join(stateDir, file));
+            filesRemoved++;
+          } catch (_error) {
+            // Ignore removal errors
+          }
+        }
+      }
+    } catch (_error) {
+      // Ignore errors
+    }
+
+    // Clean up cancel signal files and empty session directories
+    const sessionsDir = path.join(stateDir, 'sessions');
+    if (fs.existsSync(sessionsDir)) {
+      try {
+        const sessionDirs = fs.readdirSync(sessionsDir);
+        for (const sid of sessionDirs) {
+          const sessionDir = path.join(sessionsDir, sid);
+          try {
+            const stat = fs.statSync(sessionDir);
+            if (!stat.isDirectory()) continue;
+
+            const sessionFiles = fs.readdirSync(sessionDir);
+            for (const file of sessionFiles) {
+              if (/^cancel-signal/.test(file) || /stop-breaker/.test(file)) {
+                try {
+                  fs.unlinkSync(path.join(sessionDir, file));
+                  filesRemoved++;
+                } catch (_error) { /* ignore */ }
+              }
+            }
+
+            // Remove empty session directories
+            const remaining = fs.readdirSync(sessionDir);
+            if (remaining.length === 0) {
+              try {
+                fs.rmdirSync(sessionDir);
+                filesRemoved++;
+              } catch (_error) { /* ignore */ }
+              }
+          } catch (_error) {
+            // Ignore per-session errors
+          }
+        }
+      } catch (_error) {
+        // Ignore errors
+      }
+    }
+  }
+
   return filesRemoved;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1510 — ultrawork (and other mode) sessions leave stale transient files in `.omc/state/` that accumulate across sessions.

## Changes

### 1. `src/hooks/session-end/index.ts` — Comprehensive transient cleanup

`cleanupTransientState()` previously only removed `subagent-tracking.json`, stale checkpoints, and `.tmp` files. Now also cleans:

- `agent-replay-*.jsonl` — session replay logs
- `last-tool-error.json` — tool error state
- `hud-state.json` / `hud-stdin-cache.json` — HUD display cache
- `idle-notif-cooldown.json` — notification cooldown marker
- `*-stop-breaker.json` — circuit breaker state files
- `cancel-signal-*` files inside session directories
- Empty session directories after cleanup

### 2. `scripts/keyword-detector.mjs` — Add `project_path` to state

`activateState()` now includes `project_path: directory` in the state object, matching the TypeScript `activateUltrawork()` in `bridge.ts`. This ensures project isolation metadata is present regardless of which code path activates the mode.

### 3. `scripts/persistent-mode.cjs` — Fallback session scan

`readStateFileWithSession()` previously returned `null` immediately when the session-scoped file path didn't exist, with no fallback. Now:

1. Scans all session directories for a state file whose `session_id` field matches
2. Falls back to legacy path if its `session_id` matches

This handles edge cases where the session directory path doesn't resolve as expected.

## Test plan

- [x] Activate ultrawork, complete a task, end session — verify `.omc/state/` is clean (no agent-replay, hud-state, stop-breaker files remain)
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)