### PR TITLE
fix(lsp): update Kotlin LSP to official JetBrains implementation

### DIFF
--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -115,10 +115,10 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
   },
   kotlin: {
     name: 'Kotlin Language Server',
-    command: 'kotlin-language-server',
+    command: 'kotlin-lsp',
     args: [],
     extensions: ['.kt', '.kts'],
-    installHint: 'Install from https://github.com/fwcd/kotlin-language-server'
+    installHint: 'Install from https://github.com/Kotlin/kotlin-lsp (brew install JetBrains/utils/kotlin-lsp)'
   },
   elixir: {
     name: 'ElixirLS',


### PR DESCRIPTION
## Summary

- Replace deprecated `fwcd/kotlin-language-server` with official `Kotlin/kotlin-lsp`
- Update command from `kotlin-language-server` to `kotlin-lsp`
- Update install hint to point to official repo + brew tap

The [fwcd/kotlin-language-server](https://github.com/fwcd/kotlin-language-server) is now deprecated by its author in favor of the [official Kotlin LSP](https://github.com/Kotlin/kotlin-lsp) from JetBrains.

Closes #1709

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*