### PR TITLE
Protect marketplace reload syncs from dirty-repo data loss

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -8832,6 +8832,7 @@ function syncMarketplaceClone(verbose = false) {
   }
   const stdio = verbose ? "inherit" : "pipe";
   const execOpts = { encoding: "utf-8", stdio, timeout: 6e4 };
+  const queryExecOpts = { encoding: "utf-8", stdio: "pipe", timeout: 6e4 };
   try {
     (0, import_child_process13.execFileSync)("git", ["-C", marketplacePath, "fetch", "--all", "--prune"], execOpts);
   } catch (err) {
@@ -8841,14 +8842,53 @@ function syncMarketplaceClone(verbose = false) {
     (0, import_child_process13.execFileSync)("git", ["-C", marketplacePath, "checkout", "main"], { ...execOpts, timeout: 15e3 });
   } catch {
   }
+  let currentBranch = "";
   try {
-    (0, import_child_process13.execFileSync)("git", ["-C", marketplacePath, "reset", "--hard", "origin/main"], execOpts);
+    currentBranch = String((0, import_child_process13.execFileSync)("git", ["-C", marketplacePath, "rev-parse", "--abbrev-ref", "HEAD"], queryExecOpts) ?? "").trim();
   } catch (err) {
-    return { ok: false, message: `Failed to reset marketplace clone: ${err instanceof Error ? err.message : err}` };
+    return { ok: false, message: `Failed to inspect marketplace clone branch: ${err instanceof Error ? err.message : err}` };
+  }
+  if (currentBranch !== "main") {
+    return {
+      ok: false,
+      message: `Skipped marketplace clone update: expected branch main but found ${currentBranch || "unknown"}`
+    };
+  }
+  let statusOutput = "";
+  try {
+    statusOutput = String((0, import_child_process13.execFileSync)("git", ["-C", marketplacePath, "status", "--porcelain", "--untracked-files=normal"], queryExecOpts) ?? "").trim();
+  } catch (err) {
+    return { ok: false, message: `Failed to inspect marketplace clone status: ${err instanceof Error ? err.message : err}` };
+  }
+  if (statusOutput.length > 0) {
+    return {
+      ok: false,
+      message: "Skipped marketplace clone update: repo has local modifications; commit, stash, or clean it first"
+    };
+  }
+  let aheadCount = 0;
+  let behindCount = 0;
+  try {
+    const revListOutput = String((0, import_child_process13.execFileSync)("git", ["-C", marketplacePath, "rev-list", "--left-right", "--count", "HEAD...origin/main"], queryExecOpts) ?? "").trim();
+    const [aheadRaw = "0", behindRaw = "0"] = revListOutput.split(/\s+/);
+    aheadCount = Number.parseInt(aheadRaw, 10) || 0;
+    behindCount = Number.parseInt(behindRaw, 10) || 0;
+  } catch (err) {
+    return { ok: false, message: `Failed to inspect marketplace clone divergence: ${err instanceof Error ? err.message : err}` };
+  }
+  if (aheadCount > 0) {
+    return {
+      ok: false,
+      message: "Skipped marketplace clone update: repo has local commits on main; manual reconciliation required"
+    };
+  }
+  if (behindCount === 0) {
+    return { ok: true, message: "Marketplace clone already up to date" };
   }
   try {
-    (0, import_child_process13.execFileSync)("git", ["-C", marketplacePath, "clean", "-fd"], execOpts);
-  } catch {
+    (0, import_child_process13.execFileSync)("git", ["-C", marketplacePath, "merge", "--ff-only", "origin/main"], execOpts);
+  } catch (err) {
+    return { ok: false, message: `Failed to fast-forward marketplace clone: ${err instanceof Error ? err.message : err}` };
   }
   return { ok: true, message: "Marketplace clone updated" };
 }

--- a/dist/features/auto-update.js
+++ b/dist/features/auto-update.js
@@ -33,32 +33,70 @@ function syncMarketplaceClone(verbose = false) {
     }
     const stdio = verbose ? 'inherit' : 'pipe';
     const execOpts = { encoding: 'utf-8', stdio: stdio, timeout: 60000 };
+    const queryExecOpts = { encoding: 'utf-8', stdio: 'pipe', timeout: 60000 };
     try {
         execFileSync('git', ['-C', marketplacePath, 'fetch', '--all', '--prune'], execOpts);
     }
     catch (err) {
         return { ok: false, message: `Failed to fetch marketplace clone: ${err instanceof Error ? err.message : err}` };
     }
-    // Ensure we're on main (ignore errors for older clones on different branches)
     try {
         execFileSync('git', ['-C', marketplacePath, 'checkout', 'main'], { ...execOpts, timeout: 15000 });
     }
