### PR TITLE
feat(hud): add optional real-time token usage display

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -723,23 +723,25 @@ Configure HUD elements in `~/.claude/settings.json`:
     "elements": {
       "cwd": true,
       "gitRepo": true,
-      "gitBranch": true
+      "gitBranch": true,
+      "showTokens": true
     }
   }
 }
 ```
 
-| Element      | Description                    | Default |
-| ------------ | ------------------------------ | ------- |
-| `cwd`        | Show current working directory | `false` |
-| `gitRepo`    | Show git repository name       | `false` |
-| `gitBranch`  | Show current git branch        | `false` |
-| `omcLabel`   | Show [OMC] label               | `true`  |
-| `contextBar` | Show context window usage      | `true`  |
-| `agents`     | Show active agents count       | `true`  |
-| `todos`      | Show todo progress             | `true`  |
-| `ralph`      | Show ralph loop status         | `true`  |
-| `autopilot`  | Show autopilot status          | `true`  |
+| Element      | Description                                                                                       | Default |
+| ------------ | ------------------------------------------------------------------------------------------------- | ------- |
+| `cwd`        | Show current working directory                                                                    | `false` |
+| `gitRepo`    | Show git repository name                                                                          | `false` |
+| `gitBranch`  | Show current git branch                                                                           | `false` |
+| `omcLabel`   | Show [OMC] label                                                                                  | `true`  |
+| `contextBar` | Show context window usage                                                                         | `true`  |
+| `agents`     | Show active agents count                                                                          | `true`  |
+| `todos`      | Show todo progress                                                                                | `true`  |
+| `ralph`      | Show ralph loop status                                                                            | `true`  |
+| `autopilot`  | Show autopilot status                                                                             | `true`  |
+| `showTokens` | Show transcript-derived token usage (`tok:i1.2k/o340`, plus `r...` reasoning and `s...` session total when reliable) | `false` |
 
 Additional `omcHud` layout options (top-level):
 

--- a/src/__tests__/hud/defaults.test.ts
+++ b/src/__tests__/hud/defaults.test.ts
@@ -31,6 +31,10 @@ describe('HUD Default Configuration', () => {
     it('should default wrapMode to truncate', () => {
       expect(DEFAULT_HUD_CONFIG.wrapMode).toBe('truncate');
     });
+
+    it('should keep token usage display optional by default', () => {
+      expect(DEFAULT_HUD_CONFIG.elements.showTokens).toBe(false);
+    });
   });
 
   describe('PRESET_CONFIGS', () => {
@@ -67,6 +71,12 @@ describe('HUD Default Configuration', () => {
     it('should have model disabled in all presets', () => {
       presets.forEach(preset => {
         expect(PRESET_CONFIGS[preset].model).toBe(false);
+      });
+    });
+
+    it('should keep token usage display disabled in all presets', () => {
+      presets.forEach(preset => {
+        expect(PRESET_CONFIGS[preset].showTokens).toBe(false);
       });
     });
   });

--- a/src/__tests__/hud/render.test.ts
+++ b/src/__tests__/hud/render.test.ts
@@ -487,7 +487,8 @@ describe('token usage rendering', () => {
     pendingPermission: null,
     thinkingState: null,
     sessionHealth: { durationMinutes: 10, messageCount: 5, health: 'healthy' },
-    lastRequestTokenUsage: { inputTokens: 1250, outputTokens: 340 },
+    lastRequestTokenUsage: { inputTokens: 1250, outputTokens: 340, reasoningTokens: 120 },
+    sessionTotalTokens: 6590,
     omcVersion: '4.5.4',
     updateAvailable: null,
     toolCallCount: 0,
@@ -529,7 +530,7 @@ describe('token usage rendering', () => {
   it('shows last-request token usage when enabled', async () => {
     const result = await render(createTokenContext(), createTokenConfig(true));
 
-    expect(result).toContain('tok:i1.3k/o340');
+    expect(result).toContain('tok:i1.3k/o340 r120 s6.6k');
   });
 
   it('omits last-request token usage when explicitly disabled', async () => {

--- a/src/__tests__/hud/token-usage.test.ts
+++ b/src/__tests__/hud/token-usage.test.ts
@@ -54,6 +54,7 @@ describe('HUD transcript token usage plumbing', () => {
       inputTokens: 1530,
       outputTokens: 987,
     });
+    expect(result.sessionTotalTokens).toBe(2682);
   });
 
   it('treats missing token fields as zero when transcript usage only exposes one side', async () => {
@@ -73,12 +74,76 @@ describe('HUD transcript token usage plumbing', () => {
       inputTokens: 0,
       outputTokens: 64,
     });
+    expect(result.sessionTotalTokens).toBe(64);
+  });
+
+  it('captures reasoning tokens when transcript usage exposes them', async () => {
+    const transcriptPath = createTempTranscript([
+      {
+        timestamp: '2026-03-12T00:00:00.000Z',
+        message: {
+          usage: {
+            input_tokens: 1200,
+            output_tokens: 450,
+            output_tokens_details: { reasoning_tokens: 321 },
+          },
+          content: [],
+        },
+      },
+    ]);
+
+    const result = await parseTranscript(transcriptPath);
+
+    expect(result.lastRequestTokenUsage).toEqual({
+      inputTokens: 1200,
+      outputTokens: 450,
+      reasoningTokens: 321,
+    });
+    expect(result.sessionTotalTokens).toBe(1650);
+  });
+
+  it('omits session totals when the transcript contains multiple session IDs', async () => {
+    const transcriptPath = createTempTranscript([
+      {
+        sessionId: 'session-a',
+        timestamp: '2026-03-12T00:00:00.000Z',
+        message: {
+          usage: { input_tokens: 100, output_tokens: 50 },
+          content: [],
+        },
+      },
+      {
+        sessionId: 'session-b',
+        timestamp: '2026-03-12T00:01:00.000Z',
+        message: {
+          usage: { input_tokens: 200, output_tokens: 75 },
+          content: [],
+        },
+      },
+    ]);
+
+    const result = await parseTranscript(transcriptPath);
+
+    expect(result.lastRequestTokenUsage).toEqual({
+      inputTokens: 200,
+      outputTokens: 75,
+    });
+    expect(result.sessionTotalTokens).toBeUndefined();
   });
 });
 
 describe('HUD token usage rendering', () => {
   it('formats last-request token usage as plain ASCII input/output counts', () => {
     expect(renderTokenUsage({ inputTokens: 1530, outputTokens: 987 })).toBe('tok:i1.5k/o987');
+  });
+
+  it('includes reasoning and reliable session totals when available', () => {
+    expect(
+      renderTokenUsage(
+        { inputTokens: 1530, outputTokens: 987, reasoningTokens: 321 },
+        8765,
+      ),
+    ).toBe('tok:i1.5k/o987 r321 s8.8k');
   });
 
   it('returns null when no last-request token usage is available', () => {

--- a/src/hud/elements/token-usage.ts
+++ b/src/hud/elements/token-usage.ts
@@ -7,11 +7,26 @@
 import type { LastRequestTokenUsage } from '../types.js';
 import { formatTokenCount } from '../../cli/utils/formatting.js';
 
-export function renderTokenUsage(usage: LastRequestTokenUsage | null | undefined): string | null {
+export function renderTokenUsage(
+  usage: LastRequestTokenUsage | null | undefined,
+  sessionTotalTokens?: number | null,
+): string | null {
   if (!usage) return null;
 
   const hasUsage = usage.inputTokens > 0 || usage.outputTokens > 0;
   if (!hasUsage) return null;
 
-  return `tok:i${formatTokenCount(usage.inputTokens)}/o${formatTokenCount(usage.outputTokens)}`;
+  const parts = [
+    `tok:i${formatTokenCount(usage.inputTokens)}/o${formatTokenCount(usage.outputTokens)}`,
+  ];
+
+  if (usage.reasoningTokens && usage.reasoningTokens > 0) {
+    parts.push(`r${formatTokenCount(usage.reasoningTokens)}`);
+  }
+
+  if (sessionTotalTokens && sessionTotalTokens > 0) {
+    parts.push(`s${formatTokenCount(sessionTotalTokens)}`);
+  }
+
+  return parts.join(' ');
 }

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -209,6 +209,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
         getContextPercent(stdin),
       ),
       lastRequestTokenUsage: transcriptData.lastRequestTokenUsage || null,
+      sessionTotalTokens: transcriptData.sessionTotalTokens ?? null,
       omcVersion,
       updateAvailable,
       toolCallCount: transcriptData.toolCallCount,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -293,7 +293,7 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   }
 
   if (enabledElements.showTokens === true) {
-    const tokenUsage = renderTokenUsage(context.lastRequestTokenUsage);
+    const tokenUsage = renderTokenUsage(context.lastRequestTokenUsage, context.sessionTotalTokens);
     if (tokenUsage) elements.push(tokenUsage);
   }
 

--- a/src/hud/transcript.ts
+++ b/src/hud/transcript.ts
@@ -103,6 +103,13 @@ export async function parseTranscript(
   const agentMap = new Map<string, ActiveAgent>();
   const backgroundAgentMap: BackgroundAgentMap = new Map();
   const latestTodos: TodoItem[] = [];
+  const sessionTokenTotals = {
+    inputTokens: 0,
+    outputTokens: 0,
+    seenUsage: false,
+  };
+  let sessionTotalsReliable = false;
+  const observedSessionIds = new Set<string>();
 
   try {
     // Check file size to determine parsing strategy
@@ -123,6 +130,8 @@ export async function parseTranscript(
             result,
             MAX_AGENT_MAP_SIZE,
             backgroundAgentMap,
+            sessionTokenTotals,
+            observedSessionIds,
           );
         } catch {
           // Skip malformed lines
@@ -148,11 +157,15 @@ export async function parseTranscript(
             result,
             MAX_AGENT_MAP_SIZE,
             backgroundAgentMap,
+            sessionTokenTotals,
+            observedSessionIds,
           );
         } catch {
           // Skip malformed lines
         }
       }
+
+      sessionTotalsReliable = observedSessionIds.size <= 1;
     }
   } catch {
     // Return partial results on error
@@ -203,6 +216,9 @@ export async function parseTranscript(
     ...completed.slice(-(10 - running.length)),
   ].slice(0, 10);
   result.todos = latestTodos;
+  if (sessionTotalsReliable && sessionTokenTotals.seenUsage) {
+    result.sessionTotalTokens = sessionTokenTotals.inputTokens + sessionTokenTotals.outputTokens;
+  }
 
   return result;
 }
@@ -317,12 +333,26 @@ function processEntry(
   result: TranscriptData,
   maxAgentMapSize: number = 50,
   backgroundAgentMap?: BackgroundAgentMap,
+  sessionTokenTotals?: {
+    inputTokens: number;
+    outputTokens: number;
+    seenUsage: boolean;
+  },
+  observedSessionIds?: Set<string>,
 ): void {
   const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();
+  if (entry.sessionId) {
+    observedSessionIds?.add(entry.sessionId);
+  }
 
   const usage = extractLastRequestTokenUsage(entry.message?.usage);
   if (usage) {
     result.lastRequestTokenUsage = usage;
+    if (sessionTokenTotals) {
+      sessionTokenTotals.inputTokens += usage.inputTokens;
+      sessionTokenTotals.outputTokens += usage.outputTokens;
+      sessionTokenTotals.seenUsage = true;
+    }
   }
 
   // Set session start time from first entry
@@ -484,9 +514,19 @@ interface TranscriptUsage {
   output_tokens?: number;
   cache_creation_input_tokens?: number;
   cache_read_input_tokens?: number;
+  reasoning_tokens?: number;
+  output_tokens_details?: {
+    reasoning_tokens?: number;
+    reasoningTokens?: number;
+  };
+  completion_tokens_details?: {
+    reasoning_tokens?: number;
+    reasoningTokens?: number;
+  };
 }
 
 interface TranscriptEntry {
+  sessionId?: string;
   timestamp?: string;
   message?: {
     content?: ContentBlock[];
@@ -527,17 +567,34 @@ interface SkillInput {
 function extractLastRequestTokenUsage(usage: TranscriptUsage | undefined): LastRequestTokenUsage | null {
   if (!usage) return null;
 
-  const inputTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : null;
-  const outputTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : null;
+  const inputTokens = getNumericUsageValue(usage.input_tokens);
+  const outputTokens = getNumericUsageValue(usage.output_tokens);
+  const reasoningTokens = getNumericUsageValue(
+    usage.reasoning_tokens
+      ?? usage.output_tokens_details?.reasoning_tokens
+      ?? usage.output_tokens_details?.reasoningTokens
+      ?? usage.completion_tokens_details?.reasoning_tokens
+      ?? usage.completion_tokens_details?.reasoningTokens,
+  );
 
   if (inputTokens == null && outputTokens == null) {
     return null;
   }
 
-  return {
+  const normalized: LastRequestTokenUsage = {
     inputTokens: Math.max(0, Math.round(inputTokens ?? 0)),
     outputTokens: Math.max(0, Math.round(outputTokens ?? 0)),
   };
+
+  if (reasoningTokens != null && reasoningTokens > 0) {
+    normalized.reasoningTokens = Math.max(0, Math.round(reasoningTokens));
+  }
+
+  return normalized;
+}
+
+function getNumericUsageValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 // ============================================================================

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -113,6 +113,7 @@ export interface SessionHealth {
 export interface LastRequestTokenUsage {
   inputTokens: number;
   outputTokens: number;
+  reasoningTokens?: number;
 }
 
 export interface TranscriptData {
@@ -123,6 +124,7 @@ export interface TranscriptData {
   pendingPermission?: PendingPermission;
   thinkingState?: ThinkingState;
   lastRequestTokenUsage?: LastRequestTokenUsage;
+  sessionTotalTokens?: number;
   toolCallCount: number;
   agentCallCount: number;
   skillCallCount: number;
@@ -330,6 +332,9 @@ export interface HudRenderContext {
   /** Last-request token usage parsed from transcript message.usage */
   lastRequestTokenUsage?: LastRequestTokenUsage | null;
 
+  /** Session token total (input + output) when transcript parsing is reliable enough to calculate it */
+  sessionTotalTokens?: number | null;
+
   /** Installed OMC version (e.g. "4.1.10") */
   omcVersion: string | null;
 
@@ -506,6 +511,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     missionBoard: false,  // Opt-in mission board for whole-run progress tracking
     promptTime: true,  // Show last prompt time by default
     sessionHealth: true,
+    showTokens: false,
     useBars: false,  // Disabled by default for backwards compatibility
     showCallCounts: true,  // Show tool/agent/skill call counts by default (Issue #710)
     maxOutputLines: 4,
@@ -557,6 +563,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: false,
     sessionHealth: false,
+    showTokens: false,
     useBars: false,
     showCallCounts: false,
     maxOutputLines: 2,
@@ -591,6 +598,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: true,
     sessionHealth: true,
+    showTokens: false,
     useBars: true,
     showCallCounts: true,
     maxOutputLines: 4,
@@ -625,6 +633,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: true,
     sessionHealth: true,
+    showTokens: false,
     useBars: true,
     showCallCounts: true,
     maxOutputLines: 12,
@@ -659,6 +668,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: true,
     sessionHealth: true,
+    showTokens: false,
     useBars: false,
     showCallCounts: true,
     maxOutputLines: 4,
@@ -693,6 +703,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: true,
     sessionHealth: true,
+    showTokens: false,
     useBars: true,
     showCallCounts: true,
     maxOutputLines: 6,


### PR DESCRIPTION
## Summary
- add optional HUD token rendering for last-request transcript usage
- include reasoning tokens when present and session totals only when transcript parsing is reliable
- document the `omcHud.elements.showTokens` toggle and add targeted HUD tests

## Testing
- npx vitest run src/__tests__/hud/token-usage.test.ts src/__tests__/hud/render.test.ts src/__tests__/hud/defaults.test.ts src/__tests__/hud/state.test.ts src/__tests__/hud/windows-platform.test.ts
- npx eslint src/hud/transcript.ts src/hud/elements/token-usage.ts src/hud/types.ts src/hud/index.ts src/hud/render.ts src/__tests__/hud/token-usage.test.ts src/__tests__/hud/render.test.ts src/__tests__/hud/defaults.test.ts
- npm run build

Fixes #1589
