### PR TITLE
fix: clean up Kotlin LSP processes after background agent termination

### DIFF
--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -17935,13 +17935,16 @@ function getAllServers() {
 
 // src/tools/lsp/client.ts
 var DEFAULT_LSP_REQUEST_TIMEOUT_MS = (() => {
-  const env = process.env.OMC_LSP_TIMEOUT_MS;
-  if (env) {
-    const parsed = parseInt(env, 10);
-    if (!isNaN(parsed) && parsed > 0) return parsed;
-  }
-  return 15e3;
+  return readPositiveIntEnv("OMC_LSP_TIMEOUT_MS", 15e3);
 })();
+function readPositiveIntEnv(name, fallback) {
+  const env = process.env[name];
+  if (!env) {
+    return fallback;
+  }
+  const parsed = parseInt(env, 10);
+  return !isNaN(parsed) && parsed > 0 ? parsed : fallback;
+}
 function fileUri(filePath) {
   return (0, import_url.pathToFileURL)((0, import_path2.resolve)(filePath)).href;
 }
@@ -18391,12 +18394,13 @@ ${content}`;
     });
   }
 };
-var IDLE_TIMEOUT_MS = 5 * 60 * 1e3;
-var IDLE_CHECK_INTERVAL_MS = 60 * 1e3;
+var IDLE_TIMEOUT_MS = readPositiveIntEnv("OMC_LSP_IDLE_TIMEOUT_MS", 5 * 60 * 1e3);
+var IDLE_CHECK_INTERVAL_MS = readPositiveIntEnv("OMC_LSP_IDLE_CHECK_INTERVAL_MS", 60 * 1e3);
 var LspClientManager = class {
   clients = /* @__PURE__ */ new Map();
   lastUsed = /* @__PURE__ */ new Map();
   inFlightCount = /* @__PURE__ */ new Map();
+  idleDeadlines = /* @__PURE__ */ new Map();
   idleTimer = null;
   constructor() {
     this.startIdleCheck();
@@ -18409,6 +18413,14 @@ var LspClientManager = class {
    */
   registerCleanupHandlers() {
     const forceKillAll = () => {
+      if (this.idleTimer) {
+        clearInterval(this.idleTimer);
+        this.idleTimer = null;
+      }
+      for (const timer of this.idleDeadlines.values()) {
+        clearTimeout(timer);
+      }
+      this.idleDeadlines.clear();
       for (const client of this.clients.values()) {
         try {
           client.forceKill();
@@ -18421,10 +18433,7 @@ var LspClientManager = class {
     };
     process.on("exit", forceKillAll);
     for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
-      process.on(sig, () => {
-        forceKillAll();
-        process.exit(0);
-      });
+      process.on(sig, forceKillAll);
     }
   }
   /**
@@ -18447,7 +18456,7 @@ var LspClientManager = class {
         throw error2;
       }
     }
-    this.lastUsed.set(key, Date.now());
+    this.touchClient(key);
     return client;
   }
   /**
@@ -18472,7 +18481,7 @@ var LspClientManager = class {
         throw error2;
       }
     }
-    this.lastUsed.set(key, Date.now());
+    this.touchClient(key);
     this.inFlightCount.set(key, (this.inFlightCount.get(key) || 0) + 1);
     try {
       return await fn(client);
@@ -18483,8 +18492,31 @@ var LspClientManager = class {
       } else {
         this.inFlightCount.set(key, count);
       }
-      this.lastUsed.set(key, Date.now());
+      this.touchClient(key);
     }
+  }
+  touchClient(key) {
+    this.lastUsed.set(key, Date.now());
+    this.scheduleIdleDeadline(key);
+  }
+  scheduleIdleDeadline(key) {
+    this.clearIdleDeadline(key);
+    const timer = setTimeout(() => {
+      this.idleDeadlines.delete(key);
+      this.evictClientIfIdle(key);
+    }, IDLE_TIMEOUT_MS);
+    if (typeof timer === "object" && "unref" in timer) {
+      timer.unref();
+    }
+    this.idleDeadlines.set(key, timer);
+  }
+  clearIdleDeadline(key) {
+    const timer = this.idleDeadlines.get(key);
+    if (!timer) {
+      return;
+    }
+    clearTimeout(timer);
+    this.idleDeadlines.delete(key);
   }
   /**
    * Find the workspace root for a file
@@ -18524,21 +18556,35 @@ var LspClientManager = class {
    * Clients with in-flight requests are never evicted.
    */
   evictIdleClients() {
-    const now = Date.now();
-    for (const [key, lastUsedTime] of this.lastUsed.entries()) {
-      if (now - lastUsedTime > IDLE_TIMEOUT_MS) {
-        if ((this.inFlightCount.get(key) || 0) > 0) {
-          continue;
-        }
-        const client = this.clients.get(key);
-        if (client) {
-          client.disconnect().catch(() => {
-          });
-          this.clients.delete(key);
-          this.lastUsed.delete(key);
-          this.inFlightCount.delete(key);
-        }
+    for (const key of this.lastUsed.keys()) {
+      this.evictClientIfIdle(key);
+    }
+  }
+  evictClientIfIdle(key) {
+    const lastUsedTime = this.lastUsed.get(key);
+    if (lastUsedTime === void 0) {
+      this.clearIdleDeadline(key);
+      return;
+    }
+    const idleFor = Date.now() - lastUsedTime;
+    if (idleFor <= IDLE_TIMEOUT_MS) {
+      if (!this.idleDeadlines.has(key)) {
+        this.scheduleIdleDeadline(key);
       }
+      return;
+    }
+    if ((this.inFlightCount.get(key) || 0) > 0) {
+      this.scheduleIdleDeadline(key);
+      return;
+    }
+    const client = this.clients.get(key);
+    this.clearIdleDeadline(key);
+    this.clients.delete(key);
+    this.lastUsed.delete(key);
+    this.inFlightCount.delete(key);
+    if (client) {
+      client.disconnect().catch(() => {
+      });
     }
   }
   /**
@@ -18551,6 +18597,10 @@ var LspClientManager = class {
       clearInterval(this.idleTimer);
       this.idleTimer = null;
     }
+    for (const timer of this.idleDeadlines.values()) {
+      clearTimeout(timer);
+    }
+    this.idleDeadlines.clear();
     const entries = Array.from(this.clients.entries());
     const results = await Promise.allSettled(
       entries.map(([, client]) => client.disconnect())
@@ -18579,7 +18629,9 @@ var LspClientManager = class {
     this.evictIdleClients();
   }
 };
-var lspClientManager = new LspClientManager();
+var LSP_CLIENT_MANAGER_KEY = "__omcLspClientManager";
+var globalWithLspClientManager = globalThis;
+var lspClientManager = globalWithLspClientManager[LSP_CLIENT_MANAGER_KEY] || (globalWithLspClientManager[LSP_CLIENT_MANAGER_KEY] = new LspClientManager());
 async function disconnectAll() {
   return lspClientManager.disconnectAll();
 }
@@ -25059,25 +25111,41 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     };
   }
 });
+var gracefulShutdownPromise = null;
 async function gracefulShutdown(signal) {
-  const forceExitTimer = setTimeout(() => process.exit(1), 5e3);
-  forceExitTimer.unref();
-  console.error(`OMC MCP Server: received ${signal}, disconnecting LSP servers...`);
-  try {
-    await disconnectAll();
-  } catch {
+  if (gracefulShutdownPromise) {
+    return gracefulShutdownPromise;
   }
-  try {
-    await server.close();
-  } catch {
-  }
-  process.exit(0);
+  gracefulShutdownPromise = (async () => {
+    const forceExitTimer = setTimeout(() => process.exit(1), 5e3);
+    forceExitTimer.unref();
+    console.error(`OMC MCP Server: received ${signal}, disconnecting LSP servers...`);
+    try {
+      await disconnectAll();
+    } catch {
+    }
+    try {
+      await server.close();
+    } catch {
+    }
+    process.exit(0);
+  })();
+  return gracefulShutdownPromise;
 }
 process.on("SIGTERM", () => {
   gracefulShutdown("SIGTERM");
 });
 process.on("SIGINT", () => {
   gracefulShutdown("SIGINT");
+});
+process.once("disconnect", () => {
+  gracefulShutdown("parent disconnect");
+});
+process.stdin?.once("end", () => {
+  gracefulShutdown("stdin end");
+});
+process.stdin?.once("close", () => {
+  gracefulShutdown("stdin close");
 });
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/mcp/__tests__/standalone-shutdown.test.ts
+++ b/src/mcp/__tests__/standalone-shutdown.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { registerStandaloneShutdownHandlers } from '../standalone-shutdown.js';
+
+class MockProcess extends EventEmitter {
+  stdin = new EventEmitter();
+}
+
+describe('registerStandaloneShutdownHandlers', () => {
+  it('runs shutdown when stdin ends', async () => {
+    const processRef = new MockProcess();
+    const onShutdown = vi.fn(async () => undefined);
+
+    registerStandaloneShutdownHandlers({ processRef, onShutdown });
+    processRef.stdin.emit('end');
+    await vi.waitFor(() => {
+      expect(onShutdown).toHaveBeenCalledWith('stdin end');
+    });
+  });
+
+  it('runs shutdown when parent disconnects', async () => {
+    const processRef = new MockProcess();
+    const onShutdown = vi.fn(async () => undefined);
+
+    registerStandaloneShutdownHandlers({ processRef, onShutdown });
+    processRef.emit('disconnect');
+    await vi.waitFor(() => {
+      expect(onShutdown).toHaveBeenCalledWith('parent disconnect');
+    });
+  });
+
+  it('deduplicates shutdown when multiple termination events arrive', async () => {
+    const processRef = new MockProcess();
+    const onShutdown = vi.fn(async () => undefined);
+
+    registerStandaloneShutdownHandlers({ processRef, onShutdown });
+    processRef.stdin.emit('end');
+    processRef.stdin.emit('close');
+    processRef.emit('SIGTERM');
+
+    await vi.waitFor(() => {
+      expect(onShutdown).toHaveBeenCalledTimes(1);
+    });
+    expect(onShutdown).toHaveBeenCalledWith('stdin end');
+  });
+});

--- a/src/mcp/standalone-server.ts
+++ b/src/mcp/standalone-server.ts
@@ -24,6 +24,7 @@ import { stateTools } from '../tools/state-tools.js';
 import { notepadTools } from '../tools/notepad-tools.js';
 import { memoryTools } from '../tools/memory-tools.js';
 import { traceTools } from '../tools/trace-tools.js';
+import { registerStandaloneShutdownHandlers } from './standalone-shutdown.js';
 import { z } from 'zod';
 
 // Tool interface matching our tool definitions
@@ -211,8 +212,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
   process.exit(0);
 }
 
-process.on('SIGTERM', () => { gracefulShutdown('SIGTERM'); });
-process.on('SIGINT', () => { gracefulShutdown('SIGINT'); });
+registerStandaloneShutdownHandlers({
+  onShutdown: gracefulShutdown,
+});
 
 // Start the server
 async function main() {

--- a/src/mcp/standalone-shutdown.ts
+++ b/src/mcp/standalone-shutdown.ts
@@ -1,0 +1,48 @@
+export interface ShutdownProcessLike {
+  once(event: string, listener: () => void): unknown;
+  stdin?: {
+    once(event: string, listener: () => void): unknown;
+  } | null;
+}
+
+export interface RegisterStandaloneShutdownHandlersOptions {
+  onShutdown: (reason: string) => void | Promise<void>;
+  processRef?: ShutdownProcessLike;
+}
+
+/**
+ * Register MCP-server shutdown hooks for both explicit signals and the implicit
+ * "parent went away" cases that background agents hit when their stdio pipes
+ * are closed without forwarding SIGTERM/SIGINT.
+ */
+export function registerStandaloneShutdownHandlers(
+  options: RegisterStandaloneShutdownHandlersOptions
+): { shutdown: (reason: string) => Promise<void> } {
+  const processRef = options.processRef ?? process;
+  let shutdownPromise: Promise<void> | null = null;
+
+  const shutdown = async (reason: string): Promise<void> => {
+    if (!shutdownPromise) {
+      shutdownPromise = Promise.resolve(options.onShutdown(reason));
+    }
+    return shutdownPromise;
+  };
+
+  const register = (event: string, reason: string): void => {
+    processRef.once(event, () => {
+      void shutdown(reason);
+    });
+  };
+
+  register('SIGTERM', 'SIGTERM');
+  register('SIGINT', 'SIGINT');
+  register('disconnect', 'parent disconnect');
+  processRef.stdin?.once('end', () => {
+    void shutdown('stdin end');
+  });
+  processRef.stdin?.once('close', () => {
+    void shutdown('stdin close');
+  });
+
+  return { shutdown };
+}

--- a/src/tools/lsp/__tests__/client-singleton.test.ts
+++ b/src/tools/lsp/__tests__/client-singleton.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('lspClientManager singleton', () => {
+  afterEach(async () => {
+    const mod = await import('../client.js');
+    await mod.disconnectAll();
+    vi.resetModules();
+  });
+
+  it('reuses the same manager across module reloads in one process', async () => {
+    vi.resetModules();
+    const firstImport = await import('../client.js');
+    const firstManager = firstImport.lspClientManager;
+
+    vi.resetModules();
+    const secondImport = await import('../client.js');
+
+    expect(secondImport.lspClientManager).toBe(firstManager);
+  });
+});

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -14,13 +14,18 @@ import { getServerForFile, commandExists } from './servers.js';
 
 /** Default timeout (ms) for LSP requests. Override with OMC_LSP_TIMEOUT_MS env var. */
 export const DEFAULT_LSP_REQUEST_TIMEOUT_MS: number = (() => {
-  const env = process.env.OMC_LSP_TIMEOUT_MS;
-  if (env) {
-    const parsed = parseInt(env, 10);
-    if (!isNaN(parsed) && parsed > 0) return parsed;
-  }
-  return 15_000;
+  return readPositiveIntEnv('OMC_LSP_TIMEOUT_MS', 15_000);
 })();
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const env = process.env[name];
+  if (!env) {
+    return fallback;
+  }
+
+  const parsed = parseInt(env, 10);
+  return !isNaN(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 /** Convert a file path to a valid file:// URI (cross-platform) */
 function fileUri(filePath: string): string {
@@ -664,18 +669,19 @@ export class LspClient {
 }
 
 /** Idle timeout: disconnect LSP clients unused for 5 minutes */
-export const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+export const IDLE_TIMEOUT_MS = readPositiveIntEnv('OMC_LSP_IDLE_TIMEOUT_MS', 5 * 60 * 1000);
 /** Check for idle clients every 60 seconds */
-export const IDLE_CHECK_INTERVAL_MS = 60 * 1000;
+export const IDLE_CHECK_INTERVAL_MS = readPositiveIntEnv('OMC_LSP_IDLE_CHECK_INTERVAL_MS', 60 * 1000);
 
 /**
  * Client manager - maintains a pool of LSP clients per workspace/server
  * with idle eviction to free resources and in-flight request protection.
  */
-class LspClientManager {
+export class LspClientManager {
   private clients = new Map<string, LspClient>();
   private lastUsed = new Map<string, number>();
   private inFlightCount = new Map<string, number>();
+  private idleDeadlines = new Map<string, ReturnType<typeof setTimeout>>();
   private idleTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor() {
@@ -690,6 +696,14 @@ class LspClientManager {
    */
   private registerCleanupHandlers(): void {
     const forceKillAll = () => {
+      if (this.idleTimer) {
+        clearInterval(this.idleTimer);
+        this.idleTimer = null;
+      }
+      for (const timer of this.idleDeadlines.values()) {
+        clearTimeout(timer);
+      }
+      this.idleDeadlines.clear();
       for (const client of this.clients.values()) {
         try {
           client.forceKill();
@@ -736,8 +750,7 @@ class LspClientManager {
       }
     }
 
-    // Track last-used timestamp
-    this.lastUsed.set(key, Date.now());
+    this.touchClient(key);
 
     return client;
   }
@@ -768,7 +781,7 @@ class LspClientManager {
     }
 
     // Touch timestamp and increment in-flight counter
-    this.lastUsed.set(key, Date.now());
+    this.touchClient(key);
     this.inFlightCount.set(key, (this.inFlightCount.get(key) || 0) + 1);
 
     try {
@@ -781,8 +794,38 @@ class LspClientManager {
       } else {
         this.inFlightCount.set(key, count);
       }
-      this.lastUsed.set(key, Date.now());
+      this.touchClient(key);
     }
+  }
+
+  private touchClient(key: string): void {
+    this.lastUsed.set(key, Date.now());
+    this.scheduleIdleDeadline(key);
+  }
+
+  private scheduleIdleDeadline(key: string): void {
+    this.clearIdleDeadline(key);
+
+    const timer = setTimeout(() => {
+      this.idleDeadlines.delete(key);
+      this.evictClientIfIdle(key);
+    }, IDLE_TIMEOUT_MS);
+
+    if (typeof timer === 'object' && 'unref' in timer) {
+      timer.unref();
+    }
+
+    this.idleDeadlines.set(key, timer);
+  }
+
+  private clearIdleDeadline(key: string): void {
+    const timer = this.idleDeadlines.get(key);
+    if (!timer) {
+      return;
+    }
+
+    clearTimeout(timer);
+    this.idleDeadlines.delete(key);
   }
 
   /**
@@ -831,23 +874,43 @@ class LspClientManager {
    * Clients with in-flight requests are never evicted.
    */
   private evictIdleClients(): void {
-    const now = Date.now();
-    for (const [key, lastUsedTime] of this.lastUsed.entries()) {
-      if (now - lastUsedTime > IDLE_TIMEOUT_MS) {
-        // Skip eviction if there are in-flight requests
-        if ((this.inFlightCount.get(key) || 0) > 0) {
-          continue;
-        }
-        const client = this.clients.get(key);
-        if (client) {
-          client.disconnect().catch(() => {
-            // Ignore disconnect errors during eviction
-          });
-          this.clients.delete(key);
-          this.lastUsed.delete(key);
-          this.inFlightCount.delete(key);
-        }
+    for (const key of this.lastUsed.keys()) {
+      this.evictClientIfIdle(key);
+    }
+  }
+
+  private evictClientIfIdle(key: string): void {
+    const lastUsedTime = this.lastUsed.get(key);
+    if (lastUsedTime === undefined) {
+      this.clearIdleDeadline(key);
+      return;
+    }
+
+    const idleFor = Date.now() - lastUsedTime;
+    if (idleFor <= IDLE_TIMEOUT_MS) {
+      const hasDeadline = this.idleDeadlines.has(key);
+      if (!hasDeadline) {
+        this.scheduleIdleDeadline(key);
       }
+      return;
+    }
+
+    // Skip eviction if there are in-flight requests
+    if ((this.inFlightCount.get(key) || 0) > 0) {
+      this.scheduleIdleDeadline(key);
+      return;
+    }
+
+    const client = this.clients.get(key);
+    this.clearIdleDeadline(key);
+    this.clients.delete(key);
+    this.lastUsed.delete(key);
+    this.inFlightCount.delete(key);
+
+    if (client) {
+      client.disconnect().catch(() => {
+        // Ignore disconnect errors during eviction
+      });
     }
   }
 
@@ -861,6 +924,11 @@ class LspClientManager {
       clearInterval(this.idleTimer);
       this.idleTimer = null;
     }
+
+    for (const timer of this.idleDeadlines.values()) {
+      clearTimeout(timer);
+    }
+    this.idleDeadlines.clear();
 
     const entries = Array.from(this.clients.entries());
     const results = await Promise.allSettled(
@@ -898,8 +966,17 @@ class LspClientManager {
   }
 }
 
-// Export a singleton instance
-export const lspClientManager = new LspClientManager();
+const LSP_CLIENT_MANAGER_KEY = '__omcLspClientManager';
+type GlobalWithLspClientManager = typeof globalThis & {
+  [LSP_CLIENT_MANAGER_KEY]?: LspClientManager;
+};
+
+// Export a process-global singleton instance. This protects against duplicate
+// manager instances if the module is loaded more than once in the same process
+// (for example after module resets in tests or bundle indirection).
+const globalWithLspClientManager = globalThis as GlobalWithLspClientManager;
+export const lspClientManager = globalWithLspClientManager[LSP_CLIENT_MANAGER_KEY]
+  ?? (globalWithLspClientManager[LSP_CLIENT_MANAGER_KEY] = new LspClientManager());
 
 /**
  * Disconnect all LSP clients and free resources.


### PR DESCRIPTION
## Summary
- make the LSP client manager process-global so repeated module loads reuse one manager
- add deterministic per-client idle deadlines and env-configurable LSP idle timing
- shut the standalone MCP server down when its parent/stdin disappears so background-agent termination immediately tears down orphan-prone LSP children
- add regression tests for shutdown hooks and singleton reuse
- mirror the MCP shutdown fix in `bridge/mcp-server.cjs`

## Testing
- `npx tsc --noEmit`
- `npx eslint src/tools/lsp/client.ts src/mcp/standalone-server.ts src/mcp/standalone-shutdown.ts src/mcp/__tests__/standalone-shutdown.test.ts src/tools/lsp/__tests__/client-singleton.test.ts`
- `node -c bridge/mcp-server.cjs`
- `npm test -- --run src/mcp/__tests__/standalone-shutdown.test.ts src/tools/lsp/__tests__/client-singleton.test.ts src/tools/lsp/__tests__/client-eviction.test.ts src/__tests__/standalone-server.test.ts`

Closes #1717.
