### PR TITLE
fix(hooks): remove ExitPlanMode from context-safety blocked tools

### DIFF
--- a/scripts/context-safety.mjs
+++ b/scripts/context-safety.mjs
@@ -87,7 +87,11 @@ const THRESHOLD = parseInt(process.env.OMC_CONTEXT_SAFETY_THRESHOLD || '55', 10)
 // Blocking TeamCreate at high context caused silent fallback to regular subagents,
 // defeating the team orchestration pipeline. TeamCreate is lightweight infrastructure
 // setup, not expensive model inference, so context pressure is not a concern.
-const BLOCKED_TOOLS = new Set(['ExitPlanMode']);
+// ExitPlanMode was removed from BLOCKED_TOOLS in issue #1597.
+// Blocking ExitPlanMode at high context prevented long-running skills (deep-interview)
+// from ever exiting plan mode. ExitPlanMode is a lightweight state transition,
+// not expensive model inference, so context pressure is not a concern.
+const BLOCKED_TOOLS = new Set([]);
 
 /**
  * Estimate context usage percentage from the transcript file.


### PR DESCRIPTION
## Summary
- Remove `ExitPlanMode` from `BLOCKED_TOOLS` in `context-safety.mjs`
- `ExitPlanMode` is a lightweight state transition, not expensive inference — blocking it at high context prevents long-running skills (deep-interview) from ever exiting plan mode
- Follows the same pattern as #1006 which removed `TeamCreate` for the same reason

## Testing
- `npm run build`
- `npm run lint`

Fixes #1597

🤖 Generated with [Claude Code](https://claude.com/claude-code)