### PR TITLE
fix: honor Claude ask rules for git commit heredocs

### DIFF
--- a/src/hooks/__tests__/background-process-guard.test.ts
+++ b/src/hooks/__tests__/background-process-guard.test.ts
@@ -36,10 +36,10 @@ describe('Background Process Guard (issue #302)', () => {
   const originalEnv = process.env;
   let claudeConfigDir: string;
 
-  const writeClaudePermissions = (allow: string[] = []): void => {
+  const writeClaudePermissions = (allow: string[] = [], ask: string[] = []): void => {
     const settingsPath = join(claudeConfigDir, 'settings.local.json');
     mkdirSync(claudeConfigDir, { recursive: true });
-    writeFileSync(settingsPath, JSON.stringify({ permissions: { allow } }, null, 2));
+    writeFileSync(settingsPath, JSON.stringify({ permissions: { allow, ask } }, null, 2));
   };
 
   beforeEach(() => {
@@ -265,6 +265,24 @@ describe('Background Process Guard (issue #302)', () => {
       expect(result.continue).toBe(true);
       expect(result.message ?? '').not.toContain('[BACKGROUND PERMISSIONS]');
       expect(result.modifiedInput).toBeUndefined();
+    });
+
+    it('should block safe-looking background Bash when ask rules require approval', async () => {
+      writeClaudePermissions([], ['Bash(git commit:*)']);
+
+      const input: HookInput = {
+        sessionId: 'test-session',
+        toolName: 'Bash',
+        toolInput: {
+          command: `git commit -m "$(cat <<'EOF'\nfeat: test\nEOF\n)"`,
+          run_in_background: true,
+        },
+        directory: '/tmp/test',
+      };
+
+      const result = await processHook('pre-tool-use', input);
+      expect(result.continue).toBe(false);
+      expect(result.reason).toContain('[BACKGROUND PERMISSIONS]');
     });
 
     it('should keep exact pre-approved background Bash commands in background', async () => {

--- a/src/hooks/permission-handler/__tests__/index.test.ts
+++ b/src/hooks/permission-handler/__tests__/index.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { isSafeCommand, isHeredocWithSafeBase, isActiveModeRunning, processPermissionRequest } from '../index.js';
+import {
+  isSafeCommand,
+  isHeredocWithSafeBase,
+  isActiveModeRunning,
+  processPermissionRequest,
+} from '../index.js';
 import type { PermissionRequestInput } from '../index.js';
 
 describe('permission-handler', () => {
@@ -466,6 +471,20 @@ describe('permission-handler', () => {
     });
 
     describe('heredoc command handling (Issue #608)', () => {
+      it('should respect explicit ask rules for git commit heredoc commands', () => {
+        fs.mkdirSync(path.join(testDir, '.claude'), { recursive: true });
+        fs.writeFileSync(
+          path.join(testDir, '.claude', 'settings.local.json'),
+          JSON.stringify({ permissions: { ask: ['Bash(git commit:*)'] } }, null, 2),
+        );
+
+        const cmd = `git commit -m "$(cat <<'EOF'\nfeat: add new feature\n\nDetailed description here.\nEOF\n)"`;
+        const result = processPermissionRequest(createInput(cmd));
+
+        expect(result.continue).toBe(true);
+        expect(result.hookSpecificOutput?.decision?.behavior).not.toBe('allow');
+      });
+
       it('should auto-allow git commit with heredoc message', () => {
         const cmd = `git commit -m "$(cat <<'EOF'\nfeat: add new feature\n\nDetailed description here.\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n)"`;
         const result = processPermissionRequest(createInput(cmd));

--- a/src/hooks/permission-handler/index.ts
+++ b/src/hooks/permission-handler/index.ts
@@ -75,17 +75,19 @@ const BACKGROUND_MUTATION_SUBAGENTS = new Set([
   'document-specialist',
 ]);
 
-function readPermissionAllowEntries(filePath: string): string[] {
+function readPermissionStringEntries(filePath: string, key: 'allow' | 'ask'): string[] {
   try {
     if (!fs.existsSync(filePath)) {
       return [];
     }
 
     const settings = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as {
-      permissions?: { allow?: unknown };
+      permissions?: { allow?: unknown; ask?: unknown };
+      allow?: unknown;
+      ask?: unknown;
     };
-    const allow = settings?.permissions?.allow;
-    return Array.isArray(allow) ? allow.filter((entry): entry is string => typeof entry === 'string') : [];
+    const entries = settings?.permissions?.[key] ?? settings?.[key];
+    return Array.isArray(entries) ? entries.filter((entry): entry is string => typeof entry === 'string') : [];
   } catch {
     return [];
   }
@@ -102,7 +104,7 @@ export function getClaudePermissionAllowEntries(directory: string): string[] {
 
   const allowEntries = new Set<string>();
   for (const candidatePath of candidatePaths) {
-    for (const entry of readPermissionAllowEntries(candidatePath)) {
+    for (const entry of readPermissionStringEntries(candidatePath, 'allow')) {
       allowEntries.add(entry.trim());
     }
   }
@@ -137,6 +139,78 @@ export function hasClaudePermissionApproval(
   return allowEntries.includes(`Bash(${trimmedCommand})`);
 }
 
+
+export function getClaudePermissionAskEntries(directory: string): string[] {
+  const projectSettingsPath = path.join(directory, '.claude', 'settings.local.json');
+  const globalConfigDir = getClaudeConfigDir();
+  const candidatePaths = [
+    projectSettingsPath,
+    path.join(globalConfigDir, 'settings.local.json'),
+    path.join(globalConfigDir, 'settings.json'),
+  ];
+
+  const askEntries = new Set<string>();
+  for (const candidatePath of candidatePaths) {
+    for (const entry of readPermissionStringEntries(candidatePath, 'ask')) {
+      askEntries.add(entry.trim());
+    }
+  }
+
+  return [...askEntries];
+}
+
+function commandMatchesPermissionPattern(command: string, pattern: string): boolean {
+  const trimmedPattern = pattern.trim();
+  if (!trimmedPattern) {
+    return false;
+  }
+
+  if (!trimmedPattern.includes('*')) {
+    return command === trimmedPattern;
+  }
+
+  const normalizedPrefix = trimmedPattern.replace(/[\s:]*\*+$/, '').trimEnd();
+  if (!normalizedPrefix) {
+    return false;
+  }
+
+  if (!command.startsWith(normalizedPrefix)) {
+    return false;
+  }
+
+  const nextChar = command.charAt(normalizedPrefix.length);
+  return nextChar === '' || /[\s:=(["']/.test(nextChar);
+}
+
+export function hasClaudePermissionAsk(
+  directory: string,
+  toolName: 'Edit' | 'Write' | 'Bash',
+  command?: string,
+): boolean {
+  const askEntries = getClaudePermissionAskEntries(directory);
+
+  if (toolName !== 'Bash') {
+    return hasGenericToolPermission(askEntries, toolName);
+  }
+
+  const trimmedCommand = command?.trim();
+  if (!trimmedCommand) {
+    return false;
+  }
+
+  return askEntries.some(entry => {
+    if (entry === 'Bash') {
+      return true;
+    }
+
+    if (!entry.startsWith('Bash(') || !entry.endsWith(')')) {
+      return false;
+    }
+
+    return commandMatchesPermissionPattern(trimmedCommand, entry.slice(5, -1));
+  });
+}
+
 export interface BackgroundPermissionFallbackResult {
   shouldFallback: boolean;
   missingTools: string[];
@@ -165,7 +239,15 @@ export function getBackgroundBashPermissionFallback(
   directory: string,
   command?: string,
 ): BackgroundPermissionFallbackResult {
-  if (!command || isSafeCommand(command) || isHeredocWithSafeBase(command)) {
+  if (!command) {
+    return { shouldFallback: false, missingTools: [] };
+  }
+
+  if (hasClaudePermissionAsk(directory, 'Bash', command)) {
+    return { shouldFallback: true, missingTools: ['Bash'] };
+  }
+
+  if (isSafeCommand(command) || isHeredocWithSafeBase(command)) {
     return { shouldFallback: false, missingTools: [] };
   }
 
@@ -276,8 +358,10 @@ export function processPermissionRequest(input: PermissionRequestInput): HookOut
     return { continue: true };
   }
 
+  const shouldAskBashPermission = hasClaudePermissionAsk(input.cwd, 'Bash', command);
+
   // Auto-allow safe commands
-  if (isSafeCommand(command)) {
+  if (!shouldAskBashPermission && isSafeCommand(command)) {
     return {
       continue: true,
       hookSpecificOutput: {
@@ -292,7 +376,7 @@ export function processPermissionRequest(input: PermissionRequestInput): HookOut
 
   // Auto-allow heredoc commands with safe base commands (Issue #608)
   // This prevents the full heredoc body from being stored in settings.local.json
-  if (isHeredocWithSafeBase(command)) {
+  if (!shouldAskBashPermission && isHeredocWithSafeBase(command)) {
     return {
       continue: true,
       hookSpecificOutput: {


### PR DESCRIPTION
## Summary\n- honor Claude  rules before auto-allowing safe Bash commands or heredoc git commit/tag flows\n- add a regression test for  so heredoc commits no longer bypass explicit approval\n- cover the same behavior for background Bash fallback handling\n\n## Testing\n- npm test -- --run src/hooks/permission-handler/__tests__/index.test.ts src/hooks/__tests__/background-process-guard.test.ts\n- npx eslint src/hooks/permission-handler/index.ts src/hooks/permission-handler/__tests__/index.test.ts src/hooks/__tests__/background-process-guard.test.ts\n- npx tsc --noEmit\n\nCloses #1651