### PR TITLE
Strengthen deep-interview ambiguity scoring and brownfield confirmations

### DIFF
--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -238,7 +238,8 @@ If the trace produces no clear "most likely explanation" (all lanes low-confiden
 
 Follow deep-interview SKILL.md Phases 2-4 exactly:
 - Ambiguity scoring across all dimensions (same weights as deep-interview)
-- One question at a time targeting the weakest dimension
+- One question at a time targeting the weakest dimension, with the same explicit weakest-dimension rationale reporting required by deep-interview
+- Brownfield confirmation questions inherit deep-interview's repo-evidence citation requirement before asking the user to choose a direction
 - Challenge agents activate at the same round thresholds as deep-interview
 - Soft/hard caps at the same round limits as deep-interview
 - Score display after every round

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -39,7 +39,9 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 <Execution_Policy>
 - Ask ONE question at a time -- never batch multiple questions
 - Target the WEAKEST clarity dimension with each question
+- Make weakest-dimension targeting explicit every round: name the weakest dimension, state its score/gap, and explain why the next question is aimed there
 - Gather codebase facts via `explore` agent BEFORE asking the user about them
+- For brownfield confirmation questions, cite the repo evidence that triggered the question (file path, symbol, or pattern) instead of asking the user to rediscover it
 - Score ambiguity after every answer -- display the score transparently
 - Do not proceed to execution until ambiguity ≤ threshold (default 0.2)
 - Allow early exit with a clear warning if ambiguity is still high
@@ -112,7 +114,9 @@ Build the question generation prompt with:
 **Question targeting strategy:**
 - Identify the dimension with the LOWEST clarity score
 - Generate a question that specifically improves that dimension
+- State, in one sentence before the question, why this dimension is now the bottleneck to reducing ambiguity
 - Questions should expose ASSUMPTIONS, not gather feature lists
+- If the scope is still conceptually fuzzy (entities keep shifting, the user is naming symptoms, or the core noun is unstable), switch to an ontology-style question that asks what the thing fundamentally IS before returning to feature/detail questions
 
 **Question styles by dimension:**
 | Dimension | Question Style | Example |
@@ -120,14 +124,15 @@ Build the question generation prompt with:
 | Goal Clarity | "What exactly happens when...?" | "When you say 'manage tasks', what specific action does a user take first?" |
 | Constraint Clarity | "What are the boundaries?" | "Should this work offline, or is internet connectivity assumed?" |
 | Success Criteria | "How do we know it works?" | "If I showed you the finished product, what would make you say 'yes, that's it'?" |
-| Context Clarity (brownfield) | "How does this fit?" | "The existing auth uses JWT in src/auth/. Should we extend that or add a separate flow?" |
+| Context Clarity (brownfield) | "How does this fit?" | "I found JWT auth middleware in `src/auth/` (pattern: passport + JWT). Should this feature extend that path or intentionally diverge from it?" |
+| Scope-fuzzy / ontology stress | "What IS the core thing here?" | "You have named Tasks, Projects, and Workspaces across the last rounds. Which one is the core entity, and which are supporting views or containers?" |
 
 ### Step 2b: Ask the Question
 
 Use `AskUserQuestion` with the generated question. Present it clearly with the current ambiguity context:
 
 ```
-Round {n} | Targeting: {weakest_dimension} | Ambiguity: {score}%
+Round {n} | Targeting: {weakest_dimension} | Why now: {one_sentence_targeting_rationale} | Ambiguity: {score}%
 
 {question}
 ```
@@ -158,6 +163,10 @@ For each dimension provide:
 - score: float (0.0-1.0)
 - justification: one sentence explaining the score
 - gap: what's still unclear (if score < 0.9)
+
+Also identify:
+- weakest_dimension: the single lowest-confidence dimension this round
+- weakest_dimension_rationale: one sentence explaining why it is the highest-leverage target for the next question
 
 5. Ontology Extraction: Identify all key entities (nouns) discussed in the transcript.
 
@@ -210,6 +219,8 @@ Round {n} complete.
 | **Ambiguity** | | | **{score}%** | |
 
 **Ontology:** {entity_count} entities | Stability: {stability_ratio} | New: {new} | Changed: {changed} | Stable: {stable}
+
+**Next target:** {weakest_dimension} — {weakest_dimension_rationale}
 
 {score <= threshold ? "Clarity threshold met! Ready to proceed." : "Focusing next question on: {weakest_dimension}"}
 ```
@@ -409,7 +420,7 @@ Next question targets Constraints (lowest at 0.4):
 a responsive web app, or a PWA? And are there specific devices or OS versions
 you need to support?"
 ```
-Why good: Identifies weakest dimension, asks specific question to improve it, doesn't batch multiple topics.
+Why good: Identifies weakest dimension, explains why it is now the bottleneck, asks a specific question to improve it, and doesn't batch multiple topics.
 </Good>
 
 <Good>
@@ -418,11 +429,11 @@ Gathering codebase facts before asking:
 [spawns explore agent: "find authentication implementation"]
 [receives: "Auth is in src/auth/ using JWT with passport.js"]
 
-Question: "I see your project uses JWT authentication with passport.js in src/auth/.
+Question: "I found JWT authentication with passport.js in `src/auth/` (pattern match from explore).
 For this new feature, should we extend the existing auth middleware or create
 a separate authentication flow?"
 ```
-Why good: Explored first, then asked an informed question. Never asks the user what the code already reveals.
+Why good: Explored first, cited the repo evidence that triggered the question, then asked an informed confirmation question. Never asks the user what the code already reveals.
 </Good>
 
 <Good>
@@ -464,6 +475,16 @@ with no changes. The domain model is stable."
 Why good: Shows entity tracking across rounds with visible convergence. Stability ratio increases as the domain model solidifies, giving mathematical evidence that the interview is converging on a stable understanding.
 </Good>
 
+<Good>
+Ontology-style question for scope-fuzzy tasks:
+```
+Round 6 | Targeting: Goal Clarity | Why now: the core entity is still unstable across rounds, so feature questions would compound ambiguity | Ambiguity: 38%
+
+"Across the last rounds you've described this as a workflow, an inbox, and a planner. Which one is the core thing this product IS, and which ones are supporting metaphors or views?"
+```
+Why good: Uses ontology-style questioning to stabilize the core noun before drilling into features, which is the right move when the scope is fuzzy rather than merely incomplete.
+</Good>
+
 <Bad>
 Batching multiple questions:
 ```
@@ -503,6 +524,7 @@ Why bad: 45% ambiguity means nearly half the requirements are unclear. The mathe
 <Final_Checklist>
 - [ ] Interview completed (ambiguity ≤ threshold OR user chose early exit)
 - [ ] Ambiguity score displayed after every round
+- [ ] Every round explicitly names the weakest dimension and why it is the next target
 - [ ] Challenge agents activated at correct thresholds (round 4, 6, 8)
 - [ ] Spec file written to `.omc/specs/deep-interview-{slug}.md`
 - [ ] Spec includes: goal, constraints, acceptance criteria, clarity breakdown, transcript
@@ -510,6 +532,8 @@ Why bad: 45% ambiguity means nearly half the requirements are unclear. The mathe
 - [ ] Selected execution mode invoked via Skill() (never direct implementation)
 - [ ] If 3-stage pipeline selected: omc-plan --consensus --direct invoked, then autopilot with consensus plan
 - [ ] State cleaned up after execution handoff
+- [ ] Brownfield confirmation questions cite repo evidence (file/path/pattern) before asking the user to decide
+- [ ] Scope-fuzzy tasks can trigger ontology-style questioning to stabilize the core entity before feature elaboration
 - [ ] Per-round ambiguity report includes Ontology row with entity count and stability ratio
 - [ ] Spec includes Ontology (Key Entities) table and Ontology Convergence section
 </Final_Checklist>

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -194,6 +194,8 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('interview_id');
       expect(skill?.template).toContain('challenge_modes_used');
       expect(skill?.template).toContain('ontology_snapshots');
+      expect(skill?.template).toContain('explicit weakest-dimension rationale reporting');
+      expect(skill?.template).toContain('repo-evidence citation requirement');
     });
 
 
