### PR TITLE
Fix duplicate worker tracking on repeated SubagentStart events

### DIFF
--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import {
   getAgentDashboard,
   getStaleAgents,
   getTrackingStats,
+  processSubagentStart,
   readTrackingState,
   writeTrackingState,
   recordToolUsageWithTiming,
@@ -22,6 +23,7 @@ import {
   type SubagentTrackingState,
   type ToolUsageEntry,
 } from "../index.js";
+import { readMissionBoardState } from "../../../hud/mission-board.js";
 
 describe("subagent-tracker", () => {
   let testDir: string;
@@ -567,6 +569,64 @@ describe("subagent-tracker", () => {
       expect(stats.completed).toBe(0);
       expect(stats.failed).toBe(0);
       expect(stats.total).toBe(0);
+    });
+  });
+
+  describe("processSubagentStart", () => {
+    it("dedupes repeated start events for the same running agent", () => {
+      const startInput = {
+        session_id: "session-123",
+        transcript_path: join(testDir, "transcript.jsonl"),
+        cwd: testDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "worker-3",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "Implement the dispatch changes",
+        model: "gpt-5.4-mini",
+      };
+
+      const first = processSubagentStart(startInput);
+      const second = processSubagentStart(startInput);
+
+      expect(first.hookSpecificOutput?.hookEventName).toBe("SubagentStart");
+      expect(first.hookSpecificOutput?.agent_count).toBe(1);
+      expect(second.hookSpecificOutput?.hookEventName).toBe("SubagentStart");
+      expect(second.hookSpecificOutput?.agent_count).toBe(1);
+
+      const pendingState = readTrackingState(testDir);
+      expect(pendingState.total_spawned).toBe(1);
+      expect(
+        pendingState.agents.filter((agent) => agent.agent_id === "worker-3"),
+      ).toHaveLength(1);
+      expect(
+        pendingState.agents.filter((agent) => agent.status === "running"),
+      ).toHaveLength(1);
+
+      const dashboard = getAgentDashboard(testDir);
+      expect(dashboard).toContain("Agent Dashboard (1 active)");
+      expect(dashboard.match(/\[worker-/g) ?? []).toHaveLength(1);
+      expect(dashboard).toContain("executor");
+      expect(dashboard).toContain("Implement the dispatch changes");
+
+      const missionBoard = readMissionBoardState(testDir);
+      const sessionMission = missionBoard?.missions.find((mission) =>
+        mission.id.startsWith("session:session-123:"),
+      );
+      expect(sessionMission?.agents).toHaveLength(1);
+      expect(sessionMission?.timeline).toHaveLength(1);
+      expect(sessionMission?.agents[0]?.ownership).toBe("worker-3");
+
+      flushPendingWrites();
+
+      const persistedState = readTrackingState(testDir);
+      expect(persistedState.total_spawned).toBe(1);
+      expect(
+        persistedState.agents.filter((agent) => agent.agent_id === "worker-3"),
+      ).toHaveLength(1);
+      expect(
+        persistedState.agents.filter((agent) => agent.status === "running"),
+      ).toHaveLength(1);
     });
   });
 

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -579,40 +579,65 @@ export function processSubagentStart(input: SubagentStartInput): HookOutput {
   try {
     const state = readTrackingState(input.cwd);
     const parentMode = detectParentMode(input.cwd);
+    const startedAt = new Date().toISOString();
+    const taskDescription = input.prompt?.substring(0, 200); // Truncate for storage
+    const existingAgent = state.agents.find((agent) => agent.agent_id === input.agent_id);
+    const isDuplicateRunningStart = existingAgent?.status === "running";
+    let trackedAgent: SubagentInfo;
 
-    // Create new agent entry
-    const agentInfo: SubagentInfo = {
-      agent_id: input.agent_id,
-      agent_type: input.agent_type,
-      started_at: new Date().toISOString(),
-      parent_mode: parentMode,
-      task_description: input.prompt?.substring(0, 200), // Truncate for storage
-      status: "running",
-      model: input.model,
-    };
+    if (existingAgent) {
+      existingAgent.agent_type = input.agent_type;
+      existingAgent.parent_mode = parentMode;
+      existingAgent.task_description = taskDescription;
+      existingAgent.model = input.model;
 
-    // Add to state
-    state.agents.push(agentInfo);
-    state.total_spawned++;
+      if (existingAgent.status !== "running") {
+        existingAgent.status = "running";
+        existingAgent.started_at = startedAt;
+        existingAgent.completed_at = undefined;
+        existingAgent.duration_ms = undefined;
+        existingAgent.output_summary = undefined;
+        state.total_spawned++;
+      }
+      trackedAgent = existingAgent;
+    } else {
+      // Create new agent entry
+      const agentInfo: SubagentInfo = {
+        agent_id: input.agent_id,
+        agent_type: input.agent_type,
+        started_at: startedAt,
+        parent_mode: parentMode,
+        task_description: taskDescription,
+        status: "running",
+        model: input.model,
+      };
+
+      // Add to state
+      state.agents.push(agentInfo);
+      state.total_spawned++;
+      trackedAgent = agentInfo;
+    }
 
     // Write updated state
     writeTrackingState(input.cwd, state);
 
-    // Record to session replay JSONL for /trace
-    try {
-      recordAgentStart(input.cwd, input.session_id, input.agent_id, input.agent_type, input.prompt, parentMode, input.model);
-    } catch { /* best-effort */ }
+    if (!isDuplicateRunningStart) {
+      // Record to session replay JSONL for /trace
+      try {
+        recordAgentStart(input.cwd, input.session_id, input.agent_id, input.agent_type, input.prompt, parentMode, input.model);
+      } catch { /* best-effort */ }
 
-    try {
-      recordMissionAgentStart(input.cwd, {
-        sessionId: input.session_id,
-        agentId: input.agent_id,
-        agentType: input.agent_type,
-        parentMode,
-        taskDescription: input.prompt,
-        at: agentInfo.started_at,
-      });
-    } catch { /* best-effort */ }
+      try {
+        recordMissionAgentStart(input.cwd, {
+          sessionId: input.session_id,
+          agentId: input.agent_id,
+          agentType: input.agent_type,
+          parentMode,
+          taskDescription: input.prompt,
+          at: trackedAgent.started_at,
+        });
+      } catch { /* best-effort */ }
+    }
 
     // Check for stale agents
     const staleAgents = getStaleAgents(state);


### PR DESCRIPTION
## Summary
- dedupe repeated `SubagentStart` events by `agent_id` in the subagent tracker
- avoid incrementing spawn counters or writing duplicate replay/mission-board start entries for an already-running agent
- add a focused regression test covering the live pending-state/dashboard path that surfaced duplicate `@worker-*` rows

## Root cause
Issue #1791 did not reproduce as a second tmux worker pane launch in the team runtime path. The actual duplication was in `processSubagentStart()`, which appended a new running tracker entry every time the same `agent_id` emitted another start event. Because HUD/dashboard reads prefer in-memory pending tracker state before flush/merge, the UI could show phantom duplicate workers even though later disk merge logic deduped by `agent_id`.

## Verification
- `npm test -- --run src/hooks/subagent-tracker/__tests__/index.test.ts`
- `npm test -- --run src/team/__tests__/runtime-v2.dispatch.test.ts`
- `npm test -- --run src/team/__tests__/runtime-prompt-mode.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/hooks/subagent-tracker/index.ts src/hooks/subagent-tracker/__tests__/index.test.ts`
