### PR TITLE
feat(ralphthon): add autonomous hackathon lifecycle mode

### DIFF
--- a/src/cli/commands/ralphthon.ts
+++ b/src/cli/commands/ralphthon.ts
@@ -1,0 +1,378 @@
+/**
+ * omc ralphthon CLI subcommand
+ *
+ * Autonomous hackathon lifecycle:
+ *   omc ralphthon "task"                  Start new ralphthon session
+ *   omc ralphthon --resume                Resume existing session
+ *   omc ralphthon --skip-interview "task" Skip deep-interview, use task directly
+ *   omc ralphthon --max-waves 5           Set max hardening waves
+ *   omc ralphthon --poll-interval 60      Set poll interval in seconds
+ */
+
+import chalk from 'chalk';
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import {
+  readRalphthonPrd,
+  readRalphthonState,
+  writeRalphthonState,
+  clearRalphthonState,
+  initOrchestrator,
+  startOrchestratorLoop,
+  formatRalphthonStatus,
+  getRalphthonPrdPath,
+  initRalphthonPrd,
+} from '../../ralphthon/index.js';
+import type {
+  RalphthonCliOptions,
+  OrchestratorEvent,
+  RalphthonConfig,
+} from '../../ralphthon/types.js';
+import { RALPHTHON_DEFAULTS } from '../../ralphthon/types.js';
+
+// ============================================================================
+// Help Text
+// ============================================================================
+
+const RALPHTHON_HELP = `
+Usage: omc ralphthon [options] [task]
+
+Autonomous hackathon lifecycle mode.
+Generates PRD via deep-interview, executes all tasks with ralph loop,
+then auto-hardens until clean.
+
+Options:
+  --resume              Resume an existing ralphthon session
+  --skip-interview      Skip deep-interview, start execution directly
+  --max-waves <n>       Maximum hardening waves (default: ${RALPHTHON_DEFAULTS.maxWaves})
+  --poll-interval <s>   Poll interval in seconds (default: ${RALPHTHON_DEFAULTS.pollIntervalMs / 1000})
+  --help, -h            Show this help
+
+Examples:
+  omc ralphthon "Build a REST API for user management"
+  omc ralphthon --skip-interview "Implement auth middleware"
+  omc ralphthon --resume
+  omc ralphthon --max-waves 5 --poll-interval 60 "Add caching layer"
+`;
+
+// ============================================================================
+// Argument Parsing
+// ============================================================================
+
+/**
+ * Parse ralphthon CLI arguments
+ */
+export function parseRalphthonArgs(args: string[]): RalphthonCliOptions {
+  const options: RalphthonCliOptions = {
+    resume: false,
+    skipInterview: false,
+    maxWaves: RALPHTHON_DEFAULTS.maxWaves,
+    pollInterval: RALPHTHON_DEFAULTS.pollIntervalMs / 1000,
+  };
+
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    switch (arg) {
+      case '--resume':
+        options.resume = true;
+        break;
+      case '--skip-interview':
+        options.skipInterview = true;
+        break;
+      case '--max-waves': {
+        const val = parseInt(args[++i], 10);
+        if (!isNaN(val) && val > 0) options.maxWaves = val;
+        break;
+      }
+      case '--poll-interval': {
+        const val = parseInt(args[++i], 10);
+        if (!isNaN(val) && val > 0) options.pollInterval = val;
+        break;
+      }
+      case '--help':
+      case '-h':
+        console.log(RALPHTHON_HELP);
+        process.exit(0);
+        break;
+      default:
+        if (!arg.startsWith('--')) {
+          positional.push(arg);
+        }
+        break;
+    }
+  }
+
+  if (positional.length > 0) {
+    options.task = positional.join(' ');
+  }
+
+  return options;
+}
+
+// ============================================================================
+// Event Handler
+// ============================================================================
+
+function createEventLogger(): (event: OrchestratorEvent) => void {
+  return (event: OrchestratorEvent) => {
+    const ts = new Date().toLocaleTimeString();
+
+    switch (event.type) {
+      case 'task_injected':
+        console.log(chalk.cyan(`[${ts}] Task injected: ${event.taskTitle}`));
+        break;
+      case 'task_completed':
+        console.log(chalk.green(`[${ts}] Task completed: ${event.taskId}`));
+        break;
+      case 'task_failed':
+        console.log(chalk.yellow(`[${ts}] Task failed: ${event.taskId} (retry ${event.retries})`));
+        break;
+      case 'task_skipped':
+        console.log(chalk.red(`[${ts}] Task skipped: ${event.taskId} — ${event.reason}`));
+        break;
+      case 'phase_transition':
+        console.log(chalk.magenta(`[${ts}] Phase: ${event.from} -> ${event.to}`));
+        break;
+      case 'hardening_wave_start':
+        console.log(chalk.blue(`[${ts}] Hardening wave ${event.wave} started`));
+        break;
+      case 'hardening_wave_end':
+        console.log(chalk.blue(`[${ts}] Hardening wave ${event.wave} ended — ${event.newIssues} new issues`));
+        break;
+      case 'idle_detected':
+        console.log(chalk.gray(`[${ts}] Leader idle for ${Math.round(event.durationMs / 1000)}s`));
+        break;
+      case 'session_complete':
+        console.log(chalk.green.bold(`[${ts}] Ralphthon complete! ${event.tasksCompleted} done, ${event.tasksSkipped} skipped`));
+        break;
+      case 'error':
+        console.log(chalk.red(`[${ts}] Error: ${event.message}`));
+        break;
+    }
+  };
+}
+
+// ============================================================================
+// Tmux Helpers
+// ============================================================================
+
+function getCurrentTmuxSession(): string | null {
+  try {
+    return execSync("tmux display-message -p '#S'", { encoding: 'utf-8', timeout: 5000 }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function getCurrentTmuxPane(): string | null {
+  try {
+    return execSync("tmux display-message -p '#{pane_id}'", { encoding: 'utf-8', timeout: 5000 }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function isInsideTmux(): boolean {
+  return !!process.env.TMUX;
+}
+
+// ============================================================================
+// Main Command
+// ============================================================================
+
+/**
+ * Execute the ralphthon CLI command
+ */
+export async function ralphthonCommand(args: string[]): Promise<void> {
+  const options = parseRalphthonArgs(args);
+  const cwd = process.cwd();
+
+  // Resume mode
+  if (options.resume) {
+    const state = readRalphthonState(cwd);
+    if (!state || !state.active) {
+      console.error(chalk.red('No active ralphthon session found to resume.'));
+      process.exit(1);
+    }
+
+    console.log(chalk.blue('Resuming ralphthon session...'));
+    const prd = readRalphthonPrd(cwd);
+    if (prd) {
+      console.log(formatRalphthonStatus(prd));
+    }
+
+    const eventLogger = createEventLogger();
+    const { stop } = startOrchestratorLoop(cwd, state.sessionId, eventLogger);
+
+    // Handle graceful shutdown
+    const shutdown = () => {
+      console.log(chalk.yellow('\nStopping ralphthon orchestrator...'));
+      stop();
+      process.exit(0);
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+
+    return;
+  }
+
+  // New session — need task description
+  if (!options.task) {
+    console.error(chalk.red('Task description required. Usage: omc ralphthon "your task"'));
+    console.log(RALPHTHON_HELP);
+    process.exit(1);
+  }
+
+  // Must be inside tmux
+  if (!isInsideTmux()) {
+    console.error(chalk.red('Ralphthon requires tmux. Run inside a tmux session or use `omc` to launch one.'));
+    process.exit(1);
+  }
+
+  const tmuxSession = getCurrentTmuxSession();
+  const leaderPane = getCurrentTmuxPane();
+
+  if (!tmuxSession || !leaderPane) {
+    console.error(chalk.red('Could not detect tmux session/pane.'));
+    process.exit(1);
+  }
+
+  // Check for existing session
+  const existingState = readRalphthonState(cwd);
+  if (existingState?.active) {
+    console.error(chalk.red('A ralphthon session is already active. Use --resume or cancel it first.'));
+    process.exit(1);
+  }
+
+  const sessionId = `ralphthon-${Date.now()}`;
+  const config: Partial<RalphthonConfig> = {
+    maxWaves: options.maxWaves,
+    pollIntervalMs: options.pollInterval * 1000,
+    skipInterview: options.skipInterview,
+  };
+
+  console.log(chalk.blue.bold('Starting Ralphthon'));
+  console.log(chalk.gray(`Task: ${options.task}`));
+  console.log(chalk.gray(`Max waves: ${options.maxWaves}, Poll: ${options.pollInterval}s`));
+  console.log(chalk.gray(`Skip interview: ${options.skipInterview}`));
+
+  // Phase 1: Interview (unless skipped)
+  if (!options.skipInterview) {
+    console.log(chalk.cyan('\nPhase 1: Deep Interview — generating PRD...'));
+    console.log(chalk.gray('The leader pane will run deep-interview to generate the PRD.'));
+
+    // Inject deep-interview command to the leader pane
+    // The orchestrator will wait for the PRD to appear
+    const interviewPrompt = `/deep-interview ${options.task}
+
+After the interview, generate a ralphthon-prd.json file in .omc/ with this structure:
+{
+  "project": "<project name>",
+  "branchName": "<branch>",
+  "description": "<description>",
+  "stories": [{ "id": "US-001", "title": "...", "description": "...", "acceptanceCriteria": [...], "priority": "high", "tasks": [{ "id": "T-001", "title": "...", "description": "...", "status": "pending", "retries": 0 }] }],
+  "hardening": [],
+  "config": { "maxWaves": ${options.maxWaves}, "cleanWavesForTermination": 3, "pollIntervalMs": ${options.pollInterval * 1000}, "idleThresholdMs": 30000, "maxRetries": 3, "skipInterview": false }
+}`;
+
+    // Initialize state in interview phase
+    const state = initOrchestrator(
+      cwd,
+      tmuxSession,
+      leaderPane,
+      getRalphthonPrdPath(cwd),
+      sessionId,
+      config,
+    );
+    state.phase = 'interview';
+    writeRalphthonState(cwd, state, sessionId);
+
+    console.log(chalk.gray('Waiting for PRD generation...'));
+
+    // Poll for PRD file to appear
+    const prdPath = getRalphthonPrdPath(cwd);
+    const maxWaitMs = 600_000; // 10 minutes max wait for interview
+    const pollMs = 5_000;
+    let waited = 0;
+
+    while (waited < maxWaitMs) {
+      if (existsSync(prdPath)) {
+        const prd = readRalphthonPrd(cwd);
+        if (prd && prd.stories.length > 0) {
+          console.log(chalk.green('PRD generated successfully!'));
+          console.log(formatRalphthonStatus(prd));
+          break;
+        }
+      }
+      await sleep(pollMs);
+      waited += pollMs;
+    }
+
+    if (waited >= maxWaitMs) {
+      console.error(chalk.red('Timed out waiting for PRD generation.'));
+      clearRalphthonState(cwd, sessionId);
+      process.exit(1);
+    }
+  } else {
+    // Skip interview — create a simple PRD from the task
+    console.log(chalk.cyan('\nSkipping interview — creating PRD from task...'));
+
+    initRalphthonPrd(cwd, 'ralphthon', 'feat/ralphthon', options.task, [
+      {
+        id: 'US-001',
+        title: options.task.slice(0, 60),
+        description: options.task,
+        acceptanceCriteria: ['Implementation complete', 'Tests pass', 'No type errors'],
+        priority: 'high',
+        tasks: [
+          {
+            id: 'T-001',
+            title: options.task.slice(0, 60),
+            description: options.task,
+            status: 'pending',
+            retries: 0,
+          },
+        ],
+      },
+    ], config);
+
+    initOrchestrator(
+      cwd,
+      tmuxSession,
+      leaderPane,
+      getRalphthonPrdPath(cwd),
+      sessionId,
+      config,
+    );
+  }
+
+  // Phase 2: Execution — start the orchestrator loop
+  console.log(chalk.cyan('\nPhase 2: Execution — ralph loop active'));
+
+  const eventLogger = createEventLogger();
+  const { stop } = startOrchestratorLoop(cwd, sessionId, eventLogger);
+
+  // Handle graceful shutdown
+  const shutdown = () => {
+    console.log(chalk.yellow('\nStopping ralphthon orchestrator...'));
+    stop();
+    clearRalphthonState(cwd, sessionId);
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  // Keep process alive
+  console.log(chalk.gray('Orchestrator running. Press Ctrl+C to stop.'));
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,6 +45,7 @@ import {
 import { doctorConflictsCommand } from './commands/doctor-conflicts.js';
 import { sessionSearchCommand } from './commands/session-search.js';
 import { teamCommand } from './commands/team.js';
+import { ralphthonCommand } from './commands/ralphthon.js';
 import {
   teleportCommand,
   teleportListCommand,
@@ -1345,6 +1346,23 @@ program
   .argument('[args...]', 'autoresearch subcommand arguments')
   .action(async (args: string[]) => {
     await autoresearchCommand(args);
+  });
+
+/**
+ * Ralphthon command - Autonomous hackathon lifecycle
+ *
+ * Deep-interview generates PRD, ralph loop executes tasks,
+ * auto-hardening phase, terminates after clean waves.
+ */
+program
+  .command('ralphthon')
+  .description('Autonomous hackathon lifecycle: interview -> execute -> harden -> done')
+  .helpOption(false)
+  .allowUnknownOption(true)
+  .allowExcessArguments(true)
+  .argument('[args...]', 'ralphthon arguments')
+  .action(async (args: string[]) => {
+    await ralphthonCommand(args);
   });
 
 // Parse arguments

--- a/src/ralphthon/__tests__/cli.test.ts
+++ b/src/ralphthon/__tests__/cli.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for Ralphthon CLI Argument Parsing
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseRalphthonArgs } from '../../cli/commands/ralphthon.js';
+import { RALPHTHON_DEFAULTS } from '../types.js';
+
+describe('Ralphthon CLI', () => {
+  describe('parseRalphthonArgs', () => {
+    it('should parse empty args with defaults', () => {
+      const options = parseRalphthonArgs([]);
+      expect(options.resume).toBe(false);
+      expect(options.skipInterview).toBe(false);
+      expect(options.maxWaves).toBe(RALPHTHON_DEFAULTS.maxWaves);
+      expect(options.pollInterval).toBe(RALPHTHON_DEFAULTS.pollIntervalMs / 1000);
+      expect(options.task).toBeUndefined();
+    });
+
+    it('should parse task description', () => {
+      const options = parseRalphthonArgs(['Build', 'a', 'REST', 'API']);
+      expect(options.task).toBe('Build a REST API');
+    });
+
+    it('should parse --resume flag', () => {
+      const options = parseRalphthonArgs(['--resume']);
+      expect(options.resume).toBe(true);
+    });
+
+    it('should parse --skip-interview flag', () => {
+      const options = parseRalphthonArgs(['--skip-interview', 'my task']);
+      expect(options.skipInterview).toBe(true);
+      expect(options.task).toBe('my task');
+    });
+
+    it('should parse --max-waves option', () => {
+      const options = parseRalphthonArgs(['--max-waves', '5', 'my task']);
+      expect(options.maxWaves).toBe(5);
+      expect(options.task).toBe('my task');
+    });
+
+    it('should parse --poll-interval option', () => {
+      const options = parseRalphthonArgs(['--poll-interval', '60', 'my task']);
+      expect(options.pollInterval).toBe(60);
+    });
+
+    it('should handle combined options', () => {
+      const options = parseRalphthonArgs([
+        '--skip-interview',
+        '--max-waves', '3',
+        '--poll-interval', '30',
+        'Build auth system',
+      ]);
+
+      expect(options.skipInterview).toBe(true);
+      expect(options.maxWaves).toBe(3);
+      expect(options.pollInterval).toBe(30);
+      expect(options.task).toBe('Build auth system');
+    });
+
+    it('should ignore invalid --max-waves values', () => {
+      const options = parseRalphthonArgs(['--max-waves', 'abc', 'task']);
+      expect(options.maxWaves).toBe(RALPHTHON_DEFAULTS.maxWaves);
+    });
+
+    it('should ignore negative --poll-interval values', () => {
+      const options = parseRalphthonArgs(['--poll-interval', '-5', 'task']);
+      expect(options.pollInterval).toBe(RALPHTHON_DEFAULTS.pollIntervalMs / 1000);
+    });
+
+    it('should ignore unknown flags', () => {
+      const options = parseRalphthonArgs(['--unknown', 'my task']);
+      expect(options.task).toBe('my task');
+    });
+  });
+});

--- a/src/ralphthon/__tests__/orchestrator.test.ts
+++ b/src/ralphthon/__tests__/orchestrator.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Tests for Ralphthon Orchestrator
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  readRalphthonState,
+  writeRalphthonState,
+  clearRalphthonState,
+  initOrchestrator,
+  getNextAction,
+  transitionPhase,
+  startHardeningWave,
+  endHardeningWave,
+  recordTaskCompletion,
+  recordTaskSkip,
+  detectCompletionSignal,
+} from '../orchestrator.js';
+import {
+  writeRalphthonPrd,
+  createRalphthonPrd,
+} from '../prd.js';
+import type {
+  RalphthonState,
+  RalphthonStory,
+  OrchestratorEvent,
+} from '../types.js';
+import { RALPHTHON_DEFAULTS } from '../types.js';
+
+describe('Ralphthon Orchestrator', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'ralphthon-orch-test-'));
+    mkdirSync(join(testDir, '.omc', 'state'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // ============================================================================
+  // State Management
+  // ============================================================================
+
+  describe('state management', () => {
+    it('should return null when no state exists', () => {
+      expect(readRalphthonState(testDir)).toBeNull();
+    });
+
+    it('should write and read state', () => {
+      const state = createTestState();
+      expect(writeRalphthonState(testDir, state)).toBe(true);
+
+      const result = readRalphthonState(testDir);
+      expect(result).not.toBeNull();
+      expect(result!.active).toBe(true);
+      expect(result!.phase).toBe('execution');
+    });
+
+    it('should reject state from different session', () => {
+      const state = createTestState();
+      state.sessionId = 'session-1';
+      writeRalphthonState(testDir, state, 'session-1');
+
+      const result = readRalphthonState(testDir, 'session-2');
+      expect(result).toBeNull();
+    });
+
+    it('should clear state', () => {
+      const state = createTestState();
+      writeRalphthonState(testDir, state);
+
+      expect(clearRalphthonState(testDir)).toBe(true);
+      expect(readRalphthonState(testDir)).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Orchestrator Init
+  // ============================================================================
+
+  describe('initOrchestrator', () => {
+    it('should create initial state', () => {
+      const state = initOrchestrator(
+        testDir,
+        'omc-test-session',
+        '%0',
+        'prd.json',
+        'test-session',
+      );
+
+      expect(state.active).toBe(true);
+      expect(state.phase).toBe('execution');
+      expect(state.tmuxSession).toBe('omc-test-session');
+      expect(state.leaderPaneId).toBe('%0');
+      expect(state.currentWave).toBe(0);
+      expect(state.consecutiveCleanWaves).toBe(0);
+    });
+
+    it('should persist state to disk', () => {
+      initOrchestrator(testDir, 'omc-test', '%0', 'prd.json', 'test-session');
+
+      const state = readRalphthonState(testDir, 'test-session');
+      expect(state).not.toBeNull();
+      expect(state!.active).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // Next Action Logic
+  // ============================================================================
+
+  describe('getNextAction', () => {
+    it('should return complete when no state', () => {
+      const result = getNextAction(testDir);
+      expect(result.action).toBe('complete');
+    });
+
+    it('should inject task during execution phase', () => {
+      const sessionId = 'test-session';
+      setupExecutionPhase(testDir, sessionId);
+
+      const result = getNextAction(testDir, sessionId);
+      expect(result.action).toBe('inject_task');
+      expect(result.prompt).toContain('T-001');
+    });
+
+    it('should transition to hardening when all stories done', () => {
+      const sessionId = 'test-session';
+      setupExecutionPhase(testDir, sessionId);
+
+      // Mark all tasks as done
+      const prd = createTestPrdWithTasks();
+      prd.stories[0].tasks[0].status = 'done';
+      prd.stories[0].tasks[1].status = 'done';
+      prd.stories[1].tasks[0].status = 'done';
+      writeRalphthonPrd(testDir, prd);
+
+      const result = getNextAction(testDir, sessionId);
+      expect(result.action).toBe('generate_hardening');
+    });
+
+    it('should inject hardening task during hardening phase', () => {
+      const sessionId = 'test-session';
+      setupHardeningPhase(testDir, sessionId);
+
+      const result = getNextAction(testDir, sessionId);
+      expect(result.action).toBe('inject_hardening');
+      expect(result.prompt).toContain('HARDENING');
+    });
+
+    it('should complete when consecutive clean waves reached', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'hardening';
+      state.consecutiveCleanWaves = 3;
+      writeRalphthonState(testDir, state, sessionId);
+
+      // Create PRD with config
+      const prd = createTestPrdWithTasks();
+      prd.config.cleanWavesForTermination = 3;
+      writeRalphthonPrd(testDir, prd);
+
+      const result = getNextAction(testDir, sessionId);
+      expect(result.action).toBe('complete');
+    });
+
+    it('should complete when max waves reached', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'hardening';
+      state.currentWave = 10;
+      writeRalphthonState(testDir, state, sessionId);
+
+      const prd = createTestPrdWithTasks();
+      prd.config.maxWaves = 10;
+      writeRalphthonPrd(testDir, prd);
+
+      const result = getNextAction(testDir, sessionId);
+      expect(result.action).toBe('complete');
+    });
+
+    it('should wait during interview phase', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'interview';
+      writeRalphthonState(testDir, state, sessionId);
+
+      const result = getNextAction(testDir, sessionId);
+      expect(result.action).toBe('wait');
+    });
+
+    it('should generate new hardening wave when current wave done', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'hardening';
+      state.currentWave = 1;
+      state.consecutiveCleanWaves = 0;
+      writeRalphthonState(testDir, state, sessionId);
+
+      // PRD with all hardening done
+      const prd = createTestPrdWithTasks();
+      prd.stories[0].tasks[0].status = 'done';
+      prd.stories[0].tasks[1].status = 'done';
+      prd.stories[1].tasks[0].status = 'done';
+      prd.hardening = [
+        { id: 'H-01-001', title: 'Done', description: 'done', category: 'test', status: 'done', wave: 1, retries: 0 },
+      ];
+      writeRalphthonPrd(testDir, prd);
+
+      const result = getNextAction(testDir, sessionId);
+      expect(result.action).toBe('generate_hardening');
+    });
+  });
+
+  // ============================================================================
+  // Phase Transitions
+  // ============================================================================
+
+  describe('transitionPhase', () => {
+    it('should transition phase and emit event', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      writeRalphthonState(testDir, state, sessionId);
+
+      const events: OrchestratorEvent[] = [];
+      const handler = (e: OrchestratorEvent) => events.push(e);
+
+      transitionPhase(testDir, 'hardening', sessionId, handler);
+
+      const updated = readRalphthonState(testDir, sessionId);
+      expect(updated!.phase).toBe('hardening');
+      expect(updated!.active).toBe(true);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('phase_transition');
+    });
+
+    it('should deactivate on complete', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      writeRalphthonState(testDir, state, sessionId);
+
+      transitionPhase(testDir, 'complete', sessionId);
+
+      const updated = readRalphthonState(testDir, sessionId);
+      expect(updated!.active).toBe(false);
+      expect(updated!.phase).toBe('complete');
+    });
+  });
+
+  // ============================================================================
+  // Hardening Waves
+  // ============================================================================
+
+  describe('startHardeningWave', () => {
+    it('should increment wave count', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'hardening';
+      writeRalphthonState(testDir, state, sessionId);
+
+      const prd = createTestPrdWithTasks();
+      writeRalphthonPrd(testDir, prd);
+
+      const events: OrchestratorEvent[] = [];
+      const result = startHardeningWave(testDir, sessionId, e => events.push(e));
+
+      expect(result).not.toBeNull();
+      expect(result!.wave).toBe(1);
+
+      const updated = readRalphthonState(testDir, sessionId);
+      expect(updated!.currentWave).toBe(1);
+      expect(events[0].type).toBe('hardening_wave_start');
+    });
+
+    it('should transition to hardening phase if not already', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'execution';
+      writeRalphthonState(testDir, state, sessionId);
+
+      const prd = createTestPrdWithTasks();
+      writeRalphthonPrd(testDir, prd);
+
+      startHardeningWave(testDir, sessionId);
+
+      const updated = readRalphthonState(testDir, sessionId);
+      expect(updated!.phase).toBe('hardening');
+    });
+  });
+
+  describe('endHardeningWave', () => {
+    it('should increment consecutive clean waves on zero issues', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'hardening';
+      state.currentWave = 1;
+      state.consecutiveCleanWaves = 1;
+      writeRalphthonState(testDir, state, sessionId);
+
+      const prd = createTestPrdWithTasks();
+      writeRalphthonPrd(testDir, prd);
+
+      const result = endHardeningWave(testDir, 0, sessionId);
+
+      const updated = readRalphthonState(testDir, sessionId);
+      expect(updated!.consecutiveCleanWaves).toBe(2);
+      expect(result.shouldTerminate).toBe(false);
+    });
+
+    it('should reset consecutive clean waves on new issues', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'hardening';
+      state.currentWave = 1;
+      state.consecutiveCleanWaves = 2;
+      writeRalphthonState(testDir, state, sessionId);
+
+      const prd = createTestPrdWithTasks();
+      writeRalphthonPrd(testDir, prd);
+
+      endHardeningWave(testDir, 3, sessionId);
+
+      const updated = readRalphthonState(testDir, sessionId);
+      expect(updated!.consecutiveCleanWaves).toBe(0);
+    });
+
+    it('should signal termination after clean waves threshold', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.phase = 'hardening';
+      state.currentWave = 3;
+      state.consecutiveCleanWaves = 2;
+      writeRalphthonState(testDir, state, sessionId);
+
+      const prd = createTestPrdWithTasks();
+      prd.config.cleanWavesForTermination = 3;
+      writeRalphthonPrd(testDir, prd);
+
+      const result = endHardeningWave(testDir, 0, sessionId);
+      expect(result.shouldTerminate).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // Task Recording
+  // ============================================================================
+
+  describe('recordTaskCompletion', () => {
+    it('should increment completed count', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.currentTaskId = 'T-001';
+      writeRalphthonState(testDir, state, sessionId);
+
+      const events: OrchestratorEvent[] = [];
+      recordTaskCompletion(testDir, 'T-001', sessionId, e => events.push(e));
+
+      const updated = readRalphthonState(testDir, sessionId);
+      expect(updated!.tasksCompleted).toBe(1);
+      expect(updated!.currentTaskId).toBeUndefined();
+      expect(events[0].type).toBe('task_completed');
+    });
+  });
+
+  describe('recordTaskSkip', () => {
+    it('should increment skipped count', () => {
+      const sessionId = 'test-session';
+      const state = createTestState();
+      state.sessionId = sessionId;
+      state.currentTaskId = 'T-001';
+      writeRalphthonState(testDir, state, sessionId);
+
+      const events: OrchestratorEvent[] = [];
+      recordTaskSkip(testDir, 'T-001', 'max retries', sessionId, e => events.push(e));
+
+      const updated = readRalphthonState(testDir, sessionId);
+      expect(updated!.tasksSkipped).toBe(1);
+      expect(events[0].type).toBe('task_skipped');
+    });
+  });
+
+  // ============================================================================
+  // Completion Signal Detection
+  // ============================================================================
+
+  describe('detectCompletionSignal', () => {
+    // These tests verify regex patterns without needing real tmux
+    it('should match completion patterns', () => {
+      const patterns = [
+        'all stories complete',
+        'All tasks are done',
+        'ralphthon complete',
+        'hardening complete',
+        'no new issues found',
+        'No issues found',
+      ];
+
+      // Test against the regex patterns directly
+      const completionPatterns = [
+        /all\s+(?:stories|tasks)\s+(?:are\s+)?(?:complete|done)/i,
+        /ralphthon\s+complete/i,
+        /hardening\s+complete/i,
+        /no\s+(?:new\s+)?issues?\s+found/i,
+      ];
+
+      for (const text of patterns) {
+        const matches = completionPatterns.some(p => p.test(text));
+        expect(matches).toBe(true);
+      }
+    });
+  });
+});
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createTestState(): RalphthonState {
+  return {
+    active: true,
+    phase: 'execution',
+    projectPath: '/tmp/test',
+    prdPath: 'ralphthon-prd.json',
+    tmuxSession: 'omc-test',
+    leaderPaneId: '%0',
+    startedAt: new Date().toISOString(),
+    currentWave: 0,
+    consecutiveCleanWaves: 0,
+    tasksCompleted: 0,
+    tasksSkipped: 0,
+  };
+}
+
+function createTestPrdWithTasks() {
+  const stories: RalphthonStory[] = [
+    {
+      id: 'US-001',
+      title: 'First story',
+      description: 'Feature A',
+      acceptanceCriteria: ['works'],
+      priority: 'high',
+      tasks: [
+        { id: 'T-001', title: 'Build A', description: 'Build A', status: 'pending', retries: 0 },
+        { id: 'T-002', title: 'Test A', description: 'Test A', status: 'pending', retries: 0 },
+      ],
+    },
+    {
+      id: 'US-002',
+      title: 'Second story',
+      description: 'Feature B',
+      acceptanceCriteria: ['works'],
+      priority: 'medium',
+      tasks: [
+        { id: 'T-003', title: 'Build B', description: 'Build B', status: 'pending', retries: 0 },
+      ],
+    },
+  ];
+
+  return createRalphthonPrd('test-project', 'feat/test', 'Test', stories);
+}
+
+function setupExecutionPhase(testDir: string, sessionId: string) {
+  const state = createTestState();
+  state.sessionId = sessionId;
+  state.phase = 'execution';
+  writeRalphthonState(testDir, state, sessionId);
+
+  const prd = createTestPrdWithTasks();
+  writeRalphthonPrd(testDir, prd);
+}
+
+function setupHardeningPhase(testDir: string, sessionId: string) {
+  const state = createTestState();
+  state.sessionId = sessionId;
+  state.phase = 'hardening';
+  state.currentWave = 1;
+  writeRalphthonState(testDir, state, sessionId);
+
+  const prd = createTestPrdWithTasks();
+  prd.stories[0].tasks[0].status = 'done';
+  prd.stories[0].tasks[1].status = 'done';
+  prd.stories[1].tasks[0].status = 'done';
+  prd.hardening = [
+    { id: 'H-01-001', title: 'Edge test', description: 'Test edge case', category: 'edge_case', status: 'pending', wave: 1, retries: 0 },
+  ];
+  writeRalphthonPrd(testDir, prd);
+}

--- a/src/ralphthon/__tests__/prd.test.ts
+++ b/src/ralphthon/__tests__/prd.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Tests for Ralphthon PRD Module
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  readRalphthonPrd,
+  writeRalphthonPrd,
+  getRalphthonPrdStatus,
+  updateTaskStatus,
+  incrementTaskRetry,
+  updateHardeningTaskStatus,
+  incrementHardeningTaskRetry,
+  addHardeningTasks,
+  createRalphthonPrd,
+  initRalphthonPrd,
+  formatTaskPrompt,
+  formatHardeningTaskPrompt,
+  formatRalphthonStatus,
+} from '../prd.js';
+import type {
+  RalphthonPRD,
+  RalphthonStory,
+  HardeningTask,
+} from '../types.js';
+import { RALPHTHON_DEFAULTS } from '../types.js';
+
+describe('Ralphthon PRD', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'ralphthon-prd-test-'));
+    // Create .omc directory for PRD storage
+    mkdirSync(join(testDir, '.omc'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // ============================================================================
+  // Read/Write Operations
+  // ============================================================================
+
+  describe('readRalphthonPrd', () => {
+    it('should return null when no PRD exists', () => {
+      expect(readRalphthonPrd(testDir)).toBeNull();
+    });
+
+    it('should read a valid PRD from .omc directory', () => {
+      const prd = createTestPrd();
+      writeRalphthonPrd(testDir, prd);
+
+      const result = readRalphthonPrd(testDir);
+      expect(result).not.toBeNull();
+      expect(result!.project).toBe('test-project');
+      expect(result!.stories).toHaveLength(2);
+    });
+
+    it('should return null for invalid JSON', () => {
+      const { writeFileSync } = require('fs');
+      writeFileSync(join(testDir, '.omc', 'ralphthon-prd.json'), 'invalid json');
+      expect(readRalphthonPrd(testDir)).toBeNull();
+    });
+
+    it('should return null for PRD without stories array', () => {
+      const { writeFileSync } = require('fs');
+      writeFileSync(
+        join(testDir, '.omc', 'ralphthon-prd.json'),
+        JSON.stringify({ project: 'x', config: {} }),
+      );
+      expect(readRalphthonPrd(testDir)).toBeNull();
+    });
+  });
+
+  describe('writeRalphthonPrd', () => {
+    it('should write PRD to .omc directory', () => {
+      const prd = createTestPrd();
+      expect(writeRalphthonPrd(testDir, prd)).toBe(true);
+
+      const result = readRalphthonPrd(testDir);
+      expect(result).not.toBeNull();
+      expect(result!.project).toBe('test-project');
+    });
+
+    it('should create .omc directory if missing', () => {
+      rmSync(join(testDir, '.omc'), { recursive: true, force: true });
+      const prd = createTestPrd();
+      expect(writeRalphthonPrd(testDir, prd)).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // Status Computation
+  // ============================================================================
+
+  describe('getRalphthonPrdStatus', () => {
+    it('should compute correct status for fresh PRD', () => {
+      const prd = createTestPrd();
+      const status = getRalphthonPrdStatus(prd);
+
+      expect(status.totalStories).toBe(2);
+      expect(status.completedStories).toBe(0);
+      expect(status.totalTasks).toBe(3);
+      expect(status.completedTasks).toBe(0);
+      expect(status.pendingTasks).toBe(3);
+      expect(status.allStoriesDone).toBe(false);
+      expect(status.nextTask).not.toBeNull();
+      expect(status.nextTask!.task.id).toBe('T-001');
+    });
+
+    it('should detect all stories done', () => {
+      const prd = createTestPrd();
+      prd.stories[0].tasks[0].status = 'done';
+      prd.stories[0].tasks[1].status = 'done';
+      prd.stories[1].tasks[0].status = 'done';
+
+      const status = getRalphthonPrdStatus(prd);
+      expect(status.allStoriesDone).toBe(true);
+      expect(status.completedStories).toBe(2);
+      expect(status.nextTask).toBeNull();
+    });
+
+    it('should count skipped tasks as story completion', () => {
+      const prd = createTestPrd();
+      prd.stories[0].tasks[0].status = 'done';
+      prd.stories[0].tasks[1].status = 'skipped';
+
+      const status = getRalphthonPrdStatus(prd);
+      expect(status.completedStories).toBe(1); // story 0 complete (done+skipped)
+    });
+
+    it('should find next task by story priority', () => {
+      const prd = createTestPrd();
+      // story[0] has priority 'high', story[1] has 'medium'
+      prd.stories[0].tasks[0].status = 'done';
+      prd.stories[0].tasks[1].status = 'done';
+
+      const status = getRalphthonPrdStatus(prd);
+      expect(status.nextTask!.storyId).toBe('US-002');
+    });
+
+    it('should report hardening status', () => {
+      const prd = createTestPrd();
+      prd.hardening = [
+        { id: 'H-01-001', title: 'Test edge case', description: 'test', category: 'edge_case', status: 'done', wave: 1, retries: 0 },
+        { id: 'H-01-002', title: 'Add test', description: 'test', category: 'test', status: 'pending', wave: 1, retries: 0 },
+      ];
+
+      const status = getRalphthonPrdStatus(prd);
+      expect(status.totalHardeningTasks).toBe(2);
+      expect(status.completedHardeningTasks).toBe(1);
+      expect(status.pendingHardeningTasks).toBe(1);
+      expect(status.allHardeningDone).toBe(false);
+      expect(status.nextHardeningTask!.id).toBe('H-01-002');
+    });
+  });
+
+  // ============================================================================
+  // Task Operations
+  // ============================================================================
+
+  describe('updateTaskStatus', () => {
+    it('should update a task status', () => {
+      const prd = createTestPrd();
+      writeRalphthonPrd(testDir, prd);
+
+      expect(updateTaskStatus(testDir, 'US-001', 'T-001', 'done', 'Implemented')).toBe(true);
+
+      const updated = readRalphthonPrd(testDir)!;
+      expect(updated.stories[0].tasks[0].status).toBe('done');
+      expect(updated.stories[0].tasks[0].notes).toBe('Implemented');
+    });
+
+    it('should return false for non-existent story', () => {
+      const prd = createTestPrd();
+      writeRalphthonPrd(testDir, prd);
+
+      expect(updateTaskStatus(testDir, 'US-999', 'T-001', 'done')).toBe(false);
+    });
+
+    it('should return false for non-existent task', () => {
+      const prd = createTestPrd();
+      writeRalphthonPrd(testDir, prd);
+
+      expect(updateTaskStatus(testDir, 'US-001', 'T-999', 'done')).toBe(false);
+    });
+  });
+
+  describe('incrementTaskRetry', () => {
+    it('should increment retry count', () => {
+      const prd = createTestPrd();
+      writeRalphthonPrd(testDir, prd);
+
+      const result = incrementTaskRetry(testDir, 'US-001', 'T-001', 3);
+      expect(result.retries).toBe(1);
+      expect(result.skipped).toBe(false);
+    });
+
+    it('should skip task after max retries', () => {
+      const prd = createTestPrd();
+      prd.stories[0].tasks[0].retries = 2;
+      writeRalphthonPrd(testDir, prd);
+
+      const result = incrementTaskRetry(testDir, 'US-001', 'T-001', 3);
+      expect(result.retries).toBe(3);
+      expect(result.skipped).toBe(true);
+
+      const updated = readRalphthonPrd(testDir)!;
+      expect(updated.stories[0].tasks[0].status).toBe('skipped');
+    });
+  });
+
+  // ============================================================================
+  // Hardening Operations
+  // ============================================================================
+
+  describe('addHardeningTasks', () => {
+    it('should add hardening tasks to PRD', () => {
+      const prd = createTestPrd();
+      writeRalphthonPrd(testDir, prd);
+
+      const tasks = [
+        { id: 'H-01-001', title: 'Edge case test', description: 'Test edge case', category: 'edge_case' as const, wave: 1 },
+        { id: 'H-01-002', title: 'Add validation', description: 'Validate inputs', category: 'quality' as const, wave: 1 },
+      ];
+
+      expect(addHardeningTasks(testDir, tasks)).toBe(true);
+
+      const updated = readRalphthonPrd(testDir)!;
+      expect(updated.hardening).toHaveLength(2);
+      expect(updated.hardening[0].status).toBe('pending');
+      expect(updated.hardening[0].retries).toBe(0);
+    });
+
+    it('should append to existing hardening tasks', () => {
+      const prd = createTestPrd();
+      prd.hardening = [
+        { id: 'H-01-001', title: 'Existing', description: 'existing', category: 'test', status: 'done', wave: 1, retries: 0 },
+      ];
+      writeRalphthonPrd(testDir, prd);
+
+      addHardeningTasks(testDir, [
+        { id: 'H-02-001', title: 'New', description: 'new', category: 'quality' as const, wave: 2 },
+      ]);
+
+      const updated = readRalphthonPrd(testDir)!;
+      expect(updated.hardening).toHaveLength(2);
+    });
+  });
+
+  describe('updateHardeningTaskStatus', () => {
+    it('should update hardening task status', () => {
+      const prd = createTestPrd();
+      prd.hardening = [
+        { id: 'H-01-001', title: 'Test', description: 'test', category: 'test', status: 'pending', wave: 1, retries: 0 },
+      ];
+      writeRalphthonPrd(testDir, prd);
+
+      expect(updateHardeningTaskStatus(testDir, 'H-01-001', 'done', 'Fixed')).toBe(true);
+
+      const updated = readRalphthonPrd(testDir)!;
+      expect(updated.hardening[0].status).toBe('done');
+    });
+  });
+
+  describe('incrementHardeningTaskRetry', () => {
+    it('should skip hardening task after max retries', () => {
+      const prd = createTestPrd();
+      prd.hardening = [
+        { id: 'H-01-001', title: 'Test', description: 'test', category: 'test', status: 'pending', wave: 1, retries: 2 },
+      ];
+      writeRalphthonPrd(testDir, prd);
+
+      const result = incrementHardeningTaskRetry(testDir, 'H-01-001', 3);
+      expect(result.skipped).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // PRD Creation
+  // ============================================================================
+
+  describe('createRalphthonPrd', () => {
+    it('should create PRD with default config', () => {
+      const stories: RalphthonStory[] = [{
+        id: 'US-001',
+        title: 'Test',
+        description: 'test',
+        acceptanceCriteria: ['works'],
+        priority: 'high',
+        tasks: [{ id: 'T-001', title: 'Do it', description: 'do', status: 'pending', retries: 0 }],
+      }];
+
+      const prd = createRalphthonPrd('proj', 'main', 'desc', stories);
+      expect(prd.config.maxWaves).toBe(RALPHTHON_DEFAULTS.maxWaves);
+      expect(prd.hardening).toEqual([]);
+    });
+
+    it('should merge custom config', () => {
+      const prd = createRalphthonPrd('proj', 'main', 'desc', [], { maxWaves: 5 });
+      expect(prd.config.maxWaves).toBe(5);
+      expect(prd.config.maxRetries).toBe(RALPHTHON_DEFAULTS.maxRetries);
+    });
+  });
+
+  describe('initRalphthonPrd', () => {
+    it('should initialize PRD on disk', () => {
+      const stories: RalphthonStory[] = [{
+        id: 'US-001',
+        title: 'Test',
+        description: 'test',
+        acceptanceCriteria: ['works'],
+        priority: 'high',
+        tasks: [{ id: 'T-001', title: 'Do it', description: 'do', status: 'pending', retries: 0 }],
+      }];
+
+      expect(initRalphthonPrd(testDir, 'proj', 'main', 'desc', stories)).toBe(true);
+
+      const prd = readRalphthonPrd(testDir);
+      expect(prd).not.toBeNull();
+      expect(prd!.stories).toHaveLength(1);
+    });
+  });
+
+  // ============================================================================
+  // Formatting
+  // ============================================================================
+
+  describe('formatTaskPrompt', () => {
+    it('should format task prompt for injection', () => {
+      const prompt = formatTaskPrompt('US-001', {
+        id: 'T-001',
+        title: 'Build API',
+        description: 'Build REST API endpoints',
+        status: 'pending',
+        retries: 0,
+      });
+
+      expect(prompt).toContain('T-001');
+      expect(prompt).toContain('US-001');
+      expect(prompt).toContain('Build API');
+      expect(prompt).toContain('Build REST API endpoints');
+    });
+  });
+
+  describe('formatHardeningTaskPrompt', () => {
+    it('should format hardening task prompt', () => {
+      const prompt = formatHardeningTaskPrompt({
+        id: 'H-01-001',
+        title: 'Test null case',
+        description: 'Test what happens with null input',
+        category: 'edge_case',
+        status: 'pending',
+        wave: 1,
+        retries: 0,
+      });
+
+      expect(prompt).toContain('HARDENING');
+      expect(prompt).toContain('EDGE_CASE');
+      expect(prompt).toContain('H-01-001');
+    });
+  });
+
+  describe('formatRalphthonStatus', () => {
+    it('should format status summary', () => {
+      const prd = createTestPrd();
+      const status = formatRalphthonStatus(prd);
+
+      expect(status).toContain('test-project');
+      expect(status).toContain('0/2 complete');
+      expect(status).toContain('0/3 done');
+    });
+  });
+});
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createTestPrd(): RalphthonPRD {
+  return {
+    project: 'test-project',
+    branchName: 'feat/test',
+    description: 'Test project',
+    stories: [
+      {
+        id: 'US-001',
+        title: 'First story',
+        description: 'Implement feature A',
+        acceptanceCriteria: ['It works', 'Tests pass'],
+        priority: 'high',
+        tasks: [
+          { id: 'T-001', title: 'Build A', description: 'Build feature A', status: 'pending', retries: 0 },
+          { id: 'T-002', title: 'Test A', description: 'Test feature A', status: 'pending', retries: 0 },
+        ],
+      },
+      {
+        id: 'US-002',
+        title: 'Second story',
+        description: 'Implement feature B',
+        acceptanceCriteria: ['It works'],
+        priority: 'medium',
+        tasks: [
+          { id: 'T-003', title: 'Build B', description: 'Build feature B', status: 'pending', retries: 0 },
+        ],
+      },
+    ],
+    hardening: [],
+    config: { ...RALPHTHON_DEFAULTS },
+  };
+}

--- a/src/ralphthon/index.ts
+++ b/src/ralphthon/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Ralphthon Module
+ *
+ * Autonomous hackathon lifecycle: deep-interview -> PRD -> ralph execution ->
+ * auto-hardening -> termination after clean waves.
+ */
+
+// Types
+export type {
+  TaskPriority,
+  TaskStatus,
+  RalphthonPhase,
+  RalphthonTask,
+  RalphthonStory,
+  HardeningTask,
+  RalphthonConfig,
+  RalphthonPRD,
+  RalphthonState,
+  OrchestratorEvent,
+  OrchestratorEventHandler,
+  RalphthonCliOptions,
+} from './types.js';
+
+export { RALPHTHON_DEFAULTS, PRD_FILENAME } from './types.js';
+
+// PRD operations
+export {
+  getRalphthonPrdPath,
+  findRalphthonPrdPath,
+  readRalphthonPrd,
+  writeRalphthonPrd,
+  getRalphthonPrdStatus,
+  updateTaskStatus,
+  incrementTaskRetry,
+  updateHardeningTaskStatus,
+  incrementHardeningTaskRetry,
+  addHardeningTasks,
+  createRalphthonPrd,
+  initRalphthonPrd,
+  formatTaskPrompt,
+  formatHardeningTaskPrompt,
+  formatHardeningGenerationPrompt,
+  formatRalphthonStatus,
+} from './prd.js';
+
+export type { RalphthonPrdStatus } from './prd.js';
+
+// Orchestrator
+export {
+  readRalphthonState,
+  writeRalphthonState,
+  clearRalphthonState,
+  isPaneIdle,
+  paneExists,
+  sendKeysToPane,
+  capturePaneContent,
+  detectLeaderIdle,
+  detectCompletionSignal,
+  initOrchestrator,
+  getNextAction,
+  transitionPhase,
+  startHardeningWave,
+  endHardeningWave,
+  recordTaskCompletion,
+  recordTaskSkip,
+  orchestratorTick,
+  startOrchestratorLoop,
+} from './orchestrator.js';

--- a/src/ralphthon/orchestrator.ts
+++ b/src/ralphthon/orchestrator.ts
@@ -1,0 +1,632 @@
+/**
+ * Ralphthon Orchestrator
+ *
+ * Monitors the leader pane for idle/completion, injects tasks via tmux send-keys,
+ * manages phase transitions (execution -> hardening), and implements failure recovery.
+ *
+ * Dual trigger: idle detection (30s) + periodic poll (2min).
+ * Terminates after N consecutive hardening waves with no new issues.
+ */
+
+import { execSync } from 'child_process';
+import {
+  writeModeState,
+  readModeState,
+  clearModeStateFile,
+} from '../lib/mode-state-io.js';
+import {
+  readRalphthonPrd,
+  getRalphthonPrdStatus,
+  formatTaskPrompt,
+  formatHardeningTaskPrompt,
+  formatHardeningGenerationPrompt,
+} from './prd.js';
+import type {
+  RalphthonState,
+  RalphthonPhase,
+  RalphthonConfig,
+  OrchestratorEvent,
+  OrchestratorEventHandler,
+} from './types.js';
+import { RALPHTHON_DEFAULTS } from './types.js';
+
+// ============================================================================
+// State Management
+// ============================================================================
+
+const MODE_NAME = 'ralphthon';
+
+/**
+ * Read ralphthon state from disk
+ */
+export function readRalphthonState(
+  directory: string,
+  sessionId?: string,
+): RalphthonState | null {
+  const state = readModeState<RalphthonState>(MODE_NAME, directory, sessionId);
+  if (state && sessionId && state.sessionId && state.sessionId !== sessionId) {
+    return null;
+  }
+  return state;
+}
+
+/**
+ * Write ralphthon state to disk
+ */
+export function writeRalphthonState(
+  directory: string,
+  state: RalphthonState,
+  sessionId?: string,
+): boolean {
+  return writeModeState(
+    MODE_NAME,
+    state as unknown as Record<string, unknown>,
+    directory,
+    sessionId,
+  );
+}
+
+/**
+ * Clear ralphthon state
+ */
+export function clearRalphthonState(
+  directory: string,
+  sessionId?: string,
+): boolean {
+  return clearModeStateFile(MODE_NAME, directory, sessionId);
+}
+
+// ============================================================================
+// Tmux Interaction
+// ============================================================================
+
+/**
+ * Check if a tmux pane is idle (no running foreground process).
+ * Returns true if the pane's current command is a shell (bash/zsh/fish).
+ */
+export function isPaneIdle(paneId: string): boolean {
+  try {
+    const output = execSync(
+      `tmux display-message -t '${paneId}' -p '#{pane_current_command}'`,
+      { encoding: 'utf-8', timeout: 5000 },
+    ).trim();
+
+    const shellNames = ['bash', 'zsh', 'fish', 'sh', 'dash'];
+    return shellNames.includes(output);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a tmux pane exists
+ */
+export function paneExists(paneId: string): boolean {
+  try {
+    execSync(`tmux has-session -t '${paneId}' 2>/dev/null`, { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Send keys to a tmux pane (inject a command/prompt)
+ */
+export function sendKeysToPane(paneId: string, text: string): boolean {
+  try {
+    // Escape single quotes in the text for shell safety
+    const escaped = text.replace(/'/g, "'\\''");
+    execSync(
+      `tmux send-keys -t '${paneId}' '${escaped}' Enter`,
+      { timeout: 10000 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Capture the current content of a tmux pane
+ */
+export function capturePaneContent(paneId: string, lines = 50): string {
+  try {
+    return execSync(
+      `tmux capture-pane -t '${paneId}' -p -S -${lines}`,
+      { encoding: 'utf-8', timeout: 5000 },
+    ).trim();
+  } catch {
+    return '';
+  }
+}
+
+// ============================================================================
+// Idle Detection
+// ============================================================================
+
+/**
+ * Detect if the leader pane has been idle for longer than the threshold.
+ * Uses pane content analysis to detect completion patterns.
+ */
+export function detectLeaderIdle(
+  paneId: string,
+  state: RalphthonState,
+  config: RalphthonConfig,
+): { idle: boolean; durationMs: number } {
+  const isIdle = isPaneIdle(paneId);
+
+  if (!isIdle) {
+    return { idle: false, durationMs: 0 };
+  }
+
+  const now = Date.now();
+
+  if (!state.lastIdleDetectedAt) {
+    // First idle detection — mark it but don't trigger yet
+    return { idle: false, durationMs: 0 };
+  }
+
+  const idleSince = new Date(state.lastIdleDetectedAt).getTime();
+  const durationMs = now - idleSince;
+
+  return {
+    idle: durationMs >= config.idleThresholdMs,
+    durationMs,
+  };
+}
+
+/**
+ * Check pane content for completion signals
+ */
+export function detectCompletionSignal(paneId: string): boolean {
+  const content = capturePaneContent(paneId, 20);
+
+  const completionPatterns = [
+    /all\s+(?:stories|tasks)\s+(?:are\s+)?(?:complete|done)/i,
+    /ralphthon\s+complete/i,
+    /hardening\s+complete/i,
+    /no\s+(?:new\s+)?issues?\s+found/i,
+  ];
+
+  return completionPatterns.some(p => p.test(content));
+}
+
+// ============================================================================
+// Orchestrator Core
+// ============================================================================
+
+export interface OrchestratorOptions {
+  directory: string;
+  sessionId?: string;
+  config: RalphthonConfig;
+  onEvent?: OrchestratorEventHandler;
+}
+
+/**
+ * Initialize a new ralphthon orchestrator state
+ */
+export function initOrchestrator(
+  directory: string,
+  tmuxSession: string,
+  leaderPaneId: string,
+  prdPath: string,
+  sessionId?: string,
+  config?: Partial<RalphthonConfig>,
+): RalphthonState {
+  const state: RalphthonState = {
+    active: true,
+    phase: 'execution',
+    sessionId,
+    projectPath: directory,
+    prdPath,
+    tmuxSession,
+    leaderPaneId,
+    startedAt: new Date().toISOString(),
+    currentWave: 0,
+    consecutiveCleanWaves: 0,
+    tasksCompleted: 0,
+    tasksSkipped: 0,
+  };
+
+  writeRalphthonState(directory, state, sessionId);
+  return state;
+}
+
+/**
+ * Determine the next action the orchestrator should take.
+ * Returns a command string to inject, or null if no action needed.
+ */
+export function getNextAction(
+  directory: string,
+  sessionId?: string,
+): { action: 'inject_task' | 'inject_hardening' | 'generate_hardening' | 'complete' | 'wait'; prompt?: string } {
+  const state = readRalphthonState(directory, sessionId);
+  if (!state || !state.active) {
+    return { action: 'complete' };
+  }
+
+  const prd = readRalphthonPrd(directory);
+  if (!prd) {
+    return { action: 'wait' };
+  }
+
+  const status = getRalphthonPrdStatus(prd);
+  const config = prd.config;
+
+  switch (state.phase) {
+    case 'execution': {
+      if (status.allStoriesDone) {
+        // Transition to hardening phase
+        return { action: 'generate_hardening' };
+      }
+
+      if (status.nextTask) {
+        return {
+          action: 'inject_task',
+          prompt: formatTaskPrompt(status.nextTask.storyId, status.nextTask.task),
+        };
+      }
+
+      // All tasks in progress or failed, wait
+      return { action: 'wait' };
+    }
+
+    case 'hardening': {
+      // Check termination condition
+      if (state.consecutiveCleanWaves >= config.cleanWavesForTermination) {
+        return { action: 'complete' };
+      }
+
+      if (state.currentWave >= config.maxWaves) {
+        return { action: 'complete' };
+      }
+
+      if (status.nextHardeningTask) {
+        return {
+          action: 'inject_hardening',
+          prompt: formatHardeningTaskPrompt(status.nextHardeningTask),
+        };
+      }
+
+      // All hardening tasks for current wave done — generate new wave
+      if (status.allHardeningDone || status.totalHardeningTasks === 0) {
+        return { action: 'generate_hardening' };
+      }
+
+      return { action: 'wait' };
+    }
+
+    case 'complete':
+    case 'failed':
+      return { action: 'complete' };
+
+    case 'interview':
+      return { action: 'wait' };
+
+    default:
+      return { action: 'wait' };
+  }
+}
+
+/**
+ * Transition the orchestrator to a new phase
+ */
+export function transitionPhase(
+  directory: string,
+  newPhase: RalphthonPhase,
+  sessionId?: string,
+  onEvent?: OrchestratorEventHandler,
+): boolean {
+  const state = readRalphthonState(directory, sessionId);
+  if (!state) return false;
+
+  const oldPhase = state.phase;
+  state.phase = newPhase;
+
+  if (newPhase === 'complete') {
+    state.active = false;
+  }
+
+  const success = writeRalphthonState(directory, state, sessionId);
+
+  if (success && onEvent) {
+    onEvent({ type: 'phase_transition', from: oldPhase, to: newPhase });
+  }
+
+  return success;
+}
+
+/**
+ * Start a new hardening wave
+ */
+export function startHardeningWave(
+  directory: string,
+  sessionId?: string,
+  onEvent?: OrchestratorEventHandler,
+): { wave: number; prompt: string } | null {
+  const state = readRalphthonState(directory, sessionId);
+  if (!state) return null;
+
+  const prd = readRalphthonPrd(directory);
+  if (!prd) return null;
+
+  // Transition to hardening if not already
+  if (state.phase !== 'hardening') {
+    state.phase = 'hardening';
+  }
+
+  state.currentWave += 1;
+  writeRalphthonState(directory, state, sessionId);
+
+  if (onEvent) {
+    onEvent({ type: 'hardening_wave_start', wave: state.currentWave });
+  }
+
+  return {
+    wave: state.currentWave,
+    prompt: formatHardeningGenerationPrompt(state.currentWave, prd),
+  };
+}
+
+/**
+ * End a hardening wave and check if new issues were found
+ */
+export function endHardeningWave(
+  directory: string,
+  newIssueCount: number,
+  sessionId?: string,
+  onEvent?: OrchestratorEventHandler,
+): { shouldTerminate: boolean } {
+  const state = readRalphthonState(directory, sessionId);
+  if (!state) return { shouldTerminate: true };
+
+  const prd = readRalphthonPrd(directory);
+  if (!prd) return { shouldTerminate: true };
+
+  if (newIssueCount === 0) {
+    state.consecutiveCleanWaves += 1;
+  } else {
+    state.consecutiveCleanWaves = 0;
+  }
+
+  writeRalphthonState(directory, state, sessionId);
+
+  if (onEvent) {
+    onEvent({ type: 'hardening_wave_end', wave: state.currentWave, newIssues: newIssueCount });
+  }
+
+  const shouldTerminate =
+    state.consecutiveCleanWaves >= prd.config.cleanWavesForTermination ||
+    state.currentWave >= prd.config.maxWaves;
+
+  return { shouldTerminate };
+}
+
+/**
+ * Record a task completion
+ */
+export function recordTaskCompletion(
+  directory: string,
+  taskId: string,
+  sessionId?: string,
+  onEvent?: OrchestratorEventHandler,
+): boolean {
+  const state = readRalphthonState(directory, sessionId);
+  if (!state) return false;
+
+  state.tasksCompleted += 1;
+  state.currentTaskId = undefined;
+  const success = writeRalphthonState(directory, state, sessionId);
+
+  if (success && onEvent) {
+    onEvent({ type: 'task_completed', taskId });
+  }
+
+  return success;
+}
+
+/**
+ * Record a task skip (after max retries)
+ */
+export function recordTaskSkip(
+  directory: string,
+  taskId: string,
+  reason: string,
+  sessionId?: string,
+  onEvent?: OrchestratorEventHandler,
+): boolean {
+  const state = readRalphthonState(directory, sessionId);
+  if (!state) return false;
+
+  state.tasksSkipped += 1;
+  state.currentTaskId = undefined;
+  const success = writeRalphthonState(directory, state, sessionId);
+
+  if (success && onEvent) {
+    onEvent({ type: 'task_skipped', taskId, reason });
+  }
+
+  return success;
+}
+
+/**
+ * Execute one orchestrator tick.
+ * This is the main loop body — called by the poll interval and idle detector.
+ *
+ * Returns true if an action was taken, false if waiting.
+ */
+export function orchestratorTick(
+  directory: string,
+  sessionId?: string,
+  onEvent?: OrchestratorEventHandler,
+): boolean {
+  const state = readRalphthonState(directory, sessionId);
+  if (!state || !state.active) return false;
+
+  const prd = readRalphthonPrd(directory);
+  if (!prd) return false;
+
+  // Check if leader pane still exists
+  if (!paneExists(state.leaderPaneId)) {
+    transitionPhase(directory, 'failed', sessionId, onEvent);
+    if (onEvent) {
+      onEvent({ type: 'error', message: 'Leader pane no longer exists' });
+    }
+    return false;
+  }
+
+  // Get next action
+  const next = getNextAction(directory, sessionId);
+
+  switch (next.action) {
+    case 'inject_task':
+    case 'inject_hardening': {
+      if (!next.prompt) return false;
+
+      // Check if pane is idle before injecting
+      if (!isPaneIdle(state.leaderPaneId)) {
+        return false; // Leader is busy, wait
+      }
+
+      const sent = sendKeysToPane(state.leaderPaneId, next.prompt);
+      if (sent) {
+        // Update state with current task
+        state.lastPollAt = new Date().toISOString();
+        state.lastIdleDetectedAt = undefined; // Reset idle tracking
+        writeRalphthonState(directory, state, sessionId);
+
+        if (onEvent) {
+          onEvent({
+            type: 'task_injected',
+            taskId: 'current',
+            taskTitle: next.prompt.slice(0, 80),
+          });
+        }
+      }
+      return sent;
+    }
+
+    case 'generate_hardening': {
+      // Transition to hardening and inject generation prompt
+      const wave = startHardeningWave(directory, sessionId, onEvent);
+      if (!wave) return false;
+
+      if (!isPaneIdle(state.leaderPaneId)) {
+        return false;
+      }
+
+      return sendKeysToPane(state.leaderPaneId, wave.prompt);
+    }
+
+    case 'complete': {
+      transitionPhase(directory, 'complete', sessionId, onEvent);
+      if (onEvent) {
+        onEvent({
+          type: 'session_complete',
+          tasksCompleted: state.tasksCompleted,
+          tasksSkipped: state.tasksSkipped,
+        });
+      }
+      return true;
+    }
+
+    case 'wait':
+    default:
+      return false;
+  }
+}
+
+// ============================================================================
+// Orchestrator Run Loop
+// ============================================================================
+
+/**
+ * Start the orchestrator run loop.
+ * Runs until the session is complete or cancelled.
+ *
+ * This is an async function that uses setInterval for polling
+ * and returns a cleanup function.
+ */
+export function startOrchestratorLoop(
+  directory: string,
+  sessionId?: string,
+  onEvent?: OrchestratorEventHandler,
+): { stop: () => void } {
+  const state = readRalphthonState(directory, sessionId);
+  if (!state) {
+    return { stop: () => {} };
+  }
+
+  const prd = readRalphthonPrd(directory);
+  const config = prd?.config ?? RALPHTHON_DEFAULTS;
+
+  let idleCheckInterval: ReturnType<typeof setInterval> | null = null;
+  let pollInterval: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+
+  const tick = () => {
+    if (stopped) return;
+
+    const currentState = readRalphthonState(directory, sessionId);
+    if (!currentState || !currentState.active) {
+      stop();
+      return;
+    }
+
+    orchestratorTick(directory, sessionId, onEvent);
+  };
+
+  const idleCheck = () => {
+    if (stopped) return;
+
+    const currentState = readRalphthonState(directory, sessionId);
+    if (!currentState || !currentState.active) {
+      stop();
+      return;
+    }
+
+    const idleResult = detectLeaderIdle(
+      currentState.leaderPaneId,
+      currentState,
+      config,
+    );
+
+    if (isPaneIdle(currentState.leaderPaneId)) {
+      if (!currentState.lastIdleDetectedAt) {
+        currentState.lastIdleDetectedAt = new Date().toISOString();
+        writeRalphthonState(directory, currentState, sessionId);
+      }
+    } else {
+      if (currentState.lastIdleDetectedAt) {
+        currentState.lastIdleDetectedAt = undefined;
+        writeRalphthonState(directory, currentState, sessionId);
+      }
+    }
+
+    if (idleResult.idle) {
+      if (onEvent) {
+        onEvent({ type: 'idle_detected', durationMs: idleResult.durationMs });
+      }
+      // Trigger a tick on idle detection
+      tick();
+    }
+  };
+
+  const stop = () => {
+    stopped = true;
+    if (idleCheckInterval) clearInterval(idleCheckInterval);
+    if (pollInterval) clearInterval(pollInterval);
+  };
+
+  // Idle detection: check every 5 seconds for 30s threshold
+  idleCheckInterval = setInterval(idleCheck, 5000);
+
+  // Periodic poll
+  pollInterval = setInterval(tick, config.pollIntervalMs);
+
+  // Run first tick immediately
+  tick();
+
+  return { stop };
+}

--- a/src/ralphthon/prd.ts
+++ b/src/ralphthon/prd.ts
@@ -1,0 +1,432 @@
+/**
+ * Ralphthon PRD Module
+ *
+ * Extended PRD schema with hardening support for the ralphthon lifecycle.
+ * Handles read/write/status operations for ralphthon-prd.json.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { getOmcRoot } from '../lib/worktree-paths.js';
+import {
+  type RalphthonPRD,
+  type RalphthonStory,
+  type RalphthonTask,
+  type HardeningTask,
+  type RalphthonConfig,
+  type TaskStatus,
+  PRD_FILENAME,
+  RALPHTHON_DEFAULTS,
+} from './types.js';
+
+// ============================================================================
+// File Operations
+// ============================================================================
+
+/**
+ * Get the path to the ralphthon PRD file in .omc
+ */
+export function getRalphthonPrdPath(directory: string): string {
+  return join(getOmcRoot(directory), PRD_FILENAME);
+}
+
+/**
+ * Find ralphthon-prd.json (checks both root and .omc)
+ */
+export function findRalphthonPrdPath(directory: string): string | null {
+  const rootPath = join(directory, PRD_FILENAME);
+  if (existsSync(rootPath)) return rootPath;
+
+  const omcPath = getRalphthonPrdPath(directory);
+  if (existsSync(omcPath)) return omcPath;
+
+  return null;
+}
+
+/**
+ * Read ralphthon PRD from disk
+ */
+export function readRalphthonPrd(directory: string): RalphthonPRD | null {
+  const prdPath = findRalphthonPrdPath(directory);
+  if (!prdPath) return null;
+
+  try {
+    const content = readFileSync(prdPath, 'utf-8');
+    const prd = JSON.parse(content) as RalphthonPRD;
+
+    if (!prd.stories || !Array.isArray(prd.stories)) return null;
+    if (!prd.config) return null;
+
+    return prd;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write ralphthon PRD to disk
+ */
+export function writeRalphthonPrd(directory: string, prd: RalphthonPRD): boolean {
+  let prdPath = findRalphthonPrdPath(directory);
+
+  if (!prdPath) {
+    const omcDir = getOmcRoot(directory);
+    if (!existsSync(omcDir)) {
+      try {
+        mkdirSync(omcDir, { recursive: true });
+      } catch {
+        return false;
+      }
+    }
+    prdPath = getRalphthonPrdPath(directory);
+  }
+
+  try {
+    writeFileSync(prdPath, JSON.stringify(prd, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ============================================================================
+// PRD Status
+// ============================================================================
+
+export interface RalphthonPrdStatus {
+  /** Total story count */
+  totalStories: number;
+  /** Stories with all tasks done */
+  completedStories: number;
+  /** Total task count across all stories */
+  totalTasks: number;
+  /** Tasks with status 'done' */
+  completedTasks: number;
+  /** Tasks with status 'pending' */
+  pendingTasks: number;
+  /** Tasks with status 'failed' or 'skipped' */
+  failedOrSkippedTasks: number;
+  /** Whether all story tasks are done */
+  allStoriesDone: boolean;
+  /** The next pending task (across all stories, by priority) */
+  nextTask: { storyId: string; task: RalphthonTask } | null;
+  /** Total hardening tasks */
+  totalHardeningTasks: number;
+  /** Completed hardening tasks */
+  completedHardeningTasks: number;
+  /** Pending hardening tasks */
+  pendingHardeningTasks: number;
+  /** Whether all hardening tasks are done */
+  allHardeningDone: boolean;
+  /** Next pending hardening task */
+  nextHardeningTask: HardeningTask | null;
+}
+
+/**
+ * Compute full status of a ralphthon PRD
+ */
+export function getRalphthonPrdStatus(prd: RalphthonPRD): RalphthonPrdStatus {
+  const allTasks: { storyId: string; task: RalphthonTask }[] = [];
+  let completedStories = 0;
+
+  for (const story of prd.stories) {
+    const storyTasks = story.tasks;
+    for (const task of storyTasks) {
+      allTasks.push({ storyId: story.id, task });
+    }
+
+    const allDone = storyTasks.length > 0 &&
+      storyTasks.every(t => t.status === 'done' || t.status === 'skipped');
+    if (allDone) completedStories++;
+  }
+
+  const completedTasks = allTasks.filter(t => t.task.status === 'done').length;
+  const pendingTasks = allTasks.filter(t =>
+    t.task.status === 'pending' || t.task.status === 'in_progress'
+  ).length;
+  const failedOrSkippedTasks = allTasks.filter(t =>
+    t.task.status === 'failed' || t.task.status === 'skipped'
+  ).length;
+
+  // Find next pending task (by story priority order)
+  const priorityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+  const sortedStories = [...prd.stories].sort(
+    (a, b) => (priorityOrder[a.priority] ?? 3) - (priorityOrder[b.priority] ?? 3)
+  );
+
+  let nextTask: { storyId: string; task: RalphthonTask } | null = null;
+  for (const story of sortedStories) {
+    const pending = story.tasks.find(t => t.status === 'pending');
+    if (pending) {
+      nextTask = { storyId: story.id, task: pending };
+      break;
+    }
+  }
+
+  // Hardening status
+  const hardeningTasks = prd.hardening || [];
+  const completedHardening = hardeningTasks.filter(t => t.status === 'done').length;
+  const pendingHardening = hardeningTasks.filter(t =>
+    t.status === 'pending' || t.status === 'in_progress'
+  ).length;
+  const nextHardeningTask = hardeningTasks.find(t => t.status === 'pending') || null;
+
+  return {
+    totalStories: prd.stories.length,
+    completedStories,
+    totalTasks: allTasks.length,
+    completedTasks,
+    pendingTasks,
+    failedOrSkippedTasks,
+    allStoriesDone: completedStories === prd.stories.length && prd.stories.length > 0,
+    nextTask,
+    totalHardeningTasks: hardeningTasks.length,
+    completedHardeningTasks: completedHardening,
+    pendingHardeningTasks: pendingHardening,
+    allHardeningDone: hardeningTasks.length > 0 && pendingHardening === 0,
+    nextHardeningTask,
+  };
+}
+
+// ============================================================================
+// Task Operations
+// ============================================================================
+
+/**
+ * Update a story task's status
+ */
+export function updateTaskStatus(
+  directory: string,
+  storyId: string,
+  taskId: string,
+  status: TaskStatus,
+  notes?: string,
+): boolean {
+  const prd = readRalphthonPrd(directory);
+  if (!prd) return false;
+
+  const story = prd.stories.find(s => s.id === storyId);
+  if (!story) return false;
+
+  const task = story.tasks.find(t => t.id === taskId);
+  if (!task) return false;
+
+  task.status = status;
+  if (notes) task.notes = notes;
+
+  return writeRalphthonPrd(directory, prd);
+}
+
+/**
+ * Increment retry count for a task and optionally mark as failed/skipped
+ */
+export function incrementTaskRetry(
+  directory: string,
+  storyId: string,
+  taskId: string,
+  maxRetries: number,
+): { retries: number; skipped: boolean } {
+  const prd = readRalphthonPrd(directory);
+  if (!prd) return { retries: 0, skipped: false };
+
+  const story = prd.stories.find(s => s.id === storyId);
+  if (!story) return { retries: 0, skipped: false };
+
+  const task = story.tasks.find(t => t.id === taskId);
+  if (!task) return { retries: 0, skipped: false };
+
+  task.retries += 1;
+  const skipped = task.retries >= maxRetries;
+  if (skipped) {
+    task.status = 'skipped';
+    task.notes = `Skipped after ${task.retries} failed attempts`;
+  }
+
+  writeRalphthonPrd(directory, prd);
+  return { retries: task.retries, skipped };
+}
+
+/**
+ * Update a hardening task's status
+ */
+export function updateHardeningTaskStatus(
+  directory: string,
+  taskId: string,
+  status: TaskStatus,
+  notes?: string,
+): boolean {
+  const prd = readRalphthonPrd(directory);
+  if (!prd) return false;
+
+  const task = prd.hardening.find(t => t.id === taskId);
+  if (!task) return false;
+
+  task.status = status;
+  if (notes) task.notes = notes;
+
+  return writeRalphthonPrd(directory, prd);
+}
+
+/**
+ * Increment retry count for a hardening task
+ */
+export function incrementHardeningTaskRetry(
+  directory: string,
+  taskId: string,
+  maxRetries: number,
+): { retries: number; skipped: boolean } {
+  const prd = readRalphthonPrd(directory);
+  if (!prd) return { retries: 0, skipped: false };
+
+  const task = prd.hardening.find(t => t.id === taskId);
+  if (!task) return { retries: 0, skipped: false };
+
+  task.retries += 1;
+  const skipped = task.retries >= maxRetries;
+  if (skipped) {
+    task.status = 'skipped';
+    task.notes = `Skipped after ${task.retries} failed attempts`;
+  }
+
+  writeRalphthonPrd(directory, prd);
+  return { retries: task.retries, skipped };
+}
+
+/**
+ * Add hardening tasks to the PRD for a new wave
+ */
+export function addHardeningTasks(
+  directory: string,
+  tasks: Omit<HardeningTask, 'status' | 'retries'>[],
+): boolean {
+  const prd = readRalphthonPrd(directory);
+  if (!prd) return false;
+
+  const newTasks: HardeningTask[] = tasks.map(t => ({
+    ...t,
+    status: 'pending' as TaskStatus,
+    retries: 0,
+  }));
+
+  prd.hardening = [...(prd.hardening || []), ...newTasks];
+  return writeRalphthonPrd(directory, prd);
+}
+
+// ============================================================================
+// PRD Creation
+// ============================================================================
+
+/**
+ * Create a new RalphthonPRD from stories
+ */
+export function createRalphthonPrd(
+  project: string,
+  branchName: string,
+  description: string,
+  stories: RalphthonStory[],
+  config?: Partial<RalphthonConfig>,
+): RalphthonPRD {
+  return {
+    project,
+    branchName,
+    description,
+    stories,
+    hardening: [],
+    config: { ...RALPHTHON_DEFAULTS, ...config },
+  };
+}
+
+/**
+ * Initialize a ralphthon PRD on disk
+ */
+export function initRalphthonPrd(
+  directory: string,
+  project: string,
+  branchName: string,
+  description: string,
+  stories: RalphthonStory[],
+  config?: Partial<RalphthonConfig>,
+): boolean {
+  const prd = createRalphthonPrd(project, branchName, description, stories, config);
+  return writeRalphthonPrd(directory, prd);
+}
+
+// ============================================================================
+// Formatting
+// ============================================================================
+
+/**
+ * Format a task prompt for injection into the leader pane
+ */
+export function formatTaskPrompt(storyId: string, task: RalphthonTask): string {
+  return `Implement task ${task.id} from story ${storyId}: ${task.title}
+
+${task.description}
+
+When done, update the task status to "done" in the ralphthon PRD (ralphthon-prd.json).
+If you encounter issues, note them. Do NOT stop — continue to the next task.`;
+}
+
+/**
+ * Format a hardening task prompt for injection
+ */
+export function formatHardeningTaskPrompt(task: HardeningTask): string {
+  return `[HARDENING] ${task.category.toUpperCase()} task ${task.id}: ${task.title}
+
+${task.description}
+
+When done, update the hardening task status to "done" in the ralphthon PRD.
+If you find additional issues during this hardening pass, note them — they'll be picked up in the next wave.`;
+}
+
+/**
+ * Format the hardening wave generation prompt
+ */
+export function formatHardeningGenerationPrompt(wave: number, prd: RalphthonPRD): string {
+  const completedTasks = prd.stories.flatMap(s => s.tasks).filter(t => t.status === 'done');
+  const completedHardening = prd.hardening.filter(t => t.status === 'done');
+
+  return `You are in HARDENING WAVE ${wave} of a ralphthon session.
+
+Review ALL completed work and generate new hardening tasks. Focus on:
+1. Edge cases not covered by existing tests
+2. Missing test coverage for implemented features
+3. Code quality improvements (error handling, validation, types)
+4. Security considerations
+5. Performance concerns
+
+Completed story tasks: ${completedTasks.length}
+Completed hardening tasks: ${completedHardening.length}
+
+Write new hardening tasks to the ralphthon PRD (ralphthon-prd.json) in the hardening array.
+Each task needs: id (H-${String(wave).padStart(2, '0')}-NNN), title, description, category, wave: ${wave}.
+Set status to "pending" and retries to 0.
+
+If you find NO new issues, write an empty set of new tasks. This signals the code is solid.`;
+}
+
+/**
+ * Format PRD status summary for display
+ */
+export function formatRalphthonStatus(prd: RalphthonPRD): string {
+  const status = getRalphthonPrdStatus(prd);
+  const lines: string[] = [];
+
+  lines.push(`[Ralphthon: ${prd.project}]`);
+  lines.push(`Stories: ${status.completedStories}/${status.totalStories} complete`);
+  lines.push(`Tasks: ${status.completedTasks}/${status.totalTasks} done, ${status.failedOrSkippedTasks} skipped`);
+
+  if (status.totalHardeningTasks > 0) {
+    lines.push(`Hardening: ${status.completedHardeningTasks}/${status.totalHardeningTasks} done`);
+  }
+
+  if (status.nextTask) {
+    lines.push(`Next: [${status.nextTask.storyId}] ${status.nextTask.task.id} - ${status.nextTask.task.title}`);
+  } else if (status.nextHardeningTask) {
+    lines.push(`Next hardening: ${status.nextHardeningTask.id} - ${status.nextHardeningTask.title}`);
+  } else if (status.allStoriesDone) {
+    lines.push('All stories complete — ready for hardening');
+  }
+
+  return lines.join('\n');
+}

--- a/src/ralphthon/types.ts
+++ b/src/ralphthon/types.ts
@@ -1,0 +1,212 @@
+/**
+ * Ralphthon Types
+ *
+ * Autonomous hackathon lifecycle mode.
+ * Deep-interview generates PRD, ralph loop executes tasks,
+ * auto-hardening phase generates edge case/test/quality tasks,
+ * terminates after N consecutive hardening waves with no new issues.
+ */
+
+// ============================================================================
+// PRD Schema
+// ============================================================================
+
+/** Priority levels for stories and tasks */
+export type TaskPriority = 'critical' | 'high' | 'medium' | 'low';
+
+/** Status of an individual task */
+export type TaskStatus = 'pending' | 'in_progress' | 'done' | 'skipped' | 'failed';
+
+/** Phase of the ralphthon lifecycle */
+export type RalphthonPhase = 'interview' | 'execution' | 'hardening' | 'complete' | 'failed';
+
+/**
+ * A single actionable task within a story
+ */
+export interface RalphthonTask {
+  /** Unique identifier (e.g., "T-001") */
+  id: string;
+  /** Short title */
+  title: string;
+  /** Detailed description of work to do */
+  description: string;
+  /** Current status */
+  status: TaskStatus;
+  /** Number of retry attempts used */
+  retries: number;
+  /** Optional notes from implementation */
+  notes?: string;
+}
+
+/**
+ * A user story containing multiple tasks
+ */
+export interface RalphthonStory {
+  /** Unique identifier (e.g., "US-001") */
+  id: string;
+  /** Short title */
+  title: string;
+  /** Full user story description */
+  description: string;
+  /** Acceptance criteria */
+  acceptanceCriteria: string[];
+  /** Priority */
+  priority: TaskPriority;
+  /** Tasks that implement this story */
+  tasks: RalphthonTask[];
+}
+
+/**
+ * A hardening task generated during auto-hardening phase
+ */
+export interface HardeningTask {
+  /** Unique identifier (e.g., "H-001") */
+  id: string;
+  /** Short title */
+  title: string;
+  /** What to harden (edge case, test, quality improvement) */
+  description: string;
+  /** Category of hardening */
+  category: 'edge_case' | 'test' | 'quality' | 'security' | 'performance';
+  /** Current status */
+  status: TaskStatus;
+  /** Which hardening wave generated this task */
+  wave: number;
+  /** Number of retry attempts used */
+  retries: number;
+  /** Optional notes */
+  notes?: string;
+}
+
+/**
+ * Configuration for the ralphthon run
+ */
+export interface RalphthonConfig {
+  /** Maximum hardening waves before forced termination */
+  maxWaves: number;
+  /** Consecutive waves with no new issues before auto-termination */
+  cleanWavesForTermination: number;
+  /** Poll interval in milliseconds */
+  pollIntervalMs: number;
+  /** Idle detection threshold in milliseconds */
+  idleThresholdMs: number;
+  /** Maximum retries per task before skipping */
+  maxRetries: number;
+  /** Whether to skip the deep-interview phase */
+  skipInterview: boolean;
+}
+
+/**
+ * The full Ralphthon PRD document
+ */
+export interface RalphthonPRD {
+  /** Project name */
+  project: string;
+  /** Git branch name */
+  branchName: string;
+  /** Overall description */
+  description: string;
+  /** User stories with tasks */
+  stories: RalphthonStory[];
+  /** Hardening tasks (populated during hardening phase) */
+  hardening: HardeningTask[];
+  /** Run configuration */
+  config: RalphthonConfig;
+}
+
+// ============================================================================
+// Orchestrator State
+// ============================================================================
+
+/**
+ * Tracks the state of a running ralphthon session
+ */
+export interface RalphthonState {
+  /** Whether the session is active */
+  active: boolean;
+  /** Current lifecycle phase */
+  phase: RalphthonPhase;
+  /** Session ID for state isolation */
+  sessionId?: string;
+  /** Project working directory */
+  projectPath: string;
+  /** Path to the PRD file */
+  prdPath: string;
+  /** Tmux session name */
+  tmuxSession: string;
+  /** Tmux pane ID for the leader (Claude Code instance) */
+  leaderPaneId: string;
+  /** When the session started */
+  startedAt: string;
+  /** Current hardening wave number */
+  currentWave: number;
+  /** Number of consecutive clean hardening waves */
+  consecutiveCleanWaves: number;
+  /** ID of the task currently being worked on */
+  currentTaskId?: string;
+  /** Total tasks completed */
+  tasksCompleted: number;
+  /** Total tasks skipped (failed after max retries) */
+  tasksSkipped: number;
+  /** Last time idle was detected */
+  lastIdleDetectedAt?: string;
+  /** Last time a poll check was performed */
+  lastPollAt?: string;
+  /** Error message if phase is 'failed' */
+  error?: string;
+}
+
+// ============================================================================
+// Orchestrator Events
+// ============================================================================
+
+/** Events emitted by the orchestrator */
+export type OrchestratorEvent =
+  | { type: 'task_injected'; taskId: string; taskTitle: string }
+  | { type: 'task_completed'; taskId: string }
+  | { type: 'task_failed'; taskId: string; retries: number }
+  | { type: 'task_skipped'; taskId: string; reason: string }
+  | { type: 'phase_transition'; from: RalphthonPhase; to: RalphthonPhase }
+  | { type: 'hardening_wave_start'; wave: number }
+  | { type: 'hardening_wave_end'; wave: number; newIssues: number }
+  | { type: 'idle_detected'; durationMs: number }
+  | { type: 'session_complete'; tasksCompleted: number; tasksSkipped: number }
+  | { type: 'error'; message: string };
+
+/** Callback for orchestrator events */
+export type OrchestratorEventHandler = (event: OrchestratorEvent) => void;
+
+// ============================================================================
+// CLI Options
+// ============================================================================
+
+/**
+ * Parsed CLI options for omc ralphthon
+ */
+export interface RalphthonCliOptions {
+  /** Resume an existing session */
+  resume: boolean;
+  /** Skip the deep-interview phase */
+  skipInterview: boolean;
+  /** Maximum hardening waves */
+  maxWaves: number;
+  /** Poll interval in seconds */
+  pollInterval: number;
+  /** Task description (positional argument) */
+  task?: string;
+}
+
+// ============================================================================
+// Defaults
+// ============================================================================
+
+export const RALPHTHON_DEFAULTS: RalphthonConfig = {
+  maxWaves: 10,
+  cleanWavesForTermination: 3,
+  pollIntervalMs: 120_000, // 2 minutes
+  idleThresholdMs: 30_000, // 30 seconds
+  maxRetries: 3,
+  skipInterview: false,
+};
+
+export const PRD_FILENAME = 'ralphthon-prd.json';


### PR DESCRIPTION
## Summary

- Add `omc ralphthon` command — autonomous hackathon lifecycle that combines deep-interview PRD generation, ralph loop task execution, and auto-hardening phases
- Implements orchestrator with dual trigger (30s idle detection + 2min periodic poll), task injection via tmux send-keys, phase transitions, and failure recovery (retry 3x then skip)
- Terminates after 3 consecutive hardening waves with no new issues found

## Components

| File | Purpose |
|------|---------|
| `src/ralphthon/types.ts` | Type definitions (PRD schema, state, events, config) |
| `src/ralphthon/prd.ts` | PRD read/write/status operations, task management, formatting |
| `src/ralphthon/orchestrator.ts` | Core orchestrator: state mgmt, tmux interaction, idle detection, phase transitions, hardening waves |
| `src/ralphthon/index.ts` | Barrel export |
| `src/cli/commands/ralphthon.ts` | CLI command with `--resume`, `--skip-interview`, `--max-waves`, `--poll-interval` |
| `src/cli/index.ts` | Register `omc ralphthon` subcommand |

## Test plan

- [x] 60 tests passing across 3 test files (PRD, orchestrator, CLI)
- [x] PRD read/write/status computation
- [x] Task status updates and retry/skip logic
- [x] Hardening task management and wave tracking
- [x] Phase transitions and termination conditions
- [x] CLI argument parsing with all flag combinations
- [x] Clean `tsc --noEmit` build

Closes #1694

🤖 Generated with [Claude Code](https://claude.com/claude-code)