### PR TITLE
Fix HUD context percentage jitter

### DIFF
--- a/src/__tests__/hud/context.test.ts
+++ b/src/__tests__/hud/context.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getStableContextDisplayPercent,
+  renderContext,
+  renderContextWithBar,
+  resetContextDisplayState,
+} from '../../hud/elements/context.js';
+import type { HudThresholds } from '../../hud/types.js';
+
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+const thresholds: HudThresholds = {
+  contextWarning: 70,
+  contextCompactSuggestion: 80,
+  contextCritical: 85,
+  ralphWarning: 7,
+};
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_REGEX, '');
+}
+
+describe('HUD context display smoothing', () => {
+  beforeEach(() => {
+    resetContextDisplayState();
+  });
+
+  it('suppresses nearby ctx jitter in the plain display', () => {
+    expect(stripAnsi(renderContext(54, thresholds, 'session-a') ?? '')).toBe('ctx:54%');
+    expect(stripAnsi(renderContext(52, thresholds, 'session-a') ?? '')).toBe('ctx:54%');
+    expect(stripAnsi(renderContext(54, thresholds, 'session-a') ?? '')).toBe('ctx:54%');
+  });
+
+  it('updates when the context percentage changes materially', () => {
+    expect(getStableContextDisplayPercent(54, thresholds, 'session-a')).toBe(54);
+    expect(getStableContextDisplayPercent(50, thresholds, 'session-a')).toBe(50);
+    expect(stripAnsi(renderContext(50, thresholds, 'session-a') ?? '')).toBe('ctx:50%');
+  });
+
+  it('updates immediately when a threshold bucket changes', () => {
+    expect(stripAnsi(renderContext(79, thresholds, 'session-a') ?? '')).toBe('ctx:79%');
+    expect(stripAnsi(renderContext(80, thresholds, 'session-a') ?? '')).toBe('ctx:80% COMPRESS?');
+  });
+
+  it('applies the same smoothing to the bar display', () => {
+    expect(stripAnsi(renderContextWithBar(54, thresholds, 10, 'session-a') ?? '')).toContain('54%');
+    expect(stripAnsi(renderContextWithBar(52, thresholds, 10, 'session-a') ?? '')).toContain('54%');
+  });
+
+  it('resets smoothing when the display scope changes', () => {
+    expect(getStableContextDisplayPercent(54, thresholds, 'session-a')).toBe(54);
+    expect(getStableContextDisplayPercent(52, thresholds, 'session-a')).toBe(54);
+    expect(getStableContextDisplayPercent(52, thresholds, 'session-b')).toBe(52);
+  });
+
+  it('allows callers to reset cached display state', () => {
+    expect(getStableContextDisplayPercent(54, thresholds, 'session-a')).toBe(54);
+    expect(getStableContextDisplayPercent(52, thresholds, 'session-a')).toBe(54);
+
+    resetContextDisplayState();
+
+    expect(getStableContextDisplayPercent(52, thresholds, 'session-a')).toBe(52);
+  });
+});

--- a/src/hud/elements/context.ts
+++ b/src/hud/elements/context.ts
@@ -11,6 +11,113 @@ const GREEN = '\x1b[32m';
 const YELLOW = '\x1b[33m';
 const RED = '\x1b[31m';
 const DIM = '\x1b[2m';
