### PR TITLE
Adapt OMC skills toward a skills 2.0 MVP

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -168,7 +168,7 @@ The `plugin.json` defines the plugin's metadata and tools:
 
 ### Skill and Agent Discovery
 
-**Skills** are discovered from `SKILL.md` files in the skills directory. Each skill directory must contain a SKILL.md with frontmatter:
+**Skills** are discovered from `SKILL.md` files in the skills directory. OMC's canonical project-local write target remains `.omc/skills/`, and it now also reads project-local compatibility skills from `.agents/skills/`. Each skill directory must contain a SKILL.md with frontmatter:
 
 ```markdown
 ---

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -452,6 +452,12 @@ handoff: .omc/specs/deep-interview-{slug}.md
 
 When present, OMC appends a standardized **Skill Pipeline** section to the rendered skill prompt so the current stage, handoff artifact, and explicit next `Skill("oh-my-claudecode:...")` invocation are carried forward consistently.
 
+### Skills 2.0 Compatibility (MVP)
+
+OMC's canonical project-local skill directory remains `.omc/skills/`, but the runtime now also reads compatibility skills from `.agents/skills/`.
+
+For builtin and slash-loaded skills, OMC also appends a standardized **Skill Resources** section when the skill directory contains bundled assets such as helper scripts, templates, or support libraries. This helps agents reuse packaged skill resources instead of recreating them ad hoc.
+
 ---
 
 ## Hooks System

--- a/docs/design/SKILLS_2_0_ADAPTATION.md
+++ b/docs/design/SKILLS_2_0_ADAPTATION.md
@@ -1,0 +1,115 @@
+# Skills 2.0 Adaptation for OMC (MVP)
+
+## Context
+
+The broader AI coding-agent ecosystem is converging on a more package-oriented skill model:
+
+- reusable workflows live in directory-based skill packages
+- skills ship bundled resources, not just prose
+- orchestration surfaces increasingly expose explicit handoffs, tools, and workflow contracts
+
+OMC already has strong foundations here:
+
+- `SKILL.md` frontmatter
+- slash-loaded skills
+- builtin skill loading
+- pipeline / handoff metadata
+
+This MVP focuses on the smallest concrete adaptation that improves interoperability without forcing a large schema migration.
+
+## Research summary
+
+### Anthropic Claude Code
+
+Claude Code's custom subagent model emphasizes:
+
+- specialized workflow packaging
+- scoped capabilities and tools
+- explicit subagent composition
+- preloaded skills/resources
+
+### OpenAI Agents SDK
+
+The Agents SDK treats the following as first-class:
+
+- tools
+- handoffs
+- workflows/pipelines
+- guardrails
+
+### Agent Skills ecosystem
+
+The Agent Skills ecosystem centers on project-local skill packaging conventions such as `.agents/skills/`, with bundled artifacts that should be reused by the agent at execution time.
+
+## OMC gaps
+
+1. **Project-local compatibility gap**
+   - OMC's canonical project-local skill directory is `.omc/skills/`
+   - emerging conventions also use `.agents/skills/`
+   - OMC should interoperate without abandoning its own canonical layout
+
+2. **Bundled-resource visibility gap**
+   - OMC renders skill markdown well
+   - but it does not consistently call attention to `lib/`, `templates/`, scripts, or helper files shipped beside the skill
+   - this increases needless reinvention and reduces package leverage
+
+## MVP scope implemented in Phase 1
+
+### 1. Compatibility read support for `.agents/skills/`
+
+- Keep `.omc/skills/` as the canonical OMC project-local skill directory
+- Add `.agents/skills/` as a compatibility read source for:
+  - learned/project skill discovery
+  - slash-loaded skill discovery
+- Preserve deterministic priority order:
+  - project commands
+  - user commands
+  - project `.omc/skills`
+  - project `.agents/skills`
+  - user skill directories
+
+### 2. Standardized `Skill Resources` rendering
+
+When a skill directory contains extra bundled assets beyond `SKILL.md`, OMC now appends a standardized block:
+
+- skill directory path
+- bundled resource entries (for example `lib/`, `templates/`, scripts)
+- a reuse-first reminder
+
+This is rendered for:
+
+- builtin skills
+- slash-loaded skills
+
+## Why this slice
+
+This MVP is intentionally narrow:
+
+- high practical value
+- low migration risk
+- no new dependency
+- backward compatible with current skill metadata
+
+It gives OMC a real step toward a "skills 2.0" model without prematurely freezing a large frontmatter schema.
+
+## Deferred follow-ups
+
+### Phase 2
+
+Add optional richer skill contract metadata, potentially including:
+
+- deliverables
+- artifact paths
+- allowed tools
+- model/runtime preferences
+- explicit execution constraints
+
+### Phase 3
+
+Add validation / diagnostics around richer contracts and potentially artifact-first execution helpers.
+
+## Risks
+
+- `.agents/skills/` compatibility may surface overlapping names if users intentionally mirror the same skill in both locations; precedence is now explicit, but duplication may still confuse humans.
+- `Skill Resources` currently summarizes top-level bundled assets only; deeper artifact indexing is out of scope for the MVP.
+- This does not yet introduce a richer validated schema; it improves packaging and discoverability first.

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -37,6 +37,7 @@ describe('auto-slash command skill aliases', () => {
 
     mkdirSync(join(tempConfigDir, 'skills', 'team'), { recursive: true });
     mkdirSync(join(tempConfigDir, 'skills', 'project-session-manager'), { recursive: true });
+    mkdirSync(join(tempProjectDir, '.agents', 'skills'), { recursive: true });
     mkdirSync(join(tempProjectDir, '.claude', 'commands'), { recursive: true });
 
     writeFileSync(
@@ -188,5 +189,38 @@ Deep interview body`
     expect(result.replacementText).toContain('Next skill arguments: `--consensus --direct`');
     expect(result.replacementText).toContain('Skill("oh-my-claudecode:omc-plan")');
     expect(result.replacementText).toContain('`.omc/specs/deep-interview-{slug}.md`');
