### PR TITLE
feat(team): preserve worker role fanout intent

### DIFF
--- a/src/cli/commands/__tests__/team.test.ts
+++ b/src/cli/commands/__tests__/team.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { teamCommand, parseTeamArgs, assertTeamSpawnAllowed } from '../team.js';
+import { teamCommand, parseTeamArgs, buildStartupTasks, assertTeamSpawnAllowed } from '../team.js';
 
 /** Helper: capture console.log output during a callback */
 async function captureLog(fn: () => Promise<void>): Promise<string[]> {
@@ -243,6 +243,7 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     const parsed = parseTeamArgs(['1:codex,1:gemini', 'do the task']);
     expect(parsed.workerCount).toBe(2);
     expect(parsed.agentTypes).toEqual(['codex', 'gemini']);
+    expect(parsed.workerSpecs).toEqual([{ agentType: 'codex' }, { agentType: 'gemini' }]);
     expect(parsed.task).toBe('do the task');
   });
 
@@ -250,6 +251,11 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     const parsed = parseTeamArgs(['2:claude,1:codex:architect', 'design system']);
     expect(parsed.workerCount).toBe(3);
     expect(parsed.agentTypes).toEqual(['claude', 'claude', 'codex']);
+    expect(parsed.workerSpecs).toEqual([
+      { agentType: 'claude' },
+      { agentType: 'claude' },
+      { agentType: 'codex', role: 'architect' },
+    ]);
     expect(parsed.role).toBeUndefined(); // mixed roles -> no single role
     expect(parsed.task).toBe('design system');
   });
@@ -258,6 +264,11 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     const parsed = parseTeamArgs(['1:codex:executor,2:gemini:executor', 'run tasks']);
     expect(parsed.workerCount).toBe(3);
     expect(parsed.agentTypes).toEqual(['codex', 'gemini', 'gemini']);
+    expect(parsed.workerSpecs).toEqual([
+      { agentType: 'codex', role: 'executor' },
+      { agentType: 'gemini', role: 'executor' },
+      { agentType: 'gemini', role: 'executor' },
+    ]);
     expect(parsed.role).toBe('executor');
   });
 
@@ -279,6 +290,10 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     const parsed = parseTeamArgs(['2:codex:architect', 'design auth']);
     expect(parsed.workerCount).toBe(2);
     expect(parsed.agentTypes).toEqual(['codex', 'codex']);
+    expect(parsed.workerSpecs).toEqual([
+      { agentType: 'codex', role: 'architect' },
+      { agentType: 'codex', role: 'architect' },
+    ]);
     expect(parsed.role).toBe('architect');
   });
 
@@ -293,5 +308,32 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
 
   it('throws on total count exceeding maximum', () => {
     expect(() => parseTeamArgs(['15:codex,10:gemini', 'big task'])).toThrow('exceeds maximum');
+  });
+});
+
+
+describe('buildStartupTasks', () => {
+  it('adds owner-aware fanout for explicit per-worker roles', () => {
+    const parsed = parseTeamArgs(['1:codex:architect,1:gemini:writer', 'draft launch plan']);
+    expect(buildStartupTasks(parsed)).toEqual([
+      {
+        subject: 'Worker 1 (architect): draft launch plan',
+        description: 'draft launch plan',
+        owner: 'worker-1',
+      },
+      {
+        subject: 'Worker 2 (writer): draft launch plan',
+        description: 'draft launch plan',
+        owner: 'worker-2',
+      },
+    ]);
+  });
+
+  it('keeps simple fanout unchanged when no explicit roles are provided', () => {
+    const parsed = parseTeamArgs(['2:codex', 'fix tests']);
+    expect(buildStartupTasks(parsed)).toEqual([
+      { subject: 'Worker 1: fix tests', description: 'fix tests' },
+      { subject: 'Worker 2: fix tests', description: 'fix tests' },
+    ]);
   });
 });

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -14,6 +14,7 @@ import {
   executeTeamApiOperation,
   type TeamApiOperation,
 } from '../../team/api-interop.js';
+import type { CliAgentType } from '../../team/model-contract.js';
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
@@ -115,9 +116,15 @@ function slugifyTask(task: string): string {
     .slice(0, 30) || 'team-task';
 }
 
+export interface ParsedWorkerSpec {
+  agentType: string;
+  role?: string;
+}
+
 export interface ParsedTeamArgs {
   workerCount: number;
   agentTypes: string[];
+  workerSpecs: ParsedWorkerSpec[];
   role?: string;
   task: string;
   teamName: string;
@@ -175,6 +182,7 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   const args = [...tokens];
   let workerCount = 3;
   let agentTypes: string[] = [];
+  let workerSpecs: ParsedWorkerSpec[] = [];
   let json = false;
   let newWindow = false;
 
@@ -217,6 +225,7 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
         workerCount += seg.count;
         for (let i = 0; i < seg.count; i++) {
           agentTypes.push(seg.type);
+          workerSpecs.push({ agentType: seg.type, ...(seg.role ? { role: seg.role } : {}) });
         }
       }
       if (workerCount > MAX_WORKER_COUNT) {
@@ -243,6 +252,7 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
       const type = match[2] || 'claude';
       if (match[3]) role = match[3];
       agentTypes = Array.from({ length: workerCount }, () => type);
+      workerSpecs = Array.from({ length: workerCount }, () => ({ agentType: type, ...(role ? { role } : {}) }));
       filteredArgs.shift();
     }
   }
@@ -250,6 +260,7 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   // Default: 3 claude workers if no spec matched
   if (agentTypes.length === 0) {
     agentTypes = Array.from({ length: workerCount }, () => 'claude');
+    workerSpecs = Array.from({ length: workerCount }, () => ({ agentType: 'claude' }));
   }
 
   const task = filteredArgs.join(' ').trim();
