### PR TITLE
fix(auto-slash-command): include builtin skills in command discovery

### DIFF
--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -21,6 +21,7 @@ import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from '../../features/builtin-skills/runtime-guidance.js';
+import { getSkillsDir } from '../../features/builtin-skills/skills.js';
 
 /** Claude config directory */
 const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
@@ -198,14 +199,16 @@ export function discoverAllCommands(): CommandInfo[] {
   const projectOmcSkills = discoverSkillsFromDir(projectOmcSkillsDir);
   const projectAgentSkills = discoverSkillsFromDir(projectAgentSkillsDir);
   const userSkills = discoverSkillsFromDir(userSkillsDir);
+  const builtinSkills = discoverSkillsFromDir(getSkillsDir());
 
-  // Priority: project commands > user commands > project OMC skills > project compatibility skills > user skills
+  // Priority: project commands > user commands > project OMC skills > project compatibility skills > user skills > builtin skills
   const prioritized = [
     ...projectCommands,
     ...userCommands,
     ...projectOmcSkills,
     ...projectAgentSkills,
     ...userSkills,
+    ...builtinSkills,
   ];
   const seen = new Set<string>();
 


### PR DESCRIPTION
## Summary

- Fixes #1831: Builtin skill aliases (e.g. `/psm`) were not found by the auto-slash-command hook
- `discoverAllCommands()` now includes the package's builtin `skills/` directory at lowest priority
- One-line change: adds `getSkillsDir()` to the discovery pipeline

## Test plan

- [x] `findCommand('psm')` now resolves to `project-session-manager` with correct alias metadata
- [x] `executeSlashCommand({ command: 'psm' })` returns the skill template successfully
- [x] All existing tests pass (`auto-slash-aliases.test.ts`, `skills.test.ts`)
- [x] Build succeeds
- [ ] Manual verification: type `/psm` in a Claude Code session with OMC installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)