### PR TITLE
feat(docs): add Lore commit knowledge protocol to CLAUDE.md template

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,87 +1,115 @@
-# Claude AI Instructions for oh-my-claudecode
+<!-- OMC:START -->
+<!-- OMC:VERSION:4.8.2 -->
 
-This file provides context for Claude when working on this repository via GitHub Actions.
+# oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
-## Repository Overview
+You are running with oh-my-claudecode (OMC), a multi-agent orchestration layer for Claude Code.
+Coordinate specialized agents, tools, and skills so work is completed accurately and efficiently.
 
-oh-my-claudecode is a Claude Code plugin that provides multi-agent orchestration capabilities.
+<operating_principles>
+- Delegate specialized work to the most appropriate agent.
+- Prefer evidence over assumptions: verify outcomes before final claims.
+- Choose the lightest-weight path that preserves quality.
+- Consult official docs before implementing with SDKs/frameworks/APIs.
+</operating_principles>
 
-### Key Features
-- **18 specialized agents** with intelligent model routing (Haiku/Sonnet/Opus tiers)
-- **32 slash commands** including /oh-my-claudecode:ultrawork, /oh-my-claudecode:deepinit, /oh-my-claudecode:ralph
-- **Smart delegation** - automatically routes tasks to appropriate specialist agents
-- **Background execution** - runs long-running tasks asynchronously
-- **Cost optimization** - chillwork mode prefers cheaper model tiers
+<delegation_rules>
+Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
+Work directly for: trivial ops, small clarifications, single commands.
+Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
+</delegation_rules>
 
-### Installation
-```bash
-/plugin marketplace add Yeachan-Heo/oh-my-claudecode
+<model_routing>
+`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
+Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
+</model_routing>
+
+<agent_catalog>
+Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
+
+explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (sonnet), executor (sonnet), verifier (sonnet), tracer (sonnet), security-reviewer (sonnet), code-reviewer (opus), test-engineer (sonnet), designer (sonnet), writer (haiku), qa-tester (sonnet), scientist (sonnet), document-specialist (sonnet), git-master (sonnet), code-simplifier (opus), critic (opus)
+</agent_catalog>
+
+<tools>
+External AI: `/team N:executor "task"`, `omc team N:codex|gemini "..."`, `omc ask <claude|codex|gemini>`, `/ccg`
+OMC State: `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
+Teams: `TeamCreate`, `TeamDelete`, `SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`
+Notepad: `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`
+Project Memory: `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
+Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, etc.), AST (`ast_grep_search`, `ast_grep_replace`), `python_repl`
+</tools>
+
+<skills>
+Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
+
+Workflow: `autopilot`, `ralph`, `ultrawork`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`
+Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
+Utilities: `ask-codex`, `ask-gemini`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `configure-notifications`, `learn-about-omc` (`trace` is the evidence-driven tracing lane)
+</skills>
+
+<team_pipeline>
+Stages: `team-plan` → `team-prd` → `team-exec` → `team-verify` → `team-fix` (loop).
+Fix loop bounded by max attempts. `team ralph` links both modes.
+</team_pipeline>
+
+<verification>
+Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
+If verification fails, keep iterating.
+</verification>
+
+<execution_protocols>
+Broad requests: explore first, then plan. 2+ independent tasks in parallel. `run_in_background` for builds/tests.
+Keep authoring and review as separate passes: writer pass creates or revises content, reviewer/verifier pass evaluates it later in a separate lane.
+Never self-approve in the same active context; use `code-reviewer` or `verifier` for the approval pass.
+Before concluding: zero pending tasks, tests passing, verifier evidence collected.
+</execution_protocols>
+
+<commit_protocol>
+Use git trailers to preserve decision context in every commit message.
+Format: conventional commit subject line, optional body, then structured trailers.
+
+Trailers (include when applicable — skip for trivial commits like typos or formatting):
+- `Constraint:` active constraint that shaped this decision
+- `Rejected:` alternative considered | reason for rejection
+- `Directive:` warning or instruction for future modifiers of this code
+- `Confidence:` high | medium | low
+- `Scope-risk:` narrow | moderate | broad
+- `Not-tested:` edge case or scenario not covered by tests
+
+Example:
 ```