-    catch { /* ignore checkout errors on older clones */ }
-    // Reset to upstream state -- the marketplace clone is a managed read-only
-    // checkout, so any local modifications (e.g. regenerated dist files) can be
-    // safely discarded.  This avoids the "dirty worktree" failure that
-    // `git pull --ff-only` would hit when untracked/modified files exist (#978).
+    catch {
+        // Fall through to explicit branch verification below.
+    }
+    let currentBranch = '';
     try {
-        execFileSync('git', ['-C', marketplacePath, 'reset', '--hard', 'origin/main'], execOpts);
+        currentBranch = String(execFileSync('git', ['-C', marketplacePath, 'rev-parse', '--abbrev-ref', 'HEAD'], queryExecOpts) ?? '').trim();
     }
     catch (err) {
-        return { ok: false, message: `Failed to reset marketplace clone: ${err instanceof Error ? err.message : err}` };
+        return { ok: false, message: `Failed to inspect marketplace clone branch: ${err instanceof Error ? err.message : err}` };
+    }
+    if (currentBranch !== 'main') {
+        return {
+            ok: false,
+            message: `Skipped marketplace clone update: expected branch main but found ${currentBranch || 'unknown'}`,
+        };
+    }
+    let statusOutput = '';
+    try {
+        statusOutput = String(execFileSync('git', ['-C', marketplacePath, 'status', '--porcelain', '--untracked-files=normal'], queryExecOpts) ?? '').trim();
+    }
+    catch (err) {
+        return { ok: false, message: `Failed to inspect marketplace clone status: ${err instanceof Error ? err.message : err}` };
+    }
+    if (statusOutput.length > 0) {
+        return {
+            ok: false,
+            message: 'Skipped marketplace clone update: repo has local modifications; commit, stash, or clean it first',
+        };
+    }
+    let aheadCount = 0;
+    let behindCount = 0;
+    try {
+        const revListOutput = String(execFileSync('git', ['-C', marketplacePath, 'rev-list', '--left-right', '--count', 'HEAD...origin/main'], queryExecOpts) ?? '').trim();
+        const [aheadRaw = '0', behindRaw = '0'] = revListOutput.split(/\s+/);
+        aheadCount = Number.parseInt(aheadRaw, 10) || 0;
+        behindCount = Number.parseInt(behindRaw, 10) || 0;
+    }
+    catch (err) {
+        return { ok: false, message: `Failed to inspect marketplace clone divergence: ${err instanceof Error ? err.message : err}` };
+    }
+    if (aheadCount > 0) {
+        return {
+            ok: false,
+            message: 'Skipped marketplace clone update: repo has local commits on main; manual reconciliation required',
+        };
+    }
+    if (behindCount === 0) {
+        return { ok: true, message: 'Marketplace clone already up to date' };
     }
     try {
-        execFileSync('git', ['-C', marketplacePath, 'clean', '-fd'], execOpts);
+        execFileSync('git', ['-C', marketplacePath, 'merge', '--ff-only', 'origin/main'], execOpts);
     }
-    catch {
-        // clean is best-effort; untracked leftovers won't break anything
+    catch (err) {
+        return { ok: false, message: `Failed to fast-forward marketplace clone: ${err instanceof Error ? err.message : err}` };
     }
     return { ok: true, message: 'Marketplace clone updated' };
 }

--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -221,6 +221,181 @@ describe('auto-update reconciliation', () => {
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
   });
 
