### PR TITLE
fix(project-memory): inject customNotes into session context

### DIFF
--- a/src/hooks/project-memory/__tests__/formatter.test.ts
+++ b/src/hooks/project-memory/__tests__/formatter.test.ts
@@ -185,6 +185,49 @@ describe('Project Memory Formatter', () => {
       expect(summary.length).toBeLessThan(300);
       expect(summary).toContain('[Project Environment]');
     });
+
+    it('should include customNotes in context summary', () => {
+      const memory = createBaseMemory({
+        techStack: {
+          languages: [{ name: 'TypeScript', version: null, confidence: 'high', markers: ['tsconfig.json'] }],
+          frameworks: [],
+          packageManager: null,
+          runtime: null,
+        },
+        customNotes: [
+          { timestamp: Date.now(), source: 'learned', category: 'env', content: 'Requires NODE_ENV=production' },
+          { timestamp: Date.now(), source: 'manual', category: 'deploy', content: 'Uses Docker for deployment' },
+        ],
+      });
+
+      const summary = formatContextSummary(memory);
+
+      expect(summary).toContain('**Notes:**');
+      expect(summary).toContain('[env] Requires NODE_ENV=production');
+      expect(summary).toContain('[deploy] Uses Docker for deployment');
+    });
+
+    it('should limit customNotes to 5 in context summary', () => {
+      const notes = Array.from({ length: 8 }, (_, i) => ({
+        timestamp: Date.now(),
+        source: 'learned' as const,
+        category: 'test',
+        content: `Note ${i + 1}`,
+      }));
+
+      const memory = createBaseMemory({ customNotes: notes });
+      const summary = formatContextSummary(memory);
+
+      expect(summary).toContain('Note 5');
+      expect(summary).not.toContain('Note 6');
+    });
+
+    it('should not include Notes section when customNotes is empty', () => {
+      const memory = createBaseMemory({ customNotes: [] });
+      const summary = formatContextSummary(memory);
+
+      expect(summary).not.toContain('**Notes:**');
+    });
   });
 
   describe('formatFullContext', () => {

--- a/src/hooks/project-memory/__tests__/integration.test.ts
+++ b/src/hooks/project-memory/__tests__/integration.test.ts
@@ -130,6 +130,47 @@ describe('Project Memory Integration', () => {
     });
   });
 
+  describe('Rescan preserves user-contributed data', () => {
+    it('should preserve customNotes and userDirectives after rescan', async () => {
+      const packageJson = { name: 'test', scripts: { build: 'tsc' }, devDependencies: { typescript: '^5.0.0' } };
+      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson));
+      await fs.writeFile(path.join(tempDir, 'tsconfig.json'), '{}');
+
+      // Initial scan
+      const sessionId = 'test-session-rescan';
+      await registerProjectMemoryContext(sessionId, tempDir);
+
+      // Add custom notes and directives to the persisted memory
+      let memory = await loadProjectMemory(tempDir);
+      expect(memory).not.toBeNull();
+      memory!.customNotes = [
+        { timestamp: Date.now(), source: 'manual', category: 'deploy', content: 'Uses Docker' },
+      ];
+      memory!.userDirectives = [
+        { timestamp: Date.now(), directive: 'Always use strict mode', context: '', source: 'explicit', priority: 'high' },
+      ];
+      // Set lastScanned to 25 hours ago to trigger rescan
+      memory!.lastScanned = Date.now() - 25 * 60 * 60 * 1000;
+      const memoryPath = getMemoryPath(tempDir);
+      await fs.writeFile(memoryPath, JSON.stringify(memory, null, 2));
+
+      // Clear session cache and re-register (triggers rescan)
+      clearProjectMemorySession(sessionId);
+      await registerProjectMemoryContext(sessionId, tempDir);
+
+      // Verify user-contributed data survived
+      const updated = await loadProjectMemory(tempDir);
+      expect(updated).not.toBeNull();
+      expect(updated!.customNotes).toHaveLength(1);
+      expect(updated!.customNotes[0].content).toBe('Uses Docker');
+      expect(updated!.userDirectives).toHaveLength(1);
+      expect(updated!.userDirectives[0].directive).toBe('Always use strict mode');
+      // Verify lastScanned was updated (rescan happened)
+      const age = Date.now() - updated!.lastScanned;
+      expect(age).toBeLessThan(5000);
+    });
+  });
+
   describe('End-to-end PostToolUse learning flow', () => {
     it('should learn build command from Bash execution', async () => {
       // Create initial project

--- a/src/hooks/project-memory/__tests__/pre-compact.test.ts
+++ b/src/hooks/project-memory/__tests__/pre-compact.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for Project Memory PreCompact Handler
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { processPreCompact, PreCompactInput } from '../pre-compact.js';
+import { ProjectMemory } from '../types.js';
+import { SCHEMA_VERSION } from '../constants.js';
+
+// Mock dependencies
+vi.mock('../../rules-injector/finder.js', () => ({
+  findProjectRoot: vi.fn(),
+}));
+
+vi.mock('../storage.js', () => ({
+  loadProjectMemory: vi.fn(),
+}));
+
+import { findProjectRoot } from '../../rules-injector/finder.js';
+import { loadProjectMemory } from '../storage.js';
+
+const mockedFindProjectRoot = vi.mocked(findProjectRoot);
+const mockedLoadProjectMemory = vi.mocked(loadProjectMemory);
+
+const createBaseMemory = (overrides: Partial<ProjectMemory> = {}): ProjectMemory => ({
+  version: SCHEMA_VERSION,
+  lastScanned: Date.now(),
+  projectRoot: '/test',
+  techStack: { languages: [], frameworks: [], packageManager: null, runtime: null },
+  build: { buildCommand: null, testCommand: null, lintCommand: null, devCommand: null, scripts: {} },
+  conventions: { namingStyle: null, importStyle: null, testPattern: null, fileOrganization: null },
+  structure: { isMonorepo: false, workspaces: [], mainDirectories: [], gitBranches: null },
+  customNotes: [],
+  directoryMap: {},
+  hotPaths: [],
+  userDirectives: [],
+  ...overrides,
+});
+
+const baseInput: PreCompactInput = {
+  session_id: 'test-session',
+  transcript_path: '/tmp/transcript',
+  cwd: '/test',
+  permission_mode: 'default',
+  hook_event_name: 'PreCompact',
+  trigger: 'auto',
+};
+
+describe('Project Memory PreCompact Handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should treat customNotes as critical info and inject system message', async () => {
+    mockedFindProjectRoot.mockReturnValue('/test');
+    mockedLoadProjectMemory.mockResolvedValue(
+      createBaseMemory({
+        customNotes: [
+          { timestamp: Date.now(), source: 'learned', category: 'env', content: 'Requires NODE_ENV' },
+        ],
+      }),
+    );
+
+    const result = await processPreCompact(baseInput);
+
+    expect(result.continue).toBe(true);
+    expect(result.systemMessage).toBeDefined();
+    expect(result.systemMessage).toContain('Project Memory');
+    expect(result.systemMessage).toContain('[env] Requires NODE_ENV');
+  });
+
+  it('should not inject when memory has no critical info', async () => {
+    mockedFindProjectRoot.mockReturnValue('/test');
+    mockedLoadProjectMemory.mockResolvedValue(createBaseMemory());
+
+    const result = await processPreCompact(baseInput);
+
+    expect(result.continue).toBe(true);
+    expect(result.systemMessage).toBeUndefined();
+  });
+});

--- a/src/hooks/project-memory/formatter.ts
+++ b/src/hooks/project-memory/formatter.ts
@@ -83,6 +83,15 @@ export function formatContextSummary(memory: ProjectMemory): string {
     }
   }
 
+  // Add custom notes
+  if (memory.customNotes.length > 0) {
+    lines.push('');
+    lines.push('**Notes:**');
+    for (const note of memory.customNotes.slice(0, 5)) {
+      lines.push(`- [${note.category}] ${note.content}`);
+    }
+  }
+
   return lines.join('\n');
 }
 

