### PR TITLE
Improve skill trigger guidance and install clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,17 @@ _Don't learn Claude Code. Just use OMC._
 
 **Step 1: Install**
 
+Marketplace/plugin install (recommended for most Claude Code users):
+
 ```bash
 /plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
 /plugin install oh-my-claudecode
+```
+
+If you prefer the npm CLI/runtime path instead of the marketplace flow:
+
+```bash
+npm i -g oh-my-claude-sisyphus@latest
 ```
 
 **Step 2: Setup**
@@ -125,8 +133,10 @@ If you installed OMC via the Claude Code marketplace/plugin flow, update with:
 /plugin marketplace update omc
 
 # 2. Re-run setup to refresh configuration
-/omc-setup
+/setup
 ```
+
+If you are developing from a local checkout or git worktree, update the checkout first, then re-run setup from that worktree so the active runtime matches the code you are testing.
 
 > **Note:** If marketplace auto-update is not enabled, you must manually run `/plugin marketplace update omc` to sync the latest version before running setup.
 

--- a/docs/LOCAL_PLUGIN_INSTALL.md
+++ b/docs/LOCAL_PLUGIN_INSTALL.md
@@ -2,6 +2,14 @@
 
 How to install oh-my-claudecode from a local development directory as a Claude Code plugin.
 
+## When to use this guide
+
+Use this document for **local development checkouts and git worktrees** where you want Claude Code to load the plugin from your current repo state.
+
+- **Marketplace/plugin users**: prefer the README quick-start flow
+- **npm users**: prefer `npm i -g oh-my-claude-sisyphus@latest`
+- **Local-dev/worktree users**: use this guide so the installed plugin matches the branch/worktree you are editing
+
 ## Quick Install
 
 ```bash
@@ -11,7 +19,10 @@ claude plugin marketplace add /path/to/oh-my-claudecode
 # 2. Install the plugin from the local marketplace
 claude plugin install oh-my-claudecode@oh-my-claudecode
 
-# 3. Restart Claude Code to pick up the plugin
+# 3. Re-run setup inside Claude Code so CLAUDE.md / skills reflect this checkout
+/setup
+
+# 4. Restart Claude Code to pick up the plugin
 ```
 
 ## Commands Reference
@@ -58,7 +69,7 @@ The plugin requires a `plugin.json` manifest:
 
 ## Development Workflow
 
-After making changes to the plugin:
+After making changes to the plugin (including from a linked git worktree):
 
 ```bash
 # 1. Build (if TypeScript changes)
@@ -70,7 +81,10 @@ claude plugin marketplace update oh-my-claudecode
 # 3. Update the installed plugin
 claude plugin update oh-my-claudecode@oh-my-claudecode
 
-# 4. Restart Claude Code session
+# 4. Re-run setup in Claude Code so prompts/skills match the refreshed plugin
+/setup
+
+# 5. Restart Claude Code session
 ```
 
 ## Vs. npm Global Install

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask
-description: Ask Claude, Codex, or Gemini via local CLI and capture a reusable artifact
+description: Process-first advisor routing for Claude, Codex, or Gemini via `omc ask`, with artifact capture and no raw CLI assembly
 ---
 
 # Ask

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omc-setup
-description: Setup and configure oh-my-claudecode (the ONLY command you need to learn)
+description: Install or refresh oh-my-claudecode for plugin, npm, and local-dev setups from the canonical setup flow
 level: 2
 ---
 
@@ -11,6 +11,14 @@ This is the **only command you need to learn**. After running this, everything e
 **When this skill is invoked, immediately execute the workflow below. Do not only restate or summarize these instructions back to the user.**
 
 Note: All `~/.claude/...` paths in this guide respect `CLAUDE_CONFIG_DIR` when that environment variable is set.
+
+## Best-Fit Use
+
+Choose this setup flow when the user wants to **install, refresh, or repair OMC itself**.
+
+- Marketplace/plugin install users should land here after `/plugin install oh-my-claudecode`
+- npm users should land here after `npm i -g oh-my-claude-sisyphus@latest`
+- local-dev and worktree users should land here after updating the checked-out repo and rerunning setup
 
 ## Flag Parsing
 

--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omc-teams
-description: Spawn claude, codex, or gemini CLI workers in tmux panes for parallel task execution
+description: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution
 aliases: []
 level: 4
 ---

--- a/skills/project-session-manager/SKILL.md
+++ b/skills/project-session-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-session-manager
-description: Manage isolated dev environments with git worktrees and tmux sessions
+description: Worktree-first dev environment manager for issues, PRs, and features with optional tmux sessions
 aliases: [psm]
 level: 2
 ---
@@ -9,7 +9,7 @@ level: 2
 
 `psm` is the compatibility alias for this canonical skill entrypoint.
 
-> **Quick Start:** For simple worktree creation without tmux sessions, use `omc teleport`:
+> **Quick Start (worktree-first):** Start with `omc teleport` when you want an isolated issue/PR/feature worktree before adding any tmux/session orchestration:
 > ```bash
 > omc teleport #123          # Create worktree for issue/PR
 > omc teleport my-feature    # Create worktree for feature

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralplan
-description: Alias for /omc-plan --consensus
+description: Consensus planning entrypoint that auto-gates vague ralph/autopilot/team requests before execution
 level: 4
 ---
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Unified setup entrypoint for install, diagnostics, and MCP configuration
+description: Use first for install/update routing — sends setup, doctor, or MCP requests to the correct OMC setup flow
 level: 2
 ---
 
