### PR TITLE
fix(config): replace hard-coded absolute path in vitest alias

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -22,7 +23,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': '/home/bellman/Workspace/Oh-My-ClaudeCode-OMC-b2.0.0/src',
+      '@': path.resolve(__dirname, 'src'),
     },
   },
 });


### PR DESCRIPTION
## Summary

- replace hard-coded developer-local absolute path (`/home/bellman/Workspace/...`) in `vitest.config.ts` `@` alias with portable `path.resolve(__dirname, 'src')`
- ensures test path resolution works correctly for all contributors and CI environments

## Testing

- `npx vitest --run` to confirm `@` alias resolves correctly
- `npm run build`
- `npm run lint`