### PR TITLE
fix(hooks): use correct npm package name in session-start update check

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -176,7 +176,7 @@ async function checkNpmUpdate(currentVersion) {
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 2000);
-    const response = await fetch('https://registry.npmjs.org/oh-my-claudecode/latest', {
+    const response = await fetch('https://registry.npmjs.org/oh-my-claude-sisyphus/latest', {
       signal: controller.signal
     });
     clearTimeout(timeoutId);


### PR DESCRIPTION
## What does this PR do and why?

`scripts/session-start.mjs` (the deployed plugin-mode hook used by existing users) was still checking npm with the legacy package name `oh-my-claudecode` instead of the published package `oh-my-claude-sisyphus`. That meant existing users could silently miss update notifications.

## Changes

- update the npm registry URL in `scripts/session-start.mjs`
- align the deployed hook with `templates/hooks/session-start.mjs`, which already uses the correct package name

## References

- fixes #1554

## Validation

- verified `templates/hooks/session-start.mjs` already points at `oh-my-claude-sisyphus`
- verified `scripts/session-start.mjs` was the only remaining stale registry check
