### PR TITLE
Fix HUD last-request token usage display

### DIFF
--- a/src/__tests__/hud/render.test.ts
+++ b/src/__tests__/hud/render.test.ts
@@ -468,3 +468,73 @@ describe('maxWidth wrapMode behavior', () => {
     expect(stringWidth(lines[0] ?? '')).toBeLessThanOrEqual(8);
   });
 });
+
+describe('token usage rendering', () => {
+  const createTokenContext = (): HudRenderContext => ({
+    contextPercent: 30,
+    modelName: 'claude-sonnet-4-5',
+    ralph: null,
+    ultrawork: null,
+    prd: null,
+    autopilot: null,
+    activeAgents: [],
+    todos: [],
+    backgroundTasks: [],
+    cwd: '/home/user/project',
+    lastSkill: null,
+    rateLimitsResult: null,
+    customBuckets: null,
+    pendingPermission: null,
+    thinkingState: null,
+    sessionHealth: { durationMinutes: 10, messageCount: 5, health: 'healthy' },
+    lastRequestTokenUsage: { inputTokens: 1250, outputTokens: 340 },
+    omcVersion: '4.5.4',
+    updateAvailable: null,
+    toolCallCount: 0,
+    agentCallCount: 0,
+    skillCallCount: 0,
+    promptTime: null,
+    apiKeySource: null,
+    profileName: null,
+  });
+
+  const createTokenConfig = (showTokens?: boolean): HudConfig => ({
+    preset: 'focused',
+    elements: {
+      ...DEFAULT_HUD_CONFIG.elements,
+      omcLabel: true,
+      rateLimits: false,
+      ralph: false,
+      autopilot: false,
+      prdStory: false,
+      activeSkills: false,
+      contextBar: false,
+      agents: false,
+      backgroundTasks: false,
+      todos: false,
+      promptTime: false,
+      sessionHealth: true,
+      showTokens,
+      maxOutputLines: 4,
+    },
+    thresholds: DEFAULT_HUD_CONFIG.thresholds,
+    staleTaskThresholdMinutes: 30,
+    contextLimitWarning: {
+      ...DEFAULT_HUD_CONFIG.contextLimitWarning,
+      threshold: 101,
+    },
+    usageApiPollIntervalMs: DEFAULT_HUD_CONFIG.usageApiPollIntervalMs,
+  });
+
+  it('shows last-request token usage when enabled', async () => {
+    const result = await render(createTokenContext(), createTokenConfig(true));
+
+    expect(result).toContain('tok:i1.3k/o340');
+  });
+
+  it('omits last-request token usage when explicitly disabled', async () => {
+    const result = await render(createTokenContext(), createTokenConfig(false));
+
+    expect(result).not.toContain('tok:');
+  });
+});

--- a/src/__tests__/hud/token-usage.test.ts
+++ b/src/__tests__/hud/token-usage.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { parseTranscript } from '../../hud/transcript.js';
+import { renderTokenUsage } from '../../hud/elements/token-usage.js';
+
+const tempDirs: string[] = [];
+
+function createTempTranscript(lines: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'omc-hud-token-usage-'));
+  tempDirs.push(dir);
+
+  const transcriptPath = join(dir, 'transcript.jsonl');
+  writeFileSync(
+    transcriptPath,
+    `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`,
+    'utf8',
+  );
+
+  return transcriptPath;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('HUD transcript token usage plumbing', () => {
+  it('captures the latest transcript message usage as last-request input/output tokens', async () => {
+    const transcriptPath = createTempTranscript([
+      {
+        timestamp: '2026-03-12T00:00:00.000Z',
+        message: {
+          usage: { input_tokens: 120, output_tokens: 45 },
+          content: [],
+        },
+      },
+      {
+        timestamp: '2026-03-12T00:01:00.000Z',
+        message: {
+          usage: { input_tokens: 1530, output_tokens: 987 },
+          content: [],
+        },
+      },
+    ]);
+
+    const result = await parseTranscript(transcriptPath);
+
+    expect(result.lastRequestTokenUsage).toEqual({
+      inputTokens: 1530,
+      outputTokens: 987,
+    });
+  });
+
+  it('treats missing token fields as zero when transcript usage only exposes one side', async () => {
+    const transcriptPath = createTempTranscript([
+      {
+        timestamp: '2026-03-12T00:00:00.000Z',
+        message: {
+          usage: { output_tokens: 64 },
+          content: [],
+        },
+      },
+    ]);
+
+    const result = await parseTranscript(transcriptPath);
+
+    expect(result.lastRequestTokenUsage).toEqual({
+      inputTokens: 0,
+      outputTokens: 64,
+    });
+  });
+});
+
+describe('HUD token usage rendering', () => {
+  it('formats last-request token usage as plain ASCII input/output counts', () => {
+    expect(renderTokenUsage({ inputTokens: 1530, outputTokens: 987 })).toBe('tok:i1.5k/o987');
+  });
+
+  it('returns null when no last-request token usage is available', () => {
+    expect(renderTokenUsage(null)).toBeNull();
+  });
+});

--- a/src/hud/elements/token-usage.ts
+++ b/src/hud/elements/token-usage.ts
@@ -1,0 +1,17 @@
+/**
+ * OMC HUD - Token Usage Element
+ *
+ * Renders last-request input/output token usage from transcript metadata.
+ */
+
+import type { LastRequestTokenUsage } from '../types.js';
+import { formatTokenCount } from '../../cli/utils/formatting.js';
+
+export function renderTokenUsage(usage: LastRequestTokenUsage | null | undefined): string | null {
+  if (!usage) return null;
+
+  const hasUsage = usage.inputTokens > 0 || usage.outputTokens > 0;
+  if (!hasUsage) return null;
+
+  return `tok:i${formatTokenCount(usage.inputTokens)}/o${formatTokenCount(usage.outputTokens)}`;
+}

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -208,6 +208,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
         sessionStart,
         getContextPercent(stdin),
       ),