+const CONTEXT_DISPLAY_HYSTERESIS = 2;
+const CONTEXT_DISPLAY_STATE_TTL_MS = 5_000;
+
+type ContextSeverity = 'normal' | 'warning' | 'compact' | 'critical';
+
+let lastDisplayedPercent: number | null = null;
+let lastDisplayedSeverity: ContextSeverity | null = null;
+let lastDisplayScope: string | null = null;
+let lastDisplayUpdatedAt = 0;
+
+function clampContextPercent(percent: number): number {
+  return Math.min(100, Math.max(0, Math.round(percent)));
+}
+
+function getContextSeverity(
+  safePercent: number,
+  thresholds: HudThresholds,
+): ContextSeverity {
+  if (safePercent >= thresholds.contextCritical) {
+    return 'critical';
+  }
+  if (safePercent >= thresholds.contextCompactSuggestion) {
+    return 'compact';
+  }
+  if (safePercent >= thresholds.contextWarning) {
+    return 'warning';
+  }
+  return 'normal';
+}
+
+function getContextDisplayStyle(
+  safePercent: number,
+  thresholds: HudThresholds,
+): { color: string; suffix: string } {
+  const severity = getContextSeverity(safePercent, thresholds);
+
+  switch (severity) {
+    case 'critical':
+      return { color: RED, suffix: ' CRITICAL' };
+    case 'compact':
+      return { color: YELLOW, suffix: ' COMPRESS?' };
+    case 'warning':
+      return { color: YELLOW, suffix: '' };
+    default:
+      return { color: GREEN, suffix: '' };
+  }
+}
+
+/**
+ * Reset cached context display state.
+ * Useful for test isolation and fresh render sessions.
+ */
+export function resetContextDisplayState(): void {
+  lastDisplayedPercent = null;
+  lastDisplayedSeverity = null;
+  lastDisplayScope = null;
+  lastDisplayUpdatedAt = 0;
+}
+
+/**
+ * Apply display-layer hysteresis so small refresh-to-refresh ctx fluctuations
+ * do not visibly jitter in the HUD.
+ */
+export function getStableContextDisplayPercent(
+  percent: number,
+  thresholds: HudThresholds,
+  displayScope?: string | null,
+): number {
+  const safePercent = clampContextPercent(percent);
+  const severity = getContextSeverity(safePercent, thresholds);
+  const nextScope = displayScope ?? null;
+  const now = Date.now();
+
+  if (nextScope !== lastDisplayScope) {
+    lastDisplayedPercent = null;
+    lastDisplayedSeverity = null;
+    lastDisplayScope = nextScope;
+  }
+
+  if (
+    lastDisplayedPercent === null
+    || lastDisplayedSeverity === null
+    || now - lastDisplayUpdatedAt > CONTEXT_DISPLAY_STATE_TTL_MS
+  ) {
+    lastDisplayedPercent = safePercent;
+    lastDisplayedSeverity = severity;
+    lastDisplayUpdatedAt = now;
+    return safePercent;
+  }
+
+  if (severity !== lastDisplayedSeverity) {
+    lastDisplayedPercent = safePercent;
+    lastDisplayedSeverity = severity;
+    lastDisplayUpdatedAt = now;
+    return safePercent;
+  }
+
+  if (Math.abs(safePercent - lastDisplayedPercent) <= CONTEXT_DISPLAY_HYSTERESIS) {
+    lastDisplayUpdatedAt = now;
+    return lastDisplayedPercent;
+  }
+
+  lastDisplayedPercent = safePercent;
+  lastDisplayedSeverity = severity;
+  lastDisplayUpdatedAt = now;
+  return safePercent;
+}
 
 /**
  * Render context window percentage.
@@ -19,23 +126,11 @@ const DIM = '\x1b[2m';
  */
 export function renderContext(
   percent: number,
-  thresholds: HudThresholds
+  thresholds: HudThresholds,
+  displayScope?: string | null,
 ): string | null {
-  const safePercent = Math.min(100, Math.max(0, Math.round(percent)));
-  let color: string;
-  let suffix = '';
-
-  if (safePercent >= thresholds.contextCritical) {
-    color = RED;
-    suffix = ' CRITICAL';
-  } else if (safePercent >= thresholds.contextCompactSuggestion) {
-    color = YELLOW;
-    suffix = ' COMPRESS?';
-  } else if (safePercent >= thresholds.contextWarning) {
-    color = YELLOW;
-  } else {
-    color = GREEN;
-  }
+  const safePercent = getStableContextDisplayPercent(percent, thresholds, displayScope);
+  const { color, suffix } = getContextDisplayStyle(safePercent, thresholds);
 
   return `ctx:${color}${safePercent}%${suffix}${RESET}`;
 }
@@ -48,27 +143,14 @@ export function renderContext(
 export function renderContextWithBar(
   percent: number,
   thresholds: HudThresholds,
-  barWidth: number = 10
+  barWidth: number = 10,
+  displayScope?: string | null,
 ): string | null {
-  const safePercent = Math.min(100, Math.max(0, Math.round(percent)));
+  const safePercent = getStableContextDisplayPercent(percent, thresholds, displayScope);
   const filled = Math.round((safePercent / 100) * barWidth);
   const empty = barWidth - filled;
 
-  let color: string;
-  let suffix = '';
-
-  if (safePercent >= thresholds.contextCritical) {
-    color = RED;
-    suffix = ' CRITICAL';
-  } else if (safePercent >= thresholds.contextCompactSuggestion) {
-    color = YELLOW;
-    suffix = ' COMPRESS?';
-  } else if (safePercent >= thresholds.contextWarning) {
-    color = YELLOW;
-  } else {
-    color = GREEN;
-  }
-
+  const { color, suffix } = getContextDisplayStyle(safePercent, thresholds);
   const bar = `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
   return `ctx:[${bar}]${color}${safePercent}%${suffix}${RESET}`;
 }

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -264,6 +264,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     // Build render context
     const context: HudRenderContext = {
       contextPercent,
+      contextDisplayScope: currentSessionId ?? cwd,
       modelName: getModelName(stdin),
       ralph,
       ultrawork,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -335,8 +335,8 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   // Context window
   if (enabledElements.contextBar) {
     const ctx = enabledElements.useBars
-      ? renderContextWithBar(context.contextPercent, config.thresholds)
-      : renderContext(context.contextPercent, config.thresholds);
+      ? renderContextWithBar(context.contextPercent, config.thresholds, 10, context.contextDisplayScope)
+      : renderContext(context.contextPercent, config.thresholds, context.contextDisplayScope);
     if (ctx) elements.push(ctx);
   }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -279,6 +279,9 @@ export interface HudRenderContext {
   /** Context window percentage (0-100) */
   contextPercent: number;
 
+  /** Stable display scope for context smoothing (e.g. session/worktree key) */
+  contextDisplayScope?: string | null;
+
   /** Model display name */
   modelName: string;
 


### PR DESCRIPTION
## Summary
- add display-layer hysteresis for the HUD context percentage so nearby refresh-to-refresh changes do not visibly jitter
- keep updates immediate when the percentage crosses warning/compact/critical thresholds
- add focused HUD regression tests for plain and bar context rendering plus scope/reset behavior

## Testing
- npx vitest run src/__tests__/hud/ --reporter=verbose
- npx tsc --noEmit
- npm run lint -- src/hud src/__tests__/hud/context.test.ts
