### PR TITLE
Warn and suppress same-root SessionStart restores for parallel sessions

### DIFF
--- a/src/installer/__tests__/session-start-template.test.ts
+++ b/src/installer/__tests__/session-start-template.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SCRIPT_PATH = join(__dirname, '..', '..', '..', 'templates', 'hooks', 'session-start.mjs');
+const NODE = process.execPath;
+
+describe('session-start template guard for same-root parallel sessions (#1744)', () => {
+  let tempDir: string;
+  let fakeHome: string;
+  let fakeProject: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'omc-session-start-template-'));
+    fakeHome = join(tempDir, 'home');
+    fakeProject = join(tempDir, 'project');
+    mkdirSync(join(fakeProject, '.omc', 'state'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function runSessionStart(input: Record<string, unknown>) {
+    const raw = execFileSync(NODE, [SCRIPT_PATH], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+      },
+      timeout: 15000,
+    }).trim();
+
+    return JSON.parse(raw) as {
+      continue: boolean;
+      suppressOutput?: boolean;
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+  }
+
+  it('warns and suppresses conflicting same-root restore for a different active session', () => {
+    const now = new Date().toISOString();
+    writeFileSync(
+      join(fakeProject, '.omc', 'state', 'ultrawork-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: 'session-a',
+        started_at: now,
+        last_checked_at: now,
+        original_prompt: 'Old task that should not bleed into session-b',
+      }),
+    );
+
+    const output = runSessionStart({
+      hook_event_name: 'SessionStart',
+      session_id: 'session-b',
+      cwd: fakeProject,
+    });
+
+    const context = output.hookSpecificOutput?.additionalContext || '';
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[PARALLEL SESSION WARNING]');
+    expect(context).toContain('suppressed the restore');
+    expect(context).not.toContain('[ULTRAWORK MODE RESTORED]');
+    expect(context).not.toContain('Old task that should not bleed into session-b');
+  });
+
+  it('still restores ultrawork for the owning session', () => {
+    writeFileSync(
+      join(fakeProject, '.omc', 'state', 'ultrawork-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: 'session-owner',
+        started_at: '2026-03-19T00:00:00.000Z',
+        last_checked_at: '2026-03-19T00:05:00.000Z',
+        original_prompt: 'Resume me',
+      }),
+    );
+
+    const output = runSessionStart({
+      hook_event_name: 'SessionStart',
+      session_id: 'session-owner',
+      cwd: fakeProject,
+    });
+
+    const context = output.hookSpecificOutput?.additionalContext || '';
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[ULTRAWORK MODE RESTORED]');
+    expect(context).toContain('Resume me');
+    expect(context).not.toContain('[PARALLEL SESSION WARNING]');
+  });
+
+  it('does not warn for global fallback state from a different normalized project path', () => {
+    mkdirSync(join(fakeHome, '.omc', 'state'), { recursive: true });
+    writeFileSync(
+      join(fakeHome, '.omc', 'state', 'ultrawork-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: 'session-a',
+        started_at: '2026-03-19T00:00:00.000Z',
+        last_checked_at: '2026-03-19T00:05:00.000Z',
+        original_prompt: 'Different project task',
+        project_path: join(tempDir, 'other-project'),
+      }),
+    );
+
+    const output = runSessionStart({
+      hook_event_name: 'SessionStart',
+      session_id: 'session-b',
+      cwd: fakeProject,
+    });
+
+    expect(output.continue).toBe(true);
+    const context = output.hookSpecificOutput?.additionalContext || '';
+    expect(context).not.toContain('[PARALLEL SESSION WARNING]');
+    expect(context).not.toContain('[ULTRAWORK MODE RESTORED]');
+  });
+});

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // Cross-platform: Windows, macOS, Linux
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, normalize, resolve } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -185,6 +185,92 @@ ${priorityContext}
 </notepad-priority>`;
 }
 
+const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+function normalizePath(p) {
+  if (!p || typeof p !== 'string') return '';
+  let normalized = resolve(p);
+  normalized = normalize(normalized).replace(/[\/\\]+$/, '');
+  if (process.platform === 'win32') {
+    normalized = normalized.toLowerCase();
+  }
+  return normalized;
+}
+
+function getStateRecencyMs(state) {
+  if (!state || typeof state !== 'object') return 0;
+  const startedAt = state.started_at ? new Date(state.started_at).getTime() : 0;
+  const lastCheckedAt = state.last_checked_at ? new Date(state.last_checked_at).getTime() : 0;
+  return Math.max(startedAt || 0, lastCheckedAt || 0);
+}
+
+function isFreshActiveState(state) {
+  if (!state?.active) return false;
+  const recencyMs = getStateRecencyMs(state);
+  if (!Number.isFinite(recencyMs) || recencyMs <= 0) return false;
+  return (Date.now() - recencyMs) <= STALE_STATE_THRESHOLD_MS;
+}
+
+function hasConflictingUltraworkRestore(state, sessionId, directory, source) {
+  if (!sessionId || !isFreshActiveState(state)) return false;
+  if (typeof state.session_id !== 'string' || !state.session_id || state.session_id === sessionId) {
+    return false;
+  }
+
+  if (source === 'global') {
+    if (typeof state.project_path !== 'string' || !state.project_path) {
+      return false;
+    }
+    return normalizePath(state.project_path) === normalizePath(directory);
+  }
+
+  return true;
+}
+
+function getUltraworkRestoreCandidate(directory, sessionId) {
+  const localPath = join(directory, '.omc', 'state', 'ultrawork-state.json');
+  const globalPath = join(homedir(), '.omc', 'state', 'ultrawork-state.json');
+
+  const localState = readJsonFile(localPath);
+  if (hasConflictingUltraworkRestore(localState, sessionId, directory, 'local')) {
+    return { restore: null, collision: { source: 'local', state: localState } };
+  }
+  if (localState?.active && (!localState.session_id || localState.session_id === sessionId)) {
+    return { restore: localState, collision: null };
+  }
+
+  const globalState = readJsonFile(globalPath);
+  if (hasConflictingUltraworkRestore(globalState, sessionId, directory, 'global')) {
+    return { restore: null, collision: { source: 'global', state: globalState } };
+  }
+  if (globalState?.active && (!globalState.session_id || globalState.session_id === sessionId)) {
+    return { restore: globalState, collision: null };
+  }
+
+  return { restore: null, collision: null };
+}
+
+function formatUltraworkCollisionWarning(source, state) {
+  const startedAt = state?.started_at || 'an unknown time';
+  const ownerSession = state?.session_id || 'another session';
+  const scope = source === 'global' ? 'matching project path in the shared global fallback state' : 'this repo root';
+  return `<session-restore>
+
+[PARALLEL SESSION WARNING]
+
+Detected an active ultrawork session for ${scope}.
+Owner session: ${ownerSession}
+Started: ${startedAt}
+
+To avoid shared \.omc/state bleed across parallel sessions, OMC suppressed the restore for this session.
+Continue normally in this session, or use a separate worktree / close the other same-root session before resuming the prior ultrawork state.
+
+</session-restore>
+
+---
+`;
+}
+
 async function main() {
   try {
     const input = await readStdin();
@@ -248,11 +334,17 @@ To update, run: omc update
       }
     }
 
-    // Check for ultrawork state - only restore if session matches (issue #311)
-    const ultraworkState = readJsonFile(join(directory, '.omc', 'state', 'ultrawork-state.json'))
-      || readJsonFile(join(homedir(), '.omc', 'state', 'ultrawork-state.json'));
-
-    if (ultraworkState?.active && (!ultraworkState.session_id || ultraworkState.session_id === sessionId)) {
+    // Check for ultrawork state - warn on conflicting same-path session, otherwise restore.
+    const ultraworkCandidate = getUltraworkRestoreCandidate(directory, sessionId);
+    if (ultraworkCandidate.collision) {
+      messages.push(
+        formatUltraworkCollisionWarning(
+          ultraworkCandidate.collision.source,
+          ultraworkCandidate.collision.state,
+        ),
+      );
+    } else if (ultraworkCandidate.restore) {
+      const ultraworkState = ultraworkCandidate.restore;
       messages.push(`<session-restore>
 
 [ULTRAWORK MODE RESTORED]


