### PR TITLE
feat(autoresearch): backport autoresearch from OMX to OMC (Phase 1)

### DIFF
--- a/src/autoresearch/__tests__/contracts.test.ts
+++ b/src/autoresearch/__tests__/contracts.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  loadAutoresearchMissionContract,
+  parseEvaluatorResult,
+  parseSandboxContract,
+  slugifyMissionName,
+} from '../contracts.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omc-autoresearch-contracts-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+describe('autoresearch contracts', () => {
+  it('slugifies mission names deterministically', () => {
+    expect(slugifyMissionName('Missions/My Demo Mission')).toBe('missions-my-demo-mission');
+  });
+
+  it('parses sandbox contract with evaluator command and json format', () => {
+    const parsed = parseSandboxContract(`---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n---\nStay in bounds.\n`);
+    expect(parsed.evaluator.command).toBe('node scripts/eval.js');
+    expect(parsed.evaluator.format).toBe('json');
+    expect(parsed.body).toBe('Stay in bounds.');
+  });
+
+  it('rejects sandbox contract without frontmatter', () => {
+    expect(() => parseSandboxContract('No frontmatter here')).toThrow(/sandbox\.md must start with YAML frontmatter/i);
+  });
+
+  it('rejects sandbox contract without evaluator command', () => {
+    expect(() => parseSandboxContract(`---\nevaluator:\n  format: json\n---\nPolicy\n`)).toThrow(/evaluator\.command is required/i);
+  });
+
+  it('rejects sandbox contract without evaluator format', () => {
+    expect(() => parseSandboxContract(`---\nevaluator:\n  command: node eval.js\n---\nPolicy\n`)).toThrow(/evaluator\.format is required/i);
+  });
+
+  it('rejects sandbox contract with non-json evaluator format', () => {
+    expect(() => parseSandboxContract(`---\nevaluator:\n  command: node eval.js\n  format: text\n---\nPolicy\n`)).toThrow(/evaluator\.format must be json/i);
+  });
+
+  it('parses optional evaluator keep_policy', () => {
+    const parsed = parseSandboxContract(`---
+evaluator:
+  command: node scripts/eval.js
+  format: json
+  keep_policy: pass_only
+---
+Stay in bounds.
+`);
+    expect(parsed.evaluator.keep_policy).toBe('pass_only');
+  });
+
+  it('rejects unsupported evaluator keep_policy', () => {
+    expect(() => parseSandboxContract(`---
+evaluator:
+  command: node scripts/eval.js
+  format: json
+  keep_policy: maybe
+---
+Stay in bounds.
+`)).toThrow(/keep_policy must be one of/i);
+  });
+
+  it('accepts evaluator result with pass only', () => {
+    expect(parseEvaluatorResult('{"pass":true}')).toEqual({ pass: true });
+  });
+
+  it('accepts evaluator result with pass and score', () => {
+    expect(parseEvaluatorResult('{"pass":false,"score":61}')).toEqual({ pass: false, score: 61 });
+  });
+
+  it('rejects evaluator result without pass', () => {
+    expect(() => parseEvaluatorResult('{"score":61}')).toThrow(/must include boolean pass/i);
+  });
+
+  it('rejects evaluator result with non-numeric score', () => {
+    expect(() => parseEvaluatorResult('{"pass":true,"score":"high"}')).toThrow(/score must be numeric/i);
+  });
+
+  it('loads mission contract from in-repo mission directory', async () => {
+    const repo = await initRepo();
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\nShip it\n', 'utf-8');
+      await writeFile(
+        join(missionDir, 'sandbox.md'),
+        `---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n---\nStay in bounds.\n`,
+        'utf-8',
+      );
+
+      const contract = await loadAutoresearchMissionContract(missionDir);
+      expect(contract.repoRoot).toBe(repo);
+      expect(contract.missionRelativeDir.replace(/\\/g, '/')).toBe('missions/demo');
+      expect(contract.missionSlug).toBe('missions-demo');
+      expect(contract.sandbox.evaluator.command).toBe('node scripts/eval.js');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/autoresearch/__tests__/runtime-parity-extra.test.ts
+++ b/src/autoresearch/__tests__/runtime-parity-extra.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AutoresearchMissionContract } from '../contracts.js';
+import {
+  assertResetSafeWorktree,
+  decideAutoresearchOutcome,
+  loadAutoresearchRunManifest,
+  materializeAutoresearchMissionToWorktree,
+  prepareAutoresearchRuntime,
+  processAutoresearchCandidate,
+  resumeAutoresearchRuntime,
+} from '../runtime.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omc-autoresearch-parity-extra-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+async function makeContract(repo: string, keepPolicy?: 'score_improvement' | 'pass_only'): Promise<AutoresearchMissionContract> {
+  const missionDir = join(repo, 'missions', 'demo');
+  await mkdir(missionDir, { recursive: true });
+  await mkdir(join(repo, 'scripts'), { recursive: true });
+  const missionFile = join(missionDir, 'mission.md');
+  const sandboxFile = join(missionDir, 'sandbox.md');
+  const missionContent = '# Mission\nSolve the task.\n';
+  const keepPolicyLine = keepPolicy ? `  keep_policy: ${keepPolicy}\n` : '';
+  const sandboxContent = `---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n${keepPolicyLine}---\nStay inside the mission boundary.\n`;
+  await writeFile(missionFile, missionContent, 'utf-8');
+  await writeFile(sandboxFile, sandboxContent, 'utf-8');
+  await writeFile(join(repo, 'score.txt'), '1\n', 'utf-8');
+  await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true, score: 1 }));\n", 'utf-8');
+  execFileSync('git', ['add', 'missions/demo/mission.md', 'missions/demo/sandbox.md', 'scripts/eval.js', 'score.txt'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'add autoresearch fixtures'], { cwd: repo, stdio: 'ignore' });
+  return {
+    missionDir,
+    repoRoot: repo,
+    missionFile,
+    sandboxFile,
+    missionRelativeDir: 'missions/demo',
+    missionContent,
+    sandboxContent,
+    sandbox: {
+      frontmatter: { evaluator: { command: 'node scripts/eval.js', format: 'json', ...(keepPolicy ? { keep_policy: keepPolicy } : {}) } },
+      evaluator: { command: 'node scripts/eval.js', format: 'json', ...(keepPolicy ? { keep_policy: keepPolicy } : {}) },
+      body: 'Stay inside the mission boundary.',
+    },
+    missionSlug: 'missions-demo',
+  };
+}
+
+describe('autoresearch runtime parity extras', () => {
+  it('treats allowed runtime files as reset-safe and blocks unrelated dirt', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omc-worktrees`, 'autoresearch-missions-demo-20260314t020000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t020000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T020000Z' });
+
+      await writeFile(join(worktreePath, 'results.tsv'), 'iteration\tcommit\tpass\tscore\tstatus\tdescription\n', 'utf-8');
+      await writeFile(join(worktreePath, 'run.log'), 'ok\n', 'utf-8');
+      expect(() => assertResetSafeWorktree(worktreePath)).not.toThrow();
+
+      await writeFile(join(worktreePath, 'scratch.tmp'), 'nope\n', 'utf-8');
+      expect(() => assertResetSafeWorktree(worktreePath)).toThrow(/autoresearch_reset_requires_clean_worktree/i);
+
+      const manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      expect(manifest.results_file).toBe(join(worktreePath, 'results.tsv'));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects concurrent fresh runs via the repo-root active-run lock', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePathA = join(repo, '..', `${repo.split('/').pop()}.omc-worktrees`, 'autoresearch-missions-demo-20260314t030000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t030000z', worktreePathA, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContractA = await materializeAutoresearchMissionToWorktree(contract, worktreePathA);
+      await prepareAutoresearchRuntime(worktreeContractA, repo, worktreePathA, { runTag: '20260314T030000Z' });
+
+      const worktreePathB = join(repo, '..', `${repo.split('/').pop()}.omc-worktrees`, 'autoresearch-missions-demo-20260314t030500z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t030500z', worktreePathB, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContractB = await materializeAutoresearchMissionToWorktree(contract, worktreePathB);
+
+      await expect(
+        prepareAutoresearchRuntime(worktreeContractB, repo, worktreePathB, { runTag: '20260314T030500Z' }),
+      ).rejects.toThrow(/autoresearch_active_run_exists/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes a running manifest and rejects missing worktrees', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omc-worktrees`, 'autoresearch-missions-demo-20260314t040000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t040000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T040000Z' });
+      const statePath = join(repo, '.omc', 'state', 'autoresearch-state.json');
+      const idleState = {
+        schema_version: 1,
+        active: false,
+        run_id: runtime.runId,
+        mission_slug: contract.missionSlug,
+        repo_root: repo,
+        worktree_path: worktreePath,
+        status: 'idle',
+        updated_at: '2026-03-14T04:05:00.000Z',
+      };
+      await writeFile(statePath, `${JSON.stringify(idleState, null, 2)}\n`, 'utf-8');
+
+      const resumed = await resumeAutoresearchRuntime(repo, runtime.runId);
+      expect(resumed.runId).toBe(runtime.runId);
+      expect(resumed.worktreePath).toBe(worktreePath);
+
+      await writeFile(statePath, `${JSON.stringify(idleState, null, 2)}\n`, 'utf-8');
+      await rm(worktreePath, { recursive: true, force: true });
+      await expect(
+        resumeAutoresearchRuntime(repo, runtime.runId),
+      ).rejects.toThrow(/autoresearch_resume_missing_worktree/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('decides ambiguous vs keep based on keep_policy semantics', () => {
+    const candidate = {
+      status: 'candidate' as const,
+      candidate_commit: 'abc1234',
+      base_commit: 'base1234',
+      description: 'candidate',
+      notes: [] as string[],
+      created_at: '2026-03-14T05:00:00.000Z',
+    };
+
+    const ambiguous = decideAutoresearchOutcome(
+      { keep_policy: 'score_improvement', last_kept_score: null },
+      candidate,
+      { command: 'node eval.js', ran_at: '2026-03-14T05:00:01.000Z', status: 'pass', pass: true, exit_code: 0 },
+    );
+    expect(ambiguous.decision).toBe('ambiguous');
+    expect(ambiguous.keep).toBe(false);
+
+    const kept = decideAutoresearchOutcome(
+      { keep_policy: 'pass_only', last_kept_score: null },
+      candidate,
+      { command: 'node eval.js', ran_at: '2026-03-14T05:00:01.000Z', status: 'pass', pass: true, exit_code: 0 },
+    );
+    expect(kept.decision).toBe('keep');
+    expect(kept.keep).toBe(true);
+  });
+
+  it('resume rejects terminal manifests', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omc-worktrees`, 'autoresearch-missions-demo-20260314t050000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t050000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T050000Z' });
+      const manifest = JSON.parse(await readFile(runtime.manifestFile, 'utf-8')) as Record<string, unknown>;
+      manifest.status = 'completed';
+      await writeFile(runtime.manifestFile, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+      await writeFile(join(repo, '.omc', 'state', 'autoresearch-state.json'), `${JSON.stringify({
+        schema_version: 1,
+        active: false,
+        run_id: runtime.runId,
+        mission_slug: contract.missionSlug,
+        repo_root: repo,
+        worktree_path: worktreePath,
+        status: 'completed',
+        updated_at: '2026-03-14T05:05:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+
+      await expect(
+        resumeAutoresearchRuntime(repo, runtime.runId),
+      ).rejects.toThrow(/autoresearch_resume_terminal_run/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('records noop and abort candidate branches explicitly', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omc-worktrees`, 'autoresearch-missions-demo-20260314t060000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t060000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T060000Z' });
+
+      let manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'noop',
+        candidate_commit: null,
+        base_commit: manifest.last_kept_commit,
+        description: 'no useful change',
+        notes: ['noop branch'],
+        created_at: '2026-03-14T06:01:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      expect(await processAutoresearchCandidate(worktreeContract, manifest, repo)).toBe('noop');
+
+      manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'abort',
+        candidate_commit: null,
+        base_commit: manifest.last_kept_commit,
+        description: 'operator stop',
+        notes: ['abort branch'],
+        created_at: '2026-03-14T06:02:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      expect(await processAutoresearchCandidate(worktreeContract, manifest, repo)).toBe('abort');
+
+      const results = await readFile(runtime.resultsFile, 'utf-8');
+      expect(results).toMatch(/^1\t.+\t\t\tnoop\tno useful change$/m);
+      expect(results).toMatch(/^2\t.+\t\t\tabort\toperator stop$/m);
+
+      const finalManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      expect(finalManifest.status).toBe('stopped');
+      expect(finalManifest.stop_reason).toBe('candidate abort');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/autoresearch/__tests__/runtime.test.ts
+++ b/src/autoresearch/__tests__/runtime.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AutoresearchMissionContract } from '../contracts.js';
+import {
+  assertResetSafeWorktree,
+  buildAutoresearchInstructions,
+  loadAutoresearchRunManifest,
+  materializeAutoresearchMissionToWorktree,
+  prepareAutoresearchRuntime,
+  processAutoresearchCandidate,
+} from '../runtime.js';
+import { readModeState } from '../../lib/mode-state-io.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omc-autoresearch-runtime-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+async function makeContract(repo: string): Promise<AutoresearchMissionContract> {
+  const missionDir = join(repo, 'missions', 'demo');
+  await mkdir(missionDir, { recursive: true });
+  await mkdir(join(repo, 'scripts'), { recursive: true });
+  const missionFile = join(missionDir, 'mission.md');
+  const sandboxFile = join(missionDir, 'sandbox.md');
+  const missionContent = '# Mission\nSolve the task.\n';
+  const sandboxContent = `---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n---\nStay inside the mission boundary.\n`;
+  await writeFile(missionFile, missionContent, 'utf-8');
+  await writeFile(sandboxFile, sandboxContent, 'utf-8');
+  await writeFile(join(repo, 'score.txt'), '1\n', 'utf-8');
+  await writeFile(join(repo, 'scripts', 'eval.js'), "import { readFileSync } from 'node:fs';\nconst score = Number(readFileSync('score.txt', 'utf-8').trim());\nprocess.stdout.write(JSON.stringify({ pass: true, score }));\n", 'utf-8');
+  execFileSync('git', ['add', 'missions/demo/mission.md', 'missions/demo/sandbox.md', 'scripts/eval.js', 'score.txt'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'add autoresearch fixtures'], { cwd: repo, stdio: 'ignore' });
+  return {
+    missionDir,
+    repoRoot: repo,
+    missionFile,
+    sandboxFile,
+    missionRelativeDir: 'missions/demo',
+    missionContent,
+    sandboxContent,
+    sandbox: {
+      frontmatter: { evaluator: { command: 'node scripts/eval.js', format: 'json' } },
+      evaluator: { command: 'node scripts/eval.js', format: 'json' },
+      body: 'Stay inside the mission boundary.',
+    },
+    missionSlug: 'missions-demo',
+  };
+}
+
+describe('autoresearch runtime', () => {
+  it('builds bootstrap instructions with mission, sandbox, and evaluator contract', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const instructions = buildAutoresearchInstructions(contract, { runId: 'missions-demo-20260314t000000z', iteration: 1, baselineCommit: 'abc1234', lastKeptCommit: 'abc1234', resultsFile: 'results.tsv', candidateFile: '.omc/logs/autoresearch/missions-demo-20260314t000000z/candidate.json', keepPolicy: 'score_improvement' });
+      expect(instructions).toMatch(/exactly one experiment cycle/i);
+      expect(instructions).toMatch(/required output field: pass/i);
+      expect(instructions).toMatch(/optional output field: score/i);
+      expect(instructions).toMatch(/Iteration state snapshot:/i);
+      expect(instructions).toMatch(/Mission file:/i);
+      expect(instructions).toMatch(/Sandbox policy:/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('allows untracked .omc runtime files when checking reset safety', async () => {
+    const repo = await initRepo();
+    try {
+      await mkdir(join(repo, '.omc', 'logs'), { recursive: true });
+      await mkdir(join(repo, '.omc', 'state'), { recursive: true });
+      await writeFile(join(repo, '.omc', 'logs', 'hooks-2026-03-15.jsonl'), '{}\n', 'utf-8');
+      await writeFile(join(repo, '.omc', 'metrics.json'), '{}\n', 'utf-8');
+      await writeFile(join(repo, '.omc', 'state', 'hud-state.json'), '{}\n', 'utf-8');
+
+      expect(() => assertResetSafeWorktree(repo)).not.toThrow();
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('prepares runtime artifacts and persists autoresearch mode state', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      await mkdir(join(repo, 'node_modules', 'fixture-dep'), { recursive: true });
+      await writeFile(join(repo, 'node_modules', 'fixture-dep', 'index.js'), 'export default 1;\n', 'utf-8');
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omc-worktrees`, 'autoresearch-missions-demo-20260314t000000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t000000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T000000Z' });
+
+      expect(existsSync(worktreeContract.missionFile)).toBe(true);
+      expect(existsSync(worktreeContract.sandboxFile)).toBe(true);
+      expect(existsSync(runtime.instructionsFile)).toBe(true);
+      expect(existsSync(runtime.manifestFile)).toBe(true);
+      expect(existsSync(runtime.ledgerFile)).toBe(true);
+      expect(existsSync(runtime.latestEvaluatorFile)).toBe(true);
+      expect(existsSync(runtime.resultsFile)).toBe(true);
+      expect(existsSync(join(worktreePath, 'node_modules'))).toBe(true);
+      expect(() => assertResetSafeWorktree(worktreePath)).not.toThrow();
+
+      const manifest = JSON.parse(await readFile(runtime.manifestFile, 'utf-8')) as Record<string, unknown>;
+      expect(manifest.mission_slug).toBe('missions-demo');
+      expect(manifest.branch_name).toBe('autoresearch/missions-demo/20260314t000000z');
+      expect(manifest.mission_dir).toBe(join(worktreePath, 'missions', 'demo'));
+      expect(manifest.worktree_path).toBe(worktreePath);
+      expect(manifest.results_file).toBe(runtime.resultsFile);
+      expect(typeof manifest.baseline_commit).toBe('string');
+
+      const ledger = JSON.parse(await readFile(runtime.ledgerFile, 'utf-8')) as Record<string, unknown>;
+      expect(Array.isArray(ledger.entries)).toBe(true);
+      expect((ledger.entries as unknown[]).length).toBe(1);
+
+      const latestEvaluator = JSON.parse(await readFile(runtime.latestEvaluatorFile, 'utf-8')) as Record<string, unknown>;
+      expect(latestEvaluator.status).toBe('pass');
+      expect(latestEvaluator.pass).toBe(true);
+      expect(latestEvaluator.score).toBe(1);
+
+      const results = await readFile(runtime.resultsFile, 'utf-8');
+      expect(results).toMatch(/^iteration	commit	pass	score	status	description$/m);
+      expect(results).toMatch(/^0	.+	true	1	baseline	initial baseline evaluation$/m);
+
+      const state = readModeState<Record<string, unknown>>('autoresearch', repo);
+      expect(state).toBeTruthy();
+
+      const worktreeState = readModeState<Record<string, unknown>>('autoresearch', worktreePath);
+      expect(worktreeState).toBeNull();
+      expect(state?.active).toBe(true);
+      expect(state?.current_phase).toBe('running');
+      expect(state?.mission_slug).toBe('missions-demo');
+      expect(state?.mission_dir).toBe(join(worktreePath, 'missions', 'demo'));
+      expect(state?.worktree_path).toBe(worktreePath);
+      expect(state?.bootstrap_instructions_path).toBe(runtime.instructionsFile);
+      expect(state?.latest_evaluator_status).toBe('pass');
+      expect(state?.results_file).toBe(runtime.resultsFile);
+      expect(state?.baseline_commit).toBe(manifest.baseline_commit);
+
+      const instructions = await readFile(runtime.instructionsFile, 'utf-8');
+      expect(instructions).toMatch(/Last kept score:\s+1/i);
+      expect(instructions).toMatch(/previous_iteration_outcome/i);
+      expect(instructions).toMatch(/baseline established/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('autoresearch parity decisions', () => {
+  it('keeps improved candidates and resets discarded candidates back to the last kept commit', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omc-worktrees`, 'autoresearch-missions-demo-20260314t010000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t010000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T010000Z' });
+
+      await writeFile(join(worktreePath, 'score.txt'), '2\n', 'utf-8');
+      execFileSync('git', ['add', 'score.txt'], { cwd: worktreePath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'improve score'], { cwd: worktreePath, stdio: 'ignore' });
+      const improvedCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktreePath, encoding: 'utf-8' }).trim();
+      const initialManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'candidate',
+        candidate_commit: improvedCommit,
+        base_commit: initialManifest.last_kept_commit,
+        description: 'improved score',
+        notes: ['score raised to 2'],
+        created_at: '2026-03-14T01:00:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+
+      const keepDecision = await processAutoresearchCandidate(worktreeContract, initialManifest, repo);
+      expect(keepDecision).toBe('keep');
+      const keptManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      expect(keptManifest.last_kept_commit).toBe(improvedCommit);
+
+      await writeFile(join(worktreePath, 'score.txt'), '1\n', 'utf-8');
+      execFileSync('git', ['add', 'score.txt'], { cwd: worktreePath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'worse score'], { cwd: worktreePath, stdio: 'ignore' });
+      const worseCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktreePath, encoding: 'utf-8' }).trim();
+      const beforeDiscardManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'candidate',
+        candidate_commit: worseCommit,
+        base_commit: beforeDiscardManifest.last_kept_commit,
+        description: 'worse score',
+        notes: ['score dropped back to 1'],
+        created_at: '2026-03-14T01:05:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+
+      const discardDecision = await processAutoresearchCandidate(worktreeContract, beforeDiscardManifest, repo);
+      expect(discardDecision).toBe('discard');
+      const headAfterDiscard = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktreePath, encoding: 'utf-8' }).trim();
+      expect(headAfterDiscard).toBe(improvedCommit);
+
+      const finalManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      const results = await readFile(runtime.resultsFile, 'utf-8');
+      expect(results).toMatch(/^1\t.+\ttrue\t2\tkeep\timproved score$/m);
+      expect(results).toMatch(/^2\t.+\ttrue\t1\tdiscard\tworse score$/m);
+
+      const ledger = JSON.parse(await readFile(runtime.ledgerFile, 'utf-8')) as {
+        entries: Array<{ decision: string; description: string }>;
+      };
+      expect(ledger.entries.length).toBe(3);
+      expect(ledger.entries.map((entry) => [entry.decision, entry.description])).toEqual([
+        ['baseline', 'initial baseline evaluation'],
+        ['keep', 'improved score'],
+        ['discard', 'worse score'],
+      ]);
+
+      const instructions = await readFile(runtime.instructionsFile, 'utf-8');
+      expect(instructions).toMatch(/"previous_iteration_outcome": "discard:score did not improve"/);
+      expect(instructions).toMatch(/"decision": "keep"/);
+      expect(instructions).toMatch(/"decision": "discard"/);
+      expect(finalManifest.last_kept_commit).toBe(improvedCommit);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/autoresearch/contracts.ts
+++ b/src/autoresearch/contracts.ts
@@ -1,0 +1,238 @@
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { basename, join, relative, resolve } from 'path';
+
+export type AutoresearchKeepPolicy = 'score_improvement' | 'pass_only';
+
+export interface AutoresearchEvaluatorContract {
+  command: string;
+  format: 'json';
+  keep_policy?: AutoresearchKeepPolicy;
+}
+
+export interface ParsedSandboxContract {
+  frontmatter: Record<string, unknown>;
+  evaluator: AutoresearchEvaluatorContract;
+  body: string;
+}
+
+export interface AutoresearchEvaluatorResult {
+  pass: boolean;
+  score?: number;
+}
+
+export interface AutoresearchMissionContract {
+  missionDir: string;
+  repoRoot: string;
+  missionFile: string;
+  sandboxFile: string;
+  missionRelativeDir: string;
+  missionContent: string;
+  sandboxContent: string;
+  sandbox: ParsedSandboxContract;
+  missionSlug: string;
+}
+
+function contractError(message: string): Error {
+  return new Error(message);
+}
+
+function readGit(repoPath: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };
+    const stderr = typeof err.stderr === 'string'
+      ? err.stderr.trim()
+      : err.stderr instanceof Buffer
+        ? err.stderr.toString('utf-8').trim()
+        : '';
+    throw contractError(stderr || 'mission-dir must be inside a git repository.');
+  }
+}
+
+export function slugifyMissionName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48) || 'mission';
+}
+
+function ensurePathInside(parentPath: string, childPath: string): void {
+  const rel = relative(parentPath, childPath);
+  if (rel === '' || (!rel.startsWith('..') && rel !== '..')) return;
+  throw contractError('mission-dir must be inside a git repository.');
+}
+
+function extractFrontmatter(content: string): { frontmatter: string; body: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) {
+    throw contractError('sandbox.md must start with YAML frontmatter containing evaluator.command and evaluator.format=json.');
+  }
+  return {
+    frontmatter: match[1] || '',
+    body: (match[2] || '').trim(),
+  };
+}
+
+function parseSimpleYamlFrontmatter(frontmatter: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let currentSection: string | null = null;
+
+  for (const rawLine of frontmatter.split(/\r?\n/)) {
+    const line = rawLine.replace(/\t/g, '  ');
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const sectionMatch = /^([A-Za-z0-9_-]+):\s*$/.exec(trimmed);
+    if (sectionMatch) {
+      currentSection = sectionMatch[1];
+      result[currentSection] = {};
+      continue;
+    }
+
+    const nestedMatch = /^([A-Za-z0-9_-]+):\s*(.+)\s*$/.exec(trimmed);
+    if (!nestedMatch) {
+      throw contractError(`Unsupported sandbox.md frontmatter line: ${trimmed}`);
+    }
+
+    const [, key, rawValue] = nestedMatch;
+    const value = rawValue.replace(/^['"]|['"]$/g, '');
+    if (line.startsWith(' ') || line.startsWith('\t')) {
+      if (!currentSection) {
+        throw contractError(`Nested sandbox.md frontmatter key requires a parent section: ${trimmed}`);
+      }
+      const section = result[currentSection];
+      if (!section || typeof section !== 'object' || Array.isArray(section)) {
+        throw contractError(`Invalid sandbox.md frontmatter section: ${currentSection}`);
+      }
+      (section as Record<string, unknown>)[key] = value;
+      continue;
+    }
+
+    result[key] = value;
+    currentSection = null;
+  }
+
+  return result;
+}
+
+function parseKeepPolicy(raw: unknown): AutoresearchKeepPolicy | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'string') {
+    throw contractError('sandbox.md frontmatter evaluator.keep_policy must be a string when provided.');
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === 'pass_only') return 'pass_only';
+  if (normalized === 'score_improvement') return 'score_improvement';
+  throw contractError('sandbox.md frontmatter evaluator.keep_policy must be one of: score_improvement, pass_only.');
+}
+
+export function parseSandboxContract(content: string): ParsedSandboxContract {
+  const { frontmatter, body } = extractFrontmatter(content);
+  const parsedFrontmatter = parseSimpleYamlFrontmatter(frontmatter);
+  const evaluatorRaw = parsedFrontmatter.evaluator;
+
+  if (!evaluatorRaw || typeof evaluatorRaw !== 'object' || Array.isArray(evaluatorRaw)) {
+    throw contractError('sandbox.md frontmatter must define an evaluator block.');
+  }
+
+  const evaluator = evaluatorRaw as { command?: unknown; format?: unknown; keep_policy?: unknown };
+  const command = typeof evaluator.command === 'string'
+    ? evaluator.command.trim()
+    : '';
+  const format = typeof evaluator.format === 'string'
+    ? evaluator.format.trim().toLowerCase()
+    : '';
+  const keepPolicy = parseKeepPolicy(evaluator.keep_policy);
+
+  if (!command) {
+    throw contractError('sandbox.md frontmatter evaluator.command is required.');
+  }
+  if (!format) {
+    throw contractError('sandbox.md frontmatter evaluator.format is required and must be json in autoresearch v1.');
+  }
+  if (format !== 'json') {
+    throw contractError('sandbox.md frontmatter evaluator.format must be json in autoresearch v1.');
+  }
+
+  return {
+    frontmatter: parsedFrontmatter,
+    evaluator: {
+      command,
+      format: 'json',
+      ...(keepPolicy ? { keep_policy: keepPolicy } : {}),
+    },
+    body,
+  };
+}
+
+export function parseEvaluatorResult(raw: string): AutoresearchEvaluatorResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw contractError('Evaluator output must be valid JSON with required boolean pass and optional numeric score.');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw contractError('Evaluator output must be a JSON object.');
+  }
+
+  const result = parsed as Record<string, unknown>;
+  if (typeof result.pass !== 'boolean') {
+    throw contractError('Evaluator output must include boolean pass.');
+  }
+  if (result.score !== undefined && typeof result.score !== 'number') {
+    throw contractError('Evaluator output score must be numeric when provided.');
+  }
+
+  return result.score === undefined
+    ? { pass: result.pass }
+    : { pass: result.pass, score: result.score };
+}
+
+export async function loadAutoresearchMissionContract(missionDirArg: string): Promise<AutoresearchMissionContract> {
+  const missionDir = resolve(missionDirArg);
+  if (!existsSync(missionDir)) {
+    throw contractError(`mission-dir does not exist: ${missionDir}`);
+  }
+
+  const repoRoot = readGit(missionDir, ['rev-parse', '--show-toplevel']);
+  ensurePathInside(repoRoot, missionDir);
+
+  const missionFile = join(missionDir, 'mission.md');
+  const sandboxFile = join(missionDir, 'sandbox.md');
+  if (!existsSync(missionFile)) {
+    throw contractError(`mission.md is required inside mission-dir: ${missionFile}`);
+  }
+  if (!existsSync(sandboxFile)) {
+    throw contractError(`sandbox.md is required inside mission-dir: ${sandboxFile}`);
+  }
+
+  const missionContent = await readFile(missionFile, 'utf-8');
+  const sandboxContent = await readFile(sandboxFile, 'utf-8');
+  const sandbox = parseSandboxContract(sandboxContent);
+  const missionRelativeDir = relative(repoRoot, missionDir) || basename(missionDir);
+  const missionSlug = slugifyMissionName(missionRelativeDir);
+
+  return {
+    missionDir,
+    repoRoot,
+    missionFile,
+    sandboxFile,
+    missionRelativeDir,
+    missionContent,
+    sandboxContent,
+    sandbox,
+    missionSlug,
+  };
+}

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -1,0 +1,1358 @@
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdir, readFile, symlink, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import {
+  readModeState,
+  writeModeState,
+  clearModeStateFile,
+} from '../lib/mode-state-io.js';
+import {
+  parseEvaluatorResult,
+  type AutoresearchKeepPolicy,
+  type AutoresearchMissionContract,
+} from './contracts.js';
+
+export type AutoresearchCandidateStatus = 'candidate' | 'noop' | 'abort' | 'interrupted';
+export type AutoresearchDecisionStatus = 'baseline' | 'keep' | 'discard' | 'ambiguous' | 'noop' | 'abort' | 'interrupted' | 'error';
+export type AutoresearchRunStatus = 'running' | 'stopped' | 'completed' | 'failed';
+
+export interface PreparedAutoresearchRuntime {
+  runId: string;
+  runTag: string;
+  runDir: string;
+  instructionsFile: string;
+  manifestFile: string;
+  ledgerFile: string;
+  latestEvaluatorFile: string;
+  resultsFile: string;
+  stateFile: string;
+  candidateFile: string;
+  repoRoot: string;
+  worktreePath: string;
+  taskDescription: string;
+}
+
+export interface AutoresearchEvaluationRecord {
+  command: string;
+  ran_at: string;
+  status: 'pass' | 'fail' | 'error';
+  pass?: boolean;
+  score?: number;
+  exit_code?: number | null;
+  stdout?: string;
+  stderr?: string;
+  parse_error?: string;
+}
+
+export interface AutoresearchCandidateArtifact {
+  status: AutoresearchCandidateStatus;
+  candidate_commit: string | null;
+  base_commit: string;
+  description: string;
+  notes: string[];
+  created_at: string;
+}
+
+export interface AutoresearchLedgerEntry {
+  iteration: number;
+  kind: 'baseline' | 'iteration';
+  decision: AutoresearchDecisionStatus;
+  decision_reason: string;
+  candidate_status: AutoresearchCandidateStatus | 'baseline';
+  base_commit: string;
+  candidate_commit: string | null;
+  kept_commit: string;
+  keep_policy: AutoresearchKeepPolicy;
+  evaluator: AutoresearchEvaluationRecord | null;
+  created_at: string;
+  notes: string[];
+  description: string;
+}
+
+export interface AutoresearchRunManifest {
+  schema_version: 1;
+  run_id: string;
+  run_tag: string;
+  mission_dir: string;
+  mission_file: string;
+  sandbox_file: string;
+  repo_root: string;
+  worktree_path: string;
+  mission_slug: string;
+  branch_name: string;
+  baseline_commit: string;
+  last_kept_commit: string;
+  last_kept_score: number | null;
+  latest_candidate_commit: string | null;
+  results_file: string;
+  instructions_file: string;
+  manifest_file: string;
+  ledger_file: string;
+  latest_evaluator_file: string;
+  candidate_file: string;
+  evaluator: AutoresearchMissionContract['sandbox']['evaluator'];
+  keep_policy: AutoresearchKeepPolicy;
+  status: AutoresearchRunStatus;
+  stop_reason: string | null;
+  iteration: number;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+interface AutoresearchActiveRunState {
+  schema_version: 1;
+  active: boolean;
+  run_id: string | null;
+  mission_slug: string | null;
+  repo_root: string;
+  worktree_path: string | null;
+  status: AutoresearchRunStatus | 'idle';
+  updated_at: string;
+  completed_at?: string;
+}
+
+interface AutoresearchDecision {
+  decision: AutoresearchDecisionStatus;
+  decisionReason: string;
+  keep: boolean;
+  evaluator: AutoresearchEvaluationRecord | null;
+  notes: string[];
+}
+
+interface AutoresearchInstructionLedgerSummary {
+  iteration: number;
+  decision: AutoresearchDecisionStatus;
+  reason: string;
+  kept_commit: string;
+  candidate_commit: string | null;
+  evaluator_status: AutoresearchEvaluationRecord['status'] | null;
+  evaluator_score: number | null;
+  description: string;
+}
+
+const AUTORESEARCH_RESULTS_HEADER = 'iteration\tcommit\tpass\tscore\tstatus\tdescription\n';
+const AUTORESEARCH_WORKTREE_EXCLUDES = ['results.tsv', 'run.log', 'node_modules', '.omc/'];
+
+// Exclusive modes that cannot run concurrently with autoresearch
+const EXCLUSIVE_MODES = ['ralph', 'ultrawork', 'autopilot', 'autoresearch'];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function buildAutoresearchRunTag(date = new Date()): string {
+  const iso = date.toISOString();
+  return iso
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z')
+    .replace('T', 'T');
+}
+
+function buildRunId(missionSlug: string, runTag: string): string {
+  return `${missionSlug}-${runTag.toLowerCase()}`;
+}
+
+function activeRunStateFile(projectRoot: string): string {
+  return join(projectRoot, '.omc', 'state', 'autoresearch-state.json');
+}
+
+function trimContent(value: string, max = 4000): string {
+  const trimmed = value.trim();
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max)}\n...`;
+}
+
+function readGit(repoPath: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };
+    const stderr = typeof err.stderr === 'string'
+      ? err.stderr.trim()
+      : err.stderr instanceof Buffer
+        ? err.stderr.toString('utf-8').trim()
+        : '';
+    throw new Error(stderr || `git ${args.join(' ')} failed`);
+  }
+}
+
+function tryResolveGitCommit(worktreePath: string, ref: string): string | null {
+  const result = spawnSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) return null;
+  const resolved = (result.stdout || '').trim();
+  return resolved || null;
+}
+
+async function writeGitInfoExclude(worktreePath: string, pattern: string): Promise<void> {
+  const excludePath = readGit(worktreePath, ['rev-parse', '--git-path', 'info/exclude']);
+  const existing = existsSync(excludePath)
+    ? await readFile(excludePath, 'utf-8')
+    : '';
+  const lines = new Set(existing.split(/\r?\n/).filter(Boolean));
+  if (lines.has(pattern)) return;
+  const next = `${existing}${existing.endsWith('\n') || existing.length === 0 ? '' : '\n'}${pattern}\n`;
+  await ensureParentDir(excludePath);
+  await writeFile(excludePath, next, 'utf-8');
+}
+
+async function ensureRuntimeExcludes(worktreePath: string): Promise<void> {
+  for (const file of AUTORESEARCH_WORKTREE_EXCLUDES) {
+    await writeGitInfoExclude(worktreePath, file);
+  }
+}
+
+async function ensureAutoresearchWorktreeDependencies(repoRoot: string, worktreePath: string): Promise<void> {
+  const sourceNodeModules = join(repoRoot, 'node_modules');
+  const targetNodeModules = join(worktreePath, 'node_modules');
+  if (!existsSync(sourceNodeModules) || existsSync(targetNodeModules)) {
+    return;
+  }
+  await symlink(sourceNodeModules, targetNodeModules, process.platform === 'win32' ? 'junction' : 'dir');
+}
+
+function readGitShortHead(worktreePath: string): string {
+  return readGit(worktreePath, ['rev-parse', '--short=7', 'HEAD']);
+}
+
+function readGitFullHead(worktreePath: string): string {
+  return readGit(worktreePath, ['rev-parse', 'HEAD']);
+}
+
+function requireGitSuccess(worktreePath: string, args: string[]): void {
+  const result = spawnSync('git', args, {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  if (result.status === 0) return;
+  throw new Error((result.stderr || '').trim() || `git ${args.join(' ')} failed`);
+}
+
+function gitStatusLines(worktreePath: string): string[] {
+  const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    throw new Error((result.stderr || '').trim() || `git status failed for ${worktreePath}`);
+  }
+  return (result.stdout || '')
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean);
+}
+
+function isAllowedRuntimeDirtyLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length < 4) return false;
+  const path = trimmed.slice(3).trim();
+  return trimmed.startsWith('?? ') && AUTORESEARCH_WORKTREE_EXCLUDES.some((exclude) => exclude.endsWith('/')
+    ? path.startsWith(exclude) || path === exclude.slice(0, -1)
+    : path === exclude);
+}
+
+export function assertResetSafeWorktree(worktreePath: string): void {
+  const lines = gitStatusLines(worktreePath);
+  const blocking = lines.filter((line) => !isAllowedRuntimeDirtyLine(line));
+  if (blocking.length === 0) return;
+  throw new Error(`autoresearch_reset_requires_clean_worktree:${worktreePath}:${blocking.join(' | ')}`);
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await ensureParentDir(filePath);
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, 'utf-8')) as T;
+}
+
+async function readActiveRunState(projectRoot: string): Promise<AutoresearchActiveRunState | null> {
+  const file = activeRunStateFile(projectRoot);
+  if (!existsSync(file)) return null;
+  return readJsonFile<AutoresearchActiveRunState>(file);
+}
+
+async function writeActiveRunState(projectRoot: string, value: AutoresearchActiveRunState): Promise<void> {
+  await writeJsonFile(activeRunStateFile(projectRoot), value);
+}
+
+async function assertAutoresearchLockAvailable(projectRoot: string): Promise<void> {
+  const state = await readActiveRunState(projectRoot);
+  if (state?.active && state.run_id) {
+    throw new Error(`autoresearch_active_run_exists:${state.run_id}`);
+  }
+}
+
+/**
+ * Assert no exclusive mode is already active (ralph, ultrawork, autopilot).
+ * Mirrors OMX assertModeStartAllowed semantics using OMC mode-state-io.
+ */
+export async function assertModeStartAllowed(mode: string, projectRoot: string): Promise<void> {
+  for (const other of EXCLUSIVE_MODES) {
+    if (other === mode) continue;
+    const state = readModeState<Record<string, unknown>>(other, projectRoot);
+    if (state && state.active) {
+      throw new Error(`Cannot start ${mode}: ${other} is already active`);
+    }
+  }
+}
+
+async function activateAutoresearchRun(manifest: AutoresearchRunManifest): Promise<void> {
+  await writeActiveRunState(manifest.repo_root, {
+    schema_version: 1,
+    active: true,
+    run_id: manifest.run_id,
+    mission_slug: manifest.mission_slug,
+    repo_root: manifest.repo_root,
+    worktree_path: manifest.worktree_path,
+    status: manifest.status,
+    updated_at: nowIso(),
+  });
+}
+
+async function deactivateAutoresearchRun(manifest: AutoresearchRunManifest): Promise<void> {
+  const previous = await readActiveRunState(manifest.repo_root);
+  await writeActiveRunState(manifest.repo_root, {
+    schema_version: 1,
+    active: false,
+    run_id: previous?.run_id ?? manifest.run_id,
+    mission_slug: previous?.mission_slug ?? manifest.mission_slug,
+    repo_root: manifest.repo_root,
+    worktree_path: previous?.worktree_path ?? manifest.worktree_path,
+    status: manifest.status,
+    updated_at: nowIso(),
+    completed_at: nowIso(),
+  });
+}
+
+/**
+ * Start autoresearch mode state using OMC's writeModeState.
+ */
+function startAutoresearchMode(taskDescription: string, projectRoot: string): void {
+  writeModeState('autoresearch', {
+    active: true,
+    mode: 'autoresearch',
+    iteration: 0,
+    max_iterations: 1,
+    current_phase: 'starting',
+    task_description: taskDescription,
+    started_at: nowIso(),
+  }, projectRoot);
+}
+
+/**
+ * Update autoresearch mode state (merge semantics).
+ */
+function updateAutoresearchMode(updates: Record<string, unknown>, projectRoot: string): void {
+  const current = readModeState<Record<string, unknown>>('autoresearch', projectRoot);
+  if (!current) return;
+  writeModeState('autoresearch', { ...current, ...updates }, projectRoot);
+}
+
+/**
+ * Cancel autoresearch mode state.
+ */
+function cancelAutoresearchMode(projectRoot: string): void {
+  const state = readModeState<Record<string, unknown>>('autoresearch', projectRoot);
+  if (state && state.active) {
+    writeModeState('autoresearch', {
+      ...state,
+      active: false,
+      current_phase: 'cancelled',
+      completed_at: nowIso(),
+    }, projectRoot);
+  }
+}
+
+function resultPassValue(value: boolean | undefined): string {
+  return value === undefined ? '' : String(value);
+}
+
+function resultScoreValue(value: number | undefined | null): string {
+  return typeof value === 'number' ? String(value) : '';
+}
+
+async function initializeAutoresearchResultsFile(resultsFile: string): Promise<void> {
+  if (existsSync(resultsFile)) return;
+  await ensureParentDir(resultsFile);
+  await writeFile(resultsFile, AUTORESEARCH_RESULTS_HEADER, 'utf-8');
+}
+
+async function appendAutoresearchResultsRow(
+  resultsFile: string,
+  row: {
+    iteration: number;
+    commit: string;
+    pass?: boolean;
+    score?: number | null;
+    status: AutoresearchDecisionStatus;
+    description: string;
+  },
+): Promise<void> {
+  const existing = existsSync(resultsFile)
+    ? await readFile(resultsFile, 'utf-8')
+    : AUTORESEARCH_RESULTS_HEADER;
+  await writeFile(
+    resultsFile,
+    `${existing}${row.iteration}\t${row.commit}\t${resultPassValue(row.pass)}\t${resultScoreValue(row.score)}\t${row.status}\t${row.description}\n`,
+    'utf-8',
+  );
+}
+
+async function appendAutoresearchLedgerEntry(ledgerFile: string, entry: AutoresearchLedgerEntry): Promise<void> {
+  const parsed = existsSync(ledgerFile)
+    ? await readJsonFile<{
+      schema_version?: number;
+      run_id?: string;
+      created_at?: string;
+      updated_at?: string;
+      entries?: AutoresearchLedgerEntry[];
+    }>(ledgerFile)
+    : { schema_version: 1, entries: [] };
+  const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+  entries.push(entry);
+  await writeJsonFile(ledgerFile, {
+    schema_version: typeof parsed.schema_version === 'number' ? parsed.schema_version : 1,
+    run_id: parsed.run_id,
+    created_at: parsed.created_at || nowIso(),
+    updated_at: nowIso(),
+    entries,
+  });
+}
+
+async function readAutoresearchLedgerEntries(ledgerFile: string): Promise<AutoresearchLedgerEntry[]> {
+  if (!existsSync(ledgerFile)) return [];
+  const parsed = await readJsonFile<{ entries?: AutoresearchLedgerEntry[] }>(ledgerFile);
+  return Array.isArray(parsed.entries) ? parsed.entries : [];
+}
+
+export async function countTrailingAutoresearchNoops(ledgerFile: string): Promise<number> {
+  const entries = await readAutoresearchLedgerEntries(ledgerFile);
+  let count = 0;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (!entry || entry.kind !== 'iteration' || entry.decision !== 'noop') break;
+    count += 1;
+  }
+  return count;
+}
+
+function formatAutoresearchInstructionSummary(
+  entries: AutoresearchLedgerEntry[],
+  maxEntries = 3,
+): AutoresearchInstructionLedgerSummary[] {
+  return entries
+    .slice(-maxEntries)
+    .map((entry) => ({
+      iteration: entry.iteration,
+      decision: entry.decision,
+      reason: trimContent(entry.decision_reason, 160),
+      kept_commit: entry.kept_commit,
+      candidate_commit: entry.candidate_commit,
+      evaluator_status: entry.evaluator?.status ?? null,
+      evaluator_score: typeof entry.evaluator?.score === 'number' ? entry.evaluator.score : null,
+      description: trimContent(entry.description, 120),
+    }));
+}
+
+async function buildAutoresearchInstructionContext(manifest: AutoresearchRunManifest): Promise<{
+  previousIterationOutcome: string | null;
+  recentLedgerSummary: AutoresearchInstructionLedgerSummary[];
+}> {
+  const entries = await readAutoresearchLedgerEntries(manifest.ledger_file);
+  const previous = entries.at(-1);
+  return {
+    previousIterationOutcome: previous
+      ? `${previous.decision}:${trimContent(previous.decision_reason, 160)}`
+      : null,
+    recentLedgerSummary: formatAutoresearchInstructionSummary(entries),
+  };
+}
+
+export async function runAutoresearchEvaluator(
+  contract: AutoresearchMissionContract,
+  worktreePath: string,
+  ledgerFile?: string,
+  latestEvaluatorFile?: string,
+): Promise<AutoresearchEvaluationRecord> {
+  const ran_at = nowIso();
+  const result = spawnSync(contract.sandbox.evaluator.command, {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+    shell: true,
+    maxBuffer: 1024 * 1024,
+  });
+  const stdout = result.stdout?.trim() || '';
+  const stderr = result.stderr?.trim() || '';
+
+  let record: AutoresearchEvaluationRecord;
+  if (result.error || result.status !== 0) {
+    record = {
+      command: contract.sandbox.evaluator.command,
+      ran_at,
+      status: 'error',
+      exit_code: result.status,
+      stdout,
+      stderr: result.error ? [stderr, result.error.message].filter(Boolean).join('\n') : stderr,
+    };
+  } else {
+    try {
+      const parsed = parseEvaluatorResult(stdout);
+      record = {
+        command: contract.sandbox.evaluator.command,
+        ran_at,
+        status: parsed.pass ? 'pass' : 'fail',
+        pass: parsed.pass,
+        ...(parsed.score !== undefined ? { score: parsed.score } : {}),
+        exit_code: result.status,
+        stdout,
+        stderr,
+      };
+    } catch (error) {
+      record = {
+        command: contract.sandbox.evaluator.command,
+        ran_at,
+        status: 'error',
+        exit_code: result.status,
+        stdout,
+        stderr,
+        parse_error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  if (latestEvaluatorFile) {
+    await writeJsonFile(latestEvaluatorFile, record);
+  }
+  if (ledgerFile) {
+    await appendAutoresearchLedgerEntry(ledgerFile, {
+      iteration: -1,
+      kind: 'iteration',
+      decision: record.status === 'error' ? 'error' : record.status === 'pass' ? 'keep' : 'discard',
+      decision_reason: 'raw evaluator record',
+      candidate_status: 'candidate',
+      base_commit: readGitShortHead(worktreePath),
+      candidate_commit: null,
+      kept_commit: readGitShortHead(worktreePath),
+      keep_policy: contract.sandbox.evaluator.keep_policy ?? 'score_improvement',
+      evaluator: record,
+      created_at: nowIso(),
+      notes: ['raw evaluator invocation'],
+      description: 'raw evaluator record',
+    });
+  }
+  return record;
+}
+
+function comparableScore(previousScore: number | null, nextScore: number | undefined): boolean {
+  return typeof previousScore === 'number' && typeof nextScore === 'number';
+}
+
+export function decideAutoresearchOutcome(
+  manifest: Pick<AutoresearchRunManifest, 'keep_policy' | 'last_kept_score'>,
+  candidate: AutoresearchCandidateArtifact,
+  evaluation: AutoresearchEvaluationRecord | null,
+): AutoresearchDecision {
+  if (candidate.status === 'abort') {
+    return {
+      decision: 'abort',
+      decisionReason: 'candidate requested abort',
+      keep: false,
+      evaluator: null,
+      notes: ['run stopped by candidate artifact'],
+    };
+  }
+  if (candidate.status === 'noop') {
+    return {
+      decision: 'noop',
+      decisionReason: 'candidate reported noop',
+      keep: false,
+      evaluator: null,
+      notes: ['no code change was proposed'],
+    };
+  }
+  if (candidate.status === 'interrupted') {
+    return {
+      decision: 'interrupted',
+      decisionReason: 'candidate session was interrupted',
+      keep: false,
+      evaluator: null,
+      notes: ['supervisor should inspect worktree cleanliness before continuing'],
+    };
+  }
+  if (!evaluation || evaluation.status === 'error') {
+    return {
+      decision: 'discard',
+      decisionReason: 'evaluator error',
+      keep: false,
+      evaluator: evaluation,
+      notes: ['candidate discarded because evaluator errored or crashed'],
+    };
+  }
+  if (!evaluation.pass) {
+    return {
+      decision: 'discard',
+      decisionReason: 'evaluator reported failure',
+      keep: false,
+      evaluator: evaluation,
+      notes: ['candidate discarded because evaluator pass=false'],
+    };
+  }
+  if (manifest.keep_policy === 'pass_only') {
+    return {
+      decision: 'keep',
+      decisionReason: 'pass_only keep policy accepted evaluator pass=true',
+      keep: true,
+      evaluator: evaluation,
+      notes: ['candidate kept because sandbox opted into pass_only policy'],
+    };
+  }
+  if (!comparableScore(manifest.last_kept_score, evaluation.score)) {
+    return {
+      decision: 'ambiguous',
+      decisionReason: 'evaluator pass without comparable score',
+      keep: false,
+      evaluator: evaluation,
+      notes: ['candidate discarded because score_improvement policy requires comparable numeric scores'],
+    };
+  }
+  if ((evaluation.score as number) > (manifest.last_kept_score as number)) {
+    return {
+      decision: 'keep',
+      decisionReason: 'score improved over last kept score',
+      keep: true,
+      evaluator: evaluation,
+      notes: ['candidate kept because evaluator score increased'],
+    };
+  }
+  return {
+    decision: 'discard',
+    decisionReason: 'score did not improve',
+    keep: false,
+    evaluator: evaluation,
+    notes: ['candidate discarded because evaluator score was not better than the kept baseline'],
+  };
+}
+
+export function buildAutoresearchInstructions(
+  contract: AutoresearchMissionContract,
+  context: {
+    runId: string;
+    iteration: number;
+    baselineCommit: string;
+    lastKeptCommit: string;
+    lastKeptScore?: number | null;
+    resultsFile: string;
+    candidateFile: string;
+    keepPolicy: AutoresearchKeepPolicy;
+    previousIterationOutcome?: string | null;
+    recentLedgerSummary?: AutoresearchInstructionLedgerSummary[];
+  },
+): string {
+  return [
+    '# OMC Autoresearch Supervisor Instructions',
+    '',
+    `Run ID: ${context.runId}`,
+    `Mission directory: ${contract.missionDir}`,
+    `Mission file: ${contract.missionFile}`,
+    `Sandbox file: ${contract.sandboxFile}`,
+    `Mission slug: ${contract.missionSlug}`,
+    `Iteration: ${context.iteration}`,
+    `Baseline commit: ${context.baselineCommit}`,
+    `Last kept commit: ${context.lastKeptCommit}`,
+    `Last kept score: ${typeof context.lastKeptScore === 'number' ? context.lastKeptScore : 'n/a'}`,
+    `Results file: ${context.resultsFile}`,
+    `Candidate artifact: ${context.candidateFile}`,
+    `Keep policy: ${context.keepPolicy}`,
+    '',
+    'Iteration state snapshot:',
+    '```json',
+    JSON.stringify({
+      iteration: context.iteration,
+      baseline_commit: context.baselineCommit,
+      last_kept_commit: context.lastKeptCommit,
+      last_kept_score: context.lastKeptScore ?? null,
+      previous_iteration_outcome: context.previousIterationOutcome ?? 'none yet',
+      recent_ledger_summary: context.recentLedgerSummary ?? [],
+      keep_policy: context.keepPolicy,
+    }, null, 2),
+    '```',
+    '',
+    'Operate as a thin autoresearch experiment worker for exactly one experiment cycle.',
+    'Do not loop forever inside this session. Make at most one candidate commit, then write the candidate artifact JSON and exit.',
+    '',
+    'Candidate artifact contract:',
+    '- Write JSON to the exact candidate artifact path above.',
+    '- status: candidate | noop | abort | interrupted',
+    '- candidate_commit: string | null',
+    '- base_commit: current base commit before your edits',
+    '- for status=candidate, candidate_commit must resolve in git and match the worktree HEAD commit when you exit',
+    '- base_commit must still match the last kept commit provided above',
+    '- description: short one-line summary',
+    '- notes: array of short strings',
+    '- created_at: ISO timestamp',
+    '',
+    'Supervisor semantics after you exit:',
+    '- status=candidate => evaluator runs, then supervisor keeps or discards and may reset the worktree',
+    '- status=noop => supervisor logs a noop iteration and relaunches',
+    '- status=abort => supervisor stops the run',
+    '- status=interrupted => supervisor inspects worktree safety before deciding how to proceed',
+    '',
+    'Evaluator contract:',
+    `- command: ${contract.sandbox.evaluator.command}`,
+    '- format: json',
+    '- required output field: pass (boolean)',
+    '- optional output field: score (number)',
+    '',
+    'Mission content:',
+    '```md',
+    trimContent(contract.missionContent),
+    '```',
+    '',
+    'Sandbox policy:',
+    '```md',
+    trimContent(contract.sandbox.body || contract.sandboxContent),
+    '```',
+  ].join('\n');
+}
+
+export async function materializeAutoresearchMissionToWorktree(
+  contract: AutoresearchMissionContract,
+  worktreePath: string,
+): Promise<AutoresearchMissionContract> {
+  const missionDir = join(worktreePath, contract.missionRelativeDir);
+  const missionFile = join(missionDir, 'mission.md');
+  const sandboxFile = join(missionDir, 'sandbox.md');
+
+  await mkdir(missionDir, { recursive: true });
+  await writeFile(missionFile, contract.missionContent, 'utf-8');
+  await writeFile(sandboxFile, contract.sandboxContent, 'utf-8');
+
+  return {
+    ...contract,
+    missionDir,
+    missionFile,
+    sandboxFile,
+  };
+}
+
+export async function loadAutoresearchRunManifest(projectRoot: string, runId: string): Promise<AutoresearchRunManifest> {
+  const manifestFile = join(projectRoot, '.omc', 'logs', 'autoresearch', runId, 'manifest.json');
+  if (!existsSync(manifestFile)) {
+    throw new Error(`autoresearch_resume_manifest_missing:${runId}`);
+  }
+  return readJsonFile<AutoresearchRunManifest>(manifestFile);
+}
+
+async function writeRunManifest(manifest: AutoresearchRunManifest): Promise<void> {
+  manifest.updated_at = nowIso();
+  await writeJsonFile(manifest.manifest_file, manifest);
+}
+
+async function writeInstructionsFile(contract: AutoresearchMissionContract, manifest: AutoresearchRunManifest): Promise<void> {
+  const instructionContext = await buildAutoresearchInstructionContext(manifest);
+  await writeFile(
+    manifest.instructions_file,
+    `${buildAutoresearchInstructions(contract, {
+      runId: manifest.run_id,
+      iteration: manifest.iteration + 1,
+      baselineCommit: manifest.baseline_commit,
+      lastKeptCommit: manifest.last_kept_commit,
+      lastKeptScore: manifest.last_kept_score,
+      resultsFile: manifest.results_file,
+      candidateFile: manifest.candidate_file,
+      keepPolicy: manifest.keep_policy,
+      previousIterationOutcome: instructionContext.previousIterationOutcome,
+      recentLedgerSummary: instructionContext.recentLedgerSummary,
+    })}\n`,
+    'utf-8',
+  );
+}
+
+async function seedBaseline(
+  contract: AutoresearchMissionContract,
+  manifest: AutoresearchRunManifest,
+): Promise<AutoresearchEvaluationRecord> {
+  const evaluation = await runAutoresearchEvaluator(contract, manifest.worktree_path);
+  await writeJsonFile(manifest.latest_evaluator_file, evaluation);
+  await appendAutoresearchResultsRow(manifest.results_file, {
+    iteration: 0,
+    commit: readGitShortHead(manifest.worktree_path),
+    pass: evaluation.pass,
+    score: evaluation.score,
+    status: evaluation.status === 'error' ? 'error' : 'baseline',
+    description: 'initial baseline evaluation',
+  });
+  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+    iteration: 0,
+    kind: 'baseline',
+    decision: evaluation.status === 'error' ? 'error' : 'baseline',
+    decision_reason: evaluation.status === 'error' ? 'baseline evaluator error' : 'baseline established',
+    candidate_status: 'baseline',
+    base_commit: manifest.baseline_commit,
+    candidate_commit: null,
+    kept_commit: manifest.last_kept_commit,
+    keep_policy: manifest.keep_policy,
+    evaluator: evaluation,
+    created_at: nowIso(),
+    notes: ['baseline row is always recorded'],
+    description: 'initial baseline evaluation',
+  });
+  manifest.last_kept_score = evaluation.pass && typeof evaluation.score === 'number' ? evaluation.score : null;
+  await writeRunManifest(manifest);
+  await writeInstructionsFile(contract, manifest);
+  return evaluation;
+}
+
+export async function prepareAutoresearchRuntime(
+  contract: AutoresearchMissionContract,
+  projectRoot: string,
+  worktreePath: string,
+  options: { runTag?: string } = {},
+): Promise<PreparedAutoresearchRuntime> {
+  await assertAutoresearchLockAvailable(projectRoot);
+  await ensureRuntimeExcludes(worktreePath);
+  await ensureAutoresearchWorktreeDependencies(projectRoot, worktreePath);
+  assertResetSafeWorktree(worktreePath);
+
+  const runTag = options.runTag || buildAutoresearchRunTag();
+  const runId = buildRunId(contract.missionSlug, runTag);
+  const baselineCommit = readGitShortHead(worktreePath);
+  const branchName = readGit(worktreePath, ['symbolic-ref', '--quiet', '--short', 'HEAD']);
+  const runDir = join(projectRoot, '.omc', 'logs', 'autoresearch', runId);
+  const stateFile = activeRunStateFile(projectRoot);
+  const instructionsFile = join(runDir, 'bootstrap-instructions.md');
+  const manifestFile = join(runDir, 'manifest.json');
+  const ledgerFile = join(runDir, 'iteration-ledger.json');
+  const latestEvaluatorFile = join(runDir, 'latest-evaluator-result.json');
+  const candidateFile = join(runDir, 'candidate.json');
+  const resultsFile = join(worktreePath, 'results.tsv');
+  const taskDescription = `autoresearch ${contract.missionRelativeDir} (${runId})`;
+  const keepPolicy = contract.sandbox.evaluator.keep_policy ?? 'score_improvement';
+
+  await mkdir(runDir, { recursive: true });
+  await initializeAutoresearchResultsFile(resultsFile);
+  await writeJsonFile(candidateFile, {
+    status: 'noop',
+    candidate_commit: null,
+    base_commit: baselineCommit,
+    description: 'not-yet-written',
+    notes: ['candidate artifact will be overwritten by the launched session'],
+    created_at: nowIso(),
+  } satisfies AutoresearchCandidateArtifact);
+
+  const manifest: AutoresearchRunManifest = {
+    schema_version: 1,
+    run_id: runId,
+    run_tag: runTag,
+    mission_dir: contract.missionDir,
+    mission_file: contract.missionFile,
+    sandbox_file: contract.sandboxFile,
+    repo_root: projectRoot,
+    worktree_path: worktreePath,
+    mission_slug: contract.missionSlug,
+    branch_name: branchName,
+    baseline_commit: baselineCommit,
+    last_kept_commit: readGitFullHead(worktreePath),
+    last_kept_score: null,
+    latest_candidate_commit: null,
+    results_file: resultsFile,
+    instructions_file: instructionsFile,
+    manifest_file: manifestFile,
+    ledger_file: ledgerFile,
+    latest_evaluator_file: latestEvaluatorFile,
+    candidate_file: candidateFile,
+    evaluator: contract.sandbox.evaluator,
+    keep_policy: keepPolicy,
+    status: 'running',
+    stop_reason: null,
+    iteration: 0,
+    created_at: nowIso(),
+    updated_at: nowIso(),
+    completed_at: null,
+  };
+
+  await writeInstructionsFile(contract, manifest);
+  await writeRunManifest(manifest);
+  await writeJsonFile(ledgerFile, {
+    schema_version: 1,
+    run_id: runId,
+    created_at: nowIso(),
+    updated_at: nowIso(),
+    entries: [],
+  });
+  await writeJsonFile(latestEvaluatorFile, {
+    run_id: runId,
+    status: 'not-yet-run',
+    updated_at: nowIso(),
+  });
+
+  const existingModeState = readModeState<Record<string, unknown>>('autoresearch', projectRoot);
+  if (existingModeState?.active) {
+    throw new Error(`autoresearch_active_mode_exists:${String(existingModeState.run_id || 'unknown')}`);
+  }
+  startAutoresearchMode(taskDescription, projectRoot);
+  await activateAutoresearchRun(manifest);
+  updateAutoresearchMode({
+    current_phase: 'evaluating-baseline',
+    run_id: runId,
+    run_tag: runTag,
+    mission_dir: contract.missionDir,
+    mission_file: contract.missionFile,
+    sandbox_file: contract.sandboxFile,
+    mission_slug: contract.missionSlug,
+    repo_root: projectRoot,
+    worktree_path: worktreePath,
+    baseline_commit: baselineCommit,
+    last_kept_commit: manifest.last_kept_commit,
+    results_file: resultsFile,
+    manifest_path: manifestFile,
+    iteration_ledger_path: ledgerFile,
+    latest_evaluator_result_path: latestEvaluatorFile,
+    bootstrap_instructions_path: instructionsFile,
+    candidate_path: candidateFile,
+    keep_policy: keepPolicy,
+    state_file: stateFile,
+  }, projectRoot);
+
+  const evaluation = await seedBaseline(contract, manifest);
+  updateAutoresearchMode({
+    current_phase: 'running',
+    latest_evaluator_status: evaluation.status,
+    latest_evaluator_pass: evaluation.pass,
+    latest_evaluator_score: evaluation.score,
+    latest_evaluator_ran_at: evaluation.ran_at,
+    last_kept_commit: manifest.last_kept_commit,
+    last_kept_score: manifest.last_kept_score,
+  }, projectRoot);
+
+  return {
+    runId,
+    runTag,
+    runDir,
+    instructionsFile,
+    manifestFile,
+    ledgerFile,
+    latestEvaluatorFile,
+    resultsFile,
+    stateFile,
+    candidateFile,
+    repoRoot: projectRoot,
+    worktreePath,
+    taskDescription,
+  };
+}
+
+export async function resumeAutoresearchRuntime(projectRoot: string, runId: string): Promise<PreparedAutoresearchRuntime> {
+  await assertAutoresearchLockAvailable(projectRoot);
+  const manifest = await loadAutoresearchRunManifest(projectRoot, runId);
+  if (manifest.status !== 'running') {
+    throw new Error(`autoresearch_resume_terminal_run:${runId}`);
+  }
+  if (!existsSync(manifest.worktree_path)) {
+    throw new Error(`autoresearch_resume_missing_worktree:${manifest.worktree_path}`);
+  }
+  await ensureRuntimeExcludes(manifest.worktree_path);
+  await ensureAutoresearchWorktreeDependencies(projectRoot, manifest.worktree_path);
+  assertResetSafeWorktree(manifest.worktree_path);
+  startAutoresearchMode(`autoresearch resume ${runId}`, projectRoot);
+  await activateAutoresearchRun(manifest);
+  updateAutoresearchMode({
+    current_phase: 'running',
+    run_id: manifest.run_id,
+    run_tag: manifest.run_tag,
+    mission_dir: manifest.mission_dir,
+    mission_file: manifest.mission_file,
+    sandbox_file: manifest.sandbox_file,
+    mission_slug: manifest.mission_slug,
+    repo_root: manifest.repo_root,
+    worktree_path: manifest.worktree_path,
+    baseline_commit: manifest.baseline_commit,
+    last_kept_commit: manifest.last_kept_commit,
+    last_kept_score: manifest.last_kept_score,
+    results_file: manifest.results_file,
+    manifest_path: manifest.manifest_file,
+    iteration_ledger_path: manifest.ledger_file,
+    latest_evaluator_result_path: manifest.latest_evaluator_file,
+    bootstrap_instructions_path: manifest.instructions_file,
+    candidate_path: manifest.candidate_file,
+    keep_policy: manifest.keep_policy,
+    state_file: activeRunStateFile(projectRoot),
+  }, projectRoot);
+  return {
+    runId: manifest.run_id,
+    runTag: manifest.run_tag,
+    runDir: dirname(manifest.manifest_file),
+    instructionsFile: manifest.instructions_file,
+    manifestFile: manifest.manifest_file,
+    ledgerFile: manifest.ledger_file,
+    latestEvaluatorFile: manifest.latest_evaluator_file,
+    resultsFile: manifest.results_file,
+    stateFile: activeRunStateFile(projectRoot),
+    candidateFile: manifest.candidate_file,
+    repoRoot: manifest.repo_root,
+    worktreePath: manifest.worktree_path,
+    taskDescription: `autoresearch resume ${runId}`,
+  };
+}
+
+export function parseAutoresearchCandidateArtifact(raw: string): AutoresearchCandidateArtifact {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('autoresearch candidate artifact must be valid JSON');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('autoresearch candidate artifact must be a JSON object');
+  }
+  const record = parsed as Record<string, unknown>;
+  const status = record.status;
+  if (status !== 'candidate' && status !== 'noop' && status !== 'abort' && status !== 'interrupted') {
+    throw new Error('autoresearch candidate artifact status must be candidate|noop|abort|interrupted');
+  }
+  if (record.candidate_commit !== null && typeof record.candidate_commit !== 'string') {
+    throw new Error('autoresearch candidate artifact candidate_commit must be string|null');
+  }
+  if (typeof record.base_commit !== 'string' || !record.base_commit.trim()) {
+    throw new Error('autoresearch candidate artifact base_commit is required');
+  }
+  if (typeof record.description !== 'string') {
+    throw new Error('autoresearch candidate artifact description is required');
+  }
+  if (!Array.isArray(record.notes) || record.notes.some((note) => typeof note !== 'string')) {
+    throw new Error('autoresearch candidate artifact notes must be a string array');
+  }
+  if (typeof record.created_at !== 'string' || !record.created_at.trim()) {
+    throw new Error('autoresearch candidate artifact created_at is required');
+  }
+  return {
+    status,
+    candidate_commit: record.candidate_commit,
+    base_commit: record.base_commit,
+    description: record.description,
+    notes: record.notes,
+    created_at: record.created_at,
+  };
+}
+
+async function readCandidateArtifact(candidateFile: string): Promise<AutoresearchCandidateArtifact> {
+  if (!existsSync(candidateFile)) {
+    throw new Error(`autoresearch_candidate_missing:${candidateFile}`);
+  }
+  return parseAutoresearchCandidateArtifact(await readFile(candidateFile, 'utf-8'));
+}
+
+async function finalizeRun(
+  manifest: AutoresearchRunManifest,
+  projectRoot: string,
+  updates: { status: AutoresearchRunStatus; stopReason: string },
+): Promise<void> {
+  manifest.status = updates.status;
+  manifest.stop_reason = updates.stopReason;
+  manifest.completed_at = nowIso();
+  await writeRunManifest(manifest);
+  updateAutoresearchMode({
+    active: false,
+    current_phase: updates.status,
+    completed_at: manifest.completed_at,
+    stop_reason: updates.stopReason,
+  }, projectRoot);
+  await deactivateAutoresearchRun(manifest);
+}
+
+function resetToLastKeptCommit(manifest: AutoresearchRunManifest): void {
+  assertResetSafeWorktree(manifest.worktree_path);
+  requireGitSuccess(manifest.worktree_path, ['reset', '--hard', manifest.last_kept_commit]);
+}
+
+function validateAutoresearchCandidate(
+  manifest: Pick<AutoresearchRunManifest, 'last_kept_commit' | 'worktree_path'>,
+  candidate: AutoresearchCandidateArtifact,
+): { candidate: AutoresearchCandidateArtifact } | { reason: string } {
+  const resolvedBaseCommit = tryResolveGitCommit(manifest.worktree_path, candidate.base_commit);
+  if (!resolvedBaseCommit) {
+    return {
+      reason: `candidate base_commit does not resolve in git: ${candidate.base_commit}`,
+    };
+  }
+  if (resolvedBaseCommit !== manifest.last_kept_commit) {
+    return {
+      reason: `candidate base_commit ${resolvedBaseCommit} does not match last kept commit ${manifest.last_kept_commit}`,
+    };
+  }
+
+  if (candidate.status !== 'candidate') {
+    return {
+      candidate: {
+        ...candidate,
+        base_commit: resolvedBaseCommit,
+      },
+    };
+  }
+
+  if (!candidate.candidate_commit) {
+    return {
+      reason: 'candidate status requires a non-null candidate_commit',
+    };
+  }
+  const resolvedCandidateCommit = tryResolveGitCommit(manifest.worktree_path, candidate.candidate_commit);
+  if (!resolvedCandidateCommit) {
+    return {
+      reason: `candidate_commit does not resolve in git: ${candidate.candidate_commit}`,
+    };
+  }
+  const headCommit = readGitFullHead(manifest.worktree_path);
+  if (resolvedCandidateCommit !== headCommit) {
+    return {
+      reason: `candidate_commit ${resolvedCandidateCommit} does not match worktree HEAD ${headCommit}`,
+    };
+  }
+
+  return {
+    candidate: {
+      ...candidate,
+      base_commit: resolvedBaseCommit,
+      candidate_commit: resolvedCandidateCommit,
+    },
+  };
+}
+
+async function failAutoresearchIteration(
+  manifest: AutoresearchRunManifest,
+  projectRoot: string,
+  reason: string,
+  candidate?: AutoresearchCandidateArtifact,
+): Promise<'error'> {
+  const headCommit = (() => {
+    try {
+      return readGitShortHead(manifest.worktree_path);
+    } catch {
+      return manifest.baseline_commit;
+    }
+  })();
+
+  await appendAutoresearchResultsRow(manifest.results_file, {
+    iteration: manifest.iteration,
+    commit: headCommit,
+    status: 'error',
+    description: candidate?.description || 'candidate validation failed',
+  });
+  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+    iteration: manifest.iteration,
+    kind: 'iteration',
+    decision: 'error',
+    decision_reason: reason,
+    candidate_status: candidate?.status ?? 'candidate',
+    base_commit: candidate?.base_commit ?? manifest.last_kept_commit,
+    candidate_commit: candidate?.candidate_commit ?? null,
+    kept_commit: manifest.last_kept_commit,
+    keep_policy: manifest.keep_policy,
+    evaluator: null,
+    created_at: nowIso(),
+    notes: [...(candidate?.notes ?? []), `validation_error:${reason}`],
+    description: candidate?.description || 'candidate validation failed',
+  });
+  await finalizeRun(manifest, projectRoot, { status: 'failed', stopReason: reason });
+  return 'error';
+}
+
+export async function processAutoresearchCandidate(
+  contract: AutoresearchMissionContract,
+  manifest: AutoresearchRunManifest,
+  projectRoot: string,
+): Promise<AutoresearchDecisionStatus> {
+  manifest.iteration += 1;
+  let candidate: AutoresearchCandidateArtifact;
+  try {
+    candidate = await readCandidateArtifact(manifest.candidate_file);
+  } catch (error) {
+    return failAutoresearchIteration(
+      manifest,
+      projectRoot,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  const validation = validateAutoresearchCandidate(manifest, candidate);
+  if ('reason' in validation) {
+    return failAutoresearchIteration(manifest, projectRoot, validation.reason, candidate);
+  }
+  candidate = validation.candidate;
+  manifest.latest_candidate_commit = candidate.candidate_commit;
+
+  if (candidate.status === 'abort') {
+    await appendAutoresearchResultsRow(manifest.results_file, {
+      iteration: manifest.iteration,
+      commit: readGitShortHead(manifest.worktree_path),
+      status: 'abort',
+      description: candidate.description,
+    });
+    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+      iteration: manifest.iteration,
+      kind: 'iteration',
+      decision: 'abort',
+      decision_reason: 'candidate requested abort',
+      candidate_status: candidate.status,
+      base_commit: candidate.base_commit,
+      candidate_commit: candidate.candidate_commit,
+      kept_commit: manifest.last_kept_commit,
+      keep_policy: manifest.keep_policy,
+      evaluator: null,
+      created_at: nowIso(),
+      notes: candidate.notes,
+      description: candidate.description,
+    });
+    await finalizeRun(manifest, projectRoot, { status: 'stopped', stopReason: 'candidate abort' });
+    return 'abort';
+  }
+
+  if (candidate.status === 'interrupted') {
+    try {
+      assertResetSafeWorktree(manifest.worktree_path);
+    } catch {
+      await finalizeRun(manifest, projectRoot, { status: 'failed', stopReason: 'interrupted dirty worktree requires operator intervention' });
+      return 'error';
+    }
+    await appendAutoresearchResultsRow(manifest.results_file, {
+      iteration: manifest.iteration,
+      commit: readGitShortHead(manifest.worktree_path),
+      status: 'interrupted',
+      description: candidate.description,
+    });
+    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+      iteration: manifest.iteration,
+      kind: 'iteration',
+      decision: 'interrupted',
+      decision_reason: 'candidate session interrupted cleanly',
+      candidate_status: candidate.status,
+      base_commit: candidate.base_commit,
+      candidate_commit: candidate.candidate_commit,
+      kept_commit: manifest.last_kept_commit,
+      keep_policy: manifest.keep_policy,
+      evaluator: null,
+      created_at: nowIso(),
+      notes: candidate.notes,
+      description: candidate.description,
+    });
+    await writeRunManifest(manifest);
+    await writeInstructionsFile(contract, manifest);
+    return 'interrupted';
+  }
+
+  if (candidate.status === 'noop') {
+    await appendAutoresearchResultsRow(manifest.results_file, {
+      iteration: manifest.iteration,
+      commit: readGitShortHead(manifest.worktree_path),
+      status: 'noop',
+      description: candidate.description,
+    });
+    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+      iteration: manifest.iteration,
+      kind: 'iteration',
+      decision: 'noop',
+      decision_reason: 'candidate reported noop',
+      candidate_status: candidate.status,
+      base_commit: candidate.base_commit,
+      candidate_commit: candidate.candidate_commit,
+      kept_commit: manifest.last_kept_commit,
+      keep_policy: manifest.keep_policy,
+      evaluator: null,
+      created_at: nowIso(),
+      notes: candidate.notes,
+      description: candidate.description,
+    });
+    await writeRunManifest(manifest);
+    await writeInstructionsFile(contract, manifest);
+    return 'noop';
+  }
+
+  const evaluation = await runAutoresearchEvaluator(contract, manifest.worktree_path);
+  await writeJsonFile(manifest.latest_evaluator_file, evaluation);
+  const decision = decideAutoresearchOutcome(manifest, candidate, evaluation);
+  if (decision.keep) {
+    manifest.last_kept_commit = readGitFullHead(manifest.worktree_path);
+    manifest.last_kept_score = typeof evaluation.score === 'number' ? evaluation.score : manifest.last_kept_score;
+  } else {
+    resetToLastKeptCommit(manifest);
+  }
+
+  await appendAutoresearchResultsRow(manifest.results_file, {
+    iteration: manifest.iteration,
+    commit: readGitShortHead(manifest.worktree_path),
+    pass: evaluation.pass,
+    score: evaluation.score,
+    status: decision.decision,
+    description: candidate.description,
+  });
+  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+    iteration: manifest.iteration,
+    kind: 'iteration',
+    decision: decision.decision,
+    decision_reason: decision.decisionReason,
+    candidate_status: candidate.status,
+    base_commit: candidate.base_commit,
+    candidate_commit: candidate.candidate_commit,
+    kept_commit: manifest.last_kept_commit,
+    keep_policy: manifest.keep_policy,
+    evaluator: evaluation,
+    created_at: nowIso(),
+    notes: [...candidate.notes, ...decision.notes],
+    description: candidate.description,
+  });
+  await writeRunManifest(manifest);
+  await writeInstructionsFile(contract, manifest);
+  updateAutoresearchMode({
+    current_phase: 'running',
+    iteration: manifest.iteration,
+    last_kept_commit: manifest.last_kept_commit,
+    last_kept_score: manifest.last_kept_score,
+    latest_evaluator_status: evaluation.status,
+    latest_evaluator_pass: evaluation.pass,
+    latest_evaluator_score: evaluation.score,
+    latest_evaluator_ran_at: evaluation.ran_at,
+  }, projectRoot);
+  return decision.decision;
+}
+
+export async function finalizeAutoresearchRunState(
+  projectRoot: string,
+  runId: string,
+  updates: { status: AutoresearchRunStatus; stopReason: string },
+): Promise<void> {
+  const manifest = await loadAutoresearchRunManifest(projectRoot, runId);
+  if (manifest.status !== 'running') {
+    return;
+  }
+  await finalizeRun(manifest, projectRoot, updates);
+}
+
+export async function stopAutoresearchRuntime(projectRoot: string): Promise<void> {
+  const state = readModeState<Record<string, unknown>>('autoresearch', projectRoot);
+  if (!state?.active) {
+    return;
+  }
+
+  const runId = typeof state.run_id === 'string' ? state.run_id : null;
+  if (runId) {
+    await finalizeAutoresearchRunState(projectRoot, runId, {
+      status: 'stopped',
+      stopReason: 'operator stop',
+    });
+    return;
+  }
+
+  cancelAutoresearchMode(projectRoot);
+}

