### PR TITLE
feat: add mandatory deslop pass to ralph workflow (#1736)

### DIFF
--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -37,6 +37,24 @@ Do not use this skill when:
 - Stay concise and evidence-dense: inspect, edit, verify, and report.
 - Treat new user instructions as local scope updates without dropping earlier non-conflicting constraints.
 
+## Scoped File-List Usage
+
+This skill can be bounded to an explicit file list or changed-file scope when the caller already knows the safe cleanup surface.
+
+- Good fit: `oh-my-claudecode:ai-slop-cleaner skills/ralph/SKILL.md skills/ai-slop-cleaner/SKILL.md`
+- Good fit: a Ralph session handing off only the files changed in that session
+- Preserve the same regression-safe workflow even when the scope is a short file list
+- Do not silently expand a changed-file scope into broader cleanup work unless the user explicitly asks for it
+
+## Ralph Integration
+
+Ralph can invoke this skill as a bounded post-review cleanup pass.
+
+- In that workflow, the cleaner runs in standard mode (not `--review`)
+- The cleanup scope is the Ralph session's changed files only
+- After the cleanup pass, Ralph re-runs regression verification before completion
+- `--review` remains the reviewer-only follow-up mode, not the default Ralph integration path
+
 ## Review Mode (`--review`)
 
 `--review` is a reviewer-only pass after cleanup work is drafted. It exists to preserve explicit writer/reviewer separation for anti-slop work.
@@ -101,6 +119,8 @@ In review mode:
 
 - `/oh-my-claudecode:ai-slop-cleaner <target>`
 - `/oh-my-claudecode:ai-slop-cleaner <target> --review`
+- `/oh-my-claudecode:ai-slop-cleaner <file-a> <file-b> <file-c>`
+- From Ralph: run the cleaner on the Ralph session's changed files only, then return to Ralph for post-cleanup regression verification
 
 ## Good Fits
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -39,6 +39,8 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 
 **Opt-out:** If `{{PROMPT}}` contains `--no-prd`, skip PRD generation and work in legacy mode (no story tracking, generic verification). Use this for trivial quick fixes.
 
+**Deslop opt-out:** If `{{PROMPT}}` contains `--no-deslop`, skip the mandatory post-review deslop pass entirely. Use this only when the cleanup pass is intentionally out of scope for the run.
+
 **Reviewer selection:** Pass `--critic=architect`, `--critic=critic`, or `--critic=codex` in the Ralph prompt to choose the completion reviewer for that run. `architect` remains the default.
 </PRD_Mode>
 
@@ -96,7 +98,18 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
    - Ralph floor: always at least STANDARD, even for small changes
    - The selected reviewer verifies against the SPECIFIC acceptance criteria from prd.json, not vague "is it done?"
 
-8. **On approval**: Run `/oh-my-claudecode:cancel` to cleanly exit and clean up all state files
+7.5 **Mandatory Deslop Pass**:
+   - Unless `{{PROMPT}}` contains `--no-deslop`, run `oh-my-claudecode:ai-slop-cleaner` in standard mode (not `--review`) on the files changed during the current Ralph session only.
+   - Keep the scope bounded to the Ralph changed-file set; do not broaden the cleanup pass to unrelated files.
+   - If the reviewer approved the implementation but the deslop pass introduces follow-up edits, keep those edits inside the same changed-file scope before proceeding.
+
+7.6 **Regression Re-verification**:
+   - After the deslop pass, re-run all relevant tests, build, and lint checks for the Ralph session.
+   - Read the output and confirm the post-deslop regression run actually passes.
+   - If regression fails, roll back the cleaner changes or fix the regression, then rerun the verification loop until it passes.
+   - Only proceed to completion after the post-deslop regression run passes (or `--no-deslop` was explicitly specified).
+
+8. **On approval**: After Step 7.6 passes (with Step 7.5 completed, or skipped via `--no-deslop`), run `/oh-my-claudecode:cancel` to cleanly exit and clean up all state files
 
 9. **On rejection**: Fix the issues raised, re-verify with the same reviewer, then loop back to check if the story needs to be marked incomplete
 </Steps>
@@ -192,6 +205,8 @@ Why bad: Did not refine scaffold criteria into task-specific ones. This is PRD t
 - [ ] lsp_diagnostics shows 0 errors on affected files
 - [ ] progress.txt records implementation details and learnings
 - [ ] Selected reviewer verification passed against specific acceptance criteria
+- [ ] ai-slop-cleaner pass completed on changed files (or `--no-deslop` specified)
+- [ ] Post-deslop regression tests pass
 - [ ] `/oh-my-claudecode:cancel` run for clean state cleanup
 </Final_Checklist>
 


### PR DESCRIPTION
## Summary
- add a mandatory Ralph Step 7.5 deslop pass using `oh-my-claudecode:ai-slop-cleaner` on changed files only
- add Ralph Step 7.6 post-deslop regression re-verification and `--no-deslop` opt-out guidance
- document file-list scoping and Ralph integration in `ai-slop-cleaner`

## Verification
- `npm run build`
- `npm run test:run`
- `npm run lint` (passes with pre-existing warnings in unrelated `src/` files)
