### PR TITLE
fix(hooks): add OMC_QUIET hook message suppression

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -14,6 +14,13 @@ import { readStdin } from './lib/stdin.mjs';
 
 const AGENT_OUTPUT_ANALYSIS_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_ANALYSIS_LIMIT || '12000', 10);
 const AGENT_OUTPUT_SUMMARY_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_SUMMARY_LIMIT || '360', 10);
+const QUIET_LEVEL = getQuietLevel();
+
+function getQuietLevel() {
+  const parsed = Number.parseInt(process.env.OMC_QUIET || '0', 10);
+  if (Number.isNaN(parsed)) return 0;
+  return Math.max(0, parsed);
+}
 
 // Get the directory of this script to resolve the dist module
 const __filename = fileURLToPath(import.meta.url);
@@ -299,7 +306,7 @@ export function detectWriteFailure(output) {
 }
 
 // Get agent completion summary from tracking state
-function getAgentCompletionSummary(directory) {
+function getAgentCompletionSummary(directory, quietLevel = QUIET_LEVEL) {
   const trackingFile = join(directory, '.omc', 'state', 'subagent-tracking.json');
   try {
     if (existsSync(trackingFile)) {
@@ -312,10 +319,10 @@ function getAgentCompletionSummary(directory) {
       if (running.length === 0 && completed === 0 && failed === 0) return '';
 
       const parts = [];
-      if (running.length > 0) {
+      if (quietLevel < 2 && running.length > 0) {
         parts.push(`Running: ${running.length} [${running.map(a => a.agent_type.replace('oh-my-claudecode:', '')).join(', ')}]`);
       }
-      if (completed > 0) parts.push(`Completed: ${completed}`);
+      if (quietLevel < 2 && completed > 0) parts.push(`Completed: ${completed}`);
       if (failed > 0) parts.push(`Failed: ${failed}`);
 
       return parts.join(' | ');
@@ -338,7 +345,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
         message = `Command exited with code ${code} but produced valid output. This may be expected behavior.`;
       } else if (detectBashFailure(toolOutput)) {
         message = 'Command failed. Please investigate the error and fix before continuing.';
-      } else if (detectBackgroundOperation(toolOutput)) {
+      } else if (QUIET_LEVEL < 2 && detectBackgroundOperation(toolOutput)) {
         message = 'Background operation detected. Remember to verify results before proceeding.';
       }
       break;
@@ -346,12 +353,12 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
     case 'Task':
     case 'TaskCreate':
     case 'TaskUpdate': {
-      const agentSummary = getAgentCompletionSummary(directory);
+      const agentSummary = getAgentCompletionSummary(directory, QUIET_LEVEL);
       if (detectWriteFailure(toolOutput)) {
         message = 'Task delegation failed. Verify agent name and parameters.';
-      } else if (detectBackgroundOperation(toolOutput)) {
+      } else if (QUIET_LEVEL < 2 && detectBackgroundOperation(toolOutput)) {
         message = 'Background task launched. Use TaskOutput to check results when needed.';
-      } else if (toolCount > 5) {
+      } else if (QUIET_LEVEL < 2 && toolCount > 5) {
         message = `Multiple tasks delegated (${toolCount} total). Track their completion status.`;
       }
       if (wasTruncated) {
@@ -366,7 +373,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
 
     case 'TaskOutput': {
       const summary = summarizeAgentResult(toolOutput);
-      if (summary) {
+      if (QUIET_LEVEL < 2 && summary) {
         message = `TaskOutput summary: ${summary}`;
       }
       if (wasTruncated) {
@@ -379,7 +386,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
     case 'Edit':
       if (detectWriteFailure(toolOutput)) {
         message = 'Edit operation failed. Verify file exists and content matches exactly.';
-      } else {
+      } else if (QUIET_LEVEL === 0) {
         message = 'Code modified. Verify changes work as expected before marking complete.';
       }
       break;
@@ -387,35 +394,35 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
     case 'Write':
       if (detectWriteFailure(toolOutput)) {
         message = 'Write operation failed. Check file permissions and directory existence.';
-      } else {
+      } else if (QUIET_LEVEL === 0) {
         message = 'File written. Test the changes to ensure they work correctly.';
       }
       break;
 
     case 'TodoWrite':
-      if (/created|added/i.test(toolOutput)) {
+      if (QUIET_LEVEL === 0 && /created|added/i.test(toolOutput)) {
         message = 'Todo list updated. Proceed with next task on the list.';
-      } else if (/completed|done/i.test(toolOutput)) {
+      } else if (QUIET_LEVEL === 0 && /completed|done/i.test(toolOutput)) {
         message = 'Task marked complete. Continue with remaining todos.';
-      } else if (/in_progress/i.test(toolOutput)) {
+      } else if (QUIET_LEVEL === 0 && /in_progress/i.test(toolOutput)) {
         message = 'Task marked in progress. Focus on completing this task.';
       }
       break;
 
     case 'Read':
-      if (toolCount > 10) {
+      if (QUIET_LEVEL === 0 && toolCount > 10) {
         message = `Extensive reading (${toolCount} files). Consider using Grep for pattern searches.`;
       }
       break;
 
     case 'Grep':
-      if (/^0$|no matches/i.test(toolOutput)) {
+      if (QUIET_LEVEL === 0 && /^0$|no matches/i.test(toolOutput)) {
         message = 'No matches found. Verify pattern syntax or try broader search.';
       }
       break;
 
     case 'Glob':
-      if (!toolOutput.trim() || /no files/i.test(toolOutput)) {
+      if (QUIET_LEVEL === 0 && (!toolOutput.trim() || /no files/i.test(toolOutput))) {
         message = 'No files matched pattern. Verify glob syntax and directory.';
       }
       break;

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -26,6 +26,13 @@ const MODE_STATE_FILES = [
 ];
 const AGENT_HEAVY_TOOLS = new Set(['Task', 'TaskCreate', 'TaskUpdate']);
 const PREFLIGHT_CONTEXT_THRESHOLD = parseInt(process.env.OMC_AGENT_PREFLIGHT_CONTEXT_THRESHOLD || '72', 10);
+const QUIET_LEVEL = getQuietLevel();
+
+function getQuietLevel() {
+  const parsed = Number.parseInt(process.env.OMC_QUIET || '0', 10);
+  if (Number.isNaN(parsed)) return 0;
+  return Math.max(0, parsed);
+}
 
 /**
  * Resolve transcript path in worktree environments.
@@ -268,6 +275,7 @@ function getActiveTeamState(directory, sessionId) {
 // Generate agent spawn message with metadata
 function generateAgentSpawnMessage(toolInput, directory, todoStatus, sessionId) {
   if (!toolInput || typeof toolInput !== 'object') {
+    if (QUIET_LEVEL >= 2) return '';
     return `${todoStatus}Launch multiple agents in parallel when tasks are independent. Use run_in_background for long operations.`;
   }
 
@@ -291,6 +299,8 @@ function generateAgentSpawnMessage(toolInput, directory, todoStatus, sessionId) 
       `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 is set in ~/.claude/settings.json and restart Claude Code.`;
   }
 
+  if (QUIET_LEVEL >= 2) return '';
+
   const parts = [`${todoStatus}Spawning agent: ${agentType} (${model})${bg}`];
   if (desc) parts.push(`Task: ${desc}`);
   if (tracking.running > 0) parts.push(`Active agents: ${tracking.running}`);
@@ -300,6 +310,13 @@ function generateAgentSpawnMessage(toolInput, directory, todoStatus, sessionId) 
 
 // Generate contextual message based on tool type
 function generateMessage(toolName, todoStatus, modeActive = false) {
+  if (QUIET_LEVEL >= 1 && ['Bash', 'Edit', 'Write', 'Read', 'Grep', 'Glob'].includes(toolName)) {
+    return '';
+  }
+  if (QUIET_LEVEL >= 2 && toolName === 'TodoWrite') {
+    return '';
+  }
+
   const messages = {
     TodoWrite: `${todoStatus}Mark todos in_progress BEFORE starting, completed IMMEDIATELY after finishing.`,
     Bash: `${todoStatus}Use parallel execution for independent tasks. Use run_in_background for long operations (npm install, builds, tests).`,

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -6,6 +6,8 @@
 import { describe, it, expect } from 'vitest';
 import { execSync } from 'child_process';
 import { join } from 'path';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import process from 'process';
 import { detectBashFailure, detectWriteFailure, isNonZeroExitWithOutput, summarizeAgentResult } from '../../scripts/post-tool-verifier.mjs';
 
@@ -19,6 +21,15 @@ function runPostToolVerifier(input, env = {}) {
     env: { ...process.env, NODE_ENV: 'test', ...env },
   });
   return JSON.parse(stdout.trim());
+}
+
+function withTempDir(fn) {
+  const tempDir = mkdtempSync(join(tmpdir(), 'post-tool-verifier-'));
+  try {
+    return fn(tempDir);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 }
 
 describe('detectBashFailure', () => {
@@ -309,5 +320,85 @@ describe('agent output summarization / truncation (issue #1373)', () => {
     expect(out.continue).toBe(true);
     expect(out.hookSpecificOutput?.additionalContext).toContain('TaskOutput summary:');
     expect(out.hookSpecificOutput?.additionalContext).toContain('TaskOutput clipped');
+  });
+});
+
+describe('OMC_QUIET hook message suppression (issue #1646)', () => {
+  it('suppresses routine success/advice messages at OMC_QUIET=1 while keeping failures', () => {
+    const edit = runPostToolVerifier(
+      {
+        tool_name: 'Edit',
+        tool_response: 'File updated successfully',
+        session_id: 'quiet-1',
+        cwd: process.cwd(),
+      },
+      { OMC_QUIET: '1' },
+    );
+
+    expect(edit).toEqual({ continue: true, suppressOutput: true });
+
+    const grep = runPostToolVerifier(
+      {
+        tool_name: 'Grep',
+        tool_response: '0',
+        session_id: 'quiet-1',
+        cwd: process.cwd(),
+      },
+      { OMC_QUIET: '1' },
+    );
+
+    expect(grep).toEqual({ continue: true, suppressOutput: true });
+
+    const writeFailure = runPostToolVerifier(
+      {
+        tool_name: 'Write',
+        tool_response: 'Write failed: permission denied on /etc/hosts',
+        session_id: 'quiet-1',
+        cwd: process.cwd(),
+      },
+      { OMC_QUIET: '1' },
+    );
+
+    expect(writeFailure.hookSpecificOutput?.additionalContext)
+      .toContain('Write operation failed');
+  });
+
+  it('keeps important warnings at OMC_QUIET=2 but suppresses routine task summaries', () => {
+    const nonZero = runPostToolVerifier(
+      {
+        tool_name: 'Bash',
+        tool_response: 'Error: Exit code 8\nLint pass\nTest pending',
+        session_id: 'quiet-2',
+        cwd: process.cwd(),
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    expect(nonZero.hookSpecificOutput?.additionalContext)
+      .toContain('produced valid output');
+
+    const taskSummary = withTempDir((tempDir) => {
+      mkdirSync(join(tempDir, '.omc', 'state'), { recursive: true });
+      writeFileSync(
+        join(tempDir, '.omc', 'state', 'subagent-tracking.json'),
+        JSON.stringify({
+          agents: [{ status: 'running', agent_type: 'oh-my-claudecode:executor' }],
+          total_completed: 1,
+          total_failed: 0,
+        }),
+      );
+
+      return runPostToolVerifier(
+        {
+          tool_name: 'TaskOutput',
+          tool_response: 'Completed worker step A\nUpdated src/foo.ts\nTests: 12 passed',
+          session_id: 'quiet-2',
+          cwd: tempDir,
+        },
+        { OMC_QUIET: '2' },
+      );
+    });
+
+    expect(taskSummary).toEqual({ continue: true, suppressOutput: true });
   });
 });

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -7,11 +7,18 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 const SCRIPT_PATH = join(process.cwd(), 'scripts', 'pre-tool-enforcer.mjs');
 
 function runPreToolEnforcer(input: Record<string, unknown>): Record<string, unknown> {
+  return runPreToolEnforcerWithEnv(input);
+}
+
+function runPreToolEnforcerWithEnv(
+  input: Record<string, unknown>,
+  env: Record<string, string> = {},
+): Record<string, unknown> {
   const stdout = execSync(`node "${SCRIPT_PATH}"`, {
     input: JSON.stringify(input),
     encoding: 'utf-8',
     timeout: 5000,
-    env: { ...process.env, NODE_ENV: 'test' },
+    env: { ...process.env, NODE_ENV: 'test', ...env },
   });
 
   return JSON.parse(stdout.trim()) as Record<string, unknown>;
@@ -250,6 +257,94 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(readOutput.additionalContext).toBe(
       'Read multiple files in parallel when possible for faster analysis.',
     );
+  });
+
+  it('suppresses routine pre-tool reminders when OMC_QUIET=1', () => {
+    const bash = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Bash',
+        cwd: tempDir,
+      },
+      { OMC_QUIET: '1' },
+    );
+
+    expect(bash).toEqual({ continue: true, suppressOutput: true });
+
+    const read = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Read',
+        cwd: tempDir,
+      },
+      { OMC_QUIET: '1' },
+    );
+
+    expect(read).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('keeps active-mode and team-routing enforcement visible when OMC_QUIET is enabled', () => {
+    const sessionId = 'session-1646';
+    writeJson(
+      join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'),
+      {
+        active: true,
+        session_id: sessionId,
+      },
+    );
+    writeJson(
+      join(tempDir, '.omc', 'state', 'sessions', sessionId, 'team-state.json'),
+      {
+        active: true,
+        session_id: sessionId,
+        team_name: 'quiet-team',
+      },
+    );
+
+    const modeOutput = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'ToolSearch',
+        cwd: tempDir,
+        session_id: sessionId,
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    expect(String((modeOutput.hookSpecificOutput as Record<string, unknown>).additionalContext))
+      .toContain('The boulder never stops');
+
+    const taskOutput = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Task',
+        toolInput: {
+          subagent_type: 'oh-my-claudecode:executor',
+          description: 'Fix type errors',
+          prompt: 'Fix all type errors in src/auth/',
+        },
+        cwd: tempDir,
+        session_id: sessionId,
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    expect(String((taskOutput.hookSpecificOutput as Record<string, unknown>).additionalContext))
+      .toContain('TEAM ROUTING REQUIRED');
+  });
+
+  it('suppresses routine agent spawn chatter at OMC_QUIET=2 but not enforcement', () => {
+    const output = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Task',
+        toolInput: {
+          subagent_type: 'oh-my-claudecode:executor',
+          description: 'Fix type errors',
+          prompt: 'Fix all type errors in src/auth/',
+        },
+        cwd: tempDir,
+        session_id: 'session-1646-quiet',
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    expect(output).toEqual({ continue: true, suppressOutput: true });
   });
 
   it('blocks agent-heavy Task preflight when transcript context budget is exhausted', () => {


### PR DESCRIPTION
## Summary
- add `OMC_QUIET` handling to the pre/post tool hook scripts
- suppress routine hook chatter first, while preserving context guards, team/mode enforcement, and failure/warning paths
- cover the quiet-mode behavior with targeted hook tests

## Behavior
- `OMC_QUIET=0` keeps existing behavior
- `OMC_QUIET=1` suppresses routine pre-tool advice and routine post-tool success/advice messages for common read/search/edit flows
- `OMC_QUIET=2` further suppresses routine task spawn/summary chatter while still keeping important warnings, failures, context-safety notices, and active-mode enforcement visible

## Verification
- `npx vitest run src/__tests__/pre-tool-enforcer.test.ts src/__tests__/post-tool-verifier.test.mjs`
- `npm run lint` *(passes with existing repository warnings unrelated to this change)*
- `npm run build`

Closes #1646.
