### PR TITLE
fix: surface codex-aware deep-interview recommendations

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -68,6 +68,11 @@ Jumping into code without understanding requirements leads to rework, scope cree
 
 **RALPLAN-DR modes**: **Short** (default, bounded structure) and **Deliberate** (for `--deliberate` or explicit high-risk requests). Both modes keep the same Planner -> Architect -> Critic sequence and the same `AskUserQuestion` gates.
 
+**Provider overrides (supported when the provider CLI is installed):**
+- `--architect codex` — replace the Claude Architect pass with `omc ask codex --agent-prompt architect "..."` for implementation-heavy architecture review
+- `--critic codex` — replace the Claude Critic pass with `omc ask codex --agent-prompt critic "..."` for an external review pass before execution
+- If the requested provider is unavailable, briefly note that and continue with the default Claude Architect/Critic step for that stage
+
 1. **Planner** creates initial plan and a compact **RALPLAN-DR summary** before any Architect review. The summary **MUST** include:
    - **Principles** (3-5)
    - **Decision Drivers** (top 3)

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -17,6 +17,8 @@ Ralplan is a shorthand alias for `/oh-my-claudecode:omc-plan --consensus`. It tr
 
 - `--interactive`: Enables user prompts at key decision points (draft review in step 2 and final approval in step 6). Without this flag the workflow runs fully automated — Planner → Architect → Critic loop — and outputs the final plan without asking for confirmation.
 - `--deliberate`: Forces deliberate mode for high-risk work. Adds pre-mortem (3 scenarios) and expanded test planning (unit/integration/e2e/observability). Without this flag, deliberate mode can still auto-enable when the request explicitly signals high risk (auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage).
