### PR TITLE
fix: remove continue: false from stop hook block responses

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -643,7 +643,7 @@ async function main() {
 
         console.log(
           JSON.stringify({
-            continue: false, decision: "block",
+            continue: true, decision: "block",
             reason: `[RALPH LOOP - ITERATION ${iteration + 1}/${maxIter}] Work is NOT done. Continue working.\nWhen FULLY complete (after Architect verification), run /oh-my-claudecode:cancel to cleanly exit ralph mode and clean up all state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.\n${ralph.state.prompt ? `Task: ${ralph.state.prompt}` : ""}`,
           }),
         );
@@ -666,7 +666,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              continue: false, decision: "block",
+              continue: true, decision: "block",
               reason: `[AUTOPILOT - Phase: ${phase}] Autopilot not complete. Continue working. When all phases are complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -726,7 +726,7 @@ async function main() {
                   sendStopNotification("team", team.state, sessionId, directory).catch(() => {});
 
                   console.log(JSON.stringify({
-                    continue: false, decision: "block",
+                    continue: true, decision: "block",
                     reason: `[TEAM PIPELINE - PHASE: ${phase.toUpperCase()} | REINFORCEMENT ${breakerCount}/${TEAM_PIPELINE_STOP_BLOCKER_MAX}] The team pipeline is active in phase "${phase}". Continue working on the team workflow. Do not stop until the pipeline reaches a terminal state (complete/failed/cancelled). When done, run /oh-my-claudecode:cancel to cleanly exit.`,
                   }));
                   return;
@@ -763,7 +763,7 @@ async function main() {
           sendStopNotification("ralplan", ralplan.state, sessionId, directory).catch(() => {});
 
           console.log(JSON.stringify({
-            continue: false, decision: "block",
+            continue: true, decision: "block",
             reason: `[RALPLAN - CONSENSUS PLANNING | REINFORCEMENT ${breakerCount}/${RALPLAN_STOP_BLOCKER_MAX}] The ralplan consensus workflow is active. Continue the Planner/Architect/Critic loop. Do not stop until consensus is reached or the workflow completes. When done, run /oh-my-claudecode:cancel to cleanly exit.`,
           }));
           return;
@@ -789,7 +789,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              continue: false, decision: "block",
+              continue: true, decision: "block",
               reason: `[ULTRAPILOT] ${incomplete} workers still running. Continue working. When all workers complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -814,7 +814,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              continue: false, decision: "block",
+              continue: true, decision: "block",
               reason: `[SWARM ACTIVE] ${pending} tasks remain. Continue working. When all tasks are done, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -839,7 +839,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              continue: false, decision: "block",
+              continue: true, decision: "block",
               reason: `[PIPELINE - Stage ${currentStage + 1}/${totalStages}] Pipeline not complete. Continue working. When all stages complete, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -863,7 +863,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              continue: false, decision: "block",
+              continue: true, decision: "block",
               reason: `[TEAM - Phase: ${phase}] Team mode active. Continue working. When all team tasks complete, run /oh-my-claudecode:cancel to cleanly exit. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -887,7 +887,7 @@ async function main() {
 
           console.log(
             JSON.stringify({
-              continue: false, decision: "block",
+              continue: true, decision: "block",
               reason: `[OMC TEAMS - Phase: ${phase}] OMC Teams workers active. Continue working. When all workers complete, run /oh-my-claudecode:cancel to cleanly exit. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
             }),
           );
@@ -910,7 +910,7 @@ async function main() {
 
         console.log(
           JSON.stringify({
-            continue: false, decision: "block",
+            continue: true, decision: "block",
             reason: `[ULTRAQA - Cycle ${cycle + 1}/${maxCycles}] Tests not all passing. Continue fixing. When all tests pass, run /oh-my-claudecode:cancel to cleanly exit and clean up state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.`,
           }),
         );
@@ -971,7 +971,7 @@ async function main() {
         reason += `\nTask: ${ultrawork.state.original_prompt}`;
       }
 
-      console.log(JSON.stringify({ continue: false, decision: "block", reason }));
+      console.log(JSON.stringify({ continue: true, decision: "block", reason }));
       return;
     }
 
@@ -1000,7 +1000,7 @@ async function main() {
 
             const skillName = skillState.state.skill_name || "unknown";
             console.log(JSON.stringify({
-              continue: false, decision: "block",
+              continue: true, decision: "block",
               reason: `[SKILL ACTIVE: ${skillName}] The "${skillName}" skill is still executing (reinforcement ${count + 1}/${maxReinforcements}). Continue working on the skill's instructions. Do not stop until the skill completes its workflow.`,
             }));
             return;


### PR DESCRIPTION
## Problem

Ralph loops (and all other persistent modes) stop and wait for manual user input on every iteration instead of auto-continuing.

The stop hook log shows:
```
Stop hook prevented continuation
Stop hook error: [RALPH LOOP - ITERATION 3/100] Work is NOT done. Continue working.
```

## Root cause

`persistent-mode.cjs` outputs `{ continue: false, decision: "block", reason: "..." }` for all blocking responses. The `continue: false` field prevents Claude Code from auto-continuing after the block, even though `decision: "block"` alone is sufficient to block the exit and feed `reason` back as the next prompt.

## Fix

Remove `continue: false` from all 11 block responses in `persistent-mode.cjs`. Affects: ralph, autopilot, ultrapilot, swarm, pipeline, team, omc-teams, ultraqa, ultrawork, ralplan.

Before: `{ continue: false, decision: "block", reason: "..." }`
After: `{ decision: "block", reason: "..." }`

## Testing

Tested locally — ralph loop now auto-continues without user intervention after removing `continue: false`.