### PR TITLE
Add devcontainer-aware LSP runtime selection

### DIFF
--- a/src/tools/lsp/__tests__/client-devcontainer.test.ts
+++ b/src/tools/lsp/__tests__/client-devcontainer.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { spawn } from 'child_process';
+import { pathToFileURL } from 'url';
+import type { DevContainerContext } from '../devcontainer.js';
+
+vi.mock('../servers.js', () => ({
+  getServerForFile: vi.fn(),
+  commandExists: vi.fn(() => true)
+}));
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn()
+}));
+
+const mockSpawn = vi.mocked(spawn);
+
+function buildLspMessage(body: string): string {
+  return `Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`;
+}
+
+describe('LspClient devcontainer support', () => {
+  let workspaceRoot: string;
+  let filePath: string;
+  let stdoutHandler: ((data: Buffer) => void) | undefined;
+  let lastDidOpenUri: string | undefined;
+  let nextRenameResult: unknown;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'omc-lsp-client-'));
+    mkdirSync(join(workspaceRoot, 'src'), { recursive: true });
+    filePath = join(workspaceRoot, 'src', 'index.ts');
+    writeFileSync(filePath, 'export const value = 1;\n');
+    stdoutHandler = undefined;
+    lastDidOpenUri = undefined;
+    nextRenameResult = undefined;
+
+    mockSpawn.mockImplementation(() => {
+      const proc = {
+        stdin: {
+          write: vi.fn((message: string) => {
+            const body = message.split('\r\n\r\n')[1];
+            const parsed = JSON.parse(body);
+
+            if (parsed.method === 'initialize') {
+              setTimeout(() => {
+                stdoutHandler?.(
+                  Buffer.from(
+                    buildLspMessage(JSON.stringify({
+                      jsonrpc: '2.0',
+                      id: parsed.id,
+                      result: { capabilities: {} }
+                    }))
+                  )
+                );
+              }, 0);
+            }
+
+            if (parsed.method === 'textDocument/didOpen') {
+              lastDidOpenUri = parsed.params.textDocument.uri;
+            }
+
+            if (parsed.method === 'textDocument/definition') {
+              setTimeout(() => {
+                stdoutHandler?.(
+                  Buffer.from(
+                    buildLspMessage(JSON.stringify({
+                      jsonrpc: '2.0',
+                      id: parsed.id,
+                      result: {
+                        uri: 'file:///workspaces/app/src/index.ts',
+                        range: {
+                          start: { line: 0, character: 0 },
+                          end: { line: 0, character: 5 }
+                        }
+                      }
+                    }))
+                  )
+                );
+              }, 0);
+            }
+
+            if (parsed.method === 'textDocument/rename') {
+              setTimeout(() => {
+                stdoutHandler?.(
+                  Buffer.from(
+                    buildLspMessage(JSON.stringify({
+                      jsonrpc: '2.0',
+                      id: parsed.id,
+                      result: nextRenameResult ?? null
+                    }))
+                  )
+                );
+              }, 0);
+            }
+          })
+        },
+        stdout: {
+          on: vi.fn((event: string, cb: (data: Buffer) => void) => {
+            if (event === 'data') {
+              stdoutHandler = cb;
+            }
+          })
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn(),
+        kill: vi.fn(),
+        pid: 12345
+      };
+
+      return proc as unknown as ReturnType<typeof spawn>;
+    });
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('spawns the language server with docker exec and uses container URIs for didOpen', async () => {
+    const { LspClient } = await import('../client.js');
+    const context: DevContainerContext = {
+      containerId: 'container-123',
+      hostWorkspaceRoot: workspaceRoot,
+      containerWorkspaceRoot: '/workspaces/app'
+    };
+
+    const client = new LspClient(workspaceRoot, {
+      name: 'test-server',
+      command: 'typescript-language-server',
+      args: ['--stdio'],
+      extensions: ['.ts'],
+      installHint: 'npm i -g typescript-language-server'
+    }, context);
+
+    await client.connect();
+    await client.openDocument(filePath);
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'docker',
+      ['exec', '-i', '-w', '/workspaces/app', 'container-123', 'typescript-language-server', '--stdio'],
+      expect.objectContaining({
+        cwd: workspaceRoot,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: false
+      })
+    );
+    expect(lastDidOpenUri).toBe('file:///workspaces/app/src/index.ts');
+  });
+
+  it('translates incoming diagnostics and locations from container URIs back to host URIs', async () => {
+    const { LspClient } = await import('../client.js');
+    const context: DevContainerContext = {
+      containerId: 'container-123',
+      hostWorkspaceRoot: workspaceRoot,
+      containerWorkspaceRoot: '/workspaces/app'
+    };
+
+    const client = new LspClient(workspaceRoot, {
+      name: 'test-server',
+      command: 'typescript-language-server',
+      args: ['--stdio'],
+      extensions: ['.ts'],
+      installHint: 'npm i -g typescript-language-server'
+    }, context);
+
+    await client.connect();
+    (client as any).handleNotification({
+      jsonrpc: '2.0',
+      method: 'textDocument/publishDiagnostics',
+      params: {
+        uri: 'file:///workspaces/app/src/index.ts',
+        diagnostics: [{ message: 'boom', range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } } }]
+      }
+    });
+
+    const diagnostics = client.getDiagnostics(filePath);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toBe('boom');
+
+    const definition = await client.definition(filePath, 0, 0);
+    expect(definition).toEqual({
+      uri: pathToFileURL(filePath).href,
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 5 }
+      }
+    });
+  });
+
+  it('translates resource operation URIs in workspace edits back to host URIs', async () => {
+    const { LspClient } = await import('../client.js');
+    const context: DevContainerContext = {
+      containerId: 'container-123',
+      hostWorkspaceRoot: workspaceRoot,
+      containerWorkspaceRoot: '/workspaces/app'
+    };
+
+    const client = new LspClient(workspaceRoot, {
+      name: 'test-server',
+      command: 'typescript-language-server',
+      args: ['--stdio'],
+      extensions: ['.ts'],
+      installHint: 'npm i -g typescript-language-server'
+    }, context);
+
+    await client.connect();
+    nextRenameResult = {
+      documentChanges: [{
+        kind: 'rename',
+        oldUri: 'file:///workspaces/app/src/index.ts',
+        newUri: 'file:///workspaces/app/src/index-renamed.ts'
+      }]
+    };
+
+    const edit = await client.rename(filePath, 0, 0, 'renamedValue');
+    expect(edit).toEqual({
+      documentChanges: [{
+        kind: 'rename',
+        oldUri: pathToFileURL(filePath).href,
+        newUri: pathToFileURL(join(workspaceRoot, 'src', 'index-renamed.ts')).href
+      }]
+    });
+  });
+});

