### PR TITLE
Fix duplicate worker instances in parallel team launches

### DIFF
--- a/src/__tests__/hud/mission-board-state.test.ts
+++ b/src/__tests__/hud/mission-board-state.test.ts
@@ -197,4 +197,42 @@ describe('mission board state tracking', () => {
     expect(mission?.agents[0]?.status).toBe('blocked');
     expect(mission?.agents[0]?.latestUpdate).toContain('waiting for approval');
   });
+
+  it('deduplicates duplicate team worker rows when refreshing mission board state', () => {
+    const cwd = makeTempDir();
+    const teamRoot = join(cwd, '.omc', 'state', 'team', 'dedupe-demo');
+    mkdirSync(join(teamRoot, 'tasks'), { recursive: true });
+    mkdirSync(join(teamRoot, 'workers', 'worker-1'), { recursive: true });
+
+    writeFileSync(join(teamRoot, 'config.json'), JSON.stringify({
+      name: 'dedupe-demo',
+      task: 'dedupe workers',
+      created_at: '2026-03-09T09:00:00.000Z',
+      worker_count: 2,
+      workers: [
+        { name: 'worker-1', role: 'executor', assigned_tasks: ['1'] },
+        { name: 'worker-1', role: 'executor', assigned_tasks: [], pane_id: '%7' },
+      ],
+    }, null, 2));
+
+    writeFileSync(join(teamRoot, 'tasks', '1.json'), JSON.stringify({
+      id: '1',
+      subject: 'Fix duplication',
+      status: 'in_progress',
+      owner: 'worker-1',
+    }, null, 2));
+
+    writeFileSync(join(teamRoot, 'workers', 'worker-1', 'status.json'), JSON.stringify({
+      state: 'working',
+      current_task_id: '1',
+      updated_at: '2026-03-09T09:05:00.000Z',
+    }, null, 2));
+
+    const state = refreshMissionBoardState(cwd);
+    const mission = state.missions.find((entry) => entry.source === 'team' && entry.teamName === 'dedupe-demo');
+
+    expect(mission?.agents).toHaveLength(1);
+    expect(mission?.agents[0]?.name).toBe('worker-1');
+    expect(mission?.workerCount).toBe(1);
+  });
 });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -403,6 +403,54 @@ describe('team cli', () => {
     logSpy.mockRestore();
   });
 
