### PR TITLE
feat(session-search): add first-class session history search tool

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -8,7 +8,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 
 - [Installation](#installation)
 - [Configuration](#configuration)
-- [CLI Commands: ask/team](#cli-commands-askteam)
+- [CLI Commands: ask/team/session](#cli-commands-askteamsession)
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated)
 - [Agents (28 Total)](#agents-28-total)
 - [Skills (34 Total)](#skills-34-total)
@@ -190,7 +190,7 @@ Tag behavior:
 
 ---
 
-## CLI Commands: ask/team
+## CLI Commands: ask/team/session
 
 ### `omc ask`
 
@@ -217,6 +217,19 @@ omc team api claim-task --input '{"team_name":"auth-review","task_id":"1","worke
 ```
 
 Supported entrypoints: direct start (`omc team [N:agent] "<task>"`), `status`, `shutdown`, and `api`.
+
+### `omc session search`
+
+```bash
+omc session search "team leader stale"
+omc session search notify-hook --since 7d
+omc session search provider-routing --project all --json
+```
+
+- Defaults to the current project/worktree scope
+- Use `--project all` to search across all local Claude project transcripts
+- Supports `--limit`, `--session`, `--since`, `--context`, `--case-sensitive`, and `--json`
+- MCP/tool surface: `session_search` returns structured JSON for agents and automations
 
 ---
 
@@ -643,6 +656,7 @@ For complete documentation, see **[Performance Monitoring Guide](./PERFORMANCE-M
 | **Agent Observatory**   | Real-time agent status, efficiency, bottlenecks | HUD / API                            |
 | **Session-End Summaries** | Persisted per-session summaries and callback payloads | `.omc/sessions/*.json`, `session-end` |
 | **Session Replay**      | Event timeline for post-session analysis        | `.omc/state/agent-replay-*.jsonl`    |
+| **Session Search**      | Search prior local transcript/session artifacts  | `omc session search`, `session_search` |
 | **Intervention System** | Auto-detection of stale agents, cost overruns   | Automatic                            |
 
 ### CLI Commands

--- a/src/__tests__/omc-tools-server.test.ts
+++ b/src/__tests__/omc-tools-server.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { omcToolsServer, omcToolNames, getOmcToolNames } from '../mcp/omc-tools-server.js';
 
 const interopEnabled = process.env.OMC_INTEROP_TOOLS_ENABLED === '1';
-const totalTools = interopEnabled ? 48 : 40;
-const withoutLsp = interopEnabled ? 36 : 28;
-const withoutAst = interopEnabled ? 46 : 38;
-const withoutPython = interopEnabled ? 47 : 39;
-const withoutSkills = interopEnabled ? 45 : 37;
+const totalTools = interopEnabled ? 49 : 41;
+const withoutLsp = interopEnabled ? 37 : 29;
+const withoutAst = interopEnabled ? 47 : 39;
+const withoutPython = interopEnabled ? 48 : 40;
+const withoutSkills = interopEnabled ? 46 : 38;
 
 describe('omc-tools-server', () => {
   describe('omcToolNames', () => {
@@ -26,6 +26,10 @@ describe('omc-tools-server', () => {
 
     it('should have python_repl tool', () => {
       expect(omcToolNames).toContain('mcp__t__python_repl');
+    });
+
+    it('should have session_search tool', () => {
+      expect(omcToolNames).toContain('mcp__t__session_search');
     });
 
     it('should use correct MCP naming format', () => {

--- a/src/__tests__/session-history-search.test.ts
+++ b/src/__tests__/session-history-search.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  parseSinceSpec,
+  searchSessionHistory,
+} from '../features/session-history-search/index.js';
+
+function encodeProjectPath(projectPath: string): string {
+  return projectPath.replace(/[\\/]/g, '-');
+}
+
+function writeTranscript(filePath: string, entries: Array<Record<string, unknown>>): void {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, entries.map((entry) => JSON.stringify(entry)).join('\n') + '\n', 'utf-8');
+}
+
+describe('session history search', () => {
+  const repoRoot = process.cwd();
+  let tempRoot: string;
+  let claudeDir: string;
+  let otherProject: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'omc-session-search-'));
+    claudeDir = join(tempRoot, 'claude');
+    otherProject = join(tempRoot, 'other-project');
+    process.env.CLAUDE_CONFIG_DIR = claudeDir;
+    process.env.OMC_STATE_DIR = join(tempRoot, 'omc-state');
+
+    const currentProjectDir = join(claudeDir, 'projects', encodeProjectPath(repoRoot));
+    const otherProjectDir = join(claudeDir, 'projects', encodeProjectPath(otherProject));
+
+    writeTranscript(join(currentProjectDir, 'session-current.jsonl'), [
+      {
+        sessionId: 'session-current',
+        cwd: repoRoot,
+        type: 'user',
+        timestamp: '2026-03-09T10:00:00.000Z',
+        message: { role: 'user', content: 'Search prior sessions for notify-hook failures and stale team leader notes.' },
+      },
+      {
+        sessionId: 'session-current',
+        cwd: repoRoot,
+        type: 'assistant',
+        timestamp: '2026-03-09T10:05:00.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'We traced the notify-hook regression to stale team leader state in a prior run.' }] },
+      },
+    ]);
+
+    writeTranscript(join(currentProjectDir, 'session-older.jsonl'), [
+      {
+        sessionId: 'session-older',
+        cwd: repoRoot,
+        type: 'assistant',
+        timestamp: '2026-02-20T08:00:00.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Old provider routing discussion for archival context.' }] },
+      },
+    ]);
+
+    writeTranscript(join(otherProjectDir, 'session-other.jsonl'), [
+      {
+        sessionId: 'session-other',
+        cwd: otherProject,
+        type: 'assistant',
+        timestamp: '2026-03-08T12:00:00.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'notify-hook appears here too, but only in another project.' }] },
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.OMC_STATE_DIR;
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('searches the current project by default and returns structured snippets', async () => {
+    const report = await searchSessionHistory({
+      query: 'notify-hook stale team leader',
+      workingDirectory: repoRoot,
+    });
+
+    expect(report.scope.mode).toBe('current');
+    expect(report.totalMatches).toBe(2);
+    expect(report.results).toHaveLength(2);
+    expect(report.results.every((result) => result.projectPath === repoRoot)).toBe(true);
+    expect(report.results.some((result) => result.sessionId === 'session-current')).toBe(true);
+    expect(report.results[0].excerpt.toLowerCase()).toContain('notify-hook');
+    expect(report.results[0].sourcePath).toContain('session-current.jsonl');
+  });
+
+  it('supports since and session filters', async () => {
+    const recentOnly = await searchSessionHistory({
+      query: 'provider routing',
+      since: '7d',
+      project: 'all',
+      workingDirectory: repoRoot,
+    });
+    expect(recentOnly.totalMatches).toBe(0);
+
+    const olderSession = await searchSessionHistory({
+      query: 'provider routing',
+      sessionId: 'session-older',
+      project: 'all',
+      workingDirectory: repoRoot,
+    });
+    expect(olderSession.totalMatches).toBe(1);
+    expect(olderSession.results[0].sessionId).toBe('session-older');
+  });
+
+  it('can search across all projects and apply result limits', async () => {
+    const report = await searchSessionHistory({
+      query: 'notify-hook',
+      project: 'all',
+      limit: 1,
+      workingDirectory: repoRoot,
+    });
+
+    expect(report.scope.mode).toBe('all');
+    expect(report.totalMatches).toBe(3);
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0].sessionId).toBe('session-current');
+  });
+
+  it('parses relative and absolute since values', () => {
+    const relative = parseSinceSpec('7d');
+    expect(relative).toBeTypeOf('number');
+    expect(parseSinceSpec('2026-03-01')).toBe(Date.parse('2026-03-01'));
+    expect(parseSinceSpec('')).toBeUndefined();
+  });
+});

--- a/src/__tests__/standalone-server.test.ts
+++ b/src/__tests__/standalone-server.test.ts
@@ -22,12 +22,12 @@ describe('standalone-server tool composition', () => {
   ];
 
   it('should have the expected total tool count', () => {
-    // 12 LSP + 2 AST + 1 python + 5 state + 6 notepad + 4 memory + 2 trace = 32
-    expect(expectedTools).toHaveLength(32);
+    // 12 LSP + 2 AST + 1 python + 5 state + 6 notepad + 4 memory + 3 trace = 33
+    expect(expectedTools).toHaveLength(33);
   });
 
-  it('should include 2 trace tools', () => {
-    expect(traceTools).toHaveLength(2);
+  it('should include 3 trace tools', () => {
+    expect(traceTools).toHaveLength(3);
   });
 
   it('should include trace_timeline tool', () => {
@@ -38,6 +38,11 @@ describe('standalone-server tool composition', () => {
   it('should include trace_summary tool', () => {
     const names = traceTools.map(t => t.name);
     expect(names).toContain('trace_summary');
+  });
+
+  it('should include session_search tool', () => {
+    const names = traceTools.map(t => t.name);
+    expect(names).toContain('session_search');
   });
 
   it('should have no duplicate tool names', () => {

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+const cliIndexSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'index.ts'),
+  'utf-8'
+);
+
+describe('session search help text', () => {
+  it('documents the session search command examples', () => {
+    expect(cliIndexSource).toContain('omc session search "team leader stale"');
+    expect(cliIndexSource).toContain('omc session search notify-hook --since 7d');
+    expect(cliIndexSource).toContain('omc session search provider-routing --project all --json');
+  });
+});

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  formatSessionSearchReport,
+  sessionSearchCommand,
+} from '../commands/session-search.js';
+
+function encodeProjectPath(projectPath: string): string {
+  return projectPath.replace(/[\\/]/g, '-');
+}
+
+function writeTranscript(filePath: string, entries: Array<Record<string, unknown>>): void {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, entries.map((entry) => JSON.stringify(entry)).join('\n') + '\n', 'utf-8');
+}
+
+describe('session search cli command', () => {
+  const repoRoot = process.cwd();
+  let tempRoot: string;
+  let claudeDir: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'omc-session-search-cli-'));
+    claudeDir = join(tempRoot, 'claude');
+    process.env.CLAUDE_CONFIG_DIR = claudeDir;
+    process.env.OMC_STATE_DIR = join(tempRoot, 'omc-state');
+
+    writeTranscript(join(claudeDir, 'projects', encodeProjectPath(repoRoot), 'session-current.jsonl'), [
+      {
+        sessionId: 'session-current',
+        cwd: repoRoot,
+        type: 'assistant',
+        timestamp: '2026-03-09T10:05:00.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'We traced the notify-hook regression to stale team leader state in a prior run.' }] },
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.OMC_STATE_DIR;
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('prints JSON when requested', async () => {
+    const logger = { log: vi.fn() };
+    const report = await sessionSearchCommand('notify-hook', {
+      json: true,
+      workingDirectory: repoRoot,
+    }, logger);
+
+    expect(report.totalMatches).toBe(1);
+    expect(logger.log).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(String(logger.log.mock.calls[0][0]));
+    expect(parsed.totalMatches).toBe(1);
+    expect(parsed.results[0].sessionId).toBe('session-current');
+  });
+
+  it('formats human-readable output', () => {
+    const text = formatSessionSearchReport({
+      query: 'notify-hook',
+      scope: { mode: 'current', caseSensitive: false, workingDirectory: repoRoot },
+      searchedFiles: 1,
+      totalMatches: 1,
+      results: [{
+        sessionId: 'session-current',
+        timestamp: '2026-03-09T10:05:00.000Z',
+        projectPath: repoRoot,
+        sourcePath: '/tmp/session-current.jsonl',
+        sourceType: 'project-transcript',
+        line: 3,
+        role: 'assistant',
+        entryType: 'assistant',
+        excerpt: 'notify-hook regression to stale team leader state',
+      }],
+    });
+
+    expect(text).toContain('session-current');
+    expect(text).toContain('notify-hook');
+    expect(text).toContain('/tmp/session-current.jsonl:3');
+  });
+});

--- a/src/cli/commands/session-search.ts
+++ b/src/cli/commands/session-search.ts
@@ -1,0 +1,74 @@
+import chalk from 'chalk';
+import {
+  searchSessionHistory,
+  type SessionHistorySearchReport,
+} from '../../features/session-history-search/index.js';
+
+export interface SessionSearchCommandOptions {
+  limit?: number;
+  session?: string;
+  since?: string;
+  project?: string;
+  json?: boolean;
+  caseSensitive?: boolean;
+  context?: number;
+  workingDirectory?: string;
+}
+
+interface LoggerLike {
+  log: (message?: unknown) => void;
+}
+
+function formatTimestamp(timestamp?: string): string {
+  if (!timestamp) return 'unknown time';
+  const parsed = new Date(timestamp);
+  return Number.isNaN(parsed.getTime()) ? timestamp : parsed.toISOString();
+}
+
+export function formatSessionSearchReport(report: SessionHistorySearchReport): string {
+  if (report.totalMatches === 0) {
+    return [
+      `No session history matches found for ${chalk.cyan(JSON.stringify(report.query))}.`,
+      chalk.gray(`Searched ${report.searchedFiles} files in ${report.scope.mode} scope.`),
+    ].join('\n');
+  }
+
+  const lines: string[] = [
+    chalk.blue(`Session history matches for ${JSON.stringify(report.query)}`),
+    chalk.gray(`Showing ${report.results.length} of ${report.totalMatches} matches across ${report.searchedFiles} files (${report.scope.mode} scope)`),
+    '',
+  ];
+
+  report.results.forEach((result, index) => {
+    lines.push(`${chalk.bold(`${index + 1}.`)} ${result.sessionId}${result.agentId ? chalk.gray(` [agent:${result.agentId}]`) : ''}`);
+    lines.push(`   ${chalk.gray(formatTimestamp(result.timestamp))}`);
+    if (result.projectPath) {
+      lines.push(`   ${chalk.gray(result.projectPath)}`);
+    }
+    lines.push(`   ${result.excerpt}`);
+    lines.push(`   ${chalk.gray(`${result.sourcePath}:${result.line}`)}`);
+    lines.push('');
+  });
+
+  return lines.join('\n').trimEnd();
+}
+
+export async function sessionSearchCommand(
+  query: string,
+  options: SessionSearchCommandOptions,
+  logger: LoggerLike = console,
+): Promise<SessionHistorySearchReport> {
+  const report = await searchSessionHistory({
+    query,
+    limit: options.limit,
+    sessionId: options.session,
+    since: options.since,
+    project: options.project,
+    caseSensitive: options.caseSensitive,
+    contextChars: options.context,
+    workingDirectory: options.workingDirectory,
+  });
+
+  logger.log(options.json ? JSON.stringify(report, null, 2) : formatSessionSearchReport(report));
+  return report;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,6 +50,7 @@ import {
   waitDetectCommand
 } from './commands/wait.js';
 import { doctorConflictsCommand } from './commands/doctor-conflicts.js';
+import { sessionSearchCommand } from './commands/session-search.js';
 import { teamCommand } from './commands/team.js';
 import {
   teleportCommand,
@@ -1274,6 +1275,43 @@ teleportCmd
   .action(async (path: string, options) => {
     const exitCode = await teleportRemoveCommand(path, options);
     if (exitCode !== 0) process.exit(exitCode);
+  });
+
+
+/**
+ * Session command - Search prior local session history
+ */
+const sessionCmd = program
+  .command('session')
+  .alias('sessions')
+  .description('Inspect prior local session history')
+  .addHelpText('after', `
+Examples:
+  $ omc session search "team leader stale"
+  $ omc session search notify-hook --since 7d
+  $ omc session search provider-routing --project all --json`);
+
+sessionCmd
+  .command('search <query>')
+  .description('Search prior local session transcripts and OMC session artifacts')
+  .option('-l, --limit <number>', 'Maximum number of matches to return', '10')
+  .option('-s, --session <id>', 'Restrict search to a specific session id')
+  .option('--since <duration|date>', 'Only include matches since a duration (e.g. 7d, 24h) or absolute date')
+  .option('--project <scope>', 'Project scope. Defaults to current project. Use "all" to search all local projects')
+  .option('--json', 'Output results as JSON')
+  .option('--case-sensitive', 'Match query case-sensitively')
+  .option('--context <chars>', 'Approximate snippet context on each side of a match', '120')
+  .action(async (query: string, options) => {
+    await sessionSearchCommand(query, {
+      limit: parseInt(options.limit, 10),
+      session: options.session,
+      since: options.since,
+      project: options.project,
+      json: options.json,
+      caseSensitive: options.caseSensitive,
+      context: parseInt(options.context, 10),
+      workingDirectory: process.cwd(),
+    });
   });
 
 /**

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -303,3 +303,14 @@ export {
   type FileOwnership,
   type DecompositionStrategy
 } from './task-decomposer/index.js';
+
+
+// Session History Search - local transcript/session artifact search
+export {
+  searchSessionHistory,
+  parseSinceSpec,
+  type SessionHistoryMatch,
+  type SessionHistorySearchOptions,
+  type SessionHistorySearchReport,
+} from './session-history-search/index.js';
+

--- a/src/features/session-history-search/index.ts
+++ b/src/features/session-history-search/index.ts
@@ -1,0 +1,572 @@
+import { execSync } from 'child_process';
+import { createReadStream, existsSync, readdirSync, statSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join, normalize, resolve } from 'path';
+import { createInterface } from 'readline';
+import {
+  resolveToWorktreeRoot,
+  validateSessionId,
+  validateWorkingDirectory,
+  getOmcRoot,
+} from '../../lib/worktree-paths.js';
+import type {
+  SessionHistoryMatch,
+  SessionHistorySearchOptions,
+  SessionHistorySearchReport,
+} from './types.js';
+
+const DEFAULT_LIMIT = 10;
+const DEFAULT_CONTEXT_CHARS = 120;
+
+interface SearchTarget {
+  filePath: string;
+  sourceType: SessionHistoryMatch['sourceType'];
+}
+
+interface SearchableEntry {
+  sessionId: string;
+  agentId?: string;
+  timestamp?: string;
+  projectPath?: string;
+  role?: string;
+  entryType?: string;
+  texts: string[];
+}
+
+function getClaudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+}
+
+function compactWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeForSearch(value: string, caseSensitive: boolean): string {
+  const compacted = compactWhitespace(value);
+  return caseSensitive ? compacted : compacted.toLowerCase();
+}
+
+function parseSinceSpec(since?: string): number | undefined {
+  if (!since) return undefined;
+
+  const trimmed = since.trim();
+  if (!trimmed) return undefined;
+
+  const durationMatch = trimmed.match(/^(\d+)\s*([mhdw])$/i);
+  if (durationMatch) {
+    const amount = Number.parseInt(durationMatch[1], 10);
+    const unit = durationMatch[2].toLowerCase();
+    const multiplierMap: Record<string, number> = {
+      m: 60_000,
+      h: 3_600_000,
+      d: 86_400_000,
+      w: 604_800_000,
+    };
+    const multiplier = multiplierMap[unit];
+    return multiplier ? Date.now() - amount * multiplier : undefined;
+  }
+
+  const parsed = Date.parse(trimmed);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function encodeProjectPath(projectPath: string): string {
+  return projectPath.replace(/[\\/]/g, '-');
+}
+
+function getMainRepoRoot(projectRoot: string): string | null {
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const absoluteCommonDir = resolve(projectRoot, gitCommonDir);
+    const mainRepoRoot = dirname(absoluteCommonDir);
+    return mainRepoRoot === projectRoot ? null : mainRepoRoot;
+  } catch {
+    return null;
+  }
+}
+
+function getClaudeWorktreeParent(projectRoot: string): string | null {
+  const marker = `${normalize('/.claude/worktrees/')}`;
+  const normalizedRoot = normalize(projectRoot);
+  const idx = normalizedRoot.indexOf(marker);
+  if (idx === -1) return null;
+  return normalizedRoot.slice(0, idx) || null;
+}
+
+function listJsonlFiles(rootDir: string): string[] {
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+      if (entry.isFile() && (entry.name.endsWith('.jsonl') || entry.name.endsWith('.json'))) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function uniqueSortedTargets(targets: SearchTarget[]): SearchTarget[] {
+  const seen = new Set<string>();
+  return targets
+    .filter((target) => {
+      const key = `${target.sourceType}:${target.filePath}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((a, b) => {
+      const aTime = existsSync(a.filePath) ? statSync(a.filePath).mtimeMs : 0;
+      const bTime = existsSync(b.filePath) ? statSync(b.filePath).mtimeMs : 0;
+      return bTime - aTime;
+    });
+}
+
+function buildCurrentProjectTargets(projectRoot: string): SearchTarget[] {
+  const claudeDir = getClaudeConfigDir();
+  const projectRoots = new Set<string>([projectRoot]);
+  const mainRepoRoot = getMainRepoRoot(projectRoot);
+  if (mainRepoRoot) projectRoots.add(mainRepoRoot);
+  const claudeWorktreeParent = getClaudeWorktreeParent(projectRoot);
+  if (claudeWorktreeParent) projectRoots.add(claudeWorktreeParent);
+
+  const targets: SearchTarget[] = [];
+
+  for (const root of projectRoots) {
+    const encodedDir = join(claudeDir, 'projects', encodeProjectPath(root));
+    for (const filePath of listJsonlFiles(encodedDir)) {
+      targets.push({ filePath, sourceType: 'project-transcript' });
+    }
+  }
+
+  const legacyTranscriptsDir = join(claudeDir, 'transcripts');
+  for (const filePath of listJsonlFiles(legacyTranscriptsDir)) {
+    targets.push({ filePath, sourceType: 'legacy-transcript' });
+  }
+
+  const omcRoot = getOmcRoot(projectRoot);
+  const sessionSummariesDir = join(omcRoot, 'sessions');
+  for (const filePath of listJsonlFiles(sessionSummariesDir)) {
+    targets.push({ filePath, sourceType: 'omc-session-summary' });
+  }
+
+  const replayDir = join(omcRoot, 'state');
+  if (existsSync(replayDir)) {
+    for (const filePath of listJsonlFiles(replayDir)) {
+      if (filePath.includes('agent-replay-') && filePath.endsWith('.jsonl')) {
+        targets.push({ filePath, sourceType: 'omc-session-replay' });
+      }
+    }
+  }
+
+  return uniqueSortedTargets(targets);
+}
+
+function buildAllProjectTargets(): SearchTarget[] {
+  const claudeDir = getClaudeConfigDir();
+  const targets: SearchTarget[] = [];
+
+  for (const filePath of listJsonlFiles(join(claudeDir, 'projects'))) {
+    targets.push({ filePath, sourceType: 'project-transcript' });
+  }
+
+  for (const filePath of listJsonlFiles(join(claudeDir, 'transcripts'))) {
+    targets.push({ filePath, sourceType: 'legacy-transcript' });
+  }
+
+  return uniqueSortedTargets(targets);
+}
+
+function isWithinProject(projectPath: string | undefined, projectRoots: string[]): boolean {
+  if (!projectPath) {
+    return false;
+  }
+
+  const normalizedProjectPath = normalize(resolve(projectPath));
+  return projectRoots.some((root) => {
+    const normalizedRoot = normalize(resolve(root));
+    return normalizedProjectPath === normalizedRoot || normalizedProjectPath.startsWith(`${normalizedRoot}/`);
+  });
+}
+
+function matchesProjectFilter(projectPath: string | undefined, projectFilter: string | undefined): boolean {
+  if (!projectFilter || projectFilter === 'all') {
+    return true;
+  }
+
+  if (!projectPath) {
+    return false;
+  }
+
+  return projectPath.toLowerCase().includes(projectFilter.toLowerCase());
+}
+
+function stringLeaves(value: unknown, maxLeaves: number = 24): string[] {
+  const leaves: string[] = [];
+  const stack: unknown[] = [value];
+
+  while (stack.length > 0 && leaves.length < maxLeaves) {
+    const current = stack.pop();
+    if (typeof current === 'string') {
+      const compacted = compactWhitespace(current);
+      if (compacted.length > 0) {
+        leaves.push(compacted);
+      }
+      continue;
+    }
+    if (Array.isArray(current)) {
+      stack.push(...current);
+      continue;
+    }
+    if (current && typeof current === 'object') {
+      stack.push(...Object.values(current));
+    }
+  }
+
+  return leaves;
+}
+
+function extractTranscriptTexts(entry: Record<string, unknown>): string[] {
+  const texts: string[] = [];
+  const message = entry.message as Record<string, unknown> | undefined;
+  const content = message?.content;
+
+  if (typeof content === 'string') {
+    texts.push(content);
+  } else if (Array.isArray(content)) {
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const record = block as Record<string, unknown>;
+      const blockType = typeof record.type === 'string' ? record.type : undefined;
+
+      if ((blockType === 'text' || blockType === 'thinking' || blockType === 'reasoning') && typeof record.text === 'string') {
+        texts.push(record.text);
+        continue;
+      }
+
+      if (blockType === 'tool_result') {
+        texts.push(...stringLeaves(record.content));
+        continue;
+      }
+
+      if (blockType === 'tool_use') {
+        const toolName = typeof record.name === 'string' ? record.name : 'tool';
+        const inputText = stringLeaves(record.input).join(' ');
+        if (inputText) {
+          texts.push(`${toolName} ${inputText}`);
+        }
+      }
+    }
+  }
+
+  return texts;
+}
+
+function buildTranscriptEntry(entry: Record<string, unknown>): SearchableEntry | null {
+  const texts = extractTranscriptTexts(entry);
+  if (texts.length === 0) {
+    return null;
+  }
+
+  const message = entry.message as Record<string, unknown> | undefined;
+  const sessionId = typeof entry.sessionId === 'string'
+    ? entry.sessionId
+    : typeof entry.session_id === 'string'
+      ? entry.session_id
+      : typeof message?.sessionId === 'string'
+        ? message.sessionId
+        : undefined;
+
+  if (!sessionId) {
+    return null;
+  }
+
+  return {
+    sessionId,
+    agentId: typeof entry.agentId === 'string' ? entry.agentId : undefined,
+    timestamp: typeof entry.timestamp === 'string' ? entry.timestamp : undefined,
+    projectPath: typeof entry.cwd === 'string' ? entry.cwd : undefined,
+    role: typeof message?.role === 'string' ? message.role : undefined,
+    entryType: typeof entry.type === 'string' ? entry.type : undefined,
+    texts,
+  };
+}
+
+function buildJsonArtifactEntry(entry: Record<string, unknown>, sourceType: SearchTarget['sourceType']): SearchableEntry | null {
+  const sessionId = typeof entry.session_id === 'string'
+    ? entry.session_id
+    : typeof entry.sessionId === 'string'
+      ? entry.sessionId
+      : undefined;
+
+  if (!sessionId) {
+    return null;
+  }
+
+  const texts = stringLeaves(entry);
+  if (texts.length === 0) {
+    return null;
+  }
+
+  const timestamp = typeof entry.ended_at === 'string'
+    ? entry.ended_at
+    : typeof entry.started_at === 'string'
+      ? entry.started_at
+      : typeof entry.timestamp === 'string'
+        ? entry.timestamp
+        : undefined;
+
+  const entryType = sourceType === 'omc-session-summary' ? 'session-summary' : 'session-replay';
+
+  return {
+    sessionId,
+    timestamp,
+    projectPath: typeof entry.cwd === 'string' ? entry.cwd : undefined,
+    entryType,
+    texts,
+  };
+}
+
+function buildSearchableEntry(entry: Record<string, unknown>, sourceType: SearchTarget['sourceType']): SearchableEntry | null {
+  if (sourceType === 'project-transcript' || sourceType === 'legacy-transcript' || sourceType === 'omc-session-replay') {
+    return buildTranscriptEntry(entry) ?? (sourceType === 'omc-session-replay' ? buildJsonArtifactEntry(entry, sourceType) : null);
+  }
+
+  if (sourceType === 'omc-session-summary') {
+    return buildJsonArtifactEntry(entry, sourceType);
+  }
+
+  return null;
+}
+
+function findMatchIndex(text: string, query: string, caseSensitive: boolean): number {
+  const haystack = normalizeForSearch(text, caseSensitive);
+  const needle = normalizeForSearch(query, caseSensitive);
+  const directIndex = haystack.indexOf(needle);
+  if (directIndex >= 0) {
+    return directIndex;
+  }
+
+  const terms = needle.split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return -1;
+  if (terms.every((term) => haystack.includes(term))) {
+    return haystack.indexOf(terms[0]);
+  }
+
+  return -1;
+}
+
+function createExcerpt(text: string, matchIndex: number, contextChars: number): string {
+  const compacted = compactWhitespace(text);
+  if (compacted.length <= contextChars * 2) {
+    return compacted;
+  }
+
+  const safeIndex = Math.max(0, matchIndex);
+  const start = Math.max(0, safeIndex - contextChars);
+  const end = Math.min(compacted.length, safeIndex + contextChars);
+  const prefix = start > 0 ? '…' : '';
+  const suffix = end < compacted.length ? '…' : '';
+  return `${prefix}${compacted.slice(start, end).trim()}${suffix}`;
+}
+
+function buildScopeMode(project: string | undefined): 'current' | 'project' | 'all' {
+  if (!project || project === 'current') return 'current';
+  if (project === 'all') return 'all';
+  return 'project';
+}
+
+async function collectMatchesFromFile(
+  target: SearchTarget,
+  options: {
+    query: string;
+    caseSensitive: boolean;
+    contextChars: number;
+    sinceEpoch?: number;
+    sessionId?: string;
+    projectFilter?: string;
+    projectRoots?: string[];
+  },
+): Promise<SessionHistoryMatch[]> {
+  const matches: SessionHistoryMatch[] = [];
+  const fileMtime = existsSync(target.filePath) ? statSync(target.filePath).mtimeMs : 0;
+
+  if (target.sourceType === 'omc-session-summary' && target.filePath.endsWith('.json')) {
+    try {
+      const payload = JSON.parse(await import('fs/promises').then((fs) => fs.readFile(target.filePath, 'utf-8')));
+      const entry = buildSearchableEntry(payload as Record<string, unknown>, target.sourceType);
+      if (!entry) return [];
+      if (options.sessionId && entry.sessionId !== options.sessionId) return [];
+      if (options.projectRoots && options.projectRoots.length > 0 && !isWithinProject(entry.projectPath, options.projectRoots)) return [];
+      if (!matchesProjectFilter(entry.projectPath, options.projectFilter)) return [];
+      const entryEpoch = entry.timestamp ? Date.parse(entry.timestamp) : fileMtime;
+      if (options.sinceEpoch && Number.isFinite(entryEpoch) && entryEpoch < options.sinceEpoch) return [];
+
+      for (const text of entry.texts) {
+        const matchIndex = findMatchIndex(text, options.query, options.caseSensitive);
+        if (matchIndex < 0) continue;
+        matches.push({
+          sessionId: entry.sessionId,
+          timestamp: entry.timestamp,
+          projectPath: entry.projectPath,
+          sourcePath: target.filePath,
+          sourceType: target.sourceType,
+          line: 1,
+          role: entry.role,
+          entryType: entry.entryType,
+          excerpt: createExcerpt(text, matchIndex, options.contextChars),
+        });
+        break;
+      }
+    } catch {
+      return [];
+    }
+    return matches;
+  }
+
+  const stream = createReadStream(target.filePath, { encoding: 'utf-8' });
+  const reader = createInterface({ input: stream, crlfDelay: Infinity });
+  let line = 0;
+
+  try {
+    for await (const rawLine of reader) {
+      line += 1;
+      if (!rawLine.trim()) continue;
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(rawLine) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      const entry = buildSearchableEntry(parsed, target.sourceType);
+      if (!entry) continue;
+      if (options.sessionId && entry.sessionId !== options.sessionId) continue;
+      if (options.projectRoots && options.projectRoots.length > 0 && !isWithinProject(entry.projectPath, options.projectRoots)) continue;
+      if (!matchesProjectFilter(entry.projectPath, options.projectFilter)) continue;
+
+      const entryEpoch = entry.timestamp ? Date.parse(entry.timestamp) : fileMtime;
+      if (options.sinceEpoch && Number.isFinite(entryEpoch) && entryEpoch < options.sinceEpoch) continue;
+
+      for (const text of entry.texts) {
+        const matchIndex = findMatchIndex(text, options.query, options.caseSensitive);
+        if (matchIndex < 0) continue;
+        matches.push({
+          sessionId: entry.sessionId,
+          agentId: entry.agentId,
+          timestamp: entry.timestamp,
+          projectPath: entry.projectPath,
+          sourcePath: target.filePath,
+          sourceType: target.sourceType,
+          line,
+          role: entry.role,
+          entryType: entry.entryType,
+          excerpt: createExcerpt(text, matchIndex, options.contextChars),
+        });
+        break;
+      }
+    }
+  } finally {
+    reader.close();
+    stream.destroy();
+  }
+
+  return matches;
+}
+
+export async function searchSessionHistory(
+  rawOptions: SessionHistorySearchOptions,
+): Promise<SessionHistorySearchReport> {
+  const query = compactWhitespace(rawOptions.query || '');
+  if (!query) {
+    throw new Error('Query cannot be empty');
+  }
+
+  if (rawOptions.sessionId) {
+    validateSessionId(rawOptions.sessionId);
+  }
+
+  const limit = Math.max(1, rawOptions.limit ?? DEFAULT_LIMIT);
+  const contextChars = Math.max(20, rawOptions.contextChars ?? DEFAULT_CONTEXT_CHARS);
+  const caseSensitive = rawOptions.caseSensitive ?? false;
+  const sinceEpoch = parseSinceSpec(rawOptions.since);
+  const workingDirectory = validateWorkingDirectory(rawOptions.workingDirectory);
+  const currentProjectRoot = resolveToWorktreeRoot(workingDirectory);
+  const scopeMode = buildScopeMode(rawOptions.project);
+  const projectFilter = scopeMode === 'project' ? rawOptions.project : undefined;
+
+  const currentProjectRoots = [currentProjectRoot]
+    .concat(getMainRepoRoot(currentProjectRoot) ?? [])
+    .concat(getClaudeWorktreeParent(currentProjectRoot) ?? [])
+    .filter((value, index, arr): value is string => Boolean(value) && arr.indexOf(value) === index);
+
+  const targets = scopeMode === 'all'
+    ? buildAllProjectTargets()
+    : buildCurrentProjectTargets(currentProjectRoot);
+
+  const allMatches: SessionHistoryMatch[] = [];
+  for (const target of targets) {
+    const fileMatches = await collectMatchesFromFile(target, {
+      query,
+      caseSensitive,
+      contextChars,
+      sinceEpoch,
+      sessionId: rawOptions.sessionId,
+      projectFilter,
+      projectRoots: scopeMode === 'current' ? currentProjectRoots : undefined,
+    });
+    allMatches.push(...fileMatches);
+  }
+
+  allMatches.sort((a, b) => {
+    const aTime = a.timestamp ? Date.parse(a.timestamp) : 0;
+    const bTime = b.timestamp ? Date.parse(b.timestamp) : 0;
+    if (aTime !== bTime) return bTime - aTime;
+    return a.sourcePath.localeCompare(b.sourcePath);
+  });
+
+  return {
+    query,
+    scope: {
+      mode: scopeMode,
+      project: rawOptions.project,
+      workingDirectory: currentProjectRoot,
+      since: rawOptions.since,
+      caseSensitive,
+    },
+    searchedFiles: targets.length,
+    totalMatches: allMatches.length,
+    results: allMatches.slice(0, limit),
+  };
+}
+
+export { parseSinceSpec };
+export type {
+  SessionHistoryMatch,
+  SessionHistorySearchOptions,
+  SessionHistorySearchReport,
+} from './types.js';

--- a/src/features/session-history-search/types.ts
+++ b/src/features/session-history-search/types.ts
@@ -1,0 +1,37 @@
+export interface SessionHistorySearchOptions {
+  query: string;
+  limit?: number;
+  since?: string;
+  sessionId?: string;
+  project?: string;
+  caseSensitive?: boolean;
+  contextChars?: number;
+  workingDirectory?: string;
+}
+
+export interface SessionHistoryMatch {
+  sessionId: string;
+  agentId?: string;
+  timestamp?: string;
+  projectPath?: string;
+  sourcePath: string;
+  sourceType: 'project-transcript' | 'legacy-transcript' | 'omc-session-summary' | 'omc-session-replay';
+  line: number;
+  role?: string;
+  entryType?: string;
+  excerpt: string;
+}
+
+export interface SessionHistorySearchReport {
+  query: string;
+  scope: {
+    mode: 'current' | 'project' | 'all';
+    project?: string;
+    workingDirectory?: string;
+    since?: string;
+    caseSensitive: boolean;
+  };
+  searchedFiles: number;
+  totalMatches: number;
+  results: SessionHistoryMatch[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ export {
   type InjectionStrategy,
   type InjectionResult
 } from './features/index.js';
+export { searchSessionHistory, parseSinceSpec, type SessionHistoryMatch, type SessionHistorySearchOptions, type SessionHistorySearchReport } from './features/index.js';
 
 // Agent module exports (modular agent system)
 export {

--- a/src/tools/session-history-tools.ts
+++ b/src/tools/session-history-tools.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import {
+  searchSessionHistory,
+  type SessionHistorySearchOptions,
+} from '../features/session-history-search/index.js';
+import { ToolDefinition } from './types.js';
+
+function buildToolJson(report: Awaited<ReturnType<typeof searchSessionHistory>>): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export const sessionSearchTool: ToolDefinition<{
+  query: z.ZodString;
+  limit: z.ZodOptional<z.ZodNumber>;
+  sessionId: z.ZodOptional<z.ZodString>;
+  since: z.ZodOptional<z.ZodString>;
+  project: z.ZodOptional<z.ZodString>;
+  caseSensitive: z.ZodOptional<z.ZodBoolean>;
+  contextChars: z.ZodOptional<z.ZodNumber>;
+  workingDirectory: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'session_search',
+  description: 'Search prior local session history and transcript artifacts. Returns structured JSON with session ids, timestamps, source paths, and matching excerpts.',
+  schema: {
+    query: z.string().min(1).describe('Text query to search for in prior session history'),
+    limit: z.number().int().positive().optional().describe('Maximum number of matches to return (default: 10)'),
+    sessionId: z.string().optional().describe('Restrict search to a specific session id'),
+    since: z.string().optional().describe('Only include matches since a relative duration (e.g. 7d, 24h) or absolute date'),
+    project: z.string().optional().describe('Project filter. Defaults to current project. Use "all" to search across all local Claude projects.'),
+    caseSensitive: z.boolean().optional().describe('Whether to match case-sensitively (default: false)'),
+    contextChars: z.number().int().positive().optional().describe('Approximate snippet context on each side of a match (default: 120)'),
+    workingDirectory: z.string().optional().describe('Working directory used to determine the current project scope'),
+  },
+  handler: async (args) => {
+    try {
+      const report = await searchSessionHistory(args as SessionHistorySearchOptions);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: buildToolJson(report),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Error searching session history: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+        isError: true,
+      };
+    }
+  },
+};
+
+export const sessionHistoryTools = [sessionSearchTool];

--- a/src/tools/trace-tools.ts
+++ b/src/tools/trace-tools.ts
@@ -17,6 +17,7 @@ import {
   validateWorkingDirectory,
 } from '../lib/worktree-paths.js';
 import { ToolDefinition } from './types.js';
+import { sessionSearchTool } from './session-history-tools.js';
 
 // ============================================================================
 // Helpers
@@ -459,4 +460,4 @@ export const traceSummaryTool: ToolDefinition<{
 /**
  * All trace tools for registration
  */
-export const traceTools = [traceTimelineTool, traceSummaryTool];
+export const traceTools = [traceTimelineTool, traceSummaryTool, sessionSearchTool];


### PR DESCRIPTION
## Summary
- add a shared local session history search engine over Claude transcript artifacts plus OMC session artifacts
- expose it via `omc session search` and a new `session_search` MCP tool
- add focused tests and reference/help docs for the new surface

## Verification
- `npx vitest run src/__tests__/session-history-search.test.ts src/cli/__tests__/session-search.test.ts src/cli/__tests__/session-search-help.test.ts src/__tests__/omc-tools-server.test.ts src/__tests__/standalone-server.test.ts`
- `npm run build`
- `npx eslint src/features/session-history-search/index.ts src/features/session-history-search/types.ts src/tools/session-history-tools.ts src/tools/trace-tools.ts src/cli/commands/session-search.ts src/cli/index.ts src/__tests__/session-history-search.test.ts src/cli/__tests__/session-search.test.ts src/cli/__tests__/session-search-help.test.ts src/__tests__/omc-tools-server.test.ts src/__tests__/standalone-server.test.ts`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

Closes #1545