### PR TITLE
feat(team): add startup allocation policy seam

### DIFF
--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -397,7 +397,6 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
         ? parsed.task.slice(0, 80)
         : `Worker ${i + 1}: ${parsed.task}`.slice(0, 80),
       description: parsed.task,
-      owner: `worker-${i + 1}`,
     });
   }
 

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { allocateStartupTasks } from '../allocation-policy.js';
+
+describe('allocateStartupTasks', () => {
+  it('returns empty for no workers or tasks', () => {
+    expect(allocateStartupTasks(0, [{ subject: 'a', description: 'b' }])).toEqual([]);
+    expect(allocateStartupTasks(2, [])).toEqual([]);
+  });
+
+  it('preserves valid explicit owners', () => {
+    expect(allocateStartupTasks(3, [
+      { subject: 'a', description: 'b', owner: 'worker-2' },
+      { subject: 'c', description: 'd', owner: 'worker-3' },
+    ])).toEqual([
+      { workerName: 'worker-2', taskIndex: 0 },
+      { workerName: 'worker-3', taskIndex: 1 },
+    ]);
+  });
+
+  it('falls back to round-robin for missing or invalid owners', () => {
+    expect(allocateStartupTasks(2, [
+      { subject: 'a', description: 'b' },
+      { subject: 'c', description: 'd', owner: 'leader-fixed' },
+      { subject: 'e', description: 'f', owner: 'worker-9' },
+    ])).toEqual([
+      { workerName: 'worker-1', taskIndex: 0 },
+      { workerName: 'worker-2', taskIndex: 1 },
+      { workerName: 'worker-1', taskIndex: 2 },
+    ]);
+  });
+
+  it('keeps later round-robin assignments stable around explicit owners', () => {
+    expect(allocateStartupTasks(3, [
+      { subject: 'a', description: 'b' },
+      { subject: 'c', description: 'd', owner: 'worker-3' },
+      { subject: 'e', description: 'f' },
+      { subject: 'g', description: 'h' },
+    ])).toEqual([
+      { workerName: 'worker-1', taskIndex: 0 },
+      { workerName: 'worker-3', taskIndex: 1 },
+      { workerName: 'worker-2', taskIndex: 2 },
+      { workerName: 'worker-3', taskIndex: 3 },
+    ]);
+  });
+});

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -68,7 +68,11 @@ describe('runtime v2 startup inbox dispatch', () => {
     mocks.sendToWorker.mockResolvedValue(true);
     modelContractMocks.buildWorkerArgv.mockImplementation((agentType?: string) => [`/usr/bin/${agentType ?? 'claude'}`]);
     modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => `/usr/bin/${agentType ?? 'claude'}`);
-    modelContractMocks.getWorkerEnv.mockImplementation(() => ({ OMC_TEAM_WORKER: 'dispatch-team/worker-1' }));
+    modelContractMocks.getWorkerEnv.mockImplementation((...args: unknown[]) => {
+      const teamName = typeof args[0] === 'string' ? args[0] : 'dispatch-team';
+      const workerName = typeof args[1] === 'string' ? args[1] : 'worker-1';
+      return { OMC_TEAM_WORKER: `${teamName}/${workerName}` };
+    });
     modelContractMocks.isPromptModeAgent.mockReturnValue(false);
     modelContractMocks.getPromptModeArgs.mockImplementation((_agentType: string, instruction: string) => [instruction]);
     mocks.execFile.mockImplementation((file: string, args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) => {
@@ -136,6 +140,31 @@ describe('runtime v2 startup inbox dispatch', () => {
     );
   });
 
+
+  it('uses owner-aware startup allocation when task owners are provided', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-owner-startup-'));
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'dispatch-team',
+      workerCount: 2,
+      agentTypes: ['claude', 'claude'],
+      tasks: [
+        { subject: 'Owner-routed task', description: 'Should start on worker-2', owner: 'worker-2' },
+        { subject: 'Fallback task', description: 'Should start on worker-1' },
+      ],
+      cwd,
+    });
+
+    expect(runtime.config.workers.map((worker) => worker.name)).toEqual(['worker-1', 'worker-2']);
+
+    const requests = await listDispatchRequests('dispatch-team', cwd, { kind: 'inbox' });
+    expect(requests).toHaveLength(2);
+    expect(requests.map((request) => request.to_worker)).toEqual(['worker-2', 'worker-1']);
+
+    const spawnedWorkers = mocks.spawnWorkerInPane.mock.calls.map((call) => call[2]?.envVars?.OMC_TEAM_WORKER);
+    expect(spawnedWorkers).toEqual(['dispatch-team/worker-2', 'dispatch-team/worker-1']);
+  });
 
   it('passes through dedicated-window startup requests', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-new-window-'));

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -1,0 +1,55 @@
+export interface StartupAllocationTask {
+  subject: string;
+  description: string;
+  owner?: string;
+}
+
+export interface StartupAllocationDecision {
+  workerName: string;
+  taskIndex: number;
+}
+
+function workerName(index: number): string {
+  return `worker-${index + 1}`;
+}
+
+function normalizeExplicitOwner(rawOwner: string | undefined, workerCount: number): string | null {
+  if (typeof rawOwner !== 'string') return null;
+  const trimmed = rawOwner.trim();
+  const match = /^worker-(\d+)$/.exec(trimmed);
+  if (!match) return null;
+  const numeric = Number.parseInt(match[1] ?? '', 10);
+  if (!Number.isFinite(numeric) || numeric < 1 || numeric > workerCount) return null;
+  return `worker-${numeric}`;
+}
+
+export function allocateStartupTasks(
+  workerCount: number,
+  tasks: StartupAllocationTask[],
+): StartupAllocationDecision[] {
+  if (workerCount <= 0 || tasks.length === 0) return [];
+
+  const decisions: StartupAllocationDecision[] = [];
+  const nextTaskByWorker = new Map<string, number[]>();
+  for (let i = 0; i < workerCount; i += 1) {
+    nextTaskByWorker.set(workerName(i), []);
+  }
+
+  let roundRobinCursor = 0;
+
+  for (let taskIndex = 0; taskIndex < tasks.length; taskIndex += 1) {
+    const explicitOwner = normalizeExplicitOwner(tasks[taskIndex]?.owner, workerCount);
+    if (explicitOwner) {
+      decisions.push({ workerName: explicitOwner, taskIndex });
+      nextTaskByWorker.get(explicitOwner)?.push(taskIndex);
+      continue;
+    }
+
+    const targetWorker = workerName(roundRobinCursor % workerCount);
+    decisions.push({ workerName: targetWorker, taskIndex });
+    nextTaskByWorker.get(targetWorker)?.push(taskIndex);
+    roundRobinCursor += 1;
+  }
+
+  return decisions;
+}

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -22,6 +22,7 @@ import { existsSync } from 'fs';
 import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
 import { performance } from 'perf_hooks';
 import { TeamPaths, absPath, teamStateRoot } from './state-paths.js';
+import { allocateStartupTasks } from './allocation-policy.js';
 import {
   readTeamConfig,
   readWorkerStatus,
@@ -604,11 +605,12 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     }, null, 2), 'utf-8');
   }
 
