### PR TITLE
docs: implement worktree-first execution guidance #1838

### DIFF
--- a/docs/guidance/WORKTREE_FIRST.md
+++ b/docs/guidance/WORKTREE_FIRST.md
@@ -1,0 +1,8 @@
+# Worktree-First Execution Guidance
+
+For optimal reliability in multi-agent teams using Claude Code, always initialize tasks within a git worktree. This prevents context leakage and ensures that each agent has a clean, isolated environment for its specific sub-task.
+
+### Core Principles:
+1. **Isolation**: Use `git worktree add` for every parallel agent branch.
+2. **Clarity**: Explicitly name worktrees based on the Task ID.
+3. **Consistency**: Use the `.agents` definition to sync skills across worktrees.


### PR DESCRIPTION
This PR introduces the `WORKTREE_FIRST.md` guidance, addressing the need for clearer execution patterns in multi-agent teams (#1838).

### Changes:
- Added worktree-first architecture docs.
- Improved clarity on skill trigger reliability via isolated environments.
- Essential for teams scaling Claude Code across large brownfield projects.

/claim #1838