### PR TITLE
Fix forceInherit parity for Agent hook paths

### DIFF
--- a/src/__tests__/routing-force-inherit.test.ts
+++ b/src/__tests__/routing-force-inherit.test.ts
@@ -210,6 +210,45 @@ describe('routing.forceInherit (issue #1135)', () => {
       expect(modified.subagent_type).toBe('oh-my-claudecode:executor');
     });
 
+    it('strips model from Agent calls when forceInherit is true', () => {
+      mockedLoadConfig.mockReturnValue({
+        routing: { forceInherit: true },
+      } as ReturnType<typeof loadConfig>);
+
+      const toolInput: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'opus',
+      };
+
+      const result = processPreToolUse('Agent', toolInput);
+      const modified = result.modifiedInput as AgentInput;
+
+      expect(modified.model).toBeUndefined();
+      expect(modified.prompt).toBe('Do something');
+      expect(modified.subagent_type).toBe('oh-my-claudecode:executor');
+    });
+
+    it('strips model from lowercase agent calls when forceInherit is true', () => {
+      mockedLoadConfig.mockReturnValue({
+        routing: { forceInherit: true },
+      } as ReturnType<typeof loadConfig>);
+
+      const toolInput: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:executor',
+        model: 'opus',
+      };
+
+      const result = processPreToolUse('agent', toolInput);
+      const modified = result.modifiedInput as AgentInput;
+
+      expect(modified.model).toBeUndefined();
+      expect(modified.subagent_type).toBe('oh-my-claudecode:executor');
+    });
+
     it('does not strip model when forceInherit is false', () => {
       mockedLoadConfig.mockReturnValue({
         routing: { forceInherit: false },

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -711,7 +711,7 @@ export function generateConfigSchema(): object {
             type: "boolean",
             default: false,
             description:
-              "Force all agents to inherit the parent model, bypassing OMC model routing. When true, no model parameter is passed to Task calls, so agents use the user's Claude Code model setting. Auto-enabled for non-Claude providers (CC Switch, custom ANTHROPIC_BASE_URL), AWS Bedrock, and Google Vertex AI.",
+              "Force all agents to inherit the parent model, bypassing OMC model routing. When true, no model parameter is passed to Task/Agent calls, so agents use the user's Claude Code model setting. Auto-enabled for non-Claude providers (CC Switch, custom ANTHROPIC_BASE_URL), AWS Bedrock, and Google Vertex AI.",
           },
         },
       },

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -59,6 +59,11 @@ export interface EnforcementResult {
   warning?: string;
 }
 
+function isDelegationToolName(toolName: string): boolean {
+  const normalizedToolName = toolName.toLowerCase();
+  return normalizedToolName === 'agent' || normalizedToolName === 'task';
+}
+
 function canonicalizeSubagentType(subagentType: string): string {
   const hasPrefix = subagentType.startsWith('oh-my-claudecode:');
   const rawAgentType = subagentType.replace(/^oh-my-claudecode:/, '');
@@ -177,7 +182,7 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
  * Check if tool input is an agent delegation call
  */
 export function isAgentCall(toolName: string, toolInput: unknown): toolInput is AgentInput {
-  if (toolName !== 'Agent' && toolName !== 'Task') {
+  if (!isDelegationToolName(toolName)) {
     return false;
   }
 

--- a/src/features/model-routing/types.ts
+++ b/src/features/model-routing/types.ts
@@ -175,7 +175,7 @@ export interface RoutingConfig {
   /**
    * Force all agents to inherit the parent model, bypassing all routing.
    * When true, routeTask returns 'inherit' model type so no model parameter
-   * is passed to Task calls.
+   * is passed to Task/Agent calls.
    */
   forceInherit?: boolean;
   /** Minimum tier to allow (e.g. disable LOW tier by setting minTier to MEDIUM) */

--- a/src/hooks/__tests__/bridge.test.ts
+++ b/src/hooks/__tests__/bridge.test.ts
@@ -318,5 +318,51 @@ describe('processHook - Environment Kill-Switches', () => {
       const output = (result as unknown as Record<string, unknown>).hookSpecificOutput as Record<string, unknown> | undefined;
       expect(output?.permissionDecision).not.toBe('deny');
     });
+
+    it('should deny lowercase agent calls with model param when forceInherit is enabled', async () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+
+      const input: HookInput = {
+        sessionId: 'test-session',
+        prompt: 'test',
+        directory: '/tmp/test',
+        toolName: 'agent',
+        toolInput: {
+          description: 'Test agent',
+          prompt: 'Do something',
+          subagent_type: 'oh-my-claudecode:executor',
+          model: 'sonnet',
+        },
+      };
+
+      const result = await processHook('pre-tool-use', input);
+      expect(result).toHaveProperty('hookSpecificOutput');
+      const output = (result as unknown as Record<string, unknown>).hookSpecificOutput as Record<string, unknown>;
+      expect(output.permissionDecision).toBe('deny');
+      expect(output.permissionDecisionReason).toContain('MODEL ROUTING');
+    });
+  });
+
+  describe('post-tool-use delegation completion handling', () => {
+    it.each(['Task', 'Agent'])('should surface verification reminder for %s completions', async (toolName) => {
+      const input: HookInput = {
+        sessionId: 'test-session',
+        prompt: 'test',
+        directory: '/tmp/test',
+        toolName,
+        toolInput: {
+          description: 'Test agent',
+          prompt: 'Do something',
+          subagent_type: 'oh-my-claudecode:executor',
+        },
+        toolOutput: 'done',
+      };
+
+      const result = await processHook('post-tool-use', input);
+
+      expect(result.continue).toBe(true);
+      expect(result.message).toContain('MANDATORY VERIFICATION - SUBAGENTS LIE');
+      expect(result.message).toContain('done');
+    });
   });
 });

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -427,6 +427,11 @@ export interface HookOutput {
   modifiedInput?: unknown;
 }
 
+function isDelegationToolName(toolName: string | undefined): boolean {
+  const normalizedToolName = (toolName || "").toLowerCase();
+  return normalizedToolName === "task" || normalizedToolName === "agent";
+}
+
 /**
  * Hook types that can be processed
  */
@@ -1247,7 +1252,7 @@ function processPreToolUse(input: HookInput): HookOutput {
   // silently strip the model. Instead, deny the call so Claude retries without
   // the model param, letting agents inherit the parent session's model.
   // (issues #1135, #1201, #1415)
-  if (input.toolName === "Task" || input.toolName === "Agent") {
+  if (isDelegationToolName(input.toolName)) {
     const originalInput = input.toolInput as
       | Record<string, unknown>
       | undefined;
@@ -1636,9 +1641,12 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
   if (orchestratorResult.message) {
     messages.push(orchestratorResult.message);
   }
+  if (orchestratorResult.modifiedOutput) {
+    messages.push(orchestratorResult.modifiedOutput);
+  }
 
   // After Task completion, show updated agent dashboard
-  if (input.toolName === "Task") {
+  if (isDelegationToolName(input.toolName)) {
     const dashboard = getAgentDashboard(directory);
     if (dashboard) {
       messages.push(dashboard);

--- a/src/hooks/omc-orchestrator/index.ts
+++ b/src/hooks/omc-orchestrator/index.ts
@@ -163,6 +163,11 @@ export function isWriteEditTool(toolName: string): boolean {
   return WRITE_EDIT_TOOLS.includes(toolName);
 }
 
+function isDelegationToolName(toolName: string): boolean {
+  const normalizedToolName = toolName.toLowerCase();
+  return normalizedToolName === 'task' || normalizedToolName === 'agent';
+}
+
 /**
  * Get git diff statistics for the working directory
  */
@@ -451,8 +456,8 @@ export function processOrchestratorPostTool(
     }
   }
 
-  // Handle Task tool completion
-  if (toolName === 'Task' || toolName === 'task') {
+  // Handle delegation tool completion
+  if (isDelegationToolName(toolName)) {
     // Check for background task launch
     const isBackgroundLaunch = output.includes('Background task launched') || output.includes('Background task resumed');
     if (isBackgroundLaunch) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -80,7 +80,7 @@ export interface PluginConfig {
     defaultTier?: "LOW" | "MEDIUM" | "HIGH";
     /**
      * Force all agents to inherit the parent model instead of using OMC model routing.
-     * When true, the `model` parameter is stripped from all Task calls so agents use
+     * When true, the `model` parameter is stripped from all Task/Agent calls so agents use
      * the user's Claude Code model setting. Overrides all per-agent model recommendations.
      * Env: OMC_ROUTING_FORCE_INHERIT=true
      */


### PR DESCRIPTION
## Summary\n- normalize delegation-tool detection so forceInherit-sensitive hook paths treat both Task and Agent consistently, including lowercase tool names\n- make orchestrator post-tool completion handling apply to Agent as well as Task\n- surface orchestrator post-tool  through the bridge so the verification reminder actually reaches the real hook output\n- add focused regressions for Agent/lowercase-agent forceInherit handling and bridge-level post-tool reminder parity\n- update forceInherit contract wording from Task-only to Task/Agent where directly relevant\n\n## Exact scope\nTouched only the Task/Agent parity seam in:\n- \n- \n- \n- focused tests and directly-related forceInherit contract wording\n\nIntentionally left broader Task-only bookkeeping alone (background-task tracking, team-worker restrictions, etc.).\n\n## Residual risk\n- Local automated verification was blocked in this worktree because the dependency install is incomplete (/ resolution unavailable here), so I could not run Vitest/tsc locally before opening this PR.\n- The patch is narrow and diff-checked, but CI should be treated as the first full automated validation pass.\n\n## Verification attempted\n-  on the staged files\n- manual source-path audit of the affected bridge/orchestrator/enforcer flows\n\nCloses #1767