### PR TITLE
fix(ccg): use CLI-first path for ask advisors (skill nesting unsupported)

### DIFF
--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -30,11 +30,9 @@ Use this when you want parallel external perspectives without launching tmux tea
    - Codex prompt (analysis/architecture/backend)
    - Gemini prompt (UX/design/docs/alternatives)
 
-2. Claude runs:
-   - /oh-my-claudecode:ask codex "<codex prompt>"
-   - /oh-my-claudecode:ask gemini "<gemini prompt>"
-
-   (equivalent CLI path: `omc ask codex ...` + `omc ask gemini ...`)
+2. Claude runs via CLI (skill nesting not supported):
+   - `omc ask codex "<codex prompt>"`
+   - `omc ask gemini "<gemini prompt>"`
 
 3. Artifacts are written under `.omc/artifacts/ask/`
 
@@ -52,16 +50,11 @@ Split the user request into:
 - **Gemini prompt:** UX/content clarity, alternatives, edge-case usability, docs polish
 - **Synthesis plan:** how to reconcile conflicts
 
-### 2. Invoke ask skills
+### 2. Invoke advisors via CLI
 
-Use skill routing first:
+> **Note:** Skill nesting (invoking a skill from within an active skill) is not supported in Claude Code. Always use the direct CLI path via Bash tool.
 
-```bash
-/oh-my-claudecode:ask codex <codex prompt>
-/oh-my-claudecode:ask gemini <gemini prompt>
-```
-
-Equivalent direct CLI:
+Run both advisors:
 
 ```bash
 omc ask codex "<codex prompt>"


### PR DESCRIPTION
## Summary

Fixes #1661 — CCG skill instructed skill routing first (`/oh-my-claudecode:ask codex`), but Claude Code does not support skill nesting (invoking a Skill tool from within an active skill context). This caused CCG to silently fall back to Claude-only instead of using both external providers.

### Changes

- **`skills/ccg/SKILL.md`**: Replace skill routing instructions with direct CLI path (`omc ask codex/gemini`) as the primary invocation method
- Added explicit note about skill nesting limitation

### Test plan

- Documentation-only change
- Verified `omc ask codex` and `omc ask gemini` CLI paths work correctly

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*