--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parseSandboxContract } from '../../autoresearch/contracts.js';
+import { initAutoresearchMission, parseInitArgs, checkTmuxAvailable } from '../autoresearch-guided.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omc-autoresearch-guided-test-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  const { writeFile } = await import('node:fs/promises');
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+describe('initAutoresearchMission', () => {
+  it('creates mission.md with correct content', async () => {
+    const repo = await initRepo();
+    try {
+      const result = await initAutoresearchMission({
+        topic: 'Improve test coverage for the auth module',
+        evaluatorCommand: 'node scripts/eval.js',
+        keepPolicy: 'score_improvement',
+        slug: 'auth-coverage',
+        repoRoot: repo,
+      });
+
+      expect(result.slug).toBe('auth-coverage');
+      expect(result.missionDir).toBe(join(repo, 'missions', 'auth-coverage'));
+
+      const missionContent = await readFile(join(result.missionDir, 'mission.md'), 'utf-8');
+      expect(missionContent).toMatch(/# Mission/);
+      expect(missionContent).toMatch(/Improve test coverage for the auth module/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('creates sandbox.md with valid YAML frontmatter', async () => {
+    const repo = await initRepo();
+    try {
+      const result = await initAutoresearchMission({
+        topic: 'Optimize database queries',
+        evaluatorCommand: 'node scripts/eval-perf.js',
+        keepPolicy: 'pass_only',
+        slug: 'db-perf',
+        repoRoot: repo,
+      });
+
+      const sandboxContent = await readFile(join(result.missionDir, 'sandbox.md'), 'utf-8');
+      expect(sandboxContent).toMatch(/^---\n/);
+      expect(sandboxContent).toMatch(/evaluator:/);
+      expect(sandboxContent).toMatch(/command: node scripts\/eval-perf\.js/);
+      expect(sandboxContent).toMatch(/format: json/);
+      expect(sandboxContent).toMatch(/keep_policy: pass_only/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('generated sandbox.md passes parseSandboxContract validation', async () => {
+    const repo = await initRepo();
+    try {
+      const result = await initAutoresearchMission({
+        topic: 'Fix flaky tests',
+        evaluatorCommand: 'bash run-tests.sh',
+        keepPolicy: 'score_improvement',
+        slug: 'flaky-tests',
+        repoRoot: repo,
+      });
+
+      const sandboxContent = await readFile(join(result.missionDir, 'sandbox.md'), 'utf-8');
+      const parsed = parseSandboxContract(sandboxContent);
+      expect(parsed.evaluator.command).toBe('bash run-tests.sh');
+      expect(parsed.evaluator.format).toBe('json');
+      expect(parsed.evaluator.keep_policy).toBe('score_improvement');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('throws if mission directory already exists', async () => {
+    const repo = await initRepo();
+    try {
+      const missionDir = join(repo, 'missions', 'existing');
+      await mkdir(missionDir, { recursive: true });
+
+      await expect(
+        initAutoresearchMission({
+          topic: 'duplicate',
+          evaluatorCommand: 'echo ok',
+          keepPolicy: 'pass_only',
+          slug: 'existing',
+          repoRoot: repo,
+        }),
+      ).rejects.toThrow(/already exists/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('parseInitArgs', () => {
+  it('parses all flags with space-separated values', () => {
+    const result = parseInitArgs([
+      '--topic', 'my topic',
+      '--evaluator', 'node eval.js',
+      '--keep-policy', 'pass_only',
+      '--slug', 'my-slug',
+    ]);
+    expect(result.topic).toBe('my topic');
+    expect(result.evaluatorCommand).toBe('node eval.js');
+    expect(result.keepPolicy).toBe('pass_only');
+    expect(result.slug).toBe('my-slug');
+  });
+
+  it('parses all flags with = syntax', () => {
+    const result = parseInitArgs([
+      '--topic=my topic',
+      '--evaluator=node eval.js',
+      '--keep-policy=score_improvement',
+      '--slug=my-slug',
+    ]);
+    expect(result.topic).toBe('my topic');
+    expect(result.evaluatorCommand).toBe('node eval.js');
+    expect(result.keepPolicy).toBe('score_improvement');
+    expect(result.slug).toBe('my-slug');
+  });
+
+  it('returns partial result when some flags are missing', () => {
+    const result = parseInitArgs(['--topic', 'my topic']);
+    expect(result.topic).toBe('my topic');
+    expect(result.evaluatorCommand).toBeUndefined();
+    expect(result.keepPolicy).toBeUndefined();
+    expect(result.slug).toBeUndefined();
+  });
+
+  it('throws on invalid keep-policy', () => {
+    expect(() => parseInitArgs(['--keep-policy', 'invalid'])).toThrow(/must be one of/);
+  });
+
+  it('throws on unknown flags', () => {
+    expect(() => parseInitArgs(['--unknown-flag', 'value'])).toThrow(/Unknown init flag: --unknown-flag/);
+  });
+
+  it('sanitizes slug via slugifyMissionName', () => {
+    const result = parseInitArgs(['--slug', '../../etc/cron.d/omc']);
+    expect(result.slug).toBeTruthy();
+    expect(result.slug!).not.toMatch(/\.\./);
+    expect(result.slug!).not.toMatch(/\//);
+  });
+});
+
+describe('checkTmuxAvailable', () => {
+  it('returns a boolean', () => {
+    const result = checkTmuxAvailable();
+    expect(typeof result).toBe('boolean');
+  });
+});

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAutoresearchClaudeArgs, parseAutoresearchArgs } from '../autoresearch.js';
+
+describe('normalizeAutoresearchClaudeArgs', () => {
+  it('adds permission bypass by default for autoresearch workers', () => {
+    expect(normalizeAutoresearchClaudeArgs(['--model', 'opus'])).toEqual(['--model', 'opus', '--dangerously-skip-permissions']);
+  });
+
+  it('deduplicates explicit bypass flags', () => {
+    expect(normalizeAutoresearchClaudeArgs(['--dangerously-skip-permissions'])).toEqual(['--dangerously-skip-permissions']);
+  });
+});
+
+describe('parseAutoresearchArgs', () => {
+  it('parses mission-dir as first positional argument', () => {
+    const parsed = parseAutoresearchArgs(['/path/to/mission']);
+    expect(parsed.missionDir).toBe('/path/to/mission');
+    expect(parsed.runId).toBeNull();
+    expect(parsed.claudeArgs).toEqual([]);
+  });
+
+  it('parses --resume with run-id', () => {
+    const parsed = parseAutoresearchArgs(['--resume', 'my-run-id']);
+    expect(parsed.missionDir).toBeNull();
+    expect(parsed.runId).toBe('my-run-id');
+  });
+
+  it('parses --resume= with run-id', () => {
+    const parsed = parseAutoresearchArgs(['--resume=my-run-id']);
+    expect(parsed.missionDir).toBeNull();
+    expect(parsed.runId).toBe('my-run-id');
+  });
+
+  it('parses --help', () => {
+    const parsed = parseAutoresearchArgs(['--help']);
+    expect(parsed.missionDir).toBe('--help');
+  });
+
+  it('parses init subcommand', () => {
+    const parsed = parseAutoresearchArgs(['init', '--topic', 'my topic']);
+    expect(parsed.guided).toBe(true);
+    expect(parsed.initArgs).toEqual(['--topic', 'my topic']);
+  });
+
+  it('passes extra args as claudeArgs', () => {
+    const parsed = parseAutoresearchArgs(['/path/to/mission', '--model', 'opus']);
+    expect(parsed.missionDir).toBe('/path/to/mission');
+    expect(parsed.claudeArgs).toEqual(['--model', 'opus']);
+  });
+
+  it('rejects flags before mission-dir', () => {
+    expect(() => parseAutoresearchArgs(['--unknown-flag'])).toThrow(/mission-dir must be the first positional argument/);
+  });
+});

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -1,0 +1,171 @@
+import { createInterface } from 'readline/promises';
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdir, writeFile } from 'fs/promises';
+import { join, relative, resolve } from 'path';
+import { type AutoresearchKeepPolicy, parseSandboxContract, slugifyMissionName } from '../autoresearch/contracts.js';
+
+export interface InitAutoresearchOptions {
+  topic: string;
+  evaluatorCommand: string;
+  keepPolicy: AutoresearchKeepPolicy;
+  slug: string;
+  repoRoot: string;
+}
+
+export interface InitAutoresearchResult {
+  missionDir: string;
+  slug: string;
+}
+
+function shellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+function buildMissionContent(topic: string): string {
+  return `# Mission\n\n${topic}\n`;
+}
+
+function buildSandboxContent(evaluatorCommand: string, keepPolicy: AutoresearchKeepPolicy): string {
+  // Strip newlines/carriage returns to prevent YAML injection
+  const safeCommand = evaluatorCommand.replace(/[\r\n]/g, ' ').trim();
+  return `---\nevaluator:\n  command: ${safeCommand}\n  format: json\n  keep_policy: ${keepPolicy}\n---\n`;
+}
+
+export async function initAutoresearchMission(opts: InitAutoresearchOptions): Promise<InitAutoresearchResult> {
+  const missionsRoot = join(opts.repoRoot, 'missions');
+  const missionDir = join(missionsRoot, opts.slug);
+
+  // Defense-in-depth: ensure slug does not escape missions/ directory
+  const rel = relative(missionsRoot, missionDir);
+  if (!rel || rel.startsWith('..') || resolve(rel) === resolve(missionDir)) {
+    throw new Error('Invalid slug: resolves outside missions/ directory.');
+  }
+
+  if (existsSync(missionDir)) {
+    throw new Error(`Mission directory already exists: ${missionDir}`);
+  }
+
+  await mkdir(missionDir, { recursive: true });
+
+  const missionContent = buildMissionContent(opts.topic);
+  const sandboxContent = buildSandboxContent(opts.evaluatorCommand, opts.keepPolicy);
+
+  // Validate before writing — ensures contract fidelity
+  parseSandboxContract(sandboxContent);
+
+  await writeFile(join(missionDir, 'mission.md'), missionContent, 'utf-8');
+  await writeFile(join(missionDir, 'sandbox.md'), sandboxContent, 'utf-8');
+
+  return { missionDir, slug: opts.slug };
+}
+
+export function parseInitArgs(args: readonly string[]): Partial<InitAutoresearchOptions> {
+  const result: Partial<InitAutoresearchOptions> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+    if ((arg === '--topic') && next) {
+      result.topic = next;
+      i++;
+    } else if ((arg === '--evaluator') && next) {
+      result.evaluatorCommand = next;
+      i++;
+    } else if ((arg === '--keep-policy') && next) {
+      const normalized = next.trim().toLowerCase();
+      if (normalized !== 'pass_only' && normalized !== 'score_improvement') {
+        throw new Error('--keep-policy must be one of: score_improvement, pass_only');
+      }
+      result.keepPolicy = normalized;
+      i++;
+    } else if ((arg === '--slug') && next) {
+      result.slug = slugifyMissionName(next);
+      i++;
+    } else if (arg.startsWith('--topic=')) {
+      result.topic = arg.slice('--topic='.length);
+    } else if (arg.startsWith('--evaluator=')) {
+      result.evaluatorCommand = arg.slice('--evaluator='.length);
+    } else if (arg.startsWith('--keep-policy=')) {
+      const normalized = arg.slice('--keep-policy='.length).trim().toLowerCase();
+      if (normalized !== 'pass_only' && normalized !== 'score_improvement') {
+        throw new Error('--keep-policy must be one of: score_improvement, pass_only');
+      }
+      result.keepPolicy = normalized;
+    } else if (arg.startsWith('--slug=')) {
+      result.slug = slugifyMissionName(arg.slice('--slug='.length));
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown init flag: ${arg.split('=')[0]}`);
+    }
+  }
+  return result;
+}
+
+export async function guidedAutoresearchSetup(repoRoot: string): Promise<InitAutoresearchResult> {
+  if (!process.stdin.isTTY) {
+    throw new Error('Guided setup requires an interactive terminal. Use --topic, --evaluator, --keep-policy, --slug flags for non-interactive use.');
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const topic = await rl.question('Research topic/goal:\n> ');
+    if (!topic.trim()) {
+      throw new Error('Research topic is required.');
+    }
+
+    const evaluatorCommand = await rl.question('\nEvaluator command (shell command that outputs {pass: boolean, score?: number} JSON):\n> ');
+    if (!evaluatorCommand.trim()) {
+      throw new Error('Evaluator command is required.');
+    }
+
+    const keepPolicyInput = await rl.question('\nKeep policy [score_improvement/pass_only] (default: score_improvement):\n> ');
+    const keepPolicy: AutoresearchKeepPolicy = keepPolicyInput.trim().toLowerCase() === 'pass_only' ? 'pass_only' : 'score_improvement';
+
+    const suggestedSlug = slugifyMissionName(topic);
+    const slugInput = await rl.question(`\nMission slug (default: ${suggestedSlug}):\n> `);
+    const slug = slugInput.trim() ? slugifyMissionName(slugInput.trim()) : suggestedSlug;
+
+    return initAutoresearchMission({
+      topic: topic.trim(),
+      evaluatorCommand: evaluatorCommand.trim(),
+      keepPolicy,
+      slug,
+      repoRoot,
+    });
+  } finally {
+    rl.close();
+  }
+}
+
+export function checkTmuxAvailable(): boolean {
+  const result = spawnSync('tmux', ['-V'], { stdio: 'pipe' });
+  return result.status === 0;
+}
+
+export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
+  if (!checkTmuxAvailable()) {
+    throw new Error('tmux is required for background autoresearch execution. Install tmux and try again.');
+  }
+
+  const sessionName = `omc-autoresearch-${slug}`;
+
+  // Check for session name collision
+  const hasSession = spawnSync('tmux', ['has-session', '-t', sessionName], { stdio: 'pipe' });
+  if (hasSession.status === 0) {
+    throw new Error(
+      `tmux session "${sessionName}" already exists.\n` +
+      `  Attach: tmux attach -t ${sessionName}\n` +
+      `  Kill:   tmux kill-session -t ${sessionName}`,
+    );
+  }
+
+  const omcPath = resolve(join(__dirname, '..', '..', 'bin', 'omc.js'));
+  // Shell-quote all path components to handle spaces and special characters
+  const cmd = `${shellQuote(process.execPath)} ${shellQuote(omcPath)} autoresearch ${shellQuote(missionDir)}`;
+
+  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, cmd], { stdio: 'ignore' });
+
+  console.log(`\nAutoresearch launched in background tmux session.`);
+  console.log(`  Session:  ${sessionName}`);
+  console.log(`  Mission:  ${missionDir}`);
+  console.log(`  Attach:   tmux attach -t ${sessionName}`);
+}

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -1,0 +1,245 @@
+import { execFileSync, spawnSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { loadAutoresearchMissionContract } from '../autoresearch/contracts.js';
+import {
+  assertModeStartAllowed,
+  buildAutoresearchRunTag,
+  countTrailingAutoresearchNoops,
+  finalizeAutoresearchRunState,
+  loadAutoresearchRunManifest,
+  materializeAutoresearchMissionToWorktree,
+  prepareAutoresearchRuntime,
+  processAutoresearchCandidate,
+  resumeAutoresearchRuntime,
+} from '../autoresearch/runtime.js';
+import { guidedAutoresearchSetup, initAutoresearchMission, parseInitArgs, spawnAutoresearchTmux } from './autoresearch-guided.js';
+
+const CLAUDE_BYPASS_FLAG = '--dangerously-skip-permissions';
+
+export const AUTORESEARCH_HELP = `omc autoresearch - Launch OMC autoresearch with thin-supervisor parity semantics
+
+Usage:
+  omc autoresearch                                                (guided setup + background launch)
+  omc autoresearch init [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
+  omc autoresearch <mission-dir> [claude-args...]
+  omc autoresearch --resume <run-id> [claude-args...]
+
+Arguments:
+  (no args)        Interactive guided setup: collects topic, evaluator, policy, and slug,
+                   generates a mission directory, then spawns autoresearch in a background tmux session.
+  init             Non-interactive mission scaffolding via flags (all four flags required).
+  <mission-dir>    Directory inside a git repository containing mission.md and sandbox.md
+  <run-id>         Existing autoresearch run id from .omc/logs/autoresearch/<run-id>/manifest.json
+
+Behavior:
+  - validates mission.md and sandbox.md
+  - requires sandbox.md YAML frontmatter with evaluator.command and evaluator.format=json
+  - fresh launch creates a run-tagged autoresearch/<slug>/<run-tag> lane
+  - supervisor records baseline, candidate, keep/discard/reset, and results artifacts under .omc/logs/autoresearch/
+  - --resume loads the authoritative per-run manifest and continues from the last kept commit
+`;
+
+const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMC_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
+const AUTORESEARCH_MAX_CONSECUTIVE_NOOPS = 3;
+
+export function normalizeAutoresearchClaudeArgs(claudeArgs: readonly string[]): string[] {
+  const normalized: string[] = [];
+  let hasBypass = false;
+
+  for (const arg of claudeArgs) {
+    if (arg === CLAUDE_BYPASS_FLAG) {
+      if (!hasBypass) {
+        normalized.push(arg);
+        hasBypass = true;
+      }
+      continue;
+    }
+    normalized.push(arg);
+  }
+
+  if (!hasBypass) {
+    normalized.push(CLAUDE_BYPASS_FLAG);
+  }
+
+  return normalized;
+}
+
+function runAutoresearchTurn(worktreePath: string, instructionsFile: string, claudeArgs: string[]): void {
+  const prompt = readFileSync(instructionsFile, 'utf-8');
+  const launchArgs = ['--print', ...normalizeAutoresearchClaudeArgs(claudeArgs), '-p', prompt];
+  const result = spawnSync('claude', launchArgs, {
+    cwd: worktreePath,
+    stdio: ['pipe', 'inherit', 'inherit'],
+    encoding: 'utf-8',
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exitCode = typeof result.status === 'number' ? result.status : 1;
+    throw new Error(`autoresearch_claude_exec_failed:${result.status ?? 'unknown'}`);
+  }
+}
+
+export interface ParsedAutoresearchArgs {
+  missionDir: string | null;
+  runId: string | null;
+  claudeArgs: string[];
+  guided?: boolean;
+  initArgs?: string[];
+}
+
+function resolveRepoRoot(cwd: string): string {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+export function parseAutoresearchArgs(args: readonly string[]): ParsedAutoresearchArgs {
+  const values = [...args];
+  if (values.length === 0) {
+    // TTY guard: preserve error for non-interactive callers (CI, scripts, piped stdin)
+    if (!process.stdin.isTTY) {
+      throw new Error(`mission-dir is required.\n${AUTORESEARCH_HELP}`);
+    }
+    return { missionDir: null, runId: null, claudeArgs: [], guided: true };
+  }
+  const first = values[0];
+  if (first === 'init') {
+    return { missionDir: null, runId: null, claudeArgs: [], guided: true, initArgs: values.slice(1) };
+  }
+  if (first === '--help' || first === '-h' || first === 'help') {
+    return { missionDir: '--help', runId: null, claudeArgs: [] };
+  }
+  if (first === '--resume') {
+    const runId = values[1]?.trim();
+    if (!runId) {
+      throw new Error(`--resume requires <run-id>.\n${AUTORESEARCH_HELP}`);
+    }
+    return { missionDir: null, runId, claudeArgs: values.slice(2) };
+  }
+  if (first.startsWith('--resume=')) {
+    const runId = first.slice('--resume='.length).trim();
+    if (!runId) {
+      throw new Error(`--resume requires <run-id>.\n${AUTORESEARCH_HELP}`);
+    }
+    return { missionDir: null, runId, claudeArgs: values.slice(1) };
+  }
+  if (first.startsWith('-')) {
+    throw new Error(`mission-dir must be the first positional argument unless using --resume.\n${AUTORESEARCH_HELP}`);
+  }
+  return { missionDir: first, runId: null, claudeArgs: values.slice(1) };
+}
+
+async function runAutoresearchLoop(
+  claudeArgs: string[],
+  runtime: {
+    instructionsFile: string;
+    manifestFile: string;
+    repoRoot: string;
+    worktreePath: string;
+  },
+  missionDir: string,
+): Promise<void> {
+  const previousInstructionsFile = process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
+  const originalCwd = process.cwd();
+  process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = runtime.instructionsFile;
+
+  try {
+    while (true) {
+      runAutoresearchTurn(runtime.worktreePath, runtime.instructionsFile, claudeArgs);
+
+      const contract = await loadAutoresearchMissionContract(missionDir);
+      const manifest = await loadAutoresearchRunManifest(runtime.repoRoot, JSON.parse(execFileSync('cat', [runtime.manifestFile], { encoding: 'utf-8' })).run_id);
+      const decision = await processAutoresearchCandidate(contract, manifest, runtime.repoRoot);
+      if (decision === 'abort' || decision === 'error') {
+        return;
+      }
+      if (decision === 'noop') {
+        const trailingNoops = await countTrailingAutoresearchNoops(manifest.ledger_file);
+        if (trailingNoops >= AUTORESEARCH_MAX_CONSECUTIVE_NOOPS) {
+          await finalizeAutoresearchRunState(runtime.repoRoot, manifest.run_id, {
+            status: 'stopped',
+            stopReason: `repeated noop limit reached (${AUTORESEARCH_MAX_CONSECUTIVE_NOOPS})`,
+          });
+          return;
+        }
+      }
+      process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = runtime.instructionsFile;
+    }
+  } finally {
+    process.chdir(originalCwd);
+    if (typeof previousInstructionsFile === 'string') {
+      process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = previousInstructionsFile;
+    } else {
+      delete process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
+    }
+  }
+}
+
+function planWorktree(repoRoot: string, missionSlug: string, runTag: string): { worktreePath: string; branchName: string } {
+  const worktreePath = `${repoRoot}/../${repoRoot.split('/').pop()}.omc-worktrees/autoresearch-${missionSlug}-${runTag.toLowerCase()}`;
+  const branchName = `autoresearch/${missionSlug}/${runTag.toLowerCase()}`;
+  return { worktreePath, branchName };
+}
+
+export async function autoresearchCommand(args: string[]): Promise<void> {
+  const parsed = parseAutoresearchArgs(args);
+  if (parsed.missionDir === '--help') {
+    console.log(AUTORESEARCH_HELP);
+    return;
+  }
+
+  if (parsed.guided) {
+    const repoRoot = resolveRepoRoot(process.cwd());
+    let result;
+    if (parsed.initArgs && parsed.initArgs.length > 0) {
+      const initOpts = parseInitArgs(parsed.initArgs);
+      if (!initOpts.topic || !initOpts.evaluatorCommand || !initOpts.slug) {
+        throw new Error(
+          'init requires --topic, --evaluator, and --slug flags.\n' +
+          'Optional: --keep-policy (default: score_improvement)\n\n' +
+          `${AUTORESEARCH_HELP}`,
+        );
+      }
+      result = await initAutoresearchMission({
+        topic: initOpts.topic,
+        evaluatorCommand: initOpts.evaluatorCommand,
+        keepPolicy: initOpts.keepPolicy || 'score_improvement',
+        slug: initOpts.slug,
+        repoRoot,
+      });
+    } else {
+      result = await guidedAutoresearchSetup(repoRoot);
+    }
+    spawnAutoresearchTmux(result.missionDir, result.slug);
+    return;
+  }
+
+  if (parsed.runId) {
+    const repoRoot = resolveRepoRoot(process.cwd());
+    await assertModeStartAllowed('autoresearch', repoRoot);
+    const manifest = await loadAutoresearchRunManifest(repoRoot, parsed.runId);
+    const runtime = await resumeAutoresearchRuntime(repoRoot, parsed.runId);
+    await runAutoresearchLoop(parsed.claudeArgs, runtime, manifest.mission_dir);
+    return;
+  }
+
+  const contract = await loadAutoresearchMissionContract(parsed.missionDir as string);
+  await assertModeStartAllowed('autoresearch', contract.repoRoot);
+  const runTag = buildAutoresearchRunTag();
+  const plan = planWorktree(contract.repoRoot, contract.missionSlug, runTag);
+
+  execFileSync('git', ['worktree', 'add', '-b', plan.branchName, plan.worktreePath, 'HEAD'], {
+    cwd: contract.repoRoot,
+    stdio: 'ignore',
+  });
+
+  const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, plan.worktreePath);
+  const runtime = await prepareAutoresearchRuntime(worktreeContract, contract.repoRoot, plan.worktreePath, { runTag });
+  await runAutoresearchLoop(parsed.claudeArgs, runtime, worktreeContract.missionDir);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -56,6 +56,7 @@ import { launchCommand } from './launch.js';
 import { interopCommand } from './interop.js';
 import { askCommand, ASK_USAGE } from './ask.js';
 import { warnIfWin32 } from './win32-warning.js';
+import { autoresearchCommand, AUTORESEARCH_HELP } from './autoresearch.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -1330,6 +1331,20 @@ program
   .argument('[args...]', 'team subcommand arguments')
   .action(async (args: string[]) => {
     await teamCommand(args);
+  });
+
+/**
+ * Autoresearch command - thin-supervisor autoresearch with keep/discard/reset parity
+ */
+program
+  .command('autoresearch')
+  .description('Launch thin-supervisor autoresearch with keep/discard/reset parity')
+  .helpOption(false)
+  .allowUnknownOption(true)
+  .allowExcessArguments(true)
+  .argument('[args...]', 'autoresearch subcommand arguments')
+  .action(async (args: string[]) => {
+    await autoresearchCommand(args);
   });
 
 // Parse arguments


### PR DESCRIPTION
## Summary
- Backports the autoresearch thin-supervisor system from oh-my-codex (OMX) to oh-my-claudecode (OMC)
- Adapts `codex exec` invocations to `claude --print` with `--dangerously-skip-permissions`
- Replaces `.omx` state paths with `.omc` and uses OMC's `mode-state-io.ts` for state management
- Registers `omc autoresearch` CLI command with guided setup, init, run, and resume modes

## Changes
- `src/autoresearch/contracts.ts` - Mission/sandbox/evaluator contract parsing (direct port)
- `src/autoresearch/runtime.ts` - Runtime engine with keep/discard/reset parity (adapted for OMC)
- `src/cli/autoresearch.ts` - CLI command with claude --print worker turns
- `src/cli/autoresearch-guided.ts` - Interactive guided setup and tmux background launch
- `src/cli/index.ts` - Command registration
- 5 test files with 43 tests covering contracts, runtime, parity decisions, CLI args, and guided setup

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 43 autoresearch tests pass (`vitest run`)
- [ ] Manual smoke test: `omc autoresearch --help`
- [ ] Manual smoke test: `omc autoresearch init --topic "test" --evaluator "echo '{\"pass\":true}'" --slug test-mission`

Closes #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)