### PR TITLE
feat: add block-no-verify Bash PreToolUse hook to hooks/hooks.json

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -57,6 +57,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "*",
         "hooks": [
           {


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a new `matcher: "Bash"` PreToolUse hook entry in `hooks/hooks.json` to prevent agents from bypassing git hooks via the hook-skip flag.

## Details

The new entry sits alongside the existing wildcard `pre-tool-enforcer` hook and specifically guards git Bash commands:

```json
{
  "matcher": "Bash",
  "hooks": [
    {
      "type": "command",
      "command": "npx block-no-verify@1.1.2",
      "timeout": 5
    }
  ]
}
```

The package reads the `tool_input.command` from stdin and exits 2 (blocking) if the git hook-bypass flag is detected. No custom scripts, no new project dependencies.

## Closes

Closes #1770

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
