### PR TITLE
feat: add first skill pipeline handoff surface

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -397,6 +397,19 @@ All installed skills are available as slash commands with the prefix `/oh-my-cla
 | `/oh-my-claudecode:trace`                   | Show orchestration trace timeline                                                             |
 | `/oh-my-claudecode:psm <arguments>`         | Deprecated alias for project session manager                                                  |
 
+### Skill Pipeline Metadata (Preview)
+
+Built-in skills and slash-loaded skills can now declare a lightweight pipeline/handoff contract in frontmatter:
+
+```yaml
+pipeline: [deep-interview, omc-plan, autopilot]
+next-skill: omc-plan
+next-skill-args: --consensus --direct
+handoff: .omc/specs/deep-interview-{slug}.md
+```
+
+When present, OMC appends a standardized **Skill Pipeline** section to the rendered skill prompt so the current stage, handoff artifact, and explicit next `Skill("oh-my-claudecode:...")` invocation are carried forward consistently.
+
 ---
 
 ## Hooks System

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -80,6 +80,10 @@ triggers:
   - "keyword2"
 agent: executor  # Optional: which agent to use
 model: sonnet    # Optional: model override
+pipeline: [skill-name, follow-up-skill]  # Optional: standardized multi-skill flow
+next-skill: follow-up-skill              # Optional: explicit handoff target
+next-skill-args: --direct                # Optional: arguments for the next skill
+handoff: .omc/plans/example.md           # Optional: artifact/context handed to next skill
 ---
 
 # Skill Name
@@ -132,6 +136,8 @@ Any configurable options.
 3. Invoke `executor` for implementation
 4. Invoke `qa-tester` for verification
 ```
+
+If `pipeline` / `next-skill` metadata is present, OMC appends a standardized **Skill Pipeline** handoff block to the rendered skill prompt so downstream steps are explicit.
 
 **Conditional behavior:**
 ```markdown

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -2,6 +2,10 @@
 name: deep-interview
 description: Socratic deep interview with mathematical ambiguity gating before autonomous execution
 argument-hint: "<idea or vague description>"
+pipeline: [deep-interview, omc-plan, autopilot]
+next-skill: omc-plan
+next-skill-args: --consensus --direct
+handoff: .omc/specs/deep-interview-{slug}.md
 ---
 
 <Purpose>

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: omc-plan
 description: Strategic planning with optional interview workflow
+pipeline: [deep-interview, omc-plan, autopilot]
+next-skill: autopilot
+handoff: .omc/plans/ralplan-*.md
 ---
 
 <Purpose>

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -117,4 +117,35 @@ Project psm body`
     expect(result.replacementText).toContain('Deprecated Alias');
     expect(result.replacementText).toContain('/project-session-manager');
   });
+
+  it('renders skill pipeline guidance for slash-loaded skills with handoff metadata', async () => {
+    mkdirSync(join(tempConfigDir, 'skills', 'deep-interview'), { recursive: true });
+    writeFileSync(
+      join(tempConfigDir, 'skills', 'deep-interview', 'SKILL.md'),
+      `---
+name: deep-interview
+description: Deep interview
+pipeline: [deep-interview, omc-plan, autopilot]
+next-skill: omc-plan
+next-skill-args: --consensus --direct
+handoff: .omc/specs/deep-interview-{slug}.md
+---
+
+Deep interview body`
+    );
+
+    const { executeSlashCommand } = await loadExecutor();
+    const result = executeSlashCommand({
+      command: 'deep-interview',
+      args: 'improve onboarding',
+      raw: '/deep-interview improve onboarding',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('## Skill Pipeline');
+    expect(result.replacementText).toContain('Pipeline: `deep-interview → omc-plan → autopilot`');
+    expect(result.replacementText).toContain('Next skill arguments: `--consensus --direct`');
+    expect(result.replacementText).toContain('Skill("oh-my-claudecode:omc-plan")');
+    expect(result.replacementText).toContain('`.omc/specs/deep-interview-{slug}.md`');
+  });
 });

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -117,6 +117,34 @@ describe('Builtin Skills', () => {
       expect(skill?.name).toBe('ai-slop-cleaner');
     });
 
