### PR TITLE
docs: fix outdated install/uninstall references in REFERENCE.md

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -562,8 +562,8 @@ stopomc
 | Platform    | Install Method              | Hook Type      |
 | ----------- | --------------------------- | -------------- |
 | **Windows** | WSL2 recommended (see note) | Node.js (.mjs) |
-| **macOS**   | curl or npm                 | Bash (.sh)     |
-| **Linux**   | curl or npm                 | Bash (.sh)     |
+| **macOS**   | Claude Code Plugin          | Bash (.sh)     |
+| **Linux**   | Claude Code Plugin          | Bash (.sh)     |
 
 > **Note**: Bash hooks are fully portable across macOS and Linux (no GNU-specific dependencies).
 
@@ -745,11 +745,13 @@ To manually update, re-run the plugin install command or use Claude Code's built
 
 ### Uninstall
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/scripts/uninstall.sh | bash
+Use Claude Code's plugin management:
+
+```
+/plugin uninstall oh-my-claudecode@oh-my-claudecode
 ```
 
-Or manually:
+Or manually remove the installed files:
 
 ```bash
 rm ~/.claude/agents/{architect,document-specialist,explore,designer,writer,vision,critic,analyst,executor,qa-tester}.md


### PR DESCRIPTION
## Summary

- Update platform support table (line 565-566): replace "curl or npm" with "Claude Code Plugin" for macOS/Linux install method, consistent with the deprecation notice at the top of the Installation section ("Only the Claude Code Plugin method is supported")
- Replace deprecated curl uninstall one-liner (line 749) with the correct plugin command: `/plugin uninstall oh-my-claudecode@oh-my-claudecode` (matching the format used in `docs/LOCAL_PLUGIN_INSTALL.md`)

## Test plan

- [x] Verified the plugin identifier matches `docs/LOCAL_PLUGIN_INSTALL.md` line 33
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)