### PR TITLE
Fix plugin-safe omc command rendering for skills and worker prompts

### DIFF
--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -8,6 +8,8 @@ vi.mock('../team/model-contract.js', () => ({
 }));
 
 const originalCwd = process.cwd();
+const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+const originalPath = process.env.PATH;
 let tempConfigDir: string;
 let tempProjectDir: string;
 
@@ -31,6 +33,16 @@ describe('auto slash aliases + skill guidance', () => {
     rmSync(tempConfigDir, { recursive: true, force: true });
     rmSync(tempProjectDir, { recursive: true, force: true });
     delete process.env.CLAUDE_CONFIG_DIR;
+    if (originalPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
   });
 
   it('renders provider-aware execution recommendations for deep-interview when codex is available', async () => {
@@ -147,8 +159,35 @@ Deep interview body`
 
     expect(result.success).toBe(true);
     expect(result.replacementText).toContain('## Autoresearch Setup Mode');
-    expect(result.replacementText).toContain('omc autoresearch --mission "<mission>" --eval "<evaluator>"');
+    expect(result.replacementText).toContain('autoresearch --mission "<mission>" --eval "<evaluator>"');
     expect(result.replacementText).toContain('Mission seed from invocation: `improve startup performance`');
     expect(result.replacementText).not.toContain('## Skill Pipeline');
+  });
+
+  it('renders plugin-safe autoresearch guidance when omc is unavailable in slash mode', async () => {
+    process.env.CLAUDE_PLUGIN_ROOT = '/plugin-root';
+    process.env.PATH = '';
+
+    mkdirSync(join(tempConfigDir, 'skills', 'deep-interview'), { recursive: true });
+    writeFileSync(
+      join(tempConfigDir, 'skills', 'deep-interview', 'SKILL.md'),
+      `---
+name: deep-interview
+description: Deep interview
+---
+
+Deep interview body`
+    );
+
+    const { executeSlashCommand } = await loadExecutor();
+    const result = executeSlashCommand({
+      command: 'deep-interview',
+      args: '--autoresearch improve startup performance',
+      raw: '/deep-interview --autoresearch improve startup performance',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText)
+      .toContain('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs autoresearch --mission "<mission>" --eval "<evaluator>"');
   });
 });

--- a/src/__tests__/deep-interview-provider-options.test.ts
+++ b/src/__tests__/deep-interview-provider-options.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const availability = vi.hoisted(() => ({
   claude: true,
@@ -14,10 +14,37 @@ import { clearSkillsCache, getBuiltinSkill } from '../features/builtin-skills/sk
 import { renderSkillRuntimeGuidance } from '../features/builtin-skills/runtime-guidance.js';
 
 describe('deep-interview provider-aware execution recommendations', () => {
+  const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  const originalPath = process.env.PATH;
+
   beforeEach(() => {
     availability.claude = true;
     availability.codex = false;
     availability.gemini = false;
+    if (originalPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    clearSkillsCache();
+  });
+
+  afterEach(() => {
+    if (originalPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
     clearSkillsCache();
   });
 
@@ -48,9 +75,9 @@ describe('deep-interview provider-aware execution recommendations', () => {
     const ralplanSkill = getBuiltinSkill('ralplan');
 
     expect(planSkill?.template).toContain('--architect codex');
-    expect(planSkill?.template).toContain('omc ask codex --agent-prompt architect');
+    expect(planSkill?.template).toContain('ask codex --agent-prompt architect');
     expect(planSkill?.template).toContain('--critic codex');
-    expect(planSkill?.template).toContain('omc ask codex --agent-prompt critic');
+    expect(planSkill?.template).toContain('ask codex --agent-prompt critic');
 
     expect(ralplanSkill?.template).toContain('--architect codex');
     expect(ralplanSkill?.template).toContain('--critic codex');

--- a/src/__tests__/omc-cli-rendering.test.ts
+++ b/src/__tests__/omc-cli-rendering.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatOmcCliInvocation,
+  resolveOmcCliPrefix,
+  rewriteOmcCliInvocations,
+} from '../utils/omc-cli-rendering.js';
+
+describe('omc CLI rendering', () => {
+  it('uses omc when the binary is available', () => {
+    expect(resolveOmcCliPrefix({ omcAvailable: true, env: {} as NodeJS.ProcessEnv })).toBe('omc');
+    expect(formatOmcCliInvocation('team api claim-task', { omcAvailable: true, env: {} as NodeJS.ProcessEnv }))
+      .toBe('omc team api claim-task');
+  });
+
+  it('falls back to the plugin bridge when omc is unavailable but CLAUDE_PLUGIN_ROOT is set', () => {
+    const env = { CLAUDE_PLUGIN_ROOT: '/tmp/plugin-root' } as NodeJS.ProcessEnv;
+    expect(resolveOmcCliPrefix({ omcAvailable: false, env }))
+      .toBe('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs');
+    expect(formatOmcCliInvocation('autoresearch --mission "m"', { omcAvailable: false, env }))
+      .toBe('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs autoresearch --mission "m"');
+  });
+
+  it('rewrites inline and list-form omc commands for plugin installs', () => {
+    const env = { CLAUDE_PLUGIN_ROOT: '/tmp/plugin-root' } as NodeJS.ProcessEnv;
+    const input = [
+      'Run `omc autoresearch --mission "m" --eval "e"`.',
+      '- omc team api claim-task --input \'{}\' --json',
+      '> omc ask codex --agent-prompt critic "check"',
+    ].join('\n');
+
+    const output = rewriteOmcCliInvocations(input, { omcAvailable: false, env });
+
+    expect(output).toContain('`node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs autoresearch --mission "m" --eval "e"`');
+    expect(output).toContain('- node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs team api claim-task --input \'{}\' --json');
+    expect(output).toContain('> node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask codex --agent-prompt critic "check"');
+  });
+
+  it('leaves text unchanged when omc remains the selected prefix', () => {
+    const input = 'Use `omc team status demo` and\nomc team wait demo';
+    expect(rewriteOmcCliInvocations(input, { omcAvailable: true, env: {} as NodeJS.ProcessEnv })).toBe(input);
+  });
+});

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -1,9 +1,36 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createBuiltinSkills, getBuiltinSkill, listBuiltinSkillNames, clearSkillsCache } from '../features/builtin-skills/skills.js';
 
 describe('Builtin Skills', () => {
+  const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  const originalPath = process.env.PATH;
+
   // Clear cache before each test to ensure fresh loads
   beforeEach(() => {
+    if (originalPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    clearSkillsCache();
+  });
+
+  afterEach(() => {
+    if (originalPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
     clearSkillsCache();
   });
 
@@ -184,7 +211,23 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('`.omc/specs/deep-interview-{slug}.md`');
       expect(skill?.argumentHint).toContain('--autoresearch');
       expect(skill?.template).toContain('zero-learning-curve setup lane for `omc autoresearch`');
-      expect(skill?.template).toContain('omc autoresearch --mission "<mission>" --eval "<evaluator>"');
+      expect(skill?.template).toContain('autoresearch --mission "<mission>" --eval "<evaluator>"');
+    });
+
+    it('rewrites built-in skill command examples to plugin-safe bridge invocations when omc is unavailable', () => {
+      process.env.CLAUDE_PLUGIN_ROOT = '/plugin-root';
+      process.env.PATH = '';
+      clearSkillsCache();
+
+      const deepInterviewSkill = getBuiltinSkill('deep-interview');
+      const askSkill = getBuiltinSkill('ask');
+
+      expect(deepInterviewSkill?.template)
+        .toContain('zero-learning-curve setup lane for `node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs autoresearch`');
+      expect(deepInterviewSkill?.template)
+        .toContain('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs autoresearch --mission "<mission>" --eval "<evaluator>"');
+      expect(askSkill?.template)
+        .toContain('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask {{ARGUMENTS}}');
     });
 
     it('should expose pipeline metadata for omc-plan handoff into autopilot', () => {

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -14,6 +14,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import type { BuiltinSkill } from './types.js';
 import { parseFrontmatter, parseFrontmatterAliases } from '../../utils/frontmatter.js';
+import { rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from './runtime-guidance.js';
@@ -59,8 +60,9 @@ function loadSkillFromFile(skillPath: string, skillName: string): BuiltinSkill[]
     const resolvedName = metadata.name || skillName;
     const safePrimaryName = toSafeSkillName(resolvedName);
     const pipeline = parseSkillPipelineMetadata(metadata);
+    const renderedBody = rewriteOmcCliInvocations(body.trim());
     const template = [
-      body.trim(),
+      renderedBody,
       renderSkillRuntimeGuidance(safePrimaryName),
       renderSkillPipelineGuidance(safePrimaryName, pipeline),
       renderSkillResourcesGuidance(skillPath),

--- a/src/hooks/__tests__/bridge-team-worker-guard.test.ts
+++ b/src/hooks/__tests__/bridge-team-worker-guard.test.ts
@@ -52,7 +52,7 @@ describe('team-worker pre-tool guardrails', () => {
     expect(result.reason).toBe('team-worker-bash-blocked');
   });
 
-  it('allows worker-safe omc team api commands', async () => {
+  it('allows worker-safe team api commands', async () => {
     const result = await processHook('pre-tool-use', {
       toolName: 'Bash',
       toolInput: { command: 'omc team api claim-task --input \'{"team_name":"demo-team","task_id":"1","worker":"worker-1"}\' --json' },

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -18,6 +18,7 @@ import type {
 } from './types.js';
 import { resolveLiveData } from './live-data.js';
 import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
+import { formatOmcCliInvocation, rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from '../../features/builtin-skills/runtime-guidance.js';
@@ -253,13 +254,13 @@ function renderDeepInterviewAutoresearchGuidance(args: string): string {
   const missionSeed = stripInvocationFlag(args, '--autoresearch');
   const lines = [
     '## Autoresearch Setup Mode',
-    'This deep-interview invocation was launched as the zero-learning-curve setup lane for `omc autoresearch`.',
+    `This deep-interview invocation was launched as the zero-learning-curve setup lane for \`${formatOmcCliInvocation('autoresearch')}\`.`,
     '',
     'Required behavior in this mode:',
     '- If the mission is not already clear, start by asking: "What should autoresearch improve or prove for this repo?"',
     '- Treat evaluator clarity as a required readiness gate before launch.',
     '- When the mission and evaluator are ready, launch direct execution with:',
-    '  `omc autoresearch --mission "<mission>" --eval "<evaluator>" [--keep-policy <policy>] [--slug <slug>]`',
+    `  \`${formatOmcCliInvocation('autoresearch --mission "<mission>" --eval "<evaluator>" [--keep-policy <policy>] [--slug <slug>]')}\``,
     '- Do **not** hand off to `omc-plan`, `autopilot`, `ralph`, or `team` in this mode.',
   ];
 
@@ -312,7 +313,7 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
 
   // Resolve arguments in content, then execute any live-data commands
   const resolvedContent = resolveArguments(cmd.content || '', displayArgs);
-  const injectedContent = resolveLiveData(resolvedContent);
+  const injectedContent = rewriteOmcCliInvocations(resolveLiveData(resolvedContent));
   const runtimeGuidance = cmd.scope === 'skill' && !isDeepInterviewAutoresearch
     ? renderSkillRuntimeGuidance(cmd.metadata.name)
     : '';

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -23,6 +23,7 @@ import {
 } from "fs";
 import { dirname, join } from "path";
 import { resolveToWorktreeRoot, getOmcRoot } from "../lib/worktree-paths.js";
+import { formatOmcCliInvocation } from "../utils/omc-cli-rendering.js";
 
 // Hot-path imports: needed on every/most hook invocations (keyword-detector, pre/post-tool-use)
 import {
@@ -385,7 +386,7 @@ function workerBashBlockReason(command: string): string | null {
     return "Team worker cannot run tmux pane/session orchestration commands.";
   }
   if (WORKER_BLOCKED_TEAM_CLI_PATTERN.test(command)) {
-    return "Team worker cannot run team orchestration commands. Use only `omc team api ... --json`.";
+    return `Team worker cannot run team orchestration commands. Use only \`${formatOmcCliInvocation("team api ... --json")}\`.`;
   }
   if (WORKER_BLOCKED_SKILL_PATTERN.test(command)) {
     return "Team worker cannot invoke orchestration skills (`$team`, `$ultrawork`, `$autopilot`, `$ralph`).";
@@ -739,11 +740,12 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
 
       case "codex":
       case "gemini": {
+        const teamStartCommand = formatOmcCliInvocation(`team start --agent ${keywordType} --count N --task "<task from user message>"`);
         messages.push(
           `[MAGIC KEYWORD: team]\n` +
-            `User intent: delegate to ${keywordType} CLI workers via omc team CLI.\n` +
+            `User intent: delegate to ${keywordType} CLI workers via ${formatOmcCliInvocation('team')}.\n` +
             `Agent type: ${keywordType}. Parse N from user message (default 1).\n` +
-            `Invoke: omc team start --agent ${keywordType} --count N --task "<task from user message>"`,
+            `Invoke: ${teamStartCommand}`,
         );
         break;
       }

--- a/src/hooks/persistent-mode/__tests__/ralph-verification-flow.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ralph-verification-flow.test.ts
@@ -72,7 +72,7 @@ describe('Ralph verification flow', () => {
     expect(result.shouldBlock).toBe(true);
     expect(result.mode).toBe('ralph');
     expect(result.message).toContain('CODEX CRITIC VERIFICATION REQUIRED');
-    expect(result.message).toContain('omc ask codex --agent-prompt critic');
+    expect(result.message).toContain('ask codex --agent-prompt critic');
   });
 
   it('completes Ralph after generic approval marker is seen in transcript', async () => {

--- a/src/hooks/ralph/verifier.ts
+++ b/src/hooks/ralph/verifier.ts
@@ -15,6 +15,7 @@
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { resolveSessionStatePath, ensureSessionStateDir, getOmcRoot } from '../../lib/worktree-paths.js';
+import { formatOmcCliInvocation } from '../../utils/omc-cli-rendering.js';
 import type { UserStory } from './prd.js';
 import type { RalphCriticMode } from './loop.js';
 
@@ -67,7 +68,7 @@ function getVerificationAgentStep(mode?: RalphCriticMode): string {
     case 'codex':
       return `1. **Run an external Codex critic review**:
    \`\`\`
-   omc ask codex --agent-prompt critic "<verification prompt covering the task, completion claim, and acceptance criteria>"
+   ${formatOmcCliInvocation('ask codex --agent-prompt critic "<verification prompt covering the task, completion claim, and acceptance criteria>"')}
    \`\`\`
    Use the Codex output as the reviewer verdict before deciding pass/fix.`;
     default:

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   sendToWorker: vi.fn(),
   waitForPaneReady: vi.fn(),
   execFile: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 0 })),
 }));
 
 const modelContractMocks = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ const modelContractMocks = vi.hoisted(() => ({
 
 vi.mock('child_process', () => ({
   execFile: mocks.execFile,
+  spawnSync: mocks.spawnSync,
 }));
 
 vi.mock('../model-contract.js', () => ({
@@ -52,6 +54,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     mocks.sendToWorker.mockReset();
     mocks.waitForPaneReady.mockReset();
     mocks.execFile.mockReset();
+    mocks.spawnSync.mockReset();
     modelContractMocks.buildWorkerArgv.mockReset();
     modelContractMocks.resolveValidatedBinaryPath.mockReset();
     modelContractMocks.getWorkerEnv.mockReset();
@@ -67,6 +70,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     mocks.spawnWorkerInPane.mockResolvedValue(undefined);
     mocks.waitForPaneReady.mockResolvedValue(true);
     mocks.sendToWorker.mockResolvedValue(true);
+    mocks.spawnSync.mockReturnValue({ status: 0 });
     modelContractMocks.buildWorkerArgv.mockImplementation((agentType?: string) => [`/usr/bin/${agentType ?? 'claude'}`]);
     modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => `/usr/bin/${agentType ?? 'claude'}`);
     modelContractMocks.getWorkerEnv.mockImplementation((...args: unknown[]) => {
@@ -394,7 +398,7 @@ describe('runtime v2 startup inbox dispatch', () => {
 
     expect(modelContractMocks.getPromptModeArgs).toHaveBeenCalledWith(
       'codex',
-      expect.stringContaining('omc team api claim-task'),
+      expect.stringContaining('team api claim-task'),
     );
     expect(modelContractMocks.getPromptModeArgs).toHaveBeenCalledWith(
       'codex',

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { generateMailboxTriggerMessage, generateTriggerMessage, generateWorkerOverlay, getWorkerEnv } from '../worker-bootstrap.js';
 
 describe('worker-bootstrap', () => {
+  const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  const originalPath = process.env.PATH;
   const baseParams = {
     teamName: 'test-team',
     workerName: 'worker-1',
@@ -11,6 +13,32 @@ describe('worker-bootstrap', () => {
     ],
     cwd: '/tmp',
   };
+
+  beforeEach(() => {
+    if (originalPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  afterEach(() => {
+    if (originalPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+  });
 
   describe('generateWorkerOverlay', () => {
     it('uses urgent trigger wording that requires immediate work and concrete progress', () => {
@@ -97,12 +125,23 @@ describe('worker-bootstrap', () => {
     });
     it('documents CLI lifecycle examples that match the active team api contract', () => {
       const overlay = generateWorkerOverlay(baseParams);
-      expect(overlay).toContain('omc team api read-task');
-      expect(overlay).toContain('omc team api claim-task');
-      expect(overlay).toContain('omc team api transition-task-status');
-      expect(overlay).toContain('omc team api release-task-claim --input');
+      expect(overlay).toContain('team api read-task');
+      expect(overlay).toContain('team api claim-task');
+      expect(overlay).toContain('team api transition-task-status');
+      expect(overlay).toContain('team api release-task-claim --input');
       expect(overlay).toContain('claim_token');
       expect(overlay).not.toContain('Read your task file at');
+    });
+
+    it('renders plugin-safe CLI lifecycle examples when omc is unavailable in plugin installs', () => {
+      process.env.CLAUDE_PLUGIN_ROOT = '/plugin-root';
+      process.env.PATH = '';
+
+      const overlay = generateWorkerOverlay(baseParams);
+
+      expect(overlay).toContain('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs team api read-task');
+      expect(overlay).toContain('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs team api claim-task');
+      expect(overlay).toContain('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs team api transition-task-status');
     });
 
   });

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -72,6 +72,7 @@ import {
 } from './worker-bootstrap.js';
 import { queueInboxInstruction, type DispatchOutcome } from './mcp-comm.js';
 import { cleanupTeamWorktrees } from './git-worktree.js';
+import { formatOmcCliInvocation } from '../utils/omc-cli-rendering.js';
 
 // ---------------------------------------------------------------------------
 // Feature flag
@@ -241,18 +242,28 @@ function buildV2TaskInstruction(
   task: { subject: string; description: string },
   taskId: string,
 ): string {
+  const claimTaskCommand = formatOmcCliInvocation(
+    `team api claim-task --input '${JSON.stringify({ team_name: teamName, task_id: taskId, worker: workerName })}' --json`,
+    {},
+  );
+  const completeTaskCommand = formatOmcCliInvocation(
+    `team api transition-task-status --input '${JSON.stringify({ team_name: teamName, task_id: taskId, from: 'in_progress', to: 'completed', claim_token: '<claim_token>' })}' --json`,
+  );
+  const failTaskCommand = formatOmcCliInvocation(
+    `team api transition-task-status --input '${JSON.stringify({ team_name: teamName, task_id: taskId, from: 'in_progress', to: 'failed', claim_token: '<claim_token>' })}' --json`,
+  );
   return [
     `## REQUIRED: Task Lifecycle Commands`,
     `You MUST run these commands. Do NOT skip any step.`,
     ``,
     `1. Claim your task:`,
-    `   omc team api claim-task --input '{"team_name":"${teamName}","task_id":"${taskId}","worker":"${workerName}"}' --json`,
+    `   ${claimTaskCommand}`,
     `   Save the claim_token from the response.`,
     `2. Do the work described below.`,
     `3. On completion (use claim_token from step 1):`,
-    `   omc team api transition-task-status --input '{"team_name":"${teamName}","task_id":"${taskId}","from":"in_progress","to":"completed","claim_token":"<claim_token>"}' --json`,
+    `   ${completeTaskCommand}`,
     `4. On failure (use claim_token from step 1):`,
-    `   omc team api transition-task-status --input '{"team_name":"${teamName}","task_id":"${taskId}","from":"in_progress","to":"failed","claim_token":"<claim_token>"}' --json`,
+    `   ${failTaskCommand}`,
     `5. ACK/progress replies are not a stop signal. Keep executing your assigned or next feasible work until the task is actually complete or failed, then transition and exit.`,
     ``,
     `## Task Assignment`,

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile, appendFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { sanitizePromptContent } from '../agents/prompt-helpers.js';
+import { formatOmcCliInvocation } from '../utils/omc-cli-rendering.js';
 import type { CliAgentType } from './model-contract.js';
 
 export interface WorkerBootstrapParams {
@@ -43,20 +44,23 @@ export function generateMailboxTriggerMessage(
 }
 
 function agentTypeGuidance(agentType: CliAgentType): string {
+  const teamApiCommand = formatOmcCliInvocation('team api');
+  const claimTaskCommand = formatOmcCliInvocation('team api claim-task');
+  const transitionTaskStatusCommand = formatOmcCliInvocation('team api transition-task-status');
   switch (agentType) {
     case 'codex':
       return [
         '### Agent-Type Guidance (codex)',
-        '- Prefer short, explicit `omc team api ... --json` commands and parse outputs before next step.',
+        `- Prefer short, explicit \`${teamApiCommand} ... --json\` commands and parse outputs before next step.`,
         '- If a command fails, report the exact stderr to leader-fixed before retrying.',
-        '- You MUST run `omc team api claim-task` before starting work and `omc team api transition-task-status` when done.',
+        `- You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done.`,
       ].join('\n');
     case 'gemini':
       return [
         '### Agent-Type Guidance (gemini)',
         '- Execute task work in small, verifiable increments and report each milestone to leader-fixed.',
         '- Keep commit-sized changes scoped to assigned files only; no broad refactors.',
-        '- CRITICAL: You MUST run `omc team api claim-task` before starting work and `omc team api transition-task-status` when done. Do not exit without transitioning the task status.',
+        `- CRITICAL: You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done. Do not exit without transitioning the task status.`,
       ].join('\n');
     case 'claude':
     default:
@@ -88,6 +92,16 @@ export function generateWorkerOverlay(params: WorkerBootstrapParams): string {
   const heartbeatPath = `.omc/state/team/${teamName}/workers/${workerName}/heartbeat.json`;
   const inboxPath = `.omc/state/team/${teamName}/workers/${workerName}/inbox.md`;
   const statusPath = `.omc/state/team/${teamName}/workers/${workerName}/status.json`;
+  const claimTaskCommand = formatOmcCliInvocation(`team api claim-task --input "{\\"team_name\\":\\"${teamName}\\",\\"task_id\\":\\"<id>\\",\\"worker\\":\\"${workerName}\\"}" --json`);
+  const sendAckCommand = formatOmcCliInvocation(`team api send-message --input "{\\"team_name\\":\\"${teamName}\\",\\"from_worker\\":\\"${workerName}\\",\\"to_worker\\":\\"leader-fixed\\",\\"body\\":\\"ACK: ${workerName} initialized\\"}" --json`);
+  const completeTaskCommand = formatOmcCliInvocation(`team api transition-task-status --input "{\\"team_name\\":\\"${teamName}\\",\\"task_id\\":\\"<id>\\",\\"from\\":\\"in_progress\\",\\"to\\":\\"completed\\",\\"claim_token\\":\\"<claim_token>\\"}" --json`);
+  const failTaskCommand = formatOmcCliInvocation(`team api transition-task-status --input "{\\"team_name\\":\\"${teamName}\\",\\"task_id\\":\\"<id>\\",\\"from\\":\\"in_progress\\",\\"to\\":\\"failed\\",\\"claim_token\\":\\"<claim_token>\\"}" --json`);
+  const readTaskCommand = formatOmcCliInvocation(`team api read-task --input "{\\"team_name\\":\\"${teamName}\\",\\"task_id\\":\\"<id>\\"}" --json`);
+  const releaseClaimCommand = formatOmcCliInvocation(`team api release-task-claim --input "{\\"team_name\\":\\"${teamName}\\",\\"task_id\\":\\"<id>\\",\\"claim_token\\":\\"<claim_token>\\",\\"worker\\":\\"${workerName}\\"}" --json`);
+  const mailboxListCommand = formatOmcCliInvocation(`team api mailbox-list --input "{\\"team_name\\":\\"${teamName}\\",\\"worker\\":\\"${workerName}\\"}" --json`);
+  const mailboxDeliveredCommand = formatOmcCliInvocation(`team api mailbox-mark-delivered --input "{\\"team_name\\":\\"${teamName}\\",\\"worker\\":\\"${workerName}\\",\\"message_id\\":\\"<id>\\"}" --json`);
+  const teamApiCommand = formatOmcCliInvocation('team api');
+  const teamCommand = formatOmcCliInvocation('team');
 
   const taskList = sanitizedTasks.length > 0
     ? sanitizedTasks.map(t => `- **Task ${t.id}**: ${t.subject}\n  Description: ${t.description}\n  Status: pending`).join('\n')
@@ -107,14 +121,14 @@ mkdir -p $(dirname ${sentinelPath}) && touch ${sentinelPath}
 You MUST complete ALL of these steps. Do NOT skip any step. Do NOT exit without step 4.
 
 1. **Claim** your task (run this command first):
-   \`omc team api claim-task --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"worker\":\"${workerName}\"}" --json\`
+   \`${claimTaskCommand}\`
    Save the \`claim_token\` from the response — you need it for step 4.
 2. **Do the work** described in your task assignment below.
 3. **Send ACK** to the leader:
-   \`omc team api send-message --input "{\"team_name\":\"${teamName}\",\"from_worker\":\"${workerName}\",\"to_worker\":\"leader-fixed\",\"body\":\"ACK: ${workerName} initialized\"}" --json\`
+   \`${sendAckCommand}\`
 4. **Transition** the task status (REQUIRED before exit):
-   - On success: \`omc team api transition-task-status --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"from\":\"in_progress\",\"to\":\"completed\",\"claim_token\":\"<claim_token>\"}" --json\`
-   - On failure: \`omc team api transition-task-status --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"from\":\"in_progress\",\"to\":\"failed\",\"claim_token\":\"<claim_token>\"}" --json\`
+   - On success: \`${completeTaskCommand}\`
+   - On failure: \`${failTaskCommand}\`
 5. **Keep going after replies**: ACK/progress messages are not a stop signal. Keep executing your assigned or next feasible work until the task is actually complete or failed, then transition and exit.
 
 ## Identity
@@ -129,12 +143,12 @@ ${taskList}
 ## Task Lifecycle Reference (CLI API)
 Use the CLI API for all task lifecycle operations. Do NOT directly edit task files.
 
-- Inspect task state: \`omc team api read-task --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\"}" --json\`
+- Inspect task state: \`${readTaskCommand}\`
 - Task id format: State/CLI APIs use task_id: "<id>" (example: "1"), not "task-1"
-- Claim task: \`omc team api claim-task --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"worker\":\"${workerName}\"}" --json\`
-- Complete task: \`omc team api transition-task-status --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"from\":\"in_progress\",\"to\":\"completed\",\"claim_token\":\"<claim_token>\"}" --json\`
-- Fail task: \`omc team api transition-task-status --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"from\":\"in_progress\",\"to\":\"failed\",\"claim_token\":\"<claim_token>\"}" --json\`
-- Release claim (rollback): \`omc team api release-task-claim --input "{\"team_name\":\"${teamName}\",\"task_id\":\"<id>\",\"claim_token\":\"<claim_token>\",\"worker\":\"${workerName}\"}" --json\`
+- Claim task: \`${claimTaskCommand}\`
+- Complete task: \`${completeTaskCommand}\`
+- Fail task: \`${failTaskCommand}\`
+- Release claim (rollback): \`${releaseClaimCommand}\`
 
 ## Communication Protocol
 - **Inbox**: Read ${inboxPath} for new instructions
@@ -150,13 +164,13 @@ Use the CLI API for all task lifecycle operations. Do NOT directly edit task fil
 
 ## Message Protocol
 Send messages via CLI API:
-- To leader: \`omc team api send-message --input "{\\"team_name\\":\\"${teamName}\\",\\"from_worker\\":\\"${workerName}\\",\\"to_worker\\":\\"leader-fixed\\",\\"body\\":\\"<message>\\"}" --json\`
-- Check mailbox: \`omc team api mailbox-list --input "{\\"team_name\\":\\"${teamName}\\",\\"worker\\":\\"${workerName}\\"}" --json\`
-- Mark delivered: \`omc team api mailbox-mark-delivered --input "{\\"team_name\\":\\"${teamName}\\",\\"worker\\":\\"${workerName}\\",\\"message_id\\":\\"<id>\\"}" --json\`
+- To leader: \`${formatOmcCliInvocation(`team api send-message --input "{\\"team_name\\":\\"${teamName}\\",\\"from_worker\\":\\"${workerName}\\",\\"to_worker\\":\\"leader-fixed\\",\\"body\\":\\"<message>\\"}" --json`)}\`
+- Check mailbox: \`${mailboxListCommand}\`
+- Mark delivered: \`${mailboxDeliveredCommand}\`
 
 ## Startup Handshake (Required)
 Before doing any task work, send exactly one startup ACK to the leader:
-\`omc team api send-message --input "{\\"team_name\\":\\"${teamName}\\",\\"from_worker\\":\\"${workerName}\\",\\"to_worker\\":\\"leader-fixed\\",\\"body\\":\\"ACK: ${workerName} initialized\\"}" --json\`
+\`${sendAckCommand}\`
 
 ## Shutdown Protocol
 When you see a shutdown request in your inbox:
@@ -172,14 +186,14 @@ When you see a shutdown request in your inbox:
 - Do NOT write lifecycle fields (status, owner, result, error) directly in task files; use CLI API
 - Do NOT spawn sub-agents. Complete work in this worker session only.
 - Do NOT create tmux panes/sessions (\`tmux split-window\`, \`tmux new-session\`, etc.).
-- Do NOT run team spawning/orchestration commands (for example: \`omc team ...\`, \`omx team ...\`, \`$team\`, \`$ultrawork\`, \`$autopilot\`, \`$ralph\`).
-- Worker-allowed control surface is only: \`omc team api ... --json\` (and equivalent \`omx team api ... --json\` where configured).
+- Do NOT run team spawning/orchestration commands (for example: \`${teamCommand} ...\`, \`omx team ...\`, \`$team\`, \`$ultrawork\`, \`$autopilot\`, \`$ralph\`).
+- Worker-allowed control surface is only: \`${teamApiCommand} ... --json\` (and equivalent \`omx team api ... --json\` where configured).
 - If blocked, write {"state": "blocked", "reason": "..."} to your status file
 
 ${agentTypeGuidance(agentType)}
 
 ## BEFORE YOU EXIT
-You MUST call \`omc team api transition-task-status\` to mark your task as "completed" or "failed" before exiting.
+You MUST call \`${formatOmcCliInvocation('team api transition-task-status')}\` to mark your task as "completed" or "failed" before exiting.
 If you skip this step, the leader cannot track your work and the task will appear stuck.
 
 ${bootstrapInstructions ? `## Role Context\n${bootstrapInstructions}\n` : ''}`;

--- a/src/utils/omc-cli-rendering.ts
+++ b/src/utils/omc-cli-rendering.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from 'child_process';
+
+const OMC_CLI_BINARY = 'omc';
+const OMC_PLUGIN_BRIDGE_PREFIX = 'node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs';
+
+export interface OmcCliRenderOptions {
+  env?: NodeJS.ProcessEnv;
+  omcAvailable?: boolean;
+}
+
+function commandExists(command: string, env: NodeJS.ProcessEnv): boolean {
+  const lookupCommand = process.platform === 'win32' ? 'where' : 'which';
+  const result = spawnSync(lookupCommand, [command], {
+    stdio: 'ignore',
+    env,
+  });
+  return result.status === 0;
+}
+
+export function resolveOmcCliPrefix(options: OmcCliRenderOptions = {}): string {
+  const env = options.env ?? process.env;
+  const omcAvailable = options.omcAvailable ?? commandExists(OMC_CLI_BINARY, env);
+  if (omcAvailable) {
+    return OMC_CLI_BINARY;
+  }
+
+  const pluginRoot = typeof env.CLAUDE_PLUGIN_ROOT === 'string' ? env.CLAUDE_PLUGIN_ROOT.trim() : '';
+  if (pluginRoot) {
+    return OMC_PLUGIN_BRIDGE_PREFIX;
+  }
+
+  return OMC_CLI_BINARY;
+}
+
+export function formatOmcCliInvocation(
+  commandSuffix: string,
+  options: OmcCliRenderOptions = {},
+): string {
+  const suffix = commandSuffix.trim().replace(/^omc\s+/, '');
+  return `${resolveOmcCliPrefix(options)} ${suffix}`.trim();
+}
+
+export function rewriteOmcCliInvocations(
+  text: string,
+  options: OmcCliRenderOptions = {},
+): string {
+  const prefix = resolveOmcCliPrefix(options);
+  if (prefix === OMC_CLI_BINARY || !text.includes('omc ')) {
+    return text;
+  }
+
+  return text
+    .replace(/`omc (?=[^`\r\n]+`)/g, `\`${prefix} `)
+    .replace(/(^|\n)([ \t>*-]*)omc (?=\S)/g, `$1$2${prefix} `);
+}


### PR DESCRIPTION
## Summary
- add a shared renderer for user-facing omc command examples that prefers  and falls back to 
- apply the renderer only to issue-1786 skill/slash/ralph/team worker runtime surfaces that break in plugin-only installs
- add focused tests covering plugin fallback rendering and the touched runtime guidance

## Verification
- 
added 300 packages, and audited 301 packages in 3s

94 packages are looking for funding
  run `npm fund` for details

1 high severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
- 
- 

Closes #1786