### PR TITLE
Fix ralplan stop-hook leak after consensus completion

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -112,6 +112,16 @@ Jumping into code without understanding requirements leads to rework, scope cree
    - **Approve and execute via ralph**: **MUST** invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
    - **Clear context and implement**: First invoke `Skill("compact")` to compress the context window (reduces token usage accumulated during planning), then invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/`. This path is recommended when the context window is 50%+ full after the planning session.
 
+
+**Ralplan Mode-State Lifecycle (required for stop-hook cleanup)**
+- On entering consensus mode, **MUST** mark ralplan active for the current session via `state_write(mode="ralplan", active=true, current_phase="ralplan", started_at=..., session_id=...)` if that state is not already active.
+- Before **every terminal exit** from consensus mode, **MUST** retire that state for the current session:
+  - Final approved plan output in non-interactive mode -> `state_write(mode="ralplan", active=false, current_phase="complete", completed_at=..., session_id=...)`
+  - Interactive approval handoff to `team`, `ralph`, or `compact -> ralph` -> the same terminal `state_write(...)` **before** invoking the next skill
+  - Max-iteration exhaustion without consensus -> `state_write(mode="ralplan", active=false, current_phase="failed", completed_at=..., session_id=...)`
+  - User reject / explicit stop of planning -> `state_write(mode="ralplan", active=false, current_phase="cancelled", completed_at=..., session_id=...)` or `state_clear(mode="ralplan", session_id=...)` during cancel cleanup
+- Do **not** leave `ralplan-state.json` active after consensus planning ends; the persistent-mode stop hook treats active non-terminal ralplan state as in-progress work and will keep blocking stop.
+
 ### Review Mode (`--review`)
 
 1. Read plan file from `.omc/plans/`

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -58,6 +58,8 @@ The consensus workflow:
 
 > **Important:** Steps 3 and 4 MUST run sequentially. Do NOT issue both agent Task calls in the same parallel batch. Always await the Architect result before issuing the Critic Task.
 
+> **Important:** Ralplan uses first-class persistent-mode stop-hook enforcement. On entering consensus mode, mark ralplan active for the current session via `state_write(mode="ralplan", active=true, current_phase="ralplan", started_at=..., session_id=...)` if needed. Before every terminal exit (final non-interactive output, interactive handoff to `team`/`ralph`, max-iteration exhaustion, reject/cancel), retire that state via terminal `state_write(...)` (`complete` / `failed` / `cancelled` with `completed_at`) or `state_clear(mode="ralplan", session_id=...)` during cancel cleanup. Do **not** leave `ralplan-state.json` active after consensus planning ends, or the persistent-mode stop hook will continue blocking stop.
+
 Follow the Plan skill's full documentation for consensus mode details.
 
 ## Pre-Execution Gate

--- a/src/__tests__/consensus-execution-handoff.test.ts
+++ b/src/__tests__/consensus-execution-handoff.test.ts
@@ -159,6 +159,19 @@ describe('Issue #595: Consensus mode execution handoff', () => {
       expect(consensusSection).toContain('expanded test plan');
       expect(consensusSection).toContain('unit / integration / e2e / observability');
     });
+
+    it('should require writing ralplan state on consensus entry and retiring it on terminal exits', () => {
+      const skill = getBuiltinSkill('omc-plan');
+      expect(skill).toBeDefined();
+
+      const consensusSection = extractSection(skill!.template, 'Consensus Mode');
+      expect(consensusSection).toBeDefined();
+      expect(consensusSection).toContain('state_write(mode="ralplan", active=true, current_phase="ralplan"');
+      expect(consensusSection).toContain('state_write(mode="ralplan", active=false, current_phase="complete"');
+      expect(consensusSection).toContain('state_write(mode="ralplan", active=false, current_phase="failed"');
+      expect(consensusSection).toContain('state_write(mode="ralplan", active=false, current_phase="cancelled"');
+      expect(consensusSection).toContain('state_clear(mode="ralplan", session_id=...)');
+    });
   });
 
   describe('Issue #600: User feedback step between Planner and Architect/Critic', () => {

--- a/src/__tests__/deep-interview-provider-options.test.ts
+++ b/src/__tests__/deep-interview-provider-options.test.ts
@@ -56,6 +56,19 @@ describe('deep-interview provider-aware execution recommendations', () => {
     expect(ralplanSkill?.template).toContain('--critic codex');
   });
 
+
+  it('documents ralplan terminal state retirement so stop-hook protection does not leak', () => {
+    const planSkill = getBuiltinSkill('omc-plan');
+    const ralplanSkill = getBuiltinSkill('ralplan');
+
+    expect(planSkill?.template).toContain('state_write(mode="ralplan", active=false, current_phase="complete"');
+    expect(planSkill?.template).toContain('Do **not** leave `ralplan-state.json` active after consensus planning ends');
+
+    expect(ralplanSkill?.template).toContain('state_write(mode="ralplan", active=true, current_phase="ralplan"');
+    expect(ralplanSkill?.template).toContain('state_clear(mode="ralplan", session_id=...)');
+    expect(ralplanSkill?.template).toContain('persistent-mode stop hook will continue blocking stop');
+  });
+
   it('renders no extra runtime guidance when no provider-specific deep-interview variant is available', () => {
     expect(renderSkillRuntimeGuidance('deep-interview')).toBe('');
   });


### PR DESCRIPTION
## Summary
- fix issue #1777 by making the ralplan consensus workflow explicitly retire `ralplan` mode state on every terminal exit
- add focused regression assertions for the plan/ralplan built-in skill templates so future edits keep the state-retirement contract intact
- leave persistent-mode stop-hook logic unchanged; the bug was the missing consensus cleanup contract, not the blocker itself

## Root cause
`persistent-mode` correctly blocks stop whenever `ralplan-state.json` is still active and non-terminal. The consensus workflow documentation described the Planner/Architect/Critic loop and execution handoffs, but it never explicitly required retiring `ralplan` state when consensus finished, fell back after max iterations, or was cancelled/rejected. That left a valid active state file behind, so the stop hook kept reinforcing indefinitely.

## Concrete reproduction
Using the built runtime against the actual `.omc/state/sessions/<session>/ralplan-state.json` path:
- `active: true, current_phase: "ralplan"` => `checkPersistentModes(...)` returns `shouldBlock: true`, `mode: "ralplan"`, and a `ralplan-continuation` message
- after changing the same file to `active: false, current_phase: "complete", completed_at: ...` => `checkPersistentModes(...)` returns `shouldBlock: false`

## Exact scope
Changed files only:
- `skills/plan/SKILL.md`
- `skills/ralplan/SKILL.md`
- `src/__tests__/consensus-execution-handoff.test.ts`
- `src/__tests__/deep-interview-provider-options.test.ts`

## Verification
- `npm test -- --run src/__tests__/consensus-execution-handoff.test.ts src/__tests__/deep-interview-provider-options.test.ts src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts`
- `npm run build`
- `npm run lint` *(passes with existing repo warnings only; no new errors)*

## Residual risk
- This fixes the lifecycle contract at the skill/template layer and locks it with tests, but I did not run a full live interactive ralplan session inside Claude to observe the end-to-end agent behavior directly.
