### PR TITLE
fix: harden ask skill to prevent raw provider CLI synthesis

### DIFF
--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -23,11 +23,13 @@ Examples:
 
 ## Routing
 
-Preferred path:
+**Required execution path — always use this command:**
 
 ```bash
 omc ask {{ARGUMENTS}}
 ```
+
+**Do NOT manually construct raw provider CLI commands.** Never run `codex`, `claude`, or `gemini` directly to fulfill this skill. The `omc ask` wrapper handles correct flag selection, artifact persistence, and provider-version compatibility automatically. Manually assembling provider CLI flags will produce incorrect or outdated invocations.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
Strengthens the ask skill routing guidance to prevent model drift where Claude bypasses `omc ask` and manually assembles raw provider CLI commands with incorrect/outdated flags.

## Changes
- **`skills/ask/SKILL.md`**: Changed "Preferred path" to "Required execution path" with explicit prohibition against constructing raw `codex`, `claude`, or `gemini` CLI commands directly

## Why
Issue #1806 reports that `/oh-my-claudecode:ask codex` can result in Claude manually running `codex --approval-mode full-auto --quiet` instead of `omc ask codex`. Those flags are invalid on current Codex CLI versions. The `omc ask` wrapper handles correct flag selection automatically.

This is a prompt-level guardrail improvement, not a code fix — slash commands in OMC are Claude-mediated by design.

Closes #1806