### PR TITLE
fix: patch 10 bugs from full codebase review

### DIFF
--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -364,6 +364,7 @@ export function deepMerge<T extends Record<string, unknown>>(
   const result = { ...target };
 
   for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
     const sourceValue = source[key as keyof T];
     const targetValue = target[key as keyof T];
 

--- a/src/features/magic-keywords.ts
+++ b/src/features/magic-keywords.ts
@@ -17,7 +17,12 @@ const INLINE_CODE_PATTERN = /`[^`]+`/g;
  * Remove code blocks from text for keyword detection
  */
 function removeCodeBlocks(text: string): string {
+  if (text.length > 100_000) text = text.slice(0, 100_000);
   return text.replace(CODE_BLOCK_PATTERN, '').replace(INLINE_CODE_PATTERN, '');
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -330,7 +335,7 @@ Use maximum cognitive effort before responding.`;
 function removeTriggerWords(prompt: string, triggers: string[]): string {
   let result = prompt;
   for (const trigger of triggers) {
-    const regex = new RegExp(`\\b${trigger}\\b`, 'gi');
+    const regex = new RegExp(`\\b${escapeRegex(trigger)}\\b`, 'gi');
     result = result.replace(regex, '');
   }
   return result.trim();
@@ -385,7 +390,7 @@ export function createMagicKeywordProcessor(config?: PluginConfig['magicKeywords
 
     for (const keyword of keywords) {
       const hasKeyword = keyword.triggers.some(trigger => {
-        const regex = new RegExp(`\\b${trigger}\\b`, 'i');
+        const regex = new RegExp(`\\b${escapeRegex(trigger)}\\b`, 'i');
         return regex.test(removeCodeBlocks(result));
       });
 
@@ -428,7 +433,7 @@ export function detectMagicKeywords(prompt: string, config?: PluginConfig['magic
 
   for (const keyword of keywords) {
     for (const trigger of keyword.triggers) {
-      const regex = new RegExp(`\\b${trigger}\\b`, 'i');
+      const regex = new RegExp(`\\b${escapeRegex(trigger)}\\b`, 'i');
       if (regex.test(cleanedPrompt)) {
         detected.push(trigger);
         break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,9 +270,9 @@ export function createOmcSession(options?: OmcOptions): OmcSession {
   };
 
   // Find and load context files
+  const contextFiles = findContextFiles(options?.workingDirectory);
   let contextAddition = '';
   if (!options?.skipContextInjection && config.features?.autoContextInjection !== false) {
-    const contextFiles = findContextFiles(options?.workingDirectory);
     if (contextFiles.length > 0) {
       contextAddition = `\n\n## Project Context\n\n${loadContextFromFiles(contextFiles)}`;
     }
@@ -343,7 +343,7 @@ export function createOmcSession(options?: OmcOptions): OmcSession {
   const state: SessionState = {
     activeAgents: new Map(),
     backgroundTasks: [],
-    contextFiles: findContextFiles(options?.workingDirectory)
+    contextFiles
   };
 
   // Create background task manager

--- a/src/lib/file-lock.ts
+++ b/src/lib/file-lock.ts
@@ -183,11 +183,10 @@ export function acquireFileLockSync(
   // Retry loop with busy-wait using Atomics (avoids blocking the event loop
   // in a way that prevents signal handling, but is acceptable for short locks)
   const deadline = Date.now() + timeoutMs;
-  const sharedBuf = new SharedArrayBuffer(4);
-  const sharedArr = new Int32Array(sharedBuf);
 
   while (Date.now() < deadline) {
-    Atomics.wait(sharedArr, 0, 0, Math.min(retryDelayMs, deadline - Date.now()));
+    const sleepUntil = Date.now() + Math.min(retryDelayMs, deadline - Date.now());
+    while (Date.now() < sleepUntil) { /* busy-wait */ }
     const retryHandle = tryAcquireSync(lockPath, staleLockMs);
     if (retryHandle) return retryHandle;
   }

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -526,15 +526,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     return createDeprecatedCliOnlyEnvelopeWithArgs(name, args);
   }
 
-  try {
-    if (name === 'omc_run_team_start') return await handleStart(args ?? {});
-    if (name === 'omc_run_team_status') return await handleStatus(args ?? {});
-    if (name === 'omc_run_team_wait') return await handleWait(args ?? {});
-    if (name === 'omc_run_team_cleanup') return await handleCleanup(args ?? {});
-    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
-  } catch (error) {
-    return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
-  }
+  return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
 });
 
 async function main() {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -71,6 +71,7 @@ import {
 } from './worker-bootstrap.js';
 import { queueInboxInstruction, type DispatchOutcome } from './mcp-comm.js';
 import { cleanupTeamWorktrees } from './git-worktree.js';
+import { withTaskLock } from './task-file-ops.js';
 
 // ---------------------------------------------------------------------------
 // Feature flag
@@ -897,13 +898,16 @@ export async function requeueDeadWorkerTasks(
     // Reset task to pending (clear owner and claim)
     const taskPath = absPath(cwd, TeamPaths.taskFile(sanitized, task.id));
     try {
-      const raw = await import('fs/promises').then(fs => fs.readFile(taskPath, 'utf-8'));
-      const taskData = JSON.parse(raw);
-      taskData.status = 'pending';
-      taskData.owner = undefined;
-      taskData.claim = undefined;
-      await writeFile(taskPath, JSON.stringify(taskData, null, 2), 'utf-8');
-      requeued.push(task.id);
+      const result = await withTaskLock(sanitized, task.id, async () => {
+        const raw = await import('fs/promises').then(fs => fs.readFile(taskPath, 'utf-8'));
+        const taskData = JSON.parse(raw);
+        taskData.status = 'pending';
+        taskData.owner = undefined;
+        taskData.claim = undefined;
+        await writeFile(taskPath, JSON.stringify(taskData, null, 2), 'utf-8');
+        return true;
+      }, { cwd });
+      if (result) requeued.push(task.id);
     } catch {
       // Task file may have been removed; skip
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -679,9 +679,6 @@ export async function spawnWorkerForTask(
   const taskId = String(taskIndex + 1);
   const task = runtime.config.tasks[taskIndex];
   if (!task) return '';
-  const marked = await markTaskInProgress(root, taskId, workerNameValue, runtime.teamName, runtime.cwd);
-  if (!marked) return '';
-
   const { execFile } = await import('child_process');
   const { promisify } = await import('util');
   const execFileAsync = promisify(execFile);
@@ -697,6 +694,13 @@ export async function spawnWorkerForTask(
   ]);
   const paneId = splitResult.stdout.split('\n')[0]?.trim();
   if (!paneId) return '';
+
+  const marked = await markTaskInProgress(root, taskId, workerNameValue, runtime.teamName, runtime.cwd);
+  if (!marked) {
+    // Pane created but couldn't mark task — kill orphaned pane
+    try { await execFileAsync('tmux', ['kill-pane', '-t', paneId]); } catch { /* ignore */ }
+    return '';
+  }
 
   const workerIndex = parseWorkerIndex(workerNameValue);
   const agentType = runtime.config.agentTypes[workerIndex % runtime.config.agentTypes.length]
@@ -990,7 +994,7 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
 
   const paneTarget = sName.includes(':') ? sName : sName.split(':')[0];
   const panesResult = await execFileAsync('tmux', [
-    'list-panes', '-t', paneTarget, '-F', '#{pane_id}'
+    'list-panes', '-s', '-t', paneTarget, '-F', '#{pane_id}'
   ]);
   const allPanes = panesResult.stdout.trim().split('\n').filter(Boolean);
   // First pane is leader, rest are workers

--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -25,7 +25,7 @@ const BLOCKED_HOST_PATTERNS = [
   /^169\.254\.[0-9]+\.[0-9]+$/, // Link-local
   /^(0|22[4-9]|23[0-9])\.[0-9]+\.[0-9]+\.[0-9]+$/, // Multicast, reserved
   /^\[?::1\]?$/, // IPv6 loopback
-  /^\[?fc00:/i, // IPv6 unique local
+  /^\[?f[cd][0-9a-f]{2}:/i, // IPv6 unique local (fc00::/7 covers both fc and fd prefixes)
   /^\[?fe80:/i, // IPv6 link-local
   /^\[?::ffff:/i, // IPv6-mapped IPv4 (all private ranges accessible via this prefix)
   /^\[?0{0,4}:{0,2}ffff:/i, // IPv6-mapped IPv4 expanded forms


### PR DESCRIPTION
## Summary

- **Prototype pollution** guard in `deepMerge` (`agents/utils.ts`) — matches existing guard in `loader.ts`
- **SSRF bypass**: IPv6 unique-local regex now covers full `fc00::/7` range (both `fc` and `fd` prefixes)
- **ReDoS**: length guard (100K) on `removeCodeBlocks` regex hot path (`magic-keywords.ts`)
- **RegExp injection**: escape config-sourced trigger strings before `new RegExp()` — 3 call sites
- **Task stuck in_progress**: reorder pane creation before `markTaskInProgress` with orphan cleanup (`runtime.ts`)
- **resumeTeam**: scan all tmux windows with `list-panes -s` flag, not just active window
- **Non-atomic requeue**: wrap task reset in `withTaskLock` to prevent race conditions (`runtime-v2.ts`)
- **Atomics.wait crash**: replace with busy-wait loop — `Atomics.wait` throws on main thread (`file-lock.ts`)
- **Duplicate I/O**: deduplicate `findContextFiles` calls in `createOmcSession` (`index.ts`)
- **Dead code**: remove unreachable handler calls in team-server request handler (`team-server.ts`)

## Stats

8 files changed, 34 insertions, 29 deletions

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] SSRF guard tests pass (63 tests)
- [x] Team runtime tests pass (40 tests)
- [x] No new dependencies added