### PR TITLE
fix: clean stale team workers and HUD state after team clear

### DIFF
--- a/scripts/cleanup-orphans.mjs
+++ b/scripts/cleanup-orphans.mjs
@@ -71,14 +71,17 @@ function findOrphanProcesses(filterTeam) {
       const output = execSync('ps aux', { encoding: 'utf-8', timeout: 10000 });
 
       for (const line of output.split('\n')) {
-        // Match claude agent processes with team context
-        if ((line.includes('claude') || line.includes('node')) &&
-            (line.includes('--team-name') || line.includes('team_name'))) {
-
-          // Restrict team name match to valid slug characters
-          const match = line.match(/--team-name[=\s]+([\w][\w-]{0,63})/i) || line.match(/team_name[=:]\s*"?([\w][\w-]{0,63})"?/i);
-          if (match) {
-            const procTeam = match[1];
+        // Match claude/codex/gemini agent processes with team context
+        if ((line.includes('claude') || line.includes('codex') || line.includes('gemini') || line.includes('node'))) {
+          // Restrict team name match to valid slug characters.
+          // Support both native TeamDelete-style args and tmux worker env assignments.
+          const match =
+            line.match(/--team-name[=\s]+([\w][\w-]{0,63})/i)
+            || line.match(/team_name[=:]\s*"?([\w][\w-]{0,63})"?/i)
+            || line.match(/OM[CX]_TEAM_NAME=(['"]?)([\w][\w-]{0,63})\1/i)
+            || line.match(/OM[CX]_TEAM_WORKER=(['"]?)([\w][\w-]{0,63})\/worker-\d+\1/i);
+          const procTeam = match?.[2] || match?.[1];
+          if (procTeam) {
             if (filterTeam && procTeam !== filterTeam) continue;
 
             const parts = line.trim().split(/\s+/);

--- a/src/tools/__tests__/cancel-integration.test.ts
+++ b/src/tools/__tests__/cancel-integration.test.ts
@@ -295,17 +295,30 @@ describe('cancel-integration', () => {
       const sessionId = 'team-cancel-test';
       const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
       mkdirSync(sessionDir, { recursive: true });
+      const runtimeTeamDir = join(TEST_DIR, '.omc', 'state', 'team', 'demo-team');
+      mkdirSync(runtimeTeamDir, { recursive: true });
 
       // Create team state at session path
       writeFileSync(
         join(sessionDir, 'team-state.json'),
-        JSON.stringify({ active: true, phase: 'team-exec', _meta: { sessionId } })
+        JSON.stringify({ active: true, phase: 'team-exec', team_name: 'demo-team', _meta: { sessionId } })
       );
 
       // Create ghost legacy team state with matching session
       writeFileSync(
         join(TEST_DIR, '.omc', 'state', 'team-state.json'),
-        JSON.stringify({ active: true, phase: 'team-exec', _meta: { sessionId } })
+        JSON.stringify({ active: true, phase: 'team-exec', team_name: 'demo-team', _meta: { sessionId } })
+      );
+
+      writeFileSync(
+        join(TEST_DIR, '.omc', 'state', 'mission-state.json'),
+        JSON.stringify({
+          updatedAt: new Date().toISOString(),
+          missions: [
+            { id: 'team:demo-team', source: 'team', teamName: 'demo-team', name: 'demo-team' },
+            { id: 'session:keep', source: 'session', name: 'keep-session' },
+          ],
+        })
       );
 
       const result = await stateClearTool.handler({
@@ -317,9 +330,17 @@ describe('cancel-integration', () => {
       // Both files should be cleaned
       expect(existsSync(join(sessionDir, 'team-state.json'))).toBe(false);
       expect(existsSync(join(TEST_DIR, '.omc', 'state', 'team-state.json'))).toBe(false);
+      expect(existsSync(runtimeTeamDir)).toBe(false);
+
+      const missionState = JSON.parse(readFileSync(join(TEST_DIR, '.omc', 'state', 'mission-state.json'), 'utf-8'));
+      expect(missionState.missions).toEqual([
+        { id: 'session:keep', source: 'session', name: 'keep-session' },
+      ]);
 
       expect(result.content[0].text).toContain('Successfully cleared');
       expect(result.content[0].text).toContain('ghost legacy file also removed');
+      expect(result.content[0].text).toContain('removed 1 team runtime root');
+      expect(result.content[0].text).toContain('pruned 1 HUD mission entry');
     });
 
     it('should clear team state at session path while preserving unrelated legacy', async () => {
@@ -351,6 +372,37 @@ describe('cancel-integration', () => {
 
       // Legacy file should be preserved (different session)
       expect(existsSync(join(TEST_DIR, '.omc', 'state', 'team-state.json'))).toBe(true);
+    });
+
+    it('should remove all team runtime roots on broad team clear', async () => {
+      mkdirSync(join(TEST_DIR, '.omc', 'state', 'team', 'alpha-team'), { recursive: true });
+      mkdirSync(join(TEST_DIR, '.omc', 'state', 'team', 'beta-team'), { recursive: true });
+      writeFileSync(
+        join(TEST_DIR, '.omc', 'state', 'mission-state.json'),
+        JSON.stringify({
+          updatedAt: new Date().toISOString(),
+          missions: [
+            { id: 'team:alpha-team', source: 'team', teamName: 'alpha-team', name: 'alpha-team' },
+            { id: 'team:beta-team', source: 'team', teamName: 'beta-team', name: 'beta-team' },
+            { id: 'session:keep', source: 'session', name: 'keep-session' },
+          ],
+        })
+      );
+
+      const result = await stateClearTool.handler({
+        mode: 'team',
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(existsSync(join(TEST_DIR, '.omc', 'state', 'team'))).toBe(false);
+
+      const missionState = JSON.parse(readFileSync(join(TEST_DIR, '.omc', 'state', 'mission-state.json'), 'utf-8'));
+      expect(missionState.missions).toEqual([
+        { id: 'session:keep', source: 'session', name: 'keep-session' },
+      ]);
+
+      expect(result.content[0].text).toContain('Team runtime roots removed: 1');
+      expect(result.content[0].text).toContain('HUD mission entries pruned: 2');
     });
   });
 });

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -6,7 +6,8 @@
  */
 
 import { z } from 'zod';
-import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import {
   resolveStatePath,
   ensureOmcDir,
@@ -15,6 +16,7 @@ import {
   ensureSessionStateDir,
   listSessionIds,
   validateSessionId,
+  getOmcRoot,
 } from '../lib/worktree-paths.js';
 import { atomicWriteJsonSync } from '../lib/atomic-write.js';
 import { validatePayload } from '../lib/payload-limits.js';
@@ -45,6 +47,90 @@ const STATE_TOOL_MODES: [string, ...string[]] = [
 const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'deep-interview'] as const;
 type StateToolMode = typeof STATE_TOOL_MODES[number];
 const CANCEL_SIGNAL_TTL_MS = 30_000;
+
+function readTeamNamesFromStateFile(statePath: string): string[] {
+  if (!existsSync(statePath)) return [];
+
+  try {
+    const raw = JSON.parse(readFileSync(statePath, 'utf-8')) as Record<string, unknown>;
+    const teamName = typeof raw.team_name === 'string'
+      ? raw.team_name.trim()
+      : typeof raw.teamName === 'string'
+        ? raw.teamName.trim()
+        : '';
+    return teamName ? [teamName] : [];
+  } catch {
+    return [];
+  }
+}
+
+function pruneMissionBoardTeams(root: string, teamNames?: string[]): number {
+  const missionStatePath = join(getOmcRoot(root), 'state', 'mission-state.json');
+  if (!existsSync(missionStatePath)) return 0;
+
+  try {
+    const parsed = JSON.parse(readFileSync(missionStatePath, 'utf-8')) as {
+      updatedAt?: string;
+      missions?: Array<Record<string, unknown>>;
+    };
+    if (!Array.isArray(parsed.missions)) return 0;
+
+    const shouldRemoveAll = teamNames == null;
+    const teamNameSet = new Set(teamNames ?? []);
+    const remainingMissions = parsed.missions.filter((mission) => {
+      if (mission.source !== 'team') return true;
+      if (shouldRemoveAll) return false;
+      const missionTeamName = typeof mission.teamName === 'string'
+        ? mission.teamName.trim()
+        : typeof mission.name === 'string'
+          ? mission.name.trim()
+          : '';
+      return !missionTeamName || !teamNameSet.has(missionTeamName);
+    });
+
+    const removed = parsed.missions.length - remainingMissions.length;
+    if (removed > 0) {
+      writeFileSync(missionStatePath, JSON.stringify({
+        ...parsed,
+        updatedAt: new Date().toISOString(),
+        missions: remainingMissions,
+      }, null, 2));
+    }
+
+    return removed;
+  } catch {
+    return 0;
+  }
+}
+
+function cleanupTeamRuntimeState(root: string, teamNames?: string[]): number {
+  const teamStateRoot = join(getOmcRoot(root), 'state', 'team');
+  if (!existsSync(teamStateRoot)) return 0;
+
+  const shouldRemoveAll = teamNames == null;
+  let removed = 0;
+
+  if (shouldRemoveAll) {
+    try {
+      rmSync(teamStateRoot, { recursive: true, force: true });
+      return 1;
+    } catch {
+      return 0;
+    }
+  }
+
+  for (const teamName of teamNames ?? []) {
+    if (!teamName) continue;
+    try {
+      rmSync(join(teamStateRoot, teamName), { recursive: true, force: true });
+      removed += 1;
+    } catch {
+      // best effort
+    }
+  }
+
+  return removed;
+}
 
 /**
  * Get the state file path for any mode (including swarm and ralplan).
@@ -348,10 +434,20 @@ export const stateClearTool: ToolDefinition<{
     try {
       const root = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
+      const cleanedTeamNames = new Set<string>();
+
+      const collectTeamNamesForCleanup = (statePath: string): void => {
+        if (mode !== 'team') return;
+        for (const teamName of readTeamNamesFromStateFile(statePath)) {
+          cleanedTeamNames.add(teamName);
+        }
+      };
 
       // If session_id provided, clear only session-specific state
       if (sessionId) {
         validateSessionId(sessionId);
+        collectTeamNamesForCleanup(resolveSessionStatePath('team', sessionId, root));
+        collectTeamNamesForCleanup(getStateFilePath(root, 'team', sessionId));
         const now = Date.now();
         const cancelSignalPath = resolveSessionStatePath('cancel-signal', sessionId, root);
         atomicWriteJsonSync(cancelSignalPath, {
@@ -384,18 +480,28 @@ export const stateClearTool: ToolDefinition<{
           }
 
           const ghostNote = ghostCleaned ? ' (ghost legacy file also removed)' : '';
+          const runtimeCleanupNote = (() => {
+            if (mode !== 'team') return '';
+            const teamNames = [...cleanedTeamNames];
+            const removedRoots = cleanupTeamRuntimeState(root, teamNames);
+            const prunedMissions = pruneMissionBoardTeams(root, teamNames);
+            const details: string[] = [];
+            if (removedRoots > 0) details.push(`removed ${removedRoots} team runtime root(s)`);
+            if (prunedMissions > 0) details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
+            return details.length > 0 ? ` (${details.join(', ')})` : '';
+          })();
           if (success) {
             return {
               content: [{
                 type: 'text' as const,
-                text: `Successfully cleared state for mode: ${mode} in session: ${sessionId}${ghostNote}`
+                text: `Successfully cleared state for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
               }]
             };
           } else {
             return {
               content: [{
                 type: 'text' as const,
-                text: `Warning: Some files could not be removed for mode: ${mode} in session: ${sessionId}${ghostNote}`
+                text: `Warning: Some files could not be removed for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
               }]
             };
           }
@@ -424,10 +530,20 @@ export const stateClearTool: ToolDefinition<{
         }
 
         const ghostNote = ghostCleaned ? ' (ghost legacy file also removed)' : '';
+        const runtimeCleanupNote = (() => {
+          if (mode !== 'team') return '';
+          const teamNames = [...cleanedTeamNames];
+          const removedRoots = cleanupTeamRuntimeState(root, teamNames);
+          const prunedMissions = pruneMissionBoardTeams(root, teamNames);
+          const details: string[] = [];
+          if (removedRoots > 0) details.push(`removed ${removedRoots} team runtime root(s)`);
+          if (prunedMissions > 0) details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
+          return details.length > 0 ? ` (${details.join(', ')})` : '';
+        })();
         return {
           content: [{
             type: 'text' as const,
-            text: `Successfully cleared state for mode: ${mode} in session: ${sessionId}${ghostNote}`
+            text: `Successfully cleared state for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
           }]
         };
       }
@@ -435,6 +551,9 @@ export const stateClearTool: ToolDefinition<{
       // No session_id: clear from all locations (legacy + all sessions)
       let clearedCount = 0;
       const errors: string[] = [];
+      if (mode === 'team') {
+        collectTeamNamesForCleanup(getStateFilePath(root, 'team'));
+      }
 
       // Clear legacy path
       if (MODE_CONFIGS[mode as ExecutionMode]) {
@@ -462,6 +581,9 @@ export const stateClearTool: ToolDefinition<{
       // Clear all session-scoped state files
       const sessionIds = listSessionIds(root);
       for (const sid of sessionIds) {
+        if (mode === 'team') {
+          collectTeamNamesForCleanup(resolveSessionStatePath('team', sid, root));
+        }
         if (MODE_CONFIGS[mode as ExecutionMode]) {
           // Only clear if state file exists - avoid false counts for missing files
           const sessionStatePath = getStateFilePath(root, mode as ExecutionMode, sid);
@@ -485,7 +607,16 @@ export const stateClearTool: ToolDefinition<{
         }
       }
 
-      if (clearedCount === 0 && errors.length === 0) {
+      let removedTeamRoots = 0;
+      let prunedMissionEntries = 0;
+      if (mode === 'team') {
+        const teamNames = [...cleanedTeamNames];
+        const removeSelector = teamNames.length > 0 ? teamNames : undefined;
+        removedTeamRoots = cleanupTeamRuntimeState(root, removeSelector);
+        prunedMissionEntries = pruneMissionBoardTeams(root, removeSelector);
+      }
+
+      if (clearedCount === 0 && errors.length === 0 && removedTeamRoots === 0 && prunedMissionEntries === 0) {
         return {
           content: [{
             type: 'text' as const,
@@ -497,6 +628,14 @@ export const stateClearTool: ToolDefinition<{
       let message = `Cleared state for mode: ${mode}\n- Locations cleared: ${clearedCount}`;
       if (errors.length > 0) {
         message += `\n- Errors: ${errors.join(', ')}`;
+      }
+      if (mode === 'team') {
+        if (removedTeamRoots > 0) {
+          message += `\n- Team runtime roots removed: ${removedTeamRoots}`;
+        }
+        if (prunedMissionEntries > 0) {
+          message += `\n- HUD mission entries pruned: ${prunedMissionEntries}`;
+        }
       }
       message += '\nWARNING: No session_id provided. Cleared legacy plus all session-scoped state; this is a broad operation that may affect other sessions.';
 


### PR DESCRIPTION
## Summary
- clean `.omc/state/team/<team>` runtime directories when `state_clear(mode="team")` clears team mode state
- prune persisted HUD mission-board team entries during team state clear so stale worker rows disappear
- broaden orphan worker detection to match tmux-launched workers carrying `OMC_TEAM_WORKER` / `OMX_TEAM_WORKER`
- add focused regression coverage for team state clear cleanup

## Problem
Issue #1575 reports that after TeamDelete and `state_clear(mode="team")`, stale `@worker-*` entries remain in the HUD and orphan worker processes can survive because cleanup paths were split:
- `state_clear(mode="team")` only removed `team-state.json`
- HUD team rows were derived from `.omc/state/team/<team>/...`
- orphan scan missed tmux worker processes launched via `OMC_TEAM_WORKER` env assignments

## Fix
- extend `state_clear(mode="team")` to also remove matching runtime team roots under `.omc/state/team/`
- prune matching team missions from `mission-state.json` so HUD refreshes stop showing stale workers
- update `scripts/cleanup-orphans.mjs` to detect team context from:
  - `--team-name ...`
  - `team_name=...`
  - `OMC_TEAM_NAME=...` / `OMX_TEAM_NAME=...`
  - `OMC_TEAM_WORKER=<team>/worker-N` / `OMX_TEAM_WORKER=<team>/worker-N`

## Validation
- `npx vitest run src/tools/__tests__/cancel-integration.test.ts`
- `npx vitest run src/cli/__tests__/team.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/tools/state-tools.ts src/tools/__tests__/cancel-integration.test.ts`
- `node --check scripts/cleanup-orphans.mjs`

Closes #1575.
