### PR TITLE
fix(hud): stabilize ctx percentage display

### DIFF
--- a/src/__tests__/hud/stdin.test.ts
+++ b/src/__tests__/hud/stdin.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StatuslineStdin } from '../../hud/types.js';
+import { getContextPercent, stabilizeContextPercent } from '../../hud/stdin.js';
+
+function makeStdin(overrides: Partial<StatuslineStdin> = {}): StatuslineStdin {
+  return {
+    cwd: '/tmp/worktree',
+    transcript_path: '/tmp/worktree/session.jsonl',
+    model: {
+      id: 'claude-sonnet',
+      display_name: 'Claude Sonnet',
+    },
+    context_window: {
+      context_window_size: 1000,
+      current_usage: {
+        input_tokens: 520,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      ...overrides.context_window,
+    },
+    ...overrides,
+  };
+}
+
+describe('HUD stdin context percent', () => {
+  it('prefers the native percentage when available', () => {
+    const stdin = makeStdin({
+      context_window: {
+        used_percentage: 53.6,
+        context_window_size: 1000,
+        current_usage: {
+          input_tokens: 520,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    });
+
+    expect(getContextPercent(stdin)).toBe(54);
+  });
+
+  it('reuses the previous native percentage when a transient fallback would cause ctx jitter', () => {
+    const previous = makeStdin({
+      context_window: {
+        used_percentage: 54,
+        context_window_size: 1000,
+        current_usage: {
+          input_tokens: 540,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    });
+    const current = makeStdin({
+      context_window: {
+        context_window_size: 1000,
+        current_usage: {
+          input_tokens: 520,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    });
+
+    expect(getContextPercent(current)).toBe(52);
+    expect(getContextPercent(stabilizeContextPercent(current, previous))).toBe(54);
+  });
+
+  it('does not hide a real context jump when the fallback differs materially', () => {
+    const previous = makeStdin({
+      context_window: {
+        used_percentage: 80,
+        context_window_size: 1000,
+        current_usage: {
+          input_tokens: 800,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    });
+    const current = makeStdin({
+      context_window: {
+        context_window_size: 1000,
+        current_usage: {
+          input_tokens: 200,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    });
+
+    expect(getContextPercent(stabilizeContextPercent(current, previous))).toBe(20);
+  });
+});

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -6,7 +6,14 @@
  * Receives stdin JSON from Claude Code and outputs formatted statusline.
  */
 
-import { readStdin, writeStdinCache, readStdinCache, getContextPercent, getModelName } from "./stdin.js";
+import {
+  readStdin,
+  writeStdinCache,
+  readStdinCache,
+  getContextPercent,
+  getModelName,
+  stabilizeContextPercent,
+} from "./stdin.js";
 import { parseTranscript } from "./transcript.js";
 import {
   readHudState,
@@ -124,14 +131,16 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     }
 
     // Read stdin from Claude Code
+    const previousStdinCache = readStdinCache();
     let stdin = await readStdin();
 
     if (stdin) {
+      stdin = stabilizeContextPercent(stdin, previousStdinCache);
       // Persist for --watch mode so it can read data when stdin is a TTY
       writeStdinCache(stdin);
     } else if (watchMode) {
       // In watch mode stdin is always a TTY; fall back to last cached value
-      stdin = readStdinCache();
+      stdin = previousStdinCache;
       if (!stdin) {
         // Cache not yet populated (first poll before statusline fires)
         console.log("[OMC] Starting...");
@@ -250,10 +259,11 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     const missionBoard = missionBoardEnabled
       ? await refreshMissionBoardState(cwd, config.missionBoard)
       : null;
+    const contextPercent = getContextPercent(stdin);
 
     // Build render context
     const context: HudRenderContext = {
-      contextPercent: getContextPercent(stdin),
+      contextPercent,
       modelName: getModelName(stdin),
       ralph,
       ultrawork,
@@ -271,7 +281,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       thinkingState: transcriptData.thinkingState || null,
       sessionHealth: await calculateSessionHealth(
         sessionStart,
-        getContextPercent(stdin),
+        contextPercent,
       ),
       lastRequestTokenUsage: transcriptData.lastRequestTokenUsage || null,
       sessionTotalTokens: transcriptData.sessionTotalTokens ?? null,

--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -10,6 +10,8 @@ import { join } from 'path';
 import { getWorktreeRoot } from '../lib/worktree-paths.js';
 import type { StatuslineStdin } from './types.js';
 
+const TRANSIENT_CONTEXT_PERCENT_TOLERANCE = 3;
+
 // ============================================================================
 // Stdin Cache (for --watch mode)
 // ============================================================================
@@ -98,25 +100,80 @@ function getTotalTokens(stdin: StatuslineStdin): number {
   );
 }
 
+function getRoundedNativeContextPercent(stdin: StatuslineStdin | null | undefined): number | null {
+  const nativePercent = stdin?.context_window?.used_percentage;
+  if (typeof nativePercent !== 'number' || Number.isNaN(nativePercent)) {
+    return null;
+  }
+  return Math.min(100, Math.max(0, Math.round(nativePercent)));
+}
+
+function getManualContextPercent(stdin: StatuslineStdin): number | null {
+  const size = stdin.context_window?.context_window_size;
+  if (!size || size <= 0) {
+    return null;
+  }
+
+  const totalTokens = getTotalTokens(stdin);
+  return Math.min(100, Math.round((totalTokens / size) * 100));
+}
+
+function isSameContextStream(current: StatuslineStdin, previous: StatuslineStdin): boolean {
+  return current.cwd === previous.cwd
+    && current.transcript_path === previous.transcript_path
+    && current.context_window?.context_window_size === previous.context_window?.context_window_size;
+}
+
+/**
+ * Preserve the last native context percentage across transient snapshots where Claude Code
+ * omits `used_percentage`, but only when the fallback calculation is close enough to suggest
+ * the same underlying value rather than a real context jump.
+ */
+export function stabilizeContextPercent(
+  stdin: StatuslineStdin,
+  previousStdin: StatuslineStdin | null | undefined,
+): StatuslineStdin {
+  if (getRoundedNativeContextPercent(stdin) !== null) {
+    return stdin;
+  }
+
+  if (!previousStdin || !isSameContextStream(stdin, previousStdin)) {
+    return stdin;
+  }
+
+  const previousNativePercent = getRoundedNativeContextPercent(previousStdin);
+  if (previousNativePercent === null) {
+    return stdin;
+  }
+
+  const manualPercent = getManualContextPercent(stdin);
+  if (
+    manualPercent !== null
+    && Math.abs(manualPercent - previousNativePercent) > TRANSIENT_CONTEXT_PERCENT_TOLERANCE
+  ) {
+    return stdin;
+  }
+
+  return {
+    ...stdin,
+    context_window: {
+      ...stdin.context_window,
+      used_percentage: previousStdin.context_window.used_percentage ?? previousNativePercent,
+    },
+  };
+}
+
 /**
  * Get context window usage percentage.
  * Prefers native percentage from Claude Code v2.1.6+, falls back to manual calculation.
  */
 export function getContextPercent(stdin: StatuslineStdin): number {
-  // Prefer native percentage (v2.1.6+) - accurate and matches /context
-  const nativePercent = stdin.context_window?.used_percentage;
-  if (typeof nativePercent === 'number' && !Number.isNaN(nativePercent)) {
-    return Math.min(100, Math.max(0, Math.round(nativePercent)));
+  const nativePercent = getRoundedNativeContextPercent(stdin);
+  if (nativePercent !== null) {
+    return nativePercent;
   }
 
-  // Fallback: manual calculation
-  const size = stdin.context_window?.context_window_size;
-  if (!size || size <= 0) {
-    return 0;
-  }
-
-  const totalTokens = getTotalTokens(stdin);
-  return Math.min(100, Math.round((totalTokens / size) * 100));
+  return getManualContextPercent(stdin) ?? 0;
 }
 
 /**


### PR DESCRIPTION
## Summary
- stabilize HUD ctx display when Claude temporarily omits `context_window.used_percentage`
- reuse the previous native percentage only for the same transcript stream and only when the fallback value is close enough to indicate a transient omission
- add focused HUD stdin regression tests for both jitter suppression and real-jump preservation

## Root cause
The HUD prefers Claude Code's native `used_percentage`, but when that field is briefly absent it falls back to recomputing the value from `current_usage`. Those two sources are not always numerically identical, so the HUD could visibly flap between adjacent values like `54%` and `52%` across refreshes.

## Verification
- `npx eslint src/hud/index.ts src/hud/stdin.ts src/__tests__/hud/stdin.test.ts`
- `npx vitest run src/__tests__/hud/stdin.test.ts src/__tests__/hud/watch-mode-init.test.ts src/__tests__/hud/render.test.ts`
- `npx tsc --noEmit`

Closes #1790.
