### PR TITLE
fix(hooks): increase SessionEnd timeout and make notifications fire-and-forget

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -183,7 +183,7 @@
           {
             "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/session-end.mjs",
-            "timeout": 10
+            "timeout": 30
           }
         ]
       }

--- a/scripts/session-end.mjs
+++ b/scripts/session-end.mjs
@@ -4,8 +4,9 @@ const require = createRequire(import.meta.url);
 import { readStdin } from './lib/stdin.mjs';
 
 async function main() {
-  // Read stdin (timeout-protected, see issue #240/#459)
-  const input = await readStdin();
+  // Read stdin with reduced timeout for SessionEnd — the input payload is small
+  // and doesn't need the default 5s wait. This saves ~4s toward the hook timeout (#1700).
+  const input = await readStdin(1000);
 
   try {
     const data = JSON.parse(input);

--- a/src/hooks/session-end/__tests__/session-end-timeout.test.ts
+++ b/src/hooks/session-end/__tests__/session-end-timeout.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── hooks.json timeout validation ──────────────────────────────────────────
+
+describe('SessionEnd hook timeout (issue #1700)', () => {
+  it('hooks.json SessionEnd timeout is at least 30 seconds', () => {
+    // Read from the repository root hooks.json
+    const hooksJsonPath = path.resolve(__dirname, '../../../../hooks/hooks.json');
+    const hooksJson = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8'));
+
+    const sessionEndEntries = hooksJson.hooks.SessionEnd;
+    expect(sessionEndEntries).toBeDefined();
+    expect(Array.isArray(sessionEndEntries)).toBe(true);
+
+    for (const entry of sessionEndEntries) {
+      for (const hook of entry.hooks) {
+        expect(hook.timeout).toBeGreaterThanOrEqual(30);
+      }
+    }
+  });
+});
+
+// ── fire-and-forget notification behavior ──────────────────────────────────
+
+vi.mock('../callbacks.js', () => ({
+  triggerStopCallbacks: vi.fn(async () => {
+    // Simulate a slow notification (2s) — should not block session end
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }),
+}));
+
+vi.mock('../../../notifications/index.js', () => ({
+  notify: vi.fn(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }),
+}));
+
+vi.mock('../../../features/auto-update.js', () => ({
+  getOMCConfig: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../notifications/config.js', () => ({
+  buildConfigFromEnv: vi.fn(() => null),
+  getEnabledPlatforms: vi.fn(() => []),
+  getNotificationConfig: vi.fn(() => null),
+}));
+
+vi.mock('../../../tools/python-repl/bridge-manager.js', () => ({
+  cleanupBridgeSessions: vi.fn(async () => ({
+    requestedSessions: 0,
+    foundSessions: 0,
+    terminatedSessions: 0,
+    errors: [],
+  })),
+}));
+
+vi.mock('../../../openclaw/index.js', () => ({
+  wakeOpenClaw: vi.fn().mockResolvedValue({ gateway: 'test', success: true }),
+}));
+
+import { processSessionEnd } from '../index.js';
+import { triggerStopCallbacks } from '../callbacks.js';
+
+describe('SessionEnd fire-and-forget notifications (issue #1700)', () => {
+  let tmpDir: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omc-session-end-timeout-'));
+    transcriptPath = path.join(tmpDir, 'transcript.jsonl');
+    fs.writeFileSync(
+      transcriptPath,
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'done' }] },
+      }),
+      'utf-8',
+    );
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('processSessionEnd completes well before slow notifications finish', async () => {
+    const start = Date.now();
+
+    await processSessionEnd({
+      session_id: 'timeout-test-1',
+      transcript_path: transcriptPath,
+      cwd: tmpDir,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    const elapsed = Date.now() - start;
+
+    // triggerStopCallbacks was called (fire-and-forget)
+    expect(triggerStopCallbacks).toHaveBeenCalled();
+
+    // The function should complete in well under the 2s mock delay.
+    // With fire-and-forget, it races with a 5s cap, but the synchronous
+    // work should be fast. We give generous margin but ensure it's not
+    // waiting the full 2s for the mock notification to resolve.
+    // In practice this finishes in <100ms; 1500ms is a safe CI threshold.
+    expect(elapsed).toBeLessThan(1500);
+  });
+});

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -740,24 +740,32 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
     ? getEnabledPlatforms(notificationConfig, 'session-end')
     : [];
 
