### PR TITLE
docs: rebrand scoped guidance docs to oh-my-openagent

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -3,13 +3,13 @@
 
 # docs
 
-User documentation and technical guides for oh-my-claudecode.
+User documentation and technical guides for oh-my-openagent.
 
 ## Purpose
 
 This directory contains documentation for end-users and developers:
 
-- **End-user guides**: How to use oh-my-claudecode features
+- **End-user guides**: How to use oh-my-openagent features
 - **Technical reference**: Architecture, compatibility, migration
 - **Design documents**: Feature design specifications
 
@@ -72,7 +72,7 @@ This directory contains documentation for end-users and developers:
 
 Use raw GitHub URLs for external accessibility:
 
-[Migration Guide](https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/MIGRATION.md)
+[Migration Guide](https://raw.githubusercontent.com/Yeachan-Heo/oh-my-openagent/main/docs/MIGRATION.md)
 
 #### Version References
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,9 +1,9 @@
 <!-- OMC:START -->
 <!-- OMC:VERSION:4.7.9 -->
 
-# oh-my-claudecode - Intelligent Multi-Agent Orchestration
+# oh-my-openagent - Intelligent Multi-Agent Orchestration
 
-You are running with oh-my-claudecode (OMC), a multi-agent orchestration layer for Claude Code.
+You are running with oh-my-openagent (OMC), a multi-agent orchestration layer for Claude Code.
 Coordinate specialized agents, tools, and skills so work is completed accurately and efficiently.
 
 <operating_principles>
@@ -25,7 +25,7 @@ Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGE
 </model_routing>
 
 <agent_catalog>
-Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
+Prefix: `oh-my-openagent:`. See `agents/*.md` for full prompts.
 
 explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (sonnet), executor (sonnet), verifier (sonnet), security-reviewer (sonnet), code-reviewer (opus), test-engineer (sonnet), designer (sonnet), writer (haiku), qa-tester (sonnet), scientist (sonnet), document-specialist (sonnet), git-master (sonnet), code-simplifier (opus), critic (opus)
 </agent_catalog>
@@ -40,7 +40,7 @@ Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp
 </tools>
 
 <skills>
-Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
+Invoke via `/oh-my-openagent:<name>`. Trigger patterns auto-detect keywords.
 
 Workflow: `autopilot`, `ralph`, `ultrawork`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`
 Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
@@ -71,7 +71,7 @@ Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS` (comma-separated).
 </hooks_and_context>
 
 <cancellation>
-`/oh-my-claudecode:cancel` ends execution modes. Cancel when done+verified or blocked. Don't cancel if work incomplete.
+`/oh-my-openagent:cancel` ends execution modes. Cancel when done+verified or blocked. Don't cancel if work incomplete.
 </cancellation>
 
 <worktree_paths>
@@ -80,6 +80,6 @@ State: `.omc/state/`, `.omc/state/sessions/{sessionId}/`, `.omc/notepad.md`, `.o
 
 ## Setup
 
-Say "setup omc" or run `/oh-my-claudecode:omc-setup`.
+Say "setup omc" or run `/oh-my-openagent:omc-setup`.
 
 <!-- OMC:END -->


### PR DESCRIPTION
## Summary
- update `docs/AGENTS.md` product-name references from `oh-my-claudecode` to `oh-my-openagent`
- update `docs/CLAUDE.md` product-name and slash-prefix references to `/oh-my-openagent:*`
- leave stable `omc` / `.omc` compatibility namespaces unchanged to avoid unrelated branding churn

## Verification
- `git diff -- docs/AGENTS.md docs/CLAUDE.md`
- `rg -n 'oh-my-claudecode|/oh-my-claudecode:' docs/AGENTS.md docs/CLAUDE.md || true`
- `rg -n 'oh-my-openagent|/oh-my-openagent:' docs/AGENTS.md docs/CLAUDE.md`
- `git diff --check -- docs/AGENTS.md docs/CLAUDE.md`
- `npx prettier --check docs/AGENTS.md docs/CLAUDE.md` *(fails on these files before and after this patch due pre-existing markdown formatting drift; not auto-formatted to keep this PR minimal)*
- `git show HEAD:docs/AGENTS.md > tmp && git show HEAD:docs/CLAUDE.md > tmp && npx prettier --check ...` *(confirmed the same prettier failure exists on the base versions)*

## Risks / Follow-ups
- `.github/CLAUDE.md` still contains `oh-my-claudecode` references and slash prefixes; leaving it untouched here keeps this PR aligned with issue #1524's scoped guidance-doc change set, but it is remaining naming drift nearby
- `docs/AGENTS.md` now points at the future `Yeachan-Heo/oh-my-openagent` raw URL; that will depend on the repo-url rebrand work landing consistently

Closes #1524.
