### PR TITLE
fix(config): replace hard-coded absolute path in vitest alias

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -22,7 +23,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': '/home/bellman/Workspace/Oh-My-ClaudeCode-OMC-b2.0.0/src',
+      '@': path.resolve(__dirname, 'src'),
     },
   },
 });


### PR DESCRIPTION
## Summary

- The `@` path alias in `vitest.config.ts` pointed to a specific developer's local directory (`/home/bellman/Workspace/Oh-My-ClaudeCode-OMC-b2.0.0/src`), which breaks test path resolution for all other contributors and CI environments.
- Replaced with `path.resolve(__dirname, 'src')` for portable resolution across any machine.

## Changes

- Added `import path from 'path'`
- Changed `'@'` alias value from hard-coded absolute path to `path.resolve(__dirname, 'src')`

## Test plan

- [ ] Verify `@` alias resolves correctly in test imports
- [ ] Run `npx vitest --run` to confirm no regressions