### PR TITLE
fix(security): prevent shell injection in ralphthon tmux commands

### DIFF
--- a/src/cli/commands/ralphthon.ts
+++ b/src/cli/commands/ralphthon.ts
@@ -22,6 +22,7 @@ import {
   formatRalphthonStatus,
   getRalphthonPrdPath,
   initRalphthonPrd,
+  sendKeysToPane,
 } from '../../ralphthon/index.js';
 import type {
   RalphthonCliOptions,
@@ -266,7 +267,9 @@ export async function ralphthonCommand(args: string[]): Promise<void> {
 
     // Inject deep-interview command to the leader pane
     // The orchestrator will wait for the PRD to appear
-    const interviewPrompt = `/deep-interview ${options.task}
+    // Sanitize task to prevent newline/control char injection via tmux send-keys
+    const sanitizedTask = options.task!.replace(/[\r\n\0]+/g, ' ').trim();
+    const interviewPrompt = `/deep-interview ${sanitizedTask}
 
 After the interview, generate a ralphthon-prd.json file in .omc/ with this structure:
 {
@@ -289,6 +292,13 @@ After the interview, generate a ralphthon-prd.json file in .omc/ with this struc
     );
     state.phase = 'interview';
     writeRalphthonState(cwd, state, sessionId);
+
+    // Send the deep-interview prompt to the leader pane
+    if (!sendKeysToPane(leaderPane, interviewPrompt)) {
+      console.log(chalk.red('Failed to inject deep-interview prompt to leader pane.'));
+      clearRalphthonState(cwd, sessionId);
+      process.exit(1);
+    }
 
     console.log(chalk.gray('Waiting for PRD generation...'));
 

--- a/src/ralphthon/orchestrator.ts
+++ b/src/ralphthon/orchestrator.ts
@@ -8,7 +8,7 @@
  * Terminates after N consecutive hardening waves with no new issues.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import {
   writeModeState,
   readModeState,
@@ -25,7 +25,6 @@ import type {
   RalphthonState,
   RalphthonPhase,
   RalphthonConfig,
-  OrchestratorEvent,
   OrchestratorEventHandler,
 } from './types.js';
 import { RALPHTHON_DEFAULTS } from './types.js';
@@ -86,8 +85,8 @@ export function clearRalphthonState(
  */
 export function isPaneIdle(paneId: string): boolean {
   try {
-    const output = execSync(
-      `tmux display-message -t '${paneId}' -p '#{pane_current_command}'`,
+    const output = execFileSync(
+      'tmux', ['display-message', '-t', paneId, '-p', '#{pane_current_command}'],
       { encoding: 'utf-8', timeout: 5000 },
     ).trim();
 
@@ -103,7 +102,7 @@ export function isPaneIdle(paneId: string): boolean {
  */
 export function paneExists(paneId: string): boolean {
   try {
-    execSync(`tmux has-session -t '${paneId}' 2>/dev/null`, { timeout: 5000 });
+    execFileSync('tmux', ['has-session', '-t', paneId], { timeout: 5000, stdio: 'pipe' });
     return true;
   } catch {
     return false;
@@ -115,12 +114,7 @@ export function paneExists(paneId: string): boolean {
  */
 export function sendKeysToPane(paneId: string, text: string): boolean {
   try {
-    // Escape single quotes in the text for shell safety
-    const escaped = text.replace(/'/g, "'\\''");
-    execSync(
-      `tmux send-keys -t '${paneId}' '${escaped}' Enter`,
-      { timeout: 10000 },
-    );
+    execFileSync('tmux', ['send-keys', '-t', paneId, text, 'Enter'], { timeout: 10000 });
     return true;
   } catch {
     return false;
@@ -132,8 +126,8 @@ export function sendKeysToPane(paneId: string, text: string): boolean {
  */
 export function capturePaneContent(paneId: string, lines = 50): string {
   try {
-    return execSync(
-      `tmux capture-pane -t '${paneId}' -p -S -${lines}`,
+    return execFileSync(
+      'tmux', ['capture-pane', '-t', paneId, '-p', '-S', `-${lines}`],
       { encoding: 'utf-8', timeout: 5000 },
     ).trim();
   } catch {
@@ -212,7 +206,7 @@ export function initOrchestrator(
   leaderPaneId: string,
   prdPath: string,
   sessionId?: string,
-  config?: Partial<RalphthonConfig>,
+  _config?: Partial<RalphthonConfig>,
 ): RalphthonState {
   const state: RalphthonState = {
     active: true,


### PR DESCRIPTION
## Summary
- Replace `execSync` with `execFileSync` for all tmux interactions in the orchestrator to prevent shell injection via crafted pane IDs
- Fix `interviewPrompt` never being sent to the leader pane (interview phase always timed out)
- Sanitize user-supplied task input against newline/control character injection via tmux `send-keys`
- Remove unused `OrchestratorEvent` import

## Files Changed (2 files, +19/-15 lines)
- `src/ralphthon/orchestrator.ts`
- `src/cli/commands/ralphthon.ts`

## Test plan
- [x] TypeScript: 0 errors
- [x] All 6901 tests pass
- [ ] Manual: Verify ralphthon interview phase sends prompt to leader pane