### PR TITLE
follow-up: align visual-verdict with OMC-native discovery on dev

### DIFF
--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -105,7 +105,7 @@ ls -la ~/.claude/skills/ 2>/dev/null
 `architect.md`, `document-specialist.md`, `explore.md`, `executor.md`, `debugger.md`, `planner.md`, `analyst.md`, `critic.md`, `verifier.md`, `test-engineer.md`, `designer.md`, `writer.md`, `qa-tester.md`, `scientist.md`, `security-reviewer.md`, `code-reviewer.md`, `git-master.md`, `code-simplifier.md`
 
 **Known plugin skill names** (check skills/ for these):
-`ai-slop-cleaner`, `ask`, `autopilot`, `cancel`, `ccg`, `configure-notifications`, `deep-interview`, `deepinit`, `external-context`, `hud`, `learner`, `mcp-setup`, `omc-doctor`, `omc-setup`, `omc-teams`, `plan`, `project-session-manager`, `ralph`, `ralplan`, `release`, `sciomc`, `setup`, `skill`, `team`, `ultraqa`, `ultrawork`, `writer-memory`
+`ai-slop-cleaner`, `ask`, `autopilot`, `cancel`, `ccg`, `configure-notifications`, `deep-interview`, `deepinit`, `external-context`, `hud`, `learner`, `mcp-setup`, `omc-doctor`, `omc-setup`, `omc-teams`, `plan`, `project-session-manager`, `ralph`, `ralplan`, `release`, `sciomc`, `setup`, `skill`, `team`, `ultraqa`, `ultrawork`, `visual-verdict`, `writer-memory`
 
 **Known plugin command names** (check commands/ for these):
 `ultrawork.md`, `deepsearch.md`

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -13,15 +13,22 @@ Meta-skill for managing oh-my-claudecode skills via CLI-like commands.
 
 ### /skill list
 
-Show all local skills organized by scope.
+Show all available skills organized by scope.
 
 **Behavior:**
-1. Scan user skills at `~/.claude/skills/omc-learned/`
-2. Scan project skills at `.omc/skills/`
-3. Parse YAML frontmatter for metadata
-4. Display in organized table format:
+1. Scan bundled built-in skills in the plugin `skills/` directory (read-only)
+2. Scan user skills at `~/.claude/skills/omc-learned/`
+3. Scan project skills at `.omc/skills/`
+4. Parse YAML frontmatter for metadata
+5. Display in organized table format:
 
 ```
+BUILT-IN SKILLS (bundled with oh-my-claudecode):
+| Name              | Description                    | Scope    |
+|-------------------|--------------------------------|----------|
+| visual-verdict    | Structured visual QA verdicts  | built-in |
+| ralph             | Persistence loop               | built-in |
+
 USER SKILLS (~/.claude/skills/omc-learned/):
 | Name              | Triggers           | Quality | Usage | Scope |
 |-------------------|--------------------|---------|-------|-------|
@@ -35,6 +42,8 @@ PROJECT SKILLS (.omc/skills/):
 ```
 
 **Fallback:** If quality/usage stats not available, show "N/A"
+
+**Built-in skill note:** Built-in skills are bundled with oh-my-claudecode and are discoverable/readable, but not removed or edited through `/skill remove` or `/skill edit`.
 
 ---
 

--- a/skills/visual-verdict/SKILL.md
+++ b/skills/visual-verdict/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: visual-verdict
 description: Structured visual QA verdict for screenshot-to-reference comparisons
+level: 2
 ---
 
 <Purpose>
@@ -43,10 +44,8 @@ Rules:
 
 <Threshold_And_Loop>
 - Target pass threshold is **90+**.
-- If `score < 90`, continue editing and rerun `$visual-verdict` before any further code edits in the next iteration.
-- Persist the verdict in `.omx/state/{scope}/ralph-progress.json` with both:
-  - numeric signal (`score`, threshold pass/fail)
-  - qualitative signal (`reasoning`, `suggestions`, `next_actions`)
+- If `score < 90`, continue editing and rerun `/oh-my-claudecode:visual-verdict` before any further visual review pass.
+- Do **not** treat the visual task as complete until the next screenshot clears the threshold.
 </Threshold_And_Loop>
 
 <Debug_Visualization>
