### PR TITLE
fix(hooks): deactivate ultrawork state on max reinforcements and clean mission-state on session-end

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -932,7 +932,14 @@ async function main() {
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 
       if (newCount > maxReinforcements) {
-        // Max reinforcements reached - allow stop
+        // Max reinforcements reached - deactivate state before allowing stop
+        // Without this, state stays active: true and HUD keeps showing ultrawork
+        try {
+          ultrawork.state.active = false;
+          ultrawork.state.deactivated_reason = 'max_reinforcements_reached';
+          ultrawork.state.last_checked_at = new Date().toISOString();
+          writeJsonFile(ultrawork.path, ultrawork.state);
+        } catch { /* best-effort cleanup */ }
         console.log(JSON.stringify({ continue: true, suppressOutput: true }));
         return;
       }
@@ -949,8 +956,11 @@ async function main() {
       if (totalIncomplete > 0) {
         const itemType = taskCount > 0 ? "Tasks" : "todos";
         reason += ` ${totalIncomplete} incomplete ${itemType} remain. Continue working.`;
+      } else if (newCount >= 5) {
+        // Strong directive: LLM must call cancel NOW
+        reason += ` No incomplete tasks detected. You MUST invoke /oh-my-claudecode:cancel immediately to exit ultrawork mode and clean up state files. Call state_clear(mode="ultrawork") if the cancel skill is unavailable.`;
       } else if (newCount >= 3) {
-        // Only suggest cancel after minimum iterations (guard against no-tasks-created scenario)
+        // Suggest cancel after minimum iterations
         reason += ` If all work is complete, run /oh-my-claudecode:cancel to cleanly exit ultrawork mode and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force. Otherwise, continue working.`;
       } else {
         // Early iterations with no tasks yet - just tell LLM to continue

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { execSync } from "child_process";
@@ -620,6 +620,37 @@ describe("Stop Hook Blocking Contract", () => {
         sessionId,
       });
       expect(output.continue).toBe(true);
+    });
+
+    it("deactivates ultrawork state when max reinforcements reached", () => {
+      const sessionId = "ulw-max-reinforce-cjs";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      const statePath = join(sessionDir, "ultrawork-state.json");
+      writeFileSync(
+        statePath,
+        JSON.stringify({
+          active: true,
+          session_id: sessionId,
+          reinforcement_count: 51,
+          max_reinforcements: 50,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          project_path: tempDir,
+        })
+      );
+
+      const output = runScript({
+        directory: tempDir,
+        sessionId,
+      });
+      // Should allow stop
+      expect(output.continue).toBe(true);
+
+      // State should be deactivated
+      const updatedState = JSON.parse(readFileSync(statePath, "utf-8"));
+      expect(updatedState.active).toBe(false);
+      expect(updatedState.deactivated_reason).toBe("max_reinforcements_reached");
     });
 
     it("applies Team circuit breaker in cjs script", () => {

--- a/src/hooks/session-end/__tests__/mode-state-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/mode-state-cleanup.test.ts
@@ -178,4 +178,40 @@ describe('processSessionEnd mode state cleanup (issue #1427)', () => {
     expect(fs.existsSync(sessionStatePath)).toBe(false);
     expect(fs.existsSync(legacyStatePath)).toBe(false);
   });
+
+  it('cleans up mission-state.json entries for the ending session', async () => {
+    const endingSessionId = 'pid-mission-ending';
+    const otherSessionId = 'pid-mission-other';
+    const stateDir = path.join(tmpDir, '.omc', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const missionStatePath = path.join(stateDir, 'mission-state.json');
+    fs.writeFileSync(
+      missionStatePath,
+      JSON.stringify({
+        updatedAt: new Date().toISOString(),
+        missions: [
+          { id: `ultrawork-${endingSessionId}`, source: 'session', label: 'ending session mission' },
+          { id: `ultrawork-${otherSessionId}`, source: 'session', label: 'other session mission' },
+          { id: 'team-pipeline-abc', source: 'team', label: 'team mission' },
+        ],
+      }),
+      'utf-8',
+    );
+
+    await processSessionEnd({
+      session_id: endingSessionId,
+      transcript_path: transcriptPath,
+      cwd: tmpDir,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    const updated = JSON.parse(fs.readFileSync(missionStatePath, 'utf-8'));
+    expect(updated.missions).toHaveLength(2);
+    expect(updated.missions.some((m: Record<string, unknown>) => m.id === `ultrawork-${otherSessionId}`)).toBe(true);
+    expect(updated.missions.some((m: Record<string, unknown>) => m.source === 'team')).toBe(true);
+    expect(updated.missions.some((m: Record<string, unknown>) => (m.id as string).includes(endingSessionId))).toBe(false);
+  });
 });

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -500,6 +500,59 @@ export function cleanupModeStates(directory: string, sessionId?: string): { file
 }
 
 /**
+ * Clean up mission-state.json entries belonging to this session.
+ * Without this, the HUD keeps showing stale mode/mission info after session end.
+ *
+ * When sessionId is provided, only removes missions whose source is 'session'
+ * and whose id contains the sessionId. When sessionId is omitted, removes all
+ * session-sourced missions.
+ */
+export function cleanupMissionState(directory: string, sessionId?: string): number {
+  const missionStatePath = path.join(getOmcRoot(directory), 'state', 'mission-state.json');
+
+  if (!fs.existsSync(missionStatePath)) {
+    return 0;
+  }
+
+  try {
+    const content = fs.readFileSync(missionStatePath, 'utf-8');
+    const parsed = JSON.parse(content) as {
+      updatedAt?: string;
+      missions?: Array<Record<string, unknown>>;
+    };
+
+    if (!Array.isArray(parsed.missions)) {
+      return 0;
+    }
+
+    const before = parsed.missions.length;
+    parsed.missions = parsed.missions.filter((mission) => {
+      // Keep non-session missions (e.g., team missions handled by state_clear)
+      if (mission.source !== 'session') return true;
+
+      // If sessionId provided, only remove missions for this session
+      if (sessionId) {
+        const missionId = typeof mission.id === 'string' ? mission.id : '';
+        return !missionId.includes(sessionId);
+      }
+
+      // No sessionId: remove all session-sourced missions
+      return false;
+    });
+
+    const removed = before - parsed.missions.length;
+    if (removed > 0) {
+      parsed.updatedAt = new Date().toISOString();
+      fs.writeFileSync(missionStatePath, JSON.stringify(parsed, null, 2));
+    }
+
+    return removed;
+  } catch {
+    return 0;
+  }
+}
+
+/**
  * Export session summary to .omc/sessions/
  */
 export function exportSessionSummary(directory: string, metrics: SessionMetrics): void {
@@ -547,6 +600,10 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   // This ensures the stop hook won't malfunction in subsequent sessions
   // Pass session_id to only clean up this session's states
   cleanupModeStates(directory, input.session_id);
+
+  // Clean up mission-state.json entries belonging to this session
+  // Without this, the HUD keeps showing stale mode/mission info
+  cleanupMissionState(directory, input.session_id);
 
   // Clean up Python REPL bridge sessions used in this transcript (#641).
   // Best-effort only: session end should not fail because cleanup fails.


### PR DESCRIPTION
## Summary

- **Stop hook**: Deactivate ultrawork state (`active: false`) when max reinforcements reached, preventing stale state from persisting
- **Stop hook**: Use stronger cancel directive when reinforcement >= 5 with no incomplete tasks, improving LLM compliance
- **Session-end**: Add `cleanupMissionState()` to remove session-scoped mission entries from `mission-state.json`, preventing HUD from showing stale mode info

Closes #1590

## Changes

| File | Change |
|------|--------|
| `scripts/persistent-mode.cjs` | Set `active: false` + `deactivated_reason` on max reinforcements; stronger cancel message at reinforcement >= 5 |
| `src/hooks/session-end/index.ts` | New `cleanupMissionState()` function; called in `processSessionEnd()` |
| `src/hooks/persistent-mode/stop-hook-blocking.test.ts` | New test: verifies state deactivation on max reinforcements |
| `src/hooks/session-end/__tests__/mode-state-cleanup.test.ts` | New test: verifies mission-state cleanup on session end |

## Test plan

- [x] `npx vitest run src/hooks/persistent-mode/stop-hook-blocking.test.ts` — 30/30 passed (includes new `deactivates ultrawork state when max reinforcements reached`)
- [x] `npx vitest run src/hooks/session-end/` — 61/61 passed (includes new `cleans up mission-state.json entries for the ending session`)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)