### PR TITLE
fix(cli): bypass tmux for --print mode to preserve stdout pipe

### DIFF
--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -135,6 +135,16 @@ describe('runClaude — exit code propagation', () => {
       (resolveLaunchPolicy as ReturnType<typeof vi.fn>).mockReturnValue('direct');
     });
 
+    it('bypasses tmux for --print mode', () => {
+      (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
+
+      runClaude('/tmp', ['--print'], 'sid');
+
+      expect(resolveLaunchPolicy).toHaveBeenCalledWith(process.env, ['--print']);
+      expect(vi.mocked(execFileSync).mock.calls.find(([cmd]) => cmd === 'tmux')).toBeUndefined();
+      expect(vi.mocked(execFileSync).mock.calls.find(([cmd]) => cmd === 'claude')?.[1]).toEqual(['--print']);
+    });
+
     it('propagates Claude non-zero exit code', () => {
       const err = Object.assign(new Error('Command failed'), { status: 2 });
       (execFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => { throw err; });

--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, expect, it, vi, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
@@ -19,6 +20,7 @@ vi.mock('child_process', async (importOriginal) => {
 });
 
 import {
+  resolveLaunchPolicy,
   wrapWithLoginShell,
   quoteShellArg,
   sanitizeTmuxToken,
@@ -27,6 +29,29 @@ import {
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// resolveLaunchPolicy
+// ---------------------------------------------------------------------------
+describe('resolveLaunchPolicy', () => {
+  it('forces direct mode for --print even when tmux is available', () => {
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from('tmux 3.4'));
+
+    expect(resolveLaunchPolicy({}, ['--print'])).toBe('direct');
+  });
+
+  it('forces direct mode for -p even when tmux is available', () => {
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from('tmux 3.4'));
+
+    expect(resolveLaunchPolicy({}, ['-p'])).toBe('direct');
+  });
+
+  it('does not treat --print-system-prompt as print mode', () => {
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from('tmux 3.4'));
+
+    expect(resolveLaunchPolicy({ TMUX: '1' }, ['--print-system-prompt'])).toBe('inside-tmux');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -253,7 +253,7 @@ export async function preLaunch(_cwd: string, _sessionId: string): Promise<void>
  * 3. direct: tmux not available, run claude directly
  */
 export function runClaude(cwd: string, args: string[], sessionId: string): void {
-  const policy = resolveLaunchPolicy(process.env);
+  const policy = resolveLaunchPolicy(process.env, args);
 
   switch (policy) {
     case 'inside-tmux':

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -39,12 +39,19 @@ export function isClaudeAvailable(): boolean {
 }
 
 /**
- * Resolve launch policy based on environment
+ * Resolve launch policy based on environment and args
  * - inside-tmux: Already in tmux session, split pane for HUD
  * - outside-tmux: Not in tmux, create new session
  * - direct: tmux not available, run directly
+ * - direct: print mode requested so stdout can flow to parent process
  */
-export function resolveLaunchPolicy(env: NodeJS.ProcessEnv = process.env): ClaudeLaunchPolicy {
+export function resolveLaunchPolicy(
+  env: NodeJS.ProcessEnv = process.env,
+  args: string[] = [],
+): ClaudeLaunchPolicy {
+  if (args.some((arg) => arg === '--print' || arg === '-p')) {
+    return 'direct';
+  }
   if (!isTmuxAvailable()) {
     return 'direct';
   }


### PR DESCRIPTION
Fixes #1665

## Summary
- force direct launch mode when Claude is invoked with --print or -p
- keep --print-system-prompt on tmux-backed launch paths by only matching exact print flags
- add regression coverage for print-mode bypass and launch-policy detection

## Testing
- npx vitest run src/cli/__tests__/launch.test.ts src/cli/__tests__/tmux-utils.test.ts