+  });
+
+  it('discovers project-local compatibility skills from .agents/skills', async () => {
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'compat-skill', 'templates'), { recursive: true });
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'compat-skill', 'SKILL.md'),
+      `---
+name: compat-skill
+description: Compatibility skill
+---
+
+Compatibility body`
+    );
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'compat-skill', 'templates', 'example.txt'),
+      'example'
+    );
+
+    const { findCommand, executeSlashCommand, listAvailableCommands } = await loadExecutor();
+
+    expect(findCommand('compat-skill')?.scope).toBe('skill');
+    expect(listAvailableCommands().some((command) => command.name === 'compat-skill')).toBe(true);
+
+    const result = executeSlashCommand({
+      command: 'compat-skill',
+      args: '',
+      raw: '/compat-skill',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('## Skill Resources');
+    expect(result.replacementText).toContain('.agents/skills/compat-skill');
+    expect(result.replacementText).toContain('`templates/`');
   });
 });

--- a/src/__tests__/hooks/learner/bridge.test.ts
+++ b/src/__tests__/hooks/learner/bridge.test.ts
@@ -59,6 +59,23 @@ describe("Skill Bridge Module", () => {
       expect(projectFiles[0].path).toContain("test-skill.md");
     });
 
+    it("should discover compatibility skills in project .agents/skills/", () => {
+      const skillsDir = join(testProjectRoot, ".agents", "skills");
+      mkdirSync(skillsDir, { recursive: true });
+
+      writeFileSync(
+        join(skillsDir, "compat-skill.md"),
+        "---\nname: Compat Skill\ntriggers:\n  - compat\n---\nContent",
+      );
+
+      const files = findSkillFiles(testProjectRoot);
+      const projectFiles = files.filter((f) => f.scope === "project");
+
+      expect(projectFiles).toHaveLength(1);
+      expect(projectFiles[0].sourceDir).toContain(join(".agents", "skills"));
+      expect(projectFiles[0].path).toContain("compat-skill.md");
+    });
+
     it("should discover skills recursively in subdirectories", () => {
       const skillsDir = join(testProjectRoot, ".omc", "skills");
       const subDir = join(skillsDir, "subdir", "nested");

--- a/src/__tests__/mnemosyne/finder.test.ts
+++ b/src/__tests__/mnemosyne/finder.test.ts
@@ -32,6 +32,19 @@ describe('Skill Finder', () => {
     expect(projectCandidates[0].path).toBe(skillPath);
   });
 
+  it('should find compatibility project skills in .agents/skills', () => {
+    const compatDir = join(projectRoot, '.agents', 'skills');
+    mkdirSync(compatDir, { recursive: true });
+    const skillPath = join(compatDir, 'compat-skill.md');
+    writeFileSync(skillPath, '# Compat Skill');
+
+    const candidates = findSkillFiles(projectRoot);
+    const projectCandidates = candidates.filter(c => c.scope === 'project');
+
+    expect(projectCandidates.some(c => c.path === skillPath)).toBe(true);
+    expect(projectCandidates.find(c => c.path === skillPath)?.sourceDir).toBe(compatDir);
+  });
+
   it('should prioritize project skills over user skills', () => {
     // Create project skill
     const projectSkillPath = join(projectRoot, '.omc', 'skills', 'skill.md');

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -119,6 +119,15 @@ describe('Builtin Skills', () => {
       expect(skill?.name).toBe('ai-slop-cleaner');
     });
 
+    it('should surface bundled skill resources for skills with additional files', () => {
+      const skill = getBuiltinSkill('project-session-manager');
+      expect(skill).toBeDefined();
+      expect(skill?.template).toContain('## Skill Resources');
+      expect(skill?.template).toContain('skills/project-session-manager');
+      expect(skill?.template).toContain('`lib/`');
+      expect(skill?.template).toContain('`psm.sh`');
+    });
+
     it('should retrieve the trace skill by name', () => {
       const skill = getBuiltinSkill('trace');
       expect(skill).toBeDefined();

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'url';
 import type { BuiltinSkill } from './types.js';
 import { parseFrontmatter, parseFrontmatterAliases } from '../../utils/frontmatter.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
+import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from './runtime-guidance.js';
 
 // Get the project root directory (go up from src/features/builtin-skills/)
@@ -62,6 +63,7 @@ function loadSkillFromFile(skillPath: string, skillName: string): BuiltinSkill[]
       body.trim(),
       renderSkillRuntimeGuidance(safePrimaryName),
       renderSkillPipelineGuidance(safePrimaryName, pipeline),
+      renderSkillResourcesGuidance(skillPath),
     ].filter((section) => section.trim().length > 0).join('\n\n');
 
     const safeAliases = Array.from(

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -19,6 +19,7 @@ import type {
 import { resolveLiveData } from './live-data.js';
 import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
+import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from '../../features/builtin-skills/runtime-guidance.js';
 
 /** Claude config directory */
@@ -113,82 +114,99 @@ function discoverCommandsFromDir(
   return commands;
 }
 
+function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
+  if (!existsSync(skillsDir)) {
+    return [];
+  }
+
+  const skillCommands: CommandInfo[] = [];
+
+  try {
+    const skillDirs = readdirSync(skillsDir, { withFileTypes: true });
+    for (const dir of skillDirs) {
+      if (!dir.isDirectory()) continue;
+
+      const skillPath = join(skillsDir, dir.name, 'SKILL.md');
+      if (!existsSync(skillPath)) continue;
+
+      try {
+        const content = readFileSync(skillPath, 'utf-8');
+        const { metadata: fm, body } = parseFrontmatter(content);
+
+        const rawName = getFrontmatterString(fm, 'name') || dir.name;
+        const canonicalName = toSafeSkillName(rawName);
+        const aliases = Array.from(new Set(
+          parseFrontmatterAliases(fm.aliases)
+            .map((alias: string) => toSafeSkillName(alias))
+            .filter((alias: string) => alias.toLowerCase() !== canonicalName.toLowerCase())
+        ));
+        const commandNames = [canonicalName, ...aliases];
+        const description = getFrontmatterString(fm, 'description') || '';
+        const argumentHint = getFrontmatterString(fm, 'argument-hint');
+        const model = getFrontmatterString(fm, 'model');
+        const agent = getFrontmatterString(fm, 'agent');
+        const pipeline = parseSkillPipelineMetadata(fm);
+
+        for (const commandName of commandNames) {
+          const isAlias = commandName !== canonicalName;
+          const metadata: CommandMetadata = {
+            name: commandName,
+            description,
+            argumentHint,
+            model,
+            agent,
+            pipeline: isAlias ? undefined : pipeline,
+            aliases: isAlias ? undefined : aliases,
+            aliasOf: isAlias ? canonicalName : undefined,
+            deprecatedAlias: isAlias || undefined,
+            deprecationMessage: isAlias
+              ? `Alias "/${commandName}" is deprecated. Use "/${canonicalName}" instead.`
+              : undefined,
+          };
+
+          skillCommands.push({
+            name: commandName,
+            path: skillPath,
+            metadata,
+            content: body,
+            scope: 'skill',
+          });
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return skillCommands;
+}
+
 /**
  * Discover all available commands from multiple sources
  */
 export function discoverAllCommands(): CommandInfo[] {
   const userCommandsDir = join(CLAUDE_CONFIG_DIR, 'commands');
   const projectCommandsDir = join(process.cwd(), '.claude', 'commands');
-  const skillsDir = join(CLAUDE_CONFIG_DIR, 'skills');
+  const projectOmcSkillsDir = join(process.cwd(), '.omc', 'skills');
+  const projectAgentSkillsDir = join(process.cwd(), '.agents', 'skills');
+  const userSkillsDir = join(CLAUDE_CONFIG_DIR, 'skills');
 
   const userCommands = discoverCommandsFromDir(userCommandsDir, 'user');
   const projectCommands = discoverCommandsFromDir(projectCommandsDir, 'project');
+  const projectOmcSkills = discoverSkillsFromDir(projectOmcSkillsDir);
+  const projectAgentSkills = discoverSkillsFromDir(projectAgentSkillsDir);
+  const userSkills = discoverSkillsFromDir(userSkillsDir);
 
-  // Discover skills (each skill directory may have a SKILL.md)
-  const skillCommands: CommandInfo[] = [];
-  if (existsSync(skillsDir)) {
-    try {
-      const skillDirs = readdirSync(skillsDir, { withFileTypes: true });
-      for (const dir of skillDirs) {
-        if (!dir.isDirectory()) continue;
-
-        const skillPath = join(skillsDir, dir.name, 'SKILL.md');
-        if (existsSync(skillPath)) {
-          try {
-            const content = readFileSync(skillPath, 'utf-8');
-            const { metadata: fm, body } = parseFrontmatter(content);
-
-            const rawName = getFrontmatterString(fm, 'name') || dir.name;
-            const canonicalName = toSafeSkillName(rawName);
-            const aliases = Array.from(new Set(
-              parseFrontmatterAliases(fm.aliases)
-                .map((alias: string) => toSafeSkillName(alias))
-                .filter((alias: string) => alias.toLowerCase() !== canonicalName.toLowerCase())
-            ));
-            const commandNames = [canonicalName, ...aliases];
-            const description = getFrontmatterString(fm, 'description') || '';
-            const argumentHint = getFrontmatterString(fm, 'argument-hint');
-            const model = getFrontmatterString(fm, 'model');
-            const agent = getFrontmatterString(fm, 'agent');
-            const pipeline = parseSkillPipelineMetadata(fm);
-
-            for (const commandName of commandNames) {
-              const isAlias = commandName !== canonicalName;
-              const metadata: CommandMetadata = {
-                name: commandName,
-                description,
-                argumentHint,
-                model,
-                agent,
-                pipeline: isAlias ? undefined : pipeline,
-                aliases: isAlias ? undefined : aliases,
-                aliasOf: isAlias ? canonicalName : undefined,
-                deprecatedAlias: isAlias || undefined,
-                deprecationMessage: isAlias
-                  ? `Alias "/${commandName}" is deprecated. Use "/${canonicalName}" instead.`
-                  : undefined,
-              };
-
-              skillCommands.push({
-                name: commandName,
-                path: skillPath,
-                metadata,
-                content: body,
-                scope: 'skill',
-              });
-            }
-          } catch {
-            continue;
-          }
-        }
-      }
-    } catch {
-      // Ignore errors reading skills directory
-    }
-  }
-
-  // Priority: project > user > skills
-  const prioritized = [...projectCommands, ...userCommands, ...skillCommands];
+  // Priority: project commands > user commands > project OMC skills > project compatibility skills > user skills
+  const prioritized = [
+    ...projectCommands,
+    ...userCommands,
+    ...projectOmcSkills,
+    ...projectAgentSkills,
+    ...userSkills,
+  ];
   const seen = new Set<string>();
 
   return prioritized.filter((command) => {
@@ -261,8 +279,11 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   const pipelineGuidance = cmd.scope === 'skill'
     ? renderSkillPipelineGuidance(cmd.metadata.name, cmd.metadata.pipeline)
     : '';
+  const resourceGuidance = cmd.scope === 'skill' && cmd.path
+    ? renderSkillResourcesGuidance(cmd.path)
+    : '';
   sections.push(
-    [injectedContent.trim(), runtimeGuidance, pipelineGuidance]
+    [injectedContent.trim(), runtimeGuidance, pipelineGuidance, resourceGuidance]
       .filter((section) => section.trim().length > 0)
       .join('\n\n')
   );

--- a/src/hooks/learner/bridge.ts
+++ b/src/hooks/learner/bridge.ts
@@ -29,6 +29,7 @@ export const USER_SKILLS_DIR = join(
 );
 export const GLOBAL_SKILLS_DIR = join(homedir(), ".omc", "skills");
 export const PROJECT_SKILLS_SUBDIR = OmcPaths.SKILLS;
+export const PROJECT_AGENT_SKILLS_SUBDIR = join(".agents", "skills");
 export const SKILL_EXTENSION = ".md";
 
 /** Session TTL: 1 hour */
@@ -374,22 +375,28 @@ export function findSkillFiles(
 
   // 1. Search project-level skills (higher priority)
   if (scope === "project" || scope === "all") {
-    const projectSkillsDir = join(projectRoot, PROJECT_SKILLS_SUBDIR);
-    const projectFiles: string[] = [];
-    findSkillFilesRecursive(projectSkillsDir, projectFiles);
+    const projectSkillDirs = [
+      join(projectRoot, PROJECT_SKILLS_SUBDIR),
+      join(projectRoot, PROJECT_AGENT_SKILLS_SUBDIR),
+    ];
 
-    for (const filePath of projectFiles) {
-      const realPath = safeRealpathSync(filePath);
-      if (seenRealPaths.has(realPath)) continue;
-      if (!isWithinBoundary(realPath, projectSkillsDir)) continue;
-      seenRealPaths.add(realPath);
+    for (const projectSkillsDir of projectSkillDirs) {
+      const projectFiles: string[] = [];
+      findSkillFilesRecursive(projectSkillsDir, projectFiles);
 
-      candidates.push({
-        path: filePath,
-        realPath,
-        scope: "project",
-        sourceDir: projectSkillsDir,
-      });
+      for (const filePath of projectFiles) {
+        const realPath = safeRealpathSync(filePath);
+        if (seenRealPaths.has(realPath)) continue;
+        if (!isWithinBoundary(realPath, projectSkillsDir)) continue;
+        seenRealPaths.add(realPath);
+
+        candidates.push({
+          path: filePath,
+          realPath,
+          scope: "project",
+          sourceDir: projectSkillsDir,
+        });
+      }
     }
   }
 

--- a/src/hooks/learner/constants.ts
+++ b/src/hooks/learner/constants.ts
@@ -16,6 +16,9 @@ export const GLOBAL_SKILLS_DIR = join(homedir(), '.omc', 'skills');
 /** Project-level skills subdirectory */
 export const PROJECT_SKILLS_SUBDIR = OmcPaths.SKILLS;
 
+/** Project-level compatibility skills subdirectory (read-only compatibility source) */
+export const PROJECT_AGENT_SKILLS_SUBDIR = join('.agents', 'skills');
+
 /** Maximum recursion depth for skill file discovery */
 export const MAX_RECURSION_DEPTH = 10;
 

--- a/src/hooks/learner/finder.ts
+++ b/src/hooks/learner/finder.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, readdirSync, realpathSync, mkdirSync } from 'fs';
 import { join, normalize, sep } from 'path';
-import { USER_SKILLS_DIR, PROJECT_SKILLS_SUBDIR, SKILL_EXTENSION, DEBUG_ENABLED, GLOBAL_SKILLS_DIR, MAX_RECURSION_DEPTH } from './constants.js';
+import { USER_SKILLS_DIR, PROJECT_SKILLS_SUBDIR, PROJECT_AGENT_SKILLS_SUBDIR, SKILL_EXTENSION, DEBUG_ENABLED, GLOBAL_SKILLS_DIR, MAX_RECURSION_DEPTH } from './constants.js';
 import type { SkillFileCandidate } from './types.js';
 
 /**
@@ -71,28 +71,34 @@ export function findSkillFiles(
 
   // 1. Search project-level skills (if scope allows)
   if (projectRoot && (scope === 'project' || scope === 'all')) {
-    const projectSkillsDir = join(projectRoot, PROJECT_SKILLS_SUBDIR);
-    const projectFiles: string[] = [];
-    findSkillFilesRecursive(projectSkillsDir, projectFiles);
+    const projectSkillDirs = [
+      join(projectRoot, PROJECT_SKILLS_SUBDIR),
+      join(projectRoot, PROJECT_AGENT_SKILLS_SUBDIR),
+    ];
 
-    for (const filePath of projectFiles) {
-      const realPath = safeRealpathSync(filePath);
-      if (seenRealPaths.has(realPath)) continue;
-      // Symlink boundary check
-      if (!isWithinBoundary(realPath, projectSkillsDir)) {
-        if (DEBUG_ENABLED) {
-          console.warn('[learner] Symlink escape blocked:', filePath);
+    for (const projectSkillsDir of projectSkillDirs) {
+      const projectFiles: string[] = [];
+      findSkillFilesRecursive(projectSkillsDir, projectFiles);
+
+      for (const filePath of projectFiles) {
+        const realPath = safeRealpathSync(filePath);
+        if (seenRealPaths.has(realPath)) continue;
+        // Symlink boundary check
+        if (!isWithinBoundary(realPath, projectSkillsDir)) {
+          if (DEBUG_ENABLED) {
+            console.warn('[learner] Symlink escape blocked:', filePath);
+          }
+          continue;
         }
-        continue;
-      }
-      seenRealPaths.add(realPath);
+        seenRealPaths.add(realPath);
 
-      candidates.push({
-        path: filePath,
-        realPath,
-        scope: 'project',
-        sourceDir: projectSkillsDir,
-      });
+        candidates.push({
+          path: filePath,
+          realPath,
+          scope: 'project',
+          sourceDir: projectSkillsDir,
+        });
+      }
     }
   }
 

--- a/src/utils/skill-resources.ts
+++ b/src/utils/skill-resources.ts
@@ -1,0 +1,68 @@
+import { existsSync, readdirSync } from 'fs';
+import { dirname, join, relative } from 'path';
+
+const MAX_RESOURCE_ENTRIES = 12;
+
+function toDisplayPath(pathValue: string): string {
+  const relativeToCwd = relative(process.cwd(), pathValue);
+  if (
+    relativeToCwd &&
+    relativeToCwd !== '' &&
+    !relativeToCwd.startsWith('..') &&
+    relativeToCwd !== '.'
+  ) {
+    return relativeToCwd;
+  }
+
+  return pathValue;
+}
+
+export interface SkillResourceSummary {
+  skillDirectory: string;
+  entries: string[];
+}
+
+export function summarizeSkillResources(skillFilePath: string): SkillResourceSummary | undefined {
+  const skillDirectory = dirname(skillFilePath);
+  if (!existsSync(skillDirectory)) {
+    return undefined;
+  }
+
+  let directoryEntries: string[] = [];
+  try {
+    directoryEntries = readdirSync(skillDirectory, { withFileTypes: true })
+      .filter((entry) => entry.name !== 'SKILL.md' && !entry.name.startsWith('.'))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .slice(0, MAX_RESOURCE_ENTRIES)
+      .map((entry) => entry.isDirectory() ? `${entry.name}/` : entry.name);
+  } catch {
+    return undefined;
+  }
+
+  if (directoryEntries.length === 0) {
+    return undefined;
+  }
+
+  return {
+    skillDirectory: toDisplayPath(skillDirectory),
+    entries: directoryEntries,
+  };
+}
+
+export function renderSkillResourcesGuidance(skillFilePath: string): string {
+  const summary = summarizeSkillResources(skillFilePath);
+  if (!summary) {
+    return '';
+  }
+
+  const lines = [
+    '## Skill Resources',
+    `Skill directory: \`${summary.skillDirectory}\``,
+    'Bundled resources:',
+    ...summary.entries.map((entry) => `- \`${entry}\``),
+    '',
+    'Prefer reusing these bundled resources when they fit the task instead of recreating them from scratch.',
+  ];
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

This PR ships the Phase 1 / MVP slice from #1745.

It adapts OMC toward a narrower "skills 2.0" interoperability model by:

- reading project-local compatibility skills from `.agents/skills/` while keeping `.omc/skills/` as OMC's canonical project-local directory
- surfacing bundled skill assets via a standardized `Skill Resources` section for builtin and slash-loaded skills
- documenting the MVP scope and follow-up rollout in the reference/design docs

## Changes

- add `src/utils/skill-resources.ts` to summarize bundled skill assets beside `SKILL.md`
- render `Skill Resources` guidance in builtin skill templates
- render `Skill Resources` guidance in slash-loaded skill templates
- extend project skill discovery to also read `.agents/skills/` in learner/bridge code paths
- extend slash command skill discovery to include project `.omc/skills/` and `.agents/skills/`
- add docs for the MVP compatibility scope and rollout plan
- add tests for compatibility discovery and rendered resource guidance

## Verification

- `npm run build`
- `npx vitest run src/__tests__/auto-slash-aliases.test.ts src/__tests__/mnemosyne/finder.test.ts src/__tests__/hooks/learner/bridge.test.ts`

## Notes / Risks

- Full `src/__tests__/skills.test.ts` was not included in the final verification set because that harness appears to hang around builtin-skill runtime availability probing; this PR still adds coverage for the new builtin-skill resource section assertion.
- `.agents/skills/` support is intentionally compatibility-oriented and lower priority than project `.omc/skills/`.

Closes #1745
