### PR TITLE
fix(team): finish worktree trigger path hardening for #1535

### DIFF
--- a/src/team/__tests__/api-interop.dispatch.test.ts
+++ b/src/team/__tests__/api-interop.dispatch.test.ts
@@ -108,4 +108,39 @@ describe('team api dispatch-aware messaging', () => {
     expect(typeof requests[0]?.notified_at).toBe('string');
     expect(typeof requests[0]?.delivered_at).toBe('string');
   });
+
+  it('uses OMC_TEAM_STATE_ROOT placeholder in mailbox triggers for worktree-backed workers', async () => {
+    const configPath = join(cwd, '.omc', 'state', 'team', teamName, 'config.json');
+    await writeFile(configPath, JSON.stringify({
+      name: teamName,
+      task: 'dispatch',
+      agent_type: 'executor',
+      worker_count: 1,
+      max_workers: 20,
+      tmux_session: 'dispatch-session',
+      workers: [{
+        name: 'worker-1',
+        index: 1,
+        role: 'executor',
+        assigned_tasks: [],
+        worktree_path: join(cwd, '.omc', 'worktrees', teamName, 'worker-1'),
+      }],
+      created_at: '2026-03-06T00:00:00.000Z',
+      next_task_id: 2,
+    }, null, 2));
+
+    const sendResult = await executeTeamApiOperation('send-message', {
+      team_name: teamName,
+      from_worker: 'leader-fixed',
+      to_worker: 'worker-1',
+      body: 'Please continue',
+    }, cwd);
+
+    expect(sendResult.ok).toBe(true);
+
+    const requests = await listDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: 'worker-1' });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.trigger_message).toContain('$OMC_TEAM_STATE_ROOT/team/dispatch-team/mailbox/worker-1.json');
+    expect(requests[0]?.trigger_message).toContain('report progress');
+  });
 });

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -24,6 +24,17 @@ describe('worker-bootstrap', () => {
       expect(generateMailboxTriggerMessage('test-team', 'worker-1', 2)).toContain('ACK-only');
     });
 
