### PR TITLE
feat: reduce CLAUDE.md token footprint with native skills (#1812)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -24,33 +24,13 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 
-<agent_catalog>
-Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
-
-explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (sonnet), executor (sonnet), verifier (sonnet), tracer (sonnet), security-reviewer (sonnet), code-reviewer (opus), test-engineer (sonnet), designer (sonnet), writer (haiku), qa-tester (sonnet), scientist (sonnet), document-specialist (sonnet), git-master (sonnet), code-simplifier (opus), critic (opus)
-</agent_catalog>
-
-<tools>
-External AI: `/team N:executor "task"`, `omc team N:codex|gemini "..."`, `omc ask <claude|codex|gemini>`, `/ccg`
-OMC State: `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
-Teams: `TeamCreate`, `TeamDelete`, `SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`
-Notepad: `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`
-Project Memory: `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
-Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, etc.), AST (`ast_grep_search`, `ast_grep_replace`), `python_repl`
-</tools>
-
 <skills>
 Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
-
-Workflow: `autopilot`, `ralph`, `ultrawork`, `visual-verdict`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`
-Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
-Utilities: `ask-codex`, `ask-gemini`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `configure-notifications`, `learn-about-omc` (`trace` is the evidence-driven tracing lane)
+Tier-0 workflows include `autopilot`, `ultrawork`, `ralph`, `team`, and `ralplan`.
+Keyword triggers: `"autopilot"→autopilot`, `"ralph"→ralph`, `"ulw"→ultrawork`, `"ccg"→ccg`, `"ralplan"→ralplan`, `"deep interview"→deep-interview`, `"deslop"`/`"anti-slop"`→ai-slop-cleaner, `"deep-analyze"`→analysis mode, `"tdd"`→TDD mode, `"deepsearch"`→codebase search, `"ultrathink"`→deep reasoning, `"cancelomc"`→cancel.
+Team orchestration is explicit via `/team`.
+Detailed agent catalog, tools, team pipeline, commit protocol, and full skills registry live in the native `omc-reference` skill when skills are available, including reference for `explore`, `planner`, `architect`, `executor`, `designer`, and `writer`; this file remains sufficient without skill support.
 </skills>
-
-<team_pipeline>
-Stages: `team-plan` → `team-prd` → `team-exec` → `team-verify` → `team-fix` (loop).
-Fix loop bounded by max attempts. `team ralph` links both modes.
-</team_pipeline>
 
 <verification>
 Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
@@ -63,36 +43,6 @@ Keep authoring and review as separate passes: writer pass creates or revises con
 Never self-approve in the same active context; use `code-reviewer` or `verifier` for the approval pass.
 Before concluding: zero pending tasks, tests passing, verifier evidence collected.
 </execution_protocols>
-
-<commit_protocol>
-Use git trailers to preserve decision context in every commit message.
-Format: conventional commit subject line, optional body, then structured trailers.
-
-Trailers (include when applicable — skip for trivial commits like typos or formatting):
-- `Constraint:` active constraint that shaped this decision
-- `Rejected:` alternative considered | reason for rejection
-- `Directive:` warning or instruction for future modifiers of this code
-- `Confidence:` high | medium | low
-- `Scope-risk:` narrow | moderate | broad
-- `Not-tested:` edge case or scenario not covered by tests
-
-Example:
-```
-fix(auth): prevent silent session drops during long-running ops
-
-Auth service returns inconsistent status codes on token expiry,
-so the interceptor catches all 4xx and triggers inline refresh.
-
-Constraint: Auth service does not support token introspection
-Constraint: Must not add latency to non-expired-token paths
-Rejected: Extend token TTL to 24h | security policy violation
-Rejected: Background refresh on timer | race condition with concurrent requests
-Confidence: high
-Scope-risk: narrow
-Directive: Error handling is intentionally broad (all 4xx) — do not narrow without verifying upstream behavior
-Not-tested: Auth service cold-start latency >500ms
-```
-</commit_protocol>
 
 <hooks_and_context>
 Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (invoke skill), `The boulder never stops` (ralph/ultrawork active).

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -11,7 +11,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [CLI Commands: ask/team/session](#cli-commands-askteamsession)
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated)
 - [Agents (29 Total)](#agents-29-total)
-- [Skills (31 Total)](#skills-31-total)
+- [Skills (32 Total)](#skills-32-total)
 - [Slash Commands](#slash-commands)
 - [Hooks System](#hooks-system)
 - [Magic Keywords](#magic-keywords)
@@ -366,9 +366,9 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
 ---
 
-## Skills (31 Total)
+## Skills (32 Total)
 
-Includes **30 canonical skills + 1 deprecated alias** (`psm`). Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
+Includes **31 canonical skills + 1 deprecated alias** (`psm`). Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
 
 | Skill                     | Description                                                      | Manual Command                              |
 | ------------------------- | ---------------------------------------------------------------- | ------------------------------------------- |
@@ -387,6 +387,7 @@ Includes **30 canonical skills + 1 deprecated alias** (`psm`). Runtime truth com
 | `mcp-setup`               | Configure MCP servers                                            | `/oh-my-claudecode:mcp-setup`               |
 | `omc-doctor`              | Diagnose and fix installation issues                             | `/oh-my-claudecode:omc-doctor`              |
 | `omc-plan`                | Planning workflow (`/plan` safe alias)                           | `/oh-my-claudecode:omc-plan`                |
+| `omc-reference`           | Detailed OMC agent/tools/team/commit reference skill             | Auto-loaded reference only                  |
 | `omc-setup`               | One-time setup wizard                                            | `/oh-my-claudecode:omc-setup`               |
 | `omc-teams`               | Spawn `claude`/`codex`/`gemini` tmux workers for parallel execution | `/oh-my-claudecode:omc-teams`             |
 | `project-session-manager` | Manage isolated dev environments (git worktrees + tmux)          | `/oh-my-claudecode:project-session-manager` |

--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -12,6 +12,7 @@ DOWNLOAD_URL="https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/mai
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CANONICAL_CLAUDE_MD="${SCRIPT_PLUGIN_ROOT}/docs/CLAUDE.md"
+CANONICAL_OMC_REFERENCE_SKILL="${SCRIPT_PLUGIN_ROOT}/skills/omc-reference/SKILL.md"
 
 ensure_local_omc_git_exclude() {
   local exclude_path
@@ -47,15 +48,47 @@ EOF
 
 # Determine target path
 if [ "$MODE" = "local" ]; then
-  mkdir -p .claude
+  mkdir -p .claude/skills/omc-reference
   TARGET_PATH=".claude/CLAUDE.md"
+  SKILL_TARGET_PATH=".claude/skills/omc-reference/SKILL.md"
 elif [ "$MODE" = "global" ]; then
-  mkdir -p "$HOME/.claude"
+  mkdir -p "$HOME/.claude/skills/omc-reference"
   TARGET_PATH="$HOME/.claude/CLAUDE.md"
+  SKILL_TARGET_PATH="$HOME/.claude/skills/omc-reference/SKILL.md"
 else
   echo "ERROR: Invalid mode '$MODE'. Use 'local' or 'global'." >&2
   exit 1
 fi
+
+
+install_omc_reference_skill() {
+  local source_label=""
+  local temp_skill
+  temp_skill=$(mktemp /tmp/omc-reference-skill-XXXXXX.md)
+
+  if [ -f "$CANONICAL_OMC_REFERENCE_SKILL" ]; then
+    cp "$CANONICAL_OMC_REFERENCE_SKILL" "$temp_skill"
+    source_label="$CANONICAL_OMC_REFERENCE_SKILL"
+  elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/omc-reference/SKILL.md" ]; then
+    cp "${CLAUDE_PLUGIN_ROOT}/skills/omc-reference/SKILL.md" "$temp_skill"
+    source_label="${CLAUDE_PLUGIN_ROOT}/skills/omc-reference/SKILL.md"
+  else
+    rm -f "$temp_skill"
+    echo "Skipped omc-reference skill install (canonical skill source unavailable)"
+    return 0
+  fi
+
+  if [ ! -s "$temp_skill" ]; then
+    rm -f "$temp_skill"
+    echo "Skipped omc-reference skill install (empty canonical skill source: $source_label)"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$SKILL_TARGET_PATH")"
+  cp "$temp_skill" "$SKILL_TARGET_PATH"
+  rm -f "$temp_skill"
+  echo "Installed omc-reference skill to $SKILL_TARGET_PATH"
+}
 
 # Extract old version before download
 OLD_VERSION=$(grep -m1 'OMC:VERSION:' "$TARGET_PATH" 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
@@ -176,6 +209,8 @@ if ! grep -q '<!-- OMC:START -->' "$TARGET_PATH" || ! grep -q '<!-- OMC:END -->'
   echo "ERROR: Installed CLAUDE.md is missing required OMC markers: $TARGET_PATH" >&2
   exit 1
 fi
+
+install_omc_reference_skill
 
 if [ "$MODE" = "local" ]; then
   ensure_local_omc_git_exclude

--- a/skills/omc-reference/SKILL.md
+++ b/skills/omc-reference/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: omc-reference
+description: OMC agent catalog, available tools, team pipeline routing, commit protocol, and skills registry. Auto-loads when delegating to agents, using OMC tools, orchestrating teams, making commits, or invoking skills.
+user-invocable: false
+---
+
+# OMC Reference
+
+Use this built-in reference when you need detailed OMC catalog information that does not need to live in every `CLAUDE.md` session.
+
+## Agent Catalog
+
+Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
+
+- `explore` (haiku) — fast codebase search and mapping
+- `analyst` (opus) — requirements clarity and hidden constraints
+- `planner` (opus) — sequencing and execution plans
+- `architect` (opus) — system design, boundaries, and long-horizon tradeoffs
+- `debugger` (sonnet) — root-cause analysis and failure diagnosis
+- `executor` (sonnet) — implementation and refactoring
+- `verifier` (sonnet) — completion evidence and validation
+- `tracer` (sonnet) — trace gathering and evidence capture
+- `security-reviewer` (sonnet) — trust boundaries and vulnerabilities
+- `code-reviewer` (opus) — comprehensive code review
+- `test-engineer` (sonnet) — testing strategy and regression coverage
+- `designer` (sonnet) — UX and interaction design
+- `writer` (haiku) — documentation and concise content work
+- `qa-tester` (sonnet) — runtime/manual validation
+- `scientist` (sonnet) — data analysis and statistical reasoning
+- `document-specialist` (sonnet) — SDK/API/framework documentation lookup
+- `git-master` (sonnet) — commit strategy and history hygiene
+- `code-simplifier` (opus) — behavior-preserving simplification
+- `critic` (opus) — plan/design challenge and review
+
+## Model Routing
+
+- `haiku` — quick lookups, lightweight inspection, narrow docs work
+- `sonnet` — standard implementation, debugging, and review
+- `opus` — architecture, deep analysis, consensus planning, and high-risk review
+
+## Tools Reference
+
+### External AI / orchestration
+- `/team N:executor "task"`
+- `omc team N:codex|gemini "..."`
+- `omc ask <claude|codex|gemini>`
+- `/ccg`
+
+### OMC state
+- `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
+
+### Team runtime
+- `TeamCreate`, `TeamDelete`, `SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`
+
+### Notepad
+- `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`
+
+### Project memory
+- `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
+
+### Code intelligence
+- LSP: `lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, and related helpers
+- AST: `ast_grep_search`, `ast_grep_replace`
+- Utility: `python_repl`
+
+## Skills Registry
+
+Invoke built-in workflows via `/oh-my-claudecode:<name>`.
+
+### Workflow skills
+- `autopilot` — full autonomous execution from idea to working code
+- `ralph` — persistence loop until completion with verification
+- `ultrawork` — high-throughput parallel execution
+- `visual-verdict` — structured visual QA verdicts
+- `team` — coordinated team orchestration
+- `ccg` — Codex + Gemini + Claude synthesis lane
+- `ultraqa` — QA cycle: test, verify, fix, repeat
+- `omc-plan` — planning workflow and `/plan`-safe alias
+- `ralplan` — consensus planning workflow
+- `sciomc` — science/research workflow
+- `external-context` — external docs/research workflow
+- `deepinit` — hierarchical AGENTS.md generation
+- `deep-interview` — Socratic ambiguity-gated requirements workflow
+- `ai-slop-cleaner` — regression-safe cleanup workflow
+
+### Utility skills
+- `ask`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `configure-notifications`
+
+### Keyword triggers kept compact in CLAUDE.md
+- `"autopilot"→autopilot`
+- `"ralph"→ralph`
+- `"ulw"→ultrawork`
+- `"ccg"→ccg`
+- `"ralplan"→ralplan`
+- `"deep interview"→deep-interview`
+- `"deslop" / "anti-slop"→ai-slop-cleaner`
+- `"deep-analyze"→analysis mode`
+- `"tdd"→TDD mode`
+- `"deepsearch"→codebase search`
+- `"ultrathink"→deep reasoning`
+- `"cancelomc"→cancel`
+- Team orchestration is explicit via `/team`.
+
+## Team Pipeline
+
+Stages: `team-plan` → `team-prd` → `team-exec` → `team-verify` → `team-fix` (loop).
+
+- Use `team-fix` for bounded remediation loops.
+- `team ralph` links the team pipeline with Ralph-style sequential verification.
+- Prefer team mode when independent parallel lanes justify the coordination overhead.
+
+## Commit Protocol
+
+Use git trailers to preserve decision context in every commit message.
+
+### Format
+- Intent line first: why the change was made
+- Optional body with context and rationale
+- Structured trailers when applicable
+
+### Common trailers
+- `Constraint:` active constraint shaping the decision
+- `Rejected:` alternative considered | reason for rejection
+- `Directive:` forward-looking warning or instruction
+- `Confidence:` `high` | `medium` | `low`
+- `Scope-risk:` `narrow` | `moderate` | `broad`
+- `Not-tested:` known verification gap
+
+### Example
+```text
+feat(docs): reduce always-loaded OMC instruction footprint
+
+Move reference-only orchestration content into a native Claude skill so
+session-start guidance stays small while detailed OMC reference remains available.
+
+Constraint: Preserve CLAUDE.md marker-based installation flow
+Rejected: Sync all built-in skills in legacy install | broader behavior change than issue requires
+Confidence: high
+Scope-risk: narrow
+Not-tested: End-to-end plugin marketplace install in a fresh Claude profile
+```