+  it('skips marketplace auto-sync when the marketplace clone has local modifications', async () => {
+    process.env.OMC_UPDATE_RECONCILE = '1';
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tag_name: 'v4.1.5',
+        name: '4.1.5',
+        published_at: '2026-02-09T00:00:00.000Z',
+        html_url: 'https://example.com/release',
+        body: 'notes',
+        prerelease: false,
+        draft: false,
+      }),
+    }));
+
+    mockedExecSync.mockReturnValue('');
+    mockedExecFileSync.mockImplementation((command: string, args?: readonly string[]) => {
+      if (command !== 'git') {
+        return '';
+      }
+
+      if (args?.includes('fetch') || args?.includes('checkout')) {
+        return '';
+      }
+
+      if (args?.includes('rev-parse')) {
+        return 'main\n';
+      }
+
+      if (args?.includes('status')) {
+        return ' M package.json\n?? scratch.txt\n';
+      }
+
+      throw new Error(`Unexpected git command: ${String(args?.join(' '))}`);
+    });
+
+    const result = await performUpdate({ verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['-C', expect.stringContaining('/plugins/marketplaces/omc'), 'status', '--porcelain', '--untracked-files=normal'],
+      expect.any(Object)
+    );
+    expect(mockedExecFileSync).not.toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['rev-list', '--left-right', '--count', 'HEAD...origin/main']),
+      expect.any(Object)
+    );
+    expect(mockedExecFileSync).not.toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['merge', '--ff-only', 'origin/main']),
+      expect.any(Object)
+    );
+
+    delete process.env.OMC_UPDATE_RECONCILE;
+  });
+
+  it('skips marketplace auto-sync when the marketplace clone has local commits', async () => {
+    process.env.OMC_UPDATE_RECONCILE = '1';
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tag_name: 'v4.1.5',
+        name: '4.1.5',
+        published_at: '2026-02-09T00:00:00.000Z',
+        html_url: 'https://example.com/release',
+        body: 'notes',
+        prerelease: false,
+        draft: false,
+      }),
+    }));
+
+    mockedExecSync.mockReturnValue('');
+    mockedExecFileSync.mockImplementation((command: string, args?: readonly string[]) => {
+      if (command !== 'git') {
+        return '';
+      }
+
+      if (args?.includes('fetch') || args?.includes('checkout')) {
+        return '';
+      }
+
+      if (args?.includes('rev-parse')) {
+        return 'main\n';
+      }
+
+      if (args?.includes('status')) {
+        return '';
+      }
+
+      if (args?.includes('rev-list')) {
+        return '1 0\n';
+      }
+
+      throw new Error(`Unexpected git command: ${String(args?.join(' '))}`);
+    });
+
+    const result = await performUpdate({ verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['-C', expect.stringContaining('/plugins/marketplaces/omc'), 'rev-list', '--left-right', '--count', 'HEAD...origin/main'],
+      expect.any(Object)
+    );
+    expect(mockedExecFileSync).not.toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['merge', '--ff-only', 'origin/main']),
+      expect.any(Object)
+    );
+
+    delete process.env.OMC_UPDATE_RECONCILE;
+  });
+
+  it('fast-forwards a clean marketplace clone when origin/main is ahead', async () => {
+    process.env.OMC_UPDATE_RECONCILE = '1';
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tag_name: 'v4.1.5',
+        name: '4.1.5',
+        published_at: '2026-02-09T00:00:00.000Z',
+        html_url: 'https://example.com/release',
+        body: 'notes',
+        prerelease: false,
+        draft: false,
+      }),
+    }));
+
+    mockedExecSync.mockReturnValue('');
+    mockedExecFileSync.mockImplementation((command: string, args?: readonly string[]) => {
+      if (command !== 'git') {
+        return '';
+      }
+
+      if (args?.includes('fetch') || args?.includes('checkout') || args?.includes('merge')) {
+        return '';
+      }
+
+      if (args?.includes('rev-parse')) {
+        return 'main\n';
+      }
+
+      if (args?.includes('status')) {
+        return '';
+      }
+
+      if (args?.includes('rev-list')) {
+        return '0 3\n';
+      }
+
+      throw new Error(`Unexpected git command: ${String(args?.join(' '))}`);
+    });
+
+    const result = await performUpdate({ verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['-C', expect.stringContaining('/plugins/marketplaces/omc'), 'merge', '--ff-only', 'origin/main'],
+      expect.any(Object)
+    );
+    expect(mockedExecFileSync).not.toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['reset', '--hard', 'origin/main']),
+      expect.any(Object)
+    );
+
+    delete process.env.OMC_UPDATE_RECONCILE;
+  });
+
   it('re-execs with omc.cmd on Windows and persists metadata after reconciliation', async () => {
     mockPlatform('win32');
 

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -39,6 +39,7 @@ function syncMarketplaceClone(verbose: boolean = false): { ok: boolean; message:
 
   const stdio = verbose ? 'inherit' : 'pipe';
   const execOpts = { encoding: 'utf-8' as const, stdio: stdio as any, timeout: 60000 };
+  const queryExecOpts = { encoding: 'utf-8' as const, stdio: 'pipe' as const, timeout: 60000 };
 
   try {
     execFileSync('git', ['-C', marketplacePath, 'fetch', '--all', '--prune'], execOpts);
@@ -46,23 +47,72 @@ function syncMarketplaceClone(verbose: boolean = false): { ok: boolean; message:
     return { ok: false, message: `Failed to fetch marketplace clone: ${err instanceof Error ? err.message : err}` };
   }
 
-  // Ensure we're on main (ignore errors for older clones on different branches)
-  try { execFileSync('git', ['-C', marketplacePath, 'checkout', 'main'], { ...execOpts, timeout: 15000 }); } catch { /* ignore checkout errors on older clones */ }
-
-  // Reset to upstream state -- the marketplace clone is a managed read-only
-  // checkout, so any local modifications (e.g. regenerated dist files) can be
-  // safely discarded.  This avoids the "dirty worktree" failure that
-  // `git pull --ff-only` would hit when untracked/modified files exist (#978).
   try {
-    execFileSync('git', ['-C', marketplacePath, 'reset', '--hard', 'origin/main'], execOpts);
+    execFileSync('git', ['-C', marketplacePath, 'checkout', 'main'], { ...execOpts, timeout: 15000 });
+  } catch {
+    // Fall through to explicit branch verification below.
+  }
+
+  let currentBranch = '';
+  try {
+    currentBranch = String(
+      execFileSync('git', ['-C', marketplacePath, 'rev-parse', '--abbrev-ref', 'HEAD'], queryExecOpts) ?? ''
+    ).trim();
   } catch (err) {
-    return { ok: false, message: `Failed to reset marketplace clone: ${err instanceof Error ? err.message : err}` };
+    return { ok: false, message: `Failed to inspect marketplace clone branch: ${err instanceof Error ? err.message : err}` };
+  }
+
+  if (currentBranch !== 'main') {
+    return {
+      ok: false,
+      message: `Skipped marketplace clone update: expected branch main but found ${currentBranch || 'unknown'}`,
+    };
+  }
+
+  let statusOutput = '';
+  try {
+    statusOutput = String(
+      execFileSync('git', ['-C', marketplacePath, 'status', '--porcelain', '--untracked-files=normal'], queryExecOpts) ?? ''
+    ).trim();
+  } catch (err) {
+    return { ok: false, message: `Failed to inspect marketplace clone status: ${err instanceof Error ? err.message : err}` };
+  }
+
+  if (statusOutput.length > 0) {
+    return {
+      ok: false,
+      message: 'Skipped marketplace clone update: repo has local modifications; commit, stash, or clean it first',
+    };
+  }
+
+  let aheadCount = 0;
+  let behindCount = 0;
+  try {
+    const revListOutput = String(
+      execFileSync('git', ['-C', marketplacePath, 'rev-list', '--left-right', '--count', 'HEAD...origin/main'], queryExecOpts) ?? ''
+    ).trim();
+    const [aheadRaw = '0', behindRaw = '0'] = revListOutput.split(/\s+/);
+    aheadCount = Number.parseInt(aheadRaw, 10) || 0;
+    behindCount = Number.parseInt(behindRaw, 10) || 0;
+  } catch (err) {
+    return { ok: false, message: `Failed to inspect marketplace clone divergence: ${err instanceof Error ? err.message : err}` };
+  }
+
+  if (aheadCount > 0) {
+    return {
+      ok: false,
+      message: 'Skipped marketplace clone update: repo has local commits on main; manual reconciliation required',
+    };
+  }
+
+  if (behindCount === 0) {
+    return { ok: true, message: 'Marketplace clone already up to date' };
   }
 
   try {
-    execFileSync('git', ['-C', marketplacePath, 'clean', '-fd'], execOpts);
-  } catch {
-    // clean is best-effort; untracked leftovers won't break anything
+    execFileSync('git', ['-C', marketplacePath, 'merge', '--ff-only', 'origin/main'], execOpts);
+  } catch (err) {
+    return { ok: false, message: `Failed to fast-forward marketplace clone: ${err instanceof Error ? err.message : err}` };
   }
 
   return { ok: true, message: 'Marketplace clone updated' };


### PR DESCRIPTION
## Summary
- make marketplace clone sync non-destructive for dirty or locally-diverged repos
- only fast-forward clean `main` marketplace clones after fetch
- add targeted regression tests for dirty, ahead, and clean-behind marketplace states

## Context
Issue #1754 asks for marketplace-backed reload behavior to pull remote changes automatically, but this repo does not implement `/reload-plugins` directly. The nearest in-repo integration point is the shared marketplace sync helper used by update/runtime flows.

## Dirty repo behavior
- if the marketplace clone has uncommitted tracked or untracked changes: skip auto-sync and leave the repo untouched
- if the marketplace clone is locally ahead of `origin/main`: skip auto-sync and leave the repo untouched
- if the marketplace clone is clean, on `main`, and behind `origin/main`: fast-forward it with `git merge --ff-only origin/main`

## Verification
- `npm ci`
- `npx tsc --noEmit`
- `npm test -- --run src/__tests__/auto-update.test.ts`
- `node --check bridge/cli.cjs`
- `node --check dist/features/auto-update.js`

Closes #1754
