### PR TITLE
feat(lsp): Add Verilog/SystemVerilog support (verible-verilog-ls)

### DIFF
--- a/src/__tests__/lsp-servers.test.ts
+++ b/src/__tests__/lsp-servers.test.ts
@@ -4,8 +4,8 @@ import { LSP_SERVERS, getServerForFile, getServerForLanguage } from '../tools/ls
 describe('LSP Server Configurations', () => {
   const serverKeys = Object.keys(LSP_SERVERS);
 
-  it('should have 18 configured servers', () => {
-    expect(serverKeys).toHaveLength(18);
+  it('should have 19 configured servers', () => {
+    expect(serverKeys).toHaveLength(19);
   });
 
   it.each(serverKeys)('server "%s" should have valid config', (key) => {
@@ -57,6 +57,10 @@ describe('getServerForFile', () => {
     ['Program.cs', 'OmniSharp'],
     ['main.dart', 'Dart Analysis Server'],
     ['view.erb', 'Ruby Language Server (Solargraph)'],
+    ['counter.v', 'Verible Verilog Language Server'],
+    ['defs.vh', 'Verible Verilog Language Server'],
+    ['top.sv', 'Verible Verilog Language Server'],
+    ['pkg.svh', 'Verible Verilog Language Server'],
   ];
 
   it.each(cases)('should resolve "%s" to "%s"', (file, expectedName) => {
@@ -107,6 +111,10 @@ describe('getServerForLanguage', () => {
     ['cs', 'OmniSharp'],
     ['dart', 'Dart Analysis Server'],
     ['flutter', 'Dart Analysis Server'],
+    ['verilog', 'Verible Verilog Language Server'],
+    ['systemverilog', 'Verible Verilog Language Server'],
+    ['sv', 'Verible Verilog Language Server'],
+    ['v', 'Verible Verilog Language Server'],
   ];
 
   it.each(cases)('should resolve language "%s" to "%s"', (lang, expectedName) => {

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -6,7 +6,8 @@
  */
 
 import { spawnSync } from 'child_process';
-import { extname } from 'path';
+import { existsSync } from 'fs';
+import { extname, isAbsolute } from 'path';
 
 export interface LspServerConfig {
   name: string;
@@ -146,6 +147,13 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
     args: [],
     extensions: ['.swift'],
     installHint: 'Install Swift from https://swift.org/download or via Xcode'
+  },
+  verilog: {
+    name: 'Verible Verilog Language Server',
+    command: 'verible-verilog-ls',
+    args: ['--rules_config_search'],
+    extensions: ['.v', '.vh', '.sv', '.svh'],
+    installHint: 'Download from https://github.com/chipsalliance/verible/releases'
   }
 };
 
@@ -153,6 +161,7 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
  * Check if a command exists in PATH
  */
 export function commandExists(command: string): boolean {
+  if (isAbsolute(command)) return existsSync(command);
   const checkCommand = process.platform === 'win32' ? 'where' : 'which';
   const result = spawnSync(checkCommand, [command], { stdio: 'ignore' });
   return result.status === 0;
@@ -228,7 +237,11 @@ export function getServerForLanguage(language: string): LspServerConfig | null {
     'cs': 'csharp',
     'dart': 'dart',
     'flutter': 'dart',
-    'swift': 'swift'
+    'swift': 'swift',
+    'verilog': 'verilog',
+    'systemverilog': 'verilog',
+    'sv': 'verilog',
+    'v': 'verilog'
   };
 
   const serverKey = langMap[language.toLowerCase()];


### PR DESCRIPTION
## Summary

- Add `verible-verilog-ls` to `LSP_SERVERS` for `.v`, `.vh`, `.sv`, `.svh` files
- Fix `commandExists()` to handle absolute paths via `fs.existsSync` (`where`/`which` can't resolve them)
- Add language mappings: `verilog`, `systemverilog`, `sv`, `v`
- Update tests: 18 → 19 servers, add file/language resolution cases (92 tests pass)

## Motivation

Hardware engineers using Claude Code have no LSP support for Verilog/SystemVerilog. [Verible](https://github.com/chipsalliance/verible) is the most mature LSP for HDL, maintained by Chips Alliance (Google).

## Verified locally

| Tool | Result |
|------|--------|
| `lsp_servers` | Verible shows as **Installed** |
| `lsp_document_symbols` | Module/instance hierarchy parsed |
| `lsp_diagnostics` | Verible lint output returned |
| `lsp_hover` | Signal type/width info displayed |

Closes #1550

🤖 Generated with [Claude Code](https://claude.com/claude-code)