### PR TITLE
fix(hud): prevent cross-session HUD state leakage

### DIFF
--- a/src/__tests__/hud/omc-state.test.ts
+++ b/src/__tests__/hud/omc-state.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  readRalphStateForHud,
+  readUltraworkStateForHud,
+  readAutopilotStateForHud,
+  isAnyModeActive,
+  getActiveSkills,
+} from '../../hud/omc-state.js';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  utimesSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+function writeJson(path: string, data: unknown, mtimeMs = Date.now()): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(data));
+  const time = new Date(mtimeMs);
+  utimesSync(path, time, time);
+}
+
+describe('hud omc state session scoping', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+    delete process.env.OMC_STATE_DIR;
+  });
+
+  function createWorktree(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'omc-hud-state-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('keeps backward-compatible newest-session fallback when sessionId is omitted', () => {
+    const worktree = createWorktree();
+    const omcRoot = join(worktree, '.omc');
+    const older = Date.now() - 60_000;
+    const newer = Date.now();
+
+    writeJson(join(omcRoot, 'state', 'sessions', 'session-a', 'ralph-state.json'), {
+      active: true,
+      iteration: 1,
+      max_iterations: 5,
+      current_story_id: 'story-a',
+    }, older);
+    writeJson(join(omcRoot, 'state', 'sessions', 'session-b', 'ralph-state.json'), {
+      active: true,
+      iteration: 4,
+      max_iterations: 7,
+      current_story_id: 'story-b',
+    }, newer);
+
+    expect(readRalphStateForHud(worktree)).toMatchObject({
+      active: true,
+      iteration: 4,
+      maxIterations: 7,
+      currentStoryId: 'story-b',
+    });
+  });
+
+  it('reads only the requested session state when sessionId is provided', () => {
+    const worktree = createWorktree();
+    const omcRoot = join(worktree, '.omc');
+    const older = Date.now() - 60_000;
+    const newer = Date.now();
+
+    writeJson(join(omcRoot, 'state', 'sessions', 'session-a', 'ralph-state.json'), {
+      active: true,
+      iteration: 2,
+      max_iterations: 5,
+      current_story_id: 'story-a',
+    }, older);
+    writeJson(join(omcRoot, 'state', 'sessions', 'session-b', 'ralph-state.json'), {
+      active: true,
+      iteration: 9,
+      max_iterations: 9,
+      current_story_id: 'story-b',
+    }, newer);
+
+    expect(readRalphStateForHud(worktree, 'session-a')).toMatchObject({
+      active: true,
+      iteration: 2,
+      maxIterations: 5,
+      currentStoryId: 'story-a',
+    });
+  });
+
+  it('does not leak to other sessions or fallback files when a session-scoped file is missing', () => {
+    const worktree = createWorktree();
+    const omcRoot = join(worktree, '.omc');
+
+    writeJson(join(omcRoot, 'state', 'sessions', 'session-b', 'autopilot-state.json'), {
+      active: true,
+      phase: 'execution',
+      iteration: 3,
+      max_iterations: 10,
+      execution: { tasks_completed: 2, tasks_total: 4, files_created: ['a.ts'] },
+    });
+    writeJson(join(omcRoot, 'state', 'autopilot-state.json'), {
+      active: true,
+      phase: 'qa',
+      iteration: 8,
+      max_iterations: 10,
+      execution: { tasks_completed: 4, tasks_total: 4, files_created: ['b.ts', 'c.ts'] },
+    });
+
+    expect(readAutopilotStateForHud(worktree, 'session-a')).toBeNull();
+  });
+
+  it('applies session scoping to combined mode helpers', () => {
+    const worktree = createWorktree();
+    const omcRoot = join(worktree, '.omc');
+
+    writeJson(join(omcRoot, 'state', 'sessions', 'session-a', 'ralph-state.json'), {
+      active: false,
+      iteration: 1,
+      max_iterations: 5,
+      current_story_id: 'story-a',
+    });
+    writeJson(join(omcRoot, 'state', 'sessions', 'session-b', 'ralph-state.json'), {
+      active: true,
+      iteration: 3,
+      max_iterations: 8,
+      current_story_id: 'story-b',
+    });
+    writeJson(join(omcRoot, 'state', 'sessions', 'session-b', 'ultrawork-state.json'), {
+      active: true,
+      reinforcement_count: 7,
+    });
+
+    expect(isAnyModeActive(worktree)).toBe(true);
+    expect(isAnyModeActive(worktree, 'session-a')).toBe(false);
+    expect(isAnyModeActive(worktree, 'session-b')).toBe(true);
+    expect(getActiveSkills(worktree, 'session-a')).toEqual([]);
+    expect(getActiveSkills(worktree, 'session-b')).toEqual(['ralph', 'ultrawork']);
+    expect(readUltraworkStateForHud(worktree, 'session-b')).toMatchObject({
+      active: true,
+      reinforcementCount: 7,
+    });
+  });
+});

