### PR TITLE
fix: allow orchestrator to idle when sub-agents are active

### DIFF
--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -1117,6 +1117,22 @@ export async function checkPersistentModes(
   const todoResult = await checkIncompleteTodos(sessionId, workingDir, stopContext);
   const hasIncompleteTodos = todoResult.count > 0;
 
+  // Check if there are active sub-agents running.
+  // If so, the orchestrator is waiting for them to finish, which is a valid idle state.
+  // We should not block the stop event in this case.
+  try {
+    const { getActiveAgentCount } = await import('../subagent-tracker/index.js');
+    if (getActiveAgentCount(workingDir) > 0) {
+      return {
+        shouldBlock: false,
+        message: '',
+        mode: 'none'
+      };
+    }
+  } catch {
+    // If subagent-tracker module is unavailable, skip gracefully
+  }
+
   // Priority 1: Ralph (explicit loop mode)
   const ralphResult = await checkRalphLoop(sessionId, workingDir, cancelInProgress);
   if (ralphResult) {


### PR DESCRIPTION
Title: fix: allow orchestrator to idle when sub-agents are active

Fixes #1721

When running in modes like `ralplan` or `ralph`, the orchestrator delegates work to sub-agents via the `Agent` tool. While the sub-agent is actively working, the orchestrator naturally has nothing to do and tries to stop/idle. However, the Stop hook (`persistent-mode` / `skill-state`) was blocking this, forcing the orchestrator into a meaningless polling loop.

This PR adds a check in `checkPersistentModes` to consult the `subagent-tracker`. If there are active sub-agents running (`getActiveAgentCount > 0`), the orchestrator is correctly waiting for them to finish, and the stop event is allowed to proceed (idle state).