### PR TITLE
Broaden devcontainer config discovery for LSP follow-up

### DIFF
--- a/src/tools/lsp/__tests__/devcontainer.test.ts
+++ b/src/tools/lsp/__tests__/devcontainer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { pathToFileURL } from 'url';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
@@ -10,20 +10,24 @@ vi.mock('child_process', () => ({
 }));
 
 const mockSpawnSync = vi.mocked(spawnSync);
+const DEFAULT_WORKSPACE_FOLDER = '/workspaces/app';
 
 function dockerInspectResult(payload: unknown): string {
   return JSON.stringify([payload]);
 }
 
+function writeDevContainerConfig(workspaceRoot: string, relativePath: string, config: object = { workspaceFolder: DEFAULT_WORKSPACE_FOLDER }): string {
+  const fullPath = join(workspaceRoot, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, JSON.stringify(config));
+  return fullPath;
+}
+
 describe('devcontainer LSP helpers', () => {
   let workspaceRoot: string;
-  let configFilePath: string;
 
   beforeEach(() => {
     workspaceRoot = mkdtempSync(join(tmpdir(), 'omc-devcontainer-'));
-    mkdirSync(join(workspaceRoot, '.devcontainer'), { recursive: true });
-    configFilePath = join(workspaceRoot, '.devcontainer', 'devcontainer.json');
-    writeFileSync(configFilePath, JSON.stringify({ workspaceFolder: '/workspaces/app' }));
     delete process.env.OMC_LSP_CONTAINER_ID;
     vi.resetModules();
   });
@@ -35,6 +39,7 @@ describe('devcontainer LSP helpers', () => {
   });
 
   it('prefers explicit container override and translates host/container paths and URIs', async () => {
+    const configFilePath = writeDevContainerConfig(workspaceRoot, '.devcontainer/devcontainer.json');
     process.env.OMC_LSP_CONTAINER_ID = 'forced-container';
 
     mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
@@ -46,7 +51,7 @@ describe('devcontainer LSP helpers', () => {
             Id: 'forced-container',
             State: { Running: true },
             Config: { Labels: {} },
-            Mounts: [{ Source: workspaceRoot, Destination: '/workspaces/app' }]
+            Mounts: [{ Source: workspaceRoot, Destination: DEFAULT_WORKSPACE_FOLDER }]
           })
         } as ReturnType<typeof spawnSync>;
       }
@@ -60,7 +65,7 @@ describe('devcontainer LSP helpers', () => {
     expect(context).toEqual({
       containerId: 'forced-container',
       hostWorkspaceRoot: workspaceRoot,
-      containerWorkspaceRoot: '/workspaces/app',
+      containerWorkspaceRoot: DEFAULT_WORKSPACE_FOLDER,
       configFilePath
     });
 
@@ -72,6 +77,7 @@ describe('devcontainer LSP helpers', () => {
   });
 
   it('matches running devcontainer by labels and nested mount', async () => {
+    const configFilePath = writeDevContainerConfig(workspaceRoot, '.devcontainer/devcontainer.json');
     const mountedParent = join(workspaceRoot, '..');
 
     mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
@@ -105,9 +111,11 @@ describe('devcontainer LSP helpers', () => {
 
     expect(context?.containerId).toBe('abc123');
     expect(context?.containerWorkspaceRoot).toBe(`/workspaces/${workspaceRoot.split('/').pop()}`);
+    expect(context?.configFilePath).toBe(configFilePath);
   });
 
   it('finds ancestor devcontainer config for nested workspace roots', async () => {
+    const configFilePath = writeDevContainerConfig(workspaceRoot, '.devcontainer/devcontainer.json');
     const nestedWorkspaceRoot = join(workspaceRoot, 'packages', 'app');
     mkdirSync(nestedWorkspaceRoot, { recursive: true });
 
@@ -129,7 +137,7 @@ describe('devcontainer LSP helpers', () => {
                 'devcontainer.config_file': configFilePath
               }
             },
-            Mounts: [{ Source: workspaceRoot, Destination: '/workspaces/app' }]
+            Mounts: [{ Source: workspaceRoot, Destination: DEFAULT_WORKSPACE_FOLDER }]
           })
         } as ReturnType<typeof spawnSync>;
       }
@@ -148,9 +156,189 @@ describe('devcontainer LSP helpers', () => {
     });
   });
 
-  it('returns null when no matching running devcontainer exists', async () => {
-    rmSync(join(workspaceRoot, '.devcontainer'), { recursive: true, force: true });
+  it('supports .devcontainer.json at the workspace root', async () => {
+    const configFilePath = writeDevContainerConfig(workspaceRoot, '.devcontainer.json');
 
+    mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
+      expect(command).toBe('docker');
+      if (args?.[0] === 'ps') {
+        return { status: 0, stdout: 'dotfile123\n' } as ReturnType<typeof spawnSync>;
+      }
+
+      if (args?.[0] === 'inspect') {
+        return {
+          status: 0,
+          stdout: dockerInspectResult({
+            Id: 'dotfile123',
+            State: { Running: true },
+            Config: {
+              Labels: {
+                'devcontainer.local_folder': workspaceRoot,
+                'devcontainer.config_file': configFilePath
+              }
+            },
+            Mounts: [{ Source: workspaceRoot, Destination: DEFAULT_WORKSPACE_FOLDER }]
+          })
+        } as ReturnType<typeof spawnSync>;
+      }
+
+      throw new Error(`Unexpected docker args: ${args}`);
+    });
+
+    const mod = await import('../devcontainer.js');
+    const context = mod.resolveDevContainerContext(workspaceRoot);
+
+    expect(context).toEqual({
+      containerId: 'dotfile123',
+      hostWorkspaceRoot: workspaceRoot,
+      containerWorkspaceRoot: DEFAULT_WORKSPACE_FOLDER,
+      configFilePath
+    });
+  });
+
+  it('supports nested .devcontainer/<name>/devcontainer.json layouts', async () => {
+    const configFilePath = writeDevContainerConfig(workspaceRoot, '.devcontainer/custom/devcontainer.json');
+
+    mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
+      expect(command).toBe('docker');
+      if (args?.[0] === 'ps') {
+        return { status: 0, stdout: 'nested-layout\n' } as ReturnType<typeof spawnSync>;
+      }
+
+      if (args?.[0] === 'inspect') {
+        return {
+          status: 0,
+          stdout: dockerInspectResult({
+            Id: 'nested-layout',
+            State: { Running: true },
+            Config: {
+              Labels: {
+                'devcontainer.local_folder': workspaceRoot,
+                'devcontainer.config_file': configFilePath
+              }
+            },
+            Mounts: [{ Source: workspaceRoot, Destination: DEFAULT_WORKSPACE_FOLDER }]
+          })
+        } as ReturnType<typeof spawnSync>;
+      }
+
+      throw new Error(`Unexpected docker args: ${args}`);
+    });
+
+    const mod = await import('../devcontainer.js');
+    const context = mod.resolveDevContainerContext(workspaceRoot);
+
+    expect(context).toEqual({
+      containerId: 'nested-layout',
+      hostWorkspaceRoot: workspaceRoot,
+      containerWorkspaceRoot: DEFAULT_WORKSPACE_FOLDER,
+      configFilePath
+    });
+  });
+
+  it('finds ancestor .devcontainer.json for nested workspace roots', async () => {
+    const configFilePath = writeDevContainerConfig(workspaceRoot, '.devcontainer.json');
+    const nestedWorkspaceRoot = join(workspaceRoot, 'packages', 'app');
+    mkdirSync(nestedWorkspaceRoot, { recursive: true });
+
+    mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
+      expect(command).toBe('docker');
+      if (args?.[0] === 'ps') {
+        return { status: 0, stdout: 'nested-dotfile\n' } as ReturnType<typeof spawnSync>;
+      }
+
+      if (args?.[0] === 'inspect') {
+        return {
+          status: 0,
+          stdout: dockerInspectResult({
+            Id: 'nested-dotfile',
+            State: { Running: true },
+            Config: {
+              Labels: {
+                'devcontainer.local_folder': workspaceRoot,
+                'devcontainer.config_file': configFilePath
+              }
+            },
+            Mounts: [{ Source: workspaceRoot, Destination: DEFAULT_WORKSPACE_FOLDER }]
+          })
+        } as ReturnType<typeof spawnSync>;
+      }
+
+      throw new Error(`Unexpected docker args: ${args}`);
+    });
+
+    const mod = await import('../devcontainer.js');
+    const context = mod.resolveDevContainerContext(nestedWorkspaceRoot);
+
+    expect(context).toEqual({
+      containerId: 'nested-dotfile',
+      hostWorkspaceRoot: nestedWorkspaceRoot,
+      containerWorkspaceRoot: '/workspaces/app/packages/app',
+      configFilePath
+    });
+  });
+
+  it('honors config discovery precedence for conflicting layouts in the same ancestor', async () => {
+    const primaryConfigPath = writeDevContainerConfig(workspaceRoot, '.devcontainer/devcontainer.json', { workspaceFolder: '/workspaces/primary' });
+    const dotfileConfigPath = writeDevContainerConfig(workspaceRoot, '.devcontainer.json', { workspaceFolder: '/workspaces/dotfile' });
+    const alphaNestedConfigPath = writeDevContainerConfig(workspaceRoot, '.devcontainer/alpha/devcontainer.json', { workspaceFolder: '/workspaces/alpha' });
+    writeDevContainerConfig(workspaceRoot, '.devcontainer/beta/devcontainer.json', { workspaceFolder: '/workspaces/beta' });
+
+    let expectedConfigPath = primaryConfigPath;
+    let expectedWorkspaceFolder = '/workspaces/primary';
+
+    mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
+      expect(command).toBe('docker');
+      if (args?.[0] === 'ps') {
+        return { status: 0, stdout: 'precedence123\n' } as ReturnType<typeof spawnSync>;
+      }
+
+      if (args?.[0] === 'inspect') {
+        return {
+          status: 0,
+          stdout: dockerInspectResult({
+            Id: 'precedence123',
+            State: { Running: true },
+            Config: {
+              Labels: {
+                'devcontainer.local_folder': workspaceRoot,
+                'devcontainer.config_file': expectedConfigPath
+              }
+            },
+            Mounts: [{ Source: workspaceRoot, Destination: expectedWorkspaceFolder }]
+          })
+        } as ReturnType<typeof spawnSync>;
+      }
+
+      throw new Error(`Unexpected docker args: ${args}`);
+    });
+
+    const mod = await import('../devcontainer.js');
+
+    let context = mod.resolveDevContainerContext(workspaceRoot);
+    expect(context?.configFilePath).toBe(primaryConfigPath);
+    expect(context?.containerWorkspaceRoot).toBe('/workspaces/primary');
+
+    rmSync(primaryConfigPath, { force: true });
+    expectedConfigPath = dotfileConfigPath;
+    expectedWorkspaceFolder = '/workspaces/dotfile';
+    vi.resetModules();
+    const dotfileMod = await import('../devcontainer.js');
+    context = dotfileMod.resolveDevContainerContext(workspaceRoot);
+    expect(context?.configFilePath).toBe(dotfileConfigPath);
+    expect(context?.containerWorkspaceRoot).toBe('/workspaces/dotfile');
+
+    rmSync(dotfileConfigPath, { force: true });
+    expectedConfigPath = alphaNestedConfigPath;
+    expectedWorkspaceFolder = '/workspaces/alpha';
+    vi.resetModules();
+    const nestedMod = await import('../devcontainer.js');
+    context = nestedMod.resolveDevContainerContext(workspaceRoot);
+    expect(context?.configFilePath).toBe(alphaNestedConfigPath);
+    expect(context?.containerWorkspaceRoot).toBe('/workspaces/alpha');
+  });
+
+  it('returns null when no matching running devcontainer exists', async () => {
     mockSpawnSync.mockImplementation((command: string, args: ReadonlyArray<string> | undefined) => {
       expect(command).toBe('docker');
       if (args?.[0] === 'ps') {

--- a/src/tools/lsp/devcontainer.ts
+++ b/src/tools/lsp/devcontainer.ts
@@ -1,11 +1,13 @@
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
-import { resolve, join, relative, sep, dirname, parse } from 'path';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { resolve, join, relative, sep, dirname, parse, basename } from 'path';
 import { posix } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { parseJsonc } from '../../utils/jsonc.js';
 
-const DEVCONTAINER_CONFIG_PATH = ['.devcontainer', 'devcontainer.json'] as const;
+const DEVCONTAINER_PRIMARY_CONFIG_PATH = ['.devcontainer', 'devcontainer.json'] as const;
+const DEVCONTAINER_DOTFILE_NAME = '.devcontainer.json' as const;
+const DEVCONTAINER_CONFIG_DIR = '.devcontainer' as const;
 const DEVCONTAINER_LOCAL_FOLDER_LABELS = [
   'devcontainer.local_folder',
   'vsch.local.folder'
@@ -143,8 +145,8 @@ function resolveDevContainerConfigPath(workspaceRoot: string): string | undefine
   let dir = workspaceRoot;
 
   while (true) {
-    const configFilePath = join(dir, ...DEVCONTAINER_CONFIG_PATH);
-    if (existsSync(configFilePath)) {
+    const configFilePath = resolveDevContainerConfigPathAt(dir);
+    if (configFilePath) {
       return configFilePath;
     }
 
@@ -155,6 +157,50 @@ function resolveDevContainerConfigPath(workspaceRoot: string): string | undefine
 
     dir = dirname(dir);
   }
+}
+
+function resolveDevContainerConfigPathAt(dir: string): string | undefined {
+  const primaryConfigPath = join(dir, ...DEVCONTAINER_PRIMARY_CONFIG_PATH);
+  if (existsSync(primaryConfigPath)) {
+    return primaryConfigPath;
+  }
+
+  const dotfileConfigPath = join(dir, DEVCONTAINER_DOTFILE_NAME);
+  if (existsSync(dotfileConfigPath)) {
+    return dotfileConfigPath;
+  }
+
+  const devcontainerDir = join(dir, DEVCONTAINER_CONFIG_DIR);
+  if (!existsSync(devcontainerDir)) {
+    return undefined;
+  }
+
+  const nestedConfigPaths = readdirSync(devcontainerDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => join(devcontainerDir, entry.name, 'devcontainer.json'))
+    .filter(existsSync)
+    .sort((left, right) => left.localeCompare(right));
+
+  return nestedConfigPaths[0];
+}
+
+function deriveHostDevContainerRoot(configFilePath: string): string {
+  const resolvedConfigPath = resolve(configFilePath);
+  if (basename(resolvedConfigPath) === DEVCONTAINER_DOTFILE_NAME) {
+    return dirname(resolvedConfigPath);
+  }
+
+  const configParentDir = dirname(resolvedConfigPath);
+  if (basename(configParentDir) === DEVCONTAINER_CONFIG_DIR) {
+    return dirname(configParentDir);
+  }
+
+  const configGrandparentDir = dirname(configParentDir);
+  if (basename(configGrandparentDir) === DEVCONTAINER_CONFIG_DIR) {
+    return dirname(configGrandparentDir);
+  }
+
+  return dirname(configParentDir);
 }
 
 function readDevContainerConfig(configFilePath?: string): DevContainerJson | null {
@@ -284,7 +330,7 @@ function scoreContainerMatch(
   let score = 0;
   let hasDevContainerLabelMatch = false;
   const expectedLocalFolder = configFilePath
-    ? dirname(dirname(configFilePath))
+    ? deriveHostDevContainerRoot(configFilePath)
     : resolve(hostWorkspaceRoot);
 
   for (const label of DEVCONTAINER_LOCAL_FOLDER_LABELS) {


### PR DESCRIPTION
## Summary
- broaden devcontainer config discovery in `src/tools/lsp/devcontainer.ts` beyond only `.devcontainer/devcontainer.json`
- support `.devcontainer.json` plus one-level `.devcontainer/*/devcontainer.json` layouts using explicit same-ancestor precedence
- derive the expected local folder from the resolved config path so label matching still works for the newly supported layouts
- add focused unit coverage for repo-root, nested-root, and precedence-conflict config discovery cases

## Contract note
This follow-up does **not** treat #1784 as evidence that #1783's merged contract was broken.

#1783's merged contract around:
- already-running container detection
- raw `docker exec` launch
- field-aware path/URI translation
- focused unit tests

remains intact.

This PR is a narrow compatibility improvement for additional spec-defined config layouts only. It intentionally leaves `src/tools/lsp/client.ts` unchanged, so optional `devcontainer exec`, `remoteUser` / `remoteEnv` / `userEnvProbe` parity, and broader compose/effective-config work remain separate enhancement territory.

## Tests
- `npm exec -- vitest run src/tools/lsp/__tests__/devcontainer.test.ts src/tools/lsp/__tests__/client-devcontainer.test.ts`
- `npm exec -- tsc --noEmit`

## Related
- Closes #1784
- Follow-up to #1783
