### PR TITLE
chore: remove unused imports and fix test assertions

### DIFF
--- a/src/__tests__/team-server-validation.test.ts
+++ b/src/__tests__/team-server-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as path from 'path';
 
 // ---------------------------------------------------------------------------

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,8 +14,6 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { writeFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
 import {
   loadConfig,
   getConfigPaths,
@@ -57,10 +55,8 @@ import { launchCommand } from './launch.js';
 import { interopCommand } from './interop.js';
 import { askCommand, ASK_USAGE } from './ask.js';
 import { warnIfWin32 } from './win32-warning.js';
-import { autoresearchCommand, AUTORESEARCH_HELP } from './autoresearch.js';
+import { autoresearchCommand } from './autoresearch.js';
 import { runHudWatchLoop } from './hud-watch.js';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const version = getRuntimePackageVersion();
 

--- a/src/hooks/autopilot/__tests__/state.test.ts
+++ b/src/hooks/autopilot/__tests__/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
@@ -10,7 +10,6 @@ import {
   transitionPhase,
   updateExpansion,
   updateExecution,
-  getPlanPath,
 } from "../state.js";
 
 describe("AutopilotState", () => {

--- a/src/hooks/project-memory/__tests__/integration.test.ts
+++ b/src/hooks/project-memory/__tests__/integration.test.ts
@@ -141,7 +141,7 @@ describe('Project Memory Integration', () => {
       await registerProjectMemoryContext(sessionId, tempDir);
 
       // Add custom notes and directives to the persisted memory
-      let memory = await loadProjectMemory(tempDir);
+      const memory = await loadProjectMemory(tempDir);
       expect(memory).not.toBeNull();
       memory!.customNotes = [
         { timestamp: Date.now(), source: 'manual', category: 'deploy', content: 'Uses Docker' },

--- a/src/hooks/project-memory/__tests__/pre-compact.test.ts
+++ b/src/hooks/project-memory/__tests__/pre-compact.test.ts
@@ -2,7 +2,7 @@
  * Tests for Project Memory PreCompact Handler
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { processPreCompact, PreCompactInput } from '../pre-compact.js';
 import { ProjectMemory } from '../types.js';
 import { SCHEMA_VERSION } from '../constants.js';

--- a/src/notifications/config.ts
+++ b/src/notifications/config.ts
@@ -876,7 +876,6 @@ export function getReplyConfig(): import("./types.js").ReplyConfig | null {
 import type {
   CustomIntegration,
   CustomIntegrationsConfig,
-  ExtendedNotificationConfig,
 } from "./types.js";
 import { validateCustomIntegration, checkDuplicateIds } from "./validation.js";
 

--- a/src/ralphthon/__tests__/orchestrator.test.ts
+++ b/src/ralphthon/__tests__/orchestrator.test.ts
@@ -2,7 +2,7 @@
  * Tests for Ralphthon Orchestrator
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -17,7 +17,6 @@ import {
   endHardeningWave,
   recordTaskCompletion,
   recordTaskSkip,
-  detectCompletionSignal,
 } from '../orchestrator.js';
 import {
   writeRalphthonPrd,
@@ -28,7 +27,6 @@ import type {
   RalphthonStory,
   OrchestratorEvent,
 } from '../types.js';
-import { RALPHTHON_DEFAULTS } from '../types.js';
 
 describe('Ralphthon Orchestrator', () => {
   let testDir: string;

--- a/src/ralphthon/__tests__/prd.test.ts
+++ b/src/ralphthon/__tests__/prd.test.ts
@@ -24,7 +24,7 @@ import {
 import type {
   RalphthonPRD,
   RalphthonStory,
-  HardeningTask,
+
 } from '../types.js';
 import { RALPHTHON_DEFAULTS } from '../types.js';
 

--- a/src/team/__tests__/audit-log.test.ts
+++ b/src/team/__tests__/audit-log.test.ts
@@ -300,8 +300,6 @@ describe('audit-log', () => {
         logAuditEvent(testDir, event);
       }
 
-      const logPath = join(testDir, '.omc', 'logs', 'team-bridge-team1.jsonl');
-
       // Force rotation by setting low threshold
       rotateAuditLog(testDir, 'team1', 100);
 

--- a/src/team/__tests__/bridge-integration.test.ts
+++ b/src/team/__tests__/bridge-integration.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, statSync, realpathSync } from 'fs';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { homedir, tmpdir } from 'os';
 import type { BridgeConfig, TaskFile, OutboxMessage } from '../types.js';
 import { readTask, updateTask } from '../task-file-ops.js';

--- a/src/team/__tests__/edge-cases.test.ts
+++ b/src/team/__tests__/edge-cases.test.ts
@@ -48,7 +48,7 @@ import { sanitizeName, sessionName } from '../tmux-session.js';
 
 // --- team-registration imports ---
 import {
-  readProbeResult, writeProbeResult, getRegistrationStrategy,
+  readProbeResult, writeProbeResult,
   registerMcpWorker, unregisterMcpWorker, isMcpWorker, listMcpWorkers
 } from '../team-registration.js';
 

--- a/src/team/__tests__/task-file-ops.test.ts
+++ b/src/team/__tests__/task-file-ops.test.ts
@@ -8,7 +8,6 @@ import {
   acquireTaskLock, releaseTaskLock, withTaskLock,
 } from '../task-file-ops.js';
 import type { TaskFile } from '../types.js';
-import type { LockHandle } from '../task-file-ops.js';
 
 const TEST_TEAM = 'test-team-ops';
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -9,7 +9,6 @@ import {
   shouldAttemptAdaptiveRetry,
   getDefaultShell,
   buildWorkerStartCommand,
-  isUnixLikeOnWindows,
 } from '../tmux-session.js';
 
 afterEach(() => {

--- a/src/team/__tests__/unified-team.test.ts
+++ b/src/team/__tests__/unified-team.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
-import { tmpdir, homedir } from 'os';
+import { tmpdir } from 'os';
 import { getTeamMembers } from '../unified-team.js';
 import { registerMcpWorker } from '../team-registration.js';
 import { writeHeartbeat } from '../heartbeat.js';

--- a/src/team/__tests__/worker-health.test.ts
+++ b/src/team/__tests__/worker-health.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync } from 'fs';
+import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { getWorkerHealthReports, checkWorkerHealth } from '../worker-health.js';

--- a/src/team/__tests__/worker-restart.test.ts
+++ b/src/team/__tests__/worker-restart.test.ts
@@ -79,10 +79,12 @@ describe('worker-restart', () => {
     it('updates lastRestartAt timestamp', () => {
       recordRestart(testDir, teamName, workerName);
       const state1 = readRestartState(testDir, teamName, workerName);
-      // Small delay to ensure different timestamp
+      expect(state1!.lastRestartAt).not.toBe('');
       recordRestart(testDir, teamName, workerName);
       const state2 = readRestartState(testDir, teamName, workerName);
       expect(state2!.lastRestartAt).not.toBe('');
+      // Verify the timestamp was actually updated (restartCount changes guarantee a new write)
+      expect(state2!.restartCount).toBeGreaterThan(state1!.restartCount);
     });
   });
 

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -47,7 +47,6 @@ import { injectToLeaderPane, sendToWorker } from './tmux-session.js';
 import { listDispatchRequests, markDispatchRequestDelivered, markDispatchRequestNotified } from './dispatch-queue.js';
 import { generateMailboxTriggerMessage } from './worker-bootstrap.js';
 import { shutdownTeam } from './runtime.js';
-import { resolveLifecycleProfile } from './governance.js';
 import { shutdownTeamV2 } from './runtime-v2.js';
 
 const TEAM_UPDATE_TASK_MUTABLE_FIELDS = new Set(['subject', 'description', 'blocked_by', 'requires_code_change']);

--- a/src/utils/skill-resources.ts
+++ b/src/utils/skill-resources.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from 'fs';
-import { dirname, join, relative } from 'path';
+import { dirname, relative } from 'path';
 
 const MAX_RESOURCE_ENTRIES = 12;
 


### PR DESCRIPTION
## Summary
- Remove unused imports/variables across production and test files (ESLint warnings: 29 → 0)
- Fix `worker-restart` test to actually verify `restartCount` changes
- Change `let` to `const` where reassignment does not occur

## Files Changed (18 files, +17/-28 lines)
Production: `cli/index.ts`, `utils/skill-resources.ts`, `notifications/config.ts`, `team/api-interop.ts`
Tests: 14 test files

## Test plan
- [x] TypeScript: 0 errors
- [x] All 6901 tests pass