### PR TITLE
fix(state): clear session-scoped mode files during broad cleanup (#1797)

### DIFF
--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -155,6 +155,51 @@ describe("Stop Hook Blocking Contract", () => {
       expect(output.continue).toBe(true);
     });
 
+    it("allows stop after broad clear removes leftover session-scoped state", async () => {
+      const sessionA = "test-broad-clear-a";
+      const sessionB = "test-broad-clear-b";
+      const stateDir = join(tempDir, '.omc', 'state');
+      const sessionADir = join(stateDir, 'sessions', sessionA);
+      const sessionBDir = join(stateDir, 'sessions', sessionB);
+      mkdirSync(sessionADir, { recursive: true });
+      mkdirSync(sessionBDir, { recursive: true });
+      writeFileSync(
+        join(sessionADir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          iteration: 1,
+          max_iterations: 10,
+          session_id: sessionA,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+        }),
+      );
+      writeFileSync(
+        join(sessionBDir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          iteration: 1,
+          max_iterations: 10,
+          session_id: sessionB,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+        }),
+      );
+
+      const { clearModeStateFile } = await import('../../lib/mode-state-io.js');
+      expect(clearModeStateFile('ralph', tempDir)).toBe(true);
+
+      const resultA = await checkPersistentModes(sessionA, tempDir);
+      const outputA = createHookOutput(resultA);
+      expect(outputA.continue).toBe(true);
+      expect(resultA.shouldBlock).toBe(false);
+
+      const resultB = await checkPersistentModes(sessionB, tempDir);
+      const outputB = createHookOutput(resultB);
+      expect(outputB.continue).toBe(true);
+      expect(resultB.shouldBlock).toBe(false);
+    });
+
     it("allows stop for context limit even with active mode", async () => {
       const sessionId = "test-context-limit";
       activateUltrawork("Important task", sessionId, tempDir);

--- a/src/lib/__tests__/mode-state-io.test.ts
+++ b/src/lib/__tests__/mode-state-io.test.ts
@@ -290,6 +290,21 @@ describe('mode-state-io', () => {
       expect(existsSync(legacyPath)).toBe(false);
     });
 
+    it('should remove all session-scoped files when no session_id is provided', () => {
+      const sessionAPath = join(tempDir, '.omc', 'state', 'sessions', 'session-a', 'ralph-state.json');
+      const sessionBPath = join(tempDir, '.omc', 'state', 'sessions', 'session-b', 'ralph-state.json');
+      mkdirSync(join(tempDir, '.omc', 'state', 'sessions', 'session-a'), { recursive: true });
+      mkdirSync(join(tempDir, '.omc', 'state', 'sessions', 'session-b'), { recursive: true });
+      writeFileSync(sessionAPath, JSON.stringify({ active: true, session_id: 'session-a' }));
+      writeFileSync(sessionBPath, JSON.stringify({ active: true, session_id: 'session-b' }));
+
+      const result = clearModeStateFile('ralph', tempDir);
+
+      expect(result).toBe(true);
+      expect(existsSync(sessionAPath)).toBe(false);
+      expect(existsSync(sessionBPath)).toBe(false);
+    });
+
     it('should return true when file does not exist (already absent)', () => {
       const result = clearModeStateFile('ralph', tempDir);
       expect(result).toBe(true);

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -14,6 +14,7 @@ import {
   resolveSessionStatePath,
   ensureSessionStateDir,
   ensureOmcDir,
+  listSessionIds,
 } from './worktree-paths.js';
 
 export function getStateSessionOwner(state: Record<string, unknown> | null | undefined): string | undefined {
@@ -157,13 +158,27 @@ export function clearModeStateFile(
   sessionId?: string,
 ): boolean {
   let success = true;
-  const filePath = resolveFile(mode, directory, sessionId);
+  const unlinkIfPresent = (filePath: string): void => {
+    if (!existsSync(filePath)) {
+      return;
+    }
 
-  if (existsSync(filePath)) {
     try {
       unlinkSync(filePath);
     } catch {
       success = false;
+    }
+  };
+
+  if (sessionId) {
+    unlinkIfPresent(resolveFile(mode, directory, sessionId));
+  } else {
+    for (const legacyPath of getLegacyStateCandidates(mode, directory)) {
+      unlinkIfPresent(legacyPath);
+    }
+
+    for (const sid of listSessionIds(directory)) {
+      unlinkIfPresent(resolveSessionStatePath(mode, sid, directory));
     }
   }
 


### PR DESCRIPTION
## Summary
- make the shared mode-state clear helper remove session-scoped files when cleanup runs without a session id
- add regression coverage for broad helper cleanup and the stop-hook path that used to see leftover active state
- preserve existing session-owned ghost-legacy cleanup behavior for session-scoped clears

## Root cause
The persistent-mode stop hook reads session-scoped mode files first. The shared `clearModeStateFile(mode, directory)` helper only removed the legacy file when `sessionId` was omitted, so broad cleanup callers could leave `.omc/state/sessions/{sessionId}/{mode}-state.json` behind. That let the stop hook keep seeing `active: true` and re-fire continuation guidance.

## Testing
- `npm test -- --run src/lib/__tests__/mode-state-io.test.ts src/tools/__tests__/state-tools.test.ts src/hooks/persistent-mode/session-isolation.test.ts src/hooks/persistent-mode/stop-hook-blocking.test.ts src/__tests__/smoke-slack-and-state.test.ts`

Closes #1797