+- `--architect codex`: Use Codex for the Architect pass when Codex CLI is available. Otherwise, briefly note the fallback and keep the default Claude Architect review.
+- `--critic codex`: Use Codex for the Critic pass when Codex CLI is available. Otherwise, briefly note the fallback and keep the default Claude Critic review.
 
 ## Usage with interactive mode
 

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -1,4 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const availability = vi.hoisted(() => ({
+  claude: true,
+  codex: false,
+  gemini: false,
+}));
+
+vi.mock('../team/model-contract.js', () => ({
+  isCliAvailable: (agentType: 'claude' | 'codex' | 'gemini') => availability[agentType],
+}));
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -17,6 +27,10 @@ describe('auto-slash command skill aliases', () => {
   }
 
   beforeEach(() => {
+    availability.claude = true;
+    availability.codex = false;
+    availability.gemini = false;
+
     tempRoot = mkdtempSync(join(tmpdir(), 'omc-auto-slash-aliases-'));
     tempConfigDir = join(tempRoot, 'claude-config');
     tempProjectDir = join(tempRoot, 'project');
@@ -116,6 +130,33 @@ Project psm body`
     expect(result.success).toBe(true);
     expect(result.replacementText).toContain('Deprecated Alias');
     expect(result.replacementText).toContain('/project-session-manager');
+  });
+
+  it('renders provider-aware execution guidance for slash-loaded deep-interview skills when Codex is available', async () => {
+    availability.codex = true;
+
+    mkdirSync(join(tempConfigDir, 'skills', 'deep-interview'), { recursive: true });
+    writeFileSync(
+      join(tempConfigDir, 'skills', 'deep-interview', 'SKILL.md'),
+      `---
+name: deep-interview
+description: Deep interview
+---
+
+Deep interview body`
+    );
+
+    const { executeSlashCommand } = await loadExecutor();
+    const result = executeSlashCommand({
+      command: 'deep-interview',
+      args: 'improve onboarding',
+      raw: '/deep-interview improve onboarding',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('## Provider-Aware Execution Recommendations');
+    expect(result.replacementText).toContain('/ralplan --architect codex');
+    expect(result.replacementText).toContain('/ralph --critic codex');
   });
 
   it('renders skill pipeline guidance for slash-loaded skills with handoff metadata', async () => {

--- a/src/__tests__/deep-interview-provider-options.test.ts
+++ b/src/__tests__/deep-interview-provider-options.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const availability = vi.hoisted(() => ({
+  claude: true,
+  codex: false,
+  gemini: false,
+}));
+
+vi.mock('../team/model-contract.js', () => ({
+  isCliAvailable: (agentType: 'claude' | 'codex' | 'gemini') => availability[agentType],
+}));
+
+import { clearSkillsCache, getBuiltinSkill } from '../features/builtin-skills/skills.js';
+import { renderSkillRuntimeGuidance } from '../features/builtin-skills/runtime-guidance.js';
+
+describe('deep-interview provider-aware execution recommendations', () => {
+  beforeEach(() => {
+    availability.claude = true;
+    availability.codex = false;
+    availability.gemini = false;
+    clearSkillsCache();
+  });
+
+  it('injects Codex variants into the deep-interview template when Codex CLI is available', () => {
+    availability.codex = true;
+    clearSkillsCache();
+
+    const skill = getBuiltinSkill('deep-interview');
+
+    expect(skill?.template).toContain('## Provider-Aware Execution Recommendations');
+    expect(skill?.template).toContain('/ralplan --architect codex');
+    expect(skill?.template).toContain('/ralplan --critic codex');
+    expect(skill?.template).toContain('/ralph --critic codex');
+    expect(skill?.template).toContain('higher cost than Claude-only ralplan');
+  });
+
+  it('falls back to the existing Claude-only defaults when external providers are unavailable', () => {
+    const skill = getBuiltinSkill('deep-interview');
+
+    expect(skill?.template).not.toContain('## Provider-Aware Execution Recommendations');
+    expect(skill?.template).toContain('Ralplan → Autopilot (Recommended)');
+    expect(skill?.template).toContain('Execute with autopilot (skip ralplan)');
+    expect(skill?.template).toContain('Execute with ralph');
+  });
+
+  it('documents supported Codex architect/critic overrides for consensus planning', () => {
+    const planSkill = getBuiltinSkill('omc-plan');
+    const ralplanSkill = getBuiltinSkill('ralplan');
+
+    expect(planSkill?.template).toContain('--architect codex');
+    expect(planSkill?.template).toContain('omc ask codex --agent-prompt architect');
+    expect(planSkill?.template).toContain('--critic codex');
+    expect(planSkill?.template).toContain('omc ask codex --agent-prompt critic');
+
+    expect(ralplanSkill?.template).toContain('--architect codex');
+    expect(ralplanSkill?.template).toContain('--critic codex');
+  });
+
+  it('renders no extra runtime guidance when no provider-specific deep-interview variant is available', () => {
+    expect(renderSkillRuntimeGuidance('deep-interview')).toBe('');
+  });
+});

--- a/src/features/builtin-skills/runtime-guidance.ts
+++ b/src/features/builtin-skills/runtime-guidance.ts
@@ -1,0 +1,50 @@
+import { isCliAvailable, type CliAgentType } from '../../team/model-contract.js';
+
+export interface SkillRuntimeAvailability {
+  claude: boolean;
+  codex: boolean;
+  gemini: boolean;
+}
+
+export function detectSkillRuntimeAvailability(
+  detector: (agentType: CliAgentType) => boolean = isCliAvailable,
+): SkillRuntimeAvailability {
+  return {
+    claude: detector('claude'),
+    codex: detector('codex'),
+    gemini: detector('gemini'),
+  };
+}
+
+function normalizeSkillName(skillName: string): string {
+  return skillName.trim().toLowerCase();
+}
+
+function renderDeepInterviewRuntimeGuidance(availability: SkillRuntimeAvailability): string {
+  if (!availability.codex) {
+    return '';
+  }
+
+  return [
+    '## Provider-Aware Execution Recommendations',
+    'When Phase 5 presents post-interview execution choices, keep the Claude-only defaults above and add these Codex variants because Codex CLI is available:',
+    '',
+    '- `/ralplan --architect codex "<spec or task>"` — Codex handles the architect pass; best for implementation-heavy design review; higher cost than Claude-only ralplan.',
+    '- `/ralplan --critic codex "<spec or task>"` — Codex handles the critic pass; cheaper than moving the full loop off Claude; strong second-opinion review.',
+    '- `/ralph --critic codex "<spec or task>"` — Ralph still executes normally, but final verification goes through the Codex critic; smallest multi-provider upgrade.',
+    '',
+    'If Codex becomes unavailable, briefly note that and fall back to the Claude-only recommendations already listed in Phase 5.',
+  ].join('\n');
+}
+
+export function renderSkillRuntimeGuidance(
+  skillName: string,
+  availability: SkillRuntimeAvailability = detectSkillRuntimeAvailability(),
+): string {
+  switch (normalizeSkillName(skillName)) {
+    case 'deep-interview':
+      return renderDeepInterviewRuntimeGuidance(availability);
+    default:
+      return '';
+  }
+}

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'url';
 import type { BuiltinSkill } from './types.js';
 import { parseFrontmatter, parseFrontmatterAliases } from '../../utils/frontmatter.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
+import { renderSkillRuntimeGuidance } from './runtime-guidance.js';
 
 // Get the project root directory (go up from src/features/builtin-skills/)
 const __filename = fileURLToPath(import.meta.url);
@@ -59,6 +60,7 @@ function loadSkillFromFile(skillPath: string, skillName: string): BuiltinSkill[]
     const pipeline = parseSkillPipelineMetadata(metadata);
     const template = [
       body.trim(),
+      renderSkillRuntimeGuidance(safePrimaryName),
       renderSkillPipelineGuidance(safePrimaryName, pipeline),
     ].filter((section) => section.trim().length > 0).join('\n\n');
 

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -19,6 +19,7 @@ import type {
 import { resolveLiveData } from './live-data.js';
 import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
+import { renderSkillRuntimeGuidance } from '../../features/builtin-skills/runtime-guidance.js';
 
 /** Claude config directory */
 const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
@@ -254,11 +255,14 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   // Resolve arguments in content, then execute any live-data commands
   const resolvedContent = resolveArguments(cmd.content || '', args);
   const injectedContent = resolveLiveData(resolvedContent);
+  const runtimeGuidance = cmd.scope === 'skill'
+    ? renderSkillRuntimeGuidance(cmd.metadata.name)
+    : '';
   const pipelineGuidance = cmd.scope === 'skill'
     ? renderSkillPipelineGuidance(cmd.metadata.name, cmd.metadata.pipeline)
     : '';
   sections.push(
-    [injectedContent.trim(), pipelineGuidance]
+    [injectedContent.trim(), runtimeGuidance, pipelineGuidance]
       .filter((section) => section.trim().length > 0)
       .join('\n\n')
   );


### PR DESCRIPTION
## Summary
- add runtime deep-interview guidance that injects Codex-aware execution recommendations when Codex CLI is available
- keep the existing Claude-only post-interview defaults as the fallback when external providers are unavailable
- document the supported `--architect codex` / `--critic codex` plan overrides and cover both builtin-skill and slash-command paths with targeted tests

## Testing
- `npx vitest run src/__tests__/deep-interview-provider-options.test.ts src/__tests__/auto-slash-aliases.test.ts`
- `npx eslint src/features/builtin-skills/skills.ts src/features/builtin-skills/runtime-guidance.ts src/hooks/auto-slash-command/executor.ts src/__tests__/deep-interview-provider-options.test.ts src/__tests__/auto-slash-aliases.test.ts`
- `npm run build`
- `lsp_diagnostics_directory (/home/bellman/Workspace/oh-my-claudecode-issue-1600-deep-interview-provider-options): 0 errors, 0 warnings`

Fixes #1600
