### PR TITLE
fix(team): route API cleanup through shutdown governance

### DIFF
--- a/src/team/__tests__/api-interop.cleanup.test.ts
+++ b/src/team/__tests__/api-interop.cleanup.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const { shutdownTeamV2Mock, shutdownTeamMock } = vi.hoisted(() => ({
+  shutdownTeamV2Mock: vi.fn(async () => {}),
+  shutdownTeamMock: vi.fn(async () => {}),
+}));
+
+vi.mock('../runtime-v2.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../runtime-v2.js')>();
+  return {
+    ...actual,
+    shutdownTeamV2: shutdownTeamV2Mock,
+  };
+});
+
+vi.mock('../runtime.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../runtime.js')>();
+  return {
+    ...actual,
+    shutdownTeam: shutdownTeamMock,
+  };
+});
+
+import { executeTeamApiOperation } from '../api-interop.js';
+
+async function writeJson(cwd: string, relativePath: string, value: unknown): Promise<void> {
+  const fullPath = join(cwd, relativePath);
+  await mkdir(dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+describe('team api cleanup', () => {
+  let cwd = '';
+
+  afterEach(async () => {
+    shutdownTeamV2Mock.mockClear();
+    shutdownTeamMock.mockClear();
+    if (cwd) {
+      await rm(cwd, { recursive: true, force: true });
+      cwd = '';
+    }
+  });
+
+  it('routes cleanup through runtime-v2 shutdown when a v2 team config exists', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-api-cleanup-v2-'));
+    const teamName = 'cleanup-v2';
+    await writeJson(cwd, `.omc/state/team/${teamName}/config.json`, {
+      name: teamName,
+      task: 'test',
+      agent_type: 'claude',
+      worker_launch_mode: 'interactive',
+      governance: {
+        delegation_only: false,
+        plan_approval_required: false,
+        nested_teams_allowed: false,
+        one_team_per_leader_session: true,
+        cleanup_requires_all_workers_inactive: true,
+      },
+      worker_count: 0,
+      max_workers: 20,
+      workers: [],
+      created_at: new Date().toISOString(),
+      tmux_session: '',
+      next_task_id: 1,
+      leader_pane_id: null,
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+    });
+
+    const result = await executeTeamApiOperation('cleanup', { team_name: teamName }, cwd);
+
+    expect(result).toEqual({ ok: true, operation: 'cleanup', data: { team_name: teamName } });
+    expect(shutdownTeamV2Mock).toHaveBeenCalledWith(teamName, cwd);
+    expect(shutdownTeamMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces shutdown gate failures instead of deleting team state directly', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-api-cleanup-gated-'));
+    const teamName = 'cleanup-gated';
+    const teamRoot = join(cwd, '.omc', 'state', 'team', teamName);
+
+    await writeJson(cwd, `.omc/state/team/${teamName}/config.json`, {
+      name: teamName,
+      task: 'test',
+      agent_type: 'claude',
+      worker_launch_mode: 'interactive',
+      governance: {
+        delegation_only: false,
+        plan_approval_required: false,
+        nested_teams_allowed: false,
+        one_team_per_leader_session: true,
+        cleanup_requires_all_workers_inactive: true,
+      },
+      worker_count: 0,
+      max_workers: 20,
+      workers: [],
+      created_at: new Date().toISOString(),
+      tmux_session: '',
+      next_task_id: 2,
+      leader_pane_id: null,
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+    });
+    await writeJson(cwd, `.omc/state/team/${teamName}/tasks/task-1.json`, {
+      id: '1',
+      subject: 'pending work',
+      description: 'still pending',
+      status: 'pending',
+      created_at: new Date().toISOString(),
+    });
+
+    shutdownTeamV2Mock.mockImplementationOnce(async () => {
+      throw new Error('shutdown_gate_blocked:pending=1,blocked=0,in_progress=0,failed=0');
+    });
+
+    const result = await executeTeamApiOperation('cleanup', { team_name: teamName }, cwd);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.error.code).toBe('operation_failed');
+    expect(result.error.message).toContain('shutdown_gate_blocked');
+    await expect(readFile(join(teamRoot, 'config.json'), 'utf-8')).resolves.toContain(teamName);
+    expect(shutdownTeamV2Mock).toHaveBeenCalledWith(teamName, cwd);
+  });
+
+  it('falls back to raw cleanup when no config exists', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-api-cleanup-orphan-'));
+    const teamName = 'cleanup-orphan';
+    const teamRoot = join(cwd, '.omc', 'state', 'team', teamName);
+    await mkdir(join(teamRoot, 'tasks'), { recursive: true });
+    await writeFile(join(teamRoot, 'orphan.txt'), 'stale', 'utf-8');
+
+    const result = await executeTeamApiOperation('cleanup', { team_name: teamName }, cwd);
+
+    expect(result).toEqual({ ok: true, operation: 'cleanup', data: { team_name: teamName } });
+    await expect(readFile(join(teamRoot, 'orphan.txt'), 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(shutdownTeamV2Mock).not.toHaveBeenCalled();
+    expect(shutdownTeamMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -46,6 +46,8 @@ import { queueBroadcastMailboxMessage, queueDirectMailboxMessage, type DispatchO
 import { injectToLeaderPane, sendToWorker } from './tmux-session.js';
 import { listDispatchRequests, markDispatchRequestDelivered, markDispatchRequestNotified } from './dispatch-queue.js';
 import { generateMailboxTriggerMessage } from './worker-bootstrap.js';
+import { shutdownTeam } from './runtime.js';
+import { shutdownTeamV2 } from './runtime-v2.js';
 
 const TEAM_UPDATE_TASK_MUTABLE_FIELDS = new Set(['subject', 'description', 'blocked_by', 'requires_code_change']);
 const TEAM_UPDATE_TASK_REQUEST_FIELDS = new Set(['team_name', 'task_id', 'workingDirectory', ...TEAM_UPDATE_TASK_MUTABLE_FIELDS]);
@@ -180,6 +182,42 @@ export function resolveTeamApiCliCommand(env: NodeJS.ProcessEnv = process.env): 
   if (hasOmxContext) return 'omx team api';
 
   return 'omc team api';
+}
+
+function isRuntimeV2Config(config: unknown): config is { workers: unknown[] } {
+  return !!config && typeof config === 'object' && Array.isArray((config as { workers?: unknown[] }).workers);
+}
+
+function isLegacyRuntimeConfig(config: unknown): config is { tmuxSession?: string; leaderPaneId?: string | null; tmuxOwnsWindow?: boolean } {
+  return !!config && typeof config === 'object' && Array.isArray((config as { agentTypes?: unknown[] }).agentTypes);
+}
+
+async function executeTeamCleanupViaRuntime(teamName: string, cwd: string): Promise<void> {
+  const config = await teamReadConfig(teamName, cwd) as unknown;
+
+  if (!config) {
+    await teamCleanup(teamName, cwd);
+    return;
+  }
+
+  if (isRuntimeV2Config(config)) {
+    await shutdownTeamV2(teamName, cwd);
+    return;
+  }
+
+  if (isLegacyRuntimeConfig(config)) {
+    const legacyConfig = config as { tmuxSession?: string; leaderPaneId?: string | null; tmuxOwnsWindow?: boolean };
+    const sessionName = typeof legacyConfig.tmuxSession === 'string' && legacyConfig.tmuxSession.trim() !== ''
+      ? legacyConfig.tmuxSession.trim()
+      : `omc-team-${teamName}`;
+    const leaderPaneId = typeof legacyConfig.leaderPaneId === 'string' && legacyConfig.leaderPaneId.trim() !== ''
+      ? legacyConfig.leaderPaneId.trim()
+      : undefined;
+    await shutdownTeam(teamName, sessionName, cwd, 30_000, undefined, leaderPaneId, legacyConfig.tmuxOwnsWindow === true);
+    return;
+  }
+
+  await teamCleanup(teamName, cwd);
 }
 
 function readTeamStateRootFromFile(path: string): string | null {
@@ -797,7 +835,7 @@ export async function executeTeamApiOperation(
       case 'cleanup': {
         const teamName = String(args.team_name || '').trim();
         if (!teamName) return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name is required' } };
-        await teamCleanup(teamName, cwd);
+        await executeTeamCleanupViaRuntime(teamName, cwd);
         return { ok: true, operation, data: { team_name: teamName } };
       }
       case 'write-shutdown-request': {


### PR DESCRIPTION
## Summary
- route `omc team api cleanup` through runtime shutdown behavior instead of raw state deletion when a real team config exists
- preserve destructive raw cleanup only as the no-config/orphan fallback path
- add focused regression coverage for v2 cleanup routing, shutdown-gate failure surfacing, and orphan fallback cleanup

## Verification
- `npm test -- --run src/team/__tests__/api-interop.cleanup.test.ts src/team/__tests__/governance-enforcement.test.ts`
- `npx @biomejs/biome lint src/team/api-interop.ts src/team/__tests__/api-interop.cleanup.test.ts`
- `npm run build`

Closes #1618
Refs #1617
