### PR TITLE
fix(setup): preserve canonical CLAUDE markers

### DIFF
--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -9,12 +9,16 @@ set -euo pipefail
 
 MODE="${1:?Usage: setup-claude-md.sh <local|global>}"
 DOWNLOAD_URL="https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CANONICAL_CLAUDE_MD="${SCRIPT_PLUGIN_ROOT}/docs/CLAUDE.md"
 
 # Determine target path
 if [ "$MODE" = "local" ]; then
   mkdir -p .claude
   TARGET_PATH=".claude/CLAUDE.md"
 elif [ "$MODE" = "global" ]; then
+  mkdir -p "$HOME/.claude"
   TARGET_PATH="$HOME/.claude/CLAUDE.md"
 else
   echo "ERROR: Invalid mode '$MODE'. Use 'local' or 'global'." >&2
@@ -38,15 +42,32 @@ if [ -f "$TARGET_PATH" ]; then
   echo "Backed up existing CLAUDE.md to $BACKUP_PATH"
 fi
 
-# Download fresh OMC content to temp file
+# Load canonical OMC content to temp file
 TEMP_OMC=$(mktemp /tmp/omc-claude-XXXXXX.md)
 trap 'rm -f "$TEMP_OMC"' EXIT
-curl -fsSL "$DOWNLOAD_URL" -o "$TEMP_OMC"
+
+SOURCE_LABEL=""
+if [ -f "$CANONICAL_CLAUDE_MD" ]; then
+  cp "$CANONICAL_CLAUDE_MD" "$TEMP_OMC"
+  SOURCE_LABEL="$CANONICAL_CLAUDE_MD"
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/docs/CLAUDE.md" ]; then
+  cp "${CLAUDE_PLUGIN_ROOT}/docs/CLAUDE.md" "$TEMP_OMC"
+  SOURCE_LABEL="${CLAUDE_PLUGIN_ROOT}/docs/CLAUDE.md"
+else
+  curl -fsSL "$DOWNLOAD_URL" -o "$TEMP_OMC"
+  SOURCE_LABEL="$DOWNLOAD_URL"
+fi
 
 if [ ! -s "$TEMP_OMC" ]; then
   echo "ERROR: Failed to download CLAUDE.md. Aborting."
   echo "FALLBACK: Manually download from: $DOWNLOAD_URL"
   rm -f "$TEMP_OMC"
+  exit 1
+fi
+
+if ! grep -q '<!-- OMC:START -->' "$TEMP_OMC" || ! grep -q '<!-- OMC:END -->' "$TEMP_OMC"; then
+  echo "ERROR: Canonical CLAUDE.md source is missing required OMC markers: $SOURCE_LABEL" >&2
+  echo "Refusing to install a summarized or malformed CLAUDE.md." >&2
   exit 1
 fi
 
@@ -117,6 +138,11 @@ else
     echo "Migrated existing CLAUDE.md (added OMC markers, preserved old content)"
   fi
   rm -f "$TEMP_OMC"
+fi
+
+if ! grep -q '<!-- OMC:START -->' "$TARGET_PATH" || ! grep -q '<!-- OMC:END -->' "$TARGET_PATH"; then
+  echo "ERROR: Installed CLAUDE.md is missing required OMC markers: $TARGET_PATH" >&2
+  exit 1
 fi
 
 # Extract new version and report

--- a/skills/omc-setup/phases/01-install-claude-md.md
+++ b/skills/omc-setup/phases/01-install-claude-md.md
@@ -17,13 +17,20 @@ Set `CONFIG_TARGET` to `local` or `global` based on user's choice.
 
 ## Download and Install CLAUDE.md
 
-**MANDATORY**: Always run this command. Do NOT skip. Do NOT use the Write tool. Use bash curl exclusively.
+**MANDATORY**: Always run this command. Do NOT skip. Do NOT use the Write tool. Let the setup script choose the safest canonical source (bundled `docs/CLAUDE.md` first, GitHub fallback only if needed).
 
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-claude-md.sh" <CONFIG_TARGET>
 ```
 
 Replace `<CONFIG_TARGET>` with `local` or `global`.
+
+The script must install the canonical `docs/CLAUDE.md` content and preserve the required
+`<!-- OMC:START -->` / `<!-- OMC:END -->` markers. Do **not** hand-write, summarize, or
+partially reconstruct CLAUDE.md.
+
+After running the script, verify the target file contains both markers. If marker validation
+fails, stop and report the failure instead of writing CLAUDE.md manually.
 
 **FALLBACK** if curl fails:
 Tell user to manually download from:

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const SETUP_SCRIPT = join(REPO_ROOT, 'scripts', 'setup-claude-md.sh');
+
+const tempRoots: string[] = [];
+
+function createPluginFixture(claudeMdContent: string) {
+  const root = mkdtempSync(join(tmpdir(), 'omc-setup-claude-md-'));
+  tempRoots.push(root);
+
+  const pluginRoot = join(root, 'plugin');
+  const projectRoot = join(root, 'project');
+  const homeRoot = join(root, 'home');
+
+  mkdirSync(join(pluginRoot, 'scripts'), { recursive: true });
+  mkdirSync(join(pluginRoot, 'docs'), { recursive: true });
+  mkdirSync(projectRoot, { recursive: true });
+  mkdirSync(homeRoot, { recursive: true });
+
+  copyFileSync(SETUP_SCRIPT, join(pluginRoot, 'scripts', 'setup-claude-md.sh'));
+  writeFileSync(join(pluginRoot, 'docs', 'CLAUDE.md'), claudeMdContent);
+
+  return {
+    pluginRoot,
+    projectRoot,
+    homeRoot,
+    scriptPath: join(pluginRoot, 'scripts', 'setup-claude-md.sh'),
+  };
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('setup-claude-md.sh (issue #1572)', () => {
+  it('installs the canonical docs/CLAUDE.md content with OMC markers', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'local'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+
+    const installedPath = join(fixture.projectRoot, '.claude', 'CLAUDE.md');
+    expect(existsSync(installedPath)).toBe(true);
+
+    const installed = readFileSync(installedPath, 'utf-8');
+    expect(installed).toContain('<!-- OMC:START -->');
+    expect(installed).toContain('<!-- OMC:END -->');
+    expect(installed).toContain('<!-- OMC:VERSION:9.9.9 -->');
+    expect(installed).toContain('# Canonical CLAUDE');
+  });
+
+  it('refuses to install a canonical source that lacks OMC markers', () => {
+    const fixture = createPluginFixture(`# oh-my-claudecode (OMC) v9.9.9 Summary
+
+This is a summarized CLAUDE.md without markers.
+`);
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'local'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain('missing required OMC markers');
+    expect(existsSync(join(fixture.projectRoot, '.claude', 'CLAUDE.md'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- make `scripts/setup-claude-md.sh` prefer the bundled canonical `docs/CLAUDE.md` before falling back to GitHub
- fail fast when the source or installed `CLAUDE.md` is missing `<!-- OMC:START -->` / `<!-- OMC:END -->`
- add a focused regression test for the real `omc-setup` Phase 1 shell-script path

## Root cause
`/oh-my-claudecode:omc-setup` Phase 1 shells out to `scripts/setup-claude-md.sh`. If that flow consumed summarized or malformed content, it could still write `CLAUDE.md` without the required OMC markers, which then broke doctor/feature detection.

## Testing
- `npx vitest run src/__tests__/setup-claude-md-script.test.ts src/skills/__tests__/mingw-escape.test.ts`
- `npx tsc --noEmit`

Closes #1572.