+fix(auth): prevent silent session drops during long-running ops
 
-## Code Structure
+Auth service returns inconsistent status codes on token expiry,
+so the interceptor catches all 4xx and triggers inline refresh.
 
+Constraint: Auth service does not support token introspection
+Constraint: Must not add latency to non-expired-token paths
+Rejected: Extend token TTL to 24h | security policy violation
+Rejected: Background refresh on timer | race condition with concurrent requests
+Confidence: high
+Scope-risk: narrow
+Directive: Error handling is intentionally broad (all 4xx) — do not narrow without verifying upstream behavior
+Not-tested: Auth service cold-start latency >500ms
 ```
-.claude-plugin/          # Plugin metadata
-  plugin.json            # Main plugin config
-  marketplace.json       # Marketplace registration
-agents/                  # Agent definitions (YAML)
-skills/                  # Skill definitions (Markdown)
-commands/                # Slash command definitions
-hooks/                   # Hook scripts
-src/                     # Source code (if any)
-tests/                   # Test files
-```
+</commit_protocol>
 
-## When Responding to Issues
+<hooks_and_context>
+Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (invoke skill), `The boulder never stops` (ralph/ultrawork active).
+Persistence: `<remember>` (7 days), `<remember priority>` (permanent).
+Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS` (comma-separated).
+</hooks_and_context>
 
-### Installation Issues
-- Recommend running `/oh-my-claudecode:omc-doctor` to diagnose problems
-- Check if user installed via correct method: `/plugin marketplace add Yeachan-Heo/oh-my-claudecode`
-- Common issues: outdated Claude Code version, missing dependencies
+<cancellation>
+`/oh-my-claudecode:cancel` ends execution modes. Cancel when done+verified or blocked. Don't cancel if work incomplete.
+</cancellation>
 
-### Bug Reports
-- Ask for Claude Code version if not provided
-- Request reproduction steps
-- Check if issue exists in `agents/` or `skills/` definitions
+<worktree_paths>
+State: `.omc/state/`, `.omc/state/sessions/{sessionId}/`, `.omc/notepad.md`, `.omc/project-memory.json`, `.omc/plans/`, `.omc/research/`, `.omc/logs/`
+</worktree_paths>
 
-### Feature Requests
-- Acknowledge the request
-- Consider if it fits the plugin's philosophy (intelligent delegation, persistence)
-- Label appropriately
+## Setup
 
-## When Reviewing PRs
+Say "setup omc" or run `/oh-my-claudecode:omc-setup`.
 
-### Agent Definitions
-- Verify YAML syntax is correct
-- Check that `subagent_type` matches the file name
-- Ensure model tier is appropriate (haiku for simple, sonnet for medium, opus for complex)
-- Verify description matches the agent's purpose
-
-### Skill Definitions
-- Check Markdown formatting
-- Verify the skill follows existing patterns
-- Ensure instructions are clear and complete
-
-### Code Quality
-- Follow existing code patterns
-- Include tests for new functionality
-- Update version numbers if adding features
-
-## Agent Tiers
-
-| Tier | Model | Use For |
-|------|-------|---------|
-| LOW | Haiku | Simple lookups, fast searches |
-| MEDIUM | Sonnet | Standard implementation work |
-| HIGH | Opus | Complex reasoning, architecture |
-
-## Common Labels
-
-- `bug` - Something isn't working
-- `enhancement` - Feature request
-- `question` - User needs help
-- `documentation` - Docs improvement
-- `installation` - Setup/install issues
-- `agents` - Related to agent definitions
-- `stale` - No recent activity
-- `pinned` - Keep open, don't auto-close
+<!-- OMC:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,115 @@
-# Development Guidelines
+<!-- OMC:START -->
+<!-- OMC:VERSION:4.8.2 -->
 
-## Branch Strategy
-- **Default base branch: `dev`** (NOT `main`)
-- All PRs must target `dev` branch
-- Never create PRs targeting `main` directly
-- Always create worktrees from `dev`: `git worktree add <path> -b <branch> dev`
+# oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
-## PR Creation
-When creating a PR, always use:
+You are running with oh-my-claudecode (OMC), a multi-agent orchestration layer for Claude Code.
+Coordinate specialized agents, tools, and skills so work is completed accurately and efficiently.
+
+<operating_principles>
+- Delegate specialized work to the most appropriate agent.
+- Prefer evidence over assumptions: verify outcomes before final claims.
+- Choose the lightest-weight path that preserves quality.
+- Consult official docs before implementing with SDKs/frameworks/APIs.
+</operating_principles>
+
+<delegation_rules>
+Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
+Work directly for: trivial ops, small clarifications, single commands.
+Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
+</delegation_rules>
+
+<model_routing>
+`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
+Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
+</model_routing>
+
+<agent_catalog>
+Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
+
+explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (sonnet), executor (sonnet), verifier (sonnet), tracer (sonnet), security-reviewer (sonnet), code-reviewer (opus), test-engineer (sonnet), designer (sonnet), writer (haiku), qa-tester (sonnet), scientist (sonnet), document-specialist (sonnet), git-master (sonnet), code-simplifier (opus), critic (opus)
+</agent_catalog>
+
+<tools>
+External AI: `/team N:executor "task"`, `omc team N:codex|gemini "..."`, `omc ask <claude|codex|gemini>`, `/ccg`
+OMC State: `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
+Teams: `TeamCreate`, `TeamDelete`, `SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`
+Notepad: `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`
+Project Memory: `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
+Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, etc.), AST (`ast_grep_search`, `ast_grep_replace`), `python_repl`
+</tools>
+
+<skills>
+Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
+
+Workflow: `autopilot`, `ralph`, `ultrawork`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`
+Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
+Utilities: `ask-codex`, `ask-gemini`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `configure-notifications`, `learn-about-omc` (`trace` is the evidence-driven tracing lane)
+</skills>
+
+<team_pipeline>
+Stages: `team-plan` → `team-prd` → `team-exec` → `team-verify` → `team-fix` (loop).
+Fix loop bounded by max attempts. `team ralph` links both modes.
+</team_pipeline>
+
+<verification>
+Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
+If verification fails, keep iterating.
+</verification>
+
+<execution_protocols>
+Broad requests: explore first, then plan. 2+ independent tasks in parallel. `run_in_background` for builds/tests.
+Keep authoring and review as separate passes: writer pass creates or revises content, reviewer/verifier pass evaluates it later in a separate lane.
+Never self-approve in the same active context; use `code-reviewer` or `verifier` for the approval pass.
+Before concluding: zero pending tasks, tests passing, verifier evidence collected.
+</execution_protocols>
+
+<commit_protocol>
+Use git trailers to preserve decision context in every commit message.
+Format: conventional commit subject line, optional body, then structured trailers.
+
+Trailers (include when applicable — skip for trivial commits like typos or formatting):
+- `Constraint:` active constraint that shaped this decision
+- `Rejected:` alternative considered | reason for rejection
+- `Directive:` warning or instruction for future modifiers of this code
+- `Confidence:` high | medium | low
+- `Scope-risk:` narrow | moderate | broad
+- `Not-tested:` edge case or scenario not covered by tests
+
+Example:
 ```
