### PR TITLE
feat(autoresearch): launch from interview artifacts

### DIFF
--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -25,7 +25,15 @@ vi.mock('../tmux-utils.js', () => ({
   wrapWithLoginShell: wrapWithLoginShellMock,
 }));
 
-import { guidedAutoresearchSetup, initAutoresearchMission, parseInitArgs, checkTmuxAvailable, spawnAutoresearchTmux } from '../autoresearch-guided.js';
+import {
+  checkTmuxAvailable,
+  guidedAutoresearchSetup,
+  initAutoresearchMission,
+  parseInitArgs,
+  runAutoresearchNoviceBridge,
+  spawnAutoresearchTmux,
+  type AutoresearchQuestionIO,
+} from '../autoresearch-guided.js';
 
 async function initRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omc-autoresearch-guided-test-'));
@@ -36,6 +44,28 @@ async function initRepo(): Promise<string> {
   execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
   return cwd;
+}
+
+function withMockedTty<T>(fn: () => Promise<T>): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+  Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+  return fn().finally(() => {
+    if (descriptor) {
+      Object.defineProperty(process.stdin, 'isTTY', descriptor);
+    } else {
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
+    }
+  });
+}
+
+function makeFakeIo(answers: string[]): AutoresearchQuestionIO {
+  const queue = [...answers];
+  return {
+    async question(): Promise<string> {
+      return queue.shift() ?? '';
+    },
+    close(): void {},
+  };
 }
 
 describe('initAutoresearchMission', () => {
@@ -122,7 +152,6 @@ describe('initAutoresearchMission', () => {
       await rm(repo, { recursive: true, force: true });
     }
   });
-
 
   it('allows valid mission creation even when cwd is inside missions root', async () => {
     const repo = await initRepo();
@@ -219,6 +248,94 @@ describe('parseInitArgs', () => {
   });
 });
 
+describe('runAutoresearchNoviceBridge', () => {
+  it('loops through refine further before launching and writes draft + mission files', async () => {
+    const repo = await initRepo();
+    try {
+      const result = await withMockedTty(() => runAutoresearchNoviceBridge(
+        repo,
+        {},
+        makeFakeIo([
+          'Improve evaluator UX',
+          'Make success measurable',
+          'TODO replace with evaluator command',
+          'score_improvement',
+          'ux-eval',
+          'refine further',
+          'Improve evaluator UX',
+          'Passing evaluator output',
+          'node scripts/eval.js',
+          'pass_only',
+          'ux-eval',
+          'launch',
+        ]),
+      ));
+
+      const draftContent = await readFile(join(repo, '.omc', 'specs', 'deep-interview-autoresearch-ux-eval.md'), 'utf-8');
+      const resultContent = await readFile(join(repo, '.omc', 'specs', 'autoresearch-ux-eval', 'result.json'), 'utf-8');
+      const missionContent = await readFile(join(result.missionDir, 'mission.md'), 'utf-8');
+      const sandboxContent = await readFile(join(result.missionDir, 'sandbox.md'), 'utf-8');
+
+      expect(result.slug).toBe('ux-eval');
+      expect(draftContent).toMatch(/Launch-ready: yes/);
+      expect(resultContent).toMatch(/"launchReady": true/);
+      expect(missionContent).toMatch(/Improve evaluator UX/);
+      expect(sandboxContent).toMatch(/command: node scripts\/eval\.js/);
+      expect(sandboxContent).toMatch(/keep_policy: pass_only/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('uses seeded inputs while still requiring confirmation-driven launch', async () => {
+    const repo = await initRepo();
+    try {
+      const result = await withMockedTty(() => runAutoresearchNoviceBridge(
+        repo,
+        {
+          topic: 'Seeded topic',
+          evaluatorCommand: 'node scripts/eval.js',
+          keepPolicy: 'score_improvement',
+          slug: 'seeded-topic',
+        },
+        makeFakeIo([
+          '',
+          '',
+          '',
+          '',
+          '',
+          'launch',
+        ]),
+      ));
+
+      const draftContent = await readFile(join(repo, '.omc', 'specs', 'deep-interview-autoresearch-seeded-topic.md'), 'utf-8');
+      expect(result.slug).toBe('seeded-topic');
+      expect(draftContent).toMatch(/- topic: Seeded topic/);
+      expect(draftContent).toMatch(/- evaluator: node scripts\/eval\.js/);
+      expect(draftContent).toMatch(/Launch-ready: yes/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('guidedAutoresearchSetup', () => {
+  it('delegates to the novice bridge behavior', async () => {
+    const repo = await initRepo();
+    try {
+      const result = await withMockedTty(() => guidedAutoresearchSetup(
+        repo,
+        { topic: 'Seeded topic', evaluatorCommand: 'node scripts/eval.js', keepPolicy: 'score_improvement', slug: 'seeded-topic' },
+        makeFakeIo(['', '', '', '', '', 'launch']),
+      ));
+
+      expect(result.slug).toBe('seeded-topic');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('checkTmuxAvailable', () => {
   beforeEach(() => {
     tmuxAvailableMock.mockReset();
@@ -312,52 +429,5 @@ describe('spawnAutoresearchTmux', () => {
 
     expect(() => spawnAutoresearchTmux('/repo/missions/demo', 'demo')).toThrow(/did not stay available after launch/);
     expect(logSpy).not.toHaveBeenCalled();
-  });
-});
-
-
-describe('guidedAutoresearchSetup', () => {
-  it('loops on low-confidence inference until clarification produces a launch-ready handoff', async () => {
-    const questionMock = vi.fn()
-      .mockResolvedValueOnce('Improve search onboarding')
-      .mockResolvedValueOnce('')
-      .mockResolvedValueOnce('Use the vitest onboarding smoke test as evaluator');
-    const closeMock = vi.fn();
-    const createPromptInterface = vi.fn(() => ({ question: questionMock, close: closeMock }));
-    const runSetupSession = vi.fn()
-      .mockReturnValueOnce({
-        missionText: 'Improve search onboarding',
-        evaluatorCommand: 'npm run test:onboarding',
-        evaluatorSource: 'inferred',
-        confidence: 0.4,
-        slug: 'search-onboarding',
-        readyToLaunch: false,
-        clarificationQuestion: 'Which script or command should prove the goal?',
-      })
-      .mockReturnValueOnce({
-        missionText: 'Improve search onboarding',
-        evaluatorCommand: 'npm run test:onboarding',
-        evaluatorSource: 'inferred',
-        confidence: 0.92,
-        slug: 'search-onboarding',
-        readyToLaunch: true,
-      });
-
-    const isTty = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
-
-    try {
-      const repo = await initRepo();
-      const result = await guidedAutoresearchSetup(repo, {
-        createPromptInterface: createPromptInterface as never,
-        runSetupSession,
-      });
-
-      expect(result.slug).toBe('search-onboarding');
-      expect(runSetupSession).toHaveBeenCalledTimes(2);
-      expect(closeMock).toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(process.stdin, 'isTTY', { value: isTty, configurable: true });
-    }
   });
 });

--- a/src/cli/__tests__/autoresearch-intake.test.ts
+++ b/src/cli/__tests__/autoresearch-intake.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'node:child_process';
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  isLaunchReadyEvaluatorCommand,
+  writeAutoresearchDeepInterviewArtifacts,
+  writeAutoresearchDraftArtifact,
+} from '../autoresearch-intake.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omc-autoresearch-intake-test-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+describe('autoresearch intake draft artifacts', () => {
+  it('writes a canonical deep-interview autoresearch draft artifact from vague input', async () => {
+    const repo = await initRepo();
+    try {
+      const artifact = await writeAutoresearchDraftArtifact({
+        repoRoot: repo,
+        topic: 'Improve onboarding for first-time contributors',
+        keepPolicy: 'score_improvement',
+        seedInputs: { topic: 'Improve onboarding for first-time contributors' },
+      });
+
+      expect(artifact.path).toMatch(/\.omc\/specs\/deep-interview-autoresearch-improve-onboarding-for-first-time-contributors\.md$/);
+      expect(artifact.launchReady).toBe(false);
+      expect(artifact.content).toMatch(/## Mission Draft/);
+      expect(artifact.content).toMatch(/## Evaluator Draft/);
+      expect(artifact.content).toMatch(/## Launch Readiness/);
+      expect(artifact.content).toMatch(/## Seed Inputs/);
+      expect(artifact.content).toMatch(/## Confirmation Bridge/);
+      expect(artifact.content).toMatch(/TODO replace with evaluator command/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects placeholder evaluator commands and accepts concrete commands', () => {
+    expect(isLaunchReadyEvaluatorCommand('TODO replace me')).toBe(false);
+    expect(isLaunchReadyEvaluatorCommand('node scripts/eval.js')).toBe(true);
+    expect(isLaunchReadyEvaluatorCommand('bash scripts/eval.sh')).toBe(true);
+  });
+
+  it('writes launch-consumable mission/sandbox/result artifacts', async () => {
+    const repo = await initRepo();
+    try {
+      const artifacts = await writeAutoresearchDeepInterviewArtifacts({
+        repoRoot: repo,
+        topic: 'Measure onboarding friction',
+        evaluatorCommand: 'node scripts/eval.js',
+        keepPolicy: 'pass_only',
+        slug: 'onboarding-friction',
+        seedInputs: { topic: 'Measure onboarding friction' },
+      });
+
+      expect(artifacts.draftArtifactPath).toMatch(/deep-interview-autoresearch-onboarding-friction\.md$/);
+      expect(artifacts.missionArtifactPath).toMatch(/autoresearch-onboarding-friction\/mission\.md$/);
+      expect(artifacts.sandboxArtifactPath).toMatch(/autoresearch-onboarding-friction\/sandbox\.md$/);
+      expect(artifacts.resultPath).toMatch(/autoresearch-onboarding-friction\/result\.json$/);
+
+      const resultJson = JSON.parse(await readFile(artifacts.resultPath, 'utf-8')) as {
+        kind: string;
+        compileTarget: { slug: string; keepPolicy: string };
+        launchReady: boolean;
+      };
+      const missionContent = await readFile(artifacts.missionArtifactPath, 'utf-8');
+      const sandboxContent = await readFile(artifacts.sandboxArtifactPath, 'utf-8');
+
+      expect(resultJson.kind).toBe('omc.autoresearch.deep-interview/v1');
+      expect(resultJson.compileTarget.slug).toBe('onboarding-friction');
+      expect(resultJson.compileTarget.keepPolicy).toBe('pass_only');
+      expect(resultJson.launchReady).toBe(true);
+      expect(missionContent).toMatch(/Measure onboarding friction/);
+      expect(sandboxContent).toMatch(/command: node scripts\/eval\.js/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a blocked draft artifact when evaluator is still a placeholder', async () => {
+    const repo = await initRepo();
+    try {
+      const artifact = await writeAutoresearchDraftArtifact({
+        repoRoot: repo,
+        topic: 'Draft only mission',
+        evaluatorCommand: 'TODO replace with evaluator command',
+        keepPolicy: 'score_improvement',
+        slug: 'draft-only-mission',
+      });
+
+      expect(artifact.compileTarget.slug).toBe('draft-only-mission');
+      expect(artifact.launchReady).toBe(false);
+      expect(artifact.blockedReasons[0]).toMatch(/placeholder\/template/);
+
+      const draftContent = await readFile(artifact.path, 'utf-8');
+      expect(draftContent).toMatch(/Launch-ready: no/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -36,12 +36,20 @@ describe('normalizeAutoresearchClaudeArgs', () => {
 });
 
 describe('parseAutoresearchArgs', () => {
-  it('defaults to interview-first guided mode with no args', () => {
+  it('defaults to intake-first guided mode with no args', () => {
     const parsed = parseAutoresearchArgs([]);
     expect(parsed.guided).toBe(true);
     expect(parsed.missionDir).toBeNull();
     expect(parsed.runId).toBeNull();
     expect(parsed.claudeArgs).toEqual([]);
+  });
+
+  it('treats top-level topic/evaluator flags as seeded intake input', () => {
+    const parsed = parseAutoresearchArgs(['--topic', 'Improve docs', '--evaluator', 'node eval.js', '--slug', 'docs-run']);
+    expect(parsed.guided).toBe(true);
+    expect(parsed.seedArgs?.topic).toBe('Improve docs');
+    expect(parsed.seedArgs?.evaluatorCommand).toBe('node eval.js');
+    expect(parsed.seedArgs?.slug).toBe('docs-run');
   });
 
   it('parses bypass mode with mission and sandbox flags', () => {
@@ -99,11 +107,13 @@ describe('parseAutoresearchArgs', () => {
     expect(parsed.runId).toBe('my-run-id');
   });
 
-  it('parses --help', () => {
+  it('parses --help and advertises intake-first behavior', () => {
     const parsed = parseAutoresearchArgs(['--help']);
     expect(parsed.missionDir).toBe('--help');
-    expect(AUTORESEARCH_HELP).toContain('Claude setup + background launch');
-    expect(AUTORESEARCH_HELP).toMatch(/Partial bypass is invalid/);
+    expect(AUTORESEARCH_HELP).toContain('launch interactive intake, then background launch');
+    expect(AUTORESEARCH_HELP).toContain('.omc/specs');
+    expect(AUTORESEARCH_HELP).not.toContain('Claude setup + background launch');
+    expect(AUTORESEARCH_HELP).not.toContain('CODEX_HOME');
   });
 
   it('parses init subcommand', () => {
@@ -117,12 +127,7 @@ describe('parseAutoresearchArgs', () => {
     expect(parsed.missionDir).toBe('/path/to/mission');
     expect(parsed.claudeArgs).toEqual(['--model', 'opus']);
   });
-
-  it('rejects flags before mission-dir', () => {
-    expect(() => parseAutoresearchArgs(['--unknown-flag'])).toThrow(/mission-dir must be the first positional argument/);
-  });
 });
-
 
 describe('autoresearchCommand', () => {
   beforeEach(() => {
@@ -146,7 +151,30 @@ describe('autoresearchCommand', () => {
       cwdSpy.mockRestore();
     }
 
-    expect(guidedAutoresearchSetupMock).toHaveBeenCalledWith('/repo');
+    expect(guidedAutoresearchSetupMock).toHaveBeenCalledWith('/repo', undefined);
     expect(spawnAutoresearchTmuxMock).toHaveBeenCalledWith('/repo/missions/demo', 'demo');
+  });
+
+  it('routes seeded top-level flags through guided setup with seed args', async () => {
+    vi.mocked(execFileSync).mockReturnValue('/repo\n' as never);
+    guidedAutoresearchSetupMock.mockResolvedValue({
+      missionDir: '/repo/missions/docs-run',
+      slug: 'docs-run',
+    });
+
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+    try {
+      await autoresearchCommand(['--topic', 'Improve docs', '--evaluator', 'node eval.js', '--slug', 'docs-run']);
+    } finally {
+      cwdSpy.mockRestore();
+    }
+
+    expect(guidedAutoresearchSetupMock).toHaveBeenCalledWith('/repo', {
+      topic: 'Improve docs',
+      evaluatorCommand: 'node eval.js',
+      slug: 'docs-run',
+    });
+    expect(spawnAutoresearchTmuxMock).toHaveBeenCalledWith('/repo/missions/docs-run', 'docs-run');
   });
 });

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -5,14 +5,13 @@ import { join, relative, resolve, sep } from 'path';
 import { createInterface } from 'readline/promises';
 import { type AutoresearchKeepPolicy, parseSandboxContract, slugifyMissionName } from '../autoresearch/contracts.js';
 import {
-  AUTORESEARCH_SETUP_CONFIDENCE_THRESHOLD,
-  buildSetupSandboxContent,
-  type AutoresearchSetupHandoff,
-} from '../autoresearch/setup-contract.js';
-import {
-  runAutoresearchSetupSession,
-  type AutoresearchSetupSessionInput,
-} from './autoresearch-setup-session.js';
+  buildMissionContent,
+  buildSandboxContent,
+  type AutoresearchDeepInterviewResult,
+  type AutoresearchSeedInputs,
+  isLaunchReadyEvaluatorCommand,
+  writeAutoresearchDeepInterviewArtifacts,
+} from './autoresearch-intake.js';
 import { buildTmuxShellCommand, isTmuxAvailable, wrapWithLoginShell } from './tmux-utils.js';
 
 export interface InitAutoresearchOptions {
@@ -28,17 +27,54 @@ export interface InitAutoresearchResult {
   slug: string;
 }
 
-export interface GuidedAutoresearchSetupDeps {
-  createPromptInterface?: typeof createInterface;
-  runSetupSession?: (input: AutoresearchSetupSessionInput) => AutoresearchSetupHandoff;
+export interface AutoresearchQuestionIO {
+  question(prompt: string): Promise<string>;
+  close(): void;
 }
 
-function buildMissionContent(topic: string): string {
-  return `# Mission\n\n${topic}\n`;
+function createQuestionIO(): AutoresearchQuestionIO {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return {
+    question(prompt: string) {
+      return rl.question(prompt);
+    },
+    close() {
+      rl.close();
+    },
+  };
 }
 
-function buildSandboxContent(evaluatorCommand: string, keepPolicy?: AutoresearchKeepPolicy): string {
-  return buildSetupSandboxContent(evaluatorCommand, keepPolicy);
+async function promptWithDefault(io: AutoresearchQuestionIO, prompt: string, currentValue?: string): Promise<string> {
+  const suffix = currentValue?.trim() ? ` [${currentValue.trim()}]` : '';
+  const answer = await io.question(`${prompt}${suffix}\n> `);
+  return answer.trim() || currentValue?.trim() || '';
+}
+
+async function promptAction(io: AutoresearchQuestionIO, launchReady: boolean): Promise<'launch' | 'refine'> {
+  const answer = (await io.question(`\nNext step [launch/refine further] (default: ${launchReady ? 'launch' : 'refine further'})\n> `)).trim().toLowerCase();
+  if (!answer) {
+    return launchReady ? 'launch' : 'refine';
+  }
+  if (answer === 'launch') {
+    return 'launch';
+  }
+  if (answer === 'refine further' || answer === 'refine' || answer === 'r') {
+    return 'refine';
+  }
+  throw new Error('Please choose either "launch" or "refine further".');
+}
+
+function ensureLaunchReadyEvaluator(command: string): void {
+  if (!isLaunchReadyEvaluatorCommand(command)) {
+    throw new Error('Evaluator command is still a placeholder/template. Refine further before launch.');
+  }
+}
+
+export async function materializeAutoresearchDeepInterviewResult(
+  result: AutoresearchDeepInterviewResult,
+): Promise<InitAutoresearchResult> {
+  ensureLaunchReadyEvaluator(result.compileTarget.evaluatorCommand);
+  return initAutoresearchMission(result.compileTarget);
 }
 
 export async function initAutoresearchMission(opts: InitAutoresearchOptions): Promise<InitAutoresearchResult> {
@@ -106,78 +142,70 @@ export function parseInitArgs(args: readonly string[]): Partial<InitAutoresearch
   return result;
 }
 
-type QuestionInterface = { question(prompt: string): Promise<string>; close(): void };
+export async function runAutoresearchNoviceBridge(
+  repoRoot: string,
+  seedInputs: AutoresearchSeedInputs = {},
+  io: AutoresearchQuestionIO = createQuestionIO(),
+): Promise<InitAutoresearchResult> {
+  if (!process.stdin.isTTY) {
+    throw new Error('Guided setup requires an interactive terminal. Use <mission-dir> or init --topic/--evaluator/--keep-policy/--slug for non-interactive use.');
+  }
 
-async function askQuestion(rl: QuestionInterface, prompt: string): Promise<string> {
-  return (await rl.question(prompt)).trim();
+  let topic = seedInputs.topic?.trim() || '';
+  let evaluatorCommand = seedInputs.evaluatorCommand?.trim() || '';
+  let keepPolicy: AutoresearchKeepPolicy = seedInputs.keepPolicy || 'score_improvement';
+  let slug = seedInputs.slug?.trim() || '';
+
+  try {
+    while (true) {
+      topic = await promptWithDefault(io, 'Research topic/goal', topic);
+      if (!topic) {
+        throw new Error('Research topic is required.');
+      }
+
+      const evaluatorIntent = await promptWithDefault(io, '\nHow should OMC judge success? Describe it in plain language', topic);
+      evaluatorCommand = await promptWithDefault(
+        io,
+        '\nEvaluator command (leave placeholder to refine further; must output {pass:boolean, score?:number} JSON before launch)',
+        evaluatorCommand || `TODO replace with evaluator command for: ${evaluatorIntent}`,
+      );
+
+      const keepPolicyInput = await promptWithDefault(io, '\nKeep policy [score_improvement/pass_only]', keepPolicy);
+      keepPolicy = keepPolicyInput.trim().toLowerCase() === 'pass_only' ? 'pass_only' : 'score_improvement';
+
+      slug = await promptWithDefault(io, '\nMission slug', slug || slugifyMissionName(topic));
+      slug = slugifyMissionName(slug);
+
+      const deepInterview = await writeAutoresearchDeepInterviewArtifacts({
+        repoRoot,
+        topic,
+        evaluatorCommand,
+        keepPolicy,
+        slug,
+        seedInputs,
+      });
+
+      console.log(`\nDraft saved: ${deepInterview.draftArtifactPath}`);
+      console.log(`Launch readiness: ${deepInterview.launchReady ? 'ready' : deepInterview.blockedReasons.join(' ')}`);
+
+      const action = await promptAction(io, deepInterview.launchReady);
+      if (action === 'refine') {
+        continue;
+      }
+
+      return materializeAutoresearchDeepInterviewResult(deepInterview);
+    }
+  } finally {
+    io.close();
+  }
 }
 
 export async function guidedAutoresearchSetup(
   repoRoot: string,
-  deps: GuidedAutoresearchSetupDeps = {},
+  seedInputs: AutoresearchSeedInputs = {},
+  io: AutoresearchQuestionIO = createQuestionIO(),
 ): Promise<InitAutoresearchResult> {
-  if (!process.stdin.isTTY) {
-    throw new Error('Guided setup requires an interactive terminal. Use --mission, --sandbox, --keep-policy, and --slug flags for non-interactive use.');
-  }
-
-  const makeInterface = deps.createPromptInterface ?? createInterface;
-  const runSetupSession = deps.runSetupSession ?? runAutoresearchSetupSession;
-  const rl = makeInterface({ input: process.stdin, output: process.stdout }) as QuestionInterface;
-
-  try {
-    const topic = await askQuestion(rl, 'What should autoresearch improve or prove for this repo?\n> ');
-    if (!topic) {
-      throw new Error('Research mission is required.');
-    }
-
-    const explicitEvaluator = await askQuestion(
-      rl,
-      '\nOptional evaluator command (leave blank and OMC will infer one if confidence is high)\n> ',
-    );
-
-    const clarificationAnswers: string[] = [];
-    let handoff: AutoresearchSetupHandoff | null = null;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      handoff = runSetupSession({
-        repoRoot,
-        missionText: topic,
-        ...(explicitEvaluator ? { explicitEvaluatorCommand: explicitEvaluator } : {}),
-        clarificationAnswers,
-      });
-
-      if (handoff.readyToLaunch) {
-        break;
-      }
-
-      const question = handoff.clarificationQuestion
-        ?? 'I need one more detail before launch. What should the evaluator command verify?';
-      const answer = await askQuestion(rl, `\n${question}\n> `);
-      if (!answer) {
-        throw new Error('Autoresearch setup requires clarification before launch.');
-      }
-      clarificationAnswers.push(answer);
-    }
-
-    if (!handoff || !handoff.readyToLaunch) {
-      throw new Error(
-        `Autoresearch setup could not infer a launch-ready evaluator with confidence >= ${AUTORESEARCH_SETUP_CONFIDENCE_THRESHOLD}.`,
-      );
-    }
-
-    process.stdout.write(
-      `\nSetup summary\n- mission: ${handoff.missionText}\n- evaluator: ${handoff.evaluatorCommand}\n- confidence: ${handoff.confidence}\n`,
-    );
-
-    return initAutoresearchMission({
-      topic: handoff.missionText,
-      evaluatorCommand: handoff.evaluatorCommand,
-      keepPolicy: handoff.keepPolicy,
-      slug: handoff.slug || slugifyMissionName(handoff.missionText),
-      repoRoot,
-    });
-  } finally {
-    rl.close();
-  }
+  return runAutoresearchNoviceBridge(repoRoot, seedInputs, io);
 }
 
 export function checkTmuxAvailable(): boolean {

--- a/src/cli/autoresearch-intake.ts
+++ b/src/cli/autoresearch-intake.ts
@@ -1,0 +1,438 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { type AutoresearchKeepPolicy, parseSandboxContract, slugifyMissionName } from '../autoresearch/contracts.js';
+
+export interface AutoresearchSeedInputs {
+  topic?: string;
+  evaluatorCommand?: string;
+  keepPolicy?: AutoresearchKeepPolicy;
+  slug?: string;
+}
+
+export interface AutoresearchDraftCompileTarget {
+  topic: string;
+  evaluatorCommand: string;
+  keepPolicy: AutoresearchKeepPolicy;
+  slug: string;
+  repoRoot: string;
+}
+
+export interface AutoresearchDraftArtifact {
+  compileTarget: AutoresearchDraftCompileTarget;
+  path: string;
+  content: string;
+  launchReady: boolean;
+  blockedReasons: string[];
+}
+
+export interface AutoresearchDeepInterviewResult {
+  compileTarget: AutoresearchDraftCompileTarget;
+  draftArtifactPath: string;
+  missionArtifactPath: string;
+  sandboxArtifactPath: string;
+  resultPath: string;
+  missionContent: string;
+  sandboxContent: string;
+  launchReady: boolean;
+  blockedReasons: string[];
+}
+
+interface PersistedAutoresearchDeepInterviewResultV1 {
+  kind: typeof AUTORESEARCH_DEEP_INTERVIEW_RESULT_KIND;
+  compileTarget: AutoresearchDraftCompileTarget;
+  draftArtifactPath: string;
+  missionArtifactPath: string;
+  sandboxArtifactPath: string;
+  launchReady: boolean;
+  blockedReasons: string[];
+}
+
+const BLOCKED_EVALUATOR_PATTERNS = [
+  /<[^>]+>/i,
+  /\bTODO\b/i,
+  /\bTBD\b/i,
+  /REPLACE_ME/i,
+  /CHANGEME/i,
+  /your-command-here/i,
+] as const;
+
+const DEEP_INTERVIEW_DRAFT_PREFIX = 'deep-interview-autoresearch-';
+const AUTORESEARCH_ARTIFACT_DIR_PREFIX = 'autoresearch-';
+export const AUTORESEARCH_DEEP_INTERVIEW_RESULT_KIND = 'omc.autoresearch.deep-interview/v1';
+
+function defaultDraftEvaluator(topic: string): string {
+  const detail = topic.trim() || 'the mission';
+  return `TODO replace with evaluator command for: ${detail}`;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractMarkdownSection(markdown: string, heading: string): string {
+  const pattern = new RegExp(`^##\\s+${escapeRegex(heading)}\\s*$`, 'im');
+  const match = pattern.exec(markdown);
+  if (!match || match.index < 0) return '';
+  const start = match.index + match[0].length;
+  const remainder = markdown.slice(start);
+  const nextHeading = remainder.search(/^##\s+/m);
+  return (nextHeading >= 0 ? remainder.slice(0, nextHeading) : remainder).trim();
+}
+
+function parseLaunchReadinessSection(section: string): { launchReady: boolean; blockedReasons: string[] } {
+  const normalized = section.trim();
+  if (!normalized) {
+    return { launchReady: false, blockedReasons: ['Launch readiness section is missing.'] };
+  }
+
+  const launchReady = /Launch-ready:\s*yes/i.test(normalized);
+  const blockedReasons = launchReady
+    ? []
+    : normalized
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^-\s+/.test(line))
+      .map((line) => line.replace(/^-\s+/, '').trim())
+      .filter(Boolean);
+
+  return { launchReady, blockedReasons };
+}
+
+function normalizeKeepPolicy(raw: string): AutoresearchKeepPolicy {
+  return raw.trim().toLowerCase() === 'pass_only' ? 'pass_only' : 'score_improvement';
+}
+
+function buildArtifactDir(repoRoot: string, slug: string): string {
+  return join(repoRoot, '.omc', 'specs', `${AUTORESEARCH_ARTIFACT_DIR_PREFIX}${slug}`);
+}
+
+function buildDraftArtifactPath(repoRoot: string, slug: string): string {
+  return join(repoRoot, '.omc', 'specs', `${DEEP_INTERVIEW_DRAFT_PREFIX}${slug}.md`);
+}
+
+function buildResultPath(repoRoot: string, slug: string): string {
+  return join(buildArtifactDir(repoRoot, slug), 'result.json');
+}
+
+export function buildMissionContent(topic: string): string {
+  return `# Mission\n\n${topic}\n`;
+}
+
+export function buildSandboxContent(evaluatorCommand: string, keepPolicy?: AutoresearchKeepPolicy): string {
+  const safeCommand = evaluatorCommand.replace(/[\r\n]/g, ' ').trim();
+  const keepPolicyLine = keepPolicy ? `\n  keep_policy: ${keepPolicy}` : '';
+  return `---\nevaluator:\n  command: ${safeCommand}\n  format: json${keepPolicyLine}\n---\n`;
+}
+
+export function isLaunchReadyEvaluatorCommand(command: string): boolean {
+  const normalized = command.trim();
+  if (!normalized) {
+    return false;
+  }
+  return !BLOCKED_EVALUATOR_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function buildLaunchReadinessSection(launchReady: boolean, blockedReasons: readonly string[]): string {
+  if (launchReady) {
+    return 'Launch-ready: yes\n- Evaluator command is concrete and can be compiled into sandbox.md';
+  }
+
+  return [
+    'Launch-ready: no',
+    ...blockedReasons.map((reason) => `- ${reason}`),
+  ].join('\n');
+}
+
+export function buildAutoresearchDraftArtifactContent(
+  compileTarget: AutoresearchDraftCompileTarget,
+  seedInputs: AutoresearchSeedInputs,
+  launchReady: boolean,
+  blockedReasons: readonly string[],
+): string {
+  const seedTopic = seedInputs.topic?.trim() || '(none)';
+  const seedEvaluator = seedInputs.evaluatorCommand?.trim() || '(none)';
+  const seedKeepPolicy = seedInputs.keepPolicy || '(none)';
+  const seedSlug = seedInputs.slug?.trim() || '(none)';
+
+  return [
+    `# Deep Interview Autoresearch Draft — ${compileTarget.slug}`,
+    '',
+    '## Mission Draft',
+    compileTarget.topic,
+    '',
+    '## Evaluator Draft',
+    compileTarget.evaluatorCommand,
+    '',
+    '## Keep Policy',
+    compileTarget.keepPolicy,
+    '',
+    '## Session Slug',
+    compileTarget.slug,
+    '',
+    '## Seed Inputs',
+    `- topic: ${seedTopic}`,
+    `- evaluator: ${seedEvaluator}`,
+    `- keep_policy: ${seedKeepPolicy}`,
+    `- slug: ${seedSlug}`,
+    '',
+    '## Launch Readiness',
+    buildLaunchReadinessSection(launchReady, blockedReasons),
+    '',
+    '## Confirmation Bridge',
+    '- refine further',
+    '- launch',
+    '',
+  ].join('\n');
+}
+
+export async function writeAutoresearchDraftArtifact(input: {
+  repoRoot: string;
+  topic: string;
+  evaluatorCommand?: string;
+  keepPolicy: AutoresearchKeepPolicy;
+  slug?: string;
+  seedInputs?: AutoresearchSeedInputs;
+}): Promise<AutoresearchDraftArtifact> {
+  const topic = input.topic.trim();
+  if (!topic) {
+    throw new Error('Research topic is required.');
+  }
+
+  const slug = slugifyMissionName(input.slug?.trim() || topic);
+  const evaluatorCommand = (input.evaluatorCommand?.trim() || defaultDraftEvaluator(topic)).replace(/[\r\n]+/g, ' ').trim();
+  const compileTarget: AutoresearchDraftCompileTarget = {
+    topic,
+    evaluatorCommand,
+    keepPolicy: input.keepPolicy,
+    slug,
+    repoRoot: input.repoRoot,
+  };
+
+  const blockedReasons: string[] = [];
+  if (!isLaunchReadyEvaluatorCommand(evaluatorCommand)) {
+    blockedReasons.push('Evaluator command is still a placeholder/template and must be replaced before launch.');
+  }
+
+  if (blockedReasons.length === 0) {
+    parseSandboxContract(buildSandboxContent(evaluatorCommand, input.keepPolicy));
+  }
+
+  const launchReady = blockedReasons.length === 0;
+  const specsDir = join(input.repoRoot, '.omc', 'specs');
+  await mkdir(specsDir, { recursive: true });
+  const path = buildDraftArtifactPath(input.repoRoot, slug);
+  const content = buildAutoresearchDraftArtifactContent(compileTarget, input.seedInputs || {}, launchReady, blockedReasons);
+  await writeFile(path, content, 'utf-8');
+
+  return { compileTarget, path, content, launchReady, blockedReasons };
+}
+
+export async function writeAutoresearchDeepInterviewArtifacts(input: {
+  repoRoot: string;
+  topic: string;
+  evaluatorCommand?: string;
+  keepPolicy: AutoresearchKeepPolicy;
+  slug?: string;
+  seedInputs?: AutoresearchSeedInputs;
+}): Promise<AutoresearchDeepInterviewResult> {
+  const draft = await writeAutoresearchDraftArtifact(input);
+  const artifactDir = buildArtifactDir(input.repoRoot, draft.compileTarget.slug);
+  await mkdir(artifactDir, { recursive: true });
+
+  const missionArtifactPath = join(artifactDir, 'mission.md');
+  const sandboxArtifactPath = join(artifactDir, 'sandbox.md');
+  const resultPath = buildResultPath(input.repoRoot, draft.compileTarget.slug);
+  const missionContent = buildMissionContent(draft.compileTarget.topic);
+  const sandboxContent = buildSandboxContent(draft.compileTarget.evaluatorCommand, draft.compileTarget.keepPolicy);
+
+  parseSandboxContract(sandboxContent);
+  await writeFile(missionArtifactPath, missionContent, 'utf-8');
+  await writeFile(sandboxArtifactPath, sandboxContent, 'utf-8');
+
+  const persisted: PersistedAutoresearchDeepInterviewResultV1 = {
+    kind: AUTORESEARCH_DEEP_INTERVIEW_RESULT_KIND,
+    compileTarget: draft.compileTarget,
+    draftArtifactPath: draft.path,
+    missionArtifactPath,
+    sandboxArtifactPath,
+    launchReady: draft.launchReady,
+    blockedReasons: draft.blockedReasons,
+  };
+  await writeFile(resultPath, `${JSON.stringify(persisted, null, 2)}\n`, 'utf-8');
+
+  return {
+    compileTarget: draft.compileTarget,
+    draftArtifactPath: draft.path,
+    missionArtifactPath,
+    sandboxArtifactPath,
+    resultPath,
+    missionContent,
+    sandboxContent,
+    launchReady: draft.launchReady,
+    blockedReasons: draft.blockedReasons,
+  };
+}
+
+function parseDraftArtifactContent(content: string, repoRoot: string, draftArtifactPath: string): AutoresearchDeepInterviewResult {
+  const missionDraft = extractMarkdownSection(content, 'Mission Draft').trim();
+  const evaluatorDraft = extractMarkdownSection(content, 'Evaluator Draft').trim().replace(/[\r\n]+/g, ' ');
+  const keepPolicyRaw = extractMarkdownSection(content, 'Keep Policy').trim();
+  const slugRaw = extractMarkdownSection(content, 'Session Slug').trim();
+  const launchReadiness = parseLaunchReadinessSection(extractMarkdownSection(content, 'Launch Readiness'));
+
+  if (!missionDraft) {
+    throw new Error(`Missing Mission Draft section in ${draftArtifactPath}`);
+  }
+  if (!evaluatorDraft) {
+    throw new Error(`Missing Evaluator Draft section in ${draftArtifactPath}`);
+  }
+
+  const slug = slugifyMissionName(slugRaw || missionDraft);
+  const compileTarget: AutoresearchDraftCompileTarget = {
+    topic: missionDraft,
+    evaluatorCommand: evaluatorDraft,
+    keepPolicy: normalizeKeepPolicy(keepPolicyRaw || 'score_improvement'),
+    slug,
+    repoRoot,
+  };
+  const missionContent = buildMissionContent(compileTarget.topic);
+  const sandboxContent = buildSandboxContent(compileTarget.evaluatorCommand, compileTarget.keepPolicy);
+  parseSandboxContract(sandboxContent);
+
+  return {
+    compileTarget,
+    draftArtifactPath,
+    missionArtifactPath: join(buildArtifactDir(repoRoot, slug), 'mission.md'),
+    sandboxArtifactPath: join(buildArtifactDir(repoRoot, slug), 'sandbox.md'),
+    resultPath: buildResultPath(repoRoot, slug),
+    missionContent,
+    sandboxContent,
+    launchReady: launchReadiness.launchReady,
+    blockedReasons: launchReadiness.blockedReasons,
+  };
+}
+
+async function readPersistedResult(resultPath: string): Promise<AutoresearchDeepInterviewResult> {
+  const raw = await readFile(resultPath, 'utf-8');
+  const parsed = JSON.parse(raw) as Partial<PersistedAutoresearchDeepInterviewResultV1>;
+  if (parsed.kind !== AUTORESEARCH_DEEP_INTERVIEW_RESULT_KIND) {
+    throw new Error(`Unsupported autoresearch deep-interview result payload: ${resultPath}`);
+  }
+  if (!parsed.compileTarget) {
+    throw new Error(`Missing compileTarget in ${resultPath}`);
+  }
+
+  const compileTarget = parsed.compileTarget as AutoresearchDraftCompileTarget;
+  const draftArtifactPath = typeof parsed.draftArtifactPath === 'string' ? parsed.draftArtifactPath : buildDraftArtifactPath(compileTarget.repoRoot, compileTarget.slug);
+  const missionArtifactPath = typeof parsed.missionArtifactPath === 'string' ? parsed.missionArtifactPath : join(buildArtifactDir(compileTarget.repoRoot, compileTarget.slug), 'mission.md');
+  const sandboxArtifactPath = typeof parsed.sandboxArtifactPath === 'string' ? parsed.sandboxArtifactPath : join(buildArtifactDir(compileTarget.repoRoot, compileTarget.slug), 'sandbox.md');
+  const missionContent = await readFile(missionArtifactPath, 'utf-8');
+  const sandboxContent = await readFile(sandboxArtifactPath, 'utf-8');
+  parseSandboxContract(sandboxContent);
+
+  return {
+    compileTarget,
+    draftArtifactPath,
+    missionArtifactPath,
+    sandboxArtifactPath,
+    resultPath,
+    missionContent,
+    sandboxContent,
+    launchReady: parsed.launchReady === true,
+    blockedReasons: Array.isArray(parsed.blockedReasons)
+      ? parsed.blockedReasons.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      : [],
+  };
+}
+
+async function listMarkdownDraftPaths(repoRoot: string): Promise<string[]> {
+  const specsDir = join(repoRoot, '.omc', 'specs');
+  if (!existsSync(specsDir)) return [];
+  const entries = await readdir(specsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.startsWith(DEEP_INTERVIEW_DRAFT_PREFIX) && entry.name.endsWith('.md'))
+    .map((entry) => join(specsDir, entry.name));
+}
+
+export async function listAutoresearchDeepInterviewResultPaths(repoRoot: string): Promise<string[]> {
+  const specsDir = join(repoRoot, '.omc', 'specs');
+  if (!existsSync(specsDir)) return [];
+
+  const entries = await readdir(specsDir, { withFileTypes: true });
+  const resultPaths = entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(AUTORESEARCH_ARTIFACT_DIR_PREFIX))
+    .map((entry) => join(specsDir, entry.name, 'result.json'))
+    .filter((path) => existsSync(path));
+
+  return resultPaths.sort((left, right) => left.localeCompare(right));
+}
+
+async function filterRecentPaths(paths: readonly string[], newerThanMs?: number, excludePaths?: ReadonlySet<string>): Promise<string[]> {
+  const filtered: string[] = [];
+  for (const path of paths) {
+    if (excludePaths?.has(path)) {
+      continue;
+    }
+    if (typeof newerThanMs === 'number') {
+      const metadata = await stat(path).catch(() => null);
+      if (!metadata || metadata.mtimeMs < newerThanMs) {
+        continue;
+      }
+    }
+    filtered.push(path);
+  }
+  return filtered;
+}
+
+export async function resolveAutoresearchDeepInterviewResult(
+  repoRoot: string,
+  options: {
+    slug?: string;
+    newerThanMs?: number;
+    excludeResultPaths?: ReadonlySet<string>;
+  } = {},
+): Promise<AutoresearchDeepInterviewResult | null> {
+  const slug = options.slug?.trim() ? slugifyMissionName(options.slug) : null;
+
+  if (slug) {
+    const resultPath = buildResultPath(repoRoot, slug);
+    if (existsSync(resultPath)) {
+      const metadata = await stat(resultPath).catch(() => null);
+      if (!metadata || options.newerThanMs == null || metadata.mtimeMs >= options.newerThanMs) {
+        return readPersistedResult(resultPath);
+      }
+    }
+
+    const draftArtifactPath = buildDraftArtifactPath(repoRoot, slug);
+    if (existsSync(draftArtifactPath)) {
+      const metadata = await stat(draftArtifactPath).catch(() => null);
+      if (!metadata || options.newerThanMs == null || metadata.mtimeMs >= options.newerThanMs) {
+        const draftContent = await readFile(draftArtifactPath, 'utf-8');
+        return parseDraftArtifactContent(draftContent, repoRoot, draftArtifactPath);
+      }
+    }
+    return null;
+  }
+
+  const resultPaths = await filterRecentPaths(
+    await listAutoresearchDeepInterviewResultPaths(repoRoot),
+    options.newerThanMs,
+    options.excludeResultPaths,
+  );
+  const resultEntries = await Promise.all(resultPaths.map(async (path) => ({ path, metadata: await stat(path) })));
+  const newestResultPath = resultEntries.sort((left, right) => right.metadata.mtimeMs - left.metadata.mtimeMs)[0]?.path;
+  if (newestResultPath) {
+    return readPersistedResult(newestResultPath);
+  }
+
+  const draftPaths = await filterRecentPaths(await listMarkdownDraftPaths(repoRoot), options.newerThanMs);
+  const draftEntries = await Promise.all(draftPaths.map(async (path) => ({ path, metadata: await stat(path) })));
+  const newestDraftPath = draftEntries.sort((left, right) => right.metadata.mtimeMs - left.metadata.mtimeMs)[0]?.path;
+  if (!newestDraftPath) {
+    return null;
+  }
+
+  const draftContent = await readFile(newestDraftPath, 'utf-8');
+  return parseDraftArtifactContent(draftContent, repoRoot, newestDraftPath);
+}

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -17,21 +17,24 @@ import {
   resumeAutoresearchRuntime,
 } from '../autoresearch/runtime.js';
 import { guidedAutoresearchSetup, initAutoresearchMission, parseInitArgs, spawnAutoresearchTmux } from './autoresearch-guided.js';
+import { type AutoresearchSeedInputs } from './autoresearch-intake.js';
 
 const CLAUDE_BYPASS_FLAG = '--dangerously-skip-permissions';
 
 export const AUTORESEARCH_HELP = `omc autoresearch - Launch OMC autoresearch with thin-supervisor parity semantics
 
 Usage:
-  omc autoresearch                                                (Claude setup + background launch)
+  omc autoresearch                                                (launch interactive intake, then background launch)
+  omc autoresearch [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
   omc autoresearch --mission TEXT --sandbox CMD [--keep-policy P] [--slug S]
   omc autoresearch init [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
   omc autoresearch <mission-dir> [claude-args...]
   omc autoresearch --resume <run-id> [claude-args...]
 
 Arguments:
-  (no args)        Short-lived Claude-backed setup: discusses the mission, validates or infers
-                   an evaluator with confidence gating, then spawns autoresearch in a background tmux session.
+  (no args)        Launch interactive intake that refines the mission/evaluator, writes .omc/specs
+                   artifacts, and launches only after explicit confirmation.
+  --topic/...      Seed the intake with draft values; still requires refinement/confirmation before launch.
   --mission/       Explicit bypass path. --mission is raw mission text and --sandbox is the raw
   --sandbox        evaluator/sandbox command. Both flags are required together; --keep-policy and
                    --slug remain optional. Partial bypass is invalid.
@@ -41,6 +44,7 @@ Arguments:
   <run-id>         Existing autoresearch run id from .omc/logs/autoresearch/<run-id>/manifest.json
 
 Behavior:
+  - intake writes canonical artifacts under .omc/specs before launch
   - validates mission.md and sandbox.md
   - requires sandbox.md YAML frontmatter with evaluator.command and evaluator.format=json
   - fresh launch creates a run-tagged autoresearch/<slug>/<run-tag> lane
@@ -98,6 +102,7 @@ export interface ParsedAutoresearchArgs {
   claudeArgs: string[];
   guided?: boolean;
   initArgs?: string[];
+  seedArgs?: AutoresearchSeedInputs;
   missionText?: string;
   sandboxCommand?: string;
   keepPolicy?: AutoresearchKeepPolicy;
@@ -122,11 +127,7 @@ function parseAutoresearchBypassArgs(args: readonly string[]): ParsedAutoresearc
     arg === '--mission'
       || arg.startsWith('--mission=')
       || arg === '--sandbox'
-      || arg.startsWith('--sandbox=')
-      || arg === '--keep-policy'
-      || arg.startsWith('--keep-policy=')
-      || arg === '--slug'
-      || arg.startsWith('--slug='),
+      || arg.startsWith('--sandbox='),
   );
   if (!hasBypassFlag) {
     return null;
@@ -180,7 +181,7 @@ function parseAutoresearchBypassArgs(args: readonly string[]): ParsedAutoresearc
     if (arg.startsWith('-')) {
       throw new Error(
         `Unknown autoresearch flag: ${arg.split('=')[0]}.\n`
-        + 'Use --mission plus --sandbox to bypass the interview, or provide a mission-dir.\n\n'
+        + 'Use --mission plus --sandbox to bypass the intake, seed with --topic/--evaluator/--slug, or provide a mission-dir.\n\n'
         + `${AUTORESEARCH_HELP}`,
       );
     }
@@ -194,14 +195,14 @@ function parseAutoresearchBypassArgs(args: readonly string[]): ParsedAutoresearc
   const hasSandbox = typeof sandboxCommand === 'string' && sandboxCommand.trim().length > 0;
   if (hasMission !== hasSandbox) {
     throw new Error(
-      'Both --mission and --sandbox are required together to bypass the interview. '
-      + 'Provide both flags, or neither to use interactive setup.\n\n'
+      'Both --mission and --sandbox are required together to bypass the intake. '
+      + 'Provide both flags, or neither to use interactive intake.\n\n'
       + `${AUTORESEARCH_HELP}`,
     );
   }
   if (!hasMission || !hasSandbox) {
     throw new Error(
-      'Use --mission plus --sandbox together to bypass the interview. '
+      'Use --mission plus --sandbox together to bypass the intake. '
       + '--keep-policy and --slug are optional only when both are present.\n\n'
       + `${AUTORESEARCH_HELP}`,
     );
@@ -258,7 +259,13 @@ export function parseAutoresearchArgs(args: readonly string[]): ParsedAutoresear
     return { missionDir: null, runId, claudeArgs: values.slice(1) };
   }
   if (first.startsWith('-')) {
-    throw new Error(`mission-dir must be the first positional argument unless using --resume.\n${AUTORESEARCH_HELP}`);
+    return {
+      missionDir: null,
+      runId: null,
+      claudeArgs: [],
+      guided: true,
+      seedArgs: parseInitArgs(values),
+    };
   }
   return { missionDir: first, runId: null, claudeArgs: values.slice(1) };
 }
@@ -350,7 +357,7 @@ export async function autoresearchCommand(args: string[]): Promise<void> {
         repoRoot,
       });
     } else {
-      result = await guidedAutoresearchSetup(repoRoot);
+      result = await guidedAutoresearchSetup(repoRoot, parsed.seedArgs);
     }
     spawnAutoresearchTmux(result.missionDir, result.slug);
     return;


### PR DESCRIPTION
## Summary
- backport autoresearch launch-from-interview into `omc autoresearch`
- add `src/cli/autoresearch-intake.ts` as a thin `.omc/specs` artifact bridge
- preserve existing readiness authority in setup contract / guided flow
- keep `<mission-dir>` and `--resume` as first-class paths
- keep seeded flags init-only
- fix builtin skill runtime guidance to lazily detect provider availability so non-`deep-interview` skill resolution does not pay external CLI checks

## Verification
- PASS `npx vitest run src/cli/__tests__/autoresearch.test.ts src/cli/__tests__/autoresearch-guided.test.ts src/cli/__tests__/autoresearch-intake.test.ts`
- PASS `npx vitest run src/__tests__/cleanup-validation.test.ts`
- PASS `npx vitest run src/__tests__/skills.test.ts src/__tests__/consensus-execution-handoff.test.ts src/__tests__/deep-interview-provider-options.test.ts`
- PASS `npm run test:run` (359 passed, 1 skipped; 6780 passed, 7 skipped)
- PASS `npx tsc --noEmit`
- PASS `npm run lint` (warnings only, no errors)
- PASS `npm run build`

## Changed files
- `src/cli/autoresearch.ts`
- `src/cli/autoresearch-guided.ts`
- `src/cli/autoresearch-intake.ts`
- `src/cli/__tests__/autoresearch.test.ts`
- `src/cli/__tests__/autoresearch-guided.test.ts`
- `src/cli/__tests__/autoresearch-intake.test.ts`
- `src/features/builtin-skills/runtime-guidance.ts`