--- a/src/hooks/project-memory/index.ts
+++ b/src/hooks/project-memory/index.ts
@@ -61,7 +61,13 @@ export async function registerProjectMemoryContext(
 
     // Rescan if memory doesn't exist or is stale
     if (!memory || shouldRescan(memory)) {
+      const existing = memory;
       memory = await detectProjectEnvironment(projectRoot);
+      // Preserve user-contributed data that detection cannot reproduce
+      if (existing) {
+        memory.customNotes = existing.customNotes;
+        memory.userDirectives = existing.userDirectives;
+      }
       await saveProjectMemory(projectRoot, memory);
     }
 
@@ -117,7 +123,13 @@ export function clearProjectMemorySession(sessionId: string): void {
 export async function rescanProjectEnvironment(
   projectRoot: string,
 ): Promise<void> {
+  const existing = await loadProjectMemory(projectRoot);
   const memory = await detectProjectEnvironment(projectRoot);
+  // Preserve user-contributed data that detection cannot reproduce
+  if (existing) {
+    memory.customNotes = existing.customNotes;
+    memory.userDirectives = existing.userDirectives;
+  }
   await saveProjectMemory(projectRoot, memory);
 }
 

--- a/src/hooks/project-memory/pre-compact.ts
+++ b/src/hooks/project-memory/pre-compact.ts
@@ -42,7 +42,8 @@ export async function processPreCompact(input: PreCompactInput): Promise<PreComp
     const hasCriticalInfo =
       memory.userDirectives.length > 0 ||
       memory.hotPaths.length > 0 ||
-      memory.techStack.languages.length > 0;
+      memory.techStack.languages.length > 0 ||
+      memory.customNotes.length > 0;
 
     if (!hasCriticalInfo) {
       return { continue: true };


### PR DESCRIPTION
## Summary

- **formatContextSummary** now renders `customNotes` into the context string injected at session start
- **hasCriticalInfo** in pre-compact handler now checks `customNotes.length > 0`, ensuring notes survive compaction
- **rescan** (both `registerProjectMemoryContext` and `rescanProjectEnvironment`) now merges existing `customNotes` and `userDirectives` before overwriting with fresh detection results

Closes #1688

## Test plan

- [x] Added 3 formatter tests: customNotes rendered, capped at 5, empty = no section
- [x] Added 2 pre-compact tests: customNotes treated as critical info, empty = no injection
- [x] Added integration test: rescan preserves customNotes and userDirectives
- [x] All 21 project-memory tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)