+  const startupAllocations = allocateStartupTasks(config.workerCount, config.tasks);
+
   // Set up worker state dirs and overlays (with v2 CLI API instructions)
-  const workerNames: string[] = [];
-  for (let i = 0; i < config.tasks.length; i++) {
-    const wName = `worker-${i + 1}`;
-    workerNames.push(wName);
+  const workerNames = Array.from({ length: config.workerCount }, (_, index) => `worker-${index + 1}`);
+  for (let i = 0; i < workerNames.length; i++) {
+    const wName = workerNames[i];
     const agentType = (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as CliAgentType;
     await ensureWorkerStateDir(sanitized, wName, leaderCwd);
     await writeWorkerOverlay({
@@ -696,13 +698,22 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
   };
   await writeFile(absPath(leaderCwd, TeamPaths.manifest(sanitized)), JSON.stringify(teamManifest, null, 2), 'utf-8');
 
-  // Spawn workers for initial tasks (up to workerCount concurrent)
-  const maxConcurrent = Math.min(agentTypes.length, config.tasks.length);
-  for (let i = 0; i < maxConcurrent; i++) {
-    const wName = workerNames[i];
-    const taskId = String(i + 1);
-    const task = config.tasks[i];
-    if (!task) break;
+  // Spawn workers for initial tasks (at most one startup task per worker)
+  const initialStartupAllocations: typeof startupAllocations = [];
+  const seenStartupWorkers = new Set<string>();
+  for (const decision of startupAllocations) {
+    if (seenStartupWorkers.has(decision.workerName)) continue;
+    initialStartupAllocations.push(decision);
+    seenStartupWorkers.add(decision.workerName);
+    if (initialStartupAllocations.length >= config.workerCount) break;
+  }
+
+  for (const decision of initialStartupAllocations) {
+    const wName = decision.workerName;
+    const workerIndex = Number.parseInt(wName.replace('worker-', ''), 10) - 1;
+    const taskId = String(decision.taskIndex + 1);
+    const task = config.tasks[decision.taskIndex];
+    if (!task || workerIndex < 0) continue;
 
     const workerLaunch = await spawnV2Worker({
       sessionName,
@@ -710,8 +721,8 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
       existingWorkerPaneIds: workerPaneIds,
       teamName: sanitized,
       workerName: wName,
-      workerIndex: i,
-      agentType: (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as CliAgentType,
+      workerIndex,
+      agentType: (agentTypes[workerIndex % agentTypes.length] ?? agentTypes[0] ?? 'claude') as CliAgentType,
       task,
       taskId,
       cwd: leaderCwd,
@@ -720,7 +731,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
 
     if (workerLaunch.paneId) {
       workerPaneIds.push(workerLaunch.paneId);
-      const workerInfo = workersInfo[i];
+      const workerInfo = workersInfo[workerIndex];
       if (workerInfo) {
         workerInfo.pane_id = workerLaunch.paneId;
         workerInfo.assigned_tasks = workerLaunch.startupAssigned ? [taskId] : [];


### PR DESCRIPTION
## Summary
- add a dedicated startup allocation policy seam for team startup ownership decisions
- wire v2 startup spawn ordering through the policy so explicit task owners can influence initial worker selection
- keep this PR intentionally narrow: startup allocation only, no broader runtime rebalance/work-stealing changes yet

## Scope notes
This is the first safe slice of #1620. It ports the policy seam for startup allocation without ballooning into the larger conservative rebalance follow-up.

## Verification
- `npm test -- --run src/team/__tests__/allocation-policy.test.ts src/team/__tests__/runtime-v2.dispatch.test.ts`
- `npm test -- --run src/team/__tests__/runtime-prompt-mode.test.ts`
- `npm run build`

Closes #1620
Refs #1617
