### PR TITLE
fix(routing): normalize explicit model IDs in all code paths

### DIFF
--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -43,7 +43,7 @@ describe('delegation-enforcer', () => {
   });
 
   describe('enforceModel', () => {
-    it('preserves explicitly specified model', () => {
+    it('preserves explicitly specified model (already an alias)', () => {
       const input: AgentInput = {
         description: 'Test task',
         prompt: 'Do something',
@@ -55,7 +55,34 @@ describe('delegation-enforcer', () => {
 
       expect(result.injected).toBe(false);
       expect(result.modifiedInput.model).toBe('haiku');
-      expect(result.modifiedInput).toEqual(input);
+    });
+
+    it('normalizes explicit full model ID to CC alias (issue #1415)', () => {
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'claude-sonnet-4-6'
+      };
+
+      const result = enforceModel(input);
+
+      expect(result.injected).toBe(false);
+      expect(result.modifiedInput.model).toBe('sonnet');
+    });
+
+    it('normalizes explicit Bedrock model ID to CC alias (issue #1415)', () => {
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'us.anthropic.claude-sonnet-4-6-v1:0'
+      };
+
+      const result = enforceModel(input);
+
+      expect(result.injected).toBe(false);
+      expect(result.modifiedInput.model).toBe('sonnet');
     });
 
     it('injects model from agent definition when not specified', () => {

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -18,6 +18,19 @@ import { normalizeDelegationRole } from './delegation-routing/types.js';
 import { loadConfig } from '../config/loader.js';
 import { resolveClaudeFamily } from '../config/models.js';
 
+/** Map Claude model family to CC-supported alias */
+const FAMILY_TO_ALIAS: Record<string, string> = {
+  SONNET: 'sonnet',
+  OPUS: 'opus',
+  HAIKU: 'haiku',
+};
+
+/** Normalize a model ID to a CC-supported alias (sonnet/opus/haiku) if possible */
+export function normalizeToCcAlias(model: string): string {
+  const family = resolveClaudeFamily(model);
+  return family ? (FAMILY_TO_ALIAS[family] ?? model) : model;
+}
+
 /**
  * Agent input structure from Claude Agent SDK
  */
@@ -80,13 +93,16 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
     };
   }
 
-  // If model is already specified, return as-is (but canonicalize alias names)
+  // If model is already specified, normalize it to CC-supported aliases
+  // before passing through. Full IDs like 'claude-sonnet-4-6' cause 400
+  // errors on Bedrock/Vertex. (issue #1415)
   if (agentInput.model) {
+    const normalizedModel = normalizeToCcAlias(agentInput.model);
     return {
       originalInput: agentInput,
-      modifiedInput: { ...agentInput, subagent_type: canonicalSubagentType },
+      modifiedInput: { ...agentInput, subagent_type: canonicalSubagentType, model: normalizedModel },
       injected: false,
-      model: agentInput.model,
+      model: normalizedModel,
     };
   }
 
@@ -128,17 +144,8 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
   }
 
   // Normalize model to Claude Code's supported aliases (sonnet/opus/haiku).
-  // The config may resolve to full model IDs like 'claude-sonnet-4-6' or
-  // Bedrock IDs like 'us.anthropic.claude-sonnet-4-6-v1:0', but Claude Code's
-  // subagent system only accepts 'sonnet', 'opus', 'haiku', or 'inherit'.
-  // Passing full IDs causes 400 errors on Bedrock/Vertex. (issue #1201)
-  const FAMILY_TO_ALIAS: Record<string, string> = {
-    SONNET: 'sonnet',
-    OPUS: 'opus',
-    HAIKU: 'haiku',
-  };
-  const family = resolveClaudeFamily(resolvedModel);
-  const normalizedModel = family ? (FAMILY_TO_ALIAS[family] ?? resolvedModel) : resolvedModel;
+  // Full IDs cause 400 errors on Bedrock/Vertex. (issue #1201, #1415)
+  const normalizedModel = normalizeToCcAlias(resolvedModel);
 
   const modifiedInput: AgentInput = {
     ...agentInput,
@@ -226,11 +233,5 @@ export function getModelForAgent(agentType: string): string {
   }
 
   // Normalize to CC-supported aliases (sonnet/opus/haiku)
-  const FAMILY_TO_ALIAS: Record<string, string> = {
-    SONNET: 'sonnet',
-    OPUS: 'opus',
-    HAIKU: 'haiku',
-  };
-  const family = resolveClaudeFamily(agentDef.model);
-  return family ? (FAMILY_TO_ALIAS[family] ?? agentDef.model) : agentDef.model;
+  return normalizeToCcAlias(agentDef.model);
 }

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -131,6 +131,21 @@ describe('model-contract', () => {
       expect(args).toContain('--model');
       expect(args).toContain('gpt-4');
     });
+    it('normalizes full Claude model ID to alias for claude agent (issue #1415)', () => {
+      const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'claude-sonnet-4-6' });
+      expect(args).toContain('--model');
+      expect(args).toContain('sonnet');
+      expect(args).not.toContain('claude-sonnet-4-6');
+    });
+    it('normalizes Bedrock model ID to alias for claude agent (issue #1415)', () => {
+      const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'us.anthropic.claude-opus-4-6-v1:0' });
+      expect(args).toContain('--model');
+      expect(args).toContain('opus');
+    });
+    it('does not normalize non-Claude models for codex/gemini agents', () => {
+      const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'gpt-4o' });
+      expect(args).toContain('gpt-4o');
+    });
   });
 
   describe('getWorkerEnv', () => {

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'child_process';
 import { isAbsolute, normalize, win32 as win32Path } from 'path';
 import { validateTeamName } from './team-name.js';
+import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 
 export type CliAgentType = 'claude' | 'codex' | 'gemini';
 
@@ -155,7 +156,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     installInstructions: 'Install Claude CLI: https://claude.ai/download',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
       const args = ['--dangerously-skip-permissions'];
-      if (model) args.push('--model', model);
+      if (model) args.push('--model', normalizeToCcAlias(model));
       return [...args, ...extraFlags];
     },
     parseOutput(rawOutput: string): string {


### PR DESCRIPTION
## Summary

Fixes the remaining Bedrock model routing issue where full model IDs like `claude-sonnet-4-6` leaked through to the API, causing 400 errors.

PR #1464 normalized auto-injected models but missed two code paths:

- **`enforceModel()`**: Explicitly-provided models were passed through as-is without normalization to CC aliases (`sonnet`/`opus`/`haiku`)
- **`buildLaunchArgs()` in model-contract.ts**: Team worker launches passed the model directly to `--model` flag without normalization

### Changes

- Extract shared `normalizeToCcAlias()` helper from delegation-enforcer (exported, DRY)
- Apply normalization in `enforceModel()` for explicitly-provided models
- Apply normalization in claude agent's `buildLaunchArgs()` for team worker launches
- Add 5 tests covering explicit ID normalization, Bedrock ID handling, and non-Claude passthrough

Closes #1415

## Test plan

- [x] 91 tests passing across 3 test files (delegation-enforcer, bedrock-model-routing, model-contract)
- [x] Type-check clean (`tsc --noEmit`)
- [ ] Verify on Bedrock environment: Task calls and team workers use `sonnet`/`opus`/`haiku` aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)