### PR TITLE
feat: add configurable autopilot plan output paths

### DIFF
--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -1,123 +1,146 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { compactOmcStartupGuidance, loadConfig, loadContextFromFiles } from '../loader.js';
-import { saveAndClear, restore } from './test-helpers.js';
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  compactOmcStartupGuidance,
+  loadConfig,
+  loadContextFromFiles,
+} from "../loader.js";
+import { saveAndClear, restore } from "./test-helpers.js";
 
 const ALL_KEYS = [
-  'CLAUDE_CODE_USE_BEDROCK',
-  'CLAUDE_CODE_USE_VERTEX',
-  'CLAUDE_MODEL',
-  'ANTHROPIC_MODEL',
-  'ANTHROPIC_BASE_URL',
-  'OMC_ROUTING_FORCE_INHERIT',
-  'OMC_MODEL_HIGH',
-  'OMC_MODEL_MEDIUM',
-  'OMC_MODEL_LOW',
-  'CLAUDE_CODE_BEDROCK_OPUS_MODEL',
-  'CLAUDE_CODE_BEDROCK_SONNET_MODEL',
-  'CLAUDE_CODE_BEDROCK_HAIKU_MODEL',
-  'ANTHROPIC_DEFAULT_OPUS_MODEL',
-  'ANTHROPIC_DEFAULT_SONNET_MODEL',
-  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  "CLAUDE_MODEL",
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_BASE_URL",
+  "OMC_ROUTING_FORCE_INHERIT",
+  "OMC_MODEL_HIGH",
+  "OMC_MODEL_MEDIUM",
+  "OMC_MODEL_LOW",
+  "CLAUDE_CODE_BEDROCK_OPUS_MODEL",
+  "CLAUDE_CODE_BEDROCK_SONNET_MODEL",
+  "CLAUDE_CODE_BEDROCK_HAIKU_MODEL",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
 ] as const;
 
 // ---------------------------------------------------------------------------
 // Auto-forceInherit for Bedrock / Vertex (issues #1201, #1025)
 // ---------------------------------------------------------------------------