--- a/src/tools/lsp/__tests__/devcontainer.test.ts
+++ b/src/tools/lsp/__tests__/devcontainer.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn()
+}));
+
+const mockSpawnSync = vi.mocked(spawnSync);
+
+function dockerInspectResult(payload: unknown): string {
+  return JSON.stringify([payload]);
+}
+
+describe('devcontainer LSP helpers', () => {
+  let workspaceRoot: string;
+  let configFilePath: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'omc-devcontainer-'));
+    mkdirSync(join(workspaceRoot, '.devcontainer'), { recursive: true });
+    configFilePath = join(workspaceRoot, '.devcontainer', 'devcontainer.json');
+    writeFileSync(configFilePath, JSON.stringify({ workspaceFolder: '/workspaces/app' }));
+    delete process.env.OMC_LSP_CONTAINER_ID;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    delete process.env.OMC_LSP_CONTAINER_ID;
+  });
+
+  it('prefers explicit container override and translates host/container paths and URIs', async () => {
+    process.env.OMC_LSP_CONTAINER_ID = 'forced-container';
+
+    mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
+      expect(command).toBe('docker');
+      if (args?.[0] === 'inspect') {
+        return {
+          status: 0,
+          stdout: dockerInspectResult({
+            Id: 'forced-container',
+            State: { Running: true },
+            Config: { Labels: {} },
+            Mounts: [{ Source: workspaceRoot, Destination: '/workspaces/app' }]
+          })
+        } as ReturnType<typeof spawnSync>;
+      }
+
+      throw new Error(`Unexpected docker args: ${args}`);
+    });
+
+    const mod = await import('../devcontainer.js');
+    const context = mod.resolveDevContainerContext(workspaceRoot);
+
+    expect(context).toEqual({
+      containerId: 'forced-container',
+      hostWorkspaceRoot: workspaceRoot,
+      containerWorkspaceRoot: '/workspaces/app',
+      configFilePath
+    });
+
+    const hostFile = join(workspaceRoot, 'src', 'index.ts');
+    expect(mod.hostPathToContainerPath(hostFile, context)).toBe('/workspaces/app/src/index.ts');
+    expect(mod.containerPathToHostPath('/workspaces/app/src/index.ts', context)).toBe(hostFile);
+    expect(mod.hostUriToContainerUri(pathToFileURL(hostFile).href, context)).toBe('file:///workspaces/app/src/index.ts');
+    expect(mod.containerUriToHostUri('file:///workspaces/app/src/index.ts', context)).toBe(pathToFileURL(hostFile).href);
+  });
+
+  it('matches running devcontainer by labels and nested mount', async () => {
+    const mountedParent = join(workspaceRoot, '..');
+
+    mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
+      expect(command).toBe('docker');
+      if (args?.[0] === 'ps') {
+        return { status: 0, stdout: 'abc123\n' } as ReturnType<typeof spawnSync>;
+      }
+
+      if (args?.[0] === 'inspect') {
+        return {
+          status: 0,
+          stdout: dockerInspectResult({
+            Id: 'abc123',
+            State: { Running: true },
+            Config: {
+              Labels: {
+                'devcontainer.local_folder': workspaceRoot,
+                'devcontainer.config_file': configFilePath
+              }
+            },
+            Mounts: [{ Source: mountedParent, Destination: '/workspaces' }]
+          })
+        } as ReturnType<typeof spawnSync>;
+      }
+
+      throw new Error(`Unexpected docker args: ${args}`);
+    });
+
+    const mod = await import('../devcontainer.js');
+    const context = mod.resolveDevContainerContext(workspaceRoot);
+
+    expect(context?.containerId).toBe('abc123');
+    expect(context?.containerWorkspaceRoot).toBe(`/workspaces/${workspaceRoot.split('/').pop()}`);
+  });
+
+  it('finds ancestor devcontainer config for nested workspace roots', async () => {
+    const nestedWorkspaceRoot = join(workspaceRoot, 'packages', 'app');
+    mkdirSync(nestedWorkspaceRoot, { recursive: true });
+
+    mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
+      expect(command).toBe('docker');
+      if (args?.[0] === 'ps') {
+        return { status: 0, stdout: 'nested123\n' } as ReturnType<typeof spawnSync>;
+      }
+
+      if (args?.[0] === 'inspect') {
+        return {
+          status: 0,
+          stdout: dockerInspectResult({
+            Id: 'nested123',
+            State: { Running: true },
+            Config: {
+              Labels: {
+                'devcontainer.local_folder': workspaceRoot,
+                'devcontainer.config_file': configFilePath
+              }
+            },
+            Mounts: [{ Source: workspaceRoot, Destination: '/workspaces/app' }]
+          })
+        } as ReturnType<typeof spawnSync>;
+      }
+
+      throw new Error(`Unexpected docker args: ${args}`);
+    });
+
+    const mod = await import('../devcontainer.js');
+    const context = mod.resolveDevContainerContext(nestedWorkspaceRoot);
+
+    expect(context).toEqual({
+      containerId: 'nested123',
+      hostWorkspaceRoot: nestedWorkspaceRoot,
+      containerWorkspaceRoot: '/workspaces/app/packages/app',
+      configFilePath
+    });
+  });
+
+  it('returns null when no matching running devcontainer exists', async () => {
+    rmSync(join(workspaceRoot, '.devcontainer'), { recursive: true, force: true });
+
+    mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
+      expect(command).toBe('docker');
+      if (args?.[0] === 'ps') {
+        return { status: 0, stdout: 'abc123\n' } as ReturnType<typeof spawnSync>;
+      }
+
+      if (args?.[0] === 'inspect') {
+        return {
+          status: 0,
+          stdout: dockerInspectResult({
+            Id: 'abc123',
+            State: { Running: true },
+            Config: { Labels: {} },
+            Mounts: [{ Source: '/tmp/other', Destination: '/workspaces/other' }]
+          })
+        } as ReturnType<typeof spawnSync>;
+      }
+
+      throw new Error(`Unexpected docker args: ${args}`);
+    });
+
+    const mod = await import('../devcontainer.js');
+    expect(mod.resolveDevContainerContext(workspaceRoot)).toBeNull();
+  });
+});

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -9,6 +9,12 @@ import { spawn, ChildProcess } from 'child_process';
 import { readFileSync, existsSync } from 'fs';
 import { resolve, dirname, parse, join } from 'path';
 import { pathToFileURL } from 'url';
