### PR TITLE
Clarify narrow remote MCP support for #1653

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -223,6 +223,23 @@ Located at `~/.claude/settings.json`:
 }
 ```
 
+### Remote MCP / Remote OMC Shape
+
+OMC can sync and preserve **remote MCP** entries in the unified registry. That is the supported narrow answer to "connect to a remote OMC":
+
+```json
+{
+  "mcpServers": {
+    "remoteOmc": {
+      "url": "https://lab.example.com/mcp",
+      "timeout": 30
+    }
+  }
+}
+```
+
+This supports remote MCP endpoints. It does **not** create a general multi-host OMC cluster or a transparent shared remote filesystem view.
+
 ### Plugin-Embedded MCP Servers
 
 Plugins can define MCP servers in their manifest:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -129,6 +129,33 @@ If both a legacy `{worktree}/.omc/` directory and a centralized directory exist,
 
 > **NOTE**: After updating the plugin (via `npm update`, `git pull`, or Claude Code's plugin update), you MUST re-run `/oh-my-claudecode:omc-setup` to apply the latest CLAUDE.md changes.
 
+### Remote OMC / Remote MCP Access
+
+Issue #1653 asked whether OMC can "connect to a remote OMC" so one development machine can browse files on lab/test machines without opening an interactive SSH session.
+
+The narrow, coherent answer today is:
+
+- **Supported**: connect to a **remote MCP server** through the unified MCP registry
+- **Not implemented**: a general "OMC cluster", shared remote filesystem view, or automatic remote-OMC federation
+- **Still appropriate for full remote shell workflows**: SSH, worktrees, or a mounted/network filesystem
+
+If a remote host already exposes an MCP endpoint, add it to your MCP registry (or Claude settings and then re-run setup so OMC syncs the registry to Codex too):
+
+```json
+{
+  "mcpServers": {
+    "remoteOmc": {
+      "url": "https://lab.example.com/mcp",
+      "timeout": 30
+    }
+  }
+}
+```
+
+This gives OMC a coherent remote connection surface for MCP-backed tools. It does **not** make all remote files magically appear as a local workspace, and it does **not** replace SSH for arbitrary shell access.
+
+If you need richer cross-machine behavior in the future, that would require a separate authenticated remote execution/filesystem design rather than stretching the current local-workspace architecture.
+
 ### Agent Customization
 
 Edit agent files in `~/.claude/agents/` to customize behavior:

--- a/src/installer/__tests__/mcp-registry.test.ts
+++ b/src/installer/__tests__/mcp-registry.test.ts
@@ -72,6 +72,31 @@ describe('unified MCP registry sync', () => {
     expect(codexConfig).toContain('startup_timeout_sec = 15');
   });
 
+  it('round-trips URL-based remote MCP entries through the unified registry sync', () => {
+    const settings = {
+      mcpServers: {
+        remoteOmc: {
+          url: 'https://lab.example.com/mcp',
+          timeout: 30,
+        },
+      },
+    };
+
+    const { settings: syncedSettings, result } = syncUnifiedMcpRegistryTargets(settings);
+
+    expect(result.bootstrappedFromClaude).toBe(true);
+    expect(result.serverNames).toEqual(['remoteOmc']);
+    expect(syncedSettings).toEqual(settings);
+
+    const registryPath = getUnifiedMcpRegistryPath();
+    expect(JSON.parse(readFileSync(registryPath, 'utf-8'))).toEqual(settings.mcpServers);
+
+    const codexConfig = readFileSync(getCodexConfigPath(), 'utf-8');
+    expect(codexConfig).toContain('[mcp_servers.remoteOmc]');
+    expect(codexConfig).toContain('url = "https://lab.example.com/mcp"');
+    expect(codexConfig).toContain('startup_timeout_sec = 30');
+  });
+
   it('preserves unrelated Claude settings while replacing registry-defined MCP entries', () => {
     const existingSettings = {
       theme: 'dark',
@@ -206,5 +231,34 @@ describe('unified MCP registry sync', () => {
     expect(status.codexMissing).toEqual([]);
     expect(status.claudeMismatched).toEqual(['gitnexus']);
     expect(status.codexMismatched).toEqual(['gitnexus']);
+  });
+
+  it('detects mismatched URL-based remote MCP definitions during doctor inspection', () => {
+    writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({
+      remoteOmc: { url: 'https://lab.example.com/mcp', timeout: 30 },
+    }, null, 2));
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({
+      mcpServers: {
+        remoteOmc: { url: 'https://staging.example.com/mcp', timeout: 30 },
+      },
+    }, null, 2));
+    mkdirSync(codexDir, { recursive: true });
+    writeFileSync(getCodexConfigPath(), [
+      '# BEGIN OMC MANAGED MCP REGISTRY',
+      '',
+      '[mcp_servers.remoteOmc]',
+      'url = "https://staging.example.com/mcp"',
+      'startup_timeout_sec = 30',
+      '',
+      '# END OMC MANAGED MCP REGISTRY',
+      '',
+    ].join('\n'));
+
+    const status = inspectUnifiedMcpRegistrySync();
+
+    expect(status.claudeMissing).toEqual([]);
+    expect(status.codexMissing).toEqual([]);
+    expect(status.claudeMismatched).toEqual(['remoteOmc']);
+    expect(status.codexMismatched).toEqual(['remoteOmc']);
   });
 });


### PR DESCRIPTION
## Summary
- clarify the supported answer to #1653: OMC can preserve/sync remote MCP entries, but it does not implement a general remote-OMC cluster or shared remote filesystem view
- document the narrow remote MCP shape in the user-facing reference and compatibility docs
- add regression coverage for URL-based remote MCP entries in the unified MCP registry sync + doctor mismatch checks

## Why
The current architecture already has a coherent remote surface through MCP registry entries (`url`-backed servers), but not a broader remote execution/filesystem federation model. This PR makes that boundary explicit and tested instead of implying unsupported cluster semantics.

## Testing
- npm test -- src/installer/__tests__/mcp-registry.test.ts
- npm test -- src/installer/__tests__/mcp-registry.test.ts src/__tests__/mcp-default-config.test.ts

Closes #1653
