### PR TITLE
rename: update package identity for oh-my-openagent rebrand

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "omc",
+  "name": "oma",
   "description": "Claude Code native multi-agent orchestration - intelligent model routing, 28 agents, 32 skills",
   "owner": {
     "name": "Yeachan Heo",
@@ -8,7 +8,7 @@
   },
   "plugins": [
     {
-      "name": "oh-my-claudecode",
+      "name": "oh-my-openagent",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
       "version": "4.7.9",
       "author": {
@@ -17,7 +17,7 @@
       },
       "source": "./",
       "category": "productivity",
-      "homepage": "https://github.com/Yeachan-Heo/oh-my-claudecode",
+      "homepage": "https://github.com/Yeachan-Heo/oh-my-openagent",
       "tags": [
         "multi-agent",
         "orchestration",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
-  "name": "oh-my-claudecode",
+  "name": "oh-my-openagent",
   "version": "4.7.9",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
-    "name": "oh-my-claudecode contributors"
+    "name": "oh-my-openagent contributors"
   },
-  "repository": "https://github.com/Yeachan-Heo/oh-my-claudecode",
-  "homepage": "https://github.com/Yeachan-Heo/oh-my-claudecode",
+  "repository": "https://github.com/Yeachan-Heo/oh-my-openagent",
+  "homepage": "https://github.com/Yeachan-Heo/oh-my-openagent",
   "license": "MIT",
   "keywords": [
     "claude-code",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "oh-my-claude-sisyphus",
+  "name": "oh-my-openagent",
   "version": "4.7.9",
-  "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
+  "description": "Multi-agent orchestration system for Claude Code",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,9 +12,9 @@
     }
   },
   "bin": {
-    "oh-my-claudecode": "bridge/cli.cjs",
-    "omc": "bridge/cli.cjs",
-    "omc-cli": "bridge/cli.cjs"
+    "oh-my-openagent": "bridge/cli.cjs",
+    "oma": "bridge/cli.cjs",
+    "oma-cli": "bridge/cli.cjs"
   },
   "files": [
     "dist",
@@ -99,11 +99,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Yeachan-Heo/oh-my-claudecode.git"
+    "url": "git+https://github.com/Yeachan-Heo/oh-my-openagent.git"
   },
-  "homepage": "https://github.com/Yeachan-Heo/oh-my-claudecode#readme",
+  "homepage": "https://github.com/Yeachan-Heo/oh-my-openagent#readme",
   "bugs": {
-    "url": "https://github.com/Yeachan-Heo/oh-my-claudecode/issues"
+    "url": "https://github.com/Yeachan-Heo/oh-my-openagent/issues"
   },
   "author": "Yeachan Heo",
   "license": "MIT",
@@ -114,8 +114,8 @@
     "agent",
     "multi-agent",
     "orchestration",
-    "omc",
-    "claudecode",
+    "openagent",
+    "oma",
     "anthropic",
     "llm"
   ],


### PR DESCRIPTION
## Summary

Closes #1521

- Update `package.json` name from `oh-my-claude-sisyphus` to `oh-my-openagent`
- Update `package.json` bin entries (`oh-my-claudecode` → `oh-my-openagent`, `omc` → `oma`)
- Update repository, homepage, bugs URLs to `oh-my-openagent`
- Update keywords (`claudecode`/`omc` → `openagent`/`oma`)
- Update `.claude-plugin/plugin.json` name, author, repository, homepage
- Update `.claude-plugin/marketplace.json` name, plugin name, homepage

## Changed Files

- `package.json`
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`