### PR TITLE
fix(notifications): use nullish coalescing for parseInt fallback in reply config

### DIFF
--- a/src/notifications/config.ts
+++ b/src/notifications/config.ts
@@ -794,6 +794,13 @@ function parseDiscordUserIds(
   return [];
 }
 
+/** Parse an integer from a string, returning undefined for invalid/empty input. */
+function parseIntSafe(value: string | undefined): number | undefined {
+  if (value == null || value === "") return undefined;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 /**
  * Get reply injection configuration.
  *
@@ -854,9 +861,9 @@ export function getReplyConfig(): import("./types.js").ReplyConfig | null {
 
   return {
     enabled: true,
-    pollIntervalMs: parseInt(process.env.OMC_REPLY_POLL_INTERVAL_MS || "") || replyRaw?.pollIntervalMs || 3000,
-    maxMessageLength: replyRaw?.maxMessageLength || 500,
-    rateLimitPerMinute: parseInt(process.env.OMC_REPLY_RATE_LIMIT || "") || replyRaw?.rateLimitPerMinute || 10,
+    pollIntervalMs: parseIntSafe(process.env.OMC_REPLY_POLL_INTERVAL_MS) ?? replyRaw?.pollIntervalMs ?? 3000,
+    maxMessageLength: replyRaw?.maxMessageLength ?? 500,
+    rateLimitPerMinute: parseIntSafe(process.env.OMC_REPLY_RATE_LIMIT) ?? replyRaw?.rateLimitPerMinute ?? 10,
     includePrefix: process.env.OMC_REPLY_INCLUDE_PREFIX !== "false" && (replyRaw?.includePrefix !== false),
     authorizedDiscordUserIds,
   };


### PR DESCRIPTION
## Summary

- `parseInt(env || "") || fallback` treats `0` as falsy, silently ignoring an explicit zero value and falling through to the default
- replace with `parseIntSafe` helper that validates via `Number.isFinite()` and use `??` so that `0` is preserved as a valid configuration value
- add explicit radix 10 to `parseInt` calls
- also fix `maxMessageLength` to use `??` for consistency

## Testing

- `npm run build`
- `npm run lint`