### PR TITLE
fix(team): keep workers running after mailbox replies

### DIFF
--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -112,10 +112,12 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(requests[0]?.inbox_correlation_key).toBe('startup:worker-1:1');
     expect(requests[0]?.trigger_message).toContain('.omc/state/team/dispatch-team/workers/worker-1/inbox.md');
     expect(requests[0]?.trigger_message).toContain('start work now');
+    expect(requests[0]?.trigger_message).toContain('next feasible work');
 
     const inboxPath = join(cwd, '.omc', 'state', 'team', 'dispatch-team', 'workers', 'worker-1', 'inbox.md');
     const inbox = await readFile(inboxPath, 'utf-8');
     expect(inbox).toContain('Dispatch test');
+    expect(inbox).toContain('ACK/progress replies are not a stop signal');
     expect(mocks.sendToWorker).toHaveBeenCalledWith(
       'dispatch-session',
       '%2',

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -22,6 +22,7 @@ describe('worker-bootstrap', () => {
       expect(generateMailboxTriggerMessage('test-team', 'worker-1', 2)).toContain('act now');
       expect(generateMailboxTriggerMessage('test-team', 'worker-1', 2)).toContain('concrete progress');
       expect(generateMailboxTriggerMessage('test-team', 'worker-1', 2)).toContain('ACK-only');
+      expect(generateMailboxTriggerMessage('test-team', 'worker-1', 2)).toContain('next feasible work');
     });
 
     it('supports state-root placeholders for worktree-backed trigger paths', () => {
@@ -80,6 +81,13 @@ describe('worker-bootstrap', () => {
       expect(overlay).toContain('You are a **team worker**, not the team leader');
       expect(overlay).toContain('Do NOT create tmux panes/sessions');
       expect(overlay).toContain('Do NOT run team spawning/orchestration commands');
+    });
+
+    it('tells workers to keep executing after ACK or progress replies', () => {
+      const overlay = generateWorkerOverlay(baseParams);
+      expect(overlay).toContain('ACK/progress messages are not a stop signal');
+      expect(overlay).toContain('next feasible work');
+      expect(overlay).not.toContain('Exit** immediately after transitioning');
     });
 
     it('injects agent-type-specific guidance section', () => {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -249,7 +249,7 @@ function buildV2TaskInstruction(
     `   omc team api transition-task-status --input '{"team_name":"${teamName}","task_id":"${taskId}","from":"in_progress","to":"completed","claim_token":"<claim_token>"}' --json`,
     `4. On failure (use claim_token from step 1):`,
     `   omc team api transition-task-status --input '{"team_name":"${teamName}","task_id":"${taskId}","from":"in_progress","to":"failed","claim_token":"<claim_token>"}' --json`,
-    `5. Exit immediately after transitioning.`,
+    `5. ACK/progress replies are not a stop signal. Keep executing your assigned or next feasible work until the task is actually complete or failed, then transition and exit.`,
     ``,
     `## Task Assignment`,
     `Task ID: ${taskId}`,

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -25,7 +25,7 @@ export function generateTriggerMessage(
   if (teamStateRoot !== '.omc/state') {
     return `Read ${inboxPath}, work now, report progress.`;
   }
-  return `Read ${inboxPath}, start work now, then report concrete progress (not ACK-only).`;
+  return `Read ${inboxPath}, start work now, report concrete progress (not ACK-only), and keep executing your assigned or next feasible work.`;
 }
 
 export function generateMailboxTriggerMessage(
@@ -39,7 +39,7 @@ export function generateMailboxTriggerMessage(
   if (teamStateRoot !== '.omc/state') {
     return `${normalizedCount} new msg(s): check ${mailboxPath}, act and report progress.`;
   }
-  return `You have ${normalizedCount} new message(s). Check ${mailboxPath}, act now, and reply with concrete progress (not ACK-only).`;
+  return `You have ${normalizedCount} new message(s). Check ${mailboxPath}, act now, reply with concrete progress (not ACK-only), and keep executing your assigned or next feasible work.`;
 }
 
 function agentTypeGuidance(agentType: CliAgentType): string {
@@ -115,7 +115,7 @@ You MUST complete ALL of these steps. Do NOT skip any step. Do NOT exit without 
 4. **Transition** the task status (REQUIRED before exit):
    - On success: \`omc team api transition-task-status --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"from\":\"in_progress\",\"to\":\"completed\",\"claim_token\":\"<claim_token>\"}" --json\`
    - On failure: \`omc team api transition-task-status --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"from\":\"in_progress\",\"to\":\"failed\",\"claim_token\":\"<claim_token>\"}" --json\`
-5. **Exit** immediately after transitioning.
+5. **Keep going after replies**: ACK/progress messages are not a stop signal. Keep executing your assigned or next feasible work until the task is actually complete or failed, then transition and exit.
 
 ## Identity
 - **Team**: ${teamName}


### PR DESCRIPTION
## Summary
- audit post-#1540 OMX runtime/team/worker hardening already missing from this OMC backport branch
- backport the smallest high-confidence remaining gap: worker/runtime guidance that makes ACK/progress replies non-terminal
- add focused tests covering the new worker trigger and overlay wording

## Why this backport
This worktree already had the earlier startup-evidence hardening that stopped treating ACK-only mailbox replies as sufficient startup evidence. However, the worker-side/runtime instructions still told workers to exit immediately after transitioning, and trigger messages still emphasized ACK/progress replies without clarifying that those replies are **not** a stop signal.

This backport aligns the worker prompt/inbox guidance with the existing startup-evidence runtime behavior so workers keep executing assigned or next feasible work until the task is actually complete or failed.

## Verification
- `npx vitest --run src/team/__tests__/worker-bootstrap.test.ts src/team/__tests__/runtime-v2.dispatch.test.ts`
- `npx eslint src/team/runtime-v2.ts src/team/worker-bootstrap.ts src/team/__tests__/runtime-v2.dispatch.test.ts src/team/__tests__/worker-bootstrap.test.ts`
- `npx tsc --noEmit`

## Remaining audited OMC gaps not included here
Kept out of this PR to preserve the smallest safe runtime hardening backport:
- `46985dde` — `fix(team): route api cleanup through shutdown`
  - OMC still appears to let `team api cleanup` bypass shutdown gating/runtime cleanup paths.
- `5a1ae89c` — `Fix team worker cleanup on session end`
  - OMC session-end cleanup still appears to miss best-effort shutdown of session-owned tmux-backed teams/workers, leaving possible orphan panes/windows.
