### PR TITLE
fix: honor Bedrock ARN models in team member routing

### DIFF
--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -516,6 +516,19 @@ describe('delegation-enforcer', () => {
       }
     });
 
+    it('strips model when Bedrock ARN auto-enables forceInherit', () => {
+      process.env.ANTHROPIC_MODEL = 'arn:aws:bedrock:us-east-2:123456789012:inference-profile/global.anthropic.claude-opus-4-6-v1:0';
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'sonnet'
+      };
+      const result = enforceModel(input);
+      expect(result.model).toBe('inherit');
+      expect(result.modifiedInput.model).toBeUndefined();
+    });
+
     it('strips model when non-Claude provider auto-enables forceInherit', () => {
       process.env.CLAUDE_MODEL = 'glm-5';
       // forceInherit is auto-enabled by loadConfig for non-Claude providers

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -50,6 +50,12 @@ describe('loadConfig() — auto-forceInherit for non-standard providers', () => 
     expect(config.routing?.forceInherit).toBe(true);
   });
 
+  it('auto-enables forceInherit for Bedrock inference-profile ARN model IDs', () => {
+    process.env.ANTHROPIC_MODEL = 'arn:aws:bedrock:us-east-2:123456789012:inference-profile/global.anthropic.claude-opus-4-6-v1:0';
+    const config = loadConfig();
+    expect(config.routing?.forceInherit).toBe(true);
+  });
+
   it('auto-enables forceInherit when CLAUDE_CODE_USE_VERTEX=1', () => {
     process.env.CLAUDE_CODE_USE_VERTEX = '1';
     const config = loadConfig();

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -69,6 +69,16 @@ describe('isBedrock()', () => {
     expect(isBedrock()).toBe(true);
   });
 
+  it('detects Bedrock inference-profile ARNs', () => {
+    process.env.ANTHROPIC_MODEL = 'arn:aws:bedrock:us-east-2:123456789012:inference-profile/global.anthropic.claude-opus-4-6-v1:0';
+    expect(isBedrock()).toBe(true);
+  });
+
+  it('detects Bedrock application-inference-profile ARNs', () => {
+    process.env.CLAUDE_MODEL = 'arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/abc123/global.anthropic.claude-sonnet-4-6-v1:0';
+    expect(isBedrock()).toBe(true);
+  });
+
   it('also checks CLAUDE_MODEL', () => {
     process.env.CLAUDE_MODEL = 'global.anthropic.claude-sonnet-4-6[1m]';
     expect(isBedrock()).toBe(true);
@@ -129,6 +139,11 @@ describe('isNonClaudeProvider()', () => {
 
   it('returns true for global. Bedrock inference profile (the [1m] case)', () => {
     process.env.ANTHROPIC_MODEL = 'global.anthropic.claude-sonnet-4-6[1m]';
+    expect(isNonClaudeProvider()).toBe(true);
+  });
+
+  it('returns true for Bedrock inference-profile ARNs', () => {
+    process.env.ANTHROPIC_MODEL = 'arn:aws:bedrock:us-east-2:123456789012:inference-profile/global.anthropic.claude-opus-4-6-v1:0';
     expect(isNonClaudeProvider()).toBe(true);
   });
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -178,6 +178,14 @@ export function isBedrock(): boolean {
   if (modelId && /^((us|eu|ap|global)\.anthropic\.|anthropic\.claude)/i.test(modelId)) {
     return true;
   }
+  if (
+    modelId
+    && /^arn:aws(-[^:]+)?:bedrock:/i.test(modelId)
+    && /:(inference-profile|application-inference-profile)\//i.test(modelId)
+    && modelId.toLowerCase().includes('claude')
+  ) {
+    return true;
+  }
 
   return false;
 }


### PR DESCRIPTION
## Summary
- detect AWS Bedrock inference-profile and application-inference-profile ARN model identifiers as Bedrock provider signals
- auto-enable `routing.forceInherit` for those ARN-based sessions so team/subagent launches inherit the parent Bedrock model instead of sending invalid Claude defaults
- add regression coverage across config detection, config loading, and delegation enforcement

## Testing
- npx vitest run src/config/__tests__/models.test.ts src/config/__tests__/loader.test.ts src/__tests__/delegation-enforcer.test.ts
- npx vitest run src/__tests__/non-claude-provider-detection.test.ts src/__tests__/bedrock-model-routing.test.ts
- npx tsc --pretty false --noEmit

Closes #1612.
