### PR TITLE
Fix keyword-triggered persistent modes enforcing before skill confirmation

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -174,6 +174,7 @@ function activateState(directory, prompt, stateName, sessionId) {
       session_id: sessionId || undefined,
       project_path: directory,
       linked_ultrawork: true,
+      awaiting_confirmation: true,
       last_checked_at: new Date().toISOString()
     };
   } else if (stateName === 'ralplan') {
@@ -183,6 +184,7 @@ function activateState(directory, prompt, stateName, sessionId) {
       started_at: new Date().toISOString(),
       session_id: sessionId || undefined,
       project_path: directory,
+      awaiting_confirmation: true,
       last_checked_at: new Date().toISOString()
     };
   } else {
@@ -194,6 +196,7 @@ function activateState(directory, prompt, stateName, sessionId) {
       session_id: sessionId || undefined,
       project_path: directory,
       reinforcement_count: 0,
+      awaiting_confirmation: true,
       last_checked_at: new Date().toISOString()
     };
   }

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -197,6 +197,10 @@ function getSafeReinforcementCount(value) {
     : 0;
 }
 
+function isAwaitingConfirmation(state) {
+  return state?.awaiting_confirmation === true;
+}
+
 // ---------------------------------------------------------------------------
 // Stop Breaker helpers (shared by team pipeline and ralplan)
 // ---------------------------------------------------------------------------