@@ -258,8 +269,23 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   }
 
   const teamName = slugifyTask(task);
-  return { workerCount, agentTypes, role, task, teamName, json, newWindow };
+  return { workerCount, agentTypes, workerSpecs, role, task, teamName, json, newWindow };
 }
+
+export function buildStartupTasks(parsed: ParsedTeamArgs): Array<{ subject: string; description: string; owner?: string }> {
+  return Array.from({ length: parsed.workerCount }, (_, index) => {
+    const workerSpec = parsed.workerSpecs[index];
+    const roleLabel = workerSpec?.role ? ` (${workerSpec.role})` : '';
+    return {
+      subject: parsed.workerCount === 1
+        ? parsed.task.slice(0, 80)
+        : `Worker ${index + 1}${roleLabel}: ${parsed.task}`.slice(0, 80),
+      description: parsed.task,
+      ...(workerSpec?.role ? { owner: `worker-${index + 1}` } : {}),
+    };
+  });
+}
+
 
 function sampleValueForField(field: string): unknown {
   switch (field) {
@@ -389,16 +415,8 @@ function parseTeamApiArgs(args: string[]): {
 async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<void> {
   await assertTeamSpawnAllowed(cwd);
 
-  // Create tasks from the task description (one per worker, like OMX)
-  const tasks: Array<{ subject: string; description: string; owner?: string }> = [];
-  for (let i = 0; i < parsed.workerCount; i++) {
-    tasks.push({
-      subject: parsed.workerCount === 1
-        ? parsed.task.slice(0, 80)
-        : `Worker ${i + 1}: ${parsed.task}`.slice(0, 80),
-      description: parsed.task,
-    });
-  }
+  // Create startup tasks from CLI fanout intent, preserving explicit per-worker role routing.
+  const tasks = buildStartupTasks(parsed);
 
   // Load role prompt if a role was specified (e.g., 3:codex:architect)
   let rolePrompt: string | undefined;
@@ -418,6 +436,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
       tasks,
       cwd,
       newWindow: parsed.newWindow,
+      workerRoles: parsed.workerSpecs.map((spec) => spec.role ?? spec.agentType),
       ...(rolePrompt ? { roleName: parsed.role, rolePrompt } : {}),
     });
 
@@ -452,7 +471,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
   const runtime = await startTeam({
     teamName: parsed.teamName,
     workerCount: parsed.workerCount,
-    agentTypes: parsed.agentTypes as any,
+    agentTypes: parsed.agentTypes as CliAgentType[],
     tasks,
     cwd,
     newWindow: parsed.newWindow,

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -75,7 +75,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     });
     modelContractMocks.isPromptModeAgent.mockReturnValue(false);
     modelContractMocks.getPromptModeArgs.mockImplementation((_agentType: string, instruction: string) => [instruction]);
-    mocks.execFile.mockImplementation((file: string, args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+    mocks.execFile.mockImplementation((_file: string, args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) => {
       if (args[0] === 'split-window') {
         cb(null, '%2\n', '');
         return;
@@ -164,6 +164,30 @@ describe('runtime v2 startup inbox dispatch', () => {
 
     const spawnedWorkers = mocks.spawnWorkerInPane.mock.calls.map((call) => call[2]?.envVars?.OMC_TEAM_WORKER);
     expect(spawnedWorkers).toEqual(['dispatch-team/worker-2', 'dispatch-team/worker-1']);
+  });
+
+
+  it('preserves explicit worker roles in runtime config during startup fanout', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-worker-roles-'));
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'dispatch-team',
+      workerCount: 2,
+      agentTypes: ['codex', 'gemini'],
+      workerRoles: ['architect', 'writer'],
+      tasks: [
+        { subject: 'Worker 1 (architect): draft launch plan', description: 'draft launch plan', owner: 'worker-1' },
+        { subject: 'Worker 2 (writer): draft launch plan', description: 'draft launch plan', owner: 'worker-2' },
+      ],
+      cwd,
+    });
+
+    expect(runtime.config.workers.map((worker) => worker.role)).toEqual(['architect', 'writer']);
+
+    const configPath = join(cwd, '.omc', 'state', 'team', 'dispatch-team', 'config.json');
+    const persisted = JSON.parse(await readFile(configPath, 'utf-8'));
+    expect(persisted.workers.map((worker: { role: string }) => worker.role)).toEqual(['architect', 'writer']);
   });
 
   it('passes through dedicated-window startup requests', async () => {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -220,6 +220,7 @@ export interface StartTeamV2Config {
   tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[] }>;
   cwd: string;
   newWindow?: boolean;
+  workerRoles?: string[];
   roleName?: string;
   rolePrompt?: string;
 }
@@ -636,7 +637,8 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
   const workersInfo: WorkerInfo[] = workerNames.map((wName, i) => ({
     name: wName,
     index: i + 1,
-    role: (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as string,
+    role: config.workerRoles?.[i]
+      ?? (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as string,
     assigned_tasks: [] as string[],
     working_dir: leaderCwd,
   }));


### PR DESCRIPTION
Closes #1621
Refs #1617

## Summary
- preserve per-worker role metadata from heterogeneous `omc team N:type:role` CLI specs
- route startup fanout through owner-aware task generation for explicit worker-role assignments
- persist explicit worker roles into runtime v2 worker config so startup routing intent survives into team state

## Verification
- npm test -- --run src/cli/commands/__tests__/team.test.ts src/team/__tests__/runtime-v2.dispatch.test.ts
- npm run build