### PR TITLE
feat: add security-checklist skill (OWASP-based audit)

### DIFF
--- a/skills/security-checklist/SKILL.md
+++ b/skills/security-checklist/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: security-checklist
+description: OWASP Top 10 based security audit for your codebase — scans for vulnerabilities, hardcoded secrets, injection flaws, and generates a severity-ranked report
+---
+
+# Security Checklist
+
+Perform a security audit on the current codebase based on OWASP Top 10 and common vulnerability patterns.
+
+## When to Use
+
+- Before deploying code to production
+- After implementing authentication, authorization, or data handling features
+- When reviewing code that handles user input, API calls, or file operations
+- When you want a quick security health check of your project
+
+## When NOT to Use
+
+- For compliance audits requiring certified tools
+- For runtime/dynamic security testing (use dedicated scanners instead)
+
+## Process
+
+### Step 1: Scan the Codebase
+
+Read the project structure and identify security-relevant files:
+- Authentication/authorization modules
+- API endpoints and route handlers
+- Database queries and ORM usage
+- File upload/download handlers
+- Configuration files (.env, config, secrets)
+- Dependency files (package.json, requirements.txt, go.mod)
+
+### Step 2: Check OWASP Top 10 (2021)
+
+Evaluate each category and report findings:
+
+| # | Category | What to Look For |
+|---|----------|-----------------|
+| A01 | Broken Access Control | Missing auth checks, IDOR, privilege escalation |
+| A02 | Cryptographic Failures | Hardcoded secrets, weak hashing, HTTP instead of HTTPS |
+| A03 | Injection | SQL injection, XSS, command injection, template injection |
+| A04 | Insecure Design | Missing rate limiting, no input validation architecture |
+| A05 | Security Misconfiguration | Debug mode on, default credentials, verbose errors |
+| A06 | Vulnerable Components | Outdated dependencies with known CVEs |
+| A07 | Auth Failures | Weak password policy, missing MFA, session issues |
+| A08 | Data Integrity Failures | Unsigned updates, insecure deserialization, no CI/CD checks |
+| A09 | Logging Failures | No audit logs, sensitive data in logs, no alerting |
+| A10 | SSRF | Unvalidated URLs, internal network access from user input |
+
+### Step 3: Check Common Patterns
+
+- [ ] No secrets/API keys hardcoded in source code
+- [ ] Environment variables used for sensitive configuration
+- [ ] Input validation on all user-facing endpoints
+- [ ] Parameterized queries (no string concatenation for SQL)
+- [ ] CORS properly configured
+- [ ] Rate limiting on authentication endpoints
+- [ ] Error messages don't leak internal details
+- [ ] Dependencies are up to date (no known CVEs)
+- [ ] HTTPS enforced
+- [ ] Security headers set (CSP, X-Frame-Options, etc.)
+
+### Step 4: Generate Report
+
+Output a summary in this format:
+
+```
+## Security Audit Report
+
+**Project**: {project name}
+**Date**: {date}
+**Risk Level**: Critical / High / Medium / Low
+
+### Findings
+
+| Severity | Issue | File | Line | Recommendation |
+|----------|-------|------|------|----------------|
+| ...      | ...   | ...  | ...  | ...            |
+
+### Summary
+- Critical: {n} | High: {n} | Medium: {n} | Low: {n} | Info: {n}
+- Top priority: {most critical finding}
+```
+
+## Options
+
+- `/security-checklist` — Full audit (all categories)
+- `/security-checklist --quick` — Quick scan (secrets + injection + auth only)
+- `/security-checklist --deps` — Dependencies only (CVE check)

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -10,8 +10,8 @@ describe('Builtin Skills', () => {
   describe('createBuiltinSkills()', () => {
     it('should return correct number of skills (29 including aliases)', () => {
       const skills = createBuiltinSkills();
-      // 30 entries: 29 canonical skills + 1 deprecated alias (psm)
-      expect(skills).toHaveLength(30);
+      // 31 entries: 30 canonical skills + 1 deprecated alias (psm)
+      expect(skills).toHaveLength(31);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -84,6 +84,7 @@ describe('Builtin Skills', () => {
         'ralplan',
         'release',
         'sciomc',
+        'security-checklist',
         'setup',
         'skill',
         'team',
@@ -128,6 +129,14 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('Ranked Hypotheses');
       expect(skill?.template).toContain('trace_timeline');
       expect(skill?.template).toContain('trace_summary');
+    });
+    it('should retrieve the security-checklist skill with OWASP audit categories', () => {
+      const skill = getBuiltinSkill('security-checklist');
+      expect(skill).toBeDefined();
+      expect(skill?.name).toBe('security-checklist');
+      expect(skill?.template).toContain('OWASP');
+      expect(skill?.template).toContain('severity');
+      expect(skill?.template).toContain('security');
     });
     it('should retrieve the deep-dive skill with pipeline metadata and 3-point injection', () => {
       const skill = getBuiltinSkill('deep-dive');
@@ -241,7 +250,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(29);
+      expect(names).toHaveLength(30);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -273,7 +282,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131, psm still exists
-      expect(names).toHaveLength(30);
+      expect(names).toHaveLength(31);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('trace');
       expect(names).not.toContain('swarm');


### PR DESCRIPTION
## Summary
- Add `security-checklist` skill for automated OWASP Top 10 (2021) code security review
- Scans for hardcoded secrets, injection flaws, broken access control, and more
- Generates severity-ranked report (Critical/High/Medium/Low/Info)
- Includes skill count bump and test assertions in `skills.test.ts`

## Changes
- `skills/security-checklist/SKILL.md` — new skill with YAML frontmatter
- `src/__tests__/skills.test.ts` — count bump (30→31 canonical+alias, 29→30 canonical) + `getBuiltinSkill('security-checklist')` assertion

## Test plan
- [x] Skill loads via `getBuiltinSkill('security-checklist')`
- [x] Skill has required frontmatter (`name`, `description`)
- [x] Template contains OWASP-related content (`OWASP`, `severity`, `security`)
- [x] Skill count updated: `createBuiltinSkills()` → 31, `listBuiltinSkillNames()` → 30, with aliases → 31
- [x] No duplicate skill names
- [x] PR targets `dev` branch

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>