+      lastRequestTokenUsage: transcriptData.lastRequestTokenUsage || null,
       omcVersion,
       updateAvailable,
       toolCallCount: transcriptData.toolCallCount,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -19,6 +19,7 @@ import { renderRateLimits, renderRateLimitsWithBar, renderRateLimitsError, rende
 import { renderPermission } from './elements/permission.js';
 import { renderThinking } from './elements/thinking.js';
 import { renderSession } from './elements/session.js';
+import { renderTokenUsage } from './elements/token-usage.js';
 import { renderPromptTime } from './elements/prompt-time.js';
 import { renderAutopilot } from './elements/autopilot.js';
 import { renderCwd } from './elements/cwd.js';
@@ -289,6 +290,11 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
       const session = renderSession(context.sessionHealth);
       if (session) elements.push(session);
     }
+  }
+
+  if (enabledElements.showTokens === true) {
+    const tokenUsage = renderTokenUsage(context.lastRequestTokenUsage);
+    if (tokenUsage) elements.push(tokenUsage);
   }
 
   // Ralph loop state

--- a/src/hud/transcript.ts
+++ b/src/hud/transcript.ts
@@ -25,6 +25,7 @@ import type {
   ActiveAgent,
   TodoItem,
   PendingPermission,
+  LastRequestTokenUsage,
 } from "./types.js";
 
 // Performance constants
@@ -319,6 +320,11 @@ function processEntry(
 ): void {
   const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();
 
+  const usage = extractLastRequestTokenUsage(entry.message?.usage);
+  if (usage) {
+    result.lastRequestTokenUsage = usage;
+  }
+
   // Set session start time from first entry
   if (!result.sessionStart && entry.timestamp) {
     result.sessionStart = timestamp;
@@ -473,10 +479,18 @@ function processEntry(
 // Type Definitions for Transcript Parsing
 // ============================================================================
 
+interface TranscriptUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
 interface TranscriptEntry {
   timestamp?: string;
   message?: {
     content?: ContentBlock[];
+    usage?: TranscriptUsage;
   };
 }
 
@@ -507,6 +521,23 @@ interface TodoWriteInput {
 interface SkillInput {
   skill: string;
   args?: string;
+}
+
+
+function extractLastRequestTokenUsage(usage: TranscriptUsage | undefined): LastRequestTokenUsage | null {
+  if (!usage) return null;
+
+  const inputTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : null;
+  const outputTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : null;
+
+  if (inputTokens == null && outputTokens == null) {
+    return null;
+  }
+
+  return {
+    inputTokens: Math.max(0, Math.round(inputTokens ?? 0)),
+    outputTokens: Math.max(0, Math.round(outputTokens ?? 0)),
+  };
 }
 
 // ============================================================================

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -110,6 +110,11 @@ export interface SessionHealth {
   health: 'healthy' | 'warning' | 'critical';
 }
 
+export interface LastRequestTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
 export interface TranscriptData {
   agents: ActiveAgent[];
   todos: TodoItem[];
@@ -117,6 +122,7 @@ export interface TranscriptData {
   lastActivatedSkill?: SkillInvocation;
   pendingPermission?: PendingPermission;
   thinkingState?: ThinkingState;
+  lastRequestTokenUsage?: LastRequestTokenUsage;
   toolCallCount: number;
   agentCallCount: number;
   skillCallCount: number;
@@ -321,6 +327,9 @@ export interface HudRenderContext {
   /** Session health metrics */
   sessionHealth: SessionHealth | null;
 
+  /** Last-request token usage parsed from transcript message.usage */
+  lastRequestTokenUsage?: LastRequestTokenUsage | null;
+
   /** Installed OMC version (e.g. "4.1.10") */
   omcVersion: string | null;
 
@@ -420,7 +429,7 @@ export interface HudElementConfig {
   sessionHealth: boolean;     // Show session health/duration
   showSessionDuration?: boolean;  // Show session:19m duration display (default: true if sessionHealth is true)
   showHealthIndicator?: boolean;  // Show 🟢/🟡/🔴 health indicator (default: true if sessionHealth is true)
-  showTokens?: boolean;           // Show token count like 79.3k (default: true if sessionHealth is true)
+  showTokens?: boolean;           // Show last-request token usage when enabled (tok:i1.2k/o340)
   useBars: boolean;           // Show visual progress bars instead of/alongside percentages
   showCallCounts?: boolean;   // Show tool/agent/skill call counts on the right of the status line (default: true)
   maxOutputLines: number;     // Max total output lines to prevent input field shrinkage


### PR DESCRIPTION
## Summary
- plumb last-request input/output token usage from transcript `message.usage` into the HUD render context
- add an optional HUD token-usage element gated by `showTokens` using ASCII-safe `tok:i…/o…` formatting
- add focused HUD tests for transcript parsing, formatting, and render gating

## Validation
- `npm test -- --run src/__tests__/hud/token-usage.test.ts src/__tests__/hud/render.test.ts src/__tests__/hud/watch-mode-init.test.ts`
- `npx tsc --noEmit --pretty false`

Closes #1589.