### PR TITLE
Fix MCP registry sync target for Claude root config

### DIFF
--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -51,12 +51,14 @@ describe('doctor-conflicts: hook ownership classification', () => {
     mkdirSync(TEST_CLAUDE_DIR, { recursive: true });
     mkdirSync(TEST_PROJECT_CLAUDE_DIR, { recursive: true });
     process.env.CLAUDE_CONFIG_DIR = TEST_CLAUDE_DIR;
+    process.env.CLAUDE_MCP_CONFIG_PATH = join(TEST_CLAUDE_DIR, '..', '.claude.json');
     cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(TEST_PROJECT_DIR);
   });
 
   afterEach(() => {
     cwdSpy.mockRestore();
     delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.CLAUDE_MCP_CONFIG_PATH;
     delete process.env.OMC_HOME;
     delete process.env.CODEX_HOME;
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
@@ -190,7 +192,7 @@ describe('doctor-conflicts: hook ownership classification', () => {
     writeFileSync(join(registryDir, 'mcp-registry.json'), JSON.stringify({
       gitnexus: { command: 'gitnexus', args: ['mcp'] },
     }));
-    writeFileSync(join(TEST_CLAUDE_DIR, 'settings.json'), JSON.stringify({
+    writeFileSync(process.env.CLAUDE_MCP_CONFIG_PATH!, JSON.stringify({
       mcpServers: {
         gitnexus: { command: 'gitnexus', args: ['mcp'] },
       },
@@ -220,7 +222,7 @@ describe('doctor-conflicts: hook ownership classification', () => {
     writeFileSync(join(registryDir, 'mcp-registry.json'), JSON.stringify({
       gitnexus: { command: 'gitnexus', args: ['mcp'] },
     }));
-    writeFileSync(join(TEST_CLAUDE_DIR, 'settings.json'), JSON.stringify({
+    writeFileSync(process.env.CLAUDE_MCP_CONFIG_PATH!, JSON.stringify({
       mcpServers: {
         gitnexus: { command: 'gitnexus', args: ['mcp'] },
       },
@@ -361,12 +363,14 @@ describe('doctor-conflicts: CLAUDE.md companion file detection (issue #1101)', (
     mkdirSync(TEST_CLAUDE_DIR, { recursive: true });
     mkdirSync(TEST_PROJECT_CLAUDE_DIR, { recursive: true });
     process.env.CLAUDE_CONFIG_DIR = TEST_CLAUDE_DIR;
+    process.env.CLAUDE_MCP_CONFIG_PATH = join(TEST_CLAUDE_DIR, '..', '.claude.json');
     cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(TEST_PROJECT_DIR);
   });
 
   afterEach(() => {
     cwdSpy.mockRestore();
     delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.CLAUDE_MCP_CONFIG_PATH;
     delete process.env.OMC_HOME;
     delete process.env.CODEX_HOME;
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
@@ -523,6 +527,7 @@ describe('doctor-conflicts: config known fields (issue #1499)', () => {
     mkdirSync(join(TEST_PROJECT_DIR, '.omc'), { recursive: true });
     mkdirSync(join(TEST_PROJECT_DIR, '.codex'), { recursive: true });
     process.env.CLAUDE_CONFIG_DIR = TEST_CLAUDE_DIR;
+    process.env.CLAUDE_MCP_CONFIG_PATH = join(TEST_CLAUDE_DIR, '..', '.claude.json');
     process.env.OMC_HOME = join(TEST_PROJECT_DIR, '.omc');
     process.env.CODEX_HOME = join(TEST_PROJECT_DIR, '.codex');
     cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(TEST_PROJECT_DIR);
@@ -531,6 +536,7 @@ describe('doctor-conflicts: config known fields (issue #1499)', () => {
   afterEach(() => {
     cwdSpy.mockRestore();
     delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.CLAUDE_MCP_CONFIG_PATH;
     delete process.env.OMC_HOME;
     delete process.env.CODEX_HOME;
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {

--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -456,14 +456,15 @@ export function formatReport(report: ConflictReport, json: boolean): string {
   } else {
     lines.push(`  ${colors.green('✓')} Registry servers: ${report.mcpRegistrySync.serverNames.join(', ')}`);
     lines.push(`    ${colors.gray(`Registry: ${report.mcpRegistrySync.registryPath}`)}`);
+    lines.push(`    ${colors.gray(`Claude MCP: ${report.mcpRegistrySync.claudeConfigPath}`)}`);
     lines.push(`    ${colors.gray(`Codex: ${report.mcpRegistrySync.codexConfigPath}`)}`);
 
     if (report.mcpRegistrySync.claudeMissing.length > 0) {
-      lines.push(`  ${colors.yellow('⚠')} Missing from Claude settings.json: ${report.mcpRegistrySync.claudeMissing.join(', ')}`);
+      lines.push(`  ${colors.yellow('⚠')} Missing from Claude MCP config: ${report.mcpRegistrySync.claudeMissing.join(', ')}`);
     } else if (report.mcpRegistrySync.claudeMismatched.length > 0) {
-      lines.push(`  ${colors.yellow('⚠')} Mismatched in Claude settings.json: ${report.mcpRegistrySync.claudeMismatched.join(', ')}`);
+      lines.push(`  ${colors.yellow('⚠')} Mismatched in Claude MCP config: ${report.mcpRegistrySync.claudeMismatched.join(', ')}`);
     } else {
-      lines.push(`  ${colors.green('✓')} Claude settings.json is in sync`);
+      lines.push(`  ${colors.green('✓')} Claude MCP config is in sync`);
     }
 
     if (report.mcpRegistrySync.codexMissing.length > 0) {

--- a/src/installer/__tests__/mcp-registry.test.ts
+++ b/src/installer/__tests__/mcp-registry.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 
 import {
   applyRegistryToClaudeSettings,
+  getClaudeMcpConfigPath,
   getUnifiedMcpRegistryPath,
   getCodexConfigPath,
   inspectUnifiedMcpRegistrySync,
@@ -28,12 +29,14 @@ describe('unified MCP registry sync', () => {
     mkdirSync(codexDir, { recursive: true });
     mkdirSync(omcDir, { recursive: true });
     process.env.CLAUDE_CONFIG_DIR = claudeDir;
+    process.env.CLAUDE_MCP_CONFIG_PATH = join(testRoot, '.claude.json');
     process.env.CODEX_HOME = codexDir;
     process.env.OMC_HOME = omcDir;
   });
 
   afterEach(() => {
     delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.CLAUDE_MCP_CONFIG_PATH;
     delete process.env.CODEX_HOME;
     delete process.env.OMC_HOME;
 
@@ -42,7 +45,7 @@ describe('unified MCP registry sync', () => {
     }
   });
 
-  it('bootstraps the registry from Claude settings and syncs Codex config.toml from the same snapshot', () => {
+  it('bootstraps the registry from legacy Claude settings, migrates to .claude.json, and syncs Codex config.toml', () => {
     const settings = {
       theme: 'dark',
       mcpServers: {
@@ -59,10 +62,13 @@ describe('unified MCP registry sync', () => {
     expect(result.bootstrappedFromClaude).toBe(true);
     expect(result.registryExists).toBe(true);
     expect(result.serverNames).toEqual(['gitnexus']);
-    expect(syncedSettings).toEqual(settings);
+    expect(syncedSettings).toEqual({ theme: 'dark' });
 
     const registryPath = getUnifiedMcpRegistryPath();
     expect(JSON.parse(readFileSync(registryPath, 'utf-8'))).toEqual(settings.mcpServers);
+    expect(JSON.parse(readFileSync(getClaudeMcpConfigPath(), 'utf-8'))).toEqual({
+      mcpServers: settings.mcpServers,
+    });
 
     const codexConfig = readFileSync(getCodexConfigPath(), 'utf-8');
     expect(codexConfig).toContain('# BEGIN OMC MANAGED MCP REGISTRY');
@@ -86,10 +92,13 @@ describe('unified MCP registry sync', () => {
 
     expect(result.bootstrappedFromClaude).toBe(true);
     expect(result.serverNames).toEqual(['remoteOmc']);
-    expect(syncedSettings).toEqual(settings);
+    expect(syncedSettings).toEqual({});
 
     const registryPath = getUnifiedMcpRegistryPath();
     expect(JSON.parse(readFileSync(registryPath, 'utf-8'))).toEqual(settings.mcpServers);
+    expect(JSON.parse(readFileSync(getClaudeMcpConfigPath(), 'utf-8'))).toEqual({
+      mcpServers: settings.mcpServers,
+    });
 
     const codexConfig = readFileSync(getCodexConfigPath(), 'utf-8');
     expect(codexConfig).toContain('[mcp_servers.remoteOmc]');
@@ -97,7 +106,7 @@ describe('unified MCP registry sync', () => {
     expect(codexConfig).toContain('startup_timeout_sec = 30');
   });
 
-  it('preserves unrelated Claude settings while replacing registry-defined MCP entries', () => {
+  it('removes legacy mcpServers from settings.json while preserving unrelated Claude settings', () => {
     const existingSettings = {
       theme: 'dark',
       statusLine: {
@@ -109,26 +118,15 @@ describe('unified MCP registry sync', () => {
           command: 'old-gitnexus',
           args: ['legacy'],
         },
-        customLocal: {
-          command: 'custom-local',
-          args: ['serve'],
-        },
       },
     };
 
-    const registry = {
-      gitnexus: {
-        command: 'gitnexus',
-        args: ['mcp'],
-      },
-    };
-
-    const { settings, changed } = applyRegistryToClaudeSettings(existingSettings, registry, ['gitnexus']);
+    const { settings, changed } = applyRegistryToClaudeSettings(existingSettings);
     expect(changed).toBe(true);
-    expect(settings.theme).toBe('dark');
-    expect(settings.statusLine).toEqual(existingSettings.statusLine);
-    expect((settings.mcpServers as Record<string, unknown>).customLocal).toEqual(existingSettings.mcpServers.customLocal);
-    expect((settings.mcpServers as Record<string, unknown>).gitnexus).toEqual(registry.gitnexus);
+    expect(settings).toEqual({
+      theme: 'dark',
+      statusLine: existingSettings.statusLine,
+    });
   });
 
   it('keeps unrelated Codex TOML and is idempotent across repeated syncs', () => {
@@ -170,6 +168,12 @@ describe('unified MCP registry sync', () => {
   it('removes previously managed Claude and Codex MCP entries when the registry becomes empty', () => {
     writeFileSync(join(omcDir, 'mcp-registry-state.json'), JSON.stringify({ managedServers: ['gitnexus'] }, null, 2));
     writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({}, null, 2));
+    writeFileSync(getClaudeMcpConfigPath(), JSON.stringify({
+      mcpServers: {
+        gitnexus: { command: 'gitnexus', args: ['mcp'] },
+        customLocal: { command: 'custom-local', args: ['serve'] },
+      },
+    }, null, 2));
     writeFileSync(getCodexConfigPath(), [
       'model = "gpt-5"',
       '',
@@ -184,9 +188,9 @@ describe('unified MCP registry sync', () => {
     ].join('\n'));
 
     const settings = {
+      theme: 'dark',
       mcpServers: {
         gitnexus: { command: 'gitnexus', args: ['mcp'] },
-        customLocal: { command: 'custom-local', args: ['serve'] },
       },
     };
 
@@ -196,7 +200,8 @@ describe('unified MCP registry sync', () => {
     expect(result.serverNames).toEqual([]);
     expect(result.claudeChanged).toBe(true);
     expect(result.codexChanged).toBe(true);
-    expect(syncedSettings).toEqual({
+    expect(syncedSettings).toEqual({ theme: 'dark' });
+    expect(JSON.parse(readFileSync(getClaudeMcpConfigPath(), 'utf-8'))).toEqual({
       mcpServers: {
         customLocal: { command: 'custom-local', args: ['serve'] },
       },
@@ -208,7 +213,7 @@ describe('unified MCP registry sync', () => {
     writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({
       gitnexus: { command: 'gitnexus', args: ['mcp'], timeout: 15 },
     }, null, 2));
-    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({
+    writeFileSync(getClaudeMcpConfigPath(), JSON.stringify({
       mcpServers: {
         gitnexus: { command: 'gitnexus', args: ['wrong'] },
       },
@@ -233,11 +238,67 @@ describe('unified MCP registry sync', () => {
     expect(status.codexMismatched).toEqual(['gitnexus']);
   });
 
+  it('is idempotent when registry, Claude MCP root config, and Codex TOML already match', () => {
+    writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({
+      remoteOmc: { url: 'https://lab.example.com/mcp', timeout: 30 },
+    }, null, 2));
+    writeFileSync(getClaudeMcpConfigPath(), JSON.stringify({
+      mcpServers: {
+        remoteOmc: { url: 'https://lab.example.com/mcp', timeout: 30 },
+      },
+    }, null, 2));
+    writeFileSync(getCodexConfigPath(), [
+      '# BEGIN OMC MANAGED MCP REGISTRY',
+      '',
+      '[mcp_servers.remoteOmc]',
+      'url = "https://lab.example.com/mcp"',
+      'startup_timeout_sec = 30',
+      '',
+      '# END OMC MANAGED MCP REGISTRY',
+      '',
+    ].join('\n'));
+
+    const { settings, result } = syncUnifiedMcpRegistryTargets({ theme: 'dark' });
+
+    expect(settings).toEqual({ theme: 'dark' });
+    expect(result.bootstrappedFromClaude).toBe(false);
+    expect(result.claudeChanged).toBe(false);
+    expect(result.codexChanged).toBe(false);
+  });
+
+  it('preserves existing .claude.json server definitions when legacy settings still contain stale copies', () => {
+    writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({
+      gitnexus: { command: 'gitnexus', args: ['mcp'] },
+    }, null, 2));
+    writeFileSync(getClaudeMcpConfigPath(), JSON.stringify({
+      mcpServers: {
+        gitnexus: { command: 'gitnexus', args: ['mcp'] },
+        customLocal: { command: 'custom-local', args: ['serve'] },
+      },
+    }, null, 2));
+
+    const { settings, result } = syncUnifiedMcpRegistryTargets({
+      theme: 'dark',
+      mcpServers: {
+        customLocal: { command: 'stale-custom', args: ['legacy'] },
+      },
+    });
+
+    expect(settings).toEqual({ theme: 'dark' });
+    expect(result.bootstrappedFromClaude).toBe(false);
+    expect(JSON.parse(readFileSync(getClaudeMcpConfigPath(), 'utf-8'))).toEqual({
+      mcpServers: {
+        customLocal: { command: 'custom-local', args: ['serve'] },
+        gitnexus: { command: 'gitnexus', args: ['mcp'] },
+      },
+    });
+  });
+
   it('detects mismatched URL-based remote MCP definitions during doctor inspection', () => {
     writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({
       remoteOmc: { url: 'https://lab.example.com/mcp', timeout: 30 },
     }, null, 2));
-    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({
+    writeFileSync(getClaudeMcpConfigPath(), JSON.stringify({
       mcpServers: {
         remoteOmc: { url: 'https://staging.example.com/mcp', timeout: 30 },
       },

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1074,7 +1074,7 @@ export function install(options: InstallOptions = {}): InstallResult {
         log(`  Bootstrapped unified MCP registry: ${mcpSync.result.registryPath}`);
       }
       if (mcpSync.result.claudeChanged) {
-        log(`  Synced ${mcpSync.result.serverNames.length} MCP server(s) into settings.json`);
+        log(`  Synced ${mcpSync.result.serverNames.length} MCP server(s) into Claude MCP config: ${mcpSync.result.claudeConfigPath}`);
       }
       if (mcpSync.result.codexChanged) {
         log(`  Synced ${mcpSync.result.serverNames.length} MCP server(s) into Codex config: ${mcpSync.result.codexConfigPath}`);

--- a/src/installer/mcp-registry.ts
+++ b/src/installer/mcp-registry.ts
@@ -16,6 +16,7 @@ export type UnifiedMcpRegistry = Record<string, UnifiedMcpRegistryEntry>;
 
 export interface UnifiedMcpRegistrySyncResult {
   registryPath: string;
+  claudeConfigPath: string;
   codexConfigPath: string;
   registryExists: boolean;
   bootstrappedFromClaude: boolean;
@@ -26,6 +27,7 @@ export interface UnifiedMcpRegistrySyncResult {
 
 export interface UnifiedMcpRegistryStatus {
   registryPath: string;
+  claudeConfigPath: string;
   codexConfigPath: string;
   registryExists: boolean;
   serverNames: string[];
@@ -48,6 +50,14 @@ export function getUnifiedMcpRegistryPath(): string {
 
 function getUnifiedMcpRegistryStatePath(): string {
   return join(getOmcHomeDir(), 'mcp-registry-state.json');
+}
+
+export function getClaudeMcpConfigPath(): string {
+  if (process.env.CLAUDE_MCP_CONFIG_PATH?.trim()) {
+    return process.env.CLAUDE_MCP_CONFIG_PATH.trim();
+  }
+
+  return join(dirname(getConfigDir()), '.claude.json');
 }
 
 export function getCodexConfigPath(): string {
@@ -196,11 +206,25 @@ function entriesEqual(left: unknown, right: unknown): boolean {
 
 export function applyRegistryToClaudeSettings(
   settings: Record<string, unknown>,
+): { settings: Record<string, unknown>; changed: boolean } {
+  const nextSettings = { ...settings };
+  const changed = Object.prototype.hasOwnProperty.call(nextSettings, 'mcpServers');
+  delete nextSettings.mcpServers;
+
+  return {
+    settings: nextSettings,
+    changed,
+  };
+}
+
+function syncClaudeMcpConfig(
+  existingClaudeConfig: Record<string, unknown>,
   registry: UnifiedMcpRegistry,
   managedServerNames: string[] = [],
-): { settings: Record<string, unknown>; changed: boolean } {
-  const existingServers = extractClaudeMcpRegistry(settings);
-  const nextServers: UnifiedMcpRegistry = { ...existingServers };
+  legacySettingsServers: UnifiedMcpRegistry = {},
+): { claudeConfig: Record<string, unknown>; changed: boolean } {
+  const existingServers = extractClaudeMcpRegistry(existingClaudeConfig);
+  const nextServers: UnifiedMcpRegistry = { ...legacySettingsServers, ...existingServers };
 
   for (const managedName of managedServerNames) {
     delete nextServers[managedName];
@@ -210,20 +234,16 @@ export function applyRegistryToClaudeSettings(
     nextServers[name] = entry;
   }
 
-  if (entriesEqual(existingServers, nextServers)) {
-    return { settings, changed: false };
-  }
-
-  const nextSettings = { ...settings };
+  const nextClaudeConfig = { ...existingClaudeConfig };
   if (Object.keys(nextServers).length === 0) {
-    delete nextSettings.mcpServers;
+    delete nextClaudeConfig.mcpServers;
   } else {
-    nextSettings.mcpServers = nextServers;
+    nextClaudeConfig.mcpServers = nextServers;
   }
 
   return {
-    settings: nextSettings,
-    changed: true,
+    claudeConfig: nextClaudeConfig,
+    changed: !entriesEqual(existingClaudeConfig, nextClaudeConfig),
   };
 }
 
@@ -411,13 +431,25 @@ export function syncUnifiedMcpRegistryTargets(
   settings: Record<string, unknown>,
 ): { settings: Record<string, unknown>; result: UnifiedMcpRegistrySyncResult } {
   const registryPath = getUnifiedMcpRegistryPath();
+  const claudeConfigPath = getClaudeMcpConfigPath();
   const codexConfigPath = getCodexConfigPath();
   const managedServerNames = readManagedServerNames();
-  const registryState = loadOrBootstrapRegistry(settings);
+  const legacyClaudeRegistry = extractClaudeMcpRegistry(settings);
+  const currentClaudeConfig = readJsonObject(claudeConfigPath);
+  const claudeConfigForBootstrap = Object.keys(extractClaudeMcpRegistry(currentClaudeConfig)).length > 0
+    ? currentClaudeConfig
+    : settings;
+  const registryState = loadOrBootstrapRegistry(claudeConfigForBootstrap);
   const registry = registryState.registry;
   const serverNames = Object.keys(registry);
 
-  const claude = applyRegistryToClaudeSettings(settings, registry, managedServerNames);
+  const cleanedSettings = applyRegistryToClaudeSettings(settings);
+  const claude = syncClaudeMcpConfig(currentClaudeConfig, registry, managedServerNames, legacyClaudeRegistry);
+
+  if (claude.changed) {
+    ensureParentDir(claudeConfigPath);
+    writeFileSync(claudeConfigPath, JSON.stringify(claude.claudeConfig, null, 2));
+  }
 
   let codexChanged = false;
   const currentCodexConfig = existsSync(codexConfigPath) ? readFileSync(codexConfigPath, 'utf-8') : '';
@@ -428,19 +460,20 @@ export function syncUnifiedMcpRegistryTargets(
     codexChanged = true;
   }
 
-  if (registryState.registryExists) {
+  if (registryState.registryExists || Object.keys(legacyClaudeRegistry).length > 0 || managedServerNames.length > 0) {
     writeManagedServerNames(serverNames);
   }
 
   return {
-    settings: claude.settings,
+    settings: cleanedSettings.settings,
     result: {
       registryPath,
+      claudeConfigPath,
       codexConfigPath,
       registryExists: registryState.registryExists,
       bootstrappedFromClaude: registryState.bootstrappedFromClaude,
       serverNames,
-      claudeChanged: claude.changed,
+      claudeChanged: cleanedSettings.changed || claude.changed,
       codexChanged,
     },
   };
@@ -463,11 +496,13 @@ function readJsonObject(path: string): Record<string, unknown> {
 
 export function inspectUnifiedMcpRegistrySync(): UnifiedMcpRegistryStatus {
   const registryPath = getUnifiedMcpRegistryPath();
+  const claudeConfigPath = getClaudeMcpConfigPath();
   const codexConfigPath = getCodexConfigPath();
 
   if (!existsSync(registryPath)) {
     return {
       registryPath,
+      claudeConfigPath,
       codexConfigPath,
       registryExists: false,
       serverNames: [],
@@ -480,7 +515,7 @@ export function inspectUnifiedMcpRegistrySync(): UnifiedMcpRegistryStatus {
 
   const registry = loadRegistryFromDisk(registryPath);
   const serverNames = Object.keys(registry);
-  const claudeSettings = readJsonObject(join(getConfigDir(), 'settings.json'));
+  const claudeSettings = readJsonObject(claudeConfigPath);
   const claudeEntries = extractClaudeMcpRegistry(claudeSettings);
   const codexEntries = existsSync(codexConfigPath)
     ? parseCodexMcpRegistryEntries(readFileSync(codexConfigPath, 'utf-8'))
@@ -507,6 +542,7 @@ export function inspectUnifiedMcpRegistrySync(): UnifiedMcpRegistryStatus {
 
   return {
     registryPath,
+    claudeConfigPath,
     codexConfigPath,
     registryExists: true,
     serverNames,


### PR DESCRIPTION
## Summary
- move managed Claude MCP sync from `~/.claude/settings.json` to `~/.claude.json`
- migrate legacy `settings.json.mcpServers` into the root Claude MCP config while stripping `mcpServers` from the installer's final `settings.json` write
- update doctor/conflict reporting and regression tests to follow the dedicated Claude MCP config target

## Testing
- `npm test -- --run src/installer/__tests__/mcp-registry.test.ts`
- `npm test -- --run`
- `npm run build`
- `lsp_diagnostics` on affected installer files
