### PR TITLE
fix(hooks): add missing continue: false to persistent-mode.cjs Stop hook

### DIFF
--- a/scripts/code-simplifier.mjs
+++ b/scripts/code-simplifier.mjs
@@ -129,7 +129,7 @@ async function main() {
     }
 
     process.stdout.write(
-      JSON.stringify({ decision: 'block', reason: buildMessage(files) }) + '\n',
+      JSON.stringify({ continue: false, decision: 'block', reason: buildMessage(files) }) + '\n',
     );
   } catch (error) {
     try {

--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -243,6 +243,7 @@ async function main() {
       incrementBlockCount(sessionId);
 
       console.log(JSON.stringify({
+        continue: false,
         decision: 'block',
         reason: buildStopRecoveryAdvice(pct, blockCount + 1)
       }));

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -643,7 +643,7 @@ async function main() {
 
         console.log(
           JSON.stringify({
-            decision: "block",
+            continue: false, decision: "block",
             reason: `[RALPH LOOP - ITERATION ${iteration + 1}/${maxIter}] Work is NOT done. Continue working.\nWhen FULLY complete (after Architect verification), run /oh-my-claudecode:cancel to cleanly exit ralph mode and clean up all state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.\n${ralph.state.prompt ? `Task: ${ralph.state.prompt}` : ""}`,
           }),
         );
@@ -666,7 +666,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              decision: "block",
+              continue: false, decision: "block",
               reason: `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working. When all phases are complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -726,7 +726,7 @@ async function main() {
                   sendStopNotification("team", team.state, sessionId, directory).catch(() => {});
 
                   console.log(JSON.stringify({
-                    decision: "block",
+                    continue: false, decision: "block",
                     reason: `[TEAM PIPELINE - PHASE: ${phase.toUpperCase()} | REINFORCEMENT ${breakerCount}/${TEAM_PIPELINE_STOP_BLOCKER_MAX}] The team pipeline is active in phase "${phase}". Continue working on the team workflow. Do not stop until the pipeline reaches a terminal state (complete/failed/cancelled). When done, run /oh-my-claudecode:cancel to cleanly exit.`,
                   }));
                   return;
@@ -763,7 +763,7 @@ async function main() {
           sendStopNotification("ralplan", ralplan.state, sessionId, directory).catch(() => {});
 
           console.log(JSON.stringify({
-            decision: "block",
+            continue: false, decision: "block",
             reason: `[RALPLAN - CONSENSUS PLANNING | REINFORCEMENT ${breakerCount}/${RALPLAN_STOP_BLOCKER_MAX}] The ralplan consensus workflow is active. Continue the Planner/Architect/Critic loop. Do not stop until consensus is reached or the workflow completes. When done, run /oh-my-claudecode:cancel to cleanly exit.`,
           }));
           return;
@@ -789,7 +789,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              decision: "block",
+              continue: false, decision: "block",
               reason: `[ULTRAPILOT] ${incomplete} workers still running. Continue working. When all workers complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -814,7 +814,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              decision: "block",
+              continue: false, decision: "block",
               reason: `[SWARM ACTIVE] ${pending} tasks remain. Continue working. When all tasks are done, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -839,7 +839,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              decision: "block",
+              continue: false, decision: "block",
               reason: `[PIPELINE - Stage ${currentStage + 1}/${totalStages}] Pipeline not complete. Continue working. When all stages complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -863,7 +863,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              decision: "block",
+              continue: false, decision: "block",
               reason: `[TEAM - Phase: ${phase}] Team mode active. Continue working. When all team tasks complete, run /oh-my-claudecode:cancel to cleanly exit. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -887,7 +887,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              decision: "block",
+              continue: false, decision: "block",
               reason: `[OMC TEAMS - Phase: ${phase}] OMC Teams workers active. Continue working. When all workers complete, run /oh-my-claudecode:cancel to cleanly exit. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -910,7 +910,7 @@ async function main() {
 
         console.log(
           JSON.stringify({
-            decision: "block",
+            continue: false, decision: "block",
             reason: `[ULTRAQA - Cycle ${cycle + 1}/${maxCycles}] Tests not all passing. Continue fixing. When all tests pass, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
           }),
         );
@@ -961,7 +961,7 @@ async function main() {
         reason += `\nTask: ${ultrawork.state.original_prompt}`;
       }
 
-      console.log(JSON.stringify({ decision: "block", reason }));
+      console.log(JSON.stringify({ continue: false, decision: "block", reason }));
       return;
     }
 
@@ -990,7 +990,7 @@ async function main() {
 
             const skillName = skillState.state.skill_name || "unknown";
             console.log(JSON.stringify({
-              decision: "block",
+              continue: false, decision: "block",
               reason: `[SKILL ACTIVE: ${skillName}] The "${skillName}" skill is still executing (reinforcement ${count + 1}/${maxReinforcements}). Continue working on the skill's instructions. Do not stop until the skill completes its workflow.`,
             }));
             return;

--- a/templates/hooks/code-simplifier.mjs
+++ b/templates/hooks/code-simplifier.mjs
@@ -136,7 +136,7 @@ async function main() {
     }
 
     process.stdout.write(
-      JSON.stringify({ decision: 'block', reason: buildMessage(files) }) + '\n',
+      JSON.stringify({ continue: false, decision: 'block', reason: buildMessage(files) }) + '\n',
     );
   } catch (error) {
     try {


### PR DESCRIPTION
## Summary

- Add `continue: false` to all 12 blocking outputs in `persistent-mode.cjs`
- Add `continue: false` to `context-guard-stop.mjs` (1 output)
- Add `continue: false` to `code-simplifier.mjs` and its template (1 each)

The original fix (#1216) added `continue: false` to `.mjs` scripts but the `.cjs` version (referenced by `hooks.json`) was never updated. Subsequent commits (#1306, #1330, #1374, #1480, #1482) also did not carry over this fix.

## Test plan

- [x] All 31 stop-hook-blocking tests pass
- [x] context-guard-stop tests pass (2/2)
- [x] Verified all Stop hook scripts now include `continue: false` alongside `decision: "block"`

Closes #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)