### PR TITLE
fix(hud): prefer fresh Keychain entry when multiple Claude Code credentials exist

### DIFF
--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -2,8 +2,10 @@
  * Tests for z.ai host validation, response parsing, and getUsage routing.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
+import * as childProcess from 'child_process';
+import * as os from 'os';
 import { EventEmitter } from 'events';
 import { isZaiHost, parseZaiResponse, getUsage } from '../../hud/usage-api.js';
 
@@ -196,10 +198,22 @@ describe('parseZaiResponse', () => {
 
 describe('getUsage routing', () => {
   const originalEnv = { ...process.env };
+  const originalPlatform = process.platform;
   let httpsModule: { default: { request: ReturnType<typeof vi.fn> } };
+
+  beforeAll(() => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.readFileSync).mockReturnValue('{}');
+    vi.mocked(childProcess.execSync).mockImplementation(() => { throw new Error('mock: no keychain'); });
     // Reset env
     delete process.env.ANTHROPIC_BASE_URL;
     delete process.env.ANTHROPIC_AUTH_TOKEN;
@@ -217,6 +231,133 @@ describe('getUsage routing', () => {
     expect(result.error).toBe('no_credentials');
     // No network call should be made without credentials
     expect(httpsModule.default.request).not.toHaveBeenCalled();
+  });
+
+  it('prefers the username-scoped keychain entry when the legacy service-only entry is expired', async () => {
+    const oneHourFromNow = Date.now() + 60 * 60 * 1000;
+    const oneHourAgo = Date.now() - 60 * 60 * 1000;
+    const execSyncMock = vi.mocked(childProcess.execSync);
+    const username = os.userInfo().username;
+
+    execSyncMock.mockImplementation((command) => {
+      const cmd = String(command);
+      if (cmd.includes(`-a "${username}"`)) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'fresh-token',
+            refreshToken: 'fresh-refresh',
+            expiresAt: oneHourFromNow,
+          },
+        });
+      }
+      if (cmd.includes('find-generic-password -s "Claude Code-credentials" -w')) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'stale-token',
+            refreshToken: 'stale-refresh',
+            expiresAt: oneHourAgo,
+          },
+        });
+      }
+      throw new Error(`unexpected keychain lookup: ${cmd}`);
+    });
+
+    httpsModule.default.request.mockImplementationOnce((_options, callback) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void; on: typeof EventEmitter.prototype.on };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          five_hour: { utilization: 25 },
+          seven_day: { utilization: 50 },
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result).toEqual({
+      rateLimits: {
+        fiveHourPercent: 25,
+        weeklyPercent: 50,
+        fiveHourResetsAt: null,
+        weeklyResetsAt: null,
+      },
+    });
+    expect(execSyncMock).toHaveBeenCalledWith(
+      `/usr/bin/security find-generic-password -s "Claude Code-credentials" -a "${username}" -w 2>/dev/null`,
+      { encoding: 'utf-8', timeout: 2000 }
+    );
+    expect(execSyncMock).not.toHaveBeenCalledWith(
+      '/usr/bin/security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null',
+      { encoding: 'utf-8', timeout: 2000 }
+    );
+    expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
+    expect(httpsModule.default.request.mock.calls[0][0].headers.Authorization).toBe('Bearer fresh-token');
+  });
+
+  it('falls back to the legacy service-only keychain entry when the username-scoped entry is expired', async () => {
+    const oneHourFromNow = Date.now() + 60 * 60 * 1000;
+    const oneHourAgo = Date.now() - 60 * 60 * 1000;
+    const execSyncMock = vi.mocked(childProcess.execSync);
+    const username = os.userInfo().username;
+
+    execSyncMock.mockImplementation((command) => {
+      const cmd = String(command);
+      if (cmd.includes(`-a "${username}"`)) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'expired-user-token',
+            refreshToken: 'expired-user-refresh',
+            expiresAt: oneHourAgo,
+          },
+        });
+      }
+      if (cmd.includes('find-generic-password -s "Claude Code-credentials" -w')) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'fresh-legacy-token',
+            refreshToken: 'fresh-legacy-refresh',
+            expiresAt: oneHourFromNow,
+          },
+        });
+      }
+      throw new Error(`unexpected keychain lookup: ${cmd}`);
+    });
+
+    httpsModule.default.request.mockImplementationOnce((_options, callback) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void; on: typeof EventEmitter.prototype.on };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          five_hour: { utilization: 10 },
+          seven_day: { utilization: 20 },
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result).toEqual({
+      rateLimits: {
+        fiveHourPercent: 10,
+        weeklyPercent: 20,
+        fiveHourResetsAt: null,
+        weeklyResetsAt: null,
+      },
+    });
+    expect(execSyncMock).toHaveBeenCalledTimes(2);
+    expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
+    expect(httpsModule.default.request.mock.calls[0][0].headers.Authorization).toBe('Bearer fresh-legacy-token');
   });
 
   it('routes to z.ai when ANTHROPIC_BASE_URL is z.ai host', async () => {

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -17,6 +17,7 @@ import { getClaudeConfigDir } from '../utils/paths.js';
 import { join, dirname } from 'path';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
+import { userInfo } from 'os';
 import https from 'https';
 import { validateAnthropicBaseUrl } from '../utils/ssrf-guard.js';
 import {
@@ -307,16 +308,15 @@ function getKeychainServiceName(): string {
   return 'Claude Code-credentials';
 }
 
-/**
- * Read OAuth credentials from macOS Keychain
- */
-function readKeychainCredentials(): OAuthCredentials | null {
-  if (process.platform !== 'darwin') return null;
+function isCredentialExpired(creds: OAuthCredentials): boolean {
+  return creds.expiresAt != null && creds.expiresAt <= Date.now();
+}
 
+function readKeychainCredential(serviceName: string, account?: string): OAuthCredentials | null {
   try {
-    const serviceName = getKeychainServiceName();
+    const accountArg = account ? ` -a "${account}"` : '';
     const result = execSync(
-      `/usr/bin/security find-generic-password -s "${serviceName}" -w 2>/dev/null`,
+      `/usr/bin/security find-generic-password -s "${serviceName}"${accountArg} -w 2>/dev/null`,
       { encoding: 'utf-8', timeout: 2000 }
     ).trim();
 
@@ -327,19 +327,53 @@ function readKeychainCredentials(): OAuthCredentials | null {
     // Handle nested structure (claudeAiOauth wrapper)
     const creds = parsed.claudeAiOauth || parsed;
 
-    if (creds.accessToken) {
-      return {
-        accessToken: creds.accessToken,
-        expiresAt: creds.expiresAt,
-        refreshToken: creds.refreshToken,
-        source: 'keychain' as const,
-      };
+    if (!creds.accessToken) return null;
+
+    return {
+      accessToken: creds.accessToken,
+      expiresAt: creds.expiresAt,
+      refreshToken: creds.refreshToken,
+      source: 'keychain' as const,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read OAuth credentials from macOS Keychain
+ */
+function readKeychainCredentials(): OAuthCredentials | null {
+  if (process.platform !== 'darwin') return null;
+
+  const serviceName = getKeychainServiceName();
+  const candidateAccounts: Array<string | undefined> = [];
+
+  try {
+    const username = userInfo().username?.trim();
+    if (username) {
+      candidateAccounts.push(username);
     }
   } catch {
-    // Keychain access failed
+    // Best-effort only; fall back to the legacy service-only lookup below.
   }
 
-  return null;
+  candidateAccounts.push(undefined);
+
+  let expiredFallback: OAuthCredentials | null = null;
+
+  for (const account of candidateAccounts) {
+    const creds = readKeychainCredential(serviceName, account);
+    if (!creds) continue;
+
+    if (!isCredentialExpired(creds)) {
+      return creds;
+    }
+
+    expiredFallback ??= creds;
+  }
+
+  return expiredFallback;
 }
 
 /**
@@ -389,12 +423,7 @@ function getCredentials(): OAuthCredentials | null {
 function validateCredentials(creds: OAuthCredentials): boolean {
   if (!creds.accessToken) return false;
 
-  if (creds.expiresAt != null) {
-    const now = Date.now();
-    if (creds.expiresAt <= now) return false;
-  }
-
-  return true;
+  return !isCredentialExpired(creds);
 }
 
 /**


### PR DESCRIPTION
Fixes #1682

## Summary
- prefer the username-scoped Claude Code Keychain entry on macOS
- fall back to the legacy service-only lookup when needed
- retry the alternate Keychain lookup pattern when the first credential is expired
- add regression coverage for both multi-entry credential-selection paths