--- a/src/__tests__/installer-omc-reference.test.ts
+++ b/src/__tests__/installer-omc-reference.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  const { join: pathJoin } = await import('path');
+  const repoRoot = process.cwd();
+  const sourceSkillsDir = pathJoin(repoRoot, 'src', 'skills');
+  const sourceClaudeMdPath = pathJoin(repoRoot, 'src', 'docs', 'CLAUDE.md');
+  const realSkillsDir = pathJoin(repoRoot, 'skills');
+  const realClaudeMdPath = pathJoin(repoRoot, 'docs', 'CLAUDE.md');
+
+  const withRedirect = (pathLike: unknown): string => {
+    const normalized = String(pathLike).replace(/\\/g, '/');
+    const normalizedSourceSkillsDir = sourceSkillsDir.replace(/\\/g, '/');
+    const normalizedRealSkillsDir = realSkillsDir.replace(/\\/g, '/');
+
+    if (normalized === normalizedSourceSkillsDir) {
+      return realSkillsDir;
+    }
+    if (normalized.startsWith(`${normalizedSourceSkillsDir}/`)) {
+      return normalized.replace(normalizedSourceSkillsDir, normalizedRealSkillsDir);
+    }
+    if (normalized === sourceClaudeMdPath.replace(/\\/g, '/')) {
+      return realClaudeMdPath;
+    }
+    return String(pathLike);
+  };
+
+  return {
+    ...actual,
+    existsSync: vi.fn((pathLike: Parameters<typeof actual.existsSync>[0]) =>
+      actual.existsSync(withRedirect(pathLike))
+    ),
+    readFileSync: vi.fn((pathLike: Parameters<typeof actual.readFileSync>[0], options?: Parameters<typeof actual.readFileSync>[1]) =>
+      actual.readFileSync(withRedirect(pathLike), options as never)
+    ),
+    readdirSync: vi.fn((pathLike: Parameters<typeof actual.readdirSync>[0], options?: Parameters<typeof actual.readdirSync>[1]) =>
+      actual.readdirSync(withRedirect(pathLike), options as never)
+    ),
+  };
+});
+
+async function loadInstallerWithEnv(claudeConfigDir: string, homeDir: string) {
+  vi.resetModules();
+  process.env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+  process.env.HOME = homeDir;
+  return import('../installer/index.js');
+}
+
+describe('installer omc-reference legacy skill sync (issue #1812)', () => {
+  let tempRoot: string;
+  let homeDir: string;
+  let claudeConfigDir: string;
+  let originalClaudeConfigDir: string | undefined;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'omc-installer-omc-reference-'));
+    homeDir = join(tempRoot, 'home');
+    claudeConfigDir = join(homeDir, '.claude');
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(claudeConfigDir, { recursive: true });
+
+    originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    originalHome = process.env.HOME;
+  });
+
+  afterEach(() => {
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    }
+
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    rmSync(tempRoot, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it('installs only the omc-reference skill during legacy install', async () => {
+    const installer = await loadInstallerWithEnv(claudeConfigDir, homeDir);
+    const result = installer.install({
+      skipClaudeCheck: true,
+      skipHud: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.installedSkills).toContain('omc-reference/SKILL.md');
+
+    const installedSkillPath = join(claudeConfigDir, 'skills', 'omc-reference', 'SKILL.md');
+    expect(existsSync(installedSkillPath)).toBe(true);
+    expect(readFileSync(installedSkillPath, 'utf-8')).toContain('name: omc-reference');
+  });
+});

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -27,11 +27,20 @@ function createPluginFixture(claudeMdContent: string) {
 
   mkdirSync(join(pluginRoot, 'scripts'), { recursive: true });
   mkdirSync(join(pluginRoot, 'docs'), { recursive: true });
+  mkdirSync(join(pluginRoot, 'skills', 'omc-reference'), { recursive: true });
   mkdirSync(projectRoot, { recursive: true });
   mkdirSync(homeRoot, { recursive: true });
 
   copyFileSync(SETUP_SCRIPT, join(pluginRoot, 'scripts', 'setup-claude-md.sh'));
   writeFileSync(join(pluginRoot, 'docs', 'CLAUDE.md'), claudeMdContent);
+  writeFileSync(join(pluginRoot, 'skills', 'omc-reference', 'SKILL.md'), `---
+name: omc-reference
+description: Test fixture reference skill
+user-invocable: false
+---
+
+# Test OMC Reference
+`);
 
   return {
     pluginRoot,
@@ -79,6 +88,10 @@ Use the real docs file.
     expect(installed).toContain('<!-- OMC:END -->');
     expect(installed).toContain('<!-- OMC:VERSION:9.9.9 -->');
     expect(installed).toContain('# Canonical CLAUDE');
+
+    const installedSkillPath = join(fixture.projectRoot, '.claude', 'skills', 'omc-reference', 'SKILL.md');
+    expect(existsSync(installedSkillPath)).toBe(true);
+    expect(readFileSync(installedSkillPath, 'utf-8')).toContain('# Test OMC Reference');
   });
 
   it('refuses to install a canonical source that lacks OMC markers', () => {

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -35,10 +35,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (30 canonical + 1 alias)', () => {
+    it('should return correct number of skills (31 canonical + 1 alias)', () => {
       const skills = createBuiltinSkills();
-      // 31 entries: 30 canonical skills + 1 deprecated alias (psm)
-      expect(skills).toHaveLength(31);
+      // 32 entries: 31 canonical skills + 1 deprecated alias (psm)
+      expect(skills).toHaveLength(32);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -105,6 +105,7 @@ describe('Builtin Skills', () => {
         'omc-setup',
         'omc-teams',
         'omc-plan',
+        'omc-reference',
         'project-session-manager',
         'psm',
         'ralph',
@@ -297,7 +298,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(30);
+      expect(names).toHaveLength(31);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -307,6 +308,7 @@ describe('Builtin Skills', () => {
       expect(names).toContain('ralph');
       expect(names).toContain('ultrawork');
       expect(names).toContain('omc-plan');
+      expect(names).toContain('omc-reference');
       expect(names).toContain('deepinit');
       expect(names).toContain('release');
       expect(names).toContain('omc-doctor');
@@ -330,7 +332,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131, psm still exists
-      expect(names).toHaveLength(31);
+      expect(names).toHaveLength(32);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('trace');
       expect(names).toContain('visual-verdict');

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -484,6 +484,16 @@ function loadCommandDefinitions(): Record<string, string> {
 /**
  * Load CLAUDE.md content from /docs/CLAUDE.md
  */
+function loadBundledSkillContent(skillName: string): string | null {
+  const skillPath = join(getPackageDir(), 'skills', skillName, 'SKILL.md');
+
+  if (!existsSync(skillPath)) {
+    return null;
+  }
+
+  return readFileSync(skillPath, 'utf-8');
+}
+
 function loadClaudeMdContent(): string {
   const claudeMdPath = join(getPackageDir(), 'docs', 'CLAUDE.md');
 
@@ -781,6 +791,22 @@ export function install(options: InstallOptions = {}): InstallResult {
 
       // NOTE: SKILL_DEFINITIONS removed - skills now only installed via COMMAND_DEFINITIONS
       // to avoid duplicate entries in Claude Code's available skills list
+
+      const omcReferenceSkillContent = loadBundledSkillContent('omc-reference');
+      if (omcReferenceSkillContent) {
+        const omcReferenceDir = join(SKILLS_DIR, 'omc-reference');
+        const omcReferencePath = join(omcReferenceDir, 'SKILL.md');
+        if (!existsSync(omcReferenceDir)) {
+          mkdirSync(omcReferenceDir, { recursive: true });
+        }
+        if (existsSync(omcReferencePath) && !options.force) {
+          log('  Skipping omc-reference/SKILL.md (already exists)');
+        } else {
+          writeFileSync(omcReferencePath, omcReferenceSkillContent);
+          result.installedSkills.push('omc-reference/SKILL.md');
+          log('  Installed omc-reference/SKILL.md');
+        }
+      }
 
       // Install CLAUDE.md with merge support
       const claudeMdPath = join(CLAUDE_CONFIG_DIR, 'CLAUDE.md');


### PR DESCRIPTION
## Summary
- extract reference-only OMC guidance into a new built-in `omc-reference` skill
- trim `docs/CLAUDE.md` to always-needed instructions while preserving markers and Tier-0 trigger strings
- sync only `omc-reference` in setup and legacy installer flows, plus add regression coverage

## Testing
- `npx vitest --run src/__tests__/tier0-docs-consistency.test.ts`
- `npx vitest --run src/__tests__/skills.test.ts --reporter=verbose`
- `npx vitest --run src/__tests__/installer.test.ts src/__tests__/installer-omc-reference.test.ts src/__tests__/setup-claude-md-script.test.ts src/installer/__tests__/claude-md-merge.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/installer/index.ts src/__tests__/setup-claude-md-script.test.ts src/__tests__/skills.test.ts src/__tests__/installer-omc-reference.test.ts`