@@ -641,7 +645,7 @@ async function main() {
 
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions
-    if (ralph.state?.active && !isStaleState(ralph.state) && isSessionMatch(ralph.state, sessionId)) {
+    if (ralph.state?.active && !isAwaitingConfirmation(ralph.state) && !isStaleState(ralph.state) && isSessionMatch(ralph.state, sessionId)) {
       const iteration = ralph.state.iteration || 1;
       const maxIter = ralph.state.max_iterations || 100;
 
@@ -674,7 +678,7 @@ async function main() {
     }
 
     // Priority 2: Autopilot (high-level orchestration)
-    if (autopilot.state?.active && !isStaleState(autopilot.state) && isSessionMatch(autopilot.state, sessionId)) {
+    if (autopilot.state?.active && !isAwaitingConfirmation(autopilot.state) && !isStaleState(autopilot.state) && isSessionMatch(autopilot.state, sessionId)) {
       const phase = autopilot.state.phase || "unknown";
       if (phase !== "complete") {
         const newCount = (autopilot.state.reinforcement_count || 0) + 1;
@@ -765,7 +769,7 @@ async function main() {
     }
 
     // Priority 2.6: Ralplan (standalone consensus planning — first-class enforcement)
-    if (ralplan.state?.active && !isStaleState(ralplan.state) && isSessionMatch(ralplan.state, sessionId)) {
+    if (ralplan.state?.active && !isAwaitingConfirmation(ralplan.state) && !isStaleState(ralplan.state) && isSessionMatch(ralplan.state, sessionId)) {
       // Terminal phase detection
       const currentPhase = ralplan.state.current_phase;
       let ralplanTerminal = false;
@@ -950,7 +954,7 @@ async function main() {
     // Session isolation: only block if state belongs to this session (issue #311)
     // Project isolation: only block if state belongs to this project
     if (
-      ultrawork.state?.active &&
+      ultrawork.state?.active && !isAwaitingConfirmation(ultrawork.state) &&
       !isStaleState(ultrawork.state) &&
       isSessionMatch(ultrawork.state, sessionId) &&
       isStateForCurrentProject(ultrawork.state, directory, ultrawork.isGlobal)

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -193,6 +193,10 @@ function getSafeReinforcementCount(value) {
     : 0;
 }
 
+function isAwaitingConfirmation(state) {
+  return state?.awaiting_confirmation === true;
+}
+
 /**
  * Normalize a path for comparison.
  */
@@ -567,7 +571,7 @@ async function main() {
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions
     if (
-      ralph.state?.active &&
+      ralph.state?.active && !isAwaitingConfirmation(ralph.state) &&
       !isStaleState(ralph.state) &&
       isStateForCurrentProject(ralph.state, directory, ralph.isGlobal)
     ) {
@@ -618,7 +622,7 @@ async function main() {
 
     // Priority 2: Autopilot (high-level orchestration)
     if (
-      autopilot.state?.active &&
+      autopilot.state?.active && !isAwaitingConfirmation(autopilot.state) &&
       !isStaleState(autopilot.state) &&
       isStateForCurrentProject(autopilot.state, directory, autopilot.isGlobal)
     ) {
@@ -879,7 +883,7 @@ async function main() {
     // If state has session_id, it must match. If no session_id (legacy), allow.
     // Project isolation: only block if state belongs to this project
     if (
-      ultrawork.state?.active &&
+      ultrawork.state?.active && !isAwaitingConfirmation(ultrawork.state) &&
       !isStaleState(ultrawork.state) &&
       (hasValidSessionId
         ? ultrawork.state.session_id === sessionId

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -418,6 +418,50 @@ function writeSkillActiveState(directory, skillName, sessionId, rawSkillName) {
   }
 }
 
+
+function clearAwaitingConfirmationFlag(directory, stateName, sessionId) {
+  const stateDir = join(directory, '.omc', 'state');
+  const safeSessionId = sessionId && SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
+  const paths = [
+    safeSessionId ? join(stateDir, 'sessions', safeSessionId, `${stateName}-state.json`) : null,
+    join(stateDir, `${stateName}-state.json`),
+  ].filter(Boolean);
+
+  for (const statePath of paths) {
+    try {
+      if (!existsSync(statePath)) continue;
+      const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+      if (!state || typeof state !== 'object' || !state.awaiting_confirmation) continue;
+      delete state.awaiting_confirmation;
+      const tmpPath = statePath + '.tmp';
+      writeFileSync(tmpPath, JSON.stringify(state, null, 2), { mode: 0o600 });
+      renameSync(tmpPath, statePath);
+    } catch {
+      // Best-effort; don't fail the hook
+    }
+  }
+}
+
+function confirmSkillModeStates(directory, skillName, sessionId) {
+  switch (skillName) {
+    case 'ralph':
+      clearAwaitingConfirmationFlag(directory, 'ralph', sessionId);
+      clearAwaitingConfirmationFlag(directory, 'ultrawork', sessionId);
+      break;
+    case 'ultrawork':
+      clearAwaitingConfirmationFlag(directory, 'ultrawork', sessionId);
+      break;
+    case 'autopilot':
+      clearAwaitingConfirmationFlag(directory, 'autopilot', sessionId);
+      break;
+    case 'ralplan':
+      clearAwaitingConfirmationFlag(directory, 'ralplan', sessionId);
+      break;
+    default:
+      break;
+  }
+}
+
 // Record Skill/Task invocations to flow trace (best-effort)
 async function recordToolInvocation(data, directory) {
   try {
@@ -467,6 +511,7 @@ async function main() {
         const rawSkill = toolInput.skill || toolInput.skill_name || toolInput.skillName || toolInput.command || '';
         const rawSkillName = typeof rawSkill === 'string' && rawSkill.trim() ? rawSkill.trim() : undefined;
         writeSkillActiveState(directory, skillName, sid, rawSkillName);
+        confirmSkillModeStates(directory, skillName, sid);
       }
     }
 

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -380,6 +380,43 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
 
     expect(output.continue).toBe(true);
     expect(output.decision).toBeUndefined();
+  });
+
+
+  it('clears awaiting confirmation from session-scoped mode state when a skill is invoked', () => {
+    const sessionId = 'session-confirm';
+    const sessionStateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(sessionStateDir, { recursive: true });
+    writeJson(join(sessionStateDir, 'ralph-state.json'), {
+      active: true,
+      awaiting_confirmation: true,
+      session_id: sessionId,
+    });
+    writeJson(join(sessionStateDir, 'ultrawork-state.json'), {
+      active: true,
+      awaiting_confirmation: true,
+      session_id: sessionId,
+    });
+
+    const output = runPreToolEnforcer({
+      tool_name: 'Skill',
+      toolInput: {
+        skill: 'oh-my-claudecode:ralph',
+      },
+      cwd: tempDir,
+      session_id: sessionId,
+    });
+
+    expect(output.continue).toBe(true);
+    expect((output.hookSpecificOutput as Record<string, unknown>).additionalContext).toContain(
+      'The boulder never stops',
+    );
+    expect(
+      JSON.parse(readFileSync(join(sessionStateDir, 'ralph-state.json'), 'utf-8')).awaiting_confirmation,
+    ).toBeUndefined();
+    expect(
+      JSON.parse(readFileSync(join(sessionStateDir, 'ultrawork-state.json'), 'utf-8')).awaiting_confirmation,
+    ).toBeUndefined();
   });
 
   it('does not write skill-active-state for unknown custom skills', () => {

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -163,6 +163,51 @@ describe('processHook - Routing Matrix', () => {
       expect(result.continue).toBe(true);
     });
 
+
+    it('marks keyword-triggered ralph state as awaiting confirmation so stop enforcement stays inert', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-keyword-ralph-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'keyword-ralph-session';
+
+        const keywordResult = await processHook('keyword-detector', {
+          sessionId,
+          prompt:
+            'ralph fix the regression in src/hooks/bridge.ts after issue #1795 by tracing keyword-detector into persistent-mode, preserving session-scoped state behavior, verifying the confirmation gate, keeping linked ultrawork activation intact, adding a focused regression test for false-positive prose prompts, checking stop-hook enforcement only after real Skill invocation, and confirming the smallest safe fix without widening the mode activation surface or changing unrelated orchestration behavior in this worktree',
+          directory: tempDir,
+        });
+
+        expect(keywordResult.continue).toBe(true);
+        expect(keywordResult.message).toContain('[RALPH + ULTRAWORK MODE ACTIVATED]');
+
+        const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+        const ralphState = JSON.parse(readFileSync(join(sessionDir, 'ralph-state.json'), 'utf-8')) as {
+          awaiting_confirmation?: boolean;
+          active?: boolean;
+        };
+        const ultraworkState = JSON.parse(readFileSync(join(sessionDir, 'ultrawork-state.json'), 'utf-8')) as {
+          awaiting_confirmation?: boolean;
+          active?: boolean;
+        };
+
+        expect(ralphState.active).toBe(true);
+        expect(ralphState.awaiting_confirmation).toBe(true);
+        expect(ultraworkState.active).toBe(true);
+        expect(ultraworkState.awaiting_confirmation).toBe(true);
+
+        const stopResult = await processHook('persistent-mode', {
+          sessionId,
+          directory: tempDir,
+          stop_reason: 'end_turn',
+        } as HookInput);
+
+        expect(stopResult.continue).toBe(true);
+        expect(stopResult.message).toBeUndefined();
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('should activate ralph and linked ultrawork when Skill tool invokes ralph', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-ralph-'));
       try {
@@ -191,6 +236,63 @@ describe('processHook - Routing Matrix', () => {
         expect(ralphState.linked_ultrawork).toBe(true);
         expect(ultraworkState.active).toBe(true);
         expect(ultraworkState.linked_to_ralph).toBe(true);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+
+    it('clears awaiting confirmation when Skill tool actually invokes ralph', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-confirm-ralph-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'confirm-ralph-session';
+        const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+        mkdirSync(sessionDir, { recursive: true });
+        writeFileSync(
+          join(sessionDir, 'ralph-state.json'),
+          JSON.stringify({
+            active: true,
+            awaiting_confirmation: true,
+            iteration: 1,
+            max_iterations: 10,
+            session_id: sessionId,
+            started_at: new Date().toISOString(),
+            last_checked_at: new Date().toISOString(),
+            prompt: 'Test task',
+          }, null, 2),
+        );
+        writeFileSync(
+          join(sessionDir, 'ultrawork-state.json'),
+          JSON.stringify({
+            active: true,
+            awaiting_confirmation: true,
+            started_at: new Date().toISOString(),
+            original_prompt: 'Test task',
+            session_id: sessionId,
+            reinforcement_count: 0,
+            last_checked_at: new Date().toISOString(),
+          }, null, 2),
+        );
+
+        const result = await processHook('pre-tool-use', {
+          sessionId,
+          toolName: 'Skill',
+          toolInput: { skill: 'oh-my-claudecode:ralph' },
+          directory: tempDir,
+        });
+
+        expect(result.continue).toBe(true);
+
+        const ralphState = JSON.parse(readFileSync(join(sessionDir, 'ralph-state.json'), 'utf-8')) as {
+          awaiting_confirmation?: boolean;
+        };
+        const ultraworkState = JSON.parse(readFileSync(join(sessionDir, 'ultrawork-state.json'), 'utf-8')) as {
+          awaiting_confirmation?: boolean;
+        };
+
+        expect(ralphState.awaiting_confirmation).toBeUndefined();
+        expect(ultraworkState.awaiting_confirmation).toBeUndefined();
       } finally {
         rmSync(tempDir, { recursive: true, force: true });
       }

--- a/src/hooks/autopilot/enforcement.ts
+++ b/src/hooks/autopilot/enforcement.ts
@@ -149,6 +149,14 @@ export function detectAnySignal(sessionId: string): AutopilotSignal | null {
 // ENFORCEMENT
 // ============================================================================
 
+function isAwaitingConfirmation(state: unknown): boolean {
+  return Boolean(
+    state &&
+    typeof state === 'object' &&
+    (state as Record<string, unknown>).awaiting_confirmation === true
+  );
+}
+
 /**
  * Get the next phase after current phase
  */
@@ -186,6 +194,10 @@ export async function checkAutopilot(
 
   // Strict session isolation: only process state for matching session
   if (state.session_id !== sessionId) {
+    return null;
+  }
+
+  if (isAwaitingConfirmation(state)) {
     return null;
   }
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -126,6 +126,14 @@ const TEAM_STAGE_ALIASES: Record<string, string> = {
 const BACKGROUND_AGENT_ID_PATTERN = /agentId:\s*([a-zA-Z0-9_-]+)/;
 const TASK_OUTPUT_ID_PATTERN = /<task_id>([^<]+)<\/task_id>/i;
 const TASK_OUTPUT_STATUS_PATTERN = /<status>([^<]+)<\/status>/i;
+const SAFE_SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+const MODE_CONFIRMATION_SKILL_MAP: Record<string, string[]> = {
+  ralph: ["ralph", "ultrawork"],
+  ultrawork: ["ultrawork"],
+  autopilot: ["autopilot"],
+  ralplan: ["ralplan"],
+};
+
 
 function getExtraField(input: HookInput, key: string): unknown {
   return (input as Record<string, unknown>)[key];
@@ -168,6 +176,66 @@ function taskLaunchDidFail(toolOutput: unknown): boolean {
 
   const normalized = toolOutput.toLowerCase();
   return normalized.includes("error") || normalized.includes("failed");
+}
+
+function getModeStatePaths(directory: string, modeName: string, sessionId?: string): string[] {
+  const stateDir = join(getOmcRoot(directory), "state");
+  const safeSessionId = typeof sessionId === "string" && SAFE_SESSION_ID_PATTERN.test(sessionId)
+    ? sessionId
+    : undefined;
+
+  return [
+    safeSessionId ? join(stateDir, "sessions", safeSessionId, `${modeName}-state.json`) : null,
+    join(stateDir, `${modeName}-state.json`),
+  ].filter((statePath): statePath is string => Boolean(statePath));
+}
+
+function updateModeAwaitingConfirmation(
+  directory: string,
+  modeName: string,
+  sessionId: string | undefined,
+  awaitingConfirmation: boolean,
+): void {
+  for (const statePath of getModeStatePaths(directory, modeName, sessionId)) {
+    if (!existsSync(statePath)) {
+      continue;
+    }
+
+    try {
+      const state = JSON.parse(readFileSync(statePath, "utf-8")) as Record<string, unknown>;
+      if (!state || typeof state !== "object") {
+        continue;
+      }
+
+      if (awaitingConfirmation) {
+        state.awaiting_confirmation = true;
+      } else if (state.awaiting_confirmation === true) {
+        delete state.awaiting_confirmation;
+      } else {
+        continue;
+      }
+
+      writeFileSync(statePath, JSON.stringify(state, null, 2));
+    } catch {
+      // Best-effort state sync only.
+    }
+  }
+}
+
+function markModeAwaitingConfirmation(
+  directory: string,
+  sessionId: string | undefined,
+  ...modeNames: string[]
+): void {
+  for (const modeName of modeNames) {
+    updateModeAwaitingConfirmation(directory, modeName, sessionId, true);
+  }
+}
+
+function confirmSkillModeStates(directory: string, skillName: string, sessionId?: string): void {
+  for (const modeName of MODE_CONFIRMATION_SKILL_MAP[skillName] ?? []) {
+    updateModeAwaitingConfirmation(directory, modeName, sessionId, false);
+  }
 }
 
 interface TeamStagedState {
@@ -683,11 +751,14 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
 
         // Activate ralph state which also auto-activates ultrawork
         const hook = createRalphLoopHook(directory);
-        hook.startLoop(
+        const started = hook.startLoop(
           sessionId,
           cleanPrompt,
           criticMode ? { criticMode } : undefined,
         );
+        if (started) {
+          markModeAwaitingConfirmation(directory, sessionId, 'ralph', 'ultrawork');
+        }
 
         messages.push(RALPH_MESSAGE);
         break;
@@ -697,7 +768,10 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
         // Lazy-load ultrawork module
         const { activateUltrawork } = await import("./ultrawork/index.js");
         // Activate persistent ultrawork state
-        activateUltrawork(promptText, sessionId, directory);
+        const activated = activateUltrawork(promptText, sessionId, directory);
+        if (activated) {
+          markModeAwaitingConfirmation(directory, sessionId, 'ultrawork');
+        }
         messages.push(ULTRAWORK_MESSAGE);
         break;
       }
@@ -1418,8 +1492,9 @@ function processPreToolUse(input: HookInput): HookOutput {
       // the Stop hook in short-lived processes.
       try {
         writeSkillActiveState(directory, skillName, input.sessionId, rawSkillName);
+        confirmSkillModeStates(directory, skillName, input.sessionId);
       } catch {
-        // Skill-state write is best-effort; don't fail the hook on error.
+        // Skill-state/state-sync writes are best-effort; don't fail the hook on error.
       }
     }
   }

--- a/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
@@ -444,6 +444,22 @@ describe('ralplan standalone stop enforcement', () => {
     }
   });
 
+  it('ignores ralplan state that is still awaiting skill confirmation', async () => {
+    const sessionId = 'session-ralplan-awaiting-confirmation';
+    const tempDir = makeTempProject();
+
+    try {
+      writeRalplanState(tempDir, sessionId, { awaiting_confirmation: true });
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('none');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+
   it('respects session isolation', async () => {
     const sessionId = 'session-ralplan-iso-a';
     const tempDir = makeTempProject();

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -360,6 +360,14 @@ function isCriticalContextStop(stopContext?: StopContext): boolean {
   return estimateTranscriptContextPercent(transcriptPath) >= CRITICAL_CONTEXT_STOP_PERCENT;
 }
 
+function isAwaitingConfirmation(state: unknown): boolean {
+  return Boolean(
+    state &&
+    typeof state === 'object' &&
+    (state as Record<string, unknown>).awaiting_confirmation === true
+  );
+}
+
 /**
  * Check for architect approval in session transcript
  */
@@ -431,6 +439,10 @@ async function checkRalphLoop(
 
   // Strict session isolation: only process state for matching session
   if (state.session_id !== sessionId) {
+    return null;
+  }
+
+  if (isAwaitingConfirmation(state)) {
     return null;
   }
 
@@ -864,6 +876,10 @@ async function checkRalplan(
     return null;
   }
 
+  if (isAwaitingConfirmation(state)) {
+    return null;
+  }
+
   // Terminal phase detection — allow stop when ralplan has completed
   const currentPhase = (state as unknown as Record<string, unknown>).current_phase;
   if (typeof currentPhase === 'string') {
@@ -933,6 +949,10 @@ async function checkUltrawork(
 
   // Strict session isolation: only process state for matching session
   if (state.session_id !== sessionId) {
+    return null;
+  }
+
+  if (isAwaitingConfirmation(state)) {
     return null;
   }
 

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -123,6 +123,29 @@ describe("Stop Hook Blocking Contract", () => {
       rmSync(tempDir, { recursive: true, force: true });
     });
 
+
+    it("ignores ultrawork states that are still awaiting skill confirmation", async () => {
+      const sessionId = "ultrawork-awaiting-confirmation";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ultrawork-state.json"),
+        JSON.stringify({
+          active: true,
+          awaiting_confirmation: true,
+          started_at: new Date().toISOString(),
+          original_prompt: "Test task",
+          session_id: sessionId,
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString(),
+        })
+      );
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe("none");
+    });
+
     it("blocks stop for active ultrawork (shouldBlock: true -> continue: false)", async () => {
       const sessionId = "test-session-block";
       activateUltrawork("Fix the bug", sessionId, tempDir);
@@ -318,6 +341,30 @@ describe("Stop Hook Blocking Contract", () => {
       rmSync(tempDir, { recursive: true, force: true });
     });
 
+
+    it("returns continue: true when ralph is awaiting confirmation", () => {
+      const sessionId = "ralph-awaiting-confirmation-mjs";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          awaiting_confirmation: true,
+          iteration: 1,
+          max_iterations: 50,
+          session_id: sessionId,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          prompt: "Test task",
+        })
+      );
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+    });
+
     it("returns decision: block when ralph is active", () => {
       const sessionId = "ralph-mjs-test";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
@@ -433,6 +480,30 @@ describe("Stop Hook Blocking Contract", () => {
         user_requested: true,
       });
       expect(output.continue).toBe(true);
+    });
+
+
+    it("returns continue: true when ultrawork is awaiting confirmation in cjs script", () => {
+      const sessionId = "ultrawork-awaiting-confirmation-cjs";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ultrawork-state.json"),
+        JSON.stringify({
+          active: true,
+          awaiting_confirmation: true,
+          started_at: new Date().toISOString(),
+          original_prompt: "Test task",
+          session_id: sessionId,
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString(),
+          project_path: tempDir,
+        })
+      );
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
     });
 
     it("returns continue: true for authentication error stop", () => {

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'child_process';
-import { readFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { dirname, join } from 'path';
+import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { KEYWORD_DETECTOR_SCRIPT_NODE } from '../hooks.js';
 
@@ -87,6 +88,45 @@ describe('keyword-detector packaged artifacts', () => {
 
     expect(templateResult).toEqual({ continue: true, suppressOutput: true });
     expect(pluginResult).toEqual({ continue: true, suppressOutput: true });
+  });
+
+
+  it('marks packaged keyword-triggered states as awaiting confirmation', () => {
+    const templatePath = join(packageRoot, 'templates', 'hooks', 'keyword-detector.mjs');
+    const pluginPath = join(packageRoot, 'scripts', 'keyword-detector.mjs');
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'keyword-hook-awaiting-'));
+    const fakeHome = mkdtempSync(join(tmpdir(), 'keyword-hook-home-'));
+    try {
+      for (const [scriptPath, statePath] of [
+        [templatePath, join(tempDir, '.omc', 'state', 'ralph-state.json')],
+        [pluginPath, join(tempDir, '.omc', 'state', 'sessions', 'hook-session', 'ralph-state.json')],
+      ] as const) {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        execFileSync('node', [scriptPath], {
+          cwd: packageRoot,
+          env: { ...process.env, HOME: fakeHome },
+          input: JSON.stringify({
+            prompt: 'ralph fix the regression in src/hooks/bridge.ts after issue #1795',
+            directory: tempDir,
+            cwd: tempDir,
+            session_id: 'hook-session',
+          }),
+          encoding: 'utf-8',
+        });
+
+        const state = JSON.parse(readFileSync(statePath, 'utf-8')) as {
+          awaiting_confirmation?: boolean;
+        };
+        expect(state.awaiting_confirmation).toBe(true);
+
+        rmSync(join(tempDir, '.omc'), { recursive: true, force: true });
+        rmSync(join(fakeHome, '.omc'), { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 
   it('does not auto-trigger informational keyword questions in packaged artifacts', () => {

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -184,6 +184,7 @@ function activateState(directory, prompt, stateName, sessionId) {
     original_prompt: prompt,
     session_id: sessionId || undefined,
     reinforcement_count: 0,
+    awaiting_confirmation: true,
     last_checked_at: new Date().toISOString()
   };
 

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -193,6 +193,10 @@ function getSafeReinforcementCount(value) {
     : 0;
 }
 
+function isAwaitingConfirmation(state) {
+  return state?.awaiting_confirmation === true;
+}
+
 /**
  * Check if a skill active state is stale based on its per-skill TTL.
  * Unlike mode states (which use the global 2-hour threshold), skill states
@@ -640,7 +644,7 @@ async function main() {
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions
     if (
-      ralph.state?.active &&
+      ralph.state?.active && !isAwaitingConfirmation(ralph.state) &&
       !isStaleState(ralph.state) &&
       isStateForCurrentProject(ralph.state, directory, ralph.isGlobal)
     ) {
@@ -693,7 +697,7 @@ async function main() {
 
     // Priority 2: Autopilot (high-level orchestration)
     if (
-      autopilot.state?.active &&
+      autopilot.state?.active && !isAwaitingConfirmation(autopilot.state) &&
       !isStaleState(autopilot.state) &&
       isStateForCurrentProject(autopilot.state, directory, autopilot.isGlobal)
     ) {
@@ -927,7 +931,7 @@ async function main() {
     // Session isolation: only block if state belongs to this session (issue #311)
     // If state has session_id, it must match. If no session_id (legacy), allow.
     if (
-      ultrawork.state?.active &&
+      ultrawork.state?.active && !isAwaitingConfirmation(ultrawork.state) &&
       !isStaleState(ultrawork.state) &&
       (hasValidSessionId
         ? ultrawork.state.session_id === sessionId

--- a/templates/hooks/pre-tool-use.mjs
+++ b/templates/hooks/pre-tool-use.mjs
@@ -7,8 +7,9 @@
 
 import * as path from 'path';
 import { dirname } from 'path';
-import { existsSync, mkdirSync, writeFileSync, renameSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, renameSync, readFileSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { homedir } from 'os';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -108,6 +109,51 @@ function writeSkillActiveState(directory, skillName, sessionId) {
     renameSync(tmpPath, targetPath);
   } catch {
     // Best-effort; don't fail the hook
+  }
+}
+
+
+function clearAwaitingConfirmationFlag(directory, stateName, sessionId) {
+  const stateDir = path.join(directory, '.omc', 'state');
+  const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  const paths = [
+    safeSessionId ? path.join(stateDir, 'sessions', safeSessionId, `${stateName}-state.json`) : null,
+    path.join(stateDir, `${stateName}-state.json`),
+    path.join(homedir(), '.omc', 'state', `${stateName}-state.json`),
+  ].filter(Boolean);
+
+  for (const statePath of paths) {
+    try {
+      if (!existsSync(statePath)) continue;
+      const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+      if (!state || typeof state !== 'object' || !state.awaiting_confirmation) continue;
+      delete state.awaiting_confirmation;
+      const tmpPath = statePath + '.tmp';
+      writeFileSync(tmpPath, JSON.stringify(state, null, 2), { mode: 0o600 });
+      renameSync(tmpPath, statePath);
+    } catch {
+      // Best-effort; don't fail the hook
+    }
+  }
+}
+
+function confirmSkillModeStates(directory, skillName, sessionId) {
+  switch (skillName) {
+    case 'ralph':
+      clearAwaitingConfirmationFlag(directory, 'ralph', sessionId);
+      clearAwaitingConfirmationFlag(directory, 'ultrawork', sessionId);
+      break;
+    case 'ultrawork':
+      clearAwaitingConfirmationFlag(directory, 'ultrawork', sessionId);
+      break;
+    case 'autopilot':
+      clearAwaitingConfirmationFlag(directory, 'autopilot', sessionId);
+      break;
+    case 'ralplan':
+      clearAwaitingConfirmationFlag(directory, 'ralplan', sessionId);
+      break;
+    default:
+      break;
   }
 }
 


### PR DESCRIPTION
## Summary
- add an `awaiting_confirmation` gate to keyword-created persistent mode state
- keep persistent-mode enforcement inert until a real matching Skill invocation clears that gate
- add regression coverage for bridge, persistent-mode, pre-tool state confirmation, and packaged hook parity

## Root cause
`keyword-detector` was creating active mode state before the model actually invoked the matching skill. `persistent-mode` then treated that state as enforceable, so prose mentions like `ralph`/`ultrawork` could keep the stop hook alive even when Claude never executed the skill.

## Fix
- mark keyword-triggered state as `awaiting_confirmation: true`
- skip stop-hook enforcement while that flag is present
- clear the flag at Skill-tool entry for the matching mode(s), making the state enforceable only after explicit invocation

## Testing
- `npx vitest run src/hooks/__tests__/bridge-routing.test.ts src/hooks/persistent-mode/stop-hook-blocking.test.ts src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts src/__tests__/pre-tool-enforcer.test.ts src/installer/__tests__/hook-templates.test.ts`
- `npx eslint src/hooks/bridge.ts src/hooks/persistent-mode/index.ts src/hooks/autopilot/enforcement.ts src/hooks/__tests__/bridge-routing.test.ts src/hooks/persistent-mode/stop-hook-blocking.test.ts src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts src/__tests__/pre-tool-enforcer.test.ts src/installer/__tests__/hook-templates.test.ts`
- `npx tsc --noEmit`

Closes #1795.
