### PR TITLE
fix(planning): remove unnecessary global flag from module-level regex

### DIFF
--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -76,9 +76,9 @@ export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
  *   omc ralph "do the work"
  */
 const TEAM_LAUNCH_RE =
-  /\bomc\s+team\s+(?:(\d+):(\w+)\s+)?"([^"]+)"((?:\s+--[\w-]+)*)/g;
+  /\bomc\s+team\s+(?:(\d+):(\w+)\s+)?"([^"]+)"((?:\s+--[\w-]+)*)/;
 const RALPH_LAUNCH_RE =
-  /\bomc\s+ralph\s+"([^"]+)"((?:\s+--[\w-]+)*)/g;
+  /\bomc\s+ralph\s+"([^"]+)"((?:\s+--[\w-]+)*)/;
 
 function parseFlags(flagStr: string): { linkedRalph: boolean } {
   return {
@@ -107,7 +107,6 @@ export function readApprovedExecutionLaunchHint(
   }
 
   if (mode === 'team') {
-    TEAM_LAUNCH_RE.lastIndex = 0;
     const match = TEAM_LAUNCH_RE.exec(content);
     if (!match) return null;
 
@@ -126,7 +125,6 @@ export function readApprovedExecutionLaunchHint(
   }
 
   if (mode === 'ralph') {
-    RALPH_LAUNCH_RE.lastIndex = 0;
     const match = RALPH_LAUNCH_RE.exec(content);
     if (!match) return null;
 


### PR DESCRIPTION
## Problem

`TEAM_LAUNCH_RE` and `RALPH_LAUNCH_RE` in `src/planning/artifacts.ts` are declared at module level with the `/g` (global) flag, but each regex is only used with a single `exec()` call per function invocation.

The `/g` flag causes `RegExp` objects to maintain internal `lastIndex` state between calls. The current code works around this with manual `lastIndex = 0` resets before each `exec()`, but this pattern is fragile — if the regex is ever reused elsewhere without the reset, it will silently fail to match.

```typescript
// Before: /g flag requires manual lastIndex reset
TEAM_LAUNCH_RE.lastIndex = 0;
const match = TEAM_LAUNCH_RE.exec(content);
```

## Fix

- Remove `/g` flag from both `TEAM_LAUNCH_RE` and `RALPH_LAUNCH_RE`
- Remove the now-unnecessary `lastIndex = 0` reset lines

```typescript
// After: no /g flag, no lastIndex state to manage
const match = TEAM_LAUNCH_RE.exec(content);
```

## Verification

- [x] All 17 existing tests in `src/planning/__tests__/artifacts.test.ts` pass
- [x] No other files reference these regex constants (confirmed via codebase grep)
- [x] Behavioral change: none — `exec()` without `/g` returns the same first match