### PR TITLE
fix(team): map build-fix intent to code-edit capability instead of testing

### DIFF
--- a/src/team/task-router.ts
+++ b/src/team/task-router.ts
@@ -109,7 +109,7 @@ export function routeTasks(
 
 /** Maps lane intents to the worker capabilities that best serve them */
 const INTENT_CAPABILITY_MAP: Record<string, WorkerCapability[]> = {
-  'build-fix': ['testing'],
+  'build-fix': ['code-edit'],
   debug: ['general'],
   docs: ['documentation'],
   design: ['architecture', 'ui-design'],


### PR DESCRIPTION
## Problem

In `src/team/task-router.ts`, the `INTENT_CAPABILITY_MAP` maps `build-fix` intent to `['testing']` capability:

```typescript
const INTENT_CAPABILITY_MAP: Record<string, WorkerCapability[]> = {
  'build-fix': ['testing'],    // ← build-fix → testing?
  verification: ['testing'],   // ← verification → testing ✓
  implementation: ['code-edit'],
  // ...
};
```

This means workers with `testing` capability (e.g., test-engineers) get a +0.3 fitness bonus for build-fix tasks, while workers with `code-edit` capability do not.

Build-fix tasks involve fixing tsc errors, lint failures, CI breakage, and compile errors — which is code editing work, not testing. The `role-router.ts` already correctly maps `build-fix` intent → `build-fixer` role, and `ROLE_KEYWORDS['build-fixer']` includes `build`, `ci`, `compile`, `tsc`, `lint` patterns, confirming this is a code-edit domain.

The `['testing']` value appears to be a copy-paste from the `verification` entry.

## Fix

```diff
- 'build-fix': ['testing'],
+ 'build-fix': ['code-edit'],
```

## Impact

Workers with `code-edit` capability now receive the +0.3 fitness bonus for build-fix tasks instead of workers with `testing` capability. This aligns the task-router's capability scoring with the role-router's intent mapping.

## Verification

- [x] 22 role-router tests pass
- [x] 9 phase1-foundation tests pass
- [x] No other files reference `INTENT_CAPABILITY_MAP` (module-private constant)