### PR TITLE
Fix ralplan stop-hook blocking during active subagent waits

### DIFF
--- a/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
@@ -113,6 +113,28 @@ function writeStopBreaker(
   );
 }
 
+function writeSubagentTrackingState(
+  tempDir: string,
+  agents: Array<Record<string, unknown>>,
+): void {
+  const stateDir = join(tempDir, '.omc', 'state');
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    join(stateDir, 'subagent-tracking.json'),
+    JSON.stringify(
+      {
+        agents,
+        total_spawned: agents.length,
+        total_completed: agents.filter((agent) => agent.status === 'completed').length,
+        total_failed: agents.filter((agent) => agent.status === 'failed').length,
+        last_updated: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
 // ===========================================================================
 // Team Pipeline Standalone Tests
 // ===========================================================================
@@ -578,6 +600,62 @@ describe('ralplan standalone stop enforcement', () => {
       const result = await checkPersistentModes(sessionId, tempDir);
       expect(result.shouldBlock).toBe(false);
       expect(result.mode).toBe('ralplan');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows orchestrator idle when ralplan is active but delegated subagents are still running', async () => {
+    const sessionId = 'session-ralplan-active-subagents';
+    const tempDir = makeTempProject();
+
+    try {
+      writeRalplanState(tempDir, sessionId);
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: 'agent-1721-active',
+          agent_type: 'explore',
+          started_at: new Date().toISOString(),
+          parent_mode: 'ralplan',
+          status: 'running',
+        },
+      ]);
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('ralplan');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not consume ralplan breaker budget while subagents are active', async () => {
+    const sessionId = 'session-ralplan-subagent-breaker';
+    const tempDir = makeTempProject();
+
+    try {
+      writeRalplanState(tempDir, sessionId);
+      writeStopBreaker(tempDir, sessionId, 'ralplan', 30);
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: 'agent-1721-breaker',
+          agent_type: 'explore',
+          started_at: new Date().toISOString(),
+          parent_mode: 'ralplan',
+          status: 'running',
+        },
+      ]);
+
+      const bypassResult = await checkPersistentModes(sessionId, tempDir);
+      expect(bypassResult.shouldBlock).toBe(false);
+      expect(bypassResult.mode).toBe('ralplan');
+
+      writeSubagentTrackingState(tempDir, []);
+
+      const resumedResult = await checkPersistentModes(sessionId, tempDir);
+      expect(resumedResult.shouldBlock).toBe(true);
+      expect(resumedResult.mode).toBe('ralplan');
+      expect(resumedResult.message).toContain('1/30');
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -49,6 +49,7 @@ import {
 import { checkAutopilot } from '../autopilot/enforcement.js';
 import { readTeamPipelineState } from '../team-pipeline/state.js';
 import type { TeamPipelinePhase } from '../team-pipeline/types.js';
+import { getActiveAgentCount } from '../subagent-tracker/index.js';
 
 export interface ToolErrorState {
   tool_name: string;
@@ -881,6 +882,18 @@ async function checkRalplan(
       shouldBlock: false,
       message: '',
       mode: 'ralplan'
+    };
+  }
+
+  // Orchestrators are allowed to go idle while delegated work is still active.
+  // Delegation waits are expected, so clear any accumulated breaker budget and
+  // let enforcement resume from a clean slate after the running subagents finish.
+  if (getActiveAgentCount(workingDir) > 0) {
+    writeStopBreaker(workingDir, 'ralplan', 0, sessionId);
+    return {
+      shouldBlock: false,
+      message: '',
+      mode: 'ralplan',
     };
   }
 


### PR DESCRIPTION
## Summary
- allow ralplan to idle while tracked subagents are still running
- clear stale ralplan breaker budget during delegated waits so enforcement resumes at 1/30 afterward
- add regression coverage for active-subagent bypass and breaker reset behavior

## Verification
- npx vitest run src/hooks/persistent-mode/ src/hooks/skill-state/ --reporter=verbose

## Related
- Fixes #1721