### PR TITLE
fix(skill-state): default unknown skills to no protection

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -345,7 +345,7 @@ const SKILL_PROTECTION_MAP = {
 
 function getSkillProtectionLevel(skillName) {
   const normalized = (skillName || '').toLowerCase().replace(/^oh-my-claudecode:/, '');
-  return SKILL_PROTECTION_MAP[normalized] || 'light';
+  return SKILL_PROTECTION_MAP[normalized] || 'none';
 }
 
 function extractSkillName(toolInput) {

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -285,5 +285,23 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
 
     expect(output.continue).toBe(true);
     expect(output.decision).toBeUndefined();
+  });
+
+  it('does not write skill-active-state for unknown custom skills', () => {
+    const sessionId = 'session-1581';
+
+    const output = runPreToolEnforcer({
+      tool_name: 'Skill',
+      toolInput: {
+        skill: 'phase-resume',
+      },
+      cwd: tempDir,
+      session_id: sessionId,
+    });
+
+    expect(output).toEqual({ continue: true, suppressOutput: true });
+    expect(
+      existsSync(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'skill-active-state.json')),
+    ).toBe(false);
   });
 });

--- a/src/hooks/skill-state/__tests__/skill-state.test.ts
+++ b/src/hooks/skill-state/__tests__/skill-state.test.ts
@@ -52,6 +52,7 @@ describe('skill-state', () => {
 
     it('returns light only for explicitly protected simple utility skills', () => {
       expect(getSkillProtection('skill')).toBe('light');
+      expect(getSkillProtection('configure-notifications')).toBe('light');
       expect(getSkillProtection('build-fix')).toBe('none');
       expect(getSkillProtection('analyze')).toBe('none');
     });
@@ -132,6 +133,14 @@ describe('skill-state', () => {
     it('returns null for skills with none protection', () => {
       const state = writeSkillActiveState(tempDir, 'ralph', 'session-1');
       expect(state).toBeNull();
+    });
+
+    it('does not write state for unknown/custom skills', () => {
+      const state = writeSkillActiveState(tempDir, 'phase-resume', 'session-1');
+
+      expect(state).toBeNull();
+      expect(readSkillActiveState(tempDir, 'session-1')).toBeNull();
+      expect(existsSync(join(tempDir, '.omc', 'state', 'sessions', 'session-1'))).toBe(false);
     });
 
     it('creates state file on disk', () => {


### PR DESCRIPTION
## Summary
- default unknown/custom skill protection to `none` in both skill-state lookup paths
- add focused regressions proving custom skills do not write `skill-active-state.json` through the Skill tool path
- keep existing named-skill map divergence out of scope for this minimal fix

## Validation
- `npx vitest run src/hooks/skill-state/__tests__/skill-state.test.ts src/__tests__/pre-tool-enforcer.test.ts`
- `npx eslint src/hooks/skill-state/index.ts src/hooks/skill-state/__tests__/skill-state.test.ts src/__tests__/pre-tool-enforcer.test.ts`
- `npx tsc --noEmit`

Closes #1581