### PR TITLE
fix: prevent cross-session autopilot cancel cleanup

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -664,10 +664,13 @@ async function main() {
           // Fire-and-forget notification
           sendStopNotification('autopilot', autopilot.state, sessionId, directory).catch(() => {});
 
+          const cancelGuidance = typeof autopilot.state.session_id === "string" && autopilot.state.session_id === sessionId
+            ? " When all phases are complete, run /oh-my-claudecode:cancel to cleanly exit and clean up this session's autopilot state files. If cancel fails, retry with /oh-my-claudecode:cancel --force."
+            : "";
           console.log(
             JSON.stringify({
               continue: false, decision: "block",
-              reason: `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working. When all phases are complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
+              reason: `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working.${cancelGuidance}`,
             }),
           );
           return;

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -638,7 +638,10 @@ async function main() {
             autopilot.state.last_checked_at = new Date().toISOString();
             writeJsonFile(autopilot.path, autopilot.state);
 
-            let reason = `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working. When all phases are complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`;
+            const cancelGuidance = hasValidSessionId && autopilot.state.session_id === sessionId
+              ? " When all phases are complete, run /oh-my-claudecode:cancel to cleanly exit and clean up this session's autopilot state files. If cancel fails, retry with /oh-my-claudecode:cancel --force."
+              : "";
+            let reason = `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working.${cancelGuidance}`;
             if (errorGuidance) {
               reason = errorGuidance + reason;
             }

--- a/src/hooks/persistent-mode/session-isolation.test.ts
+++ b/src/hooks/persistent-mode/session-isolation.test.ts
@@ -338,6 +338,37 @@ describe("Persistent Mode Session Isolation (Issue #311)", () => {
       expect(output.decision).toBe("block");
       expect(output.continue).toBe(false);
       expect(output.reason).toContain("AUTOPILOT");
+      expect(output.reason).not.toContain('/oh-my-claudecode:cancel');
+    });
+
+    it("should include cancel guidance only for session-owned autopilot state", () => {
+      const sessionId = "session-autopilot-owned";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "autopilot-state.json"),
+        JSON.stringify(
+          {
+            active: true,
+            phase: "execution",
+            session_id: sessionId,
+            reinforcement_count: 0,
+            last_checked_at: new Date().toISOString(),
+          },
+          null,
+          2,
+        ),
+      );
+
+      const output = runPersistentModeScript({
+        directory: tempDir,
+        sessionId,
+      });
+
+      expect(output.decision).toBe("block");
+      expect(output.continue).toBe(false);
+      expect(output.reason).toContain('/oh-my-claudecode:cancel');
+      expect(output.reason).toContain("this session's autopilot state files");
     });
   });
 

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -600,6 +600,31 @@ describe("Stop Hook Blocking Contract", () => {
       expect(output.decision).toBeUndefined();
     });
 
+
+    it("omits cancel guidance for legacy autopilot state without a session id in cjs script", () => {
+      const stateDir = join(tempDir, ".omc", "state");
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(
+        join(stateDir, "autopilot-state.json"),
+        JSON.stringify({
+          active: true,
+          phase: "execution",
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString(),
+          started_at: new Date().toISOString(),
+        })
+      );
+
+      const output = runScript({
+        directory: tempDir,
+      });
+
+      expect(output.continue).toBe(false);
+      expect(output.decision).toBe("block");
+      expect(output.reason).toContain("AUTOPILOT");
+      expect(output.reason).not.toContain('/oh-my-claudecode:cancel');
+    });
+
     it("fails open for unknown Team phase in cjs script", () => {
       const sessionId = "team-phase-cjs";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);

--- a/src/lib/__tests__/mode-state-io.test.ts
+++ b/src/lib/__tests__/mode-state-io.test.ts
@@ -251,6 +251,32 @@ describe('mode-state-io', () => {
       expect(existsSync(legacyPath)).toBe(true);
     });
 
+    it('should NOT delete legacy file owned by a different session via _meta.sessionId', () => {
+      const stateDir = join(tempDir, '.omc', 'state');
+      mkdirSync(stateDir, { recursive: true });
+      const legacyPath = join(stateDir, 'autopilot-state.json');
+      writeFileSync(
+        legacyPath,
+        JSON.stringify({ active: true, _meta: { sessionId: 'session-other-321' } }),
+      );
+
+      clearModeStateFile('autopilot', tempDir, 'session-mine-123');
+      expect(existsSync(legacyPath)).toBe(true);
+    });
+
+    it('should delete legacy file owned by this session via _meta.sessionId', () => {
+      const stateDir = join(tempDir, '.omc', 'state');
+      mkdirSync(stateDir, { recursive: true });
+      const legacyPath = join(stateDir, 'autopilot-state.json');
+      writeFileSync(
+        legacyPath,
+        JSON.stringify({ active: true, _meta: { sessionId: 'session-mine-123' } }),
+      );
+
+      clearModeStateFile('autopilot', tempDir, 'session-mine-123');
+      expect(existsSync(legacyPath)).toBe(false);
+    });
+
     it('should return true when file does not exist (already absent)', () => {
       const result = clearModeStateFile('ralph', tempDir);
       expect(result).toBe(true);

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -14,6 +14,33 @@ import {
   ensureOmcDir,
 } from './worktree-paths.js';
 
+export function getStateSessionOwner(state: Record<string, unknown> | null | undefined): string | undefined {
+  if (!state || typeof state !== 'object') {
+    return undefined;
+  }
+
+  const meta = state._meta;
+  if (meta && typeof meta === 'object') {
+    const metaSessionId = (meta as Record<string, unknown>).sessionId;
+    if (typeof metaSessionId === 'string' && metaSessionId) {
+      return metaSessionId;
+    }
+  }
+
+  const topLevelSessionId = state.session_id;
+  return typeof topLevelSessionId === 'string' && topLevelSessionId
+    ? topLevelSessionId
+    : undefined;
+}
+
+export function canClearStateForSession(
+  state: Record<string, unknown> | null | undefined,
+  sessionId: string,
+): boolean {
+  const ownerSessionId = getStateSessionOwner(state);
+  return !ownerSessionId || ownerSessionId === sessionId;
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -134,9 +161,9 @@ export function clearModeStateFile(
     if (existsSync(legacyPath)) {
       try {
         const content = readFileSync(legacyPath, 'utf-8');
-        const legacyState = JSON.parse(content);
+        const legacyState = JSON.parse(content) as Record<string, unknown>;
         // Only remove if it belongs to this session or is unowned
-        if (!legacyState.session_id || legacyState.session_id === sessionId) {
+        if (canClearStateForSession(legacyState, sessionId)) {
           unlinkSync(legacyPath);
         }
       } catch {

--- a/src/tools/__tests__/cancel-integration.test.ts
+++ b/src/tools/__tests__/cancel-integration.test.ts
@@ -117,6 +117,34 @@ describe('cancel-integration', () => {
       // Legacy file should remain (belongs to different session)
       expect(existsSync(join(TEST_DIR, '.omc', 'state', 'ralph-state.json'))).toBe(true);
     });
+
+
+    it('should NOT delete legacy autopilot ghost file owned by a different session via top-level session_id', async () => {
+      const sessionId = 'autopilot-session-mine';
+      const otherSessionId = 'autopilot-session-other';
+      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+
+      writeFileSync(
+        join(sessionDir, 'autopilot-state.json'),
+        JSON.stringify({ active: true, phase: 'execution', session_id: sessionId })
+      );
+
+      writeFileSync(
+        join(TEST_DIR, '.omc', 'state', 'autopilot-state.json'),
+        JSON.stringify({ active: true, phase: 'execution', session_id: otherSessionId })
+      );
+
+      const result = await stateClearTool.handler({
+        mode: 'autopilot',
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(existsSync(join(sessionDir, 'autopilot-state.json'))).toBe(false);
+      expect(existsSync(join(TEST_DIR, '.omc', 'state', 'autopilot-state.json'))).toBe(true);
+      expect(result.content[0].text).not.toContain('ghost legacy file also removed');
+    });
   });
 
   describe('2. Force cancel (no session_id)', () => {

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -20,6 +20,7 @@ import {
 } from '../lib/worktree-paths.js';
 import { atomicWriteJsonSync } from '../lib/atomic-write.js';
 import { validatePayload } from '../lib/payload-limits.js';
+import { canClearStateForSession } from '../lib/mode-state-io.js';
 import {
   isModeActive,
   getActiveModes,
@@ -469,8 +470,7 @@ export const stateClearTool: ToolDefinition<{
             const legacyPath = getStateFilePath(root, mode as ExecutionMode);
             if (existsSync(legacyPath)) {
               const raw = JSON.parse(readFileSync(legacyPath, 'utf-8')) as Record<string, unknown>;
-              const meta = raw._meta as Record<string, unknown> | undefined;
-              if (!meta || meta.sessionId === sessionId) {
+              if (canClearStateForSession(raw, sessionId)) {
                 unlinkSync(legacyPath);
                 ghostCleaned = true;
               }
@@ -519,8 +519,7 @@ export const stateClearTool: ToolDefinition<{
           const legacyPath = resolveStatePath(mode, root);
           if (existsSync(legacyPath)) {
             const raw = JSON.parse(readFileSync(legacyPath, 'utf-8')) as Record<string, unknown>;
-            const meta = raw._meta as Record<string, unknown> | undefined;
-            if (!meta || meta.sessionId === sessionId) {
+            if (canClearStateForSession(raw, sessionId)) {
               unlinkSync(legacyPath);
               ghostCleaned = true;
             }

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -700,7 +700,10 @@ async function main() {
             autopilot.state.last_checked_at = new Date().toISOString();
             writeJsonFile(autopilot.path, autopilot.state);
 
-            let reason = `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working. When all phases are complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`;
+            const cancelGuidance = hasValidSessionId && autopilot.state.session_id === sessionId
+              ? " When all phases are complete, run /oh-my-claudecode:cancel to cleanly exit and clean up this session's autopilot state files. If cancel fails, retry with /oh-my-claudecode:cancel --force."
+              : "";
+            let reason = `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working.${cancelGuidance}`;
             if (errorGuidance) {
               reason = errorGuidance + reason;
             }


### PR DESCRIPTION
## Summary
- stop the autopilot stop-hook from suggesting `/oh-my-claudecode:cancel` unless the autopilot state is session-owned
- tighten ghost legacy cleanup ownership checks so session-scoped clears only remove matching or unowned legacy state
- add focused regression tests for cross-session autopilot prompting and state clear ownership

Closes #1615