### PR TITLE
Mitigate orphaned team tmux workers on SessionEnd

### DIFF
--- a/src/hooks/session-end/__tests__/team-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/team-cleanup.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('../callbacks.js', () => ({
+  triggerStopCallbacks: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../notifications/index.js', () => ({
+  notify: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../tools/python-repl/bridge-manager.js', () => ({
+  cleanupBridgeSessions: vi.fn(async () => ({
+    requestedSessions: 0,
+    foundSessions: 0,
+    terminatedSessions: 0,
+    errors: [],
+  })),
+}));
+
+const teamCleanupMocks = vi.hoisted(() => ({
+  teamReadManifest: vi.fn(async () => null),
+  teamReadConfig: vi.fn(async () => null),
+  teamCleanup: vi.fn(async () => undefined),
+  shutdownTeamV2: vi.fn(async () => undefined),
+  shutdownTeam: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../team/team-ops.js', async (_importOriginal) => {
+  const actual = await vi.importActual<typeof import('../../../team/team-ops.js')>(
+    '../../../team/team-ops.js',
+  );
+  return {
+    ...actual,
+    teamReadManifest: teamCleanupMocks.teamReadManifest,
+    teamReadConfig: teamCleanupMocks.teamReadConfig,
+    teamCleanup: teamCleanupMocks.teamCleanup,
+  };
+});
+
+vi.mock('../../../team/runtime-v2.js', async (_importOriginal) => {
+  const actual = await vi.importActual<typeof import('../../../team/runtime-v2.js')>(
+    '../../../team/runtime-v2.js',
+  );
+  return {
+    ...actual,
+    shutdownTeamV2: teamCleanupMocks.shutdownTeamV2,
+  };
+});
+
+vi.mock('../../../team/runtime.js', async (_importOriginal) => {
+  const actual = await vi.importActual<typeof import('../../../team/runtime.js')>(
+    '../../../team/runtime.js',
+  );
+  return {
+    ...actual,
+    shutdownTeam: teamCleanupMocks.shutdownTeam,
+  };
+});
+
+vi.mock('../../../lib/worktree-paths.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/worktree-paths.js')>(
+    '../../../lib/worktree-paths.js',
+  );
+  return {
+    ...actual,
+    resolveToWorktreeRoot: vi.fn((dir?: string) => dir ?? process.cwd()),
+  };
+});
+
+import { processSessionEnd } from '../index.js';
+
+describe('processSessionEnd team cleanup (#1632)', () => {
+  let tmpDir: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omc-session-end-team-cleanup-'));
+    transcriptPath = path.join(tmpDir, 'transcript.jsonl');
+    fs.writeFileSync(
+      transcriptPath,
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } }),
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+    teamCleanupMocks.teamReadManifest.mockReset();
+    teamCleanupMocks.teamReadConfig.mockReset();
+    teamCleanupMocks.teamCleanup.mockReset();
+    teamCleanupMocks.shutdownTeamV2.mockReset();
+    teamCleanupMocks.shutdownTeam.mockReset();
+    teamCleanupMocks.teamReadManifest.mockResolvedValue(null);
+    teamCleanupMocks.teamReadConfig.mockResolvedValue(null);
+    teamCleanupMocks.teamCleanup.mockResolvedValue(undefined);
+    teamCleanupMocks.shutdownTeamV2.mockResolvedValue(undefined);
+    teamCleanupMocks.shutdownTeam.mockResolvedValue(undefined);
+  });
+
+  it('force-shuts down a session-owned runtime-v2 team from session team state', async () => {
+    const sessionId = 'pid-1632-v2';
+    const teamSessionDir = path.join(tmpDir, '.omc', 'state', 'sessions', sessionId);
+    fs.mkdirSync(teamSessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(teamSessionDir, 'team-state.json'),
+      JSON.stringify({ active: true, session_id: sessionId, team_name: 'delivery-team', current_phase: 'team-exec' }),
+      'utf-8',
+    );
+
+    teamCleanupMocks.teamReadConfig.mockResolvedValue({
+      workers: [{ name: 'worker-1', pane_id: '%1' }],
+    } as never);
+
+    await processSessionEnd({
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      cwd: tmpDir,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+      'delivery-team',
+      tmpDir,
+      { force: true, timeoutMs: 0 },
+    );
+    expect(teamCleanupMocks.shutdownTeam).not.toHaveBeenCalled();
+  });
+
+  it('force-shuts down a legacy runtime team referenced by the ending session', async () => {
+    const sessionId = 'pid-1632-legacy';
+    const teamSessionDir = path.join(tmpDir, '.omc', 'state', 'sessions', sessionId);
+    fs.mkdirSync(teamSessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(teamSessionDir, 'team-state.json'),
+      JSON.stringify({ active: true, session_id: sessionId, team_name: 'legacy-team', current_phase: 'team-exec' }),
+      'utf-8',
+    );
+
+    teamCleanupMocks.teamReadConfig.mockResolvedValue({
+      agentTypes: ['codex'],
+      tmuxSession: 'legacy-team:0',
+      leaderPaneId: '%0',
+      tmuxOwnsWindow: false,
+    } as never);
+
+    await processSessionEnd({
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      cwd: tmpDir,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    expect(teamCleanupMocks.shutdownTeam).toHaveBeenCalledWith(
+      'legacy-team',
+      'legacy-team:0',
+      tmpDir,
+      0,
+      undefined,
+      '%0',
+      false,
+    );
+    expect(teamCleanupMocks.shutdownTeamV2).not.toHaveBeenCalled();
+  });
+
+  it('only cleans up manifests owned by the ending session', async () => {
+    const sessionId = 'pid-1632-owner';
+    const otherSessionId = 'pid-1632-other';
+    const teamRoot = path.join(tmpDir, '.omc', 'state', 'team');
+    fs.mkdirSync(path.join(teamRoot, 'owned-team'), { recursive: true });
+    fs.mkdirSync(path.join(teamRoot, 'other-team'), { recursive: true });
+
+    teamCleanupMocks.teamReadManifest.mockImplementation((async (teamName: string) => {
+      if (teamName === 'owned-team') {
+        return { leader: { session_id: sessionId } };
+      }
+      if (teamName === 'other-team') {
+        return { leader: { session_id: otherSessionId } };
+      }
+      return null;
+    }) as never);
+    teamCleanupMocks.teamReadConfig.mockImplementation((async (teamName: string) => ({
+      workers: [{ name: `${teamName}-worker`, pane_id: '%1' }],
+    })) as never);
+
+    await processSessionEnd({
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      cwd: tmpDir,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+      'owned-team',
+      tmpDir,
+      { force: true, timeoutMs: 0 },
+    );
+  });
+});

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -35,6 +35,12 @@ export interface HookOutput {
   continue: boolean;
 }
 
+interface SessionOwnedTeamCleanupResult {
+  attempted: string[];
+  cleaned: string[];
+  failed: Array<{ teamName: string; error: string }>;
+}
+
 type LegacyStopCallbackPlatform = 'file' | 'telegram' | 'discord';
 
 function hasExplicitNotificationConfig(profileName?: string): boolean {
@@ -552,6 +558,110 @@ export function cleanupMissionState(directory: string, sessionId?: string): numb
   }
 }
 
+function extractTeamNameFromState(state: Record<string, unknown> | null): string | null {
+  if (!state || typeof state !== 'object') return null;
+  const rawTeamName = state.team_name ?? state.teamName;
+  return typeof rawTeamName === 'string' && rawTeamName.trim() !== ''
+    ? rawTeamName.trim()
+    : null;
+}
+
+async function findSessionOwnedTeams(directory: string, sessionId: string): Promise<string[]> {
+  const teamNames = new Set<string>();
+  const teamState = readModeState<Record<string, unknown>>('team', directory, sessionId);
+  const stateTeamName = extractTeamNameFromState(teamState);
+  if (stateTeamName) {
+    teamNames.add(stateTeamName);
+  }
+
+  const teamRoot = path.join(getOmcRoot(directory), 'state', 'team');
+  if (!fs.existsSync(teamRoot)) {
+    return [...teamNames];
+  }
+
+  const { teamReadManifest } = await import('../../team/team-ops.js');
+
+  try {
+    const entries = fs.readdirSync(teamRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const teamName = entry.name;
+      try {
+        const manifest = await teamReadManifest(teamName, directory);
+        if (manifest?.leader.session_id === sessionId) {
+          teamNames.add(teamName);
+        }
+      } catch {
+        // Ignore malformed team state and continue scanning.
+      }
+    }
+  } catch {
+    // Best-effort only — session end must not fail because team discovery failed.
+  }
+
+  return [...teamNames];
+}
+
+async function cleanupSessionOwnedTeams(directory: string, sessionId: string): Promise<SessionOwnedTeamCleanupResult> {
+  const attempted: string[] = [];
+  const cleaned: string[] = [];
+  const failed: Array<{ teamName: string; error: string }> = [];
+  const teamNames = await findSessionOwnedTeams(directory, sessionId);
+
+  if (teamNames.length === 0) {
+    return { attempted, cleaned, failed };
+  }
+
+  const { teamReadConfig, teamCleanup } = await import('../../team/team-ops.js');
+  const { shutdownTeamV2 } = await import('../../team/runtime-v2.js');
+  const { shutdownTeam } = await import('../../team/runtime.js');
+
+  for (const teamName of teamNames) {
+    attempted.push(teamName);
+    try {
+      const config = await teamReadConfig(teamName, directory) as unknown;
+      if (!config || typeof config !== 'object') {
+        await teamCleanup(teamName, directory);
+        cleaned.push(teamName);
+        continue;
+      }
+
+      if (Array.isArray((config as { workers?: unknown[] }).workers)) {
+        await shutdownTeamV2(teamName, directory, { force: true, timeoutMs: 0 });
+        cleaned.push(teamName);
+        continue;
+      }
+
+      if (Array.isArray((config as { agentTypes?: unknown[] }).agentTypes)) {
+        const legacyConfig = config as {
+          tmuxSession?: string;
+          leaderPaneId?: string | null;
+          tmuxOwnsWindow?: boolean;
+        };
+        const sessionName = typeof legacyConfig.tmuxSession === 'string' && legacyConfig.tmuxSession.trim() !== ''
+          ? legacyConfig.tmuxSession.trim()
+          : `omc-team-${teamName}`;
+        const leaderPaneId = typeof legacyConfig.leaderPaneId === 'string' && legacyConfig.leaderPaneId.trim() !== ''
+          ? legacyConfig.leaderPaneId.trim()
+          : undefined;
+        await shutdownTeam(teamName, sessionName, directory, 0, undefined, leaderPaneId, legacyConfig.tmuxOwnsWindow === true);
+        cleaned.push(teamName);
+        continue;
+      }
+
+      await teamCleanup(teamName, directory);
+      cleaned.push(teamName);
+    } catch (error) {
+      failed.push({
+        teamName,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { attempted, cleaned, failed };
+}
+
 /**
  * Export session summary to .omc/sessions/
  */
@@ -592,6 +702,11 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   // Record and export session metrics to disk
   const metrics = recordSessionMetrics(directory, input);
   exportSessionSummary(directory, metrics);
+
+  // Best-effort cleanup for tmux-backed team workers owned by this Claude Code
+  // session. This does not fix upstream signal-forwarding behavior, but it
+  // meaningfully reduces orphaned panes/windows when SessionEnd runs normally.
+  await cleanupSessionOwnedTeams(directory, input.session_id);
 
   // Clean up transient state files
   cleanupTransientState(directory);


### PR DESCRIPTION
## Summary
- add SessionEnd-owned team cleanup that force-shuts down tmux-backed teams for the ending Claude session
- discover session-owned teams from session-scoped `team-state.json` and manifest leader session ownership
- add focused regression coverage for runtime-v2 and legacy cleanup paths

## Why
Fixes #1632.

This is a narrow OMC-side mitigation: when the Claude Code `SessionEnd` hook runs, OMC now force-cleans the team it can attribute to that session. It meaningfully reduces orphaned tmux worker accumulation on macOS without claiming to solve upstream Claude Code child/signal forwarding behavior.

## Verification
- `npx vitest run src/hooks/session-end/__tests__/mode-state-cleanup.test.ts src/hooks/session-end/__tests__/team-cleanup.test.ts`
- `npx eslint src/hooks/session-end/index.ts src/hooks/session-end/__tests__/team-cleanup.test.ts`
- `npx tsc --noEmit`