-describe('loadConfig() — auto-forceInherit for non-standard providers', () => {
+describe("loadConfig() — auto-forceInherit for non-standard providers", () => {
   let saved: Record<string, string | undefined>;
 
-  beforeEach(() => { saved = saveAndClear(ALL_KEYS); });
-  afterEach(() => { restore(saved); });
+  beforeEach(() => {
+    saved = saveAndClear(ALL_KEYS);
+  });
+  afterEach(() => {
+    restore(saved);
+  });
 
-  it('auto-enables forceInherit for global. Bedrock inference profile with [1m] suffix', () => {
-    process.env.ANTHROPIC_MODEL = 'global.anthropic.claude-sonnet-4-6[1m]';
+  it("auto-enables forceInherit for global. Bedrock inference profile with [1m] suffix", () => {
+    process.env.ANTHROPIC_MODEL = "global.anthropic.claude-sonnet-4-6[1m]";
     const config = loadConfig();
     expect(config.routing?.forceInherit).toBe(true);
   });
 
-  it('auto-enables forceInherit when CLAUDE_CODE_USE_BEDROCK=1', () => {
-    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+  it("auto-enables forceInherit when CLAUDE_CODE_USE_BEDROCK=1", () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
     const config = loadConfig();
     expect(config.routing?.forceInherit).toBe(true);
   });
 
-  it('auto-enables forceInherit for us. Bedrock region prefix', () => {
-    process.env.ANTHROPIC_MODEL = 'us.anthropic.claude-opus-4-6-v1';
+  it("auto-enables forceInherit for us. Bedrock region prefix", () => {
+    process.env.ANTHROPIC_MODEL = "us.anthropic.claude-opus-4-6-v1";
     const config = loadConfig();
     expect(config.routing?.forceInherit).toBe(true);
   });
 
-  it('auto-enables forceInherit for Bedrock inference-profile ARN model IDs', () => {
-    process.env.ANTHROPIC_MODEL = 'arn:aws:bedrock:us-east-2:123456789012:inference-profile/global.anthropic.claude-opus-4-6-v1:0';
+  it("auto-enables forceInherit for Bedrock inference-profile ARN model IDs", () => {
+    process.env.ANTHROPIC_MODEL =
+      "arn:aws:bedrock:us-east-2:123456789012:inference-profile/global.anthropic.claude-opus-4-6-v1:0";
     const config = loadConfig();
     expect(config.routing?.forceInherit).toBe(true);
   });
 
-  it('auto-enables forceInherit when CLAUDE_CODE_USE_VERTEX=1', () => {
-    process.env.CLAUDE_CODE_USE_VERTEX = '1';
+  it("auto-enables forceInherit when CLAUDE_CODE_USE_VERTEX=1", () => {
+    process.env.CLAUDE_CODE_USE_VERTEX = "1";
     const config = loadConfig();
     expect(config.routing?.forceInherit).toBe(true);
   });
 
-  it('does NOT auto-enable forceInherit for standard Anthropic API usage', () => {
-    process.env.ANTHROPIC_MODEL = 'claude-sonnet-4-6';
+  it("does NOT auto-enable forceInherit for standard Anthropic API usage", () => {
+    process.env.ANTHROPIC_MODEL = "claude-sonnet-4-6";
     const config = loadConfig();
     expect(config.routing?.forceInherit).toBe(false);
   });
 
-  it('does NOT auto-enable forceInherit when no provider env vars are set', () => {
+  it("does NOT auto-enable forceInherit when no provider env vars are set", () => {
     const config = loadConfig();
     expect(config.routing?.forceInherit).toBe(false);
   });
 
-  it('respects explicit OMC_ROUTING_FORCE_INHERIT=false even on Bedrock', () => {
+  it("respects explicit OMC_ROUTING_FORCE_INHERIT=false even on Bedrock", () => {
     // When user explicitly sets the var (even to false), auto-detection is skipped.
     // This matches the guard: process.env.OMC_ROUTING_FORCE_INHERIT === undefined
-    process.env.ANTHROPIC_MODEL = 'global.anthropic.claude-sonnet-4-6[1m]';
-    process.env.OMC_ROUTING_FORCE_INHERIT = 'false';
+    process.env.ANTHROPIC_MODEL = "global.anthropic.claude-sonnet-4-6[1m]";
+    process.env.OMC_ROUTING_FORCE_INHERIT = "false";
     const config = loadConfig();
     // env var is defined → auto-detection skipped → remains at default (false)
     expect(config.routing?.forceInherit).toBe(false);
   });
 
-  it('maps Bedrock family env vars into agent defaults and routing tiers', () => {
-    process.env.CLAUDE_CODE_BEDROCK_OPUS_MODEL = 'us.anthropic.claude-opus-4-6-v1:0';
-    process.env.CLAUDE_CODE_BEDROCK_SONNET_MODEL = 'us.anthropic.claude-sonnet-4-6-v1:0';
-    process.env.CLAUDE_CODE_BEDROCK_HAIKU_MODEL = 'us.anthropic.claude-haiku-4-5-v1:0';
+  it("maps Bedrock family env vars into agent defaults and routing tiers", () => {
+    process.env.CLAUDE_CODE_BEDROCK_OPUS_MODEL =
+      "us.anthropic.claude-opus-4-6-v1:0";
+    process.env.CLAUDE_CODE_BEDROCK_SONNET_MODEL =
+      "us.anthropic.claude-sonnet-4-6-v1:0";
+    process.env.CLAUDE_CODE_BEDROCK_HAIKU_MODEL =
+      "us.anthropic.claude-haiku-4-5-v1:0";
 
     const config = loadConfig();
 
-    expect(config.agents?.architect?.model).toBe('us.anthropic.claude-opus-4-6-v1:0');
-    expect(config.agents?.executor?.model).toBe('us.anthropic.claude-sonnet-4-6-v1:0');
-    expect(config.agents?.explore?.model).toBe('us.anthropic.claude-haiku-4-5-v1:0');
-    expect(config.routing?.tierModels?.HIGH).toBe('us.anthropic.claude-opus-4-6-v1:0');
-    expect(config.routing?.tierModels?.MEDIUM).toBe('us.anthropic.claude-sonnet-4-6-v1:0');
-    expect(config.routing?.tierModels?.LOW).toBe('us.anthropic.claude-haiku-4-5-v1:0');
+    expect(config.agents?.architect?.model).toBe(
+      "us.anthropic.claude-opus-4-6-v1:0",
+    );
+    expect(config.agents?.executor?.model).toBe(
+      "us.anthropic.claude-sonnet-4-6-v1:0",
+    );
+    expect(config.agents?.explore?.model).toBe(
+      "us.anthropic.claude-haiku-4-5-v1:0",
+    );
+    expect(config.routing?.tierModels?.HIGH).toBe(
+      "us.anthropic.claude-opus-4-6-v1:0",
+    );
+    expect(config.routing?.tierModels?.MEDIUM).toBe(
+      "us.anthropic.claude-sonnet-4-6-v1:0",
+    );
+    expect(config.routing?.tierModels?.LOW).toBe(
+      "us.anthropic.claude-haiku-4-5-v1:0",
+    );
   });
 
-  it('supports Anthropic family-default env vars for tiered routing defaults', () => {
-    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'claude-opus-4-6-custom';
-    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'claude-sonnet-4-6-custom';
-    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = 'claude-haiku-4-5-custom';
+  it("supports Anthropic family-default env vars for tiered routing defaults", () => {
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-6-custom";
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-6-custom";
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-custom";
 
     const config = loadConfig();
 
-    expect(config.agents?.architect?.model).toBe('claude-opus-4-6-custom');
-    expect(config.agents?.executor?.model).toBe('claude-sonnet-4-6-custom');
-    expect(config.agents?.explore?.model).toBe('claude-haiku-4-5-custom');
+    expect(config.agents?.architect?.model).toBe("claude-opus-4-6-custom");
+    expect(config.agents?.executor?.model).toBe("claude-sonnet-4-6-custom");
+    expect(config.agents?.explore?.model).toBe("claude-haiku-4-5-custom");
   });
-
 });
 
-describe('startup context compaction', () => {
-  it('compacts only OMC-style guidance in loadContextFromFiles while preserving key sections', () => {
-    const tempDir = mkdtempSync(join(tmpdir(), 'omc-loader-context-'));
+describe("startup context compaction", () => {
+  it("compacts only OMC-style guidance in loadContextFromFiles while preserving key sections", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omc-loader-context-"));
 
     try {
-      const omcAgentsPath = join(tempDir, 'AGENTS.md');
+      const omcAgentsPath = join(tempDir, "AGENTS.md");
       const omcGuidance = `# oh-my-codex - Intelligent Multi-Agent Orchestration
 
 <guidance_schema_contract>
@@ -150,18 +173,20 @@ schema
 
       const loaded = loadContextFromFiles([omcAgentsPath]);
 
-      expect(loaded).toContain('<operating_principles>');
-      expect(loaded).toContain('<verification>');
-      expect(loaded).not.toContain('<agent_catalog>');
-      expect(loaded).not.toContain('<skills>');
-      expect(loaded).not.toContain('<team_compositions>');
-      expect(loaded.length).toBeLessThan(omcGuidance.length + `## Context from ${omcAgentsPath}\n\n`.length - 40);
+      expect(loaded).toContain("<operating_principles>");
+      expect(loaded).toContain("<verification>");
+      expect(loaded).not.toContain("<agent_catalog>");
+      expect(loaded).not.toContain("<skills>");
+      expect(loaded).not.toContain("<team_compositions>");
+      expect(loaded.length).toBeLessThan(
+        omcGuidance.length + `## Context from ${omcAgentsPath}\n\n`.length - 40,
+      );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
 
-  it('leaves non-OMC guidance unchanged even if it uses similar tags', () => {
+  it("leaves non-OMC guidance unchanged even if it uses similar tags", () => {
     const nonOmc = `# Project guide
 
 <skills>
@@ -169,5 +194,56 @@ Keep this custom section.
 </skills>`;
 
     expect(compactOmcStartupGuidance(nonOmc)).toBe(nonOmc);
+  });
+});
+
+describe("plan output configuration", () => {
+  let saved: Record<string, string | undefined>;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    saved = saveAndClear(ALL_KEYS);
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    restore(saved);
+  });
+
+  it("includes plan output defaults", () => {
+    const config = loadConfig();
+    expect(config.planOutput).toEqual({
+      directory: ".omc/plans",
+      filenameTemplate: "{{name}}.md",
+    });
+  });
+
+  it("loads plan output overrides from project config", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omc-plan-output-"));
+
+    try {
+      const claudeDir = join(tempDir, ".claude");
+      require("node:fs").mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(
+        join(claudeDir, "omc.jsonc"),
+        JSON.stringify({
+          planOutput: {
+            directory: "docs/plans",
+            filenameTemplate: "plan-{{name}}.md",
+          },
+        }),
+      );
+
+      process.chdir(tempDir);
+
+      const config = loadConfig();
+      expect(config.planOutput).toEqual({
+        directory: "docs/plans",
+        filenameTemplate: "plan-{{name}}.md",
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/config/__tests__/plan-output.test.ts
+++ b/src/config/__tests__/plan-output.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PLAN_OUTPUT_DIRECTORY,
+  DEFAULT_PLAN_OUTPUT_FILENAME_TEMPLATE,
+  getPlanOutputDirectory,
+  getPlanOutputFilenameTemplate,
+  resolveAutopilotPlanPath,
+  resolveOpenQuestionsPlanPath,
+  resolvePlanOutputAbsolutePath,
+  resolvePlanOutputFilename,
+  resolvePlanOutputPath,
+} from "../plan-output.js";
+
+describe("plan output helpers", () => {
+  it("uses default directory and filename template", () => {
+    expect(getPlanOutputDirectory()).toBe(DEFAULT_PLAN_OUTPUT_DIRECTORY);
+    expect(getPlanOutputFilenameTemplate()).toBe(
+      DEFAULT_PLAN_OUTPUT_FILENAME_TEMPLATE,
+    );
+  });
+
+  it("renders default artifact paths", () => {
+    expect(resolveAutopilotPlanPath()).toBe(".omc/plans/autopilot-impl.md");
+    expect(resolveOpenQuestionsPlanPath()).toBe(".omc/plans/open-questions.md");
+  });
+
+  it("applies custom directory and filename template", () => {
+    const config = {
+      planOutput: {
+        directory: "docs/plans",
+        filenameTemplate: "plan-{{name}}.md",
+      },
+    };
+
+    expect(resolvePlanOutputFilename("autopilot-impl", config)).toBe(
+      "plan-autopilot-impl.md",
+    );
+    expect(resolvePlanOutputPath("autopilot-impl", config)).toBe(
+      "docs/plans/plan-autopilot-impl.md",
+    );
+  });
+
+  it("falls back safely for invalid directory and filename templates", () => {
+    const config = {
+      planOutput: {
+        directory: "../outside",
+        filenameTemplate: "../bad.md",
+      },
+    };
+
+    expect(resolvePlanOutputPath("Autopilot Impl", config)).toBe(
+      ".omc/plans/autopilot-impl.md",
+    );
+  });
+
+  it("builds absolute paths from the configured relative output path", () => {
+    const config = {
+      planOutput: {
+        directory: "docs/plans",
+        filenameTemplate: "{{kind}}.plan.md",
+      },
+    };
+
+    expect(
+      resolvePlanOutputAbsolutePath("/repo", "autopilot-impl", config),
+    ).toBe("/repo/docs/plans/autopilot-impl.plan.md");
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -11,5 +11,17 @@ export {
   findContextFiles,
   loadContextFromFiles,
   generateConfigSchema,
-  DEFAULT_CONFIG
-} from './loader.js';
+  DEFAULT_CONFIG,
+} from "./loader.js";
+
+export {
+  DEFAULT_PLAN_OUTPUT_DIRECTORY,
+  DEFAULT_PLAN_OUTPUT_FILENAME_TEMPLATE,
+  getPlanOutputDirectory,
+  getPlanOutputFilenameTemplate,
+  resolvePlanOutputFilename,
+  resolvePlanOutputPath,
+  resolvePlanOutputAbsolutePath,
+  resolveAutopilotPlanPath,
+  resolveOpenQuestionsPlanPath,
+} from "./plan-output.js";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -7,16 +7,16 @@
  * - Environment variables
  */
 
-import { readFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
-import type { PluginConfig, ExternalModelsConfig } from '../shared/types.js';
-import { getConfigDir } from '../utils/paths.js';
-import { parseJsonc } from '../utils/jsonc.js';
+import { readFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import type { PluginConfig, ExternalModelsConfig } from "../shared/types.js";
+import { getConfigDir } from "../utils/paths.js";
+import { parseJsonc } from "../utils/jsonc.js";
 import {
   getDefaultTierModels,
   BUILTIN_EXTERNAL_MODEL_DEFAULTS,
   isNonClaudeProvider,
-} from './models.js';
+} from "./models.js";
 
 /**
  * Default configuration.
@@ -57,50 +57,75 @@ export function buildDefaultConfig(): PluginConfig {
     },
     features: {
       parallelExecution: true,
-      lspTools: true,   // Real LSP integration with language servers
-      astTools: true,   // Real AST tools using ast-grep
+      lspTools: true, // Real LSP integration with language servers
+      astTools: true, // Real AST tools using ast-grep
       continuationEnforcement: true,
-      autoContextInjection: true
+      autoContextInjection: true,
     },
     mcpServers: {
       exa: { enabled: true },
-      context7: { enabled: true }
+      context7: { enabled: true },
     },
     permissions: {
       allowBash: true,
       allowEdit: true,
       allowWrite: true,
-      maxBackgroundTasks: 5
+      maxBackgroundTasks: 5,
     },
     magicKeywords: {
-      ultrawork: ['ultrawork', 'ulw', 'uw'],
-      search: ['search', 'find', 'locate'],
-      analyze: ['analyze', 'investigate', 'examine'],
-      ultrathink: ['ultrathink', 'think', 'reason', 'ponder']
+      ultrawork: ["ultrawork", "ulw", "uw"],
+      search: ["search", "find", "locate"],
+      analyze: ["analyze", "investigate", "examine"],
+      ultrathink: ["ultrathink", "think", "reason", "ponder"],
     },
     // Intelligent model routing configuration
     routing: {
       enabled: true,
-      defaultTier: 'MEDIUM',
+      defaultTier: "MEDIUM",
       forceInherit: false,
       escalationEnabled: true,
       maxEscalations: 2,
       tierModels: { ...defaultTierModels },
       agentOverrides: {
-        architect: { tier: 'HIGH', reason: 'Advisory agent requires deep reasoning' },
-        planner: { tier: 'HIGH', reason: 'Strategic planning requires deep reasoning' },
-        critic: { tier: 'HIGH', reason: 'Critical review requires deep reasoning' },
-        analyst: { tier: 'HIGH', reason: 'Pre-planning analysis requires deep reasoning' },
-        explore: { tier: 'LOW', reason: 'Exploration is search-focused' },
-        'writer': { tier: 'LOW', reason: 'Documentation is straightforward' }
+        architect: {
+          tier: "HIGH",
+          reason: "Advisory agent requires deep reasoning",
+        },
+        planner: {
+          tier: "HIGH",
+          reason: "Strategic planning requires deep reasoning",
+        },
+        critic: {
+          tier: "HIGH",
+          reason: "Critical review requires deep reasoning",
+        },
+        analyst: {
+          tier: "HIGH",
+          reason: "Pre-planning analysis requires deep reasoning",
+        },
+        explore: { tier: "LOW", reason: "Exploration is search-focused" },
+        writer: { tier: "LOW", reason: "Documentation is straightforward" },
       },
       escalationKeywords: [
-        'critical', 'production', 'urgent', 'security', 'breaking',
-        'architecture', 'refactor', 'redesign', 'root cause'
+        "critical",
+        "production",
+        "urgent",
+        "security",
+        "breaking",
+        "architecture",
+        "refactor",
+        "redesign",
+        "root cause",
       ],
       simplificationKeywords: [
-        'find', 'list', 'show', 'where', 'search', 'locate', 'grep'
-      ]
+        "find",
+        "list",
+        "show",
+        "where",
+        "search",
+        "locate",
+        "grep",
+      ],
     },
     // External models configuration (Codex, Gemini)
     // Static defaults only — env var overrides applied in loadEnvConfig()
@@ -110,16 +135,20 @@ export function buildDefaultConfig(): PluginConfig {
         geminiModel: BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel,
       },
       fallbackPolicy: {
-        onModelFailure: 'provider_chain',
+        onModelFailure: "provider_chain",
         allowCrossProvider: false,
-        crossProviderOrder: ['codex', 'gemini'],
+        crossProviderOrder: ["codex", "gemini"],
       },
     },
     // Delegation routing configuration (opt-in feature for external model routing)
     delegationRouting: {
       enabled: false,
-      defaultProvider: 'claude',
+      defaultProvider: "claude",
       roles: {},
+    },
+    planOutput: {
+      directory: ".omc/plans",
+      filenameTemplate: "{{name}}.md",
     },
     startupCodebaseMap: {
       enabled: true,
@@ -144,8 +173,8 @@ export function getConfigPaths(): { user: string; project: string } {
   const userConfigDir = getConfigDir();
 
   return {
-    user: join(userConfigDir, 'claude-omc', 'config.jsonc'),
-    project: join(process.cwd(), '.claude', 'omc.jsonc')
+    user: join(userConfigDir, "claude-omc", "config.jsonc"),
+    project: join(process.cwd(), ".claude", "omc.jsonc"),
   };
 }
 
@@ -158,7 +187,7 @@ export function loadJsoncFile(path: string): PluginConfig | null {
   }
 
   try {
-    const content = readFileSync(path, 'utf-8');
+    const content = readFileSync(path, "utf-8");
     const result = parseJsonc(content);
     return result as PluginConfig;
   } catch (error) {
@@ -175,22 +204,23 @@ export function deepMerge<T extends object>(target: T, source: Partial<T>): T {
   const mutableResult = result as Record<string, unknown>;
 
   for (const key of Object.keys(source) as (keyof T)[]) {
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+    if (key === "__proto__" || key === "constructor" || key === "prototype")
+      continue;
     const sourceValue = source[key];
     const targetValue = mutableResult[key as string];
 
     if (
       sourceValue !== undefined &&
-      typeof sourceValue === 'object' &&
+      typeof sourceValue === "object" &&
       sourceValue !== null &&
       !Array.isArray(sourceValue) &&
-      typeof targetValue === 'object' &&
+      typeof targetValue === "object" &&
       targetValue !== null &&
       !Array.isArray(targetValue)
     ) {
       mutableResult[key as string] = deepMerge(
         targetValue as Record<string, unknown>,
-        sourceValue as Record<string, unknown>
+        sourceValue as Record<string, unknown>,
       );
     } else if (sourceValue !== undefined) {
       mutableResult[key as string] = sourceValue as unknown;
@@ -210,7 +240,7 @@ export function loadEnvConfig(): Partial<PluginConfig> {
   if (process.env.EXA_API_KEY) {
     config.mcpServers = {
       ...config.mcpServers,
-      exa: { enabled: true, apiKey: process.env.EXA_API_KEY }
+      exa: { enabled: true, apiKey: process.env.EXA_API_KEY },
     };
   }
 
@@ -218,14 +248,14 @@ export function loadEnvConfig(): Partial<PluginConfig> {
   if (process.env.OMC_PARALLEL_EXECUTION !== undefined) {
     config.features = {
       ...config.features,
-      parallelExecution: process.env.OMC_PARALLEL_EXECUTION === 'true'
+      parallelExecution: process.env.OMC_PARALLEL_EXECUTION === "true",
     };
   }
 
   if (process.env.OMC_LSP_TOOLS !== undefined) {
     config.features = {
       ...config.features,
-      lspTools: process.env.OMC_LSP_TOOLS === 'true'
+      lspTools: process.env.OMC_LSP_TOOLS === "true",
     };
   }
 
@@ -234,7 +264,7 @@ export function loadEnvConfig(): Partial<PluginConfig> {
     if (!isNaN(maxTasks)) {
       config.permissions = {
         ...config.permissions,
-        maxBackgroundTasks: maxTasks
+        maxBackgroundTasks: maxTasks,
       };
     }
   }
@@ -243,29 +273,29 @@ export function loadEnvConfig(): Partial<PluginConfig> {
   if (process.env.OMC_ROUTING_ENABLED !== undefined) {
     config.routing = {
       ...config.routing,
-      enabled: process.env.OMC_ROUTING_ENABLED === 'true'
+      enabled: process.env.OMC_ROUTING_ENABLED === "true",
     };
   }
 
   if (process.env.OMC_ROUTING_FORCE_INHERIT !== undefined) {
     config.routing = {
       ...config.routing,
-      forceInherit: process.env.OMC_ROUTING_FORCE_INHERIT === 'true'
+      forceInherit: process.env.OMC_ROUTING_FORCE_INHERIT === "true",
     };
   }
 
   if (process.env.OMC_ROUTING_DEFAULT_TIER) {
     const tier = process.env.OMC_ROUTING_DEFAULT_TIER.toUpperCase();
-    if (tier === 'LOW' || tier === 'MEDIUM' || tier === 'HIGH') {
+    if (tier === "LOW" || tier === "MEDIUM" || tier === "HIGH") {
       config.routing = {
         ...config.routing,
-        defaultTier: tier as 'LOW' | 'MEDIUM' | 'HIGH'
+        defaultTier: tier as "LOW" | "MEDIUM" | "HIGH",
       };
     }
   }
 
   // Model alias overrides from environment (issue #1211)
-  const aliasKeys = ['HAIKU', 'SONNET', 'OPUS'] as const;
+  const aliasKeys = ["HAIKU", "SONNET", "OPUS"] as const;
   const modelAliases: Record<string, string> = {};
   for (const key of aliasKeys) {
     const envVal = process.env[`OMC_MODEL_ALIAS_${key}`];
@@ -277,57 +307,69 @@ export function loadEnvConfig(): Partial<PluginConfig> {
   if (Object.keys(modelAliases).length > 0) {
     config.routing = {
       ...config.routing,
-      modelAliases: modelAliases as Record<string, 'haiku' | 'sonnet' | 'opus' | 'inherit'>,
+      modelAliases: modelAliases as Record<
+        string,
+        "haiku" | "sonnet" | "opus" | "inherit"
+      >,
     };
   }
 
   if (process.env.OMC_ESCALATION_ENABLED !== undefined) {
     config.routing = {
       ...config.routing,
-      escalationEnabled: process.env.OMC_ESCALATION_ENABLED === 'true'
+      escalationEnabled: process.env.OMC_ESCALATION_ENABLED === "true",
     };
   }
 
   // External models configuration from environment
-  const externalModelsDefaults: ExternalModelsConfig['defaults'] = {};
+  const externalModelsDefaults: ExternalModelsConfig["defaults"] = {};
 
   if (process.env.OMC_EXTERNAL_MODELS_DEFAULT_PROVIDER) {
     const provider = process.env.OMC_EXTERNAL_MODELS_DEFAULT_PROVIDER;
-    if (provider === 'codex' || provider === 'gemini') {
+    if (provider === "codex" || provider === "gemini") {
       externalModelsDefaults.provider = provider;
     }
   }
 
   if (process.env.OMC_EXTERNAL_MODELS_DEFAULT_CODEX_MODEL) {
-    externalModelsDefaults.codexModel = process.env.OMC_EXTERNAL_MODELS_DEFAULT_CODEX_MODEL;
+    externalModelsDefaults.codexModel =
+      process.env.OMC_EXTERNAL_MODELS_DEFAULT_CODEX_MODEL;
   } else if (process.env.OMC_CODEX_DEFAULT_MODEL) {
     // Legacy fallback
     externalModelsDefaults.codexModel = process.env.OMC_CODEX_DEFAULT_MODEL;
   }
 
   if (process.env.OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL) {
-    externalModelsDefaults.geminiModel = process.env.OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL;
+    externalModelsDefaults.geminiModel =
+      process.env.OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL;
   } else if (process.env.OMC_GEMINI_DEFAULT_MODEL) {
     // Legacy fallback
     externalModelsDefaults.geminiModel = process.env.OMC_GEMINI_DEFAULT_MODEL;
   }
 
-  const externalModelsFallback: ExternalModelsConfig['fallbackPolicy'] = {
-    onModelFailure: 'provider_chain'
+  const externalModelsFallback: ExternalModelsConfig["fallbackPolicy"] = {
+    onModelFailure: "provider_chain",
   };
 
   if (process.env.OMC_EXTERNAL_MODELS_FALLBACK_POLICY) {
     const policy = process.env.OMC_EXTERNAL_MODELS_FALLBACK_POLICY;
-    if (policy === 'provider_chain' || policy === 'cross_provider' || policy === 'claude_only') {
+    if (
+      policy === "provider_chain" ||
+      policy === "cross_provider" ||
+      policy === "claude_only"
+    ) {
       externalModelsFallback.onModelFailure = policy;
     }
   }
 
   // Only add externalModels if any env vars were set
-  if (Object.keys(externalModelsDefaults).length > 0 || externalModelsFallback.onModelFailure !== 'provider_chain') {
+  if (
+    Object.keys(externalModelsDefaults).length > 0 ||
+    externalModelsFallback.onModelFailure !== "provider_chain"
+  ) {
     config.externalModels = {
       defaults: externalModelsDefaults,
-      fallbackPolicy: externalModelsFallback
+      fallbackPolicy: externalModelsFallback,
     };
   }
 
@@ -335,16 +377,16 @@ export function loadEnvConfig(): Partial<PluginConfig> {
   if (process.env.OMC_DELEGATION_ROUTING_ENABLED !== undefined) {
     config.delegationRouting = {
       ...config.delegationRouting,
-      enabled: process.env.OMC_DELEGATION_ROUTING_ENABLED === 'true',
+      enabled: process.env.OMC_DELEGATION_ROUTING_ENABLED === "true",
     };
   }
 
   if (process.env.OMC_DELEGATION_ROUTING_DEFAULT_PROVIDER) {
     const provider = process.env.OMC_DELEGATION_ROUTING_DEFAULT_PROVIDER;
-    if (['claude', 'codex', 'gemini'].includes(provider)) {
+    if (["claude", "codex", "gemini"].includes(provider)) {
       config.delegationRouting = {
         ...config.delegationRouting,
-        defaultProvider: provider as 'claude' | 'codex' | 'gemini',
+        defaultProvider: provider as "claude" | "codex" | "gemini",
       };
     }
   }
@@ -398,17 +440,20 @@ export function loadConfig(): PluginConfig {
 }
 
 const OMC_STARTUP_COMPACTABLE_SECTIONS = [
-  'agent_catalog',
-  'skills',
-  'team_compositions',
+  "agent_catalog",
+  "skills",
+  "team_compositions",
 ] as const;
 
 function looksLikeOmcGuidance(content: string): boolean {
-  return content.includes('<guidance_schema_contract>')
-    && /oh-my-(claudecode|codex)/i.test(content)
-    && OMC_STARTUP_COMPACTABLE_SECTIONS.some(section =>
-      content.includes(`<${section}>`) && content.includes(`</${section}>`)
-    );
+  return (
+    content.includes("<guidance_schema_contract>") &&
+    /oh-my-(claudecode|codex)/i.test(content) &&
+    OMC_STARTUP_COMPACTABLE_SECTIONS.some(
+      (section) =>
+        content.includes(`<${section}>`) && content.includes(`</${section}>`),
+    )
+  );
 }
 
 export function compactOmcStartupGuidance(content: string): string {
@@ -420,20 +465,22 @@ export function compactOmcStartupGuidance(content: string): string {
   let removedAny = false;
 
   for (const section of OMC_STARTUP_COMPACTABLE_SECTIONS) {
-    const pattern = new RegExp(`\n*<${section}>[\\s\\S]*?<\/${section}>\n*`, 'g');
-    const next = compacted.replace(pattern, '\n\n');
+    const pattern = new RegExp(
+      `\n*<${section}>[\\s\\S]*?<\/${section}>\n*`,
+      "g",
+    );
+    const next = compacted.replace(pattern, "\n\n");
     removedAny = removedAny || next !== compacted;
     compacted = next;
   }
-
 
   if (!removedAny) {
     return content;
   }
 
   return compacted
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/\n\n---\n\n---\n\n/g, '\n\n---\n\n')
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/\n\n---\n\n---\n\n/g, "\n\n---\n\n")
     .trim();
 }
 
@@ -446,10 +493,10 @@ export function findContextFiles(startDir?: string): string[] {
 
   // Files to look for
   const contextFileNames = [
-    'AGENTS.md',
-    'CLAUDE.md',
-    '.claude/CLAUDE.md',
-    '.claude/AGENTS.md'
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/CLAUDE.md",
+    ".claude/AGENTS.md",
   ];
 
   // Search in current directory and parent directories
@@ -482,14 +529,14 @@ export function loadContextFromFiles(files: string[]): string {
 
   for (const file of files) {
     try {
-      const content = compactOmcStartupGuidance(readFileSync(file, 'utf-8'));
+      const content = compactOmcStartupGuidance(readFileSync(file, "utf-8"));
       contexts.push(`## Context from ${file}\n\n${content}`);
     } catch (error) {
       console.warn(`Warning: Could not read context file ${file}:`, error);
     }
   }
 
-  return contexts.join('\n\n---\n\n');
+  return contexts.join("\n\n---\n\n");
 }
 
 /**
@@ -497,261 +544,289 @@ export function loadContextFromFiles(files: string[]): string {
  */
 export function generateConfigSchema(): object {
   return {
-    $schema: 'http://json-schema.org/draft-07/schema#',
-    title: 'Oh-My-ClaudeCode Configuration',
-    type: 'object',
+    $schema: "http://json-schema.org/draft-07/schema#",
+    title: "Oh-My-ClaudeCode Configuration",
+    type: "object",
     properties: {
       agents: {
-        type: 'object',
-        description: 'Agent model and feature configuration',
+        type: "object",
+        description: "Agent model and feature configuration",
         properties: {
           omc: {
-            type: 'object',
+            type: "object",
             properties: {
-              model: { type: 'string', description: 'Model ID for the main orchestrator' }
-            }
+              model: {
+                type: "string",
+                description: "Model ID for the main orchestrator",
+              },
+            },
           },
           explore: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           analyst: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           planner: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           architect: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           debugger: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           executor: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           verifier: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           securityReviewer: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           codeReviewer: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           testEngineer: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           designer: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           writer: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           qaTester: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           scientist: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           tracer: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           gitMaster: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           codeSimplifier: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           critic: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
+            type: "object",
+            properties: { model: { type: "string" } },
           },
           documentSpecialist: {
-            type: 'object',
-            properties: { model: { type: 'string' } }
-          }
-        }
+            type: "object",
+            properties: { model: { type: "string" } },
+          },
+        },
       },
       features: {
-        type: 'object',
-        description: 'Feature toggles',
+        type: "object",
+        description: "Feature toggles",
         properties: {
-          parallelExecution: { type: 'boolean', default: true },
-          lspTools: { type: 'boolean', default: true },
-          astTools: { type: 'boolean', default: true },
-          continuationEnforcement: { type: 'boolean', default: true },
-          autoContextInjection: { type: 'boolean', default: true }
-        }
+          parallelExecution: { type: "boolean", default: true },
+          lspTools: { type: "boolean", default: true },
+          astTools: { type: "boolean", default: true },
+          continuationEnforcement: { type: "boolean", default: true },
+          autoContextInjection: { type: "boolean", default: true },
+        },
       },
       mcpServers: {
-        type: 'object',
-        description: 'MCP server configurations',
+        type: "object",
+        description: "MCP server configurations",
         properties: {
           exa: {
-            type: 'object',
+            type: "object",
             properties: {
-              enabled: { type: 'boolean' },
-              apiKey: { type: 'string' }
-            }
+              enabled: { type: "boolean" },
+              apiKey: { type: "string" },
+            },
           },
           context7: {
-            type: 'object',
-            properties: { enabled: { type: 'boolean' } }
-          }
-        }
+            type: "object",
+            properties: { enabled: { type: "boolean" } },
+          },
+        },
       },
       permissions: {
-        type: 'object',
-        description: 'Permission settings',
+        type: "object",
+        description: "Permission settings",
         properties: {
-          allowBash: { type: 'boolean', default: true },
-          allowEdit: { type: 'boolean', default: true },
-          allowWrite: { type: 'boolean', default: true },
-          maxBackgroundTasks: { type: 'integer', default: 5, minimum: 1, maximum: 50 }
-        }
+          allowBash: { type: "boolean", default: true },
+          allowEdit: { type: "boolean", default: true },
+          allowWrite: { type: "boolean", default: true },
+          maxBackgroundTasks: {
+            type: "integer",
+            default: 5,
+            minimum: 1,
+            maximum: 50,
+          },
+        },
       },
       magicKeywords: {
-        type: 'object',
-        description: 'Magic keyword triggers',
+        type: "object",
+        description: "Magic keyword triggers",
         properties: {
-          ultrawork: { type: 'array', items: { type: 'string' } },
-          search: { type: 'array', items: { type: 'string' } },
-          analyze: { type: 'array', items: { type: 'string' } },
-          ultrathink: { type: 'array', items: { type: 'string' } }
-        }
+          ultrawork: { type: "array", items: { type: "string" } },
+          search: { type: "array", items: { type: "string" } },
+          analyze: { type: "array", items: { type: "string" } },
+          ultrathink: { type: "array", items: { type: "string" } },
+        },
       },
       routing: {
-        type: 'object',
-        description: 'Intelligent model routing configuration',
-        properties: {
-          enabled: { type: 'boolean', default: true, description: 'Enable intelligent model routing' },
-          defaultTier: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH'], default: 'MEDIUM', description: 'Default tier when no rules match' },
-          forceInherit: { type: 'boolean', default: false, description: 'Force all agents to inherit the parent model, bypassing OMC model routing. When true, no model parameter is passed to Task calls, so agents use the user\'s Claude Code model setting. Auto-enabled for non-Claude providers (CC Switch, custom ANTHROPIC_BASE_URL), AWS Bedrock, and Google Vertex AI.' },
-        }
-      },
-      externalModels: {
-        type: 'object',
-        description: 'External model provider configuration (Codex, Gemini)',
-        properties: {
-          defaults: {
-            type: 'object',
-            description: 'Default model settings for external providers',
-            properties: {
-              provider: {
-                type: 'string',
-                enum: ['codex', 'gemini'],
-                description: 'Default external provider'
-              },
-              codexModel: {
-                type: 'string',
-                default: BUILTIN_EXTERNAL_MODEL_DEFAULTS.codexModel,
-                description: 'Default Codex model'
-              },
-              geminiModel: {
-                type: 'string',
-                default: BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel,
-                description: 'Default Gemini model'
-              }
-            }
-          },
-          rolePreferences: {
-            type: 'object',
-            description: 'Provider/model preferences by agent role',
-            additionalProperties: {
-              type: 'object',
-              properties: {
-                provider: { type: 'string', enum: ['codex', 'gemini'] },
-                model: { type: 'string' }
-              },
-              required: ['provider', 'model']
-            }
-          },
-          taskPreferences: {
-            type: 'object',
-            description: 'Provider/model preferences by task type',
-            additionalProperties: {
-              type: 'object',
-              properties: {
-                provider: { type: 'string', enum: ['codex', 'gemini'] },
-                model: { type: 'string' }
-              },
-              required: ['provider', 'model']
-            }
-          },
-          fallbackPolicy: {
-            type: 'object',
-            description: 'Fallback behavior on model failure',
-            properties: {
-              onModelFailure: {
-                type: 'string',
-                enum: ['provider_chain', 'cross_provider', 'claude_only'],
-                default: 'provider_chain',
-                description: 'Fallback strategy when a model fails'
-              },
-              allowCrossProvider: {
-                type: 'boolean',
-                default: false,
-                description: 'Allow fallback to a different provider'
-              },
-              crossProviderOrder: {
-                type: 'array',
-                items: { type: 'string', enum: ['codex', 'gemini'] },
-                default: ['codex', 'gemini'],
-                description: 'Order of providers for cross-provider fallback'
-              }
-            }
-          }
-        }
-      },
-      delegationRouting: {
-        type: 'object',
-        description: 'Delegation routing configuration for external model providers (opt-in feature)',
+        type: "object",
+        description: "Intelligent model routing configuration",
         properties: {
           enabled: {
-            type: 'boolean',
+            type: "boolean",
+            default: true,
+            description: "Enable intelligent model routing",
+          },
+          defaultTier: {
+            type: "string",
+            enum: ["LOW", "MEDIUM", "HIGH"],
+            default: "MEDIUM",
+            description: "Default tier when no rules match",
+          },
+          forceInherit: {
+            type: "boolean",
             default: false,
-            description: 'Enable delegation routing to external providers (Codex, Gemini)'
+            description:
+              "Force all agents to inherit the parent model, bypassing OMC model routing. When true, no model parameter is passed to Task calls, so agents use the user's Claude Code model setting. Auto-enabled for non-Claude providers (CC Switch, custom ANTHROPIC_BASE_URL), AWS Bedrock, and Google Vertex AI.",
+          },
+        },
+      },
+      externalModels: {
+        type: "object",
+        description: "External model provider configuration (Codex, Gemini)",
+        properties: {
+          defaults: {
+            type: "object",
+            description: "Default model settings for external providers",
+            properties: {
+              provider: {
+                type: "string",
+                enum: ["codex", "gemini"],
+                description: "Default external provider",
+              },
+              codexModel: {
+                type: "string",
+                default: BUILTIN_EXTERNAL_MODEL_DEFAULTS.codexModel,
+                description: "Default Codex model",
+              },
+              geminiModel: {
+                type: "string",
+                default: BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel,
+                description: "Default Gemini model",
+              },
+            },
+          },
+          rolePreferences: {
+            type: "object",
+            description: "Provider/model preferences by agent role",
+            additionalProperties: {
+              type: "object",
+              properties: {
+                provider: { type: "string", enum: ["codex", "gemini"] },
+                model: { type: "string" },
+              },
+              required: ["provider", "model"],
+            },
+          },
+          taskPreferences: {
+            type: "object",
+            description: "Provider/model preferences by task type",
+            additionalProperties: {
+              type: "object",
+              properties: {
+                provider: { type: "string", enum: ["codex", "gemini"] },
+                model: { type: "string" },
+              },
+              required: ["provider", "model"],
+            },
+          },
+          fallbackPolicy: {
+            type: "object",
+            description: "Fallback behavior on model failure",
+            properties: {
+              onModelFailure: {
+                type: "string",
+                enum: ["provider_chain", "cross_provider", "claude_only"],
+                default: "provider_chain",
+                description: "Fallback strategy when a model fails",
+              },
+              allowCrossProvider: {
+                type: "boolean",
+                default: false,
+                description: "Allow fallback to a different provider",
+              },
+              crossProviderOrder: {
+                type: "array",
+                items: { type: "string", enum: ["codex", "gemini"] },
+                default: ["codex", "gemini"],
+                description: "Order of providers for cross-provider fallback",
+              },
+            },
+          },
+        },
+      },
+      delegationRouting: {
+        type: "object",
+        description:
+          "Delegation routing configuration for external model providers (opt-in feature)",
+        properties: {
+          enabled: {
+            type: "boolean",
+            default: false,
+            description:
+              "Enable delegation routing to external providers (Codex, Gemini)",
           },
           defaultProvider: {
-            type: 'string',
-            enum: ['claude', 'codex', 'gemini'],
-            default: 'claude',
-            description: 'Default provider for delegation routing when no specific role mapping exists'
+            type: "string",
+            enum: ["claude", "codex", "gemini"],
+            default: "claude",
+            description:
+              "Default provider for delegation routing when no specific role mapping exists",
           },
           roles: {
-            type: 'object',
-            description: 'Provider mappings by agent role',
+            type: "object",
+            description: "Provider mappings by agent role",
             additionalProperties: {
-              type: 'object',
+              type: "object",
               properties: {
-                provider: { type: 'string', enum: ['claude', 'codex', 'gemini'] },
-                tool: { type: 'string', enum: ['Task'] },
-                model: { type: 'string' },
-                agentType: { type: 'string' },
-                fallback: { type: 'array', items: { type: 'string' } }
+                provider: {
+                  type: "string",
+                  enum: ["claude", "codex", "gemini"],
+                },
+                tool: { type: "string", enum: ["Task"] },
+                model: { type: "string" },
+                agentType: { type: "string" },
+                fallback: { type: "array", items: { type: "string" } },
               },
-              required: ['provider', 'tool']
-            }
-          }
-        }
-      }
-    }
+              required: ["provider", "tool"],
+            },
+          },
+        },
+      },
+    },
   };
 }

--- a/src/config/plan-output.ts
+++ b/src/config/plan-output.ts
@@ -1,0 +1,102 @@
+import { join, posix } from "path";
+import type { PluginConfig } from "../shared/types.js";
+import { validatePath } from "../lib/worktree-paths.js";
+
+export const DEFAULT_PLAN_OUTPUT_DIRECTORY = ".omc/plans";
+export const DEFAULT_PLAN_OUTPUT_FILENAME_TEMPLATE = "{{name}}.md";
+
+export type PlanOutputKind = "autopilot-impl" | "open-questions";
+
+function sanitizePlanOutputSegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .toLowerCase()
+    .replace(/\.\./g, "")
+    .replace(/[\/]/g, "-")
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  return sanitized || "plan";
+}
+
+export function getPlanOutputDirectory(config?: PluginConfig): string {
+  const directory = config?.planOutput?.directory?.trim();
+  if (!directory) return DEFAULT_PLAN_OUTPUT_DIRECTORY;
+
+  try {
+    validatePath(directory);
+    return directory;
+  } catch {
+    return DEFAULT_PLAN_OUTPUT_DIRECTORY;
+  }
+}
+
+export function getPlanOutputFilenameTemplate(config?: PluginConfig): string {
+  const template = config?.planOutput?.filenameTemplate?.trim();
+  if (!template) return DEFAULT_PLAN_OUTPUT_FILENAME_TEMPLATE;
+
+  if (
+    template.includes("/") ||
+    template.includes("\\") ||
+    template.includes("..")
+  ) {
+    return DEFAULT_PLAN_OUTPUT_FILENAME_TEMPLATE;
+  }
+
+  return template;
+}
+
+export function resolvePlanOutputFilename(
+  kind: string,
+  config?: PluginConfig,
+): string {
+  const safeKind = sanitizePlanOutputSegment(kind);
+  const template = getPlanOutputFilenameTemplate(config);
+  const rendered = template
+    .replaceAll("{{name}}", safeKind)
+    .replaceAll("{{kind}}", safeKind)
+    .trim();
+
+  const fallback = DEFAULT_PLAN_OUTPUT_FILENAME_TEMPLATE.replace(
+    "{{name}}",
+    safeKind,
+  );
+  const filename = rendered || fallback;
+
+  if (
+    filename.includes("/") ||
+    filename.includes("\\") ||
+    filename.includes("..")
+  ) {
+    return fallback;
+  }
+
+  return filename;
+}
+
+export function resolvePlanOutputPath(
+  kind: string,
+  config?: PluginConfig,
+): string {
+  return posix.join(
+    getPlanOutputDirectory(config),
+    resolvePlanOutputFilename(kind, config),
+  );
+}
+
+export function resolvePlanOutputAbsolutePath(
+  directory: string,
+  kind: string,
+  config?: PluginConfig,
+): string {
+  return join(directory, resolvePlanOutputPath(kind, config));
+}
+
+export function resolveAutopilotPlanPath(config?: PluginConfig): string {
+  return resolvePlanOutputPath("autopilot-impl", config);
+}
+
+export function resolveOpenQuestionsPlanPath(config?: PluginConfig): string {
+  return resolvePlanOutputPath("open-questions", config);
+}

--- a/src/hooks/autopilot/__tests__/prompts.test.ts
+++ b/src/hooks/autopilot/__tests__/prompts.test.ts
@@ -1,93 +1,110 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
   getExpansionPrompt,
   getDirectPlanningPrompt,
   getExecutionPrompt,
   getQAPrompt,
   getValidationPrompt,
-  getPhasePrompt
-} from '../prompts.js';
+  getPhasePrompt,
+} from "../prompts.js";
 
-describe('Prompt Generation', () => {
-  describe('getExpansionPrompt', () => {
-    it('should include user idea', () => {
-      const prompt = getExpansionPrompt('build a CLI tool');
-      expect(prompt).toContain('build a CLI tool');
+describe("Prompt Generation", () => {
+  describe("getExpansionPrompt", () => {
+    it("should include user idea", () => {
+      const prompt = getExpansionPrompt("build a CLI tool");
+      expect(prompt).toContain("build a CLI tool");
     });
 
-    it('should include analyst Task invocation', () => {
-      const prompt = getExpansionPrompt('test');
-      expect(prompt).toContain('oh-my-claudecode:analyst');
+    it("should include analyst Task invocation", () => {
+      const prompt = getExpansionPrompt("test");
+      expect(prompt).toContain("oh-my-claudecode:analyst");
     });
 
-    it('should include architect Task invocation', () => {
-      const prompt = getExpansionPrompt('test');
-      expect(prompt).toContain('oh-my-claudecode:architect');
+    it("should include architect Task invocation", () => {
+      const prompt = getExpansionPrompt("test");
+      expect(prompt).toContain("oh-my-claudecode:architect");
+    });
+
+    it("should include custom open questions path when provided", () => {
+      const prompt = getExpansionPrompt("test", "docs/plans/questions.md");
+      expect(prompt).toContain("docs/plans/questions.md");
     });
   });
 
-  describe('getDirectPlanningPrompt', () => {
-    it('should reference spec path', () => {
-      const prompt = getDirectPlanningPrompt('/path/to/spec.md');
-      expect(prompt).toContain('/path/to/spec.md');
+  describe("getDirectPlanningPrompt", () => {
+    it("should reference spec path", () => {
+      const prompt = getDirectPlanningPrompt(
+        "/path/to/spec.md",
+        "/path/to/plan.md",
+      );
+      expect(prompt).toContain("/path/to/spec.md");
+      expect(prompt).toContain("/path/to/plan.md");
     });
 
-    it('should use direct planning mode without user interview', () => {
-      const prompt = getDirectPlanningPrompt('spec.md');
+    it("should use direct planning mode without user interview", () => {
+      const prompt = getDirectPlanningPrompt("spec.md");
       // Direct mode means no interview with user - spec is already complete
-      expect(prompt).toContain('DIRECT PLANNING');
-      expect(prompt).toContain('no interview needed');
+      expect(prompt).toContain("DIRECT PLANNING");
+      expect(prompt).toContain("no interview needed");
     });
 
-    it('should include critic Task for validation', () => {
-      const prompt = getDirectPlanningPrompt('spec.md');
-      expect(prompt).toContain('oh-my-claudecode:critic');
-    });
-  });
-
-  describe('getExecutionPrompt', () => {
-    it('should reference plan path', () => {
-      const prompt = getExecutionPrompt('/path/to/plan.md');
-      expect(prompt).toContain('/path/to/plan.md');
+    it("should include critic Task for validation", () => {
+      const prompt = getDirectPlanningPrompt("spec.md");
+      expect(prompt).toContain("oh-my-claudecode:critic");
     });
 
-    it('should specify Ralph+Ultrawork activation', () => {
-      const prompt = getExecutionPrompt('plan.md');
-      expect(prompt).toContain('Ralph');
-      expect(prompt).toContain('Ultrawork');
+    it("should include custom plan path when provided", () => {
+      const prompt = getDirectPlanningPrompt(
+        "spec.md",
+        "docs/plans/plan-autopilot-impl.md",
+      );
+      expect(prompt).toContain("docs/plans/plan-autopilot-impl.md");
     });
   });
 
-  describe('getQAPrompt', () => {
-    it('should specify build/lint/test sequence', () => {
+  describe("getExecutionPrompt", () => {
+    it("should reference plan path", () => {
+      const prompt = getExecutionPrompt("/path/to/plan.md");
+      expect(prompt).toContain("/path/to/plan.md");
+    });
+
+    it("should specify Ralph+Ultrawork activation", () => {
+      const prompt = getExecutionPrompt("plan.md");
+      expect(prompt).toContain("Ralph");
+      expect(prompt).toContain("Ultrawork");
+    });
+  });
+
+  describe("getQAPrompt", () => {
+    it("should specify build/lint/test sequence", () => {
       const prompt = getQAPrompt();
-      expect(prompt).toContain('Build');
-      expect(prompt).toContain('Lint');
-      expect(prompt).toContain('Test');
+      expect(prompt).toContain("Build");
+      expect(prompt).toContain("Lint");
+      expect(prompt).toContain("Test");
     });
   });
 
-  describe('getValidationPrompt', () => {
-    it('should specify parallel architect spawns', () => {
-      const prompt = getValidationPrompt('spec.md');
-      expect(prompt).toContain('parallel');
+  describe("getValidationPrompt", () => {
+    it("should specify parallel architect spawns", () => {
+      const prompt = getValidationPrompt("spec.md");
+      expect(prompt).toContain("parallel");
     });
 
-    it('should include all three validation types', () => {
-      const prompt = getValidationPrompt('spec.md');
-      expect(prompt).toContain('Functional');
-      expect(prompt).toContain('Security');
-      expect(prompt).toContain('Quality');
+    it("should include all three validation types", () => {
+      const prompt = getValidationPrompt("spec.md");
+      expect(prompt).toContain("Functional");
+      expect(prompt).toContain("Security");
+      expect(prompt).toContain("Quality");
     });
   });
 
-  describe('getPhasePrompt', () => {
-    it('should dispatch to correct phase', () => {
-      const expansion = getPhasePrompt('expansion', { idea: 'test' });
-      expect(expansion).toContain('EXPANSION');
+  describe("getPhasePrompt", () => {
+    it("should dispatch to correct phase", () => {
+      const expansion = getPhasePrompt("expansion", { idea: "test" });
+      expect(expansion).toContain("EXPANSION");
 
-      const qa = getPhasePrompt('qa', {});
-      expect(qa).toContain('QA');
+      const qa = getPhasePrompt("qa", {});
+      expect(qa).toContain("QA");
     });
   });
 });

--- a/src/hooks/autopilot/__tests__/state.test.ts
+++ b/src/hooks/autopilot/__tests__/state.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import {
   readAutopilotState,
   clearAutopilotState,
@@ -10,83 +10,84 @@ import {
   transitionPhase,
   updateExpansion,
   updateExecution,
-} from '../state.js';
+  getPlanPath,
+} from "../state.js";
 
-describe('AutopilotState', () => {
+describe("AutopilotState", () => {
   let testDir: string;
 
   beforeEach(() => {
-    testDir = mkdtempSync(join(tmpdir(), 'autopilot-test-'));
+    testDir = mkdtempSync(join(tmpdir(), "autopilot-test-"));
   });
 
   afterEach(() => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  describe('readAutopilotState', () => {
-    it('should return null when state file does not exist', () => {
+  describe("readAutopilotState", () => {
+    it("should return null when state file does not exist", () => {
       const state = readAutopilotState(testDir);
       expect(state).toBeNull();
     });
 
-    it('should return parsed state when file exists', () => {
-      const _state = initAutopilot(testDir, 'test idea');
+    it("should return parsed state when file exists", () => {
+      const _state = initAutopilot(testDir, "test idea");
       const readState = readAutopilotState(testDir);
       expect(readState).not.toBeNull();
-      expect(readState?.originalIdea).toBe('test idea');
+      expect(readState?.originalIdea).toBe("test idea");
     });
   });
 
-  describe('initAutopilot', () => {
-    it('should create new state with correct defaults', () => {
-      const state = initAutopilot(testDir, 'build a cli tool');
+  describe("initAutopilot", () => {
+    it("should create new state with correct defaults", () => {
+      const state = initAutopilot(testDir, "build a cli tool");
       expect(state).not.toBeNull();
       expect(state!.active).toBe(true);
-      expect(state!.phase).toBe('expansion');
-      expect(state!.originalIdea).toBe('build a cli tool');
+      expect(state!.phase).toBe("expansion");
+      expect(state!.originalIdea).toBe("build a cli tool");
       expect(state!.expansion.analyst_complete).toBe(false);
     });
   });
 
-  describe('clearAutopilotState', () => {
-    it('should delete state file', () => {
-      initAutopilot(testDir, 'test');
+  describe("clearAutopilotState", () => {
+    it("should delete state file", () => {
+      initAutopilot(testDir, "test");
       expect(isAutopilotActive(testDir)).toBe(true);
       clearAutopilotState(testDir);
       expect(isAutopilotActive(testDir)).toBe(false);
     });
 
-    it('should return true if file already missing', () => {
+    it("should return true if file already missing", () => {
       const result = clearAutopilotState(testDir);
       expect(result).toBe(true);
     });
   });
 
-  describe('transitionPhase', () => {
-    it('should update phase field', () => {
-      initAutopilot(testDir, 'test');
-      const state = transitionPhase(testDir, 'planning');
-      expect(state?.phase).toBe('planning');
+  describe("transitionPhase", () => {
+    it("should update phase field", () => {
+      initAutopilot(testDir, "test");
+      const state = transitionPhase(testDir, "planning");
+      expect(state?.phase).toBe("planning");
     });
 
-    it('should mark as inactive on complete', () => {
-      initAutopilot(testDir, 'test');
-      const state = transitionPhase(testDir, 'complete');
+    it("should mark as inactive on complete", () => {
+      initAutopilot(testDir, "test");
+      const state = transitionPhase(testDir, "complete");
       expect(state?.active).toBe(false);
       expect(state?.completed_at).not.toBeNull();
     });
   });
 
-  describe('phase updates', () => {
-    it('should update expansion data', () => {
-      initAutopilot(testDir, 'test');
+  describe("phase updates", () => {
+    it("should update expansion data", () => {
+      initAutopilot(testDir, "test");
       updateExpansion(testDir, { analyst_complete: true });
       const state = readAutopilotState(testDir);
       expect(state?.expansion.analyst_complete).toBe(true);
     });
 
-    it('should update execution data', () => {
-      initAutopilot(testDir, 'test');
+    it("should update execution data", () => {
+      initAutopilot(testDir, "test");
       updateExecution(testDir, { tasks_completed: 5, tasks_total: 10 });
       const state = readAutopilotState(testDir);
       expect(state?.execution.tasks_completed).toBe(5);

--- a/src/hooks/autopilot/adapters/execution-adapter.ts
+++ b/src/hooks/autopilot/adapters/execution-adapter.ts
@@ -7,13 +7,18 @@
  * When execution='solo', uses direct executor agents in the current session.
  */
 
-import type { PipelineStageAdapter, PipelineConfig, PipelineContext } from '../pipeline-types.js';
+import type {
+  PipelineStageAdapter,
+  PipelineConfig,
+  PipelineContext,
+} from "../pipeline-types.js";
+import { resolveAutopilotPlanPath } from "../../../config/plan-output.js";
 
-export const EXECUTION_COMPLETION_SIGNAL = 'PIPELINE_EXECUTION_COMPLETE';
+export const EXECUTION_COMPLETION_SIGNAL = "PIPELINE_EXECUTION_COMPLETE";
 
 export const executionAdapter: PipelineStageAdapter = {
-  id: 'execution',
-  name: 'Execution',
+  id: "execution",
+  name: "Execution",
   completionSignal: EXECUTION_COMPLETION_SIGNAL,
 
   shouldSkip(_config: PipelineConfig): boolean {
@@ -22,8 +27,8 @@ export const executionAdapter: PipelineStageAdapter = {
   },
 
   getPrompt(context: PipelineContext): string {
-    const planPath = context.planPath || '.omc/plans/autopilot-impl.md';
-    const isTeam = context.config.execution === 'team';
+    const planPath = context.planPath || resolveAutopilotPlanPath();
+    const isTeam = context.config.execution === "team";
 
     if (isTeam) {
       return `## PIPELINE STAGE: EXECUTION (Team Mode)

--- a/src/hooks/autopilot/adapters/ralplan-adapter.ts
+++ b/src/hooks/autopilot/adapters/ralplan-adapter.ts
@@ -9,14 +9,19 @@
  * When planning='direct', uses the simpler Architect+Critic approach.
  */
 
-import type { PipelineStageAdapter, PipelineConfig, PipelineContext } from '../pipeline-types.js';
-import { getExpansionPrompt, getDirectPlanningPrompt } from '../prompts.js';
+import type {
+  PipelineStageAdapter,
+  PipelineConfig,
+  PipelineContext,
+} from "../pipeline-types.js";
+import { resolveAutopilotPlanPath } from "../../../config/plan-output.js";
+import { getExpansionPrompt, getDirectPlanningPrompt } from "../prompts.js";
 
-export const RALPLAN_COMPLETION_SIGNAL = 'PIPELINE_RALPLAN_COMPLETE';
+export const RALPLAN_COMPLETION_SIGNAL = "PIPELINE_RALPLAN_COMPLETE";
 
 export const ralplanAdapter: PipelineStageAdapter = {
-  id: 'ralplan',
-  name: 'Planning (RALPLAN)',
+  id: "ralplan",
+  name: "Planning (RALPLAN)",
   completionSignal: RALPLAN_COMPLETION_SIGNAL,
 
   shouldSkip(config: PipelineConfig): boolean {
@@ -24,10 +29,10 @@ export const ralplanAdapter: PipelineStageAdapter = {
   },
 
   getPrompt(context: PipelineContext): string {
-    const specPath = context.specPath || '.omc/autopilot/spec.md';
-    const planPath = context.planPath || '.omc/plans/autopilot-impl.md';
+    const specPath = context.specPath || ".omc/autopilot/spec.md";
+    const planPath = context.planPath || resolveAutopilotPlanPath();
 
-    if (context.config.planning === 'ralplan') {
+    if (context.config.planning === "ralplan") {
       return `## PIPELINE STAGE: RALPLAN (Consensus Planning)
 
 Your task: Expand the idea into a detailed spec and implementation plan using consensus-driven planning.

--- a/src/hooks/autopilot/enforcement.ts
+++ b/src/hooks/autopilot/enforcement.ts
@@ -7,21 +7,32 @@
  * Also handles signal detection in session transcripts.
  */
 
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
-import { getClaudeConfigDir } from '../../utils/paths.js';
-import { OmcPaths } from '../../lib/worktree-paths.js';
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { getClaudeConfigDir } from "../../utils/paths.js";
+import {
+  resolveAutopilotPlanPath,
+  resolveOpenQuestionsPlanPath,
+} from "../../config/plan-output.js";
 import {
   readAutopilotState,
   writeAutopilotState,
   transitionPhase,
   transitionRalphToUltraQA,
   transitionUltraQAToValidation,
-  transitionToComplete
-} from './state.js';
-import { getPhasePrompt } from './prompts.js';
-import type { AutopilotState, AutopilotPhase, AutopilotSignal } from './types.js';
-import { readLastToolError, getToolErrorRetryGuidance, type ToolErrorState } from '../persistent-mode/index.js';
+  transitionToComplete,
+} from "./state.js";
+import { getPhasePrompt } from "./prompts.js";
+import type {
+  AutopilotState,
+  AutopilotPhase,
+  AutopilotSignal,
+} from "./types.js";
+import {
+  readLastToolError,
+  getToolErrorRetryGuidance,
+  type ToolErrorState,
+} from "../persistent-mode/index.js";
 import {
   readPipelineTracking,
   hasPipelineTracking,
@@ -31,7 +42,7 @@ import {
   incrementStageIteration,
   generateTransitionPrompt,
   formatPipelineHUD,
-} from './pipeline.js';
+} from "./pipeline.js";
 
 export interface AutopilotEnforcementResult {
   /** Whether to block the stop event */
@@ -58,25 +69,28 @@ export interface AutopilotEnforcementResult {
  * Signal patterns - each signal can appear in transcript
  */
 const SIGNAL_PATTERNS: Record<AutopilotSignal, RegExp> = {
-  'EXPANSION_COMPLETE': /EXPANSION_COMPLETE/i,
-  'PLANNING_COMPLETE': /PLANNING_COMPLETE/i,
-  'EXECUTION_COMPLETE': /EXECUTION_COMPLETE/i,
-  'QA_COMPLETE': /QA_COMPLETE/i,
-  'VALIDATION_COMPLETE': /VALIDATION_COMPLETE/i,
-  'AUTOPILOT_COMPLETE': /AUTOPILOT_COMPLETE/i,
-  'TRANSITION_TO_QA': /TRANSITION_TO_QA/i,
-  'TRANSITION_TO_VALIDATION': /TRANSITION_TO_VALIDATION/i,
+  EXPANSION_COMPLETE: /EXPANSION_COMPLETE/i,
+  PLANNING_COMPLETE: /PLANNING_COMPLETE/i,
+  EXECUTION_COMPLETE: /EXECUTION_COMPLETE/i,
+  QA_COMPLETE: /QA_COMPLETE/i,
+  VALIDATION_COMPLETE: /VALIDATION_COMPLETE/i,
+  AUTOPILOT_COMPLETE: /AUTOPILOT_COMPLETE/i,
+  TRANSITION_TO_QA: /TRANSITION_TO_QA/i,
+  TRANSITION_TO_VALIDATION: /TRANSITION_TO_VALIDATION/i,
 };
 
 /**
  * Detect a specific signal in the session transcript
  */
-export function detectSignal(sessionId: string, signal: AutopilotSignal): boolean {
+export function detectSignal(
+  sessionId: string,
+  signal: AutopilotSignal,
+): boolean {
   const claudeDir = getClaudeConfigDir();
   const possiblePaths = [
-    join(claudeDir, 'sessions', sessionId, 'transcript.md'),
-    join(claudeDir, 'sessions', sessionId, 'messages.json'),
-    join(claudeDir, 'transcripts', `${sessionId}.md`)
+    join(claudeDir, "sessions", sessionId, "transcript.md"),
+    join(claudeDir, "sessions", sessionId, "messages.json"),
+    join(claudeDir, "transcripts", `${sessionId}.md`),
   ];
 
   const pattern = SIGNAL_PATTERNS[signal];
@@ -85,7 +99,7 @@ export function detectSignal(sessionId: string, signal: AutopilotSignal): boolea
   for (const transcriptPath of possiblePaths) {
     if (existsSync(transcriptPath)) {
       try {
-        const content = readFileSync(transcriptPath, 'utf-8');
+        const content = readFileSync(transcriptPath, "utf-8");
         if (pattern.test(content)) {
           return true;
         }
@@ -100,14 +114,22 @@ export function detectSignal(sessionId: string, signal: AutopilotSignal): boolea
 /**
  * Get the expected signal for the current phase
  */
-export function getExpectedSignalForPhase(phase: string): AutopilotSignal | null {
+export function getExpectedSignalForPhase(
+  phase: string,
+): AutopilotSignal | null {
   switch (phase) {
-    case 'expansion': return 'EXPANSION_COMPLETE';
-    case 'planning': return 'PLANNING_COMPLETE';
-    case 'execution': return 'EXECUTION_COMPLETE';
-    case 'qa': return 'QA_COMPLETE';
-    case 'validation': return 'VALIDATION_COMPLETE';
-    default: return null;
+    case "expansion":
+      return "EXPANSION_COMPLETE";
+    case "planning":
+      return "PLANNING_COMPLETE";
+    case "execution":
+      return "EXECUTION_COMPLETE";
+    case "qa":
+      return "QA_COMPLETE";
+    case "validation":
+      return "VALIDATION_COMPLETE";
+    default:
+      return null;
   }
 }
 
@@ -132,12 +154,18 @@ export function detectAnySignal(sessionId: string): AutopilotSignal | null {
  */
 function getNextPhase(current: AutopilotPhase): AutopilotPhase | null {
   switch (current) {
-    case 'expansion': return 'planning';
-    case 'planning': return 'execution';
-    case 'execution': return 'qa';
-    case 'qa': return 'validation';
-    case 'validation': return 'complete';
-    default: return null;
+    case "expansion":
+      return "planning";
+    case "planning":
+      return "execution";
+    case "execution":
+      return "qa";
+    case "qa":
+      return "validation";
+    case "validation":
+      return "complete";
+    default:
+      return null;
   }
 }
 
@@ -147,7 +175,7 @@ function getNextPhase(current: AutopilotPhase): AutopilotPhase | null {
  */
 export async function checkAutopilot(
   sessionId?: string,
-  directory?: string
+  directory?: string,
 ): Promise<AutopilotEnforcementResult | null> {
   const workingDir = directory || process.cwd();
   const state = readAutopilotState(workingDir, sessionId);
@@ -163,28 +191,28 @@ export async function checkAutopilot(
 
   // Check max iterations (safety limit)
   if (state.iteration >= state.max_iterations) {
-    transitionPhase(workingDir, 'failed', sessionId);
+    transitionPhase(workingDir, "failed", sessionId);
     return {
       shouldBlock: false,
       message: `[AUTOPILOT STOPPED] Max iterations (${state.max_iterations}) reached. Consider reviewing progress.`,
-      phase: 'failed'
+      phase: "failed",
     };
   }
 
   // Check for completion
-  if (state.phase === 'complete') {
+  if (state.phase === "complete") {
     return {
       shouldBlock: false,
       message: `[AUTOPILOT COMPLETE] All phases finished successfully!`,
-      phase: 'complete'
+      phase: "complete",
     };
   }
 
-  if (state.phase === 'failed') {
+  if (state.phase === "failed") {
     return {
       shouldBlock: false,
       message: `[AUTOPILOT FAILED] Session ended in failure state.`,
-      phase: 'failed'
+      phase: "failed",
     };
   }
 
@@ -208,23 +236,23 @@ export async function checkAutopilot(
     const nextPhase = getNextPhase(state.phase);
     if (nextPhase) {
       // Handle special transitions
-      if (state.phase === 'execution' && nextPhase === 'qa') {
+      if (state.phase === "execution" && nextPhase === "qa") {
         const result = transitionRalphToUltraQA(workingDir, sessionId);
         if (!result.success) {
           // Transition failed, continue in current phase
           return generateContinuationPrompt(state, workingDir);
         }
-      } else if (state.phase === 'qa' && nextPhase === 'validation') {
+      } else if (state.phase === "qa" && nextPhase === "validation") {
         const result = transitionUltraQAToValidation(workingDir, sessionId);
         if (!result.success) {
           return generateContinuationPrompt(state, workingDir, sessionId);
         }
-      } else if (nextPhase === 'complete') {
+      } else if (nextPhase === "complete") {
         transitionToComplete(workingDir, sessionId);
         return {
           shouldBlock: false,
           message: `[AUTOPILOT COMPLETE] All phases finished successfully!`,
-          phase: 'complete'
+          phase: "complete",
         };
       } else {
         transitionPhase(workingDir, nextPhase, sessionId);
@@ -248,7 +276,7 @@ export async function checkAutopilot(
 function generateContinuationPrompt(
   state: AutopilotState,
   directory: string,
-  sessionId?: string
+  sessionId?: string,
 ): AutopilotEnforcementResult {
   // Read tool error before generating message
   const toolError = readLastToolError(directory);
@@ -260,12 +288,13 @@ function generateContinuationPrompt(
 
   const phasePrompt = getPhasePrompt(state.phase, {
     idea: state.originalIdea,
-    specPath: state.expansion.spec_path || `${OmcPaths.AUTOPILOT}/spec.md`,
-    planPath: state.planning.plan_path || `${OmcPaths.PLANS}/autopilot-impl.md`
+    specPath: state.expansion.spec_path || `.omc/autopilot/spec.md`,
+    planPath: state.planning.plan_path || resolveAutopilotPlanPath(),
+    openQuestionsPath: resolveOpenQuestionsPlanPath(),
   });
 
   const continuationPrompt = `<autopilot-continuation>
-${errorGuidance ? errorGuidance + '\n' : ''}
+${errorGuidance ? errorGuidance + "\n" : ""}
 [AUTOPILOT - PHASE: ${state.phase.toUpperCase()} | ITERATION ${state.iteration}/${state.max_iterations}]
 
 Your previous response did not signal phase completion. Continue working on the current phase.
@@ -294,8 +323,8 @@ IMPORTANT: When the phase is complete, output the appropriate signal:
       maxIterations: state.max_iterations,
       tasksCompleted: state.execution.tasks_completed,
       tasksTotal: state.execution.tasks_total,
-      toolError: toolError || undefined
-    }
+      toolError: toolError || undefined,
+    },
   };
 }
 
@@ -310,7 +339,7 @@ IMPORTANT: When the phase is complete, output the appropriate signal:
 function checkPipelineAutopilot(
   state: AutopilotState,
   sessionId: string | undefined,
-  directory: string
+  directory: string,
 ): AutopilotEnforcementResult | null {
   const tracking = readPipelineTracking(state);
   if (!tracking) return null;
@@ -320,52 +349,64 @@ function checkPipelineAutopilot(
     // No more stages — pipeline is complete
     return {
       shouldBlock: false,
-      message: '[AUTOPILOT COMPLETE] All pipeline stages finished successfully!',
-      phase: 'complete',
+      message:
+        "[AUTOPILOT COMPLETE] All pipeline stages finished successfully!",
+      phase: "complete",
     };
   }
 
   // Check if the current stage's completion signal has been emitted
   const completionSignal = getCurrentCompletionSignal(tracking);
-  if (completionSignal && sessionId && detectPipelineSignal(sessionId, completionSignal)) {
+  if (
+    completionSignal &&
+    sessionId &&
+    detectPipelineSignal(sessionId, completionSignal)
+  ) {
     // Current stage complete — advance to next stage
-    const { adapter: nextAdapter, phase: nextPhase } = advanceStage(directory, sessionId);
+    const { adapter: nextAdapter, phase: nextPhase } = advanceStage(
+      directory,
+      sessionId,
+    );
 
-    if (!nextAdapter || nextPhase === 'complete') {
+    if (!nextAdapter || nextPhase === "complete") {
       // Pipeline complete
-      transitionPhase(directory, 'complete', sessionId);
+      transitionPhase(directory, "complete", sessionId);
       return {
         shouldBlock: false,
-        message: '[AUTOPILOT COMPLETE] All pipeline stages finished successfully!',
-        phase: 'complete',
+        message:
+          "[AUTOPILOT COMPLETE] All pipeline stages finished successfully!",
+        phase: "complete",
       };
     }
 
-    if (nextPhase === 'failed') {
+    if (nextPhase === "failed") {
       return {
         shouldBlock: false,
-        message: '[AUTOPILOT FAILED] Pipeline stage transition failed.',
-        phase: 'failed',
+        message: "[AUTOPILOT FAILED] Pipeline stage transition failed.",
+        phase: "failed",
       };
     }
 
     // Generate transition + next stage prompt
     const transitionMsg = generateTransitionPrompt(
       currentAdapter.id,
-      nextAdapter.id
+      nextAdapter.id,
     );
 
     // Re-read tracking to get updated state
     const updatedState = readAutopilotState(directory, sessionId);
-    const updatedTracking = updatedState ? readPipelineTracking(updatedState) : null;
-    const hudLine = updatedTracking ? formatPipelineHUD(updatedTracking) : '';
+    const updatedTracking = updatedState
+      ? readPipelineTracking(updatedState)
+      : null;
+    const hudLine = updatedTracking ? formatPipelineHUD(updatedTracking) : "";
 
     const context = {
       idea: state.originalIdea,
       directory: state.project_path || directory,
       sessionId,
-      specPath: state.expansion.spec_path || '.omc/autopilot/spec.md',
-      planPath: state.planning.plan_path || '.omc/plans/autopilot-impl.md',
+      specPath: state.expansion.spec_path || ".omc/autopilot/spec.md",
+      planPath: state.planning.plan_path || resolveAutopilotPlanPath(),
+      openQuestionsPath: resolveOpenQuestionsPlanPath(),
       config: tracking.pipelineConfig,
     };
 
@@ -403,23 +444,24 @@ ${stagePrompt}
   writeAutopilotState(directory, state, sessionId);
 
   const updatedTracking = readPipelineTracking(
-    readAutopilotState(directory, sessionId)!
+    readAutopilotState(directory, sessionId)!,
   );
-  const hudLine = updatedTracking ? formatPipelineHUD(updatedTracking) : '';
+  const hudLine = updatedTracking ? formatPipelineHUD(updatedTracking) : "";
 
   const context = {
     idea: state.originalIdea,
     directory: state.project_path || directory,
     sessionId,
-    specPath: state.expansion.spec_path || '.omc/autopilot/spec.md',
-    planPath: state.planning.plan_path || '.omc/plans/autopilot-impl.md',
+    specPath: state.expansion.spec_path || ".omc/autopilot/spec.md",
+    planPath: state.planning.plan_path || resolveAutopilotPlanPath(),
+    openQuestionsPath: resolveOpenQuestionsPlanPath(),
     config: tracking.pipelineConfig,
   };
 
   const stagePrompt = currentAdapter.getPrompt(context);
 
   const continuationPrompt = `<autopilot-pipeline-continuation>
-${errorGuidance ? errorGuidance + '\n' : ''}
+${errorGuidance ? errorGuidance + "\n" : ""}
 ${hudLine}
 
 [AUTOPILOT PIPELINE - STAGE: ${currentAdapter.name.toUpperCase()} | ITERATION ${state.iteration}/${state.max_iterations}]
@@ -456,17 +498,17 @@ IMPORTANT: When this stage is complete, output the signal: ${currentAdapter.comp
 function detectPipelineSignal(sessionId: string, signal: string): boolean {
   const claudeDir = getClaudeConfigDir();
   const possiblePaths = [
-    join(claudeDir, 'sessions', sessionId, 'transcript.md'),
-    join(claudeDir, 'sessions', sessionId, 'messages.json'),
-    join(claudeDir, 'transcripts', `${sessionId}.md`),
+    join(claudeDir, "sessions", sessionId, "transcript.md"),
+    join(claudeDir, "sessions", sessionId, "messages.json"),
+    join(claudeDir, "transcripts", `${sessionId}.md`),
   ];
 
-  const pattern = new RegExp(signal, 'i');
+  const pattern = new RegExp(signal, "i");
 
   for (const transcriptPath of possiblePaths) {
     if (existsSync(transcriptPath)) {
       try {
-        const content = readFileSync(transcriptPath, 'utf-8');
+        const content = readFileSync(transcriptPath, "utf-8");
         if (pattern.test(content)) {
           return true;
         }

--- a/src/hooks/autopilot/pipeline-types.ts
+++ b/src/hooks/autopilot/pipeline-types.ts
@@ -16,23 +16,28 @@
  * Pipeline stage identifiers in execution order.
  * Each stage is optional and can be skipped via configuration.
  */
-export type PipelineStageId = 'ralplan' | 'execution' | 'ralph' | 'qa';
+export type PipelineStageId = "ralplan" | "execution" | "ralph" | "qa";
 
 /** Terminal pipeline states */
-export type PipelineTerminalState = 'complete' | 'failed' | 'cancelled';
+export type PipelineTerminalState = "complete" | "failed" | "cancelled";
 
 /** All possible pipeline phase values (stages + terminal) */
 export type PipelinePhase = PipelineStageId | PipelineTerminalState;
 
 /** Status of an individual stage */
-export type StageStatus = 'pending' | 'active' | 'complete' | 'failed' | 'skipped';
+export type StageStatus =
+  | "pending"
+  | "active"
+  | "complete"
+  | "failed"
+  | "skipped";
 
 /** The canonical stage execution order */
 export const STAGE_ORDER: readonly PipelineStageId[] = [
-  'ralplan',
-  'execution',
-  'ralph',
-  'qa',
+  "ralplan",
+  "execution",
+  "ralph",
+  "qa",
 ] as const;
 
 // ============================================================================
@@ -40,12 +45,12 @@ export const STAGE_ORDER: readonly PipelineStageId[] = [
 // ============================================================================
 
 /** Execution backend for the execution stage */
-export type ExecutionBackend = 'team' | 'solo';
+export type ExecutionBackend = "team" | "solo";
 
 /** Verification engine configuration */
 export interface VerificationConfig {
   /** Engine to use for verification (currently only 'ralph') */
-  engine: 'ralph';
+  engine: "ralph";
   /** Maximum verification iterations before giving up */
   maxIterations: number;
 }
@@ -68,7 +73,7 @@ export interface VerificationConfig {
  */
 export interface PipelineConfig {
   /** Planning stage: 'ralplan' for consensus planning, 'direct' for simple planning, false to skip */
-  planning: 'ralplan' | 'direct' | false;
+  planning: "ralplan" | "direct" | false;
   /** Execution backend: 'team' for multi-worker, 'solo' for single-session */
   execution: ExecutionBackend;
   /** Verification config, or false to skip */
@@ -79,10 +84,10 @@ export interface PipelineConfig {
 
 /** Default pipeline configuration (matches current autopilot behavior) */
 export const DEFAULT_PIPELINE_CONFIG: PipelineConfig = {
-  planning: 'ralplan',
-  execution: 'solo',
+  planning: "ralplan",
+  execution: "solo",
   verification: {
-    engine: 'ralph',
+    engine: "ralph",
     maxIterations: 100,
   },
   qa: true,
@@ -106,6 +111,8 @@ export interface PipelineContext {
   specPath?: string;
   /** Path to the generated implementation plan */
   planPath?: string;
+  /** Path to the shared open questions file */
+  openQuestionsPath?: string;
   /** The full pipeline configuration */
   config: PipelineConfig;
 }
@@ -173,13 +180,18 @@ export interface PipelineTracking {
  * Maps deprecated mode names to their pipeline configuration equivalents.
  * Used to translate ultrawork/ultrapilot invocations into autopilot + config.
  */
-export const DEPRECATED_MODE_ALIASES: Record<string, { config: Partial<PipelineConfig>; message: string }> = {
+export const DEPRECATED_MODE_ALIASES: Record<
+  string,
+  { config: Partial<PipelineConfig>; message: string }
+> = {
   ultrawork: {
-    config: { execution: 'team' },
-    message: 'ultrawork is deprecated. Use /autopilot with execution: "team" instead.',
+    config: { execution: "team" },
+    message:
+      'ultrawork is deprecated. Use /autopilot with execution: "team" instead.',
   },
   ultrapilot: {
-    config: { execution: 'team' },
-    message: 'ultrapilot is deprecated. Use /autopilot with execution: "team" instead.',
+    config: { execution: "team" },
+    message:
+      'ultrapilot is deprecated. Use /autopilot with execution: "team" instead.',
   },
 };

--- a/src/hooks/autopilot/pipeline.ts
+++ b/src/hooks/autopilot/pipeline.ts
@@ -20,15 +20,23 @@ import type {
   PipelinePhase,
   PipelineStageId,
   StageStatus,
-} from './pipeline-types.js';
-import { DEFAULT_PIPELINE_CONFIG, STAGE_ORDER, DEPRECATED_MODE_ALIASES } from './pipeline-types.js';
-import { ALL_ADAPTERS, getAdapterById } from './adapters/index.js';
+} from "./pipeline-types.js";
+import {
+  DEFAULT_PIPELINE_CONFIG,
+  STAGE_ORDER,
+  DEPRECATED_MODE_ALIASES,
+} from "./pipeline-types.js";
+import { ALL_ADAPTERS, getAdapterById } from "./adapters/index.js";
 import {
   readAutopilotState,
   writeAutopilotState,
   initAutopilot,
-} from './state.js';
-import type { AutopilotState, AutopilotConfig } from './types.js';
+} from "./state.js";
+import type { AutopilotState, AutopilotConfig } from "./types.js";
+import {
+  resolveAutopilotPlanPath,
+  resolveOpenQuestionsPlanPath,
+} from "../../config/plan-output.js";
 
 // ============================================================================
 // CONFIGURATION
@@ -42,7 +50,7 @@ import type { AutopilotState, AutopilotConfig } from './types.js';
  */
 export function resolvePipelineConfig(
   userConfig?: Partial<PipelineConfig>,
-  deprecatedMode?: string
+  deprecatedMode?: string,
 ): PipelineConfig {
   let config = { ...DEFAULT_PIPELINE_CONFIG };
 
@@ -54,9 +62,12 @@ export function resolvePipelineConfig(
 
   // Apply user overrides
   if (userConfig) {
-    if (userConfig.planning !== undefined) config.planning = userConfig.planning;
-    if (userConfig.execution !== undefined) config.execution = userConfig.execution;
-    if (userConfig.verification !== undefined) config.verification = userConfig.verification;
+    if (userConfig.planning !== undefined)
+      config.planning = userConfig.planning;
+    if (userConfig.execution !== undefined)
+      config.execution = userConfig.execution;
+    if (userConfig.verification !== undefined)
+      config.verification = userConfig.verification;
     if (userConfig.qa !== undefined) config.qa = userConfig.qa;
   }
 
@@ -81,20 +92,24 @@ export function getDeprecationWarning(mode: string): string | null {
  * Build the initial pipeline tracking state from a resolved config.
  * Creates stage entries for all stages, marking skipped stages as 'skipped'.
  */
-export function buildPipelineTracking(config: PipelineConfig): PipelineTracking {
+export function buildPipelineTracking(
+  config: PipelineConfig,
+): PipelineTracking {
   const _adapters = getActiveAdapters(config);
-  const stages: PipelineStageState[] = STAGE_ORDER.map(stageId => {
+  const stages: PipelineStageState[] = STAGE_ORDER.map((stageId) => {
     const adapter = getAdapterById(stageId);
     const isActive = adapter && !adapter.shouldSkip(config);
     return {
       id: stageId,
-      status: isActive ? 'pending' as StageStatus : 'skipped' as StageStatus,
+      status: isActive
+        ? ("pending" as StageStatus)
+        : ("skipped" as StageStatus),
       iterations: 0,
     };
   });
 
   // Find the first non-skipped stage
-  const firstActiveIndex = stages.findIndex(s => s.status !== 'skipped');
+  const firstActiveIndex = stages.findIndex((s) => s.status !== "skipped");
 
   return {
     pipelineConfig: config,
@@ -106,15 +121,19 @@ export function buildPipelineTracking(config: PipelineConfig): PipelineTracking 
 /**
  * Get the ordered list of active (non-skipped) adapters for a given config.
  */
-export function getActiveAdapters(config: PipelineConfig): PipelineStageAdapter[] {
-  return ALL_ADAPTERS.filter(adapter => !adapter.shouldSkip(config));
+export function getActiveAdapters(
+  config: PipelineConfig,
+): PipelineStageAdapter[] {
+  return ALL_ADAPTERS.filter((adapter) => !adapter.shouldSkip(config));
 }
 
 /**
  * Read pipeline tracking from an autopilot state.
  * Returns null if the state doesn't have pipeline tracking.
  */
-export function readPipelineTracking(state: AutopilotState): PipelineTracking | null {
+export function readPipelineTracking(
+  state: AutopilotState,
+): PipelineTracking | null {
   const extended = state as AutopilotState & { pipeline?: PipelineTracking };
   return extended.pipeline ?? null;
 }
@@ -125,12 +144,13 @@ export function readPipelineTracking(state: AutopilotState): PipelineTracking | 
 export function writePipelineTracking(
   directory: string,
   tracking: PipelineTracking,
-  sessionId?: string
+  sessionId?: string,
 ): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
 
-  (state as AutopilotState & { pipeline: PipelineTracking }).pipeline = tracking;
+  (state as AutopilotState & { pipeline: PipelineTracking }).pipeline =
+    tracking;
   return writeAutopilotState(directory, state, sessionId);
 }
 
@@ -158,7 +178,7 @@ export function initPipeline(
   sessionId?: string,
   autopilotConfig?: Partial<AutopilotConfig>,
   pipelineConfig?: Partial<PipelineConfig>,
-  deprecatedMode?: string
+  deprecatedMode?: string,
 ): AutopilotState | null {
   // Resolve pipeline config
   const resolvedConfig = resolvePipelineConfig(pipelineConfig, deprecatedMode);
@@ -171,13 +191,18 @@ export function initPipeline(
   const tracking = buildPipelineTracking(resolvedConfig);
 
   // Mark the first active stage as active
-  if (tracking.currentStageIndex >= 0 && tracking.currentStageIndex < tracking.stages.length) {
-    tracking.stages[tracking.currentStageIndex].status = 'active';
-    tracking.stages[tracking.currentStageIndex].startedAt = new Date().toISOString();
+  if (
+    tracking.currentStageIndex >= 0 &&
+    tracking.currentStageIndex < tracking.stages.length
+  ) {
+    tracking.stages[tracking.currentStageIndex].status = "active";
+    tracking.stages[tracking.currentStageIndex].startedAt =
+      new Date().toISOString();
   }
 
   // Persist pipeline tracking alongside autopilot state
-  (state as AutopilotState & { pipeline: PipelineTracking }).pipeline = tracking;
+  (state as AutopilotState & { pipeline: PipelineTracking }).pipeline =
+    tracking;
   writeAutopilotState(directory, state, sessionId);
 
   return state;
@@ -191,7 +216,9 @@ export function initPipeline(
  * Get the current pipeline stage adapter.
  * Returns null if the pipeline is in a terminal state or all stages are done.
  */
-export function getCurrentStageAdapter(tracking: PipelineTracking): PipelineStageAdapter | null {
+export function getCurrentStageAdapter(
+  tracking: PipelineTracking,
+): PipelineStageAdapter | null {
   const { stages, currentStageIndex } = tracking;
 
   if (currentStageIndex < 0 || currentStageIndex >= stages.length) {
@@ -199,7 +226,7 @@ export function getCurrentStageAdapter(tracking: PipelineTracking): PipelineStag
   }
 
   const currentStage = stages[currentStageIndex];
-  if (currentStage.status === 'skipped' || currentStage.status === 'complete') {
+  if (currentStage.status === "skipped" || currentStage.status === "complete") {
     // Find next active stage
     return getNextStageAdapter(tracking);
   }
@@ -211,11 +238,13 @@ export function getCurrentStageAdapter(tracking: PipelineTracking): PipelineStag
  * Get the next non-skipped stage adapter after the current one.
  * Returns null if no more stages remain.
  */
-export function getNextStageAdapter(tracking: PipelineTracking): PipelineStageAdapter | null {
+export function getNextStageAdapter(
+  tracking: PipelineTracking,
+): PipelineStageAdapter | null {
   const { stages, currentStageIndex } = tracking;
 
   for (let i = currentStageIndex + 1; i < stages.length; i++) {
-    if (stages[i].status !== 'skipped') {
+    if (stages[i].status !== "skipped") {
       return getAdapterById(stages[i].id) ?? null;
     }
   }
@@ -232,20 +261,20 @@ export function getNextStageAdapter(tracking: PipelineTracking): PipelineStageAd
  */
 export function advanceStage(
   directory: string,
-  sessionId?: string
+  sessionId?: string,
 ): { adapter: PipelineStageAdapter | null; phase: PipelinePhase } {
   const state = readAutopilotState(directory, sessionId);
-  if (!state) return { adapter: null, phase: 'failed' };
+  if (!state) return { adapter: null, phase: "failed" };
 
   const tracking = readPipelineTracking(state);
-  if (!tracking) return { adapter: null, phase: 'failed' };
+  if (!tracking) return { adapter: null, phase: "failed" };
 
   const { stages, currentStageIndex } = tracking;
 
   // Mark current stage as complete
   if (currentStageIndex >= 0 && currentStageIndex < stages.length) {
     const currentStage = stages[currentStageIndex];
-    currentStage.status = 'complete';
+    currentStage.status = "complete";
     currentStage.completedAt = new Date().toISOString();
 
     // Call onExit if the adapter supports it
@@ -259,7 +288,7 @@ export function advanceStage(
   // Find next non-skipped stage
   let nextIndex = -1;
   for (let i = currentStageIndex + 1; i < stages.length; i++) {
-    if (stages[i].status !== 'skipped') {
+    if (stages[i].status !== "skipped") {
       nextIndex = i;
       break;
     }
@@ -269,12 +298,12 @@ export function advanceStage(
     // All stages complete — pipeline is done
     tracking.currentStageIndex = stages.length;
     writePipelineTracking(directory, tracking, sessionId);
-    return { adapter: null, phase: 'complete' };
+    return { adapter: null, phase: "complete" };
   }
 
   // Activate next stage
   tracking.currentStageIndex = nextIndex;
-  stages[nextIndex].status = 'active';
+  stages[nextIndex].status = "active";
   stages[nextIndex].startedAt = new Date().toISOString();
   writePipelineTracking(directory, tracking, sessionId);
 
@@ -294,7 +323,7 @@ export function advanceStage(
 export function failCurrentStage(
   directory: string,
   error: string,
-  sessionId?: string
+  sessionId?: string,
 ): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
@@ -304,7 +333,7 @@ export function failCurrentStage(
 
   const { stages, currentStageIndex } = tracking;
   if (currentStageIndex >= 0 && currentStageIndex < stages.length) {
-    stages[currentStageIndex].status = 'failed';
+    stages[currentStageIndex].status = "failed";
     stages[currentStageIndex].error = error;
   }
 
@@ -316,7 +345,7 @@ export function failCurrentStage(
  */
 export function incrementStageIteration(
   directory: string,
-  sessionId?: string
+  sessionId?: string,
 ): boolean {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return false;
@@ -339,7 +368,9 @@ export function incrementStageIteration(
 /**
  * Get the completion signal expected for the current pipeline stage.
  */
-export function getCurrentCompletionSignal(tracking: PipelineTracking): string | null {
+export function getCurrentCompletionSignal(
+  tracking: PipelineTracking,
+): string | null {
   const { stages, currentStageIndex } = tracking;
   if (currentStageIndex < 0 || currentStageIndex >= stages.length) return null;
 
@@ -368,7 +399,7 @@ export function getSignalToStageMap(): Map<string, PipelineStageId> {
  */
 export function generatePipelinePrompt(
   directory: string,
-  sessionId?: string
+  sessionId?: string,
 ): string | null {
   const state = readAutopilotState(directory, sessionId);
   if (!state) return null;
@@ -388,9 +419,9 @@ export function generatePipelinePrompt(
  */
 export function generateTransitionPrompt(
   fromStage: PipelineStageId,
-  toStage: PipelineStageId | 'complete'
+  toStage: PipelineStageId | "complete",
 ): string {
-  if (toStage === 'complete') {
+  if (toStage === "complete") {
     return `## PIPELINE COMPLETE
 
 All pipeline stages have completed successfully!
@@ -431,28 +462,35 @@ export function getPipelineStatus(tracking: PipelineTracking): {
 
   for (const stage of tracking.stages) {
     switch (stage.status) {
-      case 'complete':
+      case "complete":
         completed.push(stage.id);
         break;
-      case 'active':
+      case "active":
         current = stage.id;
         break;
-      case 'pending':
+      case "pending":
         pending.push(stage.id);
         break;
-      case 'skipped':
+      case "skipped":
         skipped.push(stage.id);
         break;
     }
   }
 
-  const activeStages = tracking.stages.filter(s => s.status !== 'skipped');
+  const activeStages = tracking.stages.filter((s) => s.status !== "skipped");
   const completedCount = completed.length;
   const totalActive = activeStages.length;
   const isComplete = current === null && pending.length === 0;
   const progress = `${completedCount}/${totalActive} stages`;
 
-  return { currentStage: current, completedStages: completed, pendingStages: pending, skippedStages: skipped, isComplete, progress };
+  return {
+    currentStage: current,
+    completedStages: completed,
+    pendingStages: pending,
+    skippedStages: skipped,
+    isComplete,
+    progress,
+  };
 }
 
 /**
@@ -466,25 +504,25 @@ export function formatPipelineHUD(tracking: PipelineTracking): string {
     const adapter = getAdapterById(stage.id);
     const name = adapter?.name ?? stage.id;
     switch (stage.status) {
-      case 'complete':
+      case "complete":
         parts.push(`[OK] ${name}`);
         break;
-      case 'active':
+      case "active":
         parts.push(`[>>] ${name} (iter ${stage.iterations})`);
         break;
-      case 'pending':
+      case "pending":
         parts.push(`[..] ${name}`);
         break;
-      case 'skipped':
+      case "skipped":
         parts.push(`[--] ${name}`);
         break;
-      case 'failed':
+      case "failed":
         parts.push(`[!!] ${name}`);
         break;
     }
   }
 
-  return `Pipeline ${status.progress}: ${parts.join(' | ')}`;
+  return `Pipeline ${status.progress}: ${parts.join(" | ")}`;
 }
 
 // ============================================================================
@@ -494,13 +532,17 @@ export function formatPipelineHUD(tracking: PipelineTracking): string {
 /**
  * Build a PipelineContext from autopilot state and pipeline tracking.
  */
-function buildContext(state: AutopilotState, tracking: PipelineTracking): PipelineContext {
+function buildContext(
+  state: AutopilotState,
+  tracking: PipelineTracking,
+): PipelineContext {
   return {
     idea: state.originalIdea,
     directory: state.project_path || process.cwd(),
     sessionId: state.session_id,
-    specPath: state.expansion.spec_path || '.omc/autopilot/spec.md',
-    planPath: state.planning.plan_path || '.omc/plans/autopilot-impl.md',
+    specPath: state.expansion.spec_path || ".omc/autopilot/spec.md",
+    planPath: state.planning.plan_path || resolveAutopilotPlanPath(),
+    openQuestionsPath: resolveOpenQuestionsPlanPath(),
     config: tracking.pipelineConfig,
   };
 }

--- a/src/hooks/autopilot/prompts.ts
+++ b/src/hooks/autopilot/prompts.ts
@@ -1,15 +1,43 @@
+import {
+  resolveAutopilotPlanPath,
+  resolveOpenQuestionsPlanPath,
+} from "../../config/plan-output.js";
 /**
  * Autopilot Prompt Generation
  *
  * Generates phase-specific prompts that include Task tool invocations
  * for Claude to execute. This is the core of the agent invocation mechanism.
  */
+import type { PluginConfig } from "../../shared/types.js";
+
+function resolvePromptPlanPath(
+  planPathOrConfig?: string | PluginConfig,
+): string {
+  return typeof planPathOrConfig === "string"
+    ? planPathOrConfig
+    : resolveAutopilotPlanPath(planPathOrConfig);
+}
+
+function resolvePromptOpenQuestionsPath(
+  openQuestionsPathOrConfig?: string | PluginConfig,
+): string {
+  return typeof openQuestionsPathOrConfig === "string"
+    ? openQuestionsPathOrConfig
+    : resolveOpenQuestionsPlanPath(openQuestionsPathOrConfig);
+}
 
 /**
  * Generate the expansion phase prompt (Phase 0)
  * Analyst extracts requirements, Architect creates technical spec
  */
-export function getExpansionPrompt(idea: string): string {
+export function getExpansionPrompt(
+  idea: string,
+  openQuestionsPathOrConfig?: string | PluginConfig,
+): string {
+  const openQuestionsPath = resolvePromptOpenQuestionsPath(
+    openQuestionsPathOrConfig,
+  );
+
   return `## AUTOPILOT PHASE 0: IDEA EXPANSION
 
 Your task: Expand this product idea into detailed requirements and technical spec.
@@ -59,7 +87,7 @@ Output as structured markdown."
 
 ### Step 2.5: Persist Open Questions
 
-If the Analyst output includes a \`### Open Questions\` section, extract those items and save them to \`.omc/plans/open-questions.md\` using the standard format:
+If the Analyst output includes a \`### Open Questions\` section, extract those items and save them to \`${openQuestionsPath}\` using the standard format:
 
 \`\`\`
 ## [Topic] - [Date]
@@ -83,7 +111,12 @@ When the spec is saved, signal: EXPANSION_COMPLETE
  * Generate the direct planning prompt (Phase 1)
  * Uses Architect instead of Planner to create plan directly from spec
  */
-export function getDirectPlanningPrompt(specPath: string): string {
+export function getDirectPlanningPrompt(
+  specPath: string,
+  planPathOrConfig?: string | PluginConfig,
+): string {
+  const planPath = resolvePromptPlanPath(planPathOrConfig);
+
   return `## AUTOPILOT PHASE 1: DIRECT PLANNING
 
 The spec is complete from Phase 0. Create implementation plan directly (no interview needed).
@@ -124,7 +157,7 @@ Generate a comprehensive implementation plan with:
    - Identified risks
    - Mitigation strategies
 
-Save to: .omc/plans/autopilot-impl.md
+Save to: ${planPath}
 
 Signal completion with: PLAN_CREATED"
 )
@@ -140,7 +173,7 @@ Task(
   model="opus",
   prompt="REVIEW IMPLEMENTATION PLAN
 
-Plan file: .omc/plans/autopilot-impl.md
+Plan file: ${planPath}
 Original spec: ${specPath}
 
 Verify:
@@ -357,10 +390,10 @@ When all approve: AUTOPILOT_COMPLETE
  */
 function escapeForPrompt(text: string): string {
   return text
-    .replace(/\\/g, '\\\\')
+    .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
-    .replace(/`/g, '\\`')
-    .replace(/\$/g, '\\$');
+    .replace(/`/g, "\\`")
+    .replace(/\$/g, "\\$");
 }
 
 /**
@@ -372,20 +405,27 @@ export function getPhasePrompt(
     idea?: string;
     specPath?: string;
     planPath?: string;
-  }
+    openQuestionsPath?: string;
+  },
 ): string {
   switch (phase) {
-    case 'expansion':
-      return getExpansionPrompt(context.idea || '');
-    case 'planning':
-      return getDirectPlanningPrompt(context.specPath || '.omc/autopilot/spec.md');
-    case 'execution':
-      return getExecutionPrompt(context.planPath || '.omc/plans/autopilot-impl.md');
-    case 'qa':
+    case "expansion":
+      return getExpansionPrompt(
+        context.idea || "",
+        context.openQuestionsPath || resolveOpenQuestionsPlanPath(),
+      );
+    case "planning":
+      return getDirectPlanningPrompt(
+        context.specPath || ".omc/autopilot/spec.md",
+        context.planPath || resolveAutopilotPlanPath(),
+      );
+    case "execution":
+      return getExecutionPrompt(context.planPath || resolveAutopilotPlanPath());
+    case "qa":
       return getQAPrompt();
-    case 'validation':
-      return getValidationPrompt(context.specPath || '.omc/autopilot/spec.md');
+    case "validation":
+      return getValidationPrompt(context.specPath || ".omc/autopilot/spec.md");
     default:
-      return '';
+      return "";
   }
 }

--- a/src/hooks/autopilot/state.ts
+++ b/src/hooks/autopilot/state.ts
@@ -17,6 +17,7 @@ import {
 import {
   resolveStatePath,
   resolveSessionStatePath,
+  getOmcRoot,
 } from "../../lib/worktree-paths.js";
 import type {
   AutopilotState,
@@ -24,6 +25,8 @@ import type {
   AutopilotConfig,
 } from "./types.js";
 import { DEFAULT_CONFIG } from "./types.js";
+import { loadConfig } from "../../config/loader.js";
+import { resolvePlanOutputAbsolutePath } from "../../config/plan-output.js";
 import {
   readRalphState,
   clearRalphState,
@@ -35,7 +38,6 @@ import {
   readUltraQAState,
 } from "../ultraqa/index.js";
 import { canStartMode } from "../mode-registry/index.js";
-import { getOmcRoot } from "../../lib/worktree-paths.js";
 
 const SPEC_DIR = "autopilot";
 
@@ -353,7 +355,11 @@ export function getSpecPath(directory: string): string {
  * Get the plan file path
  */
 export function getPlanPath(directory: string): string {
-  return join(getOmcRoot(directory), "plans", "autopilot-impl.md");
+  return resolvePlanOutputAbsolutePath(
+    directory,
+    "autopilot-impl",
+    loadConfig(),
+  );
 }
 
 // ============================================================================

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -13,14 +13,29 @@
  * ```
  */
 
-import { pathToFileURL } from 'url';
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { pathToFileURL } from "url";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
 import { dirname, join } from "path";
 import { resolveToWorktreeRoot, getOmcRoot } from "../lib/worktree-paths.js";
 
 // Hot-path imports: needed on every/most hook invocations (keyword-detector, pre/post-tool-use)
-import { removeCodeBlocks, getAllKeywordsWithSizeCheck, applyRalplanGate, sanitizeForKeywordDetection, NON_LATIN_SCRIPT_PATTERN } from "./keyword-detector/index.js";
-import { processOrchestratorPreTool, processOrchestratorPostTool } from "./omc-orchestrator/index.js";
+import {
+  removeCodeBlocks,
+  getAllKeywordsWithSizeCheck,
+  applyRalplanGate,
+  sanitizeForKeywordDetection,
+  NON_LATIN_SCRIPT_PATTERN,
+} from "./keyword-detector/index.js";
+import {
+  processOrchestratorPreTool,
+  processOrchestratorPostTool,
+} from "./omc-orchestrator/index.js";
 import { normalizeHookInput } from "./bridge-normalize.js";
 import {
   addBackgroundTask,
@@ -28,6 +43,10 @@ import {
 } from "../hud/background-tasks.js";
 import { readHudState, writeHudState } from "../hud/state.js";
 import { compactOmcStartupGuidance, loadConfig } from "../config/loader.js";
+import {
+  resolveAutopilotPlanPath,
+  resolveOpenQuestionsPlanPath,
+} from "../config/plan-output.js";
 import { writeSkillActiveState } from "./skill-state/index.js";
 import {
   ULTRAWORK_MESSAGE,
@@ -41,16 +60,15 @@ import {
   PROMPT_TRANSLATION_MESSAGE,
 } from "../installer/hooks.js";
 // Agent dashboard is used in pre/post-tool-use hot path
-import {
-  getAgentDashboard,
-} from "./subagent-tracker/index.js";
+import { getAgentDashboard } from "./subagent-tracker/index.js";
 // Session replay recordFileTouch is used in pre-tool-use hot path
-import {
-  recordFileTouch,
-} from "./subagent-tracker/session-replay.js";
+import { recordFileTouch } from "./subagent-tracker/session-replay.js";
 
 // Type-only imports for lazy-loaded modules (zero runtime cost)
-import type { SubagentStartInput, SubagentStopInput } from "./subagent-tracker/index.js";
+import type {
+  SubagentStartInput,
+  SubagentStopInput,
+} from "./subagent-tracker/index.js";
 import type { PreCompactInput } from "./pre-compact/index.js";
 import type { SetupInput } from "./setup/index.js";
 import {
@@ -65,7 +83,8 @@ import { wrapUntrustedFileContent } from "../agents/prompt-helpers.js";
 
 const PKILL_F_FLAG_PATTERN = /\bpkill\b.*\s-f\b/;
 const PKILL_FULL_FLAG_PATTERN = /\bpkill\b.*--full\b/;
-const WORKER_BLOCKED_TMUX_PATTERN = /\btmux\s+(split-window|new-session|new-window|join-pane)\b/i;
+const WORKER_BLOCKED_TMUX_PATTERN =
+  /\btmux\s+(split-window|new-session|new-window|join-pane)\b/i;
 const WORKER_BLOCKED_TEAM_CLI_PATTERN = /\bom[cx]\s+team\b(?!\s+api\b)/i;
 const WORKER_BLOCKED_SKILL_PATTERN = /\$(team|ultrawork|autopilot|ralph)\b/i;
 
@@ -141,7 +160,9 @@ function readTeamStagedState(
     }
 
     try {
-      const parsed = JSON.parse(readFileSync(statePath, "utf-8")) as TeamStagedState;
+      const parsed = JSON.parse(
+        readFileSync(statePath, "utf-8"),
+      ) as TeamStagedState;
       if (typeof parsed !== "object" || parsed === null) {
         continue;
       }
@@ -172,7 +193,12 @@ function getTeamStage(state: TeamStagedState): string {
 }
 
 function getTeamStageForEnforcement(state: TeamStagedState): string | null {
-  const rawStage = state.stage ?? state.current_stage ?? state.currentStage ?? state.current_phase ?? state.phase;
+  const rawStage =
+    state.stage ??
+    state.current_stage ??
+    state.currentStage ??
+    state.current_phase ??
+    state.phase;
   if (typeof rawStage !== "string") {
     return null;
   }
@@ -187,7 +213,10 @@ function getTeamStageForEnforcement(state: TeamStagedState): string | null {
   return alias && TEAM_ACTIVE_STAGES.has(alias) ? alias : null;
 }
 
-function readTeamStopBreakerCount(directory: string, sessionId?: string): number {
+function readTeamStopBreakerCount(
+  directory: string,
+  sessionId?: string,
+): number {
   const stateDir = join(getOmcRoot(directory), "state");
   const breakerPath = sessionId
     ? join(stateDir, "sessions", sessionId, "team-stop-breaker.json")
@@ -197,10 +226,16 @@ function readTeamStopBreakerCount(directory: string, sessionId?: string): number
     if (!existsSync(breakerPath)) {
       return 0;
     }
-    const parsed = JSON.parse(readFileSync(breakerPath, "utf-8")) as { count?: unknown; updated_at?: unknown };
+    const parsed = JSON.parse(readFileSync(breakerPath, "utf-8")) as {
+      count?: unknown;
+      updated_at?: unknown;
+    };
     if (typeof parsed.updated_at === "string") {
       const updatedAt = new Date(parsed.updated_at).getTime();
-      if (Number.isFinite(updatedAt) && Date.now() - updatedAt > TEAM_STOP_BLOCKER_TTL_MS) {
+      if (
+        Number.isFinite(updatedAt) &&
+        Date.now() - updatedAt > TEAM_STOP_BLOCKER_TTL_MS
+      ) {
         return 0;
       }
     }
@@ -211,7 +246,11 @@ function readTeamStopBreakerCount(directory: string, sessionId?: string): number
   }
 }
 
-function writeTeamStopBreakerCount(directory: string, sessionId: string | undefined, count: number): void {
+function writeTeamStopBreakerCount(
+  directory: string,
+  sessionId: string | undefined,
+  count: number,
+): void {
   const stateDir = join(getOmcRoot(directory), "state");
   const breakerPath = sessionId
     ? join(stateDir, "sessions", sessionId, "team-stop-breaker.json")
@@ -233,7 +272,11 @@ function writeTeamStopBreakerCount(directory: string, sessionId: string | undefi
     mkdirSync(dirname(breakerPath), { recursive: true });
     writeFileSync(
       breakerPath,
-      JSON.stringify({ count: safeCount, updated_at: new Date().toISOString() }, null, 2),
+      JSON.stringify(
+        { count: safeCount, updated_at: new Date().toISOString() },
+        null,
+        2,
+      ),
       "utf-8",
     );
   } catch {
@@ -242,7 +285,12 @@ function writeTeamStopBreakerCount(directory: string, sessionId: string | undefi
 }
 
 function isTeamStateTerminal(state: TeamStagedState): boolean {
-  if (state.terminal === true || state.cancelled === true || state.canceled === true || state.completed === true) {
+  if (
+    state.terminal === true ||
+    state.cancelled === true ||
+    state.canceled === true ||
+    state.completed === true
+  ) {
     return true;
   }
 
@@ -269,10 +317,14 @@ function getTeamStagePrompt(stage: string): string {
   }
 }
 
-function teamWorkerIdentityFromEnv(env: NodeJS.ProcessEnv = process.env): string {
-  const omc = typeof env.OMC_TEAM_WORKER === "string" ? env.OMC_TEAM_WORKER.trim() : "";
+function teamWorkerIdentityFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const omc =
+    typeof env.OMC_TEAM_WORKER === "string" ? env.OMC_TEAM_WORKER.trim() : "";
   if (omc) return omc;
-  const omx = typeof env.OMX_TEAM_WORKER === "string" ? env.OMX_TEAM_WORKER.trim() : "";
+  const omx =
+    typeof env.OMX_TEAM_WORKER === "string" ? env.OMX_TEAM_WORKER.trim() : "";
   return omx;
 }
 
@@ -461,42 +513,49 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
     enabled: taskSizeConfig.enabled !== false,
     smallWordLimit: taskSizeConfig.smallWordLimit ?? 50,
     largeWordLimit: taskSizeConfig.largeWordLimit ?? 200,
-    suppressHeavyModesForSmallTasks: taskSizeConfig.suppressHeavyModesForSmallTasks !== false,
+    suppressHeavyModesForSmallTasks:
+      taskSizeConfig.suppressHeavyModesForSmallTasks !== false,
   });
 
   // Apply ralplan-first gate BEFORE task-size suppression (issue #997).
   // Reconstruct the full keyword set so the gate sees execution keywords
   // that task-size suppression may have already removed for small tasks.
-  const fullKeywords = [...sizeCheckResult.keywords, ...sizeCheckResult.suppressedKeywords];
+  const fullKeywords = [
+    ...sizeCheckResult.keywords,
+    ...sizeCheckResult.suppressedKeywords,
+  ];
   const gateResult = applyRalplanGate(fullKeywords, cleanedText);
 
   let keywords: typeof fullKeywords;
   if (gateResult.gateApplied) {
     // Gate fired: redirect to ralplan (task-size suppression is moot — we're planning, not executing)
     keywords = gateResult.keywords;
-    const gated = gateResult.gatedKeywords.join(', ');
+    const gated = gateResult.gatedKeywords.join(", ");
     messages.push(
       `[RALPLAN GATE] Redirecting ${gated} → ralplan for scoping.\n` +
-      `Tip: add a concrete anchor to run directly next time:\n` +
-      `  \u2022 "ralph fix the bug in src/auth.ts"  (file path)\n` +
-      `  \u2022 "ralph implement #42"               (issue number)\n` +
-      `  \u2022 "ralph fix processKeyword"           (symbol name)\n` +
-      `Or prefix with \`force:\` / \`!\` to bypass.`
+        `Tip: add a concrete anchor to run directly next time:\n` +
+        `  \u2022 "ralph fix the bug in src/auth.ts"  (file path)\n` +
+        `  \u2022 "ralph implement #42"               (issue number)\n` +
+        `  \u2022 "ralph fix processKeyword"           (symbol name)\n` +
+        `Or prefix with \`force:\` / \`!\` to bypass.`,
     );
   } else {
     // Gate did not fire: use task-size-suppressed result as normal
     keywords = sizeCheckResult.keywords;
 
     // Notify user when heavy modes were suppressed for a small task
-    if (sizeCheckResult.suppressedKeywords.length > 0 && sizeCheckResult.taskSizeResult) {
-      const suppressed = sizeCheckResult.suppressedKeywords.join(', ');
+    if (
+      sizeCheckResult.suppressedKeywords.length > 0 &&
+      sizeCheckResult.taskSizeResult
+    ) {
+      const suppressed = sizeCheckResult.suppressedKeywords.join(", ");
       const reason = sizeCheckResult.taskSizeResult.reason;
       messages.push(
         `[TASK-SIZE: SMALL] Heavy orchestration mode(s) suppressed: ${suppressed}.\n` +
-        `Reason: ${reason}\n` +
-        `Running directly without heavy agent stacking. ` +
-        `Prefix with \`quick:\`, \`simple:\`, or \`tiny:\` to always use lightweight mode. ` +
-        `Use explicit mode keywords (e.g. \`ralph\`) only when you need full orchestration.`
+          `Reason: ${reason}\n` +
+          `Running directly without heavy agent stacking. ` +
+          `Prefix with \`quick:\`, \`simple:\`, or \`tiny:\` to always use lightweight mode. ` +
+          `Use explicit mode keywords (e.g. \`ralph\`) only when you need full orchestration.`,
       );
     }
   }
@@ -517,7 +576,7 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
 
   if (keywords.length === 0) {
     if (messages.length > 0) {
-      return { continue: true, message: messages.join('\n\n---\n\n') };
+      return { continue: true, message: messages.join("\n\n---\n\n") };
     }
     return { continue: true };
   }
@@ -527,13 +586,24 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
     switch (keywordType) {
       case "ralph": {
         // Lazy-load ralph module
-        const { createRalphLoopHook, findPrdPath: findPrd, initPrd: initPrdFn, initProgress: initProgressFn, detectNoPrdFlag: detectNoPrd, stripNoPrdFlag: stripNoPrd, detectCriticModeFlag, stripCriticModeFlag } = await import("./ralph/index.js");
+        const {
+          createRalphLoopHook,
+          findPrdPath: findPrd,
+          initPrd: initPrdFn,
+          initProgress: initProgressFn,
+          detectNoPrdFlag: detectNoPrd,
+          stripNoPrdFlag: stripNoPrd,
+          detectCriticModeFlag,
+          stripCriticModeFlag,
+        } = await import("./ralph/index.js");
 
         // Handle --no-prd flag
         const noPrd = detectNoPrd(promptText);
         const criticMode = detectCriticModeFlag(promptText) ?? undefined;
         const promptWithoutCriticFlag = stripCriticModeFlag(promptText);
-        const cleanPrompt = noPrd ? stripNoPrd(promptWithoutCriticFlag) : promptWithoutCriticFlag;
+        const cleanPrompt = noPrd
+          ? stripNoPrd(promptWithoutCriticFlag)
+          : promptWithoutCriticFlag;
 
         // Auto-generate scaffold PRD if none exists and --no-prd not set
         const existingPrd = findPrd(directory);
@@ -541,9 +611,13 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
           const { basename } = await import("path");
           const { execSync } = await import("child_process");
           const projectName = basename(directory);
-          let branchName = 'ralph/task';
+          let branchName = "ralph/task";
           try {
-            branchName = execSync('git rev-parse --abbrev-ref HEAD', { cwd: directory, encoding: 'utf-8', timeout: 5000 }).trim();
+            branchName = execSync("git rev-parse --abbrev-ref HEAD", {
+              cwd: directory,
+              encoding: "utf-8",
+              timeout: 5000,
+            }).trim();
           } catch {
             // Not a git repo or git not available — use fallback
           }
@@ -553,7 +627,11 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
 
         // Activate ralph state which also auto-activates ultrawork
         const hook = createRalphLoopHook(directory);
-        hook.startLoop(sessionId, cleanPrompt, criticMode ? { criticMode } : undefined);
+        hook.startLoop(
+          sessionId,
+          cleanPrompt,
+          criticMode ? { criticMode } : undefined,
+        );
 
         messages.push(RALPH_MESSAGE);
         break;
@@ -607,9 +685,9 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
       case "gemini": {
         messages.push(
           `[MAGIC KEYWORD: team]\n` +
-          `User intent: delegate to ${keywordType} CLI workers via omc team CLI.\n` +
-          `Agent type: ${keywordType}. Parse N from user message (default 1).\n` +
-          `Invoke: omc team start --agent ${keywordType} --count N --task "<task from user message>"`
+            `User intent: delegate to ${keywordType} CLI workers via omc team CLI.\n` +
+            `Agent type: ${keywordType}. Parse N from user message (default 1).\n` +
+            `Invoke: omc team start --agent ${keywordType} --count N --task "<task from user message>"`,
         );
         break;
       }
@@ -651,13 +729,21 @@ async function processStopContinuation(_input: HookInput): Promise<HookOutput> {
  * ultrawork self-heal, and architect rejection handling).
  */
 async function processPersistentMode(input: HookInput): Promise<HookOutput> {
-  const rawSessionId = (input as Record<string, unknown>).session_id as string | undefined;
+  const rawSessionId = (input as Record<string, unknown>).session_id as
+    | string
+    | undefined;
   const sessionId = input.sessionId ?? rawSessionId;
   const directory = resolveToWorktreeRoot(input.directory);
 
   // Lazy-load persistent-mode and todo-continuation modules
-  const { checkPersistentModes, createHookOutput, shouldSendIdleNotification, recordIdleNotificationSent } = await import("./persistent-mode/index.js");
-  const { isExplicitCancelCommand, isAuthenticationError } = await import("./todo-continuation/index.js");
+  const {
+    checkPersistentModes,
+    createHookOutput,
+    shouldSendIdleNotification,
+    recordIdleNotificationSent,
+  } = await import("./persistent-mode/index.js");
+  const { isExplicitCancelCommand, isAuthenticationError } =
+    await import("./todo-continuation/index.js");
 
   // Extract stop context for abort detection (supports both camelCase and snake_case)
   const stopContext: StopContext = {
@@ -701,18 +787,26 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
   // Skip legacy bridge.ts team enforcement if persistent-mode already
   // handled this stop event (or intentionally emitted a stop message).
   // Prevents mixed/double continuation prompts across modes.
-  if (result.mode !== 'none' || Boolean(output.message)) {
+  if (result.mode !== "none" || Boolean(output.message)) {
     return output;
   }
 
   const teamState = readTeamStagedState(directory, sessionId);
-  if (!teamState || teamState.active !== true || isTeamStateTerminal(teamState)) {
+  if (
+    !teamState ||
+    teamState.active !== true ||
+    isTeamStateTerminal(teamState)
+  ) {
     writeTeamStopBreakerCount(directory, sessionId, 0);
     // No persistent mode and no active team — Claude is truly idle.
     // Send session-idle notification (non-blocking) unless this was a user abort or context limit.
     if (result.mode === "none" && sessionId) {
-      const isAbort = stopContext.user_requested === true || stopContext.userRequested === true;
-      const isContextLimit = stopContext.stop_reason === "context_limit" || stopContext.stopReason === "context_limit";
+      const isAbort =
+        stopContext.user_requested === true ||
+        stopContext.userRequested === true;
+      const isContextLimit =
+        stopContext.stop_reason === "context_limit" ||
+        stopContext.stopReason === "context_limit";
       if (!isAbort && !isContextLimit) {
         // Always wake OpenClaw on stop — cooldown only applies to user-facing notifications
         _openclaw.wake("stop", { sessionId, projectPath: directory });
@@ -722,13 +816,15 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
         const stateDir = join(getOmcRoot(directory), "state");
         if (shouldSendIdleNotification(stateDir, sessionId)) {
           recordIdleNotificationSent(stateDir, sessionId);
-          import("../notifications/index.js").then(({ notify }) =>
-            notify("session-idle", {
-              sessionId,
-              projectPath: directory,
-              profileName: process.env.OMC_NOTIFY_PROFILE,
-            }).catch(() => {})
-          ).catch(() => {});
+          import("../notifications/index.js")
+            .then(({ notify }) =>
+              notify("session-idle", {
+                sessionId,
+                projectPath: directory,
+                profileName: process.env.OMC_NOTIFY_PROFILE,
+              }).catch(() => {}),
+            )
+            .catch(() => {});
         }
       }
 
@@ -812,13 +908,15 @@ async function processSessionStart(input: HookInput): Promise<HookOutput> {
 
   // Send session-start notification (non-blocking, swallows errors)
   if (sessionId) {
-    import("../notifications/index.js").then(({ notify }) =>
-      notify("session-start", {
-        sessionId,
-        projectPath: directory,
-        profileName: process.env.OMC_NOTIFY_PROFILE,
-      }).catch(() => {})
-    ).catch(() => {});
+    import("../notifications/index.js")
+      .then(({ notify }) =>
+        notify("session-start", {
+          sessionId,
+          projectPath: directory,
+          profileName: process.env.OMC_NOTIFY_PROFILE,
+        }).catch(() => {}),
+      )
+      .catch(() => {});
     // Wake OpenClaw gateway for session-start (non-blocking)
     _openclaw.wake("session-start", { sessionId, projectPath: directory });
   }
@@ -828,20 +926,27 @@ async function processSessionStart(input: HookInput): Promise<HookOutput> {
     Promise.all([
       import("../notifications/reply-listener.js"),
       import("../notifications/config.js"),
-    ]).then(
-      ([
-        { startReplyListener },
-        { getReplyConfig, getNotificationConfig, getReplyListenerPlatformConfig },
-      ]) => {
-      const replyConfig = getReplyConfig();
-      if (!replyConfig) return;
-      const notifConfig = getNotificationConfig();
-      const platformConfig = getReplyListenerPlatformConfig(notifConfig);
-      startReplyListener({
-        ...replyConfig,
-        ...platformConfig,
-      });
-    }).catch(() => {});
+    ])
+      .then(
+        ([
+          { startReplyListener },
+          {
+            getReplyConfig,
+            getNotificationConfig,
+            getReplyListenerPlatformConfig,
+          },
+        ]) => {
+          const replyConfig = getReplyConfig();
+          if (!replyConfig) return;
+          const notifConfig = getNotificationConfig();
+          const platformConfig = getReplyListenerPlatformConfig(notifConfig);
+          startReplyListener({
+            ...replyConfig,
+            ...platformConfig,
+          });
+        },
+      )
+      .catch(() => {});
   }
 
   const messages: string[] = [];
@@ -933,10 +1038,12 @@ Treat this as prior-session context only. Prioritize the user's newest request, 
   }
 
   // Load root AGENTS.md if it exists (deepinit output - issue #613)
-  const agentsMdPath = join(directory, 'AGENTS.md');
+  const agentsMdPath = join(directory, "AGENTS.md");
   if (existsSync(agentsMdPath)) {
     try {
-      let agentsContent = compactOmcStartupGuidance(readFileSync(agentsMdPath, 'utf-8')).trim();
+      let agentsContent = compactOmcStartupGuidance(
+        readFileSync(agentsMdPath, "utf-8"),
+      ).trim();
       if (agentsContent) {
         // Truncate to ~5000 tokens (20000 chars) to avoid context bloat
         const MAX_AGENTS_CHARS = 20000;
@@ -944,7 +1051,10 @@ Treat this as prior-session context only. Prioritize the user's newest request, 
           agentsContent = agentsContent.slice(0, MAX_AGENTS_CHARS);
         }
         // Security: wrap untrusted file content to prevent prompt injection
-        const wrappedContent = wrapUntrustedFileContent(agentsMdPath, agentsContent);
+        const wrappedContent = wrapUntrustedFileContent(
+          agentsMdPath,
+          agentsContent,
+        );
         messages.push(`<session-restore>
 
 [ROOT AGENTS.md LOADED]
@@ -1022,18 +1132,26 @@ export function dispatchAskUserQuestionNotification(
   directory: string,
   toolInput: unknown,
 ): void {
-  const input = toolInput as { questions?: Array<{ question?: string }> } | undefined;
+  const input = toolInput as
+    | { questions?: Array<{ question?: string }> }
+    | undefined;
   const questions = input?.questions || [];
-  const questionText = questions.map(q => q.question || "").filter(Boolean).join("; ") || "User input requested";
+  const questionText =
+    questions
+      .map((q) => q.question || "")
+      .filter(Boolean)
+      .join("; ") || "User input requested";
 
-  import("../notifications/index.js").then(({ notify }) =>
-    notify("ask-user-question", {
-      sessionId,
-      projectPath: directory,
-      question: questionText,
-      profileName: process.env.OMC_NOTIFY_PROFILE,
-    }).catch(() => {})
-  ).catch(() => {});
+  import("../notifications/index.js")
+    .then(({ notify }) =>
+      notify("ask-user-question", {
+        sessionId,
+        projectPath: directory,
+        question: questionText,
+        profileName: process.env.OMC_NOTIFY_PROFILE,
+      }).catch(() => {}),
+    )
+    .catch(() => {});
 }
 
 /** @internal Object wrapper so tests can spy on the dispatch call. */
@@ -1050,11 +1168,14 @@ export const _notify = {
  * never blocks hooks or surfaces errors.
  */
 export const _openclaw = {
-  wake: (event: import("../openclaw/types.js").OpenClawHookEvent, context: import("../openclaw/types.js").OpenClawContext) => {
+  wake: (
+    event: import("../openclaw/types.js").OpenClawHookEvent,
+    context: import("../openclaw/types.js").OpenClawContext,
+  ) => {
     if (process.env.OMC_OPENCLAW !== "1") return;
-    import("../openclaw/index.js").then(({ wakeOpenClaw }) =>
-      wakeOpenClaw(event, context).catch(() => {})
-    ).catch(() => {});
+    import("../openclaw/index.js")
+      .then(({ wakeOpenClaw }) => wakeOpenClaw(event, context).catch(() => {}))
+      .catch(() => {});
   },
 };
 
@@ -1085,7 +1206,8 @@ function processPreToolUse(input: HookInput): HookOutput {
     }
 
     if (input.toolName === "Bash") {
-      const command = (input.toolInput as { command?: string } | undefined)?.command ?? "";
+      const command =
+        (input.toolInput as { command?: string } | undefined)?.command ?? "";
       const reason = workerBashBlockReason(command);
       if (reason) {
         return {
@@ -1114,7 +1236,9 @@ function processPreToolUse(input: HookInput): HookOutput {
     };
   }
 
-  const preToolMessages = enforcementResult.message ? [enforcementResult.message] : [];
+  const preToolMessages = enforcementResult.message
+    ? [enforcementResult.message]
+    : [];
   let modifiedToolInput: Record<string, unknown> | undefined;
 
   // Force-inherit: deny Task calls that carry a `model` parameter when
@@ -1124,7 +1248,9 @@ function processPreToolUse(input: HookInput): HookOutput {
   // the model param, letting agents inherit the parent session's model.
   // (issues #1135, #1201)
   if (input.toolName === "Task") {
-    const originalTaskInput = input.toolInput as Record<string, unknown> | undefined;
+    const originalTaskInput = input.toolInput as
+      | Record<string, unknown>
+      | undefined;
     const taskModel = originalTaskInput?.model;
 
     if (taskModel) {
@@ -1146,10 +1272,14 @@ function processPreToolUse(input: HookInput): HookOutput {
     }
 
     if (originalTaskInput?.run_in_background === true) {
-      const subagentType = typeof originalTaskInput.subagent_type === "string"
-        ? originalTaskInput.subagent_type
-        : undefined;
-      const permissionFallback = getBackgroundTaskPermissionFallback(directory, subagentType);
+      const subagentType =
+        typeof originalTaskInput.subagent_type === "string"
+          ? originalTaskInput.subagent_type
+          : undefined;
+      const permissionFallback = getBackgroundTaskPermissionFallback(
+        directory,
+        subagentType,
+      );
 
       if (permissionFallback.shouldFallback) {
         const reason = `[BACKGROUND PERMISSIONS] ${subagentType || "This background agent"} may need ${permissionFallback.missingTools.join(", ")} permissions, but background agents cannot request interactive approval. Re-run without \`run_in_background=true\` or pre-approve ${permissionFallback.missingTools.join(", ")} in Claude Code settings.`;
@@ -1163,17 +1293,24 @@ function processPreToolUse(input: HookInput): HookOutput {
   }
 
   if (input.toolName === "Bash") {
-    const originalBashInput = input.toolInput as Record<string, unknown> | undefined;
+    const originalBashInput = input.toolInput as
+      | Record<string, unknown>
+      | undefined;
     const nextBashInput = originalBashInput ? { ...originalBashInput } : {};
 
     if (nextBashInput.run_in_background === true) {
-      const command = typeof nextBashInput.command === "string"
-        ? nextBashInput.command
-        : undefined;
-      const permissionFallback = getBackgroundBashPermissionFallback(directory, command);
+      const command =
+        typeof nextBashInput.command === "string"
+          ? nextBashInput.command
+          : undefined;
+      const permissionFallback = getBackgroundBashPermissionFallback(
+        directory,
+        command,
+      );
 
       if (permissionFallback.shouldFallback) {
-        const reason = "[BACKGROUND PERMISSIONS] This Bash command is not auto-approved for background execution. Re-run without `run_in_background=true` or pre-approve the command in Claude Code settings.";
+        const reason =
+          "[BACKGROUND PERMISSIONS] This Bash command is not auto-approved for background execution. Re-run without `run_in_background=true` or pre-approve the command in Claude Code settings.";
         return {
           continue: false,
           reason,
@@ -1192,8 +1329,15 @@ function processPreToolUse(input: HookInput): HookOutput {
       sessionId: input.sessionId,
       projectPath: directory,
       question: (() => {
-        const ti = input.toolInput as { questions?: Array<{ question?: string }> } | undefined;
-        return ti?.questions?.map(q => q.question || "").filter(Boolean).join("; ") || "";
+        const ti = input.toolInput as
+          | { questions?: Array<{ question?: string }> }
+          | undefined;
+        return (
+          ti?.questions
+            ?.map((q) => q.question || "")
+            .filter(Boolean)
+            .join("; ") || ""
+        );
       })(),
     });
   }
@@ -1218,29 +1362,35 @@ function processPreToolUse(input: HookInput): HookOutput {
   // Notify when a new agent is spawned via Task tool (issue #761)
   // Fire-and-forget: verbosity filtering is handled inside notify()
   if (input.toolName === "Task" && input.sessionId) {
-    const taskInput = input.toolInput as {
-      subagent_type?: string;
-      description?: string;
-    } | undefined;
+    const taskInput = input.toolInput as
+      | {
+          subagent_type?: string;
+          description?: string;
+        }
+      | undefined;
     const agentType = taskInput?.subagent_type;
     const agentName = agentType?.includes(":")
       ? agentType.split(":").pop()
       : agentType;
-    import("../notifications/index.js").then(({ notify }) =>
-      notify("agent-call", {
-        sessionId: input.sessionId!,
-        projectPath: directory,
-        agentName,
-        agentType,
-        profileName: process.env.OMC_NOTIFY_PROFILE,
-      }).catch(() => {})
-    ).catch(() => {});
+    import("../notifications/index.js")
+      .then(({ notify }) =>
+        notify("agent-call", {
+          sessionId: input.sessionId!,
+          projectPath: directory,
+          agentName,
+          agentType,
+          profileName: process.env.OMC_NOTIFY_PROFILE,
+        }).catch(() => {}),
+      )
+      .catch(() => {});
   }
 
   // Warn about pkill -f self-termination risk (issue #210)
   // Matches: pkill -f, pkill -9 -f, pkill --full, etc.
   if (input.toolName === "Bash") {
-    const effectiveBashInput = (modifiedToolInput ?? input.toolInput) as { command?: string } | undefined;
+    const effectiveBashInput = (modifiedToolInput ?? input.toolInput) as
+      | { command?: string }
+      | undefined;
     const command = effectiveBashInput?.command ?? "";
     if (
       PKILL_F_FLAG_PATTERN.test(command) ||
@@ -1329,7 +1479,9 @@ function processPreToolUse(input: HookInput): HookOutput {
   if (input.toolName === "Task") {
     const dashboard = getAgentDashboard(directory);
     if (dashboard) {
-      const combined = [...preToolMessages, dashboard].filter(Boolean).join("\n\n");
+      const combined = [...preToolMessages, dashboard]
+        .filter(Boolean)
+        .join("\n\n");
       return {
         continue: true,
         ...(combined ? { message: combined } : {}),
@@ -1351,11 +1503,12 @@ function processPreToolUse(input: HookInput): HookOutput {
 
   return {
     continue: true,
-    ...(preToolMessages.length > 0 ? { message: preToolMessages.join("\n\n") } : {}),
+    ...(preToolMessages.length > 0
+      ? { message: preToolMessages.join("\n\n") }
+      : {}),
     ...(modifiedToolInput ? { modifiedInput: modifiedToolInput } : {}),
   };
 }
-
 
 /**
  * Process post-tool-use hook
@@ -1367,11 +1520,7 @@ function getInvokedSkillName(toolInput: unknown): string | null {
 
   const input = toolInput as Record<string, unknown>;
   const rawSkill =
-    input.skill ??
-    input.skill_name ??
-    input.skillName ??
-    input.command ??
-    null;
+    input.skill ?? input.skill_name ?? input.skillName ?? input.command ?? null;
 
   if (typeof rawSkill !== "string" || rawSkill.trim().length === 0) {
     return null;
@@ -1394,7 +1543,16 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
   if (toolName === "skill") {
     const skillName = getInvokedSkillName(input.toolInput);
     if (skillName === "ralph") {
-      const { createRalphLoopHook, findPrdPath: findPrd, initPrd: initPrdFn, initProgress: initProgressFn, detectNoPrdFlag: detectNoPrd, stripNoPrdFlag: stripNoPrd, detectCriticModeFlag, stripCriticModeFlag } = await import("./ralph/index.js");
+      const {
+        createRalphLoopHook,
+        findPrdPath: findPrd,
+        initPrd: initPrdFn,
+        initProgress: initProgressFn,
+        detectNoPrdFlag: detectNoPrd,
+        stripNoPrdFlag: stripNoPrd,
+        detectCriticModeFlag,
+        stripCriticModeFlag,
+      } = await import("./ralph/index.js");
       const rawPrompt =
         typeof input.prompt === "string" && input.prompt.trim().length > 0
           ? input.prompt
@@ -1404,7 +1562,9 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
       const noPrd = detectNoPrd(rawPrompt);
       const criticMode = detectCriticModeFlag(rawPrompt) ?? undefined;
       const promptWithoutCriticFlag = stripCriticModeFlag(rawPrompt);
-      const cleanPrompt = noPrd ? stripNoPrd(promptWithoutCriticFlag) : promptWithoutCriticFlag;
+      const cleanPrompt = noPrd
+        ? stripNoPrd(promptWithoutCriticFlag)
+        : promptWithoutCriticFlag;
 
       // Auto-generate scaffold PRD if none exists and --no-prd not set
       const existingPrd = findPrd(directory);
@@ -1412,9 +1572,13 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
         const { basename } = await import("path");
         const { execSync } = await import("child_process");
         const projectName = basename(directory);
-        let branchName = 'ralph/task';
+        let branchName = "ralph/task";
         try {
-          branchName = execSync('git rev-parse --abbrev-ref HEAD', { cwd: directory, encoding: 'utf-8', timeout: 5000 }).trim();
+          branchName = execSync("git rev-parse --abbrev-ref HEAD", {
+            cwd: directory,
+            encoding: "utf-8",
+            timeout: 5000,
+          }).trim();
         } catch {
           // Not a git repo or git not available — use fallback
         }
@@ -1423,7 +1587,11 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
       }
 
       const hook = createRalphLoopHook(directory);
-      hook.startLoop(input.sessionId, cleanPrompt, criticMode ? { criticMode } : undefined);
+      hook.startLoop(
+        input.sessionId,
+        cleanPrompt,
+        criticMode ? { criticMode } : undefined,
+      );
     }
 
     // Clear skill-active state on skill completion to prevent false-blocking.
@@ -1485,7 +1653,8 @@ async function processAutopilot(input: HookInput): Promise<HookOutput> {
   const directory = resolveToWorktreeRoot(input.directory);
 
   // Lazy-load autopilot module
-  const { readAutopilotState, getPhasePrompt } = await import("./autopilot/index.js");
+  const { readAutopilotState, getPhasePrompt } =
+    await import("./autopilot/index.js");
 
   const state = readAutopilotState(directory, input.sessionId);
 
@@ -1494,10 +1663,12 @@ async function processAutopilot(input: HookInput): Promise<HookOutput> {
   }
 
   // Check phase and inject appropriate prompt
+  const config = loadConfig();
   const context = {
     idea: state.originalIdea,
     specPath: state.expansion.spec_path || ".omc/autopilot/spec.md",
-    planPath: state.planning.plan_path || ".omc/plans/autopilot-impl.md",
+    planPath: state.planning.plan_path || resolveAutopilotPlanPath(config),
+    openQuestionsPath: resolveOpenQuestionsPlanPath(config),
   };
 
   const phasePrompt = getPhasePrompt(state.phase, context);
@@ -1582,7 +1753,13 @@ export async function processHook(
 
       // Lazy-loaded async hook types
       case "session-end": {
-        if (!validateHookInput<SessionEndInput>(input, requiredKeysForHook("session-end"), "session-end")) {
+        if (
+          !validateHookInput<SessionEndInput>(
+            input,
+            requiredKeysForHook("session-end"),
+            "session-end",
+          )
+        ) {
           return { continue: true };
         }
         const { handleSessionEnd } = await import("./session-end/index.js");
@@ -1609,11 +1786,16 @@ export async function processHook(
 
       case "subagent-start": {
         if (
-          !validateHookInput<SubagentStartInput>(input, requiredKeysForHook("subagent-start"), "subagent-start")
+          !validateHookInput<SubagentStartInput>(
+            input,
+            requiredKeysForHook("subagent-start"),
+            "subagent-start",
+          )
         ) {
           return { continue: true };
         }
-        const { processSubagentStart } = await import("./subagent-tracker/index.js");
+        const { processSubagentStart } =
+          await import("./subagent-tracker/index.js");
         // Reconstruct snake_case fields from normalized camelCase input.
         // normalizeHookInput maps cwd→directory and session_id→sessionId,
         // but SubagentStartInput expects the original snake_case field names.
@@ -1636,17 +1818,23 @@ export async function processHook(
 
       case "subagent-stop": {
         if (
-          !validateHookInput<SubagentStopInput>(input, requiredKeysForHook("subagent-stop"), "subagent-stop")
+          !validateHookInput<SubagentStopInput>(
+            input,
+            requiredKeysForHook("subagent-stop"),
+            "subagent-stop",
+          )
         ) {
           return { continue: true };
         }
-        const { processSubagentStop } = await import("./subagent-tracker/index.js");
+        const { processSubagentStop } =
+          await import("./subagent-tracker/index.js");
         // Reconstruct snake_case fields from normalized camelCase input.
         // Same normalization mismatch as subagent-start: cwd→directory, session_id→sessionId.
         const normalizedStop = input as unknown as Record<string, unknown>;
         const stopInput: SubagentStopInput = {
           cwd: (normalizedStop.directory ?? normalizedStop.cwd) as string,
-          session_id: (normalizedStop.sessionId ?? normalizedStop.session_id) as string,
+          session_id: (normalizedStop.sessionId ??
+            normalizedStop.session_id) as string,
           agent_id: normalizedStop.agent_id as string,
           agent_type: normalizedStop.agent_type as string,
           transcript_path: normalizedStop.transcript_path as string,
@@ -1661,7 +1849,13 @@ export async function processHook(
       }
 
       case "pre-compact": {
-        if (!validateHookInput<PreCompactInput>(input, requiredKeysForHook("pre-compact"), "pre-compact")) {
+        if (
+          !validateHookInput<PreCompactInput>(
+            input,
+            requiredKeysForHook("pre-compact"),
+            "pre-compact",
+          )
+        ) {
           return { continue: true };
         }
         const { processPreCompact } = await import("./pre-compact/index.js");
@@ -1681,7 +1875,13 @@ export async function processHook(
 
       case "setup-init":
       case "setup-maintenance": {
-        if (!validateHookInput<SetupInput>(input, requiredKeysForHook(hookType), hookType)) {
+        if (
+          !validateHookInput<SetupInput>(
+            input,
+            requiredKeysForHook(hookType),
+            hookType,
+          )
+        ) {
           return { continue: true };
         }
         const { processSetup } = await import("./setup/index.js");
@@ -1700,11 +1900,16 @@ export async function processHook(
 
       case "permission-request": {
         if (
-          !validateHookInput<PermissionRequestInput>(input, requiredKeysForHook("permission-request"), "permission-request")
+          !validateHookInput<PermissionRequestInput>(
+            input,
+            requiredKeysForHook("permission-request"),
+            "permission-request",
+          )
         ) {
           return { continue: true };
         }
-        const { handlePermissionRequest } = await import("./permission-handler/index.js");
+        const { handlePermissionRequest } =
+          await import("./permission-handler/index.js");
         // De-normalize: PermissionRequestInput expects snake_case fields
         // (session_id, cwd, tool_name, tool_input).
         const rawPR = input as unknown as Record<string, unknown>;
@@ -1712,7 +1917,8 @@ export async function processHook(
           session_id: (rawPR.sessionId ?? rawPR.session_id) as string,
           cwd: (rawPR.directory ?? rawPR.cwd) as string,
           tool_name: (rawPR.toolName ?? rawPR.tool_name) as string,
-          tool_input: (rawPR.toolInput ?? rawPR.tool_input) as PermissionRequestInput["tool_input"],
+          tool_input: (rawPR.toolInput ??
+            rawPR.tool_input) as PermissionRequestInput["tool_input"],
           transcript_path: rawPR.transcript_path as string,
           permission_mode: (rawPR.permission_mode ?? "default") as string,
           hook_event_name: "PermissionRequest",
@@ -1723,8 +1929,13 @@ export async function processHook(
 
       case "code-simplifier": {
         const directory = input.directory ?? process.cwd();
-        const stateDir = join(resolveToWorktreeRoot(directory), ".omc", "state");
-        const { processCodeSimplifier } = await import("./code-simplifier/index.js");
+        const stateDir = join(
+          resolveToWorktreeRoot(directory),
+          ".omc",
+          "state",
+        );
+        const { processCodeSimplifier } =
+          await import("./code-simplifier/index.js");
         const result = processCodeSimplifier(directory, stateDir);
         if (result.shouldBlock) {
           return { continue: false, message: result.message };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,7 +2,7 @@
  * Shared types for Oh-My-ClaudeCode
  */
 
-export type ModelType = 'sonnet' | 'opus' | 'haiku' | 'inherit';
+export type ModelType = "sonnet" | "opus" | "haiku" | "inherit";
 
 export interface AgentConfig {
   name: string;
@@ -77,7 +77,7 @@ export interface PluginConfig {
     /** Enable intelligent model routing */
     enabled?: boolean;
     /** Default tier when no rules match */
-    defaultTier?: 'LOW' | 'MEDIUM' | 'HIGH';
+    defaultTier?: "LOW" | "MEDIUM" | "HIGH";
     /**
      * Force all agents to inherit the parent model instead of using OMC model routing.
      * When true, the `model` parameter is stripped from all Task calls so agents use
@@ -96,10 +96,13 @@ export interface PluginConfig {
       HIGH?: string;
     };
     /** Agent-specific tier overrides */
-    agentOverrides?: Record<string, {
-      tier: 'LOW' | 'MEDIUM' | 'HIGH';
-      reason: string;
-    }>;
+    agentOverrides?: Record<
+      string,
+      {
+        tier: "LOW" | "MEDIUM" | "HIGH";
+        reason: string;
+      }
+    >;
     /**
      * Model alias overrides.
      *
@@ -114,7 +117,7 @@ export interface PluginConfig {
      *
      * Env: OMC_MODEL_ALIAS_HAIKU, OMC_MODEL_ALIAS_SONNET, OMC_MODEL_ALIAS_OPUS
      */
-    modelAliases?: Partial<Record<'haiku' | 'sonnet' | 'opus', ModelType>>;
+    modelAliases?: Partial<Record<"haiku" | "sonnet" | "opus", ModelType>>;
     /** Keywords that force escalation to higher tier */
     escalationKeywords?: string[];
     /** Keywords that suggest lower tier */
@@ -126,6 +129,14 @@ export interface PluginConfig {
 
   // Delegation routing configuration
   delegationRouting?: DelegationRoutingConfig;
+
+  // Plan output configuration (issue #1636)
+  planOutput?: {
+    /** Relative directory for generated plan artifacts. Default: .omc/plans */
+    directory?: string;
+    /** Filename template. Supported tokens: {{name}}, {{kind}}. Default: {{name}}.md */
+    filenameTemplate?: string;
+  };
 
   // Startup codebase map injection (issue #804)
   startupCodebaseMap?: {
@@ -141,7 +152,7 @@ export interface PluginConfig {
   guards?: {
     factcheck?: {
       enabled?: boolean;
-      mode?: 'strict' | 'declared' | 'manual' | 'quick';
+      mode?: "strict" | "declared" | "manual" | "quick";
       strict_project_patterns?: string[];
       forbidden_path_prefixes?: string[];
       forbidden_path_substrings?: string[];
@@ -184,7 +195,7 @@ export interface SessionState {
 
 export interface AgentState {
   name: string;
-  status: 'idle' | 'running' | 'completed' | 'error';
+  status: "idle" | "running" | "completed" | "error";
   lastMessage?: string;
   startTime?: number;
 }
@@ -193,7 +204,7 @@ export interface BackgroundTask {
   id: string;
   agentName: string;
   prompt: string;
-  status: 'pending' | 'running' | 'completed' | 'error';
+  status: "pending" | "running" | "completed" | "error";
   result?: string;
   error?: string;
 }
@@ -205,7 +216,13 @@ export interface MagicKeyword {
 }
 
 export interface HookDefinition {
-  event: 'PreToolUse' | 'PostToolUse' | 'Stop' | 'SessionStart' | 'SessionEnd' | 'UserPromptSubmit';
+  event:
+    | "PreToolUse"
+    | "PostToolUse"
+    | "Stop"
+    | "SessionStart"
+    | "SessionEnd"
+    | "UserPromptSubmit";
   matcher?: string;
   command?: string;
   handler?: (context: HookContext) => Promise<HookResult>;
@@ -227,7 +244,7 @@ export interface HookResult {
 /**
  * External model provider type
  */
-export type ExternalModelProvider = 'codex' | 'gemini';
+export type ExternalModelProvider = "codex" | "gemini";
 
 /**
  * External model configuration for a specific role or task
@@ -250,7 +267,7 @@ export interface ExternalModelsDefaults {
  * External models fallback policy
  */
 export interface ExternalModelsFallbackPolicy {
-  onModelFailure: 'provider_chain' | 'cross_provider' | 'claude_only';
+  onModelFailure: "provider_chain" | "cross_provider" | "claude_only";
   allowCrossProvider?: boolean;
   crossProviderOrder?: ExternalModelProvider[];
 }
@@ -288,14 +305,14 @@ export interface ResolveOptions {
  * Provider type for delegation routing
  */
 export type DelegationProvider =
-  | 'claude'
+  | "claude"
   /** Use /team to coordinate Codex CLI workers in tmux panes. */
-  | 'codex'
+  | "codex"
   /** Use /team to coordinate Gemini CLI workers in tmux panes. */
-  | 'gemini';
+  | "gemini";
 
 /** Tool type for delegation routing — only Claude Task is supported. */
-export type DelegationTool = 'Task';
+export type DelegationTool = "Task";
 
 /**
  * Individual route configuration for a role


### PR DESCRIPTION
## Summary
- add a `planOutput` config shape for relative plan output directory and filename template
- add narrow path-resolution helpers for autopilot plan and open-questions artifacts
- wire the highest-value autopilot plan-path consumers to resolved config-driven paths and cover them with focused tests

## Testing
- npm test -- --run src/config/__tests__/plan-output.test.ts src/config/__tests__/loader.test.ts src/hooks/autopilot/__tests__/prompts.test.ts src/hooks/autopilot/__tests__/state.test.ts
- npm run build

Closes #1636