### PR TITLE
fix(security): add regex safety guards against ReDoS and injection

### DIFF
--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -307,6 +307,29 @@ describe('resolveLiveData - security', () => {
     expect(result).not.toContain('error');
   });
 
+  it('rejects unsafe regex in denied_patterns (ReDoS prevention)', () => {
+    setupPolicy({
+      denied_patterns: ['(a+)+$'],
+      allowed_commands: ['echo'],
+    });
+    const result = resolveLiveData('!echo hello');
+    // Unsafe denied pattern → fail closed: command blocked
+    expect(result).toContain('error="true"');
+    expect(result).toContain('unsafe regex rejected');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
+  it('skips unsafe regex in allowed_patterns without crashing', () => {
+    setupPolicy({
+      allowed_patterns: ['(a+)+$'],
+    });
+    const result = resolveLiveData('!echo hello');
+    // Unsafe allowed pattern → skipped (fail closed), no pattern matches
+    expect(result).toContain('error="true"');
+    expect(result).toContain('not in allowlist');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
   it('blocks commands when no policy file exists (secure by default)', () => {
     mockedExistsSync.mockReturnValue(false);
     resetSecurityPolicy(); // Clear cached policy so new one is loaded

--- a/src/features/magic-keywords.ts
+++ b/src/features/magic-keywords.ts
@@ -35,8 +35,15 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
   return INFORMATIONAL_INTENT_PATTERNS.some(pattern => pattern.test(context));
 }
 
+/**
+ * Escape regex metacharacters so a string matches literally inside new RegExp().
+ */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function hasActionableTrigger(text: string, trigger: string): boolean {
-  const pattern = new RegExp(`\\b${trigger}\\b`, 'gi');
+  const pattern = new RegExp(`\\b${escapeRegExp(trigger)}\\b`, 'gi');
 
   for (const match of text.matchAll(pattern)) {
     if (match.index === undefined) {
@@ -363,7 +370,7 @@ Use maximum cognitive effort before responding.`;
 function removeTriggerWords(prompt: string, triggers: string[]): string {
   let result = prompt;
   for (const trigger of triggers) {
-    const regex = new RegExp(`\\b${trigger}\\b`, 'gi');
+    const regex = new RegExp(`\\b${escapeRegExp(trigger)}\\b`, 'gi');
     result = result.replace(regex, '');
   }
   return result.trim();

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -18,6 +18,7 @@
 import { execSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
+import safe from "safe-regex";
 import { getWorktreeRoot, getOmcRoot } from "../../lib/worktree-paths.js";
 
 const TIMEOUT_MS = 10_000;
@@ -169,6 +170,11 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   if (policy.denied_patterns) {
     for (const pat of policy.denied_patterns) {
       try {
+        if (!safe(pat)) {
+          // Unsafe regex in deny list: block the command to fail closed.
+          // A ReDoS-capable pattern is treated as a blanket deny.
+          return { allowed: false, reason: `unsafe regex rejected: ${pat}` };
+        }
         if (new RegExp(pat).test(command)) {
           return { allowed: false, reason: `denied by pattern: ${pat}` };
         }
@@ -208,6 +214,12 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   if (policy.allowed_patterns) {
     for (const pat of policy.allowed_patterns) {
       try {
+        if (!safe(pat)) {
+          // Unsafe regex in allow list: skip to fail closed.
+          // The pattern cannot grant access — remaining patterns
+          // or allowed_commands may still match.
+          continue;
+        }
         if (new RegExp(pat).test(command)) {
           patternAllowed = true;
           break;

--- a/src/types/safe-regex.d.ts
+++ b/src/types/safe-regex.d.ts
@@ -1,0 +1,4 @@
+declare module "safe-regex" {
+  function safe(re: string | RegExp, opts?: { limit?: number }): boolean;
+  export default safe;
+}


### PR DESCRIPTION
## Summary

Two locations compile user-supplied strings into `new RegExp()` without validation, creating ReDoS and regex injection vectors. This PR adds safety guards to both.

## Changes

### 1. `src/hooks/auto-slash-command/live-data.ts` — ReDoS prevention

Security policy files (`.omc/config/live-data-policy.json`) contain `denied_patterns` / `allowed_patterns` that are compiled directly via `new RegExp(pat)`. A catastrophic backtracking pattern like `(a+)+$` freezes the process.

**Fix:** Validate patterns with `safe-regex` (already in `package.json` but never imported) before compilation. Unsafe `denied_patterns` are rejected; unsafe `allowed_patterns` are skipped.

### 2. `src/features/magic-keywords.ts` — Regex injection prevention

Config trigger strings from `.claude/omc.jsonc` are interpolated into `new RegExp()` without escaping metacharacters. A trigger like `c++` becomes `\bc++\b` which matches unintended input; a trigger like `(.*){10}` causes catastrophic backtracking.

**Fix:** Add `escapeRegExp()` to ensure triggers match literally. Applied to `removeTriggerWords()` and `hasActionableTrigger()`.

### Supporting files

- `src/types/safe-regex.d.ts` — Type declaration for the untyped `safe-regex` package
- `src/__tests__/live-data.test.ts` — 2 new tests for ReDoS pattern rejection

## Test Plan

- [x] `npx vitest run src/__tests__/live-data.test.ts` — 40 tests passed
- [x] `npx tsc --noEmit` — zero errors
- [x] Normal patterns (`^git\s`, `.*sudo.*`) unaffected by `safe-regex`

## Checklist

- [x] Self-review complete
- [x] `tsc --noEmit` passes
- [x] Tests pass
- [x] No breaking changes

## Related Issue

- Resolves: #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)