### PR TITLE
feat(agents): structured output templates for explore and verifier

### DIFF
--- a/agents/explore.md
+++ b/agents/explore.md
@@ -70,25 +70,26 @@ disallowedTools: Write, Edit
   </Execution_Policy>
 
   <Output_Format>
-    <results>
-    <files>
-    - /absolute/path/to/file1.ts -- [why this file is relevant]
-    - /absolute/path/to/file2.ts -- [why this file is relevant]
-    </files>
+    Structure your response EXACTLY as follows. Do not add preamble or meta-commentary.
 
-    <relationships>
-    [How the files/patterns connect to each other]
-    [Data flow or dependency explanation if relevant]
-    </relationships>
+    ## Findings
+    - **Files**: [/absolute/path/file1.ts:line — why relevant], [/absolute/path/file2.ts:line — why relevant]
+    - **Root cause**: [One sentence identifying the core issue or answer]
+    - **Evidence**: [Key code snippet, log line, or data point that supports the finding]
 
-    <answer>
-    [Direct answer to their actual need, not just a file list]
-    </answer>
+    ## Impact
+    - **Scope**: single-file | multi-file | cross-module
+    - **Risk**: low | medium | high
+    - **Affected areas**: [List of modules/features that depend on findings]
 
-    <next_steps>
-    [What they should do with this information, or "Ready to proceed"]
-    </next_steps>
-    </results>
+    ## Relationships
+    [How the found files/patterns connect — data flow, dependency chain, or call graph]
+
+    ## Recommendation
+    - [Concrete next action for the caller — not "consider" or "you might want to", but "do X"]
+
+    ## Next Steps
+    - [What agent or action should follow — "Ready for executor" or "Needs architect review for cross-module risk"]
   </Output_Format>
 
   <Failure_Modes_To_Avoid>

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -52,27 +52,34 @@ model: claude-sonnet-4-6
   </Execution_Policy>
 
   <Output_Format>
+    Structure your response EXACTLY as follows. Do not add preamble or meta-commentary.
+
     ## Verification Report
 
-    ### Summary
-    **Status**: [PASS / FAIL / INCOMPLETE]
-    **Confidence**: [High / Medium / Low]
+    ### Verdict
+    **Status**: PASS | FAIL | INCOMPLETE
+    **Confidence**: high | medium | low
+    **Blockers**: [count — 0 means PASS]
 
-    ### Evidence Reviewed
-    - Tests: [pass/fail] [test results summary]
-    - Types: [pass/fail] [lsp_diagnostics summary]
-    - Build: [pass/fail] [build output]
-    - Runtime: [pass/fail] [execution results]
+    ### Evidence
+    | Check | Result | Command/Source | Output |
+    |-------|--------|----------------|--------|
+    | Tests | pass/fail | `npm test` | X passed, Y failed |
+    | Types | pass/fail | `lsp_diagnostics_directory` | N errors |
+    | Build | pass/fail | `npm run build` | exit code |
+    | Runtime | pass/fail | [manual check] | [observation] |
 
     ### Acceptance Criteria
-    1. [Criterion] - [VERIFIED / PARTIAL / MISSING] - [evidence]
-    2. [Criterion] - [VERIFIED / PARTIAL / MISSING] - [evidence]
+    | # | Criterion | Status | Evidence |
+    |---|-----------|--------|----------|
+    | 1 | [criterion text] | VERIFIED / PARTIAL / MISSING | [specific evidence] |
 
-    ### Gaps Found
-    - [Gap description] - Risk: [High/Medium/Low]
+    ### Gaps
+    - [Gap description] — Risk: high/medium/low — Suggestion: [how to close]
 
     ### Recommendation
-    [APPROVE / REQUEST CHANGES / NEEDS MORE EVIDENCE]
+    APPROVE | REQUEST_CHANGES | NEEDS_MORE_EVIDENCE
+    [One sentence justification]
   </Output_Format>
 
   <Failure_Modes_To_Avoid>


### PR DESCRIPTION
## Summary

Replace free-form output format in explore and verifier with structured Markdown.

**2 files changed, 40 insertions(+), 32 deletions(-)**

- **explore**: Findings (files+root cause+evidence) / Impact (scope+risk) / Relationships / Recommendation / Next Steps
- **verifier**: Verdict (status+confidence+blockers) / Evidence table / Acceptance Criteria table / Gaps / Recommendation

Based on output-first design from [Agentic Engineering](https://www.jayminwest.com/agentic-engineering-book/2-prompt/2-structuring).

## Test plan
- [x] `<Output_Format>` tags preserved
- [x] Only inner content replaced, no other sections touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)