### PR TITLE
Fix Kotlin LSP stdio launch and initialize timeout handling

### DIFF
--- a/src/__tests__/lsp-servers.test.ts
+++ b/src/__tests__/lsp-servers.test.ts
@@ -17,6 +17,11 @@ describe('LSP Server Configurations', () => {
     expect(config.installHint).toBeTruthy();
   });
 
+  it('kotlin should use stdio and an extended initialize timeout', () => {
+    expect(LSP_SERVERS.kotlin.args).toContain('--stdio');
+    expect(LSP_SERVERS.kotlin.initializeTimeoutMs).toBeGreaterThan(15_000);
+  });
+
   it('should have no duplicate extension mappings across servers', () => {
     const seen = new Map<string, string>();
     for (const [key, config] of Object.entries(LSP_SERVERS)) {

--- a/src/tools/lsp/__tests__/client-timeout-env.test.ts
+++ b/src/tools/lsp/__tests__/client-timeout-env.test.ts
@@ -7,9 +7,13 @@ describe('DEFAULT_LSP_REQUEST_TIMEOUT_MS', () => {
     delete process.env.OMC_LSP_TIMEOUT_MS;
   });
 
-  async function importTimeout(): Promise<number> {
+  async function importClientModule() {
     vi.resetModules();
-    const mod = await import('../client.js');
+    return import('../client.js');
+  }
+
+  async function importTimeout(): Promise<number> {
+    const mod = await importClientModule();
     return mod.DEFAULT_LSP_REQUEST_TIMEOUT_MS;
   }
 
@@ -41,5 +45,21 @@ describe('DEFAULT_LSP_REQUEST_TIMEOUT_MS', () => {
     process.env.OMC_LSP_TIMEOUT_MS = '-5000';
     const timeout = await importTimeout();
     expect(timeout).toBe(15_000);
+  });
+
+  it('should keep non-initialize requests on the base timeout', async () => {
+    const mod = await importClientModule();
+    expect(mod.getLspRequestTimeout({}, 'hover')).toBe(15_000);
+  });
+
+  it('should use kotlin initialize timeout minimum when larger than default', async () => {
+    const mod = await importClientModule();
+    expect(mod.getLspRequestTimeout({ initializeTimeoutMs: 5 * 60 * 1000 }, 'initialize')).toBe(5 * 60 * 1000);
+  });
+
+  it('should preserve larger env-based timeouts over kotlin minimum', async () => {
+    process.env.OMC_LSP_TIMEOUT_MS = '600000';
+    const mod = await importClientModule();
+    expect(mod.getLspRequestTimeout({ initializeTimeoutMs: 5 * 60 * 1000 }, 'initialize')).toBe(600000);
   });
 });

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -17,6 +17,18 @@ export const DEFAULT_LSP_REQUEST_TIMEOUT_MS: number = (() => {
   return readPositiveIntEnv('OMC_LSP_TIMEOUT_MS', 15_000);
 })();
 
+export function getLspRequestTimeout(
+  serverConfig: Pick<LspServerConfig, 'initializeTimeoutMs'>,
+  method: string,
+  baseTimeout = DEFAULT_LSP_REQUEST_TIMEOUT_MS
+): number {
+  if (method === 'initialize' && serverConfig.initializeTimeoutMs) {
+    return Math.max(baseTimeout, serverConfig.initializeTimeoutMs);
+  }
+
+  return baseTimeout;
+}
+
 function readPositiveIntEnv(name: string, fallback: number): number {
   const env = process.env[name];
   if (!env) {
@@ -349,10 +361,12 @@ export class LspClient {
   /**
    * Send a request to the server
    */
-  private async request<T>(method: string, params: unknown, timeout = DEFAULT_LSP_REQUEST_TIMEOUT_MS): Promise<T> {
+  private async request<T>(method: string, params: unknown, timeout?: number): Promise<T> {
     if (!this.process?.stdin) {
       throw new Error('LSP server not connected');
     }
+
+    const effectiveTimeout = timeout ?? getLspRequestTimeout(this.serverConfig, method);
 
     const id = ++this.requestId;
     const request: JsonRpcRequest = {
@@ -368,8 +382,8 @@ export class LspClient {
     return new Promise((resolve, reject) => {
       const timeoutHandle = setTimeout(() => {
         this.pendingRequests.delete(id);
-        reject(new Error(`LSP request '${method}' timed out after ${timeout}ms`));
-      }, timeout);
+        reject(new Error(`LSP request '${method}' timed out after ${effectiveTimeout}ms`));
+      }, effectiveTimeout);
 
       this.pendingRequests.set(id, {
         resolve: resolve as (value: unknown) => void,
@@ -421,7 +435,7 @@ export class LspClient {
         }
       },
       initializationOptions: this.serverConfig.initializationOptions || {}
-    });
+    }, getLspRequestTimeout(this.serverConfig, 'initialize'));
 
     this.notify('initialized', {});
   }

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -16,6 +16,7 @@ export interface LspServerConfig {
   extensions: string[];
   installHint: string;
   initializationOptions?: Record<string, unknown>;
+  initializeTimeoutMs?: number;
 }
 
 /**
@@ -116,9 +117,10 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
   kotlin: {
     name: 'Kotlin Language Server',
     command: 'kotlin-lsp',
-    args: [],
+    args: ['--stdio'],
     extensions: ['.kt', '.kts'],
-    installHint: 'Install from https://github.com/Kotlin/kotlin-lsp (brew install JetBrains/utils/kotlin-lsp)'
+    installHint: 'Install from https://github.com/Kotlin/kotlin-lsp (brew install JetBrains/utils/kotlin-lsp)',
+    initializeTimeoutMs: 5 * 60 * 1000
   },
   elixir: {
     name: 'ElixirLS',


### PR DESCRIPTION
## Summary
- launch `kotlin-lsp` with `--stdio` so the Kotlin server matches OMC's existing stdio JSON-RPC transport contract
- add explicit Kotlin `initializeTimeoutMs` server metadata and teach the shared LSP client to honor per-server initialize budgets instead of inflating the global default
- add focused regression coverage for Kotlin server config and timeout selection behavior

## Scope
This PR is intentionally narrow. It fixes the two concrete failure modes from #1764:
1. Kotlin was launched without `--stdio`
2. Kotlin initialize could exceed the shared 15s default in large Gradle projects

It does **not** implement eager/background LSP startup, plugin-owned server reuse, or pull-based diagnostics support.

## Files changed
- `src/tools/lsp/servers.ts`
- `src/tools/lsp/client.ts`
- `src/__tests__/lsp-servers.test.ts`
- `src/tools/lsp/__tests__/client-timeout-env.test.ts`

## Verification
- `npm test -- src/tools/lsp/__tests__/client-timeout-env.test.ts`
- `npm test -- src/__tests__/lsp-servers.test.ts`
- `npm test -- src/tools/lsp/__tests__/client-win32-spawn.test.ts`
- `npx vitest run src/tools/lsp/__tests__/client-timeout-env.test.ts src/tools/lsp/__tests__/client-win32-spawn.test.ts src/tools/lsp/__tests__/client-handle-data.test.ts src/tools/lsp/__tests__/client-singleton.test.ts src/tools/lsp/__tests__/client-eviction.test.ts src/__tests__/lsp-servers.test.ts`
- `npm run build`
- `npm run lint` (passes with pre-existing repo warnings only; no new lint errors)

## Residual risk
- This PR does **not** add support for Kotlin's pull-based diagnostics flow (`textDocument/diagnostic`). If `kotlin-lsp` does not publish diagnostics compatibly with OMC's current push-based handling in some environments, that remains a follow-up.
- I could not run a live `kotlin-lsp` process against a real Gradle multi-module workspace in this environment, so end-to-end Kotlin validation remains outstanding even though the launcher and timeout contracts are now covered by unit tests.

Closes #1764
