### PR TITLE
fix(hooks): handle deepsearch as mode message instead of skill invocation

### DIFF
--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -85,6 +85,17 @@ Perform a focused security review of the relevant changes or target area. Check 
 ---
 `;
 
+const SEARCH_MESSAGE = `<search-mode>
+MAXIMIZE SEARCH EFFORT. Launch multiple background agents IN PARALLEL:
+- explore agents (codebase patterns, file structures)
+- document-specialist agents (remote repos, official docs, GitHub examples)
+Plus direct tools: Grep, Glob
+NEVER stop at first result - be exhaustive.
+</search-mode>
+
+---
+`;
+
 // Extract prompt from various JSON structures
 function extractPrompt(input) {
   try {
@@ -480,6 +491,7 @@ async function main() {
     const additionalContextParts = [];
     for (const [keywordName, message] of [
       ['ultrathink', ULTRATHINK_MESSAGE],
+      ['deepsearch', SEARCH_MESSAGE],
       ['analyze', ANALYZE_MESSAGE],
       ['tdd', TDD_MESSAGE],
       ['code-review', CODE_REVIEW_MESSAGE],


### PR DESCRIPTION
## Summary

- **Bug**: The `deepsearch` keyword triggers `createSkillInvocation('deepsearch', ...)` in `keyword-detector.mjs`, which tells Claude to call `Skill("oh-my-claudecode:deepsearch")`. However, no `skills/deepsearch/SKILL.md` directory exists, resulting in an **"Unknown skill: oh-my-claudecode:deepsearch"** error.
- **Root cause**: In the mode-message handling block (lines 481-493), five keywords (`ultrathink`, `analyze`, `tdd`, `code-review`, `security-review`) are correctly intercepted and emitted as inline `additionalContext` messages. `deepsearch` was missing from this list, so it fell through to `createMultiSkillInvocation()` which generates a Skill tool call for a non-existent skill.
- **Fix**: Add `SEARCH_MESSAGE` constant (matching `bridge.ts` and `installer/hooks.ts`) and include `['deepsearch', SEARCH_MESSAGE]` in the mode-message handling loop so it is emitted as `additionalContext` instead of a skill invocation.

## Details

### How it breaks (before fix)

```
User types "deepsearch" →
  keyword-detector.mjs detects keyword →
    NOT in mode-message list →
      falls through to createSkillInvocation('deepsearch', ...) →
        hook outputs: "You MUST invoke Skill: oh-my-claudecode:deepsearch" →
          Claude calls Skill("oh-my-claudecode:deepsearch") →
            ❌ "Unknown skill: oh-my-claudecode:deepsearch"
```

### How it works (after fix)

```
User types "deepsearch" →
  keyword-detector.mjs detects keyword →
    found in mode-message list with SEARCH_MESSAGE →
      emitted as additionalContext →
        ✅ Claude receives <search-mode> instructions directly
```

### Files changed

- `templates/hooks/keyword-detector.mjs`: Added `SEARCH_MESSAGE` constant and `['deepsearch', SEARCH_MESSAGE]` entry in mode-message handling block

## Test plan

- [x] All 375 existing tests pass (`vitest run` on keyword-detector and hooks test files)
- [ ] Manual verification: type "deepsearch" in a prompt and confirm no "Unknown skill" error
- [ ] Verify `<search-mode>` message is injected into context correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)