### PR TITLE
fix: preserve portable HOME paths in HUD skill statusLine guidance

### DIFF
--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -151,21 +151,21 @@ node -e "if(process.platform==='win32'){console.log('Skipped (Windows)')}else{re
 
 Read `~/.claude/settings.json`, then update/add the `statusLine` field.
 
-**IMPORTANT:** The command must use an absolute path, not `~`, because Windows does not expand `~` in shell commands.
+**IMPORTANT:** Do not use `~` in the command. On Unix, use `$HOME` to keep the path portable across machines. On Windows, use an absolute path because Windows does not expand `~` in shell commands.
 
-First, determine the correct path:
+If you are on Windows, first determine the correct path:
 ```bash
 node -e "const p=require('path').join(require('os').homedir(),'.claude','hud','omc-hud.mjs').split(require('path').sep).join('/');console.log(JSON.stringify(p))"
 ```
 
 **IMPORTANT:** The command path MUST use forward slashes on all platforms. Claude Code executes statusLine commands via bash, which interprets backslashes as escape characters and breaks the path.
 
-Then set the `statusLine` field using the resolved path. On Unix it will look like:
+Then set the `statusLine` field. On Unix it should stay portable and look like:
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "node /home/username/.claude/hud/omc-hud.mjs"
+    "command": "node $HOME/.claude/hud/omc-hud.mjs"
   }
 }
 ```
@@ -319,7 +319,7 @@ If the HUD is not showing:
 {
   "statusLine": {
     "type": "command",
-    "command": "node /home/username/.claude/hud/omc-hud.mjs"
+    "command": "node $HOME/.claude/hud/omc-hud.mjs"
   }
 }
 ```

--- a/src/skills/__tests__/mingw-escape.test.ts
+++ b/src/skills/__tests__/mingw-escape.test.ts
@@ -126,6 +126,14 @@ describe('MINGW64 escape safety: no "!" in node -e inline scripts (issue #729)',
       expect(chmodLine).toContain("==='win32'");
     });
 
+    it('hud SKILL.md keeps Unix statusLine guidance portable while preserving Windows-safe paths', () => {
+      const content = readFileSync(join(REPO_ROOT, 'skills', 'hud', 'SKILL.md'), 'utf-8');
+      expect(content).toContain('"command": "node $HOME/.claude/hud/omc-hud.mjs"');
+      expect(content).toContain('"command": "node C:/Users/username/.claude/hud/omc-hud.mjs"');
+      expect(content).not.toContain('"command": "node /home/username/.claude/hud/omc-hud.mjs"');
+      expect(content).not.toContain('The command must use an absolute path, not `~`');
+    });
+
     it("omc-setup version-detect script uses v==='' not !v", () => {
       const setupDir = join(REPO_ROOT, 'skills', 'omc-setup');
       const files = [


### PR DESCRIPTION
## Summary
- update `skills/hud/SKILL.md` so Unix `statusLine` guidance uses portable `$HOME` paths instead of absolute home paths
- keep Windows-specific absolute path guidance only where needed and preserve forward-slash guidance
- add a regression test to prevent future absolute Unix path examples from reappearing

## Root cause
Issue #1561 was caused by stale HUD skill instructions, not the installer/runtime path formatter. The HUD skill still told the agent to resolve `homedir()` and write an absolute Unix path into `statusLine`, which overwrote the portable `$HOME` behavior introduced in #1404.

## Testing
- `npx vitest run src/skills/__tests__/mingw-escape.test.ts`
- `npm run build`
- `npm run lint` *(passes with pre-existing repo warnings only)*

Closes #1561