### PR DESCRIPTION
## Summary
- add a narrow SessionStart guard in the installer template to detect an active different-session ultrawork state in the same non-worktree path
- warn and suppress the conflicting restore while preserving the existing `continue: true` SessionStart contract
- add a direct template-execution regression test for the shipped installer surface, while leaving script/bridge behavior unchanged

## Scope
This PR intentionally changes only:
- `templates/hooks/session-start.mjs`
- `src/installer/__tests__/session-start-template.test.ts`

It intentionally does **not** change:
- `scripts/session-start.mjs` (parity / no-regression only)
- `src/hooks/bridge.ts` (no behavior change)
- `persistent-mode` or state-manager storage layout

## Why this approach
Issue #1744 is a startup restore seam problem, not a broad storage-architecture problem. The installer template still read shared root-local ultrawork state directly, so a second same-root session could inherit restore context from another active session. A warning + restore suppression at SessionStart fixes that with minimal churn.

## Verification
- `npm test -- --run src/installer/__tests__/session-start-template.test.ts`
- `npm test -- --run src/__tests__/session-start-script-context.test.ts`
- `npm test -- --run src/hooks/__tests__/bridge-routing.test.ts`
- `npm test -- --run src/lib/__tests__/worktree-paths.test.ts`
- `npm run build`

## Residual risk
- The guard currently targets the legacy root-local ultrawork restore seam in the installer template; it does not attempt a broader migration of all mode state to session-scoped storage.
- Real installed `~/.claude/hooks/session-start.mjs` behavior is covered via direct template execution in-repo, not by an external end-to-end manual install test.

## Related
- Fixes #1744