+  it('team status deduplicates workerPaneIds from duplicate worker config rows', async () => {
+    const { teamCommand } = await import('../team.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    mocks.isRuntimeV2Enabled.mockReturnValue(true);
+    mocks.monitorTeamV2.mockResolvedValue({
+      teamName: 'demo-team',
+      phase: 'team-exec',
+      workers: [],
+      tasks: { total: 1, pending: 0, blocked: 0, in_progress: 1, completed: 0, failed: 0, items: [] },
+      deadWorkers: [],
+      nonReportingWorkers: [],
+      recommendations: [],
+      allTasksTerminal: false,
+      performance: { total_ms: 1, list_tasks_ms: 1, worker_scan_ms: 0, mailbox_delivery_ms: 0, updated_at: new Date().toISOString() },
+    });
+
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-v2-status-dedup-'));
+    const root = join(cwd, '.omc', 'state', 'team', 'demo-team');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'config.json'), JSON.stringify({
+      name: 'demo-team',
+      task: 'demo',
+      agent_type: 'executor',
+      worker_count: 2,
+      max_workers: 20,
+      tmux_session: 'demo-session:0',
+      workers: [
+        { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [], pane_id: '%1' },
+        { name: 'worker-1', index: 0, role: 'executor', assigned_tasks: [] },
+      ],
+      created_at: new Date().toISOString(),
+      next_task_id: 2,
+      leader_pane_id: '%0',
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+    }));
+
+    await teamCommand(['status', 'demo-team', '--json', '--cwd', cwd]);
+
+    const payload = JSON.parse(logSpy.mock.calls[0][0] as string) as { workerPaneIds: string[] };
+    expect(payload.workerPaneIds).toEqual(['%1']);
+
+    rmSync(cwd, { recursive: true, force: true });
+    logSpy.mockRestore();
+  });
+
   it('team status supports team-name target via runtime snapshot', async () => {
     const { teamCommand } = await import('../team.js');
 

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -515,7 +515,11 @@ export async function teamStatusByTeamName(teamName: string, cwd = process.cwd()
       running: true,
       sessionName: config?.tmux_session,
       leaderPaneId: config?.leader_pane_id,
-      workerPaneIds: (config?.workers ?? []).map((worker) => worker.pane_id).filter((paneId): paneId is string => typeof paneId === 'string'),
+      workerPaneIds: Array.from(new Set(
+        (config?.workers ?? [])
+          .map((worker) => worker.pane_id)
+          .filter((paneId): paneId is string => typeof paneId === 'string' && paneId.trim().length > 0),
+      )),
       snapshot,
     };
   }

--- a/src/hud/mission-board.ts
+++ b/src/hud/mission-board.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { atomicWriteJsonSync } from '../lib/atomic-write.js';
 import { getOmcRoot } from '../lib/worktree-paths.js';
 import { truncateToWidth } from '../utils/string-width.js';
+import { canonicalizeWorkers } from '../team/worker-canonicalization.js';
 
 export type MissionBoardSource = 'session' | 'team';
 export type MissionBoardStatus = 'blocked' | 'waiting' | 'running' | 'done';
@@ -375,7 +376,12 @@ function collectTeamMission(teamRoot: string, teamName: string, config: Required
   const teamConfig = readJsonSafe<TeamConfigLike>(join(teamRoot, 'config.json'));
   if (!teamConfig) return null;
 
-  const workers = Array.isArray(teamConfig.workers) ? teamConfig.workers : [];
+  const workers = canonicalizeWorkers((Array.isArray(teamConfig.workers) ? teamConfig.workers : []).map((worker, index) => ({
+    name: worker.name ?? '',
+    index: index + 1,
+    role: worker.role ?? 'worker',
+    assigned_tasks: Array.isArray(worker.assigned_tasks) ? worker.assigned_tasks : [],
+  }))).workers;
   const tasksDir = join(teamRoot, 'tasks');
   const tasks = existsSync(tasksDir)
     ? readdirSync(tasksDir)
@@ -486,7 +492,7 @@ function collectTeamMission(teamRoot: string, teamName: string, config: Required
     createdAt,
     updatedAt,
     status: deriveTeamStatus(taskCounts, agents),
-    workerCount: teamConfig.worker_count || workers.length,
+    workerCount: workers.length,
     taskCounts,
     agents,
     timeline: timeline.slice(-config.maxTimelineEvents),

--- a/src/team/__tests__/api-interop.dispatch.test.ts
+++ b/src/team/__tests__/api-interop.dispatch.test.ts
@@ -143,4 +143,39 @@ describe('team api dispatch-aware messaging', () => {
     expect(requests[0]?.trigger_message).toContain('$OMC_TEAM_STATE_ROOT/team/dispatch-team/mailbox/worker-1.json');
     expect(requests[0]?.trigger_message).toContain('report progress');
   });
+
+  it('uses the canonical worker pane when duplicate worker records exist', async () => {
+    const configPath = join(cwd, '.omc', 'state', 'team', teamName, 'config.json');
+    await writeFile(configPath, JSON.stringify({
+      name: teamName,
+      task: 'dispatch',
+      agent_type: 'executor',
+      worker_count: 2,
+      max_workers: 20,
+      tmux_session: 'dispatch-session',
+      workers: [
+        { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        { name: 'worker-1', index: 0, role: 'executor', assigned_tasks: [], pane_id: '%9' },
+      ],
+      created_at: '2026-03-06T00:00:00.000Z',
+      next_task_id: 2,
+      leader_pane_id: '%0',
+    }, null, 2));
+
+    const result = await executeTeamApiOperation('send-message', {
+      team_name: teamName,
+      from_worker: 'leader-fixed',
+      to_worker: 'worker-1',
+      body: 'Continue',
+    }, cwd);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const messageId = (result.data as { message?: { message_id?: string } }).message?.message_id;
+    expect(typeof messageId).toBe('string');
+    const requests = await listDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: 'worker-1' });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.message_id).toBe(messageId);
+    expect(requests[0]?.status).toBe('pending');
+  });
 });

--- a/src/team/__tests__/runtime-v2.monitor.test.ts
+++ b/src/team/__tests__/runtime-v2.monitor.test.ts
@@ -130,4 +130,38 @@ describe('monitorTeamV2 pane-based stall inference', () => {
 
     expect(snapshot?.nonReportingWorkers).toEqual([]);
   });