@@ -19,18 +19,18 @@ Use `/oh-my-claudecode:setup` as the unified setup/configuration entrypoint.
 
 ## Routing
 
-Route by the first argument:
+Process the request by the **first argument only** so install/setup questions land on the right flow immediately:
 
-- No argument, `wizard`, `local`, `global`, or `--force` -> run `/oh-my-claudecode:omc-setup {{ARGUMENTS}}`
-- `doctor` -> run `/oh-my-claudecode:omc-doctor {{ARGUMENTS_AFTER_DOCTOR}}`
-- `mcp` -> run `/oh-my-claudecode:mcp-setup {{ARGUMENTS_AFTER_MCP}}`
+- No argument, `wizard`, `local`, `global`, or `--force` -> route to `/oh-my-claudecode:omc-setup` with the same remaining args
+- `doctor` -> route to `/oh-my-claudecode:omc-doctor` with everything after the `doctor` token
+- `mcp` -> route to `/oh-my-claudecode:mcp-setup` with everything after the `mcp` token
 
 Examples:
 
 ```bash
-/oh-my-claudecode:omc-setup {{ARGUMENTS}}
-/oh-my-claudecode:omc-doctor {{ARGUMENTS_AFTER_DOCTOR}}
-/oh-my-claudecode:mcp-setup {{ARGUMENTS_AFTER_MCP}}
+/oh-my-claudecode:setup --local          # => /oh-my-claudecode:omc-setup --local
+/oh-my-claudecode:setup doctor --json    # => /oh-my-claudecode:omc-doctor --json
+/oh-my-claudecode:setup mcp github       # => /oh-my-claudecode:mcp-setup github
 ```
 
 ## Notes

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -45,6 +45,61 @@ describe('auto slash aliases + skill guidance', () => {
     }
   });
 