+import {
+  resolveDevContainerContext,
+  hostUriToContainerUri,
+  containerUriToHostUri
+} from './devcontainer.js';
+import type { DevContainerContext } from './devcontainer.js';
 import type { LspServerConfig } from './servers.js';
 import { getServerForFile, commandExists } from './servers.js';
 
@@ -140,11 +146,13 @@ export class LspClient {
   private diagnosticWaiters = new Map<string, Array<() => void>>();
   private workspaceRoot: string;
   private serverConfig: LspServerConfig;
+  private devContainerContext: DevContainerContext | null;
   private initialized = false;
 
-  constructor(workspaceRoot: string, serverConfig: LspServerConfig) {
+  constructor(workspaceRoot: string, serverConfig: LspServerConfig, devContainerContext: DevContainerContext | null = null) {
     this.workspaceRoot = resolve(workspaceRoot);
     this.serverConfig = serverConfig;
+    this.devContainerContext = devContainerContext;
   }
 
   /**
@@ -155,10 +163,13 @@ export class LspClient {
       return; // Already connected
     }
 
-    if (!commandExists(this.serverConfig.command)) {
+    const spawnCommand = this.devContainerContext ? 'docker' : this.serverConfig.command;
+
+    if (!commandExists(spawnCommand)) {
       throw new Error(
-        `Language server '${this.serverConfig.command}' not found.\n` +
-        `Install with: ${this.serverConfig.installHint}`
+        this.devContainerContext
+          ? `Docker CLI not found. Required to start '${this.serverConfig.command}' inside container ${this.devContainerContext.containerId}.`
+          : `Language server '${this.serverConfig.command}' not found.\nInstall with: ${this.serverConfig.installHint}`
       );
     }
 
@@ -167,10 +178,15 @@ export class LspClient {
       // shell execution. Without this, spawn() fails with ENOENT. (#569)
       // Safe: server commands come from a hardcoded registry (servers.ts),
       // not user input, so shell metacharacter injection is not a concern.
-      this.process = spawn(this.serverConfig.command, this.serverConfig.args, {
+      const command = this.devContainerContext ? 'docker' : this.serverConfig.command;
+      const args = this.devContainerContext
+        ? ['exec', '-i', '-w', this.devContainerContext.containerWorkspaceRoot, this.devContainerContext.containerId, this.serverConfig.command, ...this.serverConfig.args]
+        : this.serverConfig.args;
+
+      this.process = spawn(command, args, {
         cwd: this.workspaceRoot,
         stdio: ['pipe', 'pipe', 'pipe'],
-        shell: process.platform === 'win32'
+        shell: !this.devContainerContext && process.platform === 'win32'
       });
 
       this.process.stdout?.on('data', (data: Buffer) => {
@@ -334,7 +350,7 @@ export class LspClient {
    */
   private handleNotification(notification: JsonRpcNotification): void {
     if (notification.method === 'textDocument/publishDiagnostics') {
-      const params = notification.params as { uri: string; diagnostics: Diagnostic[] };
+      const params = this.translateIncomingPayload(notification.params) as { uri: string; diagnostics: Diagnostic[] };
       this.diagnostics.set(params.uri, params.diagnostics);
       // Wake any waiters registered via waitForDiagnostics()
       const waiters = this.diagnosticWaiters.get(params.uri);
@@ -404,8 +420,8 @@ export class LspClient {
   private async initialize(): Promise<void> {
     await this.request('initialize', {
       processId: process.pid,
-      rootUri: pathToFileURL(this.workspaceRoot).href,
-      rootPath: this.workspaceRoot,
+      rootUri: this.getWorkspaceRootUri(),
+      rootPath: this.getServerWorkspaceRoot(),
       capabilities: {
         textDocument: {
           hover: { contentFormat: ['markdown', 'plaintext'] },
@@ -430,9 +446,10 @@ export class LspClient {
    * Open a document for editing
    */
   async openDocument(filePath: string): Promise<void> {
-    const uri = fileUri(filePath);
+    const hostUri = fileUri(filePath);
+    const uri = this.toServerUri(hostUri);
 
-    if (this.openDocuments.has(uri)) return;
+    if (this.openDocuments.has(hostUri)) return;
 
     if (!existsSync(filePath)) {
       throw new Error(`File not found: ${filePath}`);
@@ -450,7 +467,7 @@ export class LspClient {
       }
     });
 
-    this.openDocuments.add(uri);
+    this.openDocuments.add(hostUri);
 
     // Wait a bit for the server to process the document
     await new Promise(resolve => setTimeout(resolve, 100));
@@ -460,15 +477,16 @@ export class LspClient {
    * Close a document
    */
   closeDocument(filePath: string): void {
-    const uri = fileUri(filePath);
+    const hostUri = fileUri(filePath);
+    const uri = this.toServerUri(hostUri);
 
-    if (!this.openDocuments.has(uri)) return;
+    if (!this.openDocuments.has(hostUri)) return;
 
     this.notify('textDocument/didClose', {
       textDocument: { uri }
     });
 
-    this.openDocuments.delete(uri);
+    this.openDocuments.delete(hostUri);
   }
 
   /**
@@ -525,7 +543,7 @@ export class LspClient {
    */
   private async prepareDocument(filePath: string): Promise<string> {
     await this.openDocument(filePath);
-    return fileUri(filePath);
+    return this.toServerUri(fileUri(filePath));
   }
 
   // LSP Request Methods
@@ -535,10 +553,11 @@ export class LspClient {
    */
   async hover(filePath: string, line: number, character: number): Promise<Hover | null> {
     const uri = await this.prepareDocument(filePath);
-    return this.request<Hover | null>('textDocument/hover', {
+    const result = await this.request<Hover | null>('textDocument/hover', {
       textDocument: { uri },
       position: { line, character }
     });
+    return this.translateIncomingPayload(result) as Hover | null;
   }
 
   /**
@@ -546,10 +565,11 @@ export class LspClient {
    */
   async definition(filePath: string, line: number, character: number): Promise<Location | Location[] | null> {
     const uri = await this.prepareDocument(filePath);
-    return this.request<Location | Location[] | null>('textDocument/definition', {
+    const result = await this.request<Location | Location[] | null>('textDocument/definition', {
       textDocument: { uri },
       position: { line, character }
     });
+    return this.translateIncomingPayload(result) as Location | Location[] | null;
   }
 
   /**
@@ -557,11 +577,12 @@ export class LspClient {
    */
   async references(filePath: string, line: number, character: number, includeDeclaration = true): Promise<Location[] | null> {
     const uri = await this.prepareDocument(filePath);
-    return this.request<Location[] | null>('textDocument/references', {
+    const result = await this.request<Location[] | null>('textDocument/references', {
       textDocument: { uri },
       position: { line, character },
       context: { includeDeclaration }
     });
+    return this.translateIncomingPayload(result) as Location[] | null;
   }
 
   /**
@@ -569,16 +590,18 @@ export class LspClient {
    */
   async documentSymbols(filePath: string): Promise<DocumentSymbol[] | SymbolInformation[] | null> {
     const uri = await this.prepareDocument(filePath);
-    return this.request<DocumentSymbol[] | SymbolInformation[] | null>('textDocument/documentSymbol', {
+    const result = await this.request<DocumentSymbol[] | SymbolInformation[] | null>('textDocument/documentSymbol', {
       textDocument: { uri }
     });
+    return this.translateIncomingPayload(result) as DocumentSymbol[] | SymbolInformation[] | null;
   }
 
   /**
    * Search workspace symbols
    */
   async workspaceSymbols(query: string): Promise<SymbolInformation[] | null> {
-    return this.request<SymbolInformation[] | null>('workspace/symbol', { query });
+    const result = await this.request<SymbolInformation[] | null>('workspace/symbol', { query });
+    return this.translateIncomingPayload(result) as SymbolInformation[] | null;
   }
 
   /**
@@ -648,11 +671,12 @@ export class LspClient {
    */
   async rename(filePath: string, line: number, character: number, newName: string): Promise<WorkspaceEdit | null> {
     const uri = await this.prepareDocument(filePath);
-    return this.request<WorkspaceEdit | null>('textDocument/rename', {
+    const result = await this.request<WorkspaceEdit | null>('textDocument/rename', {
       textDocument: { uri },
       position: { line, character },
       newName
     });
+    return this.translateIncomingPayload(result) as WorkspaceEdit | null;
   }
 
   /**
@@ -660,11 +684,67 @@ export class LspClient {
    */
   async codeActions(filePath: string, range: Range, diagnostics: Diagnostic[] = []): Promise<CodeAction[] | null> {
     const uri = await this.prepareDocument(filePath);
-    return this.request<CodeAction[] | null>('textDocument/codeAction', {
+    const result = await this.request<CodeAction[] | null>('textDocument/codeAction', {
       textDocument: { uri },
       range,
       context: { diagnostics }
     });
+    return this.translateIncomingPayload(result) as CodeAction[] | null;
+  }
+
+  private getServerWorkspaceRoot(): string {
+    return this.devContainerContext?.containerWorkspaceRoot ?? this.workspaceRoot;
+  }
+
+  private getWorkspaceRootUri(): string {
+    return this.toServerUri(pathToFileURL(this.workspaceRoot).href);
+  }
+
+  private toServerUri(uri: string): string {
+    return hostUriToContainerUri(uri, this.devContainerContext);
+  }
+
+  private toHostUri(uri: string): string {
+    return containerUriToHostUri(uri, this.devContainerContext);
+  }
+
+  private translateIncomingPayload<T>(value: T): T {
+    if (!this.devContainerContext || value == null) {
+      return value;
+    }
+
+    return this.translateIncomingValue(value) as T;
+  }
+
+  private translateIncomingValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map(item => this.translateIncomingValue(item));
+    }
+
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+
+    const record = value as Record<string, unknown>;
+    const translatedEntries = Object.entries(record).map(([key, entryValue]) => {
+      if ((key === 'uri' || key === 'targetUri' || key === 'newUri' || key === 'oldUri') && typeof entryValue === 'string') {
+        return [key, this.toHostUri(entryValue)];
+      }
+
+      if (key === 'changes' && entryValue && typeof entryValue === 'object' && !Array.isArray(entryValue)) {
+        const translatedChanges = Object.fromEntries(
+          Object.entries(entryValue as Record<string, unknown>).map(([uri, changeValue]) => [
+            this.toHostUri(uri),
+            this.translateIncomingValue(changeValue)
+          ])
+        );
+        return [key, translatedChanges];
+      }
+
+      return [key, this.translateIncomingValue(entryValue)];
+    });
+
+    return Object.fromEntries(translatedEntries);
   }
 }
 
@@ -737,11 +817,12 @@ export class LspClientManager {
 
     // Find workspace root
     const workspaceRoot = this.findWorkspaceRoot(filePath);
-    const key = `${workspaceRoot}:${serverConfig.command}`;
+    const devContainerContext = resolveDevContainerContext(workspaceRoot);
+    const key = `${workspaceRoot}:${serverConfig.command}:${devContainerContext?.containerId ?? 'host'}`;
 
     let client = this.clients.get(key);
     if (!client) {
-      client = new LspClient(workspaceRoot, serverConfig);
+      client = new LspClient(workspaceRoot, serverConfig, devContainerContext);
       try {
         await client.connect();
         this.clients.set(key, client);
@@ -767,11 +848,12 @@ export class LspClientManager {
     }
 
     const workspaceRoot = this.findWorkspaceRoot(filePath);
-    const key = `${workspaceRoot}:${serverConfig.command}`;
+    const devContainerContext = resolveDevContainerContext(workspaceRoot);
+    const key = `${workspaceRoot}:${serverConfig.command}:${devContainerContext?.containerId ?? 'host'}`;
 
     let client = this.clients.get(key);
     if (!client) {
-      client = new LspClient(workspaceRoot, serverConfig);
+      client = new LspClient(workspaceRoot, serverConfig, devContainerContext);
       try {
         await client.connect();
         this.clients.set(key, client);

--- a/src/tools/lsp/devcontainer.ts
+++ b/src/tools/lsp/devcontainer.ts
@@ -1,0 +1,338 @@
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { resolve, join, relative, sep, dirname, parse } from 'path';
+import { posix } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { parseJsonc } from '../../utils/jsonc.js';
+
+const DEVCONTAINER_CONFIG_PATH = ['.devcontainer', 'devcontainer.json'] as const;
+const DEVCONTAINER_LOCAL_FOLDER_LABELS = [
+  'devcontainer.local_folder',
+  'vsch.local.folder'
+] as const;
+const DEVCONTAINER_CONFIG_FILE_LABELS = [
+  'devcontainer.config_file',
+  'vsch.config.file'
+] as const;
+
+interface DockerInspectMount {
+  Source?: string;
+  Destination?: string;
+  Type?: string;
+}
+
+interface DockerInspectState {
+  Running?: boolean;
+}
+
+interface DockerInspectConfig {
+  Labels?: Record<string, string>;
+}
+
+interface DockerInspectResult {
+  Id?: string;
+  Config?: DockerInspectConfig;
+  Mounts?: DockerInspectMount[];
+  State?: DockerInspectState;
+}
+
+interface DevContainerJson {
+  workspaceFolder?: string;
+}
+
+export interface DevContainerContext {
+  containerId: string;
+  hostWorkspaceRoot: string;
+  containerWorkspaceRoot: string;
+  configFilePath?: string;
+}
+
+export function resolveDevContainerContext(workspaceRoot: string): DevContainerContext | null {
+  const hostWorkspaceRoot = resolve(workspaceRoot);
+  const configFilePath = resolveDevContainerConfigPath(hostWorkspaceRoot);
+  const config = readDevContainerConfig(configFilePath);
+  const overrideContainerId = process.env.OMC_LSP_CONTAINER_ID?.trim();
+
+  if (overrideContainerId) {
+    return buildContextFromContainer(overrideContainerId, hostWorkspaceRoot, configFilePath, config);
+  }
+
+  const containerIds = listRunningContainerIds();
+  if (containerIds.length === 0) {
+    return null;
+  }
+
+  let bestMatch: { score: number; context: DevContainerContext } | null = null;
+
+  for (const containerId of containerIds) {
+    const inspect = inspectContainer(containerId);
+    if (!inspect) {
+      continue;
+    }
+
+    const score = scoreContainerMatch(inspect, hostWorkspaceRoot, configFilePath);
+    if (score <= 0) {
+      continue;
+    }
+
+    const context = buildContextFromInspect(inspect, hostWorkspaceRoot, configFilePath, config);
+    if (!context) {
+      continue;
+    }
+
+    if (!bestMatch || score > bestMatch.score) {
+      bestMatch = { score, context };
+    }
+  }
+
+  return bestMatch?.context ?? null;
+}
+
+export function hostPathToContainerPath(filePath: string, context: DevContainerContext | null | undefined): string {
+  if (!context) {
+    return resolve(filePath);
+  }
+
+  const resolvedPath = resolve(filePath);
+  const relativePath = relative(context.hostWorkspaceRoot, resolvedPath);
+  if (relativePath === '') {
+    return context.containerWorkspaceRoot;
+  }
+  if (relativePath.startsWith('..') || relativePath.includes(`..${sep}`)) {
+    return resolvedPath;
+  }
+
+  const posixRelativePath = relativePath.split(sep).join('/');
+  return posix.join(context.containerWorkspaceRoot, posixRelativePath);
+}
+
+export function containerPathToHostPath(filePath: string, context: DevContainerContext | null | undefined): string {
+  if (!context) {
+    return resolve(filePath);
+  }
+
+  const normalizedContainerPath = normalizeContainerPath(filePath);
+  const relativePath = posix.relative(context.containerWorkspaceRoot, normalizedContainerPath);
+  if (relativePath === '') {
+    return context.hostWorkspaceRoot;
+  }
+  if (relativePath.startsWith('..') || relativePath.includes('../')) {
+    return normalizedContainerPath;
+  }
+
+  return resolve(context.hostWorkspaceRoot, ...relativePath.split('/'));
+}
+
+export function hostUriToContainerUri(uri: string, context: DevContainerContext | null | undefined): string {
+  if (!context || !uri.startsWith('file://')) {
+    return uri;
+  }
+
+  return containerPathToFileUri(hostPathToContainerPath(fileURLToPath(uri), context));
+}
+
+export function containerUriToHostUri(uri: string, context: DevContainerContext | null | undefined): string {
+  if (!context || !uri.startsWith('file://')) {
+    return uri;
+  }
+
+  return pathToFileURL(containerPathToHostPath(fileURLToPath(uri), context)).href;
+}
+
+function resolveDevContainerConfigPath(workspaceRoot: string): string | undefined {
+  let dir = workspaceRoot;
+
+  while (true) {
+    const configFilePath = join(dir, ...DEVCONTAINER_CONFIG_PATH);
+    if (existsSync(configFilePath)) {
+      return configFilePath;
+    }
+
+    const parsed = parse(dir);
+    if (parsed.root === dir) {
+      return undefined;
+    }
+
+    dir = dirname(dir);
+  }
+}
+
+function readDevContainerConfig(configFilePath?: string): DevContainerJson | null {
+  if (!configFilePath || !existsSync(configFilePath)) {
+    return null;
+  }
+
+  try {
+    const parsed = parseJsonc(readFileSync(configFilePath, 'utf-8'));
+    return typeof parsed === 'object' && parsed !== null ? parsed as DevContainerJson : null;
+  } catch {
+    return null;
+  }
+}
+
+function listRunningContainerIds(): string[] {
+  const result = runDocker(['ps', '-q']);
+  if (!result || result.status !== 0) {
+    return [];
+  }
+
+  const stdout = typeof result.stdout === 'string' ? result.stdout : result.stdout.toString('utf8');
+
+  return stdout
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+function inspectContainer(containerId: string): DockerInspectResult | null {
+  const result = runDocker(['inspect', containerId]);
+  if (!result || result.status !== 0) {
+    return null;
+  }
+
+  try {
+    const stdout = typeof result.stdout === 'string' ? result.stdout : result.stdout.toString('utf8');
+    const parsed = JSON.parse(stdout) as DockerInspectResult[];
+    const inspect = parsed[0];
+    if (!inspect?.Id || inspect.State?.Running === false) {
+      return null;
+    }
+    return inspect;
+  } catch {
+    return null;
+  }
+}
+
+function buildContextFromContainer(
+  containerId: string,
+  hostWorkspaceRoot: string,
+  configFilePath?: string,
+  config?: DevContainerJson | null
+): DevContainerContext | null {
+  const inspect = inspectContainer(containerId);
+  if (!inspect) {
+    return null;
+  }
+
+  return buildContextFromInspect(inspect, hostWorkspaceRoot, configFilePath, config);
+}
+
+function buildContextFromInspect(
+  inspect: DockerInspectResult,
+  hostWorkspaceRoot: string,
+  configFilePath?: string,
+  config?: DevContainerJson | null
+): DevContainerContext | null {
+  const containerWorkspaceRoot = deriveContainerWorkspaceRoot(inspect, hostWorkspaceRoot, config?.workspaceFolder);
+  if (!containerWorkspaceRoot || !inspect.Id) {
+    return null;
+  }
+
+  return {
+    containerId: inspect.Id,
+    hostWorkspaceRoot,
+    containerWorkspaceRoot,
+    configFilePath
+  };
+}
+
+function deriveContainerWorkspaceRoot(
+  inspect: DockerInspectResult,
+  hostWorkspaceRoot: string,
+  workspaceFolder?: string
+): string | null {
+  const mounts = Array.isArray(inspect.Mounts) ? inspect.Mounts : [];
+
+  let bestMountMatch: { sourceLength: number; destination: string } | null = null;
+  for (const mount of mounts) {
+    const source = mount.Source ? resolve(mount.Source) : '';
+    const destination = mount.Destination ? normalizeContainerPath(mount.Destination) : '';
+    if (!source || !destination) {
+      continue;
+    }
+
+    if (source === hostWorkspaceRoot) {
+      return destination;
+    }
+
+    const relativePath = relative(source, hostWorkspaceRoot);
+    if (relativePath === '' || relativePath.startsWith('..') || relativePath.includes(`..${sep}`)) {
+      continue;
+    }
+
+    if (!bestMountMatch || source.length > bestMountMatch.sourceLength) {
+      bestMountMatch = {
+        sourceLength: source.length,
+        destination: posix.join(destination, relativePath.split(sep).join('/'))
+      };
+    }
+  }
+
+  if (bestMountMatch) {
+    return bestMountMatch.destination;
+  }
+
+  return workspaceFolder ? normalizeContainerPath(workspaceFolder) : null;
+}
+
+function scoreContainerMatch(
+  inspect: DockerInspectResult,
+  hostWorkspaceRoot: string,
+  configFilePath?: string
+): number {
+  const labels = inspect.Config?.Labels ?? {};
+  let score = 0;
+  let hasDevContainerLabelMatch = false;
+  const expectedLocalFolder = configFilePath
+    ? dirname(dirname(configFilePath))
+    : resolve(hostWorkspaceRoot);
+
+  for (const label of DEVCONTAINER_LOCAL_FOLDER_LABELS) {
+    if (labels[label] && resolve(labels[label]) === expectedLocalFolder) {
+      score += 4;
+      hasDevContainerLabelMatch = true;
+    }
+  }
+
+  if (configFilePath) {
+    for (const label of DEVCONTAINER_CONFIG_FILE_LABELS) {
+      if (labels[label] && resolve(labels[label]) === configFilePath) {
+        score += 3;
+        hasDevContainerLabelMatch = true;
+      }
+    }
+  }
+
+  const mappedWorkspaceRoot = deriveContainerWorkspaceRoot(inspect, hostWorkspaceRoot);
+  if (mappedWorkspaceRoot && (Boolean(configFilePath) || hasDevContainerLabelMatch)) {
+    score += 1;
+  }
+
+  return score;
+}
+
+function normalizeContainerPath(filePath: string): string {
+  return posix.normalize(filePath.replace(/\\/g, '/'));
+}
+
+function containerPathToFileUri(filePath: string): string {
+  const normalizedPath = normalizeContainerPath(filePath);
+  const encodedPath = normalizedPath
+    .split('/')
+    .map(segment => encodeURIComponent(segment))
+    .join('/');
+  return `file://${encodedPath.startsWith('/') ? encodedPath : `/${encodedPath}`}`;
+}
+
+function runDocker(args: string[]): ReturnType<typeof spawnSync> | null {
+  const result = spawnSync('docker', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore']
+  });
+
+  if (result.error) {
+    return null;
+  }
+
+  return result;
+}

--- a/src/tools/lsp/index.ts
+++ b/src/tools/lsp/index.ts
@@ -25,6 +25,15 @@ export {
 export type { LspServerConfig } from './servers.js';
 
 export {
+  resolveDevContainerContext,
+  hostPathToContainerPath,
+  containerPathToHostPath,
+  hostUriToContainerUri,
+  containerUriToHostUri
+} from './devcontainer.js';
+export type { DevContainerContext } from './devcontainer.js';
+
+export {
   uriToPath,
   formatPosition,
   formatRange,


### PR DESCRIPTION
## Summary
- detect an already-running matching devcontainer for the LSP workspace, with `OMC_LSP_CONTAINER_ID` override support
- launch language servers inside the container via `docker exec -i -w ...` when a mapped runtime exists, while preserving host fallback behavior
- translate host/container file paths and `file://` URIs at the LSP boundary for diagnostics, definitions/references, and workspace edits
- add focused unit tests for runtime detection, spawn behavior, and path/URI translation

## Test notes
- `./node_modules/.bin/vitest run src/tools/lsp/__tests__/devcontainer.test.ts src/tools/lsp/__tests__/client-devcontainer.test.ts src/tools/lsp/__tests__/client-win32-spawn.test.ts src/tools/lsp/__tests__/client-handle-data.test.ts src/tools/lsp/__tests__/client-timeout-env.test.ts src/tools/lsp/__tests__/client-singleton.test.ts`
- `./node_modules/.bin/tsc --noEmit`

## Scope notes
- already-running devcontainers only
- no container lifecycle management
- path/URI translation stays field-aware to avoid mutating arbitrary document content strings