+    it('supports state-root placeholders for worktree-backed trigger paths', () => {
+      expect(generateTriggerMessage('test-team', 'worker-1', '$OMC_TEAM_STATE_ROOT'))
+        .toContain('$OMC_TEAM_STATE_ROOT/team/test-team/workers/worker-1/inbox.md');
+      expect(generateTriggerMessage('test-team', 'worker-1', '$OMC_TEAM_STATE_ROOT'))
+        .toContain('work now');
+      expect(generateMailboxTriggerMessage('test-team', 'worker-1', 2, '$OMC_TEAM_STATE_ROOT'))
+        .toContain('$OMC_TEAM_STATE_ROOT/team/test-team/mailbox/worker-1.json');
+      expect(generateMailboxTriggerMessage('test-team', 'worker-1', 2, '$OMC_TEAM_STATE_ROOT'))
+        .toContain('report progress');
+    });
+
     it('includes sentinel file write instruction first', () => {
       const overlay = generateWorkerOverlay(baseParams);
       const sentinelIdx = overlay.indexOf('.ready');

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -298,6 +298,11 @@ export function buildLegacyTeamDeprecationHint(
 
 const QUEUED_FOR_HOOK_DISPATCH_REASON = 'queued_for_hook_dispatch';
 const LEADER_PANE_MISSING_MAILBOX_PERSISTED_REASON = 'leader_pane_missing_mailbox_persisted';
+const WORKTREE_TRIGGER_STATE_ROOT = '$OMC_TEAM_STATE_ROOT';
+
+function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
+  return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
+}
 
 function queuedForHookDispatch(): DispatchOutcome {
   return {
@@ -347,13 +352,14 @@ function findWorkerDispatchTarget(
   teamName: string,
   toWorker: string,
   cwd: string,
-): Promise<{ paneId?: string; workerIndex?: number }>
+): Promise<{ paneId?: string; workerIndex?: number; instructionStateRoot?: string }>
 {
   return teamReadConfig(teamName, cwd).then((config) => {
     const recipient = config?.workers.find((worker) => worker.name === toWorker);
     return {
       paneId: recipient?.pane_id,
       workerIndex: recipient?.index,
+      instructionStateRoot: resolveInstructionStateRoot(recipient?.worktree_path),
     };
   });
 }
@@ -465,7 +471,7 @@ export async function executeTeamApiOperation(
           toWorkerIndex: target.workerIndex,
           toPaneId: target.paneId,
           body,
-          triggerMessage: generateMailboxTriggerMessage(teamName, toWorker),
+          triggerMessage: generateMailboxTriggerMessage(teamName, toWorker, 1, target.instructionStateRoot),
           cwd,
           notify: ({ workerName }, triggerMessage) => notifyMailboxTarget(teamName, workerName, triggerMessage, cwd),
           deps: {
@@ -494,7 +500,12 @@ export async function executeTeamApiOperation(
         const config = await teamReadConfig(teamName, cwd);
         const recipients = (config?.workers ?? [])
           .filter((worker) => worker.name !== fromWorker)
-          .map((worker) => ({ workerName: worker.name, workerIndex: worker.index, paneId: worker.pane_id }));
+          .map((worker) => ({
+            workerName: worker.name,
+            workerIndex: worker.index,
+            paneId: worker.pane_id,
+            instructionStateRoot: resolveInstructionStateRoot(worker.worktree_path),
+          }));
 
         await queueBroadcastMailboxMessage({
           teamName,
@@ -502,7 +513,12 @@ export async function executeTeamApiOperation(
           recipients,
           body,
           cwd,
-          triggerFor: (workerName) => generateMailboxTriggerMessage(teamName, workerName),
+          triggerFor: (workerName) => generateMailboxTriggerMessage(
+            teamName,
+            workerName,
+            1,
+            recipients.find((recipient) => recipient.workerName === workerName)?.instructionStateRoot,
+          ),
           notify: ({ workerName }, triggerMessage) => notifyMailboxTarget(teamName, workerName, triggerMessage, cwd),
           deps: {
             sendDirectMessage,

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -12,13 +12,34 @@ export interface WorkerBootstrapParams {
   cwd: string;
 }
 
-export function generateTriggerMessage(teamName: string, workerName: string): string {
-  return `Read .omc/state/team/${teamName}/workers/${workerName}/inbox.md, start work now, then report concrete progress (not ACK-only).`;
+function buildInstructionPath(...parts: string[]): string {
+  return join(...parts).replaceAll('\\', '/');
 }
 
-export function generateMailboxTriggerMessage(teamName: string, workerName: string, count = 1): string {
+export function generateTriggerMessage(
+  teamName: string,
+  workerName: string,
+  teamStateRoot = '.omc/state',
+): string {
+  const inboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'workers', workerName, 'inbox.md');
+  if (teamStateRoot !== '.omc/state') {
+    return `Read ${inboxPath}, work now, report progress.`;
+  }
+  return `Read ${inboxPath}, start work now, then report concrete progress (not ACK-only).`;
+}
+
+export function generateMailboxTriggerMessage(
+  teamName: string,
+  workerName: string,
+  count = 1,
+  teamStateRoot = '.omc/state',
+): string {
   const normalizedCount = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
-  return `You have ${normalizedCount} new message(s). Check .omc/state/team/${teamName}/mailbox/${workerName}.json, act now, and reply with concrete progress (not ACK-only).`;
+  const mailboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'mailbox', `${workerName}.json`);
+  if (teamStateRoot !== '.omc/state') {
+    return `${normalizedCount} new msg(s): check ${mailboxPath}, act and report progress.`;
+  }
+  return `You have ${normalizedCount} new message(s). Check ${mailboxPath}, act now, and reply with concrete progress (not ACK-only).`;
 }
 
 function agentTypeGuidance(agentType: CliAgentType): string {


### PR DESCRIPTION
## Summary
- follow up #1538 by porting the remaining applicable OMX #707 hardening into OMC shared team-runtime helpers
- make worker trigger/mailbox messages state-root-aware for worktree-backed workers via `$OMC_TEAM_STATE_ROOT`
- thread the new placeholder-aware mailbox trigger generation through API interop dispatch and add focused regression coverage

## Checklist

### Already covered by #1538 / current OMC dev
- [x] OMX #694 worker trigger wording hardening
- [x] OMX #696 startup dispatch evidence gating + retry on the active `runtime-v2` path
- [x] OMX #697 detached worker worktree cleanup on shutdown
- [x] OMX #700 pane-evidence-based stall/non-reporting inference in `runtime-v2`

### Still missing before this PR
- [x] OMX #707 worktree worker inbox/mailbox path resolution on shared OMC helper surfaces
  - `src/team/worker-bootstrap.ts`
  - `src/team/api-interop.ts`
  - covered with focused tests in:
    - `src/team/__tests__/worker-bootstrap.test.ts`
    - `src/team/__tests__/api-interop.dispatch.test.ts`

### Intentionally not applicable for this track
- [x] OMX #708 explicit shared worker launch-arg profile normalization
  - OMC does not expose an `OMC_TEAM_WORKER_LAUNCH_ARGS` equivalent surface today
  - Codex bypass is already injected by OMC's typed `model-contract.ts` launch builder
- [x] OMX #700 notify-hook script hardening
  - OMC has no matching `scripts/notify-hook/team-leader-nudge.js` surface
  - equivalent runtime behavior already lives in `src/team/runtime-v2.ts`

## Validation
- `npm run test:run -- src/team/__tests__/worker-bootstrap.test.ts src/team/__tests__/api-interop.dispatch.test.ts`
- TypeScript diagnostics clean on:
  - `src/team/worker-bootstrap.ts`
  - `src/team/api-interop.ts`
  - `src/team/__tests__/worker-bootstrap.test.ts`
  - `src/team/__tests__/api-interop.dispatch.test.ts`

Closes #1535.
