### PR TITLE
Fix issue #1751: clean up leftover split-pane worker shells on team shutdown

### DIFF
--- a/src/team/__tests__/runtime-v2.shutdown-pane-cleanup.test.ts
+++ b/src/team/__tests__/runtime-v2.shutdown-pane-cleanup.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+type ExecFileCallback = (err: Error | null, stdout: string, stderr: string) => void;
+type ExecCallback = (err: Error | null, stdout: string, stderr: string) => void;
+
+const execFileMock = vi.hoisted(() => vi.fn());
+const execMock = vi.hoisted(() => vi.fn());
+const tmuxCalls = vi.hoisted(() => [] as string[][]);
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    exec: execMock,
+    execFile: execFileMock,
+  };
+});
+
+async function writeJson(cwd: string, relativePath: string, value: unknown): Promise<void> {
+  const fullPath = join(cwd, relativePath);
+  await mkdir(dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+describe('shutdownTeamV2 split-pane pane cleanup', () => {
+  let cwd = '';
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-pane-cleanup-'));
+    tmuxCalls.length = 0;
+    execFileMock.mockReset();
+    execMock.mockReset();
+
+    const run = (args: string[]) => {
+      tmuxCalls.push(args);
+      let stdout = '';
+      if (args[0] === 'list-panes') {
+        stdout = '%1\n%2\n%3\n';
+      } else if (args[0] === 'display-message' && args.includes('#{pane_dead}')) {
+        stdout = '1\n';
+      }
+      return { stdout, stderr: '' };
+    };
+
+    const parseTmuxShellCmd = (cmd: string): string[] | null => {
+      const match = cmd.match(/^tmux\s+(.+)$/);
+      if (!match) return null;
+      const args = match[1].match(/'([^']*(?:\\.[^']*)*)'|"([^"]*)"/g);
+      if (!args) return null;
+      return args.map((token) => {
+        if (token.startsWith("'")) return token.slice(1, -1).replace(/'\\''/g, "'");
+        return token.slice(1, -1);
+      });
+    };
+
+    execFileMock.mockImplementation((_cmd: string, args: string[], cb?: ExecFileCallback) => {
+      const { stdout, stderr } = run(args);
+      if (cb) cb(null, stdout, stderr);
+      return {} as never;
+    });
+    (execFileMock as unknown as Record<symbol, unknown>)[Symbol.for('nodejs.util.promisify.custom')] =
+      async (_cmd: string, args: string[]) => run(args);
+
+    execMock.mockImplementation((cmd: string, cb: ExecCallback) => {
+      const { stdout, stderr } = run(parseTmuxShellCmd(cmd) ?? []);
+      cb(null, stdout, stderr);
+      return {} as never;
+    });
+    (execMock as unknown as Record<symbol, unknown>)[Symbol.for('nodejs.util.promisify.custom')] =
+      async (cmd: string) => run(parseTmuxShellCmd(cmd) ?? []);
+  });
+
+  afterEach(async () => {
+    tmuxCalls.length = 0;
+    execFileMock.mockReset();
+    execMock.mockReset();
+    if (cwd) {
+      await rm(cwd, { recursive: true, force: true });
+      cwd = '';
+    }
+  });
+
+  it('kills discovered split-pane worker panes beyond stale recorded pane metadata', async () => {
+    const teamName = 'pane-cleanup-team';
+    const teamRoot = `.omc/state/team/${teamName}`;
+
+    await writeJson(cwd, `${teamRoot}/config.json`, {
+      name: teamName,
+      task: 'demo',
+      agent_type: 'claude',
+      worker_launch_mode: 'interactive',
+      worker_count: 2,
+      max_workers: 20,
+      workers: [
+        { name: 'worker-1', index: 1, role: 'claude', assigned_tasks: [], pane_id: '%2' },
+        { name: 'worker-2', index: 2, role: 'claude', assigned_tasks: [] },
+      ],
+      created_at: new Date().toISOString(),
+      tmux_session: 'leader-session:0',
+      tmux_window_owned: false,
+      next_task_id: 1,
+      leader_pane_id: '%1',
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+    });
+
+    const { shutdownTeamV2 } = await import('../runtime-v2.js');
+    await shutdownTeamV2(teamName, cwd, { timeoutMs: 0 });
+
+    const killPaneTargets = tmuxCalls
+      .filter((args) => args[0] === 'kill-pane')
+      .map((args) => args[2]);
+
+    expect(killPaneTargets).toEqual(['%2', '%3']);
+    expect(killPaneTargets).not.toContain('%1');
+    await expect(readFile(join(cwd, teamRoot, 'config.json'), 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/src/team/__tests__/tmux-session.kill-team-session.test.ts
+++ b/src/team/__tests__/tmux-session.kill-team-session.test.ts
@@ -1,21 +1,37 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
 
 const mocked = vi.hoisted(() => ({
-  execFileCalls: [] as string[][],
+  execCalls: [] as string[][],
   currentSession: 'leader-session',
+  listedPanes: '%10\n%11\n',
 }));
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
 
   const run = (args: string[]): { stdout: string; stderr: string } => {
-    mocked.execFileCalls.push(args);
+    mocked.execCalls.push(args);
     if (args[0] === 'display-message' && args[1] === '-p' && args[2] === '#S') {
       return { stdout: `${mocked.currentSession}\n`, stderr: '' };
     }
+    if (args[0] === 'list-panes') {
+      return { stdout: mocked.listedPanes, stderr: '' };
+    }
     return { stdout: '', stderr: '' };
+  };
+
+  const parseTmuxShellCmd = (cmd: string): string[] | null => {
+    const match = cmd.match(/^tmux\s+(.+)$/);
+    if (!match) return null;
+    const args = match[1].match(/'([^']*(?:\\.[^']*)*)'|"([^"]*)"/g);
+    if (!args) return null;
+    return args.map((token) => {
+      if (token.startsWith("'")) return token.slice(1, -1).replace(/'\\''/g, "'");
+      return token.slice(1, -1);
+    });
   };
 
   const execFileMock = vi.fn((_cmd: string, args: string[], cb: ExecFileCallback) => {
@@ -23,23 +39,32 @@ vi.mock('child_process', async (importOriginal) => {
     cb(null, out.stdout, out.stderr);
     return {} as never;
   });
-
-  const promisifyCustom = Symbol.for('nodejs.util.promisify.custom');
-  (execFileMock as unknown as Record<symbol, unknown>)[promisifyCustom] =
+  (execFileMock as unknown as Record<symbol, unknown>)[Symbol.for('nodejs.util.promisify.custom')] =
     async (_cmd: string, args: string[]) => run(args);
+
+  const execMock = vi.fn((cmd: string, cb: ExecCallback) => {
+    const args = parseTmuxShellCmd(cmd) ?? [];
+    const out = run(args);
+    cb(null, out.stdout, out.stderr);
+    return {} as never;
+  });
+  (execMock as unknown as Record<symbol, unknown>)[Symbol.for('nodejs.util.promisify.custom')] =
+    async (cmd: string) => run(parseTmuxShellCmd(cmd) ?? []);
 
   return {
     ...actual,
+    exec: execMock,
     execFile: execFileMock,
   };
 });
 
-import { killTeamSession } from '../tmux-session.js';
+import { killTeamSession, resolveSplitPaneWorkerPaneIds } from '../tmux-session.js';
 
 describe('killTeamSession safeguards', () => {
   afterEach(() => {
-    mocked.execFileCalls = [];
+    mocked.execCalls = [];
     mocked.currentSession = 'leader-session';
+    mocked.listedPanes = '%10\n%11\n';
     vi.unstubAllEnvs();
   });
 
@@ -49,7 +74,7 @@ describe('killTeamSession safeguards', () => {
 
     await killTeamSession('leader-session');
 
-    expect(mocked.execFileCalls.some((args) => args[0] === 'kill-session')).toBe(false);
+    expect(mocked.execCalls.some((args) => args[0] === 'kill-session')).toBe(false);
   });
 
   it('kills a different detached session', async () => {
@@ -58,7 +83,7 @@ describe('killTeamSession safeguards', () => {
 
     await killTeamSession('worker-detached-session');
 
-    expect(mocked.execFileCalls.some((args) =>
+    expect(mocked.execCalls.some((args) =>
       args[0] === 'kill-session' && args.includes('worker-detached-session'),
     )).toBe(true);
   });
@@ -66,21 +91,32 @@ describe('killTeamSession safeguards', () => {
   it('kills only worker panes in split-pane mode', async () => {
     await killTeamSession('leader-session:0', ['%10', '%11'], '%10');
 
-    const killPaneTargets = mocked.execFileCalls
+    const killPaneTargets = mocked.execCalls
       .filter((args) => args[0] === 'kill-pane')
       .map((args) => args[2]);
 
     expect(killPaneTargets).toEqual(['%11']);
-    expect(mocked.execFileCalls.some((args) => args[0] === 'kill-session')).toBe(false);
-    expect(mocked.execFileCalls.some((args) => args[0] === 'kill-window')).toBe(false);
+    expect(mocked.execCalls.some((args) => args[0] === 'kill-session')).toBe(false);
+    expect(mocked.execCalls.some((args) => args[0] === 'kill-window')).toBe(false);
   });
 
   it('kills an owned team window when session owns that window', async () => {
     await killTeamSession('leader-session:3', ['%10', '%11'], '%10', { sessionMode: 'dedicated-window' });
 
-    expect(mocked.execFileCalls.some((args) =>
+    expect(mocked.execCalls.some((args) =>
       args[0] === 'kill-window' && args.includes('leader-session:3'),
     )).toBe(true);
-    expect(mocked.execFileCalls.some((args) => args[0] === 'kill-pane')).toBe(false);
+    expect(mocked.execCalls.some((args) => args[0] === 'kill-pane')).toBe(false);
+  });
+
+  it('discovers additional split-pane worker panes from the recorded team target', async () => {
+    mocked.listedPanes = '%10\n%11\n%12\n';
+
+    const paneIds = await resolveSplitPaneWorkerPaneIds('leader-session:0', ['%11'], '%10');
+
+    expect(paneIds).toEqual(['%11', '%12']);
+    expect(mocked.execCalls.some((args) =>
+      args[0] === 'list-panes' && args.includes('leader-session:0'),
+    )).toBe(true);
   });
 });

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -1238,11 +1238,18 @@ export async function shutdownTeamV2(
 
   // 4. Force kill remaining tmux panes
   try {
-    const { killWorkerPanes, killTeamSession } = await import('./tmux-session.js');
-    const workerPaneIds = config.workers
+    const { killWorkerPanes, killTeamSession, resolveSplitPaneWorkerPaneIds } = await import('./tmux-session.js');
+    const recordedWorkerPaneIds = config.workers
       .map((w) => w.pane_id)
       .filter((p): p is string => typeof p === 'string' && p.trim().length > 0);
     const ownsWindow = config.tmux_window_owned === true;
+    const workerPaneIds = ownsWindow
+      ? recordedWorkerPaneIds
+      : await resolveSplitPaneWorkerPaneIds(
+        config.tmux_session,
+        recordedWorkerPaneIds,
+        config.leader_pane_id ?? undefined,
+      );
     await killWorkerPanes({
       paneIds: workerPaneIds,
       leaderPaneId: config.leader_pane_id ?? undefined,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -6,7 +6,7 @@ import { buildWorkerArgv, resolveValidatedBinaryPath, getWorkerEnv as getModelWo
 import { validateTeamName } from './team-name.js';
 import {
   createTeamSession, spawnWorkerInPane, sendToWorker,
-  isWorkerAlive, killTeamSession, waitForPaneReady,
+  isWorkerAlive, killTeamSession, resolveSplitPaneWorkerPaneIds, waitForPaneReady,
   type TeamSession, type WorkerPaneConfig,
 } from './tmux-session.js';
 import {
@@ -954,7 +954,10 @@ export async function shutdownTeam(
   const sessionMode = (ownsWindow ?? Boolean(configData?.tmuxOwnsWindow))
     ? (sessionName.includes(':') ? 'dedicated-window' : 'detached-session')
     : 'split-pane';
-  await killTeamSession(sessionName, workerPaneIds, leaderPaneId, { sessionMode });
+  const effectiveWorkerPaneIds = sessionMode === 'split-pane'
+    ? await resolveSplitPaneWorkerPaneIds(sessionName, workerPaneIds, leaderPaneId)
+    : workerPaneIds;
+  await killTeamSession(sessionName, effectiveWorkerPaneIds, leaderPaneId, { sessionMode });
 
   // Clean up state
   try {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -942,6 +942,40 @@ export async function killWorkerPanes(opts: {
   }
 }
 
+function isPaneId(value: string | undefined): value is string {
+  return typeof value === 'string' && /^%\d+$/.test(value.trim());
+}
+
+function dedupeWorkerPaneIds(paneIds: Array<string | undefined>, leaderPaneId?: string): string[] {
+  const unique = new Set<string>();
+  for (const paneId of paneIds) {
+    if (!isPaneId(paneId)) continue;
+    const normalized = paneId.trim();
+    if (normalized === leaderPaneId) continue;
+    unique.add(normalized);
+  }
+  return [...unique];
+}
+
+export async function resolveSplitPaneWorkerPaneIds(
+  sessionName: string,
+  recordedPaneIds?: string[],
+  leaderPaneId?: string,
+): Promise<string[]> {
+  const resolved = dedupeWorkerPaneIds(recordedPaneIds ?? [], leaderPaneId);
+  if (!sessionName.includes(':')) return resolved;
+
+  try {
+    const paneResult = await tmuxAsync(['list-panes', '-t', sessionName, '-F', '#{pane_id}']);
+    return dedupeWorkerPaneIds(
+      [...resolved, ...paneResult.stdout.split('\n').map((paneId) => paneId.trim())],
+      leaderPaneId,
+    );
+  } catch {
+    return resolved;
+  }
+}
+
 /**
  * Kill the team tmux session or just the worker panes, depending on how the
  * team was created.


### PR DESCRIPTION
## Summary
- fix split-pane team shutdown so cleanup reconciles live tmux worker panes instead of trusting stale `config.workers[].pane_id` alone
- share the same split-pane pane-discovery fallback with the legacy runtime shutdown path
- add focused regression tests for pane discovery and runtime-v2 split-pane shutdown cleanup

## Root cause
`shutdownTeamV2()` only killed worker panes recorded in team config. When split-pane worker metadata drifted or a worker pane survived as an empty shell without a current `pane_id` entry, shutdown skipped that leftover pane and only cleaned the panes it still knew about.

## Changed files
- `src/team/tmux-session.ts`
- `src/team/runtime-v2.ts`
- `src/team/runtime.ts`
- `src/team/__tests__/tmux-session.kill-team-session.test.ts`
- `src/team/__tests__/runtime-v2.shutdown-pane-cleanup.test.ts`

## Verification
- `vitest run src/team/__tests__/runtime-v2.shutdown-pane-cleanup.test.ts src/team/__tests__/tmux-session.kill-team-session.test.ts`
- `vitest run src/team/__tests__/runtime-v2.dispatch.test.ts src/team/__tests__/api-interop.cleanup.test.ts`
- `vitest run src/team/__tests__/runtime-v2.shutdown.test.ts`

## Notes
- dedicated-window and detached-session behavior is unchanged
- `~/.claude/tasks/*` was inspected but not modified: there were no empty task dirs locally, and current evidence does not prove team ownership for UUID-named directories