@@ -74,3 +73,5 @@ When mismatch diagnosis is hard:
 }
 ```
 </Example>
+
+Task: {{ARGUMENTS}}

--- a/src/__tests__/visual-verdict-skill.test.ts
+++ b/src/__tests__/visual-verdict-skill.test.ts
@@ -24,4 +24,10 @@ describe('visual-verdict skill contract', () => {
     expect(visualVerdictSkill).toMatch(/pixel diff/i);
     expect(visualVerdictSkill).toMatch(/pixelmatch/i);
   });
+
+  it('uses OMC-native invocation guidance instead of OMX state-path wording', () => {
+    expect(visualVerdictSkill).toContain('/oh-my-claudecode:visual-verdict');
+    expect(visualVerdictSkill).not.toMatch(/\.omx\//i);
+    expect(visualVerdictSkill).toContain('Task: {{ARGUMENTS}}');
+  });
 });


### PR DESCRIPTION
## Summary
- retarget this work to `dev` and keep only the net-new follow-up diff on top of the existing visual-verdict MVP already merged there via #1765
- make `/skill list` explicitly surface bundled built-in skills so `visual-verdict` is discoverable from OMC's own skill-management surface
- remove lingering OMX-specific `.omx/...` guidance from the bundled `visual-verdict` skill contract, add OMC-native invocation wording, and teach `omc-doctor` that `visual-verdict` is now a known bundled plugin skill
- lock the OMC-native wording with a focused regression test in `src/__tests__/visual-verdict-skill.test.ts`

## Why this changed after the first upload
The first version of this PR was opened against `main`.

After reviewing the branch policy comments on #1801, I re-checked the repository state and found two important facts:
1. this repo requires PRs to target `dev`, and
2. `dev` already contains the initial visual-verdict MVP from #1765.

Because of that, simply retargeting the original `main`-based branch would have mixed older branch drift with the real follow-up diff. I rebuilt the branch on top of `origin/dev` and kept only the improvements that are still genuinely new relative to the current `dev` branch.

## What this PR now does on top of `dev`
### 1. `/skill` discoverability now includes bundled skills
The existing MVP added the bundled `visual-verdict` skill itself, but `/skill list` still described only user/project-local skills.

This follow-up updates `skills/skill/SKILL.md` so the OMC skill-management surface explicitly shows bundled built-in skills as a read-only section. That makes `visual-verdict` discoverable from the exact surface called out in issue #1763, without pretending built-in skills are editable/removable local skills.

### 2. The bundled skill contract is now OMC-native
The current `dev` copy of `skills/visual-verdict/SKILL.md` still carried OMX-oriented wording:
- it referred to rerunning `$visual-verdict`
- it referenced `.omx/state/{scope}/ralph-progress.json`

That wording is misleading in OMC, because this repo does not currently expose the same OMX visual-loop persistence surface.

This follow-up keeps the bundled skill but rewrites the guidance to OMC-native terms:
- rerun `/oh-my-claudecode:visual-verdict`
- remove the `.omx/...` persistence instruction
- keep the threshold guidance focused on the user-facing visual review loop only
- add the standard `Task: {{ARGUMENTS}}` placeholder expected by bundled skill prompts

### 3. `omc-doctor` now recognizes the bundled skill
`skills/omc-doctor/SKILL.md` maintains the known bundled skill inventory used for legacy-skill diagnostics. This PR adds `visual-verdict` there so the doctor guidance stays aligned with the actual bundled skill set.

### 4. Regression coverage for the OMC-native wording
I added a focused assertion in `src/__tests__/visual-verdict-skill.test.ts` to verify that the bundled skill:
- references `/oh-my-claudecode:visual-verdict`
- does **not** mention `.omx/`
- includes the expected `Task: {{ARGUMENTS}}` placeholder

## What this PR intentionally does **not** do
This is still **not** a full visual runtime parity port.

It does **not** introduce:
- OMX `src/visual/*` runtime helpers
- OMX-specific visual verdict persistence
- new OMC hook/state machinery for visual-loop ledgers

That remains separate scope from this follow-up. This PR is only about making the already-merged skill MVP read correctly and show up correctly in OMC's own built-in skill surfaces.

## Verification
### Targeted tests
- `npm test -- --run src/__tests__/skills.test.ts src/__tests__/visual-verdict-skill.test.ts src/__tests__/tier0-docs-consistency.test.ts`

### Typecheck
- `npx tsc --noEmit`

## Scope notes
- base branch corrected from `main` to `dev`
- branch rebuilt on top of current `origin/dev`
- diff narrowed to the real follow-up changes only

Related: #1763
Related: #1765
