### PR TITLE
Fix bridge skill discovery for canonical temp paths

### DIFF
--- a/src/__tests__/hooks/learner/bridge.test.ts
+++ b/src/__tests__/hooks/learner/bridge.test.ts
@@ -9,7 +9,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  symlinkSync,
+} from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
@@ -117,6 +124,33 @@ describe("Skill Bridge Module", () => {
 
       expect(projectFiles).toHaveLength(1);
       expect(projectFiles[0].path).toContain("valid.md");
+    });
+
+    it("should treat symlinked project roots as within boundary", () => {
+      const skillsDir = join(testProjectRoot, ".omc", "skills");
+      mkdirSync(skillsDir, { recursive: true });
+
+      writeFileSync(
+        join(skillsDir, "linked-skill.md"),
+        "---\nname: Linked Skill\ntriggers:\n  - linked\n---\nContent",
+      );
+
+      const linkedProjectRoot = join(
+        tmpdir(),
+        `omc-bridge-link-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      );
+
+      try {
+        symlinkSync(testProjectRoot, linkedProjectRoot, "dir");
+
+        const files = findSkillFiles(linkedProjectRoot);
+        const projectFiles = files.filter((f) => f.scope === "project");
+
+        expect(projectFiles).toHaveLength(1);
+        expect(projectFiles[0].path).toContain("linked-skill.md");
+      } finally {
+        rmSync(linkedProjectRoot, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/hooks/learner/bridge.ts
+++ b/src/hooks/learner/bridge.ts
@@ -352,8 +352,12 @@ function safeRealpathSync(filePath: string): string {
  * Check if a resolved path is within a boundary directory.
  */
 function isWithinBoundary(realPath: string, boundary: string): boolean {
-  const normalizedReal = realPath.replace(/\\/g, "/").replace(/\/+/g, "/");
-  const normalizedBoundary = boundary.replace(/\\/g, "/").replace(/\/+/g, "/");
+  const normalizedReal = safeRealpathSync(realPath)
+    .replace(/\\/g, "/")
+    .replace(/\/+/g, "/");
+  const normalizedBoundary = safeRealpathSync(boundary)
+    .replace(/\\/g, "/")
+    .replace(/\/+/g, "/");
   return (
     normalizedReal === normalizedBoundary ||
     normalizedReal.startsWith(normalizedBoundary + "/")


### PR DESCRIPTION
## Summary\n- canonicalize both the discovered file path and boundary path inside bridge boundary checks\n- add a regression test for symlinked project roots so bridge discovery handles lexical vs real paths consistently\n- verify the bridge learner test target passes\n\n## Testing\n- npx vitest run src/__tests__/hooks/learner/bridge.test.ts --reporter=verbose\n- npx tsc --noEmit\n