-gh pr create --base dev ...
-```
+fix(auth): prevent silent session drops during long-running ops
 
-## Commit Convention
-- Use English for all commit messages, PR titles, and issue comments
-- Format: `type(scope): description`
+Auth service returns inconsistent status codes on token expiry,
+so the interceptor catches all 4xx and triggers inline refresh.
+
+Constraint: Auth service does not support token introspection
+Constraint: Must not add latency to non-expired-token paths
+Rejected: Extend token TTL to 24h | security policy violation
+Rejected: Background refresh on timer | race condition with concurrent requests
+Confidence: high
+Scope-risk: narrow
+Directive: Error handling is intentionally broad (all 4xx) — do not narrow without verifying upstream behavior
+Not-tested: Auth service cold-start latency >500ms
+```
+</commit_protocol>
+
+<hooks_and_context>
+Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (invoke skill), `The boulder never stops` (ralph/ultrawork active).
+Persistence: `<remember>` (7 days), `<remember priority>` (permanent).
+Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS` (comma-separated).
+</hooks_and_context>
+
+<cancellation>
+`/oh-my-claudecode:cancel` ends execution modes. Cancel when done+verified or blocked. Don't cancel if work incomplete.
+</cancellation>
+
+<worktree_paths>
+State: `.omc/state/`, `.omc/state/sessions/{sessionId}/`, `.omc/notepad.md`, `.omc/project-memory.json`, `.omc/plans/`, `.omc/research/`, `.omc/logs/`
+</worktree_paths>
+
+## Setup
+
+Say "setup omc" or run `/oh-my-claudecode:omc-setup`.
+
+<!-- OMC:END -->

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -64,6 +64,36 @@ Never self-approve in the same active context; use `code-reviewer` or `verifier`
 Before concluding: zero pending tasks, tests passing, verifier evidence collected.
 </execution_protocols>
 
+<commit_protocol>
+Use git trailers to preserve decision context in every commit message.
+Format: conventional commit subject line, optional body, then structured trailers.
+
+Trailers (include when applicable — skip for trivial commits like typos or formatting):
+- `Constraint:` active constraint that shaped this decision
+- `Rejected:` alternative considered | reason for rejection
+- `Directive:` warning or instruction for future modifiers of this code
+- `Confidence:` high | medium | low
+- `Scope-risk:` narrow | moderate | broad
+- `Not-tested:` edge case or scenario not covered by tests
+
+Example:
+```
+fix(auth): prevent silent session drops during long-running ops
+
+Auth service returns inconsistent status codes on token expiry,
+so the interceptor catches all 4xx and triggers inline refresh.
+
+Constraint: Auth service does not support token introspection
+Constraint: Must not add latency to non-expired-token paths
+Rejected: Extend token TTL to 24h | security policy violation
+Rejected: Background refresh on timer | race condition with concurrent requests
+Confidence: high
+Scope-risk: narrow
+Directive: Error handling is intentionally broad (all 4xx) — do not narrow without verifying upstream behavior
+Not-tested: Auth service cold-start latency >500ms
+```
+</commit_protocol>
+
 <hooks_and_context>
 Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (invoke skill), `The boulder never stops` (ralph/ultrawork active).
 Persistence: `<remember>` (7 days), `<remember priority>` (permanent).


### PR DESCRIPTION
Adds the Lore commit knowledge protocol to the CLAUDE.md template, based on the [Lore paper (arXiv:2603.15566)](https://arxiv.org/abs/2603.15566).

## What

New `<commit_protocol>` section in CLAUDE.md that instructs agents to use git trailers for preserving decision context in commit messages:

- `Constraint:` — active constraints that shaped the decision
- `Rejected:` — alternatives considered with rejection reasons
- `Directive:` — warnings/instructions for future code modifiers
- `Confidence:` — decision confidence level
- `Scope-risk:` — change impact scope
- `Not-tested:` — uncovered edge cases

## Why

Every commit captures a diff but discards the reasoning — constraints, rejected alternatives, and forward-looking context (the "Decision Shadow"). Lore uses native git trailers to make this knowledge machine-parseable and permanently bound to the code change.

## Changes

- `docs/CLAUDE.md` — added `<commit_protocol>` section
- `CLAUDE.md` and `.github/CLAUDE.md` — synced

All three copies are identical. No code changes, only documentation.