### PR TITLE
Ensure CLAUDE.md setup follows the active plugin version after upgrades

### DIFF
--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -11,7 +11,46 @@ MODE="${1:?Usage: setup-claude-md.sh <local|global>}"
 DOWNLOAD_URL="https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-CANONICAL_CLAUDE_MD="${SCRIPT_PLUGIN_ROOT}/docs/CLAUDE.md"
+
+# Resolve active plugin root from installed_plugins.json.
+# Handles stale CLAUDE_PLUGIN_ROOT when a session was started before a plugin
+# update (e.g. 4.8.2 session invoking setup after updating to 4.9.0).
+# Same pattern as run.cjs resolveTarget() fallback.
+resolve_active_plugin_root() {
+  local config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  local installed_plugins="${config_dir}/plugins/installed_plugins.json"
+
+  if [ -f "$installed_plugins" ] && command -v jq >/dev/null 2>&1; then
+    local active_path
+    active_path=$(jq -r '
+      to_entries[]
+      | select(.key | test("oh-my-claudecode"))
+      | .value[0].installPath // empty
+    ' "$installed_plugins" 2>/dev/null)
+
+    if [ -n "$active_path" ] && [ -d "$active_path" ]; then
+      echo "$active_path"
+      return 0
+    fi
+  fi
+
+  # Fallback: scan sibling version directories for the latest (mirrors run.cjs)
+  local cache_base
+  cache_base="$(dirname "$SCRIPT_PLUGIN_ROOT")"
+  if [ -d "$cache_base" ]; then
+    local latest
+    latest=$(ls -1 "$cache_base" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | sort -t. -k1,1nr -k2,2nr -k3,3nr | head -1)
+    if [ -n "$latest" ] && [ -d "${cache_base}/${latest}" ]; then
+      echo "${cache_base}/${latest}"
+      return 0
+    fi
+  fi
+
+  echo "$SCRIPT_PLUGIN_ROOT"
+}
+
+ACTIVE_PLUGIN_ROOT="$(resolve_active_plugin_root)"
+CANONICAL_CLAUDE_MD="${ACTIVE_PLUGIN_ROOT}/docs/CLAUDE.md"
 
 ensure_local_omc_git_exclude() {
   local exclude_path

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -185,3 +185,133 @@ Use the real docs file.
     expect(excludeContents.match(/# BEGIN OMC local artifacts/g)).toHaveLength(1);
   });
 });
