### PR TITLE
fix(hooks): use correct npm package name in session-start update check

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -176,7 +176,7 @@ async function checkNpmUpdate(currentVersion) {
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 2000);
-    const response = await fetch('https://registry.npmjs.org/oh-my-claudecode/latest', {
+    const response = await fetch('https://registry.npmjs.org/oh-my-claude-sisyphus/latest', {
       signal: controller.signal
     });
     clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary

`scripts/session-start.mjs` (the hook executed in plugin mode) was checking the npm registry using the wrong package name (`oh-my-claudecode`) instead of the actual published name (`oh-my-claude-sisyphus`). This caused plugin-mode users to silently miss update notifications.

### Changes
- Fix npm registry URL in `scripts/session-start.mjs:179`: `oh-my-claudecode` → `oh-my-claude-sisyphus`
- `templates/hooks/session-start.mjs:72` already uses the correct package name — this PR aligns the two files

### Context
Users who haven't updated for ~1 month may not realize updates are available because the update check silently fails against the wrong package name. See #1554 for the broader package migration issue.

## Test Plan
- [ ] Run OMC in plugin mode and verify update notifications appear when a newer version is available on npm
- [ ] Confirm `templates/hooks/session-start.mjs` and `scripts/session-start.mjs` now use the same registry URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)