--- a/src/__tests__/hud/watch-mode-init.test.ts
+++ b/src/__tests__/hud/watch-mode-init.test.ts
@@ -37,6 +37,9 @@ const fakeConfig = {
 describe('HUD watch mode initialization', () => {
   const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
   let initializeHUDState: ReturnType<typeof vi.fn>;
+  let readRalphStateForHud: ReturnType<typeof vi.fn>;
+  let readUltraworkStateForHud: ReturnType<typeof vi.fn>;
+  let readAutopilotStateForHud: ReturnType<typeof vi.fn>;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
@@ -44,6 +47,9 @@ describe('HUD watch mode initialization', () => {
     vi.resetModules();
 
     initializeHUDState = vi.fn(async () => {});
+    readRalphStateForHud = vi.fn(() => null);
+    readUltraworkStateForHud = vi.fn(() => null);
+    readAutopilotStateForHud = vi.fn(() => null);
 
     vi.doMock('../../hud/stdin.js', () => ({
       readStdin: vi.fn(async () => null),
@@ -76,10 +82,10 @@ describe('HUD watch mode initialization', () => {
     }));
 
     vi.doMock('../../hud/omc-state.js', () => ({
-      readRalphStateForHud: vi.fn(() => null),
-      readUltraworkStateForHud: vi.fn(() => null),
+      readRalphStateForHud,
+      readUltraworkStateForHud,
       readPrdStateForHud: vi.fn(() => null),
-      readAutopilotStateForHud: vi.fn(() => null),
+      readAutopilotStateForHud,
     }));
 
     vi.doMock('../../hud/usage-api.js', () => ({ getUsage: vi.fn(async () => null) }));
@@ -109,6 +115,7 @@ describe('HUD watch mode initialization', () => {
   });
 
   afterEach(() => {
+    fakeStdin.transcript_path = '/tmp/worktree/transcript.jsonl';
     vi.resetModules();
     vi.clearAllMocks();
     vi.doUnmock('../../hud/stdin.js');
@@ -147,5 +154,16 @@ describe('HUD watch mode initialization', () => {
     await hud.main(true, false);
 
     expect(initializeHUDState).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the current session id to OMC state readers', async () => {
+    const hud = await importHudModule();
+    fakeStdin.transcript_path = '/tmp/worktree/transcripts/123e4567-e89b-12d3-a456-426614174000.jsonl';
+
+    await hud.main(true, false);
+
+    expect(readRalphStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
+    expect(readUltraworkStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
+    expect(readAutopilotStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
   });
 });

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -165,11 +165,13 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       staleTaskThresholdMinutes: config.staleTaskThresholdMinutes,
     });
 
+    const currentSessionId = extractSessionIdFromPath(resolvedTranscriptPath ?? stdin.transcript_path);
+
     // Read OMC state files
-    const ralph = readRalphStateForHud(cwd);
-    const ultrawork = readUltraworkStateForHud(cwd);
+    const ralph = readRalphStateForHud(cwd, currentSessionId ?? undefined);
+    const ultrawork = readUltraworkStateForHud(cwd, currentSessionId ?? undefined);
     const prd = readPrdStateForHud(cwd);
-    const autopilot = readAutopilotStateForHud(cwd);
+    const autopilot = readAutopilotStateForHud(cwd, currentSessionId ?? undefined);
 
     // Read HUD state for background tasks
     const hudState = readHudState(cwd);
@@ -181,7 +183,6 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     // We persist the real start time in HUD state on first observation.
     // Scoped per session ID so a new session in the same cwd resets the timestamp.
     let sessionStart = transcriptData.sessionStart;
-    const currentSessionId = extractSessionIdFromPath(resolvedTranscriptPath ?? stdin.transcript_path);
     const sameSession = hudState?.sessionId === currentSessionId;
     if (sameSession && hudState?.sessionStartTimestamp) {
       // Use persisted value (the real session start) - but validate first

--- a/src/hud/omc-state.ts
+++ b/src/hud/omc-state.ts
@@ -43,12 +43,18 @@ function isStateFileStale(filePath: string): boolean {
  * Returns the most recently modified matching path, or null if none found.
  * This ensures the HUD displays state from any active session (Issue #456).
  */
-function resolveStatePath(directory: string, filename: string): string | null {
+function resolveStatePath(directory: string, filename: string, sessionId?: string): string | null {
+  const omcRoot = getOmcRoot(directory);
+
+  if (sessionId) {
+    const sessionPath = join(omcRoot, 'state', 'sessions', sessionId, filename);
+    return existsSync(sessionPath) ? sessionPath : null;
+  }
+
   let bestPath: string | null = null;
   let bestMtime = 0;
 
   // Check session-scoped paths first (most likely location after Issue #456 fix)
-  const omcRoot = getOmcRoot(directory);
   const sessionsDir = join(omcRoot, 'state', 'sessions');
   if (existsSync(sessionsDir)) {
     try {
@@ -119,8 +125,8 @@ interface RalphLoopState {
  * Read Ralph Loop state for HUD display.
  * Returns null if no state file exists or on error.
  */
-export function readRalphStateForHud(directory: string): RalphStateForHud | null {
-  const stateFile = resolveStatePath(directory, 'ralph-state.json');
+export function readRalphStateForHud(directory: string, sessionId?: string): RalphStateForHud | null {
+  const stateFile = resolveStatePath(directory, 'ralph-state.json', sessionId);
 
   if (!stateFile) {
     return null;
@@ -165,10 +171,11 @@ interface UltraworkState {
  * Checks only local .omc/state location.
  */
 export function readUltraworkStateForHud(
-  directory: string
+  directory: string,
+  sessionId?: string
 ): UltraworkStateForHud | null {
   // Check local state only (with new path fallback)
-  const localFile = resolveStatePath(directory, 'ultrawork-state.json');
+  const localFile = resolveStatePath(directory, 'ultrawork-state.json', sessionId);
 
   if (!localFile || isStateFileStale(localFile)) {
     return null;
@@ -269,8 +276,8 @@ interface AutopilotStateFile {
  * Read Autopilot state for HUD display.
  * Returns shape matching AutopilotStateForHud from elements/autopilot.ts.
  */
-export function readAutopilotStateForHud(directory: string): AutopilotStateForHud | null {
-  const stateFile = resolveStatePath(directory, 'autopilot-state.json');
+export function readAutopilotStateForHud(directory: string, sessionId?: string): AutopilotStateForHud | null {
+  const stateFile = resolveStatePath(directory, 'autopilot-state.json', sessionId);
 
   if (!stateFile) {
     return null;
@@ -310,10 +317,10 @@ export function readAutopilotStateForHud(directory: string): AutopilotStateForHu
 /**
  * Check if any OMC mode is currently active
  */
-export function isAnyModeActive(directory: string): boolean {
-  const ralph = readRalphStateForHud(directory);
-  const ultrawork = readUltraworkStateForHud(directory);
-  const autopilot = readAutopilotStateForHud(directory);
+export function isAnyModeActive(directory: string, sessionId?: string): boolean {
+  const ralph = readRalphStateForHud(directory, sessionId);
+  const ultrawork = readUltraworkStateForHud(directory, sessionId);
+  const autopilot = readAutopilotStateForHud(directory, sessionId);
 
   return (ralph?.active ?? false) || (ultrawork?.active ?? false) || (autopilot?.active ?? false);
 }
@@ -321,20 +328,20 @@ export function isAnyModeActive(directory: string): boolean {
 /**
  * Get active skill names for display
  */
-export function getActiveSkills(directory: string): string[] {
+export function getActiveSkills(directory: string, sessionId?: string): string[] {
   const skills: string[] = [];
 
-  const autopilot = readAutopilotStateForHud(directory);
+  const autopilot = readAutopilotStateForHud(directory, sessionId);
   if (autopilot?.active) {
     skills.push('autopilot');
   }
 
-  const ralph = readRalphStateForHud(directory);
+  const ralph = readRalphStateForHud(directory, sessionId);
   if (ralph?.active) {
     skills.push('ralph');
   }
 
-  const ultrawork = readUltraworkStateForHud(directory);
+  const ultrawork = readUltraworkStateForHud(directory, sessionId);
   if (ultrawork?.active) {
     skills.push('ultrawork');
   }


### PR DESCRIPTION
## Summary\n- pass the current transcript-derived session id into HUD OMC state readers\n- make HUD state resolution read only the requested session file when a session id is available\n- add HUD tests for backward-compatible fallback scanning and cross-session isolation\n\n## Testing\n- npx vitest run src/__tests__/hud/ src/hooks/ultrawork/ --reporter=verbose\n- npx tsc --noEmit\n