+  // Fire-and-forget: notifications and reply-listener cleanup are non-critical
+  // and should not count against the SessionEnd hook timeout (#1700).
+  // We collect the promises but don't await them — Node will flush them before
+  // the process exits (the hook runner keeps the process alive until stdout closes).
+  const fireAndForget: Promise<unknown>[] = [];
+
   // Trigger stop hook callbacks (#395). When an explicit session-end notification
   // config already covers Discord/Telegram, skip the overlapping legacy callback
   // path so session-end is only dispatched once per platform.
-  await triggerStopCallbacks(metrics, {
-    session_id: input.session_id,
-    cwd: input.cwd,
-  }, {
-    skipPlatforms: shouldUseNewNotificationSystem
-      ? getLegacyPlatformsCoveredByNotifications(enabledNotificationPlatforms)
-      : [],
-  });
+  fireAndForget.push(
+    triggerStopCallbacks(metrics, {
+      session_id: input.session_id,
+      cwd: input.cwd,
+    }, {
+      skipPlatforms: shouldUseNewNotificationSystem
+        ? getLegacyPlatformsCoveredByNotifications(enabledNotificationPlatforms)
+        : [],
+    }).catch(() => { /* notification failures must not block session end */ }),
+  );
 
   // Trigger the new notification system when session-end notifications come
   // from an explicit notifications/profile/env config. Legacy stopHookCallbacks
   // are already handled above and must not be dispatched twice.
   if (shouldUseNewNotificationSystem) {
-    try {
-      await notify('session-end', {
+    fireAndForget.push(
+      notify('session-end', {
         sessionId: input.session_id,
         projectPath: input.cwd,
         durationMs: metrics.duration_ms,
@@ -767,29 +775,36 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
         reason: metrics.reason,
         timestamp: metrics.ended_at,
         profileName,
-      });
-    } catch {
-      // Notification failures should never block session end
-    }
+      }).catch(() => { /* notification failures must not block session end */ }),
+    );
   }
-
 
   // Clean up reply session registry and stop daemon if no active sessions remain
-  try {
-    const { removeSession, loadAllMappings } = await import('../../notifications/session-registry.js');
-    const { stopReplyListener } = await import('../../notifications/reply-listener.js');
+  fireAndForget.push(
+    (async () => {
+      try {
+        const { removeSession, loadAllMappings } = await import('../../notifications/session-registry.js');
+        const { stopReplyListener } = await import('../../notifications/reply-listener.js');
 
-    // Remove this session's message mappings
-    removeSession(input.session_id);
+        // Remove this session's message mappings
+        removeSession(input.session_id);
 
-    // Stop daemon if registry is now empty (no other active sessions)
-    const remainingMappings = loadAllMappings();
-    if (remainingMappings.length === 0) {
-      await stopReplyListener();
-    }
-  } catch {
-    // Reply listener cleanup failures should never block session end
-  }
+        // Stop daemon if registry is now empty (no other active sessions)
+        const remainingMappings = loadAllMappings();
+        if (remainingMappings.length === 0) {
+          await stopReplyListener();
+        }
+      } catch {
+        // Reply listener cleanup failures should never block session end
+      }
+    })(),
+  );
+
+  // Don't await — let Node flush these before the process exits.
+  // The hook runner keeps the process alive until stdout closes, so these
+  // will settle naturally. Awaiting them would defeat the fire-and-forget
+  // optimization and risk hitting the hook timeout (#1700).
+  void Promise.allSettled(fireAndForget);
 
   // Return simple response - metrics are persisted to .omc/sessions/
   return { continue: true };


### PR DESCRIPTION
## Summary
- Increase `hooks.json` SessionEnd timeout from 10s to 30s (short-term safety net)
- Reduce `readStdin` timeout to 1s for session-end script (input payload is small, doesn't need 5s)
- Make notifications (`triggerStopCallbacks`, `notify`) and reply-listener cleanup fire-and-forget in `processSessionEnd` so they don't count against the hook timeout budget

## Root cause
The 10s SessionEnd hook timeout was too tight. The default 5s stdin read + notification dispatch + state cleanup regularly exceeded it, causing `Hook cancelled` errors on every exit.

## Test plan
- [x] Added `session-end-timeout.test.ts` validating hooks.json timeout >= 30s
- [x] Added test verifying `processSessionEnd` completes fast even with slow (2s) mock notifications
- [x] All 66 existing session-end tests pass (10 test files)

Closes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)