+
+  it('deduplicates duplicate worker rows from persisted config during monitoring', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-monitor-dedup-'));
+    await writeConfigAndTask('pending');
+    const root = join(cwd, '.omc', 'state', 'team', 'demo-team');
+    await writeFile(join(root, 'config.json'), JSON.stringify({
+      name: 'demo-team',
+      task: 'demo',
+      agent_type: 'claude',
+      worker_launch_mode: 'interactive',
+      worker_count: 2,
+      max_workers: 20,
+      workers: [
+        { name: 'worker-1', index: 1, role: 'claude', assigned_tasks: ['1'] },
+        { name: 'worker-1', index: 0, role: 'claude', assigned_tasks: [], pane_id: '%2', working_dir: cwd },
+      ],
+      created_at: new Date().toISOString(),
+      tmux_session: 'demo-session:0',
+      leader_pane_id: '%1',
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+      next_task_id: 2,
+      team_state_root: join(cwd, '.omc', 'state', 'team', 'demo-team'),
+      workspace_mode: 'single',
+    }, null, 2), 'utf-8');
+
+    const { monitorTeamV2 } = await import('../runtime-v2.js');
+    const snapshot = await monitorTeamV2('demo-team', cwd);
+
+    expect(snapshot?.workers).toHaveLength(1);
+    expect(snapshot?.workers[0]?.name).toBe('worker-1');
+    expect(snapshot?.workers[0]?.assignedTasks).toEqual(['1']);
+  });
 });

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { scaleUp } from '../scaling.js';
+
+describe('scaleUp duplicate worker guard', () => {
+  let cwd: string;
+
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('refuses to spawn a duplicate worker identity when next_worker_index collides', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-scaling-duplicate-'));
+    const teamName = 'demo-team';
+    const root = join(cwd, '.omc', 'state', 'team', teamName);
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, 'config.json'), JSON.stringify({
+      name: teamName,
+      task: 'demo',
+      agent_type: 'claude',
+      worker_launch_mode: 'interactive',
+      worker_count: 1,
+      max_workers: 20,
+      workers: [{ name: 'worker-1', index: 1, role: 'claude', assigned_tasks: [] }],
+      created_at: new Date().toISOString(),
+      tmux_session: 'demo-session:0',
+      next_task_id: 2,
+      next_worker_index: 1,
+      leader_pane_id: '%0',
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+      team_state_root: root,
+    }, null, 2), 'utf-8');
+
+    const result = await scaleUp(
+      teamName,
+      1,
+      'claude',
+      [{ subject: 'demo', description: 'demo task' }],
+      cwd,
+      { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain('refusing to spawn duplicate worker identity');
+
+    const config = JSON.parse(await readFile(join(root, 'config.json'), 'utf-8')) as { workers: Array<{ name: string }> };
+    expect(config.workers.map((worker) => worker.name)).toEqual(['worker-1']);
+  });
+});

--- a/src/team/__tests__/worker-canonicalization.test.ts
+++ b/src/team/__tests__/worker-canonicalization.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalizeWorkers } from '../worker-canonicalization.js';
+
+describe('canonicalizeWorkers', () => {
+  it('prefers pane identity, backfills metadata, and unions assigned tasks', () => {
+    const result = canonicalizeWorkers([
+      {
+        name: 'worker-2',
+        index: 2,
+        role: 'executor',
+        assigned_tasks: ['1'],
+        working_dir: '/tmp/a',
+      },
+      {
+        name: 'worker-2',
+        index: 0,
+        role: '',
+        assigned_tasks: ['2', '1'],
+        pane_id: '%5',
+        pid: 1234,
+      },
+    ]);
+
+    expect(result.duplicateNames).toEqual(['worker-2']);
+    expect(result.workers).toHaveLength(1);
+    expect(result.workers[0]).toMatchObject({
+      name: 'worker-2',
+      pane_id: '%5',
+      pid: 1234,
+      role: 'executor',
+      index: 2,
+      working_dir: '/tmp/a',
+      assigned_tasks: ['2', '1'],
+    });
+  });
+});

--- a/src/team/monitor.ts
+++ b/src/team/monitor.ts
@@ -28,6 +28,7 @@ import type {
 } from './types.js';
 import type { TeamPhase } from './phase-controller.js';
 import { normalizeTeamManifest } from './governance.js';
+import { canonicalizeTeamConfigWorkers } from './worker-canonicalization.js';
 
 // ---------------------------------------------------------------------------
 // State I/O helpers (self-contained, no external deps beyond fs)
