### PR TITLE
fix(cli): skip tmux wrapping in cmux terminal to prevent orphaned sessions

### DIFF
--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -18,11 +18,15 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
+import { execFileSync } from 'child_process';
 import {
   wrapWithLoginShell,
   quoteShellArg,
   sanitizeTmuxToken,
+  resolveLaunchPolicy,
 } from '../tmux-utils.js';
+
+const mockedExecFileSync = vi.mocked(execFileSync);
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -152,6 +156,41 @@ describe('sanitizeTmuxToken', () => {
   it('returns "unknown" for empty result', () => {
     expect(sanitizeTmuxToken('...')).toBe('unknown');
     expect(sanitizeTmuxToken('!!!')).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLaunchPolicy
+// ---------------------------------------------------------------------------
+describe('resolveLaunchPolicy', () => {
+  it('returns "inside-tmux" when TMUX is set', () => {
+    mockedExecFileSync.mockReturnValue('tmux 3.6a' as any);
+    expect(resolveLaunchPolicy({ TMUX: '/tmp/tmux-501/default,1234,0' })).toBe('inside-tmux');
+  });
+
+  it('returns "direct" when CMUX_SURFACE_ID is set (cmux terminal)', () => {
+    mockedExecFileSync.mockReturnValue('tmux 3.6a' as any);
+    expect(resolveLaunchPolicy({ CMUX_SURFACE_ID: 'C0D4B400-6C27-4957-BD01-32735B2251CD' })).toBe('direct');
+  });
+
+  it('prefers inside-tmux over cmux when both TMUX and CMUX_SURFACE_ID are set', () => {
+    mockedExecFileSync.mockReturnValue('tmux 3.6a' as any);
+    expect(resolveLaunchPolicy({
+      TMUX: '/tmp/tmux-501/default,1234,0',
+      CMUX_SURFACE_ID: 'some-id',
+    })).toBe('inside-tmux');
+  });
+
+  it('returns "outside-tmux" when tmux is available but no TMUX or CMUX env', () => {
+    mockedExecFileSync.mockReturnValue('tmux 3.6a' as any);
+    expect(resolveLaunchPolicy({})).toBe('outside-tmux');
+  });
+
+  it('returns "direct" when tmux is not available', () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error('tmux not found');
+    });
+    expect(resolveLaunchPolicy({})).toBe('direct');
   });
 });
 

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -318,7 +318,12 @@ function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string): 
   try {
     execFileSync('tmux', tmuxArgs, { stdio: 'inherit' });
   } catch {
-    // tmux failed, fall back to direct launch
+    // tmux attach failed — kill the orphaned detached session that
+    // new-session -d just created so they don't accumulate.
+    try {
+      execFileSync('tmux', ['kill-session', '-t', sessionName], { stdio: 'ignore' });
+    } catch { /* session may already be gone */ }
+    // fall back to direct launch
     runClaudeDirect(cwd, args);
   }
 }

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -48,7 +48,14 @@ export function resolveLaunchPolicy(env: NodeJS.ProcessEnv = process.env): Claud
   if (!isTmuxAvailable()) {
     return 'direct';
   }
-  return env.TMUX ? 'inside-tmux' : 'outside-tmux';
+  if (env.TMUX) return 'inside-tmux';
+  // Terminal emulators that embed their own multiplexer (e.g. cmux, a
+  // Ghostty-based terminal) set CMUX_SURFACE_ID but not TMUX.  tmux
+  // attach-session fails in these environments because the host PTY is
+  // not directly compatible, leaving orphaned detached sessions.
+  // Fall back to direct mode so Claude launches without tmux wrapping.
+  if (env.CMUX_SURFACE_ID) return 'direct';
+  return 'outside-tmux';
 }
 
 /**


### PR DESCRIPTION
## Summary

- Detect `CMUX_SURFACE_ID` env var in `resolveLaunchPolicy()` and return `'direct'` policy, skipping tmux wrapping in [cmux](https://cmux.dev) (Ghostty-based terminal emulator) environments
- Clean up orphaned detached tmux sessions in `runClaudeOutsideTmux()` catch block when `tmux attach-session` fails
- Add 5 unit tests for `resolveLaunchPolicy` covering all policy branches

## Problem

When `omc` launches from cmux, `resolveLaunchPolicy()` returns `'outside-tmux'` (tmux is available, but `$TMUX` is not set). `runClaudeOutsideTmux()` then:

1. Creates a detached tmux session via `tmux new-session -d` (succeeds)
2. Attempts `tmux attach-session` (fails with **"open terminal failed: not a terminal"**)
3. Falls back to `runClaudeDirect()` — Claude starts without tmux

This leaves an **orphaned detached tmux session on every `omc` invocation**. After a few attempts:

```
$ tmux list-sessions
omc-myproject-detached-20260318083247: 1 windows (0 clients)
omc-myproject-detached-20260318083326: 1 windows (0 clients)
omc-myproject-detached-20260318083345: 1 windows (0 clients)
```

### Root cause

cmux sets `CMUX_SURFACE_ID` and `CMUX_SOCKET_PATH` but not `$TMUX`. Its PTY is not directly compatible with `tmux attach-session`, which requires a real terminal via `isatty()` + `/dev/tty`.

## Changes

### `src/cli/tmux-utils.ts`
- `resolveLaunchPolicy()`: Check for `CMUX_SURFACE_ID` after the `$TMUX` check, before falling through to `'outside-tmux'`. Returns `'direct'` for cmux environments.

### `src/cli/launch.ts`
- `runClaudeOutsideTmux()`: When `tmux attach-session` fails, kill the detached session created by `new-session -d` before falling back to direct mode. This is a defensive improvement that helps all terminals, not just cmux.

### `src/cli/__tests__/tmux-utils.test.ts`
- 5 new tests for `resolveLaunchPolicy`:
  - `TMUX` set → `'inside-tmux'`
  - `CMUX_SURFACE_ID` set → `'direct'`
  - Both `TMUX` + `CMUX_SURFACE_ID` → `'inside-tmux'` (TMUX takes precedence)
  - Neither set, tmux available → `'outside-tmux'`
  - tmux not available → `'direct'`

## Test plan

- [x] `npx vitest run src/cli/__tests__/tmux-utils.test.ts` — 22 tests pass (17 existing + 5 new)
- [x] `npx eslint src/cli/tmux-utils.ts src/cli/launch.ts` — no errors
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual: run `omc` from cmux terminal — Claude launches directly without "open terminal failed" error
- [ ] Manual: run `omc` from plain terminal — tmux session created and attached as before
- [ ] Manual: run `omc` from inside tmux — Claude launches in current pane as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)