### PR TITLE
fix: allow idle while delegated subagents run

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -368,6 +368,18 @@ function readStateFileWithSession(stateDir, filename, sessionId) {
   return readStateFile(stateDir, filename);
 }
 
+function getActiveSubagentCount(stateDir) {
+  try {
+    const tracking = readJsonFile(join(stateDir, "subagent-tracking.json"));
+    if (!tracking || !Array.isArray(tracking.agents)) {
+      return 0;
+    }
+    return tracking.agents.filter((agent) => agent?.status === "running").length;
+  } catch {
+    return 0;
+  }
+}
+
 /**
  * Count incomplete Tasks from Claude Code's native Task system.
  */
@@ -1009,6 +1021,11 @@ async function main() {
           const maxReinforcements = skillState.state.max_reinforcements || 3;
 
           if (count < maxReinforcements) {
+            if (getActiveSubagentCount(stateDir) > 0) {
+              console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+              return;
+            }
+
             skillState.state.reinforcement_count = count + 1;
             skillState.state.last_checked_at = new Date().toISOString();
             writeJsonFile(skillState.path, skillState.state);

--- a/src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
@@ -40,6 +40,28 @@ function writeSkillState(
   );
 }
 
+function writeSubagentTrackingState(
+  tempDir: string,
+  agents: Array<Record<string, unknown>>,
+): void {
+  const stateDir = join(tempDir, '.omc', 'state');
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    join(stateDir, 'subagent-tracking.json'),
+    JSON.stringify(
+      {
+        agents,
+        total_spawned: agents.length,
+        total_completed: agents.filter((agent) => agent.status === 'completed').length,
+        total_failed: agents.filter((agent) => agent.status === 'failed').length,
+        last_updated: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
 describe('persistent-mode skill-state stop integration (issue #1033)', () => {
   it('blocks stop when a skill is actively executing', async () => {
     const sessionId = 'session-skill-1033-block';
@@ -64,6 +86,42 @@ describe('persistent-mode skill-state stop integration (issue #1033)', () => {
     try {
       const result = await checkPersistentModes(sessionId, tempDir);
       expect(result.shouldBlock).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows orchestrator idle when a skill is active but delegated subagents are still running', async () => {
+    const sessionId = 'session-skill-1721-active-agents';
+    const tempDir = makeTempProject();
+
+    try {
+      writeSkillState(tempDir, sessionId, 'ralplan');
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: 'agent-1721',
+          agent_type: 'explore',
+          started_at: new Date().toISOString(),
+          parent_mode: 'none',
+          status: 'running',
+        },
+      ]);
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+
+      const statePath = join(
+        tempDir,
+        '.omc',
+        'state',
+        'sessions',
+        sessionId,
+        'skill-active-state.json',
+      );
+      const persisted = JSON.parse(readFileSync(statePath, 'utf-8')) as {
+        reinforcement_count?: number;
+      };
+      expect(persisted.reinforcement_count).toBe(0);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -21,6 +21,28 @@ function writeTranscriptWithContext(filePath: string, contextWindow: number, inp
   );
 }
 
+function writeSubagentTrackingState(
+  tempDir: string,
+  agents: Array<Record<string, unknown>>,
+): void {
+  const stateDir = join(tempDir, ".omc", "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    join(stateDir, "subagent-tracking.json"),
+    JSON.stringify(
+      {
+        agents,
+        total_spawned: agents.length,
+        total_completed: agents.filter((agent) => agent.status === "completed").length,
+        total_failed: agents.filter((agent) => agent.status === "failed").length,
+        last_updated: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
 describe("Stop Hook Blocking Contract", () => {
   describe("createHookOutput", () => {
     it("returns continue: false when shouldBlock is true", () => {
@@ -568,6 +590,43 @@ describe("Stop Hook Blocking Contract", () => {
         stop_reason: "oauth_expired",
       });
       expect(output.continue).toBe(true);
+    });
+
+    it("returns continue: true when skill state is active but delegated subagents are still running", () => {
+      const sessionId = "skill-active-subagents-cjs";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "skill-active-state.json"),
+        JSON.stringify({
+          active: true,
+          skill_name: "ralplan",
+          session_id: sessionId,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          reinforcement_count: 0,
+          max_reinforcements: 5,
+          stale_ttl_ms: 15 * 60 * 1000,
+        }),
+      );
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: "agent-cjs-1",
+          agent_type: "explore",
+          started_at: new Date().toISOString(),
+          parent_mode: "none",
+          status: "running",
+        },
+      ]);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+
+      const persisted = JSON.parse(
+        readFileSync(join(sessionDir, "skill-active-state.json"), "utf-8"),
+      ) as { reinforcement_count?: number };
+      expect(persisted.reinforcement_count).toBe(0);
     });
 
     it("returns continue: true for critical transcript context when autopilot is active", () => {

--- a/src/hooks/skill-state/__tests__/skill-state.test.ts
+++ b/src/hooks/skill-state/__tests__/skill-state.test.ts
@@ -20,6 +20,28 @@ function makeTempDir(): string {
   return tempDir;
 }
 
+function writeSubagentTrackingState(
+  tempDir: string,
+  agents: Array<Record<string, unknown>>,
+): void {
+  const stateDir = join(tempDir, '.omc', 'state');
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    join(stateDir, 'subagent-tracking.json'),
+    JSON.stringify(
+      {
+        agents,
+        total_spawned: agents.length,
+        total_completed: agents.filter((agent) => agent.status === 'completed').length,
+        total_failed: agents.filter((agent) => agent.status === 'failed').length,
+        last_updated: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
 describe('skill-state', () => {
   let tempDir: string;
 
@@ -336,6 +358,25 @@ describe('skill-state', () => {
       // Different session should not be blocked
       const result = checkSkillActiveState(tempDir, 'session-2');
       expect(result.shouldBlock).toBe(false);
+    });
+
+    it('allows orchestrator idle while delegated subagents are still running', () => {
+      writeSkillActiveState(tempDir, 'plan', 'session-1');
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: 'agent-1',
+          agent_type: 'executor',
+          started_at: new Date().toISOString(),
+          parent_mode: 'none',
+          status: 'running',
+        },
+      ]);
+
+      const result = checkSkillActiveState(tempDir, 'session-1');
+      expect(result.shouldBlock).toBe(false);
+
+      const state = readSkillActiveState(tempDir, 'session-1');
+      expect(state?.reinforcement_count).toBe(0);
     });
 
     it('clears stale state and allows stop', () => {

--- a/src/hooks/skill-state/index.ts
+++ b/src/hooks/skill-state/index.ts
@@ -17,6 +17,7 @@
  */
 
 import { writeModeState, readModeState, clearModeStateFile } from '../../lib/mode-state-io.js';
+import { getActiveAgentCount } from '../subagent-tracker/index.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -253,6 +254,13 @@ export function checkSkillActiveState(
   if (state.reinforcement_count >= state.max_reinforcements) {
     clearSkillActiveState(directory, sessionId);
     return { shouldBlock: false, message: '' };
+  }
+
+  // Orchestrators are allowed to go idle while delegated work is still active.
+  // Do not consume a reinforcement here; the skill is still active and should
+  // resume enforcement only after the running subagents finish.
+  if (getActiveAgentCount(directory) > 0) {
+    return { shouldBlock: false, message: '', skillName: state.skill_name };
   }
 
   // Block the stop and increment reinforcement count

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -349,6 +349,18 @@ function readStateFileWithSession(stateDir, globalStateDir, filename, sessionId)
   return readStateFile(stateDir, globalStateDir, filename);
 }
 
+function getActiveSubagentCount(stateDir) {
+  try {
+    const tracking = readJsonFile(join(stateDir, "subagent-tracking.json"));
+    if (!tracking || !Array.isArray(tracking.agents)) {
+      return 0;
+    }
+    return tracking.agents.filter((agent) => agent?.status === "running").length;
+  } catch {
+    return 0;
+  }
+}
+
 /**
  * Count incomplete Tasks from Claude Code's native Task system.
  */
@@ -984,6 +996,11 @@ async function main() {
         const maxReinforcements = skillState.state.max_reinforcements || 3;
 
         if (count < maxReinforcements) {
+          if (getActiveSubagentCount(stateDir) > 0) {
+            console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+            return;
+          }
+
           const toolError = readLastToolError(stateDir);
           const errorGuidance = getToolErrorRetryGuidance(toolError);
 


### PR DESCRIPTION
## Summary
- allow the skill-active stop hook to skip reinforcement while delegated subagents are still running
- preserve skill-active state and reinforcement counters so enforcement resumes after agents finish
- cover the regression in skill-state, persistent-mode integration, and persistent-mode.cjs script tests

## Testing
- npm test -- --run src/hooks/skill-state/__tests__/skill-state.test.ts src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts src/hooks/persistent-mode/stop-hook-blocking.test.ts
- npm run build
- npm run lint