### PR TITLE
fix(readme): exclude archived featured contributor repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,12 +404,16 @@ MIT
 <!-- OMC:FEATURED-CONTRIBUTORS:START -->
 ## Featured by OmC Contributors
 
-Top personal non-fork repos from all-time OMC contributors (100+ GitHub stars).
+Top personal non-fork, non-archived repos from all-time OMC contributors (100+ GitHub stars).
 
 - [@Yeachan-Heo](https://github.com/Yeachan-Heo) — [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) (⭐ 9.4k)
-- [@junhoyeo](https://github.com/junhoyeo) — [threads-api](https://github.com/junhoyeo/threads-api) (⭐ 1.6k)
-
-_Refresh with `npm run sync-featured-contributors` to pull the full live list from GitHub._
+- [@junhoyeo](https://github.com/junhoyeo) — [tokscale](https://github.com/junhoyeo/tokscale) (⭐ 1.1k)
+- [@marlocarlo](https://github.com/marlocarlo) — [psmux](https://github.com/marlocarlo/psmux) (⭐ 450)
+- [@BowTiedSwan](https://github.com/BowTiedSwan) — [buildflow](https://github.com/BowTiedSwan/buildflow) (⭐ 282)
+- [@emgeee](https://github.com/emgeee) — [mean-tutorial](https://github.com/emgeee/mean-tutorial) (⭐ 200)
+- [@anduinnn](https://github.com/anduinnn) — [HiFiNi-Auto-CheckIn](https://github.com/anduinnn/HiFiNi-Auto-CheckIn) (⭐ 171)
+- [@Znuff](https://github.com/Znuff) — [consolas-powerline](https://github.com/Znuff/consolas-powerline) (⭐ 145)
+- [@shaun0927](https://github.com/shaun0927) — [openchrome](https://github.com/shaun0927/openchrome) (⭐ 136)
 
 <!-- OMC:FEATURED-CONTRIBUTORS:END -->
 

--- a/src/__tests__/featured-contributors-generator.test.ts
+++ b/src/__tests__/featured-contributors-generator.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../lib/featured-contributors.js';
 
 describe('featured contributors generator', () => {
-  it('picks the top personal non-fork repo for a contributor', () => {
+  it('picks the top personal non-fork non-archived repo for a contributor', () => {
     const repo = pickTopPersonalRepo('alice', [
       {
         name: 'forked-hit',
@@ -18,6 +18,15 @@ describe('featured contributors generator', () => {
         html_url: 'https://github.com/alice/forked-hit',
         stargazers_count: 500,
         fork: true,
+        owner: { login: 'alice', type: 'User' },
+      },
+      {
+        name: 'archived-hit',
+        full_name: 'alice/archived-hit',
+        html_url: 'https://github.com/alice/archived-hit',
+        stargazers_count: 450,
+        fork: false,
+        archived: true,
         owner: { login: 'alice', type: 'User' },
       },
       {
@@ -72,6 +81,7 @@ describe('featured contributors generator', () => {
     expect(block).toContain(FEATURED_CONTRIBUTORS_START_MARKER);
     expect(block).toContain(FEATURED_CONTRIBUTORS_END_MARKER);
     expect(block).toContain(FEATURED_CONTRIBUTORS_TITLE);
+    expect(block).toContain('Top personal non-fork, non-archived repos');
     expect(block.indexOf('@alice')).toBeLessThan(block.indexOf('@charlie'));
     expect(block).toContain('(⭐ 2.4k)');
     expect(block).toContain('(⭐ 150)');
@@ -103,6 +113,27 @@ describe('featured contributors generator', () => {
     expect(updated).toContain('New block');
     expect(updated).not.toContain('Old block');
     expect(updated).toContain('## Star History');
+  });
+
+  it('replacing an existing marker block stays idempotent around trailing spacing', () => {
+    const featuredSection =
+      `${FEATURED_CONTRIBUTORS_START_MARKER}\nNew block\n${FEATURED_CONTRIBUTORS_END_MARKER}\n`;
+    const original = [
+      '# README',
+      '',
+      FEATURED_CONTRIBUTORS_START_MARKER,
+      'Old block',
+      FEATURED_CONTRIBUTORS_END_MARKER,
+      '',
+      '',
+      '## Star History',
+    ].join('\n');
+
+    const once = upsertFeaturedContributorsSection(original, featuredSection);
+    const twice = upsertFeaturedContributorsSection(once, featuredSection);
+
+    expect(once).toBe(twice);
+    expect(once).toContain(`${FEATURED_CONTRIBUTORS_END_MARKER}\n\n## Star History`);
   });
 
   it('formats star counts compactly for README output', () => {

--- a/src/lib/featured-contributors.ts
+++ b/src/lib/featured-contributors.ts
@@ -27,6 +27,7 @@ export interface GitHubRepo {
   html_url: string;
   stargazers_count: number;
   fork: boolean;
+  archived?: boolean;
   owner: {
     login: string;
     type: string;
@@ -214,7 +215,11 @@ export function sortFeaturedContributors(entries: FeaturedContributor[]): Featur
 
 export function pickTopPersonalRepo(login: string, repos: GitHubRepo[]): GitHubRepo | null {
   const eligibleRepos = repos.filter(
-    (repo) => !repo.fork && repo.owner.login === login && repo.owner.type === 'User'
+    (repo) =>
+      !repo.fork &&
+      !repo.archived &&
+      repo.owner.login === login &&
+      repo.owner.type === 'User'
   );
 
   if (eligibleRepos.length === 0) {
@@ -283,7 +288,7 @@ export function renderFeaturedContributorsSection(
     FEATURED_CONTRIBUTORS_START_MARKER,
     FEATURED_CONTRIBUTORS_TITLE,
     '',
-    `Top personal non-fork repos from all-time OMC contributors (${minStars}+ GitHub stars).`,
+    `Top personal non-fork, non-archived repos from all-time OMC contributors (${minStars}+ GitHub stars).`,
     '',
   ];
 
@@ -312,7 +317,11 @@ export function upsertFeaturedContributorsSection(
 
   if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
     const blockEnd = endIndex + FEATURED_CONTRIBUTORS_END_MARKER.length;
-    return `${readmeContent.slice(0, startIndex)}${featuredSection}${readmeContent.slice(blockEnd)}`;
+    const trailingContent = readmeContent.slice(blockEnd);
+
+    return trailingContent.length === 0
+      ? `${readmeContent.slice(0, startIndex)}${featuredSection}`
+      : `${readmeContent.slice(0, startIndex)}${featuredSection}${trailingContent.replace(/^\n+/, '\n')}`;
   }
 
   const anchorIndex = readmeContent.indexOf(anchor);


### PR DESCRIPTION
## Summary
- exclude archived repositories from featured contributor repo selection
- align the generated README copy with the new non-archived rule
- make README block replacement idempotent so `sync-featured-contributors` verify stays green after a sync

## Verification
- `npm run test:run -- src/__tests__/featured-contributors-generator.test.ts`
- `npx eslint src/lib/featured-contributors.ts src/__tests__/featured-contributors-generator.test.ts`
- `npx tsc --noEmit`
- `npm run sync-featured-contributors`
- `npm run sync-featured-contributors:verify`

## README impact
- confirmed `Yeachan-Heo/oh-my-claudecode` is not archived and remains featured
- confirmed the previously seeded `junhoyeo/threads-api` repo is archived, so it is no longer eligible
- after re-sync, junhoyeo now resolves to `junhoyeo/tokscale`, and the live generated block expands to 8 qualifying contributors
