### PR TITLE
fix(hud): reduce HUD usage API retry hammering (#1513)

### DIFF
--- a/src/__tests__/hud/usage-api-stale.test.ts
+++ b/src/__tests__/hud/usage-api-stale.test.ts
@@ -311,4 +311,32 @@ describe('usage API stale data handling', () => {
     expect(written.errorReason).toBe('network');
     expect(written.lastSuccessAt).toBe(sixteenMinutesAgo);
   });
+
+  it('reuses stale transient failure cache long enough to avoid immediate retry hammering', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T00:00:00Z'));
+
+    const validTransientFailureCache = JSON.stringify({
+      timestamp: Date.now() - 90_000,
+      source: 'zai',
+      lastSuccessAt: Date.now() - 90_000,
+      data: { fiveHourPercent: 11 },
+      error: true,
+      errorReason: 'network',
+    });
+
+    const { fsModule } = createFsMock({ [CACHE_PATH]: validTransientFailureCache });
+    setupMocks(fsModule, 500, '');
+
+    const httpsModule = await import('https') as unknown as { default: { request: ReturnType<typeof vi.fn> } };
+    const { getUsage } = await import('../../hud/usage-api.js');
+    const result = await getUsage();
+
+    expect(result.rateLimits?.fiveHourPercent).toBe(11);
+    expect(result.error).toBe('network');
+    expect(result.stale).toBe(true);
+    expect(httpsModule.default.request).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
 });

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -462,4 +462,47 @@ describe('getUsage routing', () => {
 
     vi.useRealTimers();
   });
+
+  it('reuses transient network failure cache to avoid immediate retry hammering without stale data', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-07T00:00:00Z'));
+
+    process.env.ANTHROPIC_BASE_URL = 'https://api.z.ai/v1';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
+
+    const mockedExistsSync = vi.mocked(fs.existsSync);
+    const mockedReadFileSync = vi.mocked(fs.readFileSync);
+
+    mockedExistsSync.mockImplementation((path) => {
+      const file = String(path);
+      return file.endsWith('settings.json') || file.endsWith('.usage-cache.json');
+    });
+    mockedReadFileSync.mockImplementation((path) => {
+      const file = String(path);
+      if (file.endsWith('settings.json')) {
+        return JSON.stringify({
+          omcHud: {
+            usageApiPollIntervalMs: 60_000,
+          },
+        });
+      }
+      if (file.endsWith('.usage-cache.json')) {
+        return JSON.stringify({
+          timestamp: Date.now() - 90_000,
+          source: 'zai',
+          data: null,
+          error: true,
+          errorReason: 'network',
+        });
+      }
+      return '{}';
+    });
+
+    const result = await getUsage();
+
+    expect(result).toEqual({ rateLimits: null, error: 'network' });
+    expect(httpsModule.default.request).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
 });

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -29,7 +29,8 @@ import { readHudConfig } from './state.js';
 import { lockPathFor, withFileLock, type FileLockOptions } from '../lib/file-lock.js';
 
 // Cache configuration
-const CACHE_TTL_FAILURE_MS = 15 * 1000; // 15 seconds for failures
+const CACHE_TTL_FAILURE_MS = 15 * 1000; // 15 seconds for non-transient failures
+const CACHE_TTL_TRANSIENT_NETWORK_MS = 2 * 60 * 1000; // 2 minutes to avoid hammering transient API failures
 const MAX_RATE_LIMITED_BACKOFF_MS = 5 * 60 * 1000; // 5 minutes max for sustained 429s
 const API_TIMEOUT_MS = 10000;
 const MAX_STALE_DATA_MS = 15 * 60 * 1000; // 15 minutes — discard stale data after this
@@ -218,6 +219,10 @@ function getRateLimitedBackoffMs(pollIntervalMs: number, count: number): number 
   );
 }
 
+function getTransientNetworkBackoffMs(pollIntervalMs: number): number {
+  return Math.max(CACHE_TTL_TRANSIENT_NETWORK_MS, sanitizePollIntervalMs(pollIntervalMs));
+}
+
 function isCacheValid(cache: UsageCache, pollIntervalMs: number): boolean {
   if (cache.rateLimited) {
     if (cache.rateLimitedUntil != null) {
@@ -227,7 +232,11 @@ function isCacheValid(cache: UsageCache, pollIntervalMs: number): boolean {
     const count = cache.rateLimitedCount || 1;
     return Date.now() - cache.timestamp < getRateLimitedBackoffMs(pollIntervalMs, count);
   }
-  const ttl = cache.error ? CACHE_TTL_FAILURE_MS : sanitizePollIntervalMs(pollIntervalMs);
+  const ttl = cache.error
+    ? cache.errorReason === 'network'
+      ? getTransientNetworkBackoffMs(pollIntervalMs)
+      : CACHE_TTL_FAILURE_MS
+    : sanitizePollIntervalMs(pollIntervalMs);
   return Date.now() - cache.timestamp < ttl;
 }
 


### PR DESCRIPTION
## Summary
- prefer stale last-known-good HUD usage data when the upstream usage API transiently fails
- extend transient network failure cache backoff to reduce retry hammering without changing 429 stale-cache behavior
- add focused HUD tests covering transient failure cache reuse, stale cutoff, and stale-data-over-[API err] rendering

## Testing
- npm exec eslint -- src/hud/usage-api.ts src/__tests__/hud/usage-api.test.ts src/__tests__/hud/usage-api-stale.test.ts src/__tests__/hud/render-rate-limits-priority.test.ts
- npx vitest run src/__tests__/hud/usage-api-stale.test.ts src/__tests__/hud/usage-api.test.ts src/__tests__/hud/render-rate-limits-priority.test.ts src/__tests__/hud/limits-error.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json
