### PR TITLE
fix(team): require real startup evidence

### DIFF
--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -196,7 +196,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(requests[0]?.status).toBe('notified');
   });
 
-  it('accepts Claude startup once leader mailbox ack evidence appears', async () => {
+  it('does not treat ACK-only mailbox replies as Claude startup evidence', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-claude-evidence-ack-'));
 
     mocks.sendToWorker.mockImplementation(async () => {
@@ -222,6 +222,35 @@ describe('runtime v2 startup inbox dispatch', () => {
       workerCount: 1,
       agentTypes: ['claude'],
       tasks: [{ subject: 'Dispatch test', description: 'Verify Claude mailbox ack evidence' }],
+      cwd,
+    });
+
+    expect(runtime.config.workers[0]?.assigned_tasks).toEqual([]);
+    expect(mocks.sendToWorker).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts Claude startup once the worker claims the task', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-claude-evidence-claim-'));
+
+    mocks.sendToWorker.mockImplementation(async () => {
+      const taskDir = join(cwd, '.omc', 'state', 'team', 'dispatch-team', 'tasks');
+      const taskPath = join(taskDir, 'task-1.json');
+      const existing = JSON.parse(await readFile(taskPath, 'utf-8'));
+      await writeFile(taskPath, JSON.stringify({
+        ...existing,
+        status: 'in_progress',
+        owner: 'worker-1',
+      }, null, 2), 'utf-8');
+      return true;
+    });
+
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'dispatch-team',
+      workerCount: 1,
+      agentTypes: ['claude'],
+      tasks: [{ subject: 'Dispatch test', description: 'Verify Claude claim evidence' }],
       cwd,
     });
 

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -319,25 +319,21 @@ interface SpawnV2WorkerResult {
   startupFailureReason?: string;
 }
 
-interface MailboxSnapshot {
-  messages?: Array<{ from_worker?: string }>;
-}
-
 function hasWorkerStatusProgress(status: WorkerStatus, taskId: string): boolean {
   if (status.current_task_id === taskId) return true;
   return ['working', 'blocked', 'done', 'failed'].includes(status.state);
 }
 
-async function hasLeaderMailboxAck(
+async function hasWorkerTaskClaimEvidence(
   teamName: string,
   workerName: string,
   cwd: string,
+  taskId: string,
 ): Promise<boolean> {
   try {
-    const raw = await readFile(absPath(cwd, TeamPaths.mailbox(teamName, 'leader-fixed')), 'utf-8');
-    const mailbox = JSON.parse(raw) as MailboxSnapshot;
-    return Array.isArray(mailbox.messages)
-      && mailbox.messages.some((message) => message?.from_worker === workerName);
+    const raw = await readFile(absPath(cwd, TeamPaths.taskFile(teamName, taskId)), 'utf-8');
+    const task = JSON.parse(raw) as TeamTask;
+    return task.owner === workerName && ['in_progress', 'completed', 'failed'].includes(task.status);
   } catch {
     return false;
   }
@@ -349,11 +345,11 @@ async function hasClaudeStartupEvidence(
   taskId: string,
   cwd: string,
 ): Promise<boolean> {
-  const [hasAck, status] = await Promise.all([
-    hasLeaderMailboxAck(teamName, workerName, cwd),
+  const [hasClaimEvidence, status] = await Promise.all([
+    hasWorkerTaskClaimEvidence(teamName, workerName, cwd, taskId),
     readWorkerStatus(teamName, workerName, cwd),
   ]);
-  return hasAck || hasWorkerStatusProgress(status, taskId);
+  return hasClaimEvidence || hasWorkerStatusProgress(status, taskId);
 }
 
 async function waitForClaudeStartupEvidence(


### PR DESCRIPTION
## Summary
- stop treating ACK-only leader-mailbox replies as sufficient Claude startup evidence in `runtime-v2`
- require real work-start evidence from task claim ownership or worker status progress before settling startup
- add focused regression coverage for ACK-only failure and claim-based success

## Audit context for #1540
Reviewed recent OMX team/runtime hardening adjacent to the #1538/#1539 backports.

### Classified items
- **OMX #686** — not applicable to active OMC runtime surface
  - upstream patch targets `scripts/notify-hook/team-leader-nudge.js`
  - OMC does not have that active notify-hook path; active worker nudging is `src/team/idle-nudge.ts`, which already operates on known worker pane ids and skips the leader pane
- **OMX #687** — not directly applicable as-is
  - upstream change is tied to OMX notify-hook scripts + root `.omx/state/team-state.json` sync behavior
  - OMC uses different team-state/session plumbing and does not share the same notify-hook entrypoints
- **OMX #691** — applicable and was missing
  - OMC `src/team/runtime-v2.ts` still accepted ACK-only mailbox replies as startup evidence
  - fixed in this PR by requiring task-claim or status-based work-start evidence instead
- **OMX #694** — already covered by OMC #1538
- **OMX #696** — already covered by OMC #1538
- **OMX #697** — already covered by OMC #1538
- **OMX #700** — already covered by OMC #1538
- **OMX #707** — already covered by OMC #1539
- **OMX #708** — not applicable to OMC
  - OMC does not expose the same explicit worker-launch-args profile surface; typed launch building already injects unattended Codex/Gemini flags
- **OMX #711** — not applicable to current OMC active path
  - upstream issue is Codex ACK-without-claim startup settlement on a different runtime path
  - OMC’s active Codex path uses prompt-mode launch args rather than settling startup from hook-delivered ACKs

## Validation
- `npx tsc --noEmit --pretty false --project tsconfig.json`
- `npx eslint src/team/runtime-v2.ts src/team/__tests__/runtime-v2.dispatch.test.ts`
- `npm run test:run -- src/team/__tests__/runtime-v2.dispatch.test.ts`

Refs #1540