@@ -211,6 +213,10 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('Skill("oh-my-claudecode:omc-plan")');
       expect(skill?.template).toContain('`--consensus --direct`');
       expect(skill?.template).toContain('`.omc/specs/deep-interview-{slug}.md`');
+      expect(skill?.template).toContain('Why now: {one_sentence_targeting_rationale}');
+      expect(skill?.template).toContain('cite the repo evidence');
+      expect(skill?.template).toContain('Ontology-style question for scope-fuzzy tasks');
+      expect(skill?.template).toContain('Every round explicitly names the weakest dimension and why it is the next target');
       expect(skill?.argumentHint).toContain('--autoresearch');
       expect(skill?.template).toContain('zero-learning-curve setup lane for `omc autoresearch`');
       expect(skill?.template).toContain('autoresearch --mission "<mission>" --eval "<evaluator>"');

--- a/src/cli/commands/ralphthon.ts
+++ b/src/cli/commands/ralphthon.ts
@@ -23,6 +23,7 @@ import {
   getRalphthonPrdPath,
   initRalphthonPrd,
   sendKeysToPane,
+  buildRalphthonDeepInterviewPrompt,
 } from '../../ralphthon/index.js';
 import type {
   RalphthonCliOptions,
@@ -267,19 +268,11 @@ export async function ralphthonCommand(args: string[]): Promise<void> {
 
     // Inject deep-interview command to the leader pane
     // The orchestrator will wait for the PRD to appear
-    // Sanitize task to prevent newline/control char injection via tmux send-keys
-    const sanitizedTask = options.task!.replace(/[\r\n\0]+/g, ' ').trim();
-    const interviewPrompt = `/deep-interview ${sanitizedTask}
-
-After the interview, generate a ralphthon-prd.json file in .omc/ with this structure:
-{
-  "project": "<project name>",
-  "branchName": "<branch>",
-  "description": "<description>",
-  "stories": [{ "id": "US-001", "title": "...", "description": "...", "acceptanceCriteria": [...], "priority": "high", "tasks": [{ "id": "T-001", "title": "...", "description": "...", "status": "pending", "retries": 0 }] }],
-  "hardening": [],
-  "config": { "maxWaves": ${options.maxWaves}, "cleanWavesForTermination": 3, "pollIntervalMs": ${options.pollInterval * 1000}, "idleThresholdMs": 30000, "maxRetries": 3, "skipInterview": false }
-}`;
+    const interviewPrompt = buildRalphthonDeepInterviewPrompt(
+      options.task!,
+      options.maxWaves!,
+      options.pollInterval! * 1000,
+    );
 
     // Initialize state in interview phase
     const state = initOrchestrator(

--- a/src/ralphthon/__tests__/cli.test.ts
+++ b/src/ralphthon/__tests__/cli.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { parseRalphthonArgs } from '../../cli/commands/ralphthon.js';
+import { buildRalphthonDeepInterviewPrompt } from '../deep-interview-prompt.js';
 import { RALPHTHON_DEFAULTS } from '../types.js';
 
 describe('Ralphthon CLI', () => {
@@ -74,3 +75,23 @@ describe('Ralphthon CLI', () => {
     });
   });
 });
+
+  describe('buildRalphthonDeepInterviewPrompt', () => {
+    it('adds the explicit weakest-dimension, citation, and ontology guidance', () => {
+      const prompt = buildRalphthonDeepInterviewPrompt('Improve onboarding', 5, 60000);
+
+      expect(prompt).toContain('name the weakest dimension');
+      expect(prompt).toContain('cite the repo evidence');
+      expect(prompt).toContain('ontology-style questioning');
+      expect(prompt).toContain('"maxWaves": 5');
+      expect(prompt).toContain('"pollIntervalMs": 60000');
+    });
+
+    it('sanitizes multiline task input before embedding it in the slash command', () => {
+      const prompt = buildRalphthonDeepInterviewPrompt('Fix auth\n\u0000flow', 3, 30000);
+
+      expect(prompt).toContain('/deep-interview Fix auth flow');
+      expect(prompt).not.toContain('\n\u0000flow');
+    });
+  });
+

--- a/src/ralphthon/deep-interview-prompt.ts
+++ b/src/ralphthon/deep-interview-prompt.ts
@@ -1,0 +1,20 @@
+export function buildRalphthonDeepInterviewPrompt(task: string, maxWaves: number, pollIntervalMs: number): string {
+  const sanitizedTask = task.replace(/[\r\n\0]+/g, ' ').trim();
+
+  return `/deep-interview ${sanitizedTask}
+
+Interview guidance for this ralphthon intake:
+- Treat current weakest-dimension targeting as explicit every round: name the weakest dimension, explain why it is the bottleneck, then ask one question.
+- For brownfield confirmations, cite the repo evidence that triggered the question (file path, symbol, or pattern) before asking the user to choose a direction.
+- If scope remains fuzzy because the core entity keeps shifting, use ontology-style questioning to identify what the thing fundamentally IS before asking for more feature detail.
+
+After the interview, generate a ralphthon-prd.json file in .omc/ with this structure:
+{
+  "project": "<project name>",
+  "branchName": "<branch>",
+  "description": "<description>",
+  "stories": [{ "id": "US-001", "title": "...", "description": "...", "acceptanceCriteria": [...], "priority": "high", "tasks": [{ "id": "T-001", "title": "...", "description": "...", "status": "pending", "retries": 0 }] }],
+  "hardening": [],
+  "config": { "maxWaves": ${maxWaves}, "cleanWavesForTermination": 3, "pollIntervalMs": ${pollIntervalMs}, "idleThresholdMs": 30000, "maxRetries": 3, "skipInterview": false }
+}`;
+}

--- a/src/ralphthon/index.ts
+++ b/src/ralphthon/index.ts
@@ -45,6 +45,9 @@ export {
 
 export type { RalphthonPrdStatus } from './prd.js';
 
+// Deep interview handoff
+export { buildRalphthonDeepInterviewPrompt } from './deep-interview-prompt.js';
+
 // Orchestrator
 export {
   readRalphthonState,


### PR DESCRIPTION
## Summary
- make deep-interview round-by-round weakest-dimension targeting explicit, including rationale for why that dimension is next
- require repo-evidence citations in brownfield confirmation questions and add an ontology-style prompt pattern for scope-fuzzy tasks
- move ralphthon deep-interview handoff text into a dedicated helper under `src/ralphthon/` and cover it with regression tests

## Testing
- `npx tsc --noEmit`
- `npx vitest run src/__tests__/skills.test.ts src/__tests__/deep-interview-provider-options.test.ts src/ralphthon/__tests__/cli.test.ts`
- `npm test` *(currently fails due to a pre-existing unrelated failure in `src/team/__tests__/api-interop.dispatch.test.ts`: duplicate worker pane canonicalization expects `pending` but receives `notified`)*

Closes #1836
