### PR TITLE
test(installer): lock MCP config ownership at install boundary

### DIFF
--- a/src/__tests__/installer-mcp-config.test.ts
+++ b/src/__tests__/installer-mcp-config.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  const { join: pathJoin } = await import('path');
+  const repoRoot = process.cwd();
+  const sourceClaudeMdPath = pathJoin(repoRoot, 'src', 'docs', 'CLAUDE.md');
+  const realClaudeMdPath = pathJoin(repoRoot, 'docs', 'CLAUDE.md');
+
+  const withRedirect = (pathLike: unknown): string => {
+    const normalized = String(pathLike).replace(/\\/g, '/');
+    if (normalized === sourceClaudeMdPath.replace(/\\/g, '/')) {
+      return realClaudeMdPath;
+    }
+    return String(pathLike);
+  };
+
+  return {
+    ...actual,
+    existsSync: vi.fn((pathLike: Parameters<typeof actual.existsSync>[0]) =>
+      actual.existsSync(withRedirect(pathLike))
+    ),
+    readFileSync: vi.fn((pathLike: Parameters<typeof actual.readFileSync>[0], options?: Parameters<typeof actual.readFileSync>[1]) =>
+      actual.readFileSync(withRedirect(pathLike), options as never)
+    ),
+  };
+});
+
+async function loadInstallerWithEnv(claudeConfigDir: string, homeDir: string, codexHome: string, omcHome: string) {
+  vi.resetModules();
+  process.env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+  process.env.HOME = homeDir;
+  process.env.CODEX_HOME = codexHome;
+  process.env.OMC_HOME = omcHome;
+  delete process.env.CLAUDE_MCP_CONFIG_PATH;
+  delete process.env.OMC_MCP_REGISTRY_PATH;
+  return import('../installer/index.js');
+}
+
+describe('installer MCP config ownership (issue #1802)', () => {
+  let tempRoot: string;
+  let homeDir: string;
+  let claudeConfigDir: string;
+  let codexHome: string;
+  let omcHome: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'omc-installer-mcp-config-'));
+    homeDir = join(tempRoot, 'home');
+    claudeConfigDir = join(homeDir, '.claude');
+    codexHome = join(tempRoot, '.codex');
+    omcHome = join(tempRoot, '.omc');
+
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(claudeConfigDir, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(omcHome, { recursive: true });
+
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(tempRoot, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it('moves legacy settings.json mcpServers into ~/.claude.json during install', async () => {
+    const settingsPath = join(claudeConfigDir, 'settings.json');
+    const claudeRootConfigPath = join(homeDir, '.claude.json');
+    const codexConfigPath = join(codexHome, 'config.toml');
+    const registryPath = join(omcHome, 'mcp-registry.json');
+
+    writeFileSync(settingsPath, JSON.stringify({
+      theme: 'dark',
+      statusLine: {
+        type: 'command',
+        command: 'node hud.mjs',
+      },
+      mcpServers: {
+        gitnexus: {
+          command: 'gitnexus',
+          args: ['mcp'],
+          timeout: 15,
+        },
+      },
+    }, null, 2));
+
+    const installer = await loadInstallerWithEnv(claudeConfigDir, homeDir, codexHome, omcHome);
+    const result = installer.install({
+      skipClaudeCheck: true,
+      skipHud: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(existsSync(settingsPath)).toBe(true);
+    expect(existsSync(claudeRootConfigPath)).toBe(true);
+    expect(existsSync(registryPath)).toBe(true);
+    expect(existsSync(codexConfigPath)).toBe(true);
+
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+    expect(settings).toEqual({
+      theme: 'dark',
+      statusLine: {
+        type: 'command',
+        command: 'node hud.mjs',
+      },
+    });
+    expect(settings).not.toHaveProperty('mcpServers');
+
+    const claudeRootConfig = JSON.parse(readFileSync(claudeRootConfigPath, 'utf-8')) as Record<string, unknown>;
+    expect(claudeRootConfig).toEqual({
+      mcpServers: {
+        gitnexus: {
+          command: 'gitnexus',
+          args: ['mcp'],
+          timeout: 15,
+        },
+      },
+    });
+
+    expect(JSON.parse(readFileSync(registryPath, 'utf-8'))).toEqual({
+      gitnexus: {
+        command: 'gitnexus',
+        args: ['mcp'],
+        timeout: 15,
+      },
+    });
+
+    const codexConfig = readFileSync(codexConfigPath, 'utf-8');
+    expect(codexConfig).toContain('# BEGIN OMC MANAGED MCP REGISTRY');
+    expect(codexConfig).toContain('[mcp_servers.gitnexus]');
+    expect(codexConfig).toContain('command = "gitnexus"');
+  });
+});


### PR DESCRIPTION
## Summary
- add an `install()`-boundary regression for issue #1802
- prove legacy `mcpServers` migrate out of `~/.claude/settings.json` into `~/.claude.json`
- lock the current installer behavior with real orchestration coverage instead of helper-only coverage

## Root cause
Issue #1802 reported MCP servers being written to the wrong Claude config file. The real installer boundary was not covered by tests, so the observed behavior could not be distinguished from helper-only correctness.

This PR adds an install-level regression and confirms the current installer flow already does the right thing:
- `settings.json` is cleaned of `mcpServers`
- `~/.claude.json` receives the MCP server definitions
- unified registry / Codex sync still happen

## Files changed
- `src/__tests__/installer-mcp-config.test.ts`

## Verification
- `npx vitest run src/__tests__/installer-mcp-config.test.ts --reporter=verbose`
- `npx vitest run src/installer/__tests__/mcp-registry.test.ts src/__tests__/installer-mcp-config.test.ts --reporter=verbose`
- `npx tsc --noEmit`
- `npm run lint -- src/__tests__/installer-mcp-config.test.ts`
- `npx vitest run --reporter=verbose`

## Notes
- This resolved as a test-gap fix, not a production routing patch.
- Existing repo lint warnings remain warnings only and were not introduced by this PR.
- Full verbose Vitest pass completed successfully in this branch.
