### PR TITLE
fix(security): close remaining regex safety gap from #1758

### DIFF
--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -307,6 +307,27 @@ describe('resolveLiveData - security', () => {
     expect(result).not.toContain('error');
   });
 
+  it('rejects unsafe regex in denied_patterns (ReDoS prevention)', () => {
+    setupPolicy({
+      denied_patterns: ['(a+)+$'],
+      allowed_commands: ['echo'],
+    });
+    const result = resolveLiveData('!echo hello');
+    expect(result).toContain('error="true"');
+    expect(result).toContain('unsafe regex rejected');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
+  it('skips unsafe regex in allowed_patterns without crashing', () => {
+    setupPolicy({
+      allowed_patterns: ['(a+)+$'],
+    });
+    const result = resolveLiveData('!echo hello');
+    expect(result).toContain('error="true"');
+    expect(result).toContain('not in allowlist');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
   it('blocks commands when no policy file exists (secure by default)', () => {
     mockedExistsSync.mockReturnValue(false);
     resetSecurityPolicy(); // Clear cached policy so new one is loaded

--- a/src/__tests__/magic-keywords.test.ts
+++ b/src/__tests__/magic-keywords.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createMagicKeywordProcessor, detectMagicKeywords } from '../features/magic-keywords.js';
+
+describe('magic keyword regex safety', () => {
+  it('detects escaped punctuation triggers literally without regex injection', () => {
+    expect(detectMagicKeywords('please c++ this', { ultrawork: ['c++'] })).toEqual(['c++']);
+    expect(detectMagicKeywords('please (.*){10} this', { ultrawork: ['(.*){10}'] })).toEqual(['(.*){10}']);
+  });
+
+  it('processes punctuation triggers without throwing or compiling attacker regex', () => {
+    const processPrompt = createMagicKeywordProcessor({ ultrawork: ['c++'] });
+    expect(() => processPrompt('c++ fix this')).not.toThrow();
+    expect(processPrompt('c++ fix this')).toContain('ULTRAWORK MODE ENABLED!');
+  });
+
+  it('does not match punctuation triggers inside larger word characters', () => {
+    expect(detectMagicKeywords('xc++y', { ultrawork: ['c++'] })).toEqual([]);
+  });
+});

--- a/src/features/magic-keywords.ts
+++ b/src/features/magic-keywords.ts
@@ -36,7 +36,7 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
 }
 
 function hasActionableTrigger(text: string, trigger: string): boolean {
-  const pattern = new RegExp(`\\b${trigger}\\b`, 'gi');
+  const pattern = createTriggerRegex(trigger, 'gi');
 
   for (const match of text.matchAll(pattern)) {
     if (match.index === undefined) {
@@ -51,6 +51,24 @@ function hasActionableTrigger(text: string, trigger: string): boolean {
   }
 
   return false;
+}
+
+/**
+ * Escape regex metacharacters so a string matches literally inside new RegExp().
+ */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Match triggers literally while preserving "whole token" behavior for word characters.
+ *
+ * `\\b...\\b` is unsafe for unescaped custom triggers and also fails for literals like `c++`
+ * because `+` is not a word character. Using word-boundary lookarounds preserves the intent
+ * without interpreting trigger content as regex.
+ */
+function createTriggerRegex(trigger: string, flags: string): RegExp {
+  return new RegExp(`(?<!\\w)${escapeRegExp(trigger)}(?!\\w)`, flags);
 }
 
 /**
@@ -363,7 +381,7 @@ Use maximum cognitive effort before responding.`;
 function removeTriggerWords(prompt: string, triggers: string[]): string {
   let result = prompt;
   for (const trigger of triggers) {
-    const regex = new RegExp(`\\b${trigger}\\b`, 'gi');
+    const regex = createTriggerRegex(trigger, 'gi');
     result = result.replace(regex, '');
   }
   return result.trim();

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -18,6 +18,7 @@
 import { execSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
+import safe from "safe-regex";
 import { getWorktreeRoot, getOmcRoot } from "../../lib/worktree-paths.js";
 
 const TIMEOUT_MS = 10_000;
@@ -169,6 +170,9 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   if (policy.denied_patterns) {
     for (const pat of policy.denied_patterns) {
       try {
+        if (!safe(pat)) {
+          return { allowed: false, reason: `unsafe regex rejected: ${pat}` };
+        }
         if (new RegExp(pat).test(command)) {
           return { allowed: false, reason: `denied by pattern: ${pat}` };
         }
@@ -208,6 +212,9 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   if (policy.allowed_patterns) {
     for (const pat of policy.allowed_patterns) {
       try {
+        if (!safe(pat)) {
+          continue;
+        }
         if (new RegExp(pat).test(command)) {
           patternAllowed = true;
           break;

--- a/src/safe-regex.d.ts
+++ b/src/safe-regex.d.ts
@@ -1,0 +1,4 @@
+declare module "safe-regex" {
+  function safe(re: string | RegExp, opts?: { limit?: number }): boolean;
+  export default safe;
+}


### PR DESCRIPTION
## Summary

Issue #1758 identified two unsafe user-controlled regex construction paths:

1. `src/hooks/auto-slash-command/live-data.ts`
2. `src/features/magic-keywords.ts`

PR #1757 correctly identified both paths, but it is not sufficient to merge as-is for this issue closure because:
- it carries dirty/unrelated PR history (`HANDOFF.md` cleanup commit), and
- its magic-keywords patch uses `\\b${escapeRegExp(trigger)}\\b`, which still fails for punctuation-edge literal triggers like `c++` after escaping.

This PR lands the clean minimal fix on a fresh branch:
- validate `live-data` policy regexes with `safe-regex`
- use literal safe trigger matching in `magic-keywords` via regex escaping plus word-boundary lookarounds that still work for punctuation triggers
- add targeted tests only

## Changed files

- `src/hooks/auto-slash-command/live-data.ts`
- `src/features/magic-keywords.ts`
- `src/safe-regex.d.ts`
- `src/__tests__/live-data.test.ts`
- `src/__tests__/magic-keywords.test.ts`

## Verification

- `npx vitest run src/__tests__/live-data.test.ts src/__tests__/magic-keywords.test.ts`
- `npx tsc --noEmit`

## Residual risk

- Trigger customization still relies on regex-based tokenization semantics; punctuation-edge literals are now covered, but any future changes to trigger-boundary rules should be regression-tested with punctuation and multilingual inputs together.

Closes #1758.
