### PR TITLE
Fix Windows update reconcile execFileSync EINVAL on omc.cmd

### DIFF
--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -453,6 +453,7 @@ describe('auto-update reconciliation', () => {
       encoding: 'utf-8',
       stdio: 'pipe',
       timeout: 60000,
+      shell: true,
       windowsHide: true,
       env: expect.objectContaining({ OMC_UPDATE_RECONCILE: '1' }),
     }));
@@ -502,6 +503,11 @@ describe('auto-update reconciliation', () => {
     expect(result.success).toBe(false);
     expect(result.message).toBe('Updated to 4.1.6, but runtime reconciliation failed');
     expect(result.errors).toEqual(['spawnSync C:\\Users\\bellman\\AppData\\Roaming\\npm\\omc.cmd ENOENT']);
+    expect(mockedExecFileSync).toHaveBeenNthCalledWith(2, 'C:\\Users\\bellman\\AppData\\Roaming\\npm\\omc.cmd', ['update-reconcile'], expect.objectContaining({
+      shell: true,
+      windowsHide: true,
+      env: expect.objectContaining({ OMC_UPDATE_RECONCILE: '1' }),
+    }));
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
   });
 

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -650,7 +650,7 @@ export async function performUpdate(options?: {
             stdio: options?.verbose ? 'inherit' : 'pipe',
             timeout: 60000,
             env: { ...process.env, OMC_UPDATE_RECONCILE: '1' },
-            ...(process.platform === 'win32' ? { windowsHide: true } : {}),
+            ...(process.platform === 'win32' ? { windowsHide: true, shell: true } : {}),
           });
         } catch (reconcileError) {
           return {


### PR DESCRIPTION
## Summary
- add Windows shell mediation when `performUpdate()` re-execs the resolved `omc` launcher for `update-reconcile`
- keep the change scoped to the resolved launcher path and leave direct executable invocations unchanged
- extend Windows regression coverage to assert `shell: true` on both success and failure paths

## Testing
- `npx vitest run src/__tests__/auto-update.test.ts`
- `npx eslint src/features/auto-update.ts src/__tests__/auto-update.test.ts`
- `npm run build`
- `npx vitest run`

## Notes
- Audited all `execFileSync` calls in `src/features/auto-update.ts`: only the resolved `omcPath` re-exec can point at a `.cmd` launcher on Windows; the others target `git` and `where.exe` directly.