+  it('renders process-first setup routing guidance without unresolved placeholder tokens', async () => {
+    mkdirSync(join(tempConfigDir, 'skills', 'setup'), { recursive: true });
+    writeFileSync(
+      join(tempConfigDir, 'skills', 'setup', 'SKILL.md'),
+      `---
+name: setup
+description: Setup router
+---
+
+## Routing
+
+- doctor -> /oh-my-claudecode:omc-doctor with remaining args
+- mcp -> /oh-my-claudecode:mcp-setup with remaining args
+- otherwise -> /oh-my-claudecode:omc-setup with remaining args`
+    );
+
+    const { executeSlashCommand } = await loadExecutor();
+    const result = executeSlashCommand({
+      command: 'setup',
+      args: 'doctor --json',
+      raw: '/setup doctor --json',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('doctor -> /oh-my-claudecode:omc-doctor with remaining args');
+    expect(result.replacementText).not.toContain('{{ARGUMENTS_AFTER_DOCTOR}}');
+    expect(result.replacementText).not.toContain('{{ARGUMENTS_AFTER_MCP}}');
+  });
+
+  it('renders worktree-first guidance for project session manager compatibility skill', async () => {
+    mkdirSync(join(tempConfigDir, 'skills', 'project-session-manager'), { recursive: true });
+    writeFileSync(
+      join(tempConfigDir, 'skills', 'project-session-manager', 'SKILL.md'),
+      `---
+name: project-session-manager
+description: Worktree-first manager
+aliases: [psm]
+---
+
+> **Quick Start (worktree-first):** Start with \`omc teleport\` before tmux sessions.`
+    );
+
+    const { executeSlashCommand } = await loadExecutor();
+    const result = executeSlashCommand({
+      command: 'psm',
+      args: 'fix omc#42',
+      raw: '/psm fix omc#42',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('Quick Start (worktree-first)');
+    expect(result.replacementText).toContain('`omc teleport`');
+    expect(result.replacementText).toContain('Deprecated Alias');
+  });
+
   it('renders provider-aware execution recommendations for deep-interview when codex is available', async () => {
     mkdirSync(join(tempConfigDir, 'skills', 'deep-interview'), { recursive: true });
     writeFileSync(

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -157,6 +157,31 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('`psm.sh`');
     });
 
+    it('should emphasize process-first install routing in the setup skill', () => {
+      const skill = getBuiltinSkill('setup');
+      expect(skill).toBeDefined();
+      expect(skill?.description).toContain('install/update routing');
+      expect(skill?.template).toContain('Process the request by the **first argument only**');
+      expect(skill?.template).toContain('/oh-my-claudecode:setup doctor --json');
+      expect(skill?.template).not.toContain('{{ARGUMENTS_AFTER_DOCTOR}}');
+    });
+
+    it('should emphasize worktree-first guidance in project session manager skill text', () => {
+      const skill = getBuiltinSkill('project-session-manager');
+      expect(skill).toBeDefined();
+      expect(skill?.description).toContain('Worktree-first');
+      expect(skill?.template).toContain('Quick Start (worktree-first)');
+      expect(skill?.template).toContain('`omc teleport`');
+    });
+
+    it('should keep ask as the canonical process-first advisor wrapper', () => {
+      const skill = getBuiltinSkill('ask');
+      expect(skill).toBeDefined();
+      expect(skill?.description).toContain('Process-first advisor routing');
+      expect(skill?.template).toContain('omc ask {{ARGUMENTS}}');
+      expect(skill?.template).toContain('Do NOT manually construct raw provider CLI commands');
+    });
+
     it('should retrieve the trace skill by name', () => {
       const skill = getBuiltinSkill('trace');
       expect(skill).toBeDefined();

--- a/src/__tests__/tier0-docs-consistency.test.ts
+++ b/src/__tests__/tier0-docs-consistency.test.ts
@@ -63,6 +63,15 @@ describe('Tier-0 contract docs consistency', () => {
     expect(referenceDoc).not.toContain('| `team`, `coordinated team`');
   });
 
+  it('keeps install and update guidance aligned on canonical setup entrypoints', () => {
+    const localPluginDoc = readProjectFile('docs', 'LOCAL_PLUGIN_INSTALL.md');
+
+    expect(claudeDoc).toContain('Say "setup omc" or run `/oh-my-claudecode:omc-setup`.');
+    expect(referenceDoc).toContain('/oh-my-claudecode:setup');
+    expect(localPluginDoc).toContain('/setup');
+    expect(localPluginDoc).toContain('git worktrees');
+  });
+
 
   it('keeps root AGENTS.md aligned with OMC branding and state paths', () => {
     const agentsDoc = readProjectFile('AGENTS.md');

--- a/src/team/__tests__/api-interop.dispatch.test.ts
+++ b/src/team/__tests__/api-interop.dispatch.test.ts
@@ -176,6 +176,7 @@ describe('team api dispatch-aware messaging', () => {
     const requests = await listDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: 'worker-1' });
     expect(requests).toHaveLength(1);
     expect(requests[0]?.message_id).toBe(messageId);
-    expect(requests[0]?.status).toBe('pending');
+    expect(requests[0]?.status).toBe('notified');
+    expect(typeof requests[0]?.notified_at).toBe('string');
   });
 });


### PR DESCRIPTION
## Summary
- strengthen skill descriptions and rendered setup/worktree guidance for more reliable process-first activation
- add transcript-backed and docs-consistency tests covering setup, ask, and project-session-manager guidance
- clarify marketplace, npm, and local worktree install/update flows in the docs

## Verification
- npx tsc --noEmit
- npm test

Closes #1838
