### PR TITLE
fix: let omc-doctor companion checks pass when no companion files exist

### DIFF
--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -53,10 +53,10 @@ ls -la ~/.claude/CLAUDE.md 2>/dev/null
 grep -q "<!-- OMC:START -->" ~/.claude/CLAUDE.md 2>/dev/null && echo "Has OMC config" || echo "Missing OMC config in CLAUDE.md"
 
 # Check companion files for file-split pattern (e.g. CLAUDE-omc.md)
-ls ~/.claude/CLAUDE-*.md 2>/dev/null
-for f in ~/.claude/CLAUDE-*.md; do
-  [ -f "$f" ] && grep -q "<!-- OMC:START -->" "$f" 2>/dev/null && echo "Has OMC config in companion: $f"
-done
+find "$HOME/.claude" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null
+while IFS= read -r f; do
+  grep -q "<!-- OMC:START -->" "$f" 2>/dev/null && echo "Has OMC config in companion: $f"
+done < <(find "$HOME/.claude" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null)
 
 # Check if CLAUDE.md references a companion file
 grep -o "CLAUDE-[^ )]*\.md" ~/.claude/CLAUDE.md 2>/dev/null

--- a/src/__tests__/hud-windows.test.ts
+++ b/src/__tests__/hud-windows.test.ts
@@ -175,6 +175,8 @@ describe('HUD Windows Compatibility', () => {
       expect(content).toContain("node -e");
       // Should use path.join for constructing paths
       expect(content).toContain("p.join(d,'plugins','cache','omc','oh-my-claudecode')");
+      expect(content).not.toContain('ls ~/.claude/CLAUDE-*.md');
+      expect(content).toContain("find \"$HOME/.claude\" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null");
     });
 
     it('hud skill should use cross-platform Node.js commands for plugin detection', () => {


### PR DESCRIPTION
## Summary
- replace the omc-doctor skill's companion-file glob/ls check with a no-match-safe `find` pipeline
- preserve real companion marker detection without treating a missing `CLAUDE-*.md` set as a failure
- add a focused regression assertion for the updated skill guidance

## Verification
- reproduced the no-companion case from the omc-doctor skill shell path and confirmed clean exit in bash and zsh
- `npm run test:run -- src/__tests__/hud-windows.test.ts src/__tests__/doctor-conflicts.test.ts`
- `npx tsc --noEmit`
- `npm run lint -- src/__tests__/hud-windows.test.ts` *(passes with existing repo warnings only)*

Fixes #1630