+
+describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {
+  it('uses docs/CLAUDE.md from the active version in installed_plugins.json, not the stale script location', () => {
+    // Simulate: script lives at old version (4.8.2), but installed_plugins.json points to new version (4.9.0)
+    const root = mkdtempSync(join(tmpdir(), 'omc-stale-root-'));
+    tempRoots.push(root);
+
+    const cacheBase = join(root, '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const oldVersion = join(cacheBase, '4.8.2');
+    const newVersion = join(cacheBase, '4.9.0');
+    const projectRoot = join(root, 'project');
+    const homeRoot = join(root, 'home');
+
+    // Create old version (where the script will be copied)
+    mkdirSync(join(oldVersion, 'scripts'), { recursive: true });
+    mkdirSync(join(oldVersion, 'docs'), { recursive: true });
+    copyFileSync(SETUP_SCRIPT, join(oldVersion, 'scripts', 'setup-claude-md.sh'));
+    writeFileSync(
+      join(oldVersion, 'docs', 'CLAUDE.md'),
+      `<!-- OMC:START -->\n<!-- OMC:VERSION:4.8.2 -->\n\n# Old Version\n<!-- OMC:END -->\n`,
+    );
+
+    // Create new version (the active one)
+    mkdirSync(join(newVersion, 'docs'), { recursive: true });
+    writeFileSync(
+      join(newVersion, 'docs', 'CLAUDE.md'),
+      `<!-- OMC:START -->\n<!-- OMC:VERSION:4.9.0 -->\n\n# New Version\n<!-- OMC:END -->\n`,
+    );
+
+    // Create installed_plugins.json pointing to the new version
+    mkdirSync(join(homeRoot, '.claude', 'plugins'), { recursive: true });
+    writeFileSync(
+      join(homeRoot, '.claude', 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        'oh-my-claudecode@omc': [
+          {
+            installPath: newVersion,
+            version: '4.9.0',
+          },
+        ],
+      }),
+    );
+
+    // Create project dir and settings.json (needed for plugin verification)
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(join(homeRoot, '.claude'), { recursive: true });
+    writeFileSync(
+      join(homeRoot, '.claude', 'settings.json'),
+      JSON.stringify({ plugins: ['oh-my-claudecode'] }),
+    );
+
+    // Run the OLD version's script — it should resolve to the NEW version's docs/CLAUDE.md
+    const result = spawnSync(
+      'bash',
+      [join(oldVersion, 'scripts', 'setup-claude-md.sh'), 'local'],
+      {
+        cwd: projectRoot,
+        env: {
+          ...process.env,
+          HOME: homeRoot,
+          CLAUDE_CONFIG_DIR: join(homeRoot, '.claude'),
+        },
+        encoding: 'utf-8',
+      },
+    );
+
+    expect(result.status).toBe(0);
+
+    const installed = readFileSync(join(projectRoot, '.claude', 'CLAUDE.md'), 'utf-8');
+    // Should contain the NEW version, not the old one
+    expect(installed).toContain('<!-- OMC:VERSION:4.9.0 -->');
+    expect(installed).toContain('# New Version');
+    expect(installed).not.toContain('<!-- OMC:VERSION:4.8.2 -->');
+  });
+
+  it('falls back to scanning cache for latest version when installed_plugins.json is unavailable', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-stale-fallback-'));
+    tempRoots.push(root);
+
+    const cacheBase = join(root, '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const oldVersion = join(cacheBase, '4.8.2');
+    const newVersion = join(cacheBase, '4.9.0');
+    const projectRoot = join(root, 'project');
+    const homeRoot = join(root, 'home');
+
+    // Create old version (where the script lives)
+    mkdirSync(join(oldVersion, 'scripts'), { recursive: true });
+    mkdirSync(join(oldVersion, 'docs'), { recursive: true });
+    copyFileSync(SETUP_SCRIPT, join(oldVersion, 'scripts', 'setup-claude-md.sh'));
+    writeFileSync(
+      join(oldVersion, 'docs', 'CLAUDE.md'),
+      `<!-- OMC:START -->\n<!-- OMC:VERSION:4.8.2 -->\n\n# Old\n<!-- OMC:END -->\n`,
+    );
+
+    // Create new version (no installed_plugins.json, relies on cache scan)
+    mkdirSync(join(newVersion, 'docs'), { recursive: true });
+    writeFileSync(
+      join(newVersion, 'docs', 'CLAUDE.md'),
+      `<!-- OMC:START -->\n<!-- OMC:VERSION:4.9.0 -->\n\n# New\n<!-- OMC:END -->\n`,
+    );
+
+    // No installed_plugins.json — fallback to cache scan
+    mkdirSync(join(homeRoot, '.claude'), { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+    writeFileSync(
+      join(homeRoot, '.claude', 'settings.json'),
+      JSON.stringify({ plugins: ['oh-my-claudecode'] }),
+    );
+
+    const result = spawnSync(
+      'bash',
+      [join(oldVersion, 'scripts', 'setup-claude-md.sh'), 'local'],
+      {
+        cwd: projectRoot,
+        env: {
+          ...process.env,
+          HOME: homeRoot,
+          CLAUDE_CONFIG_DIR: join(homeRoot, '.claude'),
+        },
+        encoding: 'utf-8',
+      },
+    );
+
+    expect(result.status).toBe(0);
+
+    const installed = readFileSync(join(projectRoot, '.claude', 'CLAUDE.md'), 'utf-8');
+    expect(installed).toContain('<!-- OMC:VERSION:4.9.0 -->');
+    expect(installed).not.toContain('<!-- OMC:VERSION:4.8.2 -->');
+  });
+});


### PR DESCRIPTION
Stale sessions can invoke setup from an older cached plugin path after the plugin has already been updated. Resolve the active plugin root first so omc-setup installs the current version's docs/CLAUDE.md instead of reusing stale versioned content.

The script now prefers installed_plugins.json and falls back to the latest cached semver directory when the active install record is unavailable. Regression tests cover both the active install-path case and the cache-scan fallback.

Constraint: setup-claude-md.sh must keep working when invoked from stale cached plugin scripts
Rejected: Always use the invoking script directory | reuses stale versioned docs after plugin upgrades
Rejected: Fetch docs only from GitHub main | ignores the active local plugin install and breaks offline/local-version expectations
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep setup aligned with the active installed plugin version, not the calling script path
Tested: npm run test:run -- src/__tests__/setup-claude-md-script.test.ts
Not-tested: End-to-end omc-setup invocation through a real Claude plugin upgrade flow