### PR TITLE
fix: prevent skill-active-state collision between OMC and project custom skills

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -360,7 +360,14 @@ const SKILL_PROTECTION_MAP = {
   deepinit: 'heavy',
 };
 
-function getSkillProtectionLevel(skillName) {
+function getSkillProtectionLevel(skillName, rawSkillName) {
+  // When rawSkillName is provided, only apply protection to OMC-prefixed skills.
+  // Non-prefixed skills are project custom skills or other plugins — no protection.
+  // See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/1581
+  if (rawSkillName != null && typeof rawSkillName === 'string' &&
+      !rawSkillName.toLowerCase().startsWith('oh-my-claudecode:')) {
+    return 'none';
+  }
   const normalized = (skillName || '').toLowerCase().replace(/^oh-my-claudecode:/, '');
   return SKILL_PROTECTION_MAP[normalized] || 'none';
 }
@@ -373,8 +380,8 @@ function extractSkillName(toolInput) {
   return normalized.includes(':') ? normalized.split(':').at(-1).toLowerCase() : normalized.toLowerCase();
 }
 
-function writeSkillActiveState(directory, skillName, sessionId) {
-  const protection = getSkillProtectionLevel(skillName);
+function writeSkillActiveState(directory, skillName, sessionId, rawSkillName) {
+  const protection = getSkillProtectionLevel(skillName, rawSkillName);
   if (protection === 'none') return;
 
   const config = SKILL_PROTECTION_CONFIGS[protection];
@@ -456,7 +463,10 @@ async function main() {
       if (skillName) {
         const sid = typeof data.session_id === 'string' ? data.session_id
           : typeof data.sessionId === 'string' ? data.sessionId : '';
-        writeSkillActiveState(directory, skillName, sid);
+        // Pass rawSkillName to distinguish OMC skills from project custom skills (issue #1581)
+        const rawSkill = toolInput.skill || toolInput.skill_name || toolInput.skillName || toolInput.command || '';
+        const rawSkillName = typeof rawSkill === 'string' && rawSkill.trim() ? rawSkill.trim() : undefined;
+        writeSkillActiveState(directory, skillName, sid, rawSkillName);
       }
     }
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1345,14 +1345,17 @@ function processPreToolUse(input: HookInput): HookOutput {
   // Activate skill state when Skill tool is invoked (issue #1033)
   // This writes skill-active-state.json so the Stop hook can prevent premature
   // session termination while a skill is executing.
+  // Pass rawSkillName so writeSkillActiveState can distinguish OMC built-in
+  // skills from project custom skills with the same name (issue #1581).
   if (input.toolName === "Skill") {
     const skillName = getInvokedSkillName(input.toolInput);
     if (skillName) {
+      const rawSkillName = getRawSkillName(input.toolInput);
       // Use the statically-imported synchronous write so it completes before
       // the Stop hook can fire. The previous fire-and-forget .then() raced with
       // the Stop hook in short-lived processes.
       try {
-        writeSkillActiveState(directory, skillName, input.sessionId);
+        writeSkillActiveState(directory, skillName, input.sessionId, rawSkillName);
       } catch {
         // Skill-state write is best-effort; don't fail the hook on error.
       }
@@ -1531,6 +1534,19 @@ function getInvokedSkillName(toolInput: unknown): string | null {
     ? normalized.split(":").at(-1)
     : normalized;
   return namespaced?.toLowerCase() || null;
+}
+
+/**
+ * Extract the raw (un-normalized) skill name from Skill tool input.
+ * Used to distinguish OMC built-in skills (prefixed with 'oh-my-claudecode:')
+ * from project custom skills or other plugin skills with the same bare name.
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/1581
+ */
+function getRawSkillName(toolInput: unknown): string | undefined {
+  if (!toolInput || typeof toolInput !== "object") return undefined;
+  const input = toolInput as Record<string, unknown>;
+  const raw = input.skill ?? input.skill_name ?? input.skillName ?? input.command ?? null;
+  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : undefined;
 }
 
 async function processPostToolUse(input: HookInput): Promise<HookOutput> {

--- a/src/hooks/skill-state/__tests__/skill-state.test.ts
+++ b/src/hooks/skill-state/__tests__/skill-state.test.ts
@@ -85,6 +85,30 @@ describe('skill-state', () => {
       expect(getSkillProtection('SKILL')).toBe('light');
       expect(getSkillProtection('Plan')).toBe('medium');
     });
+
+    it('returns none for project custom skills with same name as OMC skills (issue #1581)', () => {
+      // rawSkillName without oh-my-claudecode: prefix → project custom skill
+      expect(getSkillProtection('plan', 'plan')).toBe('none');
+      expect(getSkillProtection('review', 'review')).toBe('none');
+      expect(getSkillProtection('tdd', 'tdd')).toBe('none');
+    });
+
+    it('returns protection for OMC skills when rawSkillName has prefix', () => {
+      expect(getSkillProtection('plan', 'oh-my-claudecode:plan')).toBe('medium');
+      expect(getSkillProtection('deepinit', 'oh-my-claudecode:deepinit')).toBe('heavy');
+    });
+
+    it('returns none for other plugin skills with rawSkillName', () => {
+      // ouroboros:plan, claude-mem:make-plan etc. should not get OMC protection
+      expect(getSkillProtection('plan', 'ouroboros:plan')).toBe('none');
+      expect(getSkillProtection('make-plan', 'claude-mem:make-plan')).toBe('none');
+    });
+
+    it('falls back to map lookup when rawSkillName is not provided', () => {
+      // Backward compatibility: no rawSkillName → use SKILL_PROTECTION map
+      expect(getSkillProtection('plan')).toBe('medium');
+      expect(getSkillProtection('deepinit')).toBe('heavy');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -153,6 +177,20 @@ describe('skill-state', () => {
     it('strips namespace prefix from skill name', () => {
       const state = writeSkillActiveState(tempDir, 'oh-my-claudecode:plan', 'session-1');
       expect(state!.skill_name).toBe('plan');
+    });
+
+    it('does not write state for project custom skills with same name as OMC skills (issue #1581)', () => {
+      // rawSkillName='plan' (no prefix) → project custom skill → no state
+      const state = writeSkillActiveState(tempDir, 'plan', 'session-1', 'plan');
+      expect(state).toBeNull();
+      expect(readSkillActiveState(tempDir, 'session-1')).toBeNull();
+    });
+
+    it('writes state for OMC skills when rawSkillName has prefix', () => {
+      const state = writeSkillActiveState(tempDir, 'plan', 'session-1', 'oh-my-claudecode:plan');
+      expect(state).not.toBeNull();
+      expect(state!.skill_name).toBe('plan');
+      expect(state!.max_reinforcements).toBe(5);
     });
 
     it('overwrites existing state when new skill is invoked', () => {

--- a/src/hooks/skill-state/index.ts
+++ b/src/hooks/skill-state/index.ts
@@ -129,10 +129,19 @@ const SKILL_PROTECTION: Record<string, SkillProtectionLevel> = {
  * Anthropic's example-skills, document-skills, superpowers, data, etc.)
  * default to 'none' so the Stop hook does not block them.
  *
- * Note: bridge.ts strips the 'oh-my-claudecode:' prefix before calling
- * this function, so skill names arrive in bare form (e.g., 'plan', 'xlsx').
+ * @param skillName - The normalized (prefix-stripped) skill name.
+ * @param rawSkillName - The original skill name as invoked (e.g., 'oh-my-claudecode:plan'
+ *   or 'plan'). When provided, only skills invoked with the 'oh-my-claudecode:' prefix
+ *   are eligible for protection. This prevents project custom skills (e.g., a user's
+ *   `.claude/skills/plan/`) from being confused with OMC built-in skills of the same name.
+ *   See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/1581
  */
-export function getSkillProtection(skillName: string): SkillProtectionLevel {
+export function getSkillProtection(skillName: string, rawSkillName?: string): SkillProtectionLevel {
+  // When rawSkillName is provided, only apply protection to OMC-prefixed skills.
+  // Non-prefixed skills are project custom skills or other plugins — no protection.
+  if (rawSkillName != null && !rawSkillName.toLowerCase().startsWith('oh-my-claudecode:')) {
+    return 'none';
+  }
   const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, '');
   return SKILL_PROTECTION[normalized] ?? 'none';
 }
@@ -140,8 +149,8 @@ export function getSkillProtection(skillName: string): SkillProtectionLevel {
 /**
  * Get the protection config for a skill.
  */
-export function getSkillConfig(skillName: string): SkillStateConfig {
-  return PROTECTION_CONFIGS[getSkillProtection(skillName)];
+export function getSkillConfig(skillName: string, rawSkillName?: string): SkillStateConfig {
+  return PROTECTION_CONFIGS[getSkillProtection(skillName, rawSkillName)];
 }
 
 /**
@@ -162,13 +171,17 @@ export function readSkillActiveState(
 /**
  * Write skill active state.
  * Called when a skill is invoked via the Skill tool.
+ *
+ * @param rawSkillName - The original skill name as invoked, used to distinguish
+ *   OMC built-in skills from project custom skills. See getSkillProtection().
  */
 export function writeSkillActiveState(
   directory: string,
   skillName: string,
-  sessionId?: string
+  sessionId?: string,
+  rawSkillName?: string,
 ): SkillActiveState | null {
-  const protection = getSkillProtection(skillName);
+  const protection = getSkillProtection(skillName, rawSkillName);
 
   // Skills with 'none' protection don't need state tracking
   if (protection === 'none') {


### PR DESCRIPTION
## Problem

When a project defines a custom skill with the same bare name as an OMC built-in skill (e.g., `.claude/skills/plan/` vs `oh-my-claudecode:plan`), the pre-tool hook applies OMC's `SKILL_PROTECTION` map to the custom skill because `extractSkillName()` / `getInvokedSkillName()` strip the namespace prefix before lookup. This writes `skill-active-state.json` with `active: true`, causing the stop hook to block session termination with reinforcement messages — even after the custom skill has completed.

### Reproduction

1. Create a project skill at `.claude/skills/plan/` (or any name in `SKILL_PROTECTION_MAP`)
2. Invoke it via `/plan`
3. The Skill tool sends `skill: "plan"` (no OMC prefix)
4. `getSkillProtectionLevel("plan")` returns `'medium'` → state file written
5. Stop hook blocks with `[SKILL ACTIVE: plan]` reinforcement messages

This is a follow-up to #1581 — that fix changed the default for **unregistered** skills to `'none'`, but skills like `plan`, `review`, `tdd` are **explicitly registered** in `SKILL_PROTECTION_MAP` with non-none levels, so the collision persists.

## Fix

Pass the raw (un-normalized) skill name through the call chain so `getSkillProtection()` can distinguish OMC built-in skills (prefixed with `oh-my-claudecode:`) from project custom or other plugin skills. Non-OMC-prefixed skills now correctly default to `'none'` protection regardless of name collisions.

### Changes

| File | Change |
|------|--------|
| `src/hooks/skill-state/index.ts` | Add optional `rawSkillName` param to `getSkillProtection()` and `writeSkillActiveState()` |
| `src/hooks/bridge.ts` | Add `getRawSkillName()` helper; pass raw name to `writeSkillActiveState()` |
| `scripts/pre-tool-enforcer.mjs` | Same fix for the CJS runtime hook path |
| `src/hooks/skill-state/__tests__/skill-state.test.ts` | 7 new test cases for custom skill distinction |

### Behavior matrix

| Invocation | `rawSkillName` | Protection |
|---|---|---|
| `Skill(skill: "oh-my-claudecode:plan")` | `"oh-my-claudecode:plan"` | `medium` ✅ |
| `Skill(skill: "plan")` (project custom) | `"plan"` | `none` ✅ |
| `Skill(skill: "ouroboros:plan")` | `"ouroboros:plan"` | `none` ✅ |
| `Skill(skill: "plan")` (no rawSkillName, legacy) | `undefined` | `medium` (backward compat) |

## Test plan

- [x] `skill-state.test.ts`: 44 tests passed (7 new)
- [x] `skill-state-stop.test.ts`: 8 tests passed (integration)
- [x] Backward compatible — `rawSkillName` is optional; omitting it preserves existing behavior

Retargeted from #1739 (was targeting main).