### PR TITLE
feat(update): add --clean flag to bypass 24h cache purge grace period

### DIFF
--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -238,15 +238,13 @@ describe('purgeStalePluginCacheVersions', () => {
   });
 
   // --- C3 fix: recently modified directories are skipped ---
-  it('skips recently modified directories (race condition guard)', () => {
+  function setupFreshNonActiveCache() {
     const cacheDir = '/mock/.claude/plugins/cache';
-
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue(JSON.stringify({
       version: 2,
       plugins: { 'plugin@omc': [{ installPath: '/other/path' }] },
     }));
-
     mockedReaddirSync.mockImplementation((p, _opts?) => {
       const ps = String(p);
       if (ps === cacheDir) return [dirent('omc')] as any;
@@ -254,11 +252,27 @@ describe('purgeStalePluginCacheVersions', () => {
       if (ps.endsWith('plugin')) return [dirent('1.0.0')] as any;
       return [] as any;
     });
-
-    // Directory was just modified (fresh) — should be skipped
     mockedStatSync.mockReturnValue(freshStats());
+  }
 
+  it('skips recently modified directories (race condition guard)', () => {
+    setupFreshNonActiveCache();
     const result = purgeStalePluginCacheVersions();
+    expect(result.removed).toBe(0);
+    expect(mockedRmSync).not.toHaveBeenCalled();
+  });
+
+  // --- skipGracePeriod option ---
+  it('removes fresh directories when skipGracePeriod is true', () => {
+    setupFreshNonActiveCache();
+    const result = purgeStalePluginCacheVersions({ skipGracePeriod: true });
+    expect(result.removed).toBe(1);
+    expect(mockedRmSync).toHaveBeenCalled();
+  });
+
+  it('still respects grace period when skipGracePeriod is false', () => {
+    setupFreshNonActiveCache();
+    const result = purgeStalePluginCacheVersions({ skipGracePeriod: false });
     expect(result.removed).toBe(0);
     expect(mockedRmSync).not.toHaveBeenCalled();
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -884,6 +884,7 @@ program
   .option('-f, --force', 'Force reinstall even if up to date')
   .option('-q, --quiet', 'Suppress output except for errors')
   .option('--standalone', 'Force npm update even in plugin context')
+  .option('--clean', 'Purge old plugin cache versions immediately (bypass 24h grace period)')
   .addHelpText('after', `
 Examples:
   $ omc update                   Check and install updates
@@ -935,7 +936,7 @@ Examples:
         console.log(chalk.blue('\nStarting update...\n'));
       }
 
-      const result = await performUpdate({ verbose: !options.quiet, standalone: options.standalone });
+      const result = await performUpdate({ verbose: !options.quiet, standalone: options.standalone, clean: options.clean });
 
       if (result.success) {
         if (!options.quiet) {
@@ -965,9 +966,10 @@ program
   .command('update-reconcile')
   .description('Internal: Reconcile runtime state after update (called by update command)')
   .option('-v, --verbose', 'Show detailed output')
+  .option('--skip-grace-period', 'Bypass 24h grace period for cache purge')
   .action(async (options) => {
     try {
-      const reconcileResult = reconcileUpdateRuntime({ verbose: options.verbose });
+      const reconcileResult = reconcileUpdateRuntime({ verbose: options.verbose, skipGracePeriod: options.skipGracePeriod });
       if (!reconcileResult.success) {
         console.error(chalk.red('Reconciliation failed:'));
         if (reconcileResult.errors) {

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -450,7 +450,7 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
  * This is safe to run repeatedly and refreshes local runtime artifacts that may
  * lag behind an updated package or plugin cache.
  */
-export function reconcileUpdateRuntime(options?: { verbose?: boolean }): UpdateReconcileResult {
+export function reconcileUpdateRuntime(options?: { verbose?: boolean; skipGracePeriod?: boolean }): UpdateReconcileResult {
   const errors: string[] = [];
 
   const projectScopedPlugin = isProjectScopedPlugin();
@@ -484,7 +484,7 @@ export function reconcileUpdateRuntime(options?: { verbose?: boolean }): UpdateR
 
   // Purge stale plugin cache versions (non-fatal)
   try {
-    const purgeResult = purgeStalePluginCacheVersions();
+    const purgeResult = purgeStalePluginCacheVersions({ skipGracePeriod: options?.skipGracePeriod });
     if (purgeResult.removed > 0 && options?.verbose) {
       console.log(`[omc] Purged ${purgeResult.removed} stale plugin cache version(s)`);
     }
@@ -548,6 +548,7 @@ export async function performUpdate(options?: {
   skipConfirmation?: boolean;
   verbose?: boolean;
   standalone?: boolean;
+  clean?: boolean;
 }): Promise<UpdateResult> {
   const installed = getInstalledVersion();
   const previousVersion = installed?.version ?? null;
@@ -594,7 +595,7 @@ export async function performUpdate(options?: {
 
         // Re-exec with reconcile subcommand
         try {
-          execFileSync(omcPath, ['update-reconcile'], {
+          execFileSync(omcPath, ['update-reconcile', ...(options?.clean ? ['--skip-grace-period'] : [])], {
             encoding: 'utf-8',
             stdio: options?.verbose ? 'inherit' : 'pipe',
             timeout: 60000,
@@ -627,7 +628,7 @@ export async function performUpdate(options?: {
         };
       } else {
         // We're in the re-exec'd process - run reconciliation directly
-        const reconcileResult = reconcileUpdateRuntime({ verbose: options?.verbose });
+        const reconcileResult = reconcileUpdateRuntime({ verbose: options?.verbose, skipGracePeriod: options?.clean });
         if (!reconcileResult.success) {
           return {
             success: false,

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -138,7 +138,7 @@ function stripTrailing(p: string): string {
  * are still referenced by long-running sessions via CLAUDE_PLUGIN_ROOT. */
 const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
-export function purgeStalePluginCacheVersions(): PurgeCacheResult {
+export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: boolean }): PurgeCacheResult {
   const result: PurgeCacheResult = { removed: 0, removedPaths: [], errors: [] };
 
   const configDir = getClaudeConfigDir();
@@ -185,6 +185,7 @@ export function purgeStalePluginCacheVersions(): PurgeCacheResult {
   }
 
   const now = Date.now();
+  const activePathsArray = [...activePaths];
 
   for (const marketplace of marketplaces) {
     const marketDir = join(cacheDir, marketplace);
@@ -210,16 +211,18 @@ export function purgeStalePluginCacheVersions(): PurgeCacheResult {
 
         // Check if this version or any of its subdirectories are referenced
         const isActive = activePaths.has(normalised) ||
-          Array.from(activePaths).some(ap => ap.startsWith(normalised + '/'));
+          activePathsArray.some(ap => ap.startsWith(normalised + '/'));
 
         if (isActive) continue;
 
         // Grace period: skip recently modified directories to avoid
         // race conditions during concurrent plugin updates
-        try {
-          const stats = statSync(versionDir);
-          if (now - stats.mtimeMs < STALE_THRESHOLD_MS) continue;
-        } catch { continue; }
+        if (!options?.skipGracePeriod) {
+          try {
+            const stats = statSync(versionDir);
+            if (now - stats.mtimeMs < STALE_THRESHOLD_MS) continue;
+          } catch { continue; }
+        }
 
         if (safeRmSync(versionDir)) {
           result.removed++;


### PR DESCRIPTION
## Summary
- add `--clean` flag to `omc update` that bypasses the 24h grace period for stale plugin cache purge
- thread `skipGracePeriod` option through `performUpdate` → `reconcileUpdateRuntime` → `purgeStalePluginCacheVersions`
- forward `--skip-grace-period` to the re-exec'd `omc update-reconcile` subprocess so the flag works across both code paths
- pre-compute `activePathsArray` before the purge loop to avoid repeated `Array.from(Set)` allocation per iteration
- extract shared test mock setup into `setupFreshNonActiveCache()` helper to reduce duplication

## Context
Users who run `omc update` daily never get stale plugin cache versions cleaned up because the 24h grace period mtime keeps resetting on each update. This forces users to run `omc doctor` manually. The `--clean` flag provides an explicit opt-in to immediate cleanup.

## Verification
- `npx vitest run src/__tests__/purge-stale-cache.test.ts` (11 tests pass)
- `npx tsc --noEmit` (zero errors)

Closes #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)