### PR TITLE
fix(team): remove double shell-escaping of env vars in worker spawn

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -238,6 +238,57 @@ describe('buildWorkerStartCommand', () => {
     expect(cmd).toContain('; and source');
   });
 
+  it('does not double-escape env vars in launchBinary mode (issue #1415)', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    vi.stubEnv('SHELL', '/bin/zsh');
+    vi.stubEnv('HOME', '/home/tester');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: {
+        ANTHROPIC_MODEL: 'us.anthropic.claude-sonnet-4-6-v1[1m]',
+        CLAUDE_CODE_USE_BEDROCK: '1',
+      },
+      launchBinary: '/usr/local/bin/claude',
+      launchArgs: ['--dangerously-skip-permissions'],
+      cwd: '/tmp'
+    });
+
+    // env assignments must appear WITHOUT extra wrapping quotes.
+    // Correct:   ANTHROPIC_MODEL='us.anthropic.claude-sonnet-4-6-v1[1m]'
+    // Wrong:     'ANTHROPIC_MODEL='"'"'us.anthropic...'"'"''  (double-escaped)
+    expect(cmd).toContain("ANTHROPIC_MODEL='us.anthropic.claude-sonnet-4-6-v1[1m]'");
+    expect(cmd).toContain("CLAUDE_CODE_USE_BEDROCK='1'");
+
+    // The env keyword and other args should still be shell-escaped
+    expect(cmd).toMatch(/^'env'/);
+    expect(cmd).toContain("'/usr/local/bin/claude'");
+    expect(cmd).toContain("'--dangerously-skip-permissions'");
+  });
+
+  it('env vars with special characters survive single escaping correctly', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    vi.stubEnv('SHELL', '/bin/bash');
+    vi.stubEnv('HOME', '/home/tester');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: {
+        OMC_TEAM_WORKER: 'my-team/worker-1',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'global.anthropic.claude-sonnet-4-6[1m]',
+      },
+      launchBinary: '/usr/local/bin/claude',
+      launchArgs: [],
+      cwd: '/tmp'
+    });
+
+    // Values with / and [] must be preserved without extra quoting
+    expect(cmd).toContain("OMC_TEAM_WORKER='my-team/worker-1'");
+    expect(cmd).toContain("ANTHROPIC_DEFAULT_SONNET_MODEL='global.anthropic.claude-sonnet-4-6[1m]'");
+  });
+
   it('rejects relative launchBinary containing spaces', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -180,15 +180,16 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
     // Fish doesn't support combined -lc; use separate -l -c flags
     const shellFlags = isFish ? ['-l', '-c'] : ['-lc'];
 
+    // envAssignments are already shell-escaped (KEY='value'), so they must
+    // NOT go through shellEscape again — that would wrap them in a second
+    // layer of quotes, causing `env` to receive literal quote characters
+    // in the values (e.g. ANTHROPIC_MODEL="'us.anthropic...'" instead of
+    // ANTHROPIC_MODEL="us.anthropic..."). Issue #1415.
     return [
-      'env',
+      shellEscape('env'),
       ...envAssignments,
-      shell,
-      ...shellFlags,
-      script,
-      '--',
-      ...launchWords,
-    ].map(shellEscape).join(' ');
+      ...[shell, ...shellFlags, script, '--', ...launchWords].map(shellEscape),
+    ].join(' ');
   }
 
   const envString = Object.entries(config.envVars)


### PR DESCRIPTION
## Summary

- Fixes the root cause of Bedrock team worker 400 errors (`claude-sonnet-4-6` invalid model)
- `buildWorkerStartCommand` applied `shellEscape` twice to env var values: once in `envAssignments` construction, then again via `.map(shellEscape)` on the final array
- This caused `env` to receive values wrapped in **literal single quotes**, corrupting every forwarded env var

## Root Cause (empirically proven)

```
# Current code (double-escaped) — BROKEN:
ANTHROPIC_MODEL='us.anthropic.claude-opus-4-6-v1[1m]'     ← literal quotes in value
CLAUDE_CODE_USE_BEDROCK='1'                                 ← '1' !== '1', Bedrock detection fails

# Fixed code (single-escaped) — CORRECT:
ANTHROPIC_MODEL=us.anthropic.claude-opus-4-6-v1[1m]        ← clean value
CLAUDE_CODE_USE_BEDROCK=1                                    ← matches === '1'
```

The double-escaping caused spawned team workers to:
1. Not detect Bedrock (`CLAUDE_CODE_USE_BEDROCK='1'` !== `'1'`)
2. Not inherit the parent's model (`ANTHROPIC_MODEL` corrupted with literal quotes)
3. Fall back to Claude Code's built-in default: `claude-sonnet-4-6`
4. Bedrock rejects `claude-sonnet-4-6` with 400 error

## Fix

Exclude already-escaped `envAssignments` from the final `.map(shellEscape)` pass in `buildWorkerStartCommand`. The env assignments are already shell-safe (`KEY='value'`), so the second escaping layer wraps them in additional quotes that become literal characters.

## Test plan

- [x] New test: `does not double-escape env vars in launchBinary mode (issue #1415)` — verifies Bedrock model IDs with `[1m]` suffix pass through without extra quotes
- [x] New test: `env vars with special characters survive single escaping correctly` — verifies values with `/` and `[]` are preserved
- [x] All 32 existing tmux-session tests pass (no regressions)
- [x] Empirically verified by executing the actual compiled plugin modules and comparing env var values

Fixes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)