+    it('should expose pipeline metadata for deep-interview handoff into omc-plan', () => {
+      const skill = getBuiltinSkill('deep-interview');
+      expect(skill?.pipeline).toEqual({
+        steps: ['deep-interview', 'omc-plan', 'autopilot'],
+        nextSkill: 'omc-plan',
+        nextSkillArgs: '--consensus --direct',
+        handoff: '.omc/specs/deep-interview-{slug}.md',
+      });
+      expect(skill?.template).toContain('## Skill Pipeline');
+      expect(skill?.template).toContain('Pipeline: `deep-interview → omc-plan → autopilot`');
+      expect(skill?.template).toContain('Skill("oh-my-claudecode:omc-plan")');
+      expect(skill?.template).toContain('`--consensus --direct`');
+      expect(skill?.template).toContain('`.omc/specs/deep-interview-{slug}.md`');
+    });
+
+    it('should expose pipeline metadata for omc-plan handoff into autopilot', () => {
+      const skill = getBuiltinSkill('omc-plan');
+      expect(skill?.pipeline).toEqual({
+        steps: ['deep-interview', 'omc-plan', 'autopilot'],
+        nextSkill: 'autopilot',
+        handoff: '.omc/plans/ralplan-*.md',
+      });
+      expect(skill?.template).toContain('## Skill Pipeline');
+      expect(skill?.template).toContain('Next skill: `autopilot`');
+      expect(skill?.template).toContain('Skill("oh-my-claudecode:autopilot")');
+      expect(skill?.template).toContain('`.omc/plans/ralplan-*.md`');
+    });
+
     it('should expose review mode guidance for ai-slop-cleaner', () => {
       const skill = getBuiltinSkill('ai-slop-cleaner');
       expect(skill).toBeDefined();

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -14,6 +14,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import type { BuiltinSkill } from './types.js';
 import { parseFrontmatter, parseFrontmatterAliases } from '../../utils/frontmatter.js';
+import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
 
 // Get the project root directory (go up from src/features/builtin-skills/)
 const __filename = fileURLToPath(import.meta.url);
@@ -53,9 +54,14 @@ function loadSkillFromFile(skillPath: string, skillName: string): BuiltinSkill[]
   try {
     const content = readFileSync(skillPath, 'utf-8');
     const { metadata, body } = parseFrontmatter(content);
-
     const resolvedName = metadata.name || skillName;
     const safePrimaryName = toSafeSkillName(resolvedName);
+    const pipeline = parseSkillPipelineMetadata(metadata);
+    const template = [
+      body.trim(),
+      renderSkillPipelineGuidance(safePrimaryName, pipeline),
+    ].filter((section) => section.trim().length > 0).join('\n\n');
+
     const safeAliases = Array.from(
       new Set(
         parseFrontmatterAliases(metadata.aliases)
@@ -82,11 +88,12 @@ function loadSkillFromFile(skillPath: string, skillName: string): BuiltinSkill[]
           ? undefined
           : `Skill alias "${name}" is deprecated. Use "${safePrimaryName}" instead.`,
         description: metadata.description || '',
-        template: body.trim(),
+        template,
         // Optional fields from frontmatter
         model: metadata.model,
         agent: metadata.agent,
         argumentHint: metadata['argument-hint'],
+        pipeline: name === safePrimaryName ? pipeline : undefined,
       });
     }
 

--- a/src/features/builtin-skills/types.ts
+++ b/src/features/builtin-skills/types.ts
@@ -6,6 +6,8 @@
  * Adapted from oh-my-opencode's builtin-skills feature.
  */
 
+import type { SkillPipelineMetadata } from '../../utils/skill-pipeline.js';
+
 /**
  * Configuration for MCP server integration with a skill
  */
@@ -51,6 +53,8 @@ export interface BuiltinSkill {
   subtask?: boolean;
   /** Hint for arguments (optional) */
   argumentHint?: string;
+  /** Optional skill-to-skill pipeline metadata */
+  pipeline?: SkillPipelineMetadata;
   /** MCP server configuration (optional) */
   mcpConfig?: SkillMcpConfig;
 }

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -18,6 +18,7 @@ import type {
 } from './types.js';
 import { resolveLiveData } from './live-data.js';
 import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
+import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
 
 /** Claude config directory */
 const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
@@ -148,6 +149,7 @@ export function discoverAllCommands(): CommandInfo[] {
             const argumentHint = getFrontmatterString(fm, 'argument-hint');
             const model = getFrontmatterString(fm, 'model');
             const agent = getFrontmatterString(fm, 'agent');
+            const pipeline = parseSkillPipelineMetadata(fm);
 
             for (const commandName of commandNames) {
               const isAlias = commandName !== canonicalName;
@@ -157,6 +159,7 @@ export function discoverAllCommands(): CommandInfo[] {
                 argumentHint,
                 model,
                 agent,
+                pipeline: isAlias ? undefined : pipeline,
                 aliases: isAlias ? undefined : aliases,
                 aliasOf: isAlias ? canonicalName : undefined,
                 deprecatedAlias: isAlias || undefined,
@@ -251,7 +254,14 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   // Resolve arguments in content, then execute any live-data commands
   const resolvedContent = resolveArguments(cmd.content || '', args);
   const injectedContent = resolveLiveData(resolvedContent);
-  sections.push(injectedContent.trim());
+  const pipelineGuidance = cmd.scope === 'skill'
+    ? renderSkillPipelineGuidance(cmd.metadata.name, cmd.metadata.pipeline)
+    : '';
+  sections.push(
+    [injectedContent.trim(), pipelineGuidance]
+      .filter((section) => section.trim().length > 0)
+      .join('\n\n')
+  );
 
   if (args && !cmd.content?.includes('$ARGUMENTS')) {
     sections.push('\n\n---\n');

--- a/src/hooks/auto-slash-command/types.ts
+++ b/src/hooks/auto-slash-command/types.ts
@@ -1,3 +1,5 @@
+import type { SkillPipelineMetadata } from '../../utils/skill-pipeline.js';
+
 /**
  * Auto Slash Command Types
  *
@@ -57,6 +59,7 @@ export interface CommandMetadata {
   argumentHint?: string;
   model?: string;
   agent?: string;
+  pipeline?: SkillPipelineMetadata;
   aliases?: string[];
   aliasOf?: string;
   deprecatedAlias?: boolean;

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -70,3 +70,27 @@ export function parseFrontmatterAliases(rawAliases: string | undefined): string[
   const singleAlias = stripOptionalQuotes(trimmed);
   return singleAlias ? [singleAlias] : [];
 }
+
+/**
+ * Parse a generic frontmatter list field into an array of strings.
+ * Supports inline YAML list syntax: `[foo, bar]` or a single scalar value.
+ */
+export function parseFrontmatterList(rawValue: string | undefined): string[] {
+  if (!rawValue) return [];
+
+  const trimmed = rawValue.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) return [];
+
+    return inner
+      .split(',')
+      .map((item) => stripOptionalQuotes(item))
+      .filter((item) => item.length > 0);
+  }
+
+  const singleValue = stripOptionalQuotes(trimmed);
+  return singleValue ? [singleValue] : [];
+}

--- a/src/utils/skill-pipeline.ts
+++ b/src/utils/skill-pipeline.ts
@@ -1,0 +1,125 @@
+import { parseFrontmatterList, stripOptionalQuotes } from './frontmatter.js';
+
+export interface SkillPipelineMetadata {
+  steps: string[];
+  nextSkill?: string;
+  nextSkillArgs?: string;
+  handoff?: string;
+}
+
+function normalizeSkillReference(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+
+  const trimmed = stripOptionalQuotes(value).trim();
+  if (!trimmed) return undefined;
+
+  return trimmed
+    .replace(/^\/oh-my-claudecode:/i, '')
+    .replace(/^oh-my-claudecode:/i, '')
+    .replace(/^\//, '')
+    .trim()
+    .toLowerCase() || undefined;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized) continue;
+
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    results.push(normalized);
+  }
+
+  return results;
+}
+
+export function parseSkillPipelineMetadata(
+  frontmatter: Record<string, string>,
+): SkillPipelineMetadata | undefined {
+  const steps = uniqueStrings(
+    parseFrontmatterList(frontmatter.pipeline)
+      .map((step) => normalizeSkillReference(step))
+      .filter((step): step is string => Boolean(step))
+  );
+  const nextSkill = normalizeSkillReference(frontmatter['next-skill']);
+  const nextSkillArgs = stripOptionalQuotes(frontmatter['next-skill-args'] ?? '').trim() || undefined;
+  const handoff = stripOptionalQuotes(frontmatter.handoff ?? '').trim() || undefined;
+
+  if (steps.length === 0 && !nextSkill && !nextSkillArgs && !handoff) {
+    return undefined;
+  }
+
+  return {
+    steps,
+    nextSkill,
+    nextSkillArgs,
+    handoff,
+  };
+}
+
+export function renderSkillPipelineGuidance(
+  skillName: string,
+  pipeline: SkillPipelineMetadata | undefined,
+): string {
+  if (!pipeline) {
+    return '';
+  }
+
+  const currentSkill = normalizeSkillReference(skillName) ?? skillName.trim().toLowerCase();
+  const steps = uniqueStrings([
+    ...pipeline.steps,
+    currentSkill,
+    ...(pipeline.nextSkill ? [pipeline.nextSkill] : []),
+  ]);
+  const nextInvocation = pipeline.nextSkill
+    ? [
+      `Skill("oh-my-claudecode:${pipeline.nextSkill}")`,
+      pipeline.nextSkillArgs ? `with arguments \`${pipeline.nextSkillArgs}\`` : undefined,
+      'using the handoff context from this stage',
+    ].filter(Boolean).join(' ')
+    : undefined;
+
+  const lines: string[] = [
+    '## Skill Pipeline',
+  ];
+
+  if (steps.length > 0) {
+    lines.push(`Pipeline: \`${steps.join(' → ')}\``);
+  }
+
+  lines.push(`Current stage: \`${currentSkill}\``);
+
+  if (pipeline.nextSkill) {
+    lines.push(`Next skill: \`${pipeline.nextSkill}\``);
+  }
+
+  if (pipeline.nextSkillArgs) {
+    lines.push(`Next skill arguments: \`${pipeline.nextSkillArgs}\``);
+  }
+
+  if (pipeline.handoff) {
+    lines.push(`Handoff artifact: \`${pipeline.handoff}\``);
+  }
+
+  lines.push('');
+
+  if (pipeline.nextSkill) {
+    lines.push('When this stage completes:');
+    if (pipeline.handoff) {
+      lines.push(`1. Write or update the handoff artifact at \`${pipeline.handoff}\`.`);
+    } else {
+      lines.push('1. Write a concise handoff note before moving to the next skill.');
+    }
+    lines.push('2. Carry forward the concrete output, decisions made, and remaining risks or assumptions.');
+    lines.push(`3. Invoke ${nextInvocation}.`);
+  } else {
+    lines.push('This is the terminal stage in the declared skill pipeline. Do not hand off to another skill unless the user explicitly asks.');
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- add a minimal skill pipeline metadata surface (`pipeline`, `next-skill`, `next-skill-args`, `handoff`) for skill frontmatter
- render a standardized `## Skill Pipeline` handoff block in builtin skill templates and slash-loaded skills
- wire the existing `deep-interview -> omc-plan -> autopilot` workflow through the new pattern with focused tests/docs

## Verification
- `npm run test:run -- src/__tests__/skills.test.ts src/__tests__/auto-slash-aliases.test.ts`
- `npm run build`
- `npm run lint` *(existing repo warnings only; no new errors)*
- LSP diagnostics on modified TS files via OMX code-intel (`diagnosticCount: 0`)

## Risks / Follow-ups
- This is an explicit handoff/prompt-surface implementation, not automatic runtime skill execution yet
- only one real workflow is modeled in this first slice; follow-up work can add richer branching or automatic chaining once the pattern settles

Closes #1488.