@@ -57,7 +58,8 @@ async function writeAtomic(filePath: string, data: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export async function readTeamConfig(teamName: string, cwd: string): Promise<TeamConfig | null> {
-  return readJsonSafe<TeamConfig>(absPath(cwd, TeamPaths.config(teamName)));
+  const config = await readJsonSafe<TeamConfig>(absPath(cwd, TeamPaths.config(teamName)));
+  return config ? canonicalizeTeamConfigWorkers(config) : null;
 }
 
 export async function readTeamManifest(teamName: string, cwd: string): Promise<TeamManifestV2 | null> {

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -148,6 +148,17 @@ export async function scaleUp(
       const workerIndex = nextIndex;
       nextIndex++;
       const workerName = `worker-${workerIndex}`;
+      if (config.workers.some((worker) => worker.name === workerName)) {
+        await teamAppendEvent(sanitized, {
+          type: 'team_leader_nudge',
+          worker: 'leader-fixed',
+          reason: `scale_up_duplicate_worker_blocked:${workerName}`,
+        }, leaderCwd);
+        return {
+          ok: false,
+          error: `Worker ${workerName} already exists in team ${sanitized}; refusing to spawn duplicate worker identity.`,
+        };
+      }
 
       // Create worker directory
       const workerDirPath = absPath(leaderCwd, TeamPaths.workerDir(sanitized, workerName));

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -51,6 +51,7 @@ import {
   releaseTaskClaim as releaseTaskClaimImpl,
   listTasks as listTasksImpl,
 } from './state/tasks.js';
+import { canonicalizeTeamConfigWorkers } from './worker-canonicalization.js';
 
 // Re-export types for consumers
 export type {
@@ -194,7 +195,7 @@ export async function teamReadConfig(teamName: string, cwd: string): Promise<Tea
   // Try manifest first, fall back to config.json
   const manifest = await teamReadManifest(teamName, cwd);
   if (manifest) {
-    return {
+    return canonicalizeTeamConfigWorkers({
       name: manifest.name,
       task: manifest.task,
       agent_type: 'claude',
@@ -215,11 +216,12 @@ export async function teamReadConfig(teamName: string, cwd: string): Promise<Tea
       resize_hook_name: manifest.resize_hook_name,
       resize_hook_target: manifest.resize_hook_target,
       next_worker_index: manifest.next_worker_index,
-    };
+    });
   }
 
   const configPath = absPath(cwd, TeamPaths.config(teamName));
-  return readJsonSafe<TeamConfig>(configPath);
+  const config = await readJsonSafe<TeamConfig>(configPath);
+  return config ? canonicalizeTeamConfigWorkers(config) : null;
 }
 
 export async function teamReadManifest(teamName: string, cwd: string): Promise<TeamManifestV2 | null> {

--- a/src/team/worker-canonicalization.ts
+++ b/src/team/worker-canonicalization.ts
@@ -1,0 +1,112 @@
+import type { TeamConfig, WorkerInfo } from './types.js';
+
+export interface WorkerCanonicalizationResult {
+  workers: WorkerInfo[];
+  duplicateNames: string[];
+}
+
+function hasText(value: string | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasAssignedTasks(worker: WorkerInfo): boolean {
+  return Array.isArray(worker.assigned_tasks) && worker.assigned_tasks.length > 0;
+}
+
+function workerPriority(worker: WorkerInfo): number {
+  if (hasText(worker.pane_id)) return 4;
+  if (typeof worker.pid === 'number' && Number.isFinite(worker.pid)) return 3;
+  if (hasAssignedTasks(worker)) return 2;
+  if (typeof worker.index === 'number' && worker.index > 0) return 1;
+  return 0;
+}
+
+function mergeAssignedTasks(primary: string[] | undefined, secondary: string[] | undefined): string[] {
+  const merged: string[] = [];
+  for (const taskId of [...(primary ?? []), ...(secondary ?? [])]) {
+    if (typeof taskId !== 'string' || taskId.trim() === '' || merged.includes(taskId)) continue;
+    merged.push(taskId);
+  }
+  return merged;
+}
+
+function backfillText(primary: string | undefined, secondary: string | undefined): string | undefined {
+  return hasText(primary) ? primary : secondary;
+}
+
+function backfillBoolean(primary: boolean | undefined, secondary: boolean | undefined): boolean | undefined {
+  return typeof primary === 'boolean' ? primary : secondary;
+}
+
+function backfillNumber(primary: number | undefined, secondary: number | undefined, predicate?: (value: number) => boolean): number | undefined {
+  const isUsable = (value: number | undefined): value is number =>
+    typeof value === 'number' && Number.isFinite(value) && (predicate ? predicate(value) : true);
+  return isUsable(primary) ? primary : isUsable(secondary) ? secondary : undefined;
+}
+
+function chooseWinningWorker(existing: WorkerInfo, incoming: WorkerInfo): { winner: WorkerInfo; loser: WorkerInfo } {
+  const existingPriority = workerPriority(existing);
+  const incomingPriority = workerPriority(incoming);
+  if (incomingPriority > existingPriority) return { winner: incoming, loser: existing };
+  if (incomingPriority < existingPriority) return { winner: existing, loser: incoming };
+  if ((incoming.index ?? 0) >= (existing.index ?? 0)) return { winner: incoming, loser: existing };
+  return { winner: existing, loser: incoming };
+}
+
+export function canonicalizeWorkers(workers: WorkerInfo[]): WorkerCanonicalizationResult {
+  const byName = new Map<string, WorkerInfo>();
+  const duplicateNames = new Set<string>();
+
+  for (const worker of workers) {
+    const name = typeof worker.name === 'string' ? worker.name.trim() : '';
+    if (!name) continue;
+
+    const normalized: WorkerInfo = {
+      ...worker,
+      name,
+      assigned_tasks: Array.isArray(worker.assigned_tasks) ? worker.assigned_tasks : [],
+    };
+
+    const existing = byName.get(name);
+    if (!existing) {
+      byName.set(name, normalized);
+      continue;
+    }
+
+    duplicateNames.add(name);
+    const { winner, loser } = chooseWinningWorker(existing, normalized);
+    byName.set(name, {
+      ...winner,
+      name,
+      assigned_tasks: mergeAssignedTasks(winner.assigned_tasks, loser.assigned_tasks),
+      pane_id: backfillText(winner.pane_id, loser.pane_id),
+      pid: backfillNumber(winner.pid, loser.pid),
+      index: backfillNumber(winner.index, loser.index, (value) => value > 0) ?? 0,
+      role: backfillText(winner.role, loser.role) ?? winner.role,
+      worker_cli: backfillText(winner.worker_cli, loser.worker_cli) as WorkerInfo['worker_cli'],
+      working_dir: backfillText(winner.working_dir, loser.working_dir),
+      worktree_path: backfillText(winner.worktree_path, loser.worktree_path),
+      worktree_branch: backfillText(winner.worktree_branch, loser.worktree_branch),
+      worktree_detached: backfillBoolean(winner.worktree_detached, loser.worktree_detached),
+      team_state_root: backfillText(winner.team_state_root, loser.team_state_root),
+    });
+  }
+
+  return {
+    workers: Array.from(byName.values()),
+    duplicateNames: Array.from(duplicateNames.values()),
+  };
+}
+
+export function canonicalizeTeamConfigWorkers(config: TeamConfig): TeamConfig {
+  const { workers, duplicateNames } = canonicalizeWorkers(config.workers ?? []);
+  if (duplicateNames.length > 0) {
+    console.warn(
+      `[team] canonicalized duplicate worker entries: ${duplicateNames.join(', ')}`
+    );
+  }
+  return {
+    ...config,
+    workers,
+  };
+}


### PR DESCRIPTION
## Summary
- prevent duplicate worker identities from being appended during scaling
- canonicalize duplicate worker rows at shared team config read boundaries
- deduplicate direct consumer outputs in CLI status and HUD mission board
- add regression coverage for monitor, API interop, CLI status, scaling, and HUD state

## Root cause
Persisted `config.workers` could contain duplicate rows for the same worker name. Downstream consumers trusted that state directly, so duplicate logical workers leaked into monitor/status/HUD surfaces and pane-targeted operations.

## Testing
- `npx vitest --run src/team/__tests__/worker-canonicalization.test.ts src/team/__tests__/scaling.test.ts src/team/__tests__/runtime-v2.monitor.test.ts src/team/__tests__/api-interop.dispatch.test.ts src/cli/__tests__/team.test.ts src/__tests__/hud/mission-board-state.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/team/worker-canonicalization.ts src/team/monitor.ts src/team/team-ops.ts src/team/scaling.ts src/team/runtime-v2.ts src/team/api-interop.ts src/cli/team.ts src/hud/mission-board.ts src/team/__tests__/worker-canonicalization.test.ts src/team/__tests__/scaling.test.ts src/team/__tests__/runtime-v2.monitor.test.ts src/team/__tests__/api-interop.dispatch.test.ts src/__tests__/hud/mission-board-state.test.ts src/cli/__tests__/team.test.ts`

## Notes
- preserves canonicalization winner semantics for pane-sensitive flows: `pane_id > pid > assigned_tasks > index`
- read-time dedup tolerates stale persisted duplicate config without rewriting old state in place
