### PR TITLE
Harden OMC HUD transcript parsing, caching, and setup config preservation

### DIFF
--- a/src/__tests__/hud/defaults.test.ts
+++ b/src/__tests__/hud/defaults.test.ts
@@ -32,6 +32,10 @@ describe('HUD Default Configuration', () => {
       expect(DEFAULT_HUD_CONFIG.wrapMode).toBe('truncate');
     });
 
+    it('should default session duration display to enabled', () => {
+      expect(DEFAULT_HUD_CONFIG.elements.showSessionDuration).toBe(true);
+    });
+
     it('should keep token usage display optional by default', () => {
       expect(DEFAULT_HUD_CONFIG.elements.showTokens).toBe(false);
     });

--- a/src/__tests__/hud/render.test.ts
+++ b/src/__tests__/hud/render.test.ts
@@ -542,3 +542,64 @@ describe('token usage rendering', () => {
     expect(result).not.toContain('tok:');
   });
 });
+
+
+describe('optional HUD line defaults', () => {
+  it('does not emit a blank header line when all top-line elements are disabled', async () => {
+    const context: HudRenderContext = {
+      contextPercent: 30,
+      modelName: 'claude-sonnet-4-5',
+      ralph: null,
+      ultrawork: null,
+      prd: null,
+      autopilot: null,
+      activeAgents: [],
+      todos: [],
+      backgroundTasks: [],
+      cwd: '/home/user/project',
+      lastSkill: null,
+      rateLimitsResult: null,
+      customBuckets: null,
+      pendingPermission: null,
+      thinkingState: null,
+      sessionHealth: { durationMinutes: 10, messageCount: 5, health: 'healthy' },
+      omcVersion: '4.5.4',
+      updateAvailable: null,
+      toolCallCount: 0,
+      agentCallCount: 0,
+      skillCallCount: 0,
+      promptTime: null,
+      apiKeySource: null,
+      profileName: null,
+      sessionSummary: null,
+    };
+
+    const config: HudConfig = {
+      ...DEFAULT_HUD_CONFIG,
+      elements: {
+        ...DEFAULT_HUD_CONFIG.elements,
+        omcLabel: false,
+        rateLimits: false,
+        permissionStatus: false,
+        thinking: false,
+        promptTime: false,
+        sessionHealth: false,
+        ralph: false,
+        autopilot: false,
+        prdStory: false,
+        activeSkills: false,
+        lastSkill: false,
+        contextBar: false,
+        agents: false,
+        backgroundTasks: false,
+        todos: false,
+        showCallCounts: false,
+        cwd: true,
+        gitRepo: false,
+        gitBranch: false,
+      },
+    };
+
+    await expect(render(context, config)).resolves.toBe('~/workspace/project');
+  });
+});

--- a/src/__tests__/hud/state.test.ts
+++ b/src/__tests__/hud/state.test.ts
@@ -1,30 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readHudConfig } from '../../hud/state.js';
-import { DEFAULT_HUD_CONFIG } from '../../hud/types.js';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readHudConfig, writeHudConfig } from "../../hud/state.js";
+import { DEFAULT_HUD_CONFIG } from "../../hud/types.js";
 
 // Mock fs and os modules
-vi.mock('node:fs', () => ({
+vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
   mkdirSync: vi.fn(),
 }));
 
-vi.mock('node:os', () => ({
-  homedir: () => '/Users/testuser',
+vi.mock("../../lib/atomic-write.js", () => ({
+  atomicWriteJsonSync: vi.fn(),
+  atomicWriteFileSync: vi.fn(),
 }));
 
-import { existsSync, readFileSync } from 'node:fs';
+vi.mock("node:os", () => ({
+  homedir: () => "/Users/testuser",
+}));
+
+import { existsSync, readFileSync } from "node:fs";
+import { atomicWriteFileSync } from "../../lib/atomic-write.js";
 const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
+const mockAtomicWriteFileSync = vi.mocked(atomicWriteFileSync);
 
-describe('readHudConfig', () => {
+describe("readHudConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('priority order', () => {
-    it('returns defaults when no config files exist', () => {
+  describe("priority order", () => {
+    it("returns defaults when no config files exist", () => {
       mockExistsSync.mockReturnValue(false);
 
       const config = readHudConfig();
@@ -32,19 +38,23 @@ describe('readHudConfig', () => {
       expect(config).toEqual(DEFAULT_HUD_CONFIG);
     });
 
-    it('reads from settings.json omcHud key first', () => {
+    it("reads from settings.json omcHud key first", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);
-        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(
+          s,
+        );
       });
-      mockReadFileSync.mockReturnValue(JSON.stringify({
-        omcHud: {
-          elements: {
-            gitRepo: true,
-            gitBranch: true,
-          }
-        }
-      }));
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          omcHud: {
+            elements: {
+              gitRepo: true,
+              gitBranch: true,
+            },
+          },
+        }),
+      );
 
       const config = readHudConfig();
 
@@ -52,25 +62,35 @@ describe('readHudConfig', () => {
       expect(config.elements.gitBranch).toBe(true);
     });
 
-    it('falls back to legacy hud-config.json when settings.json has no omcHud', () => {
+    it("falls back to legacy hud-config.json when settings.json has no omcHud", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);
-        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s) ||
-               /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(s);
+        return (
+          /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s) ||
+          /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(
+            s,
+          )
+        );
       });
       mockReadFileSync.mockImplementation((path) => {
         const s = String(path);
-        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)) {
+        if (
+          /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)
+        ) {
           return JSON.stringify({ someOtherKey: true });
         }
-        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(s)) {
+        if (
+          /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(
+            s,
+          )
+        ) {
           return JSON.stringify({
             elements: {
               cwd: true,
-            }
+            },
           });
         }
-        return '{}';
+        return "{}";
       });
 
       const config = readHudConfig();
@@ -78,28 +98,34 @@ describe('readHudConfig', () => {
       expect(config.elements.cwd).toBe(true);
     });
 
-    it('prefers settings.json over legacy hud-config.json', () => {
+    it("prefers settings.json over legacy hud-config.json", () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockImplementation((path) => {
         const s = String(path);
-        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)) {
+        if (
+          /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)
+        ) {
           return JSON.stringify({
             omcHud: {
               elements: {
                 gitRepo: true,
-              }
-            }
+              },
+            },
           });
         }
-        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(s)) {
+        if (
+          /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(
+            s,
+          )
+        ) {
           return JSON.stringify({
             elements: {
               gitRepo: false,
               cwd: true,
-            }
+            },
           });
         }
-        return '{}';
+        return "{}";
       });
 
       const config = readHudConfig();
@@ -109,32 +135,40 @@ describe('readHudConfig', () => {
     });
   });
 
-  describe('error handling', () => {
-    it('returns defaults when settings.json is invalid JSON', () => {
+  describe("error handling", () => {
+    it("returns defaults when settings.json is invalid JSON", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);
-        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(
+          s,
+        );
       });
-      mockReadFileSync.mockReturnValue('invalid json');
+      mockReadFileSync.mockReturnValue("invalid json");
 
       const config = readHudConfig();
 
       expect(config).toEqual(DEFAULT_HUD_CONFIG);
     });
 
-    it('falls back to legacy when settings.json read fails', () => {
+    it("falls back to legacy when settings.json read fails", () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockImplementation((path) => {
         const s = String(path);
-        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)) {
-          throw new Error('Read error');
+        if (
+          /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s)
+        ) {
+          throw new Error("Read error");
         }
-        if (/[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(s)) {
+        if (
+          /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]\.omc[\\/]hud-config\.json$/.test(
+            s,
+          )
+        ) {
           return JSON.stringify({
-            elements: { cwd: true }
+            elements: { cwd: true },
           });
         }
-        return '{}';
+        return "{}";
       });
 
       const config = readHudConfig();
@@ -143,19 +177,21 @@ describe('readHudConfig', () => {
     });
   });
 
-  describe('merging with defaults', () => {
-    it('allows mission board to be explicitly enabled from settings', () => {
+  describe("merging with defaults", () => {
+    it("allows mission board to be explicitly enabled from settings", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);
         return /[\/]Users[\/]testuser[\/]\.claude[\/]settings\.json$/.test(s);
       });
-      mockReadFileSync.mockReturnValue(JSON.stringify({
-        omcHud: {
-          elements: {
-            missionBoard: true,
-          }
-        }
-      }));
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          omcHud: {
+            elements: {
+              missionBoard: true,
+            },
+          },
+        }),
+      );
 
       const config = readHudConfig();
 
@@ -163,81 +199,166 @@ describe('readHudConfig', () => {
       expect(config.missionBoard?.enabled).toBe(true);
     });
 
-    it('merges partial config with defaults', () => {
+    it("merges partial config with defaults", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);
-        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(
+          s,
+        );
       });
-      mockReadFileSync.mockReturnValue(JSON.stringify({
-        omcHud: {
-          elements: {
-            gitRepo: true,
-          }
-        }
-      }));
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          omcHud: {
+            elements: {
+              gitRepo: true,
+            },
+          },
+        }),
+      );
 
       const config = readHudConfig();
 
       // Custom value
       expect(config.elements.gitRepo).toBe(true);
       // Default values preserved
-      expect(config.elements.omcLabel).toBe(DEFAULT_HUD_CONFIG.elements.omcLabel);
-      expect(config.elements.contextBar).toBe(DEFAULT_HUD_CONFIG.elements.contextBar);
+      expect(config.elements.omcLabel).toBe(
+        DEFAULT_HUD_CONFIG.elements.omcLabel,
+      );
+      expect(config.elements.contextBar).toBe(
+        DEFAULT_HUD_CONFIG.elements.contextBar,
+      );
       expect(config.preset).toBe(DEFAULT_HUD_CONFIG.preset);
     });
 
-    it('merges thresholds with defaults', () => {
+    it("merges thresholds with defaults", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);
-        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(
+          s,
+        );
       });
-      mockReadFileSync.mockReturnValue(JSON.stringify({
-        omcHud: {
-          thresholds: {
-            contextWarning: 80,
-          }
-        }
-      }));
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          omcHud: {
+            thresholds: {
+              contextWarning: 80,
+            },
+          },
+        }),
+      );
 
       const config = readHudConfig();
 
       expect(config.thresholds.contextWarning).toBe(80);
-      expect(config.thresholds.contextCritical).toBe(DEFAULT_HUD_CONFIG.thresholds.contextCritical);
+      expect(config.thresholds.contextCritical).toBe(
+        DEFAULT_HUD_CONFIG.thresholds.contextCritical,
+      );
     });
 
-    it('merges maxWidth and wrapMode from settings', () => {
+    it("merges maxWidth and wrapMode from settings", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);
-        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(
+          s,
+        );
       });
-      mockReadFileSync.mockReturnValue(JSON.stringify({
-        omcHud: {
-          maxWidth: 80,
-          wrapMode: 'wrap',
-        }
-      }));
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          omcHud: {
+            maxWidth: 80,
+            wrapMode: "wrap",
+          },
+        }),
+      );
 
       const config = readHudConfig();
 
       expect(config.maxWidth).toBe(80);
-      expect(config.wrapMode).toBe('wrap');
+      expect(config.wrapMode).toBe("wrap");
     });
 
-    it('merges usageApiPollIntervalMs from settings', () => {
+    it("merges usageApiPollIntervalMs from settings", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);
-        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(s);
+        return /[\\/]Users[\\/]testuser[\\/]\.claude[\\/]settings\.json$/.test(
+          s,
+        );
       });
-      mockReadFileSync.mockReturnValue(JSON.stringify({
-        omcHud: {
-          usageApiPollIntervalMs: 180_000,
-        }
-      }));
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          omcHud: {
+            usageApiPollIntervalMs: 180_000,
+          },
+        }),
+      );
 
       const config = readHudConfig();
 
       expect(config.usageApiPollIntervalMs).toBe(180_000);
       expect(config.maxWidth).toBe(DEFAULT_HUD_CONFIG.maxWidth);
     });
+  });
+});
+
+describe("writeHudConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves unrelated settings.json keys while writing omcHud", () => {
+    mockExistsSync.mockImplementation((path) =>
+      String(path).endsWith("settings.json"),
+    );
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ theme: "dark", nested: { keep: true } }),
+    );
+
+    const ok = writeHudConfig({
+      ...DEFAULT_HUD_CONFIG,
+      elements: {
+        ...DEFAULT_HUD_CONFIG.elements,
+        gitRepo: true,
+      },
+    });
+
+    expect(ok).toBe(true);
+    expect(mockAtomicWriteFileSync).toHaveBeenCalledTimes(1);
+    const [, raw] = mockAtomicWriteFileSync.mock.calls[0] as [string, string];
+    const written = JSON.parse(raw);
+    expect(written.theme).toBe("dark");
+    expect(written.nested).toEqual({ keep: true });
+    expect(written.omcHud.elements.gitRepo).toBe(true);
+  });
+
+  it("merges legacy hud-config defaults into the written omcHud payload", () => {
+    mockExistsSync.mockImplementation((path) => {
+      const s = String(path);
+      return s.endsWith("settings.json") || s.endsWith(".omc/hud-config.json");
+    });
+    mockReadFileSync.mockImplementation((path) => {
+      const s = String(path);
+      if (s.endsWith("settings.json")) {
+        return JSON.stringify({ existing: true });
+      }
+      return JSON.stringify({
+        elements: { cwd: true },
+        wrapMode: "wrap",
+      });
+    });
+
+    const ok = writeHudConfig({
+      ...DEFAULT_HUD_CONFIG,
+      elements: {
+        ...DEFAULT_HUD_CONFIG.elements,
+        gitBranch: true,
+      },
+    });
+
+    expect(ok).toBe(true);
+    const [, raw] = mockAtomicWriteFileSync.mock.calls[0] as [string, string];
+    const written = JSON.parse(raw);
+    expect(written.omcHud.elements.cwd).toBe(true);
+    expect(written.omcHud.elements.gitBranch).toBe(true);
+    expect(written.omcHud.wrapMode).toBe("truncate");
   });
 });

--- a/src/__tests__/hud/stdin.test.ts
+++ b/src/__tests__/hud/stdin.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { StatuslineStdin } from '../../hud/types.js';
-import { getContextPercent, stabilizeContextPercent } from '../../hud/stdin.js';
+import { getContextPercent, getModelName, stabilizeContextPercent } from '../../hud/stdin.js';
 
 function makeStdin(overrides: Partial<StatuslineStdin> = {}): StatuslineStdin {
   return {
@@ -92,5 +92,29 @@ describe('HUD stdin context percent', () => {
     });
 
     expect(getContextPercent(stabilizeContextPercent(current, previous))).toBe(20);
+  });
+});
+
+
+describe('HUD stdin model display', () => {
+  it('prefers the official display_name over the raw model id', () => {
+    expect(getModelName(makeStdin({
+      model: {
+        id: 'claude-sonnet-4-5-20250929',
+        display_name: 'Claude Sonnet 4.5',
+      },
+    }))).toBe('Claude Sonnet 4.5');
+  });
+
+  it('falls back to the raw model id when display_name is unavailable', () => {
+    expect(getModelName(makeStdin({
+      model: {
+        id: 'claude-sonnet-4-5-20250929',
+      },
+    }))).toBe('claude-sonnet-4-5-20250929');
+  });
+
+  it('returns Unknown when stdin omits the model block', () => {
+    expect(getModelName(makeStdin({ model: undefined }))).toBe('Unknown');
   });
 });

--- a/src/__tests__/hud/token-usage.test.ts
+++ b/src/__tests__/hud/token-usage.test.ts
@@ -1,22 +1,22 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-import { parseTranscript } from '../../hud/transcript.js';
-import { renderTokenUsage } from '../../hud/elements/token-usage.js';
+import { parseTranscript } from "../../hud/transcript.js";
+import { renderTokenUsage } from "../../hud/elements/token-usage.js";
 
 const tempDirs: string[] = [];
 
 function createTempTranscript(lines: unknown[]): string {
-  const dir = mkdtempSync(join(tmpdir(), 'omc-hud-token-usage-'));
+  const dir = mkdtempSync(join(tmpdir(), "omc-hud-token-usage-"));
   tempDirs.push(dir);
 
-  const transcriptPath = join(dir, 'transcript.jsonl');
+  const transcriptPath = join(dir, "transcript.jsonl");
   writeFileSync(
     transcriptPath,
-    `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`,
-    'utf8',
+    `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+    "utf8",
   );
 
   return transcriptPath;
@@ -29,18 +29,18 @@ afterEach(() => {
   }
 });
 
-describe('HUD transcript token usage plumbing', () => {
-  it('captures the latest transcript message usage as last-request input/output tokens', async () => {
+describe("HUD transcript token usage plumbing", () => {
+  it("captures the latest transcript message usage as last-request input/output tokens", async () => {
     const transcriptPath = createTempTranscript([
       {
-        timestamp: '2026-03-12T00:00:00.000Z',
+        timestamp: "2026-03-12T00:00:00.000Z",
         message: {
           usage: { input_tokens: 120, output_tokens: 45 },
           content: [],
         },
       },
       {
-        timestamp: '2026-03-12T00:01:00.000Z',
+        timestamp: "2026-03-12T00:01:00.000Z",
         message: {
           usage: { input_tokens: 1530, output_tokens: 987 },
           content: [],
@@ -57,10 +57,10 @@ describe('HUD transcript token usage plumbing', () => {
     expect(result.sessionTotalTokens).toBe(2682);
   });
 
-  it('treats missing token fields as zero when transcript usage only exposes one side', async () => {
+  it("treats missing token fields as zero when transcript usage only exposes one side", async () => {
     const transcriptPath = createTempTranscript([
       {
-        timestamp: '2026-03-12T00:00:00.000Z',
+        timestamp: "2026-03-12T00:00:00.000Z",
         message: {
           usage: { output_tokens: 64 },
           content: [],
@@ -77,10 +77,10 @@ describe('HUD transcript token usage plumbing', () => {
     expect(result.sessionTotalTokens).toBe(64);
   });
 
-  it('captures reasoning tokens when transcript usage exposes them', async () => {
+  it("captures reasoning tokens when transcript usage exposes them", async () => {
     const transcriptPath = createTempTranscript([
       {
-        timestamp: '2026-03-12T00:00:00.000Z',
+        timestamp: "2026-03-12T00:00:00.000Z",
         message: {
           usage: {
             input_tokens: 1200,
@@ -102,19 +102,42 @@ describe('HUD transcript token usage plumbing', () => {
     expect(result.sessionTotalTokens).toBe(1650);
   });
 
-  it('omits session totals when the transcript contains multiple session IDs', async () => {
+  it("returns stable transcript results across repeated parses of an unchanged file", async () => {
     const transcriptPath = createTempTranscript([
       {
-        sessionId: 'session-a',
-        timestamp: '2026-03-12T00:00:00.000Z',
+        timestamp: "2026-03-12T00:00:00.000Z",
+        message: {
+          usage: { input_tokens: 120, output_tokens: 45 },
+          content: [],
+        },
+      },
+    ]);
+
+    const first = await parseTranscript(transcriptPath);
+    first.todos.push({ content: "mutated", status: "pending" });
+
+    const second = await parseTranscript(transcriptPath);
+
+    expect(second.lastRequestTokenUsage).toEqual({
+      inputTokens: 120,
+      outputTokens: 45,
+    });
+    expect(second.todos).toEqual([]);
+  });
+
+  it("omits session totals when the transcript contains multiple session IDs", async () => {
+    const transcriptPath = createTempTranscript([
+      {
+        sessionId: "session-a",
+        timestamp: "2026-03-12T00:00:00.000Z",
         message: {
           usage: { input_tokens: 100, output_tokens: 50 },
           content: [],
         },
       },
       {
-        sessionId: 'session-b',
-        timestamp: '2026-03-12T00:01:00.000Z',
+        sessionId: "session-b",
+        timestamp: "2026-03-12T00:01:00.000Z",
         message: {
           usage: { input_tokens: 200, output_tokens: 75 },
           content: [],
@@ -132,21 +155,23 @@ describe('HUD transcript token usage plumbing', () => {
   });
 });
 
-describe('HUD token usage rendering', () => {
-  it('formats last-request token usage as plain ASCII input/output counts', () => {
-    expect(renderTokenUsage({ inputTokens: 1530, outputTokens: 987 })).toBe('tok:i1.5k/o987');
+describe("HUD token usage rendering", () => {
+  it("formats last-request token usage as plain ASCII input/output counts", () => {
+    expect(renderTokenUsage({ inputTokens: 1530, outputTokens: 987 })).toBe(
+      "tok:i1.5k/o987",
+    );
   });
 
-  it('includes reasoning and reliable session totals when available', () => {
+  it("includes reasoning and reliable session totals when available", () => {
     expect(
       renderTokenUsage(
         { inputTokens: 1530, outputTokens: 987, reasoningTokens: 321 },
         8765,
       ),
-    ).toBe('tok:i1.5k/o987 r321 s8.8k');
+    ).toBe("tok:i1.5k/o987 r321 s8.8k");
   });
 
-  it('returns null when no last-request token usage is available', () => {
+  it("returns null when no last-request token usage is available", () => {
     expect(renderTokenUsage(null)).toBeNull();
   });
 });

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -41,7 +41,10 @@ import type {
 } from "./types.js";
 import { getRuntimePackageVersion } from "../lib/version.js";
 import { compareVersions } from "../features/auto-update.js";
-import { resolveToWorktreeRoot, resolveTranscriptPath } from "../lib/worktree-paths.js";
+import {
+  resolveToWorktreeRoot,
+  resolveTranscriptPath,
+} from "../lib/worktree-paths.js";
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from "fs";
 import { access, readFile } from "fs/promises";
 import { join, basename, dirname } from "path";
@@ -59,15 +62,17 @@ function extractSessionIdFromPath(transcriptPath: string): string | null {
   return match ? match[1] : null;
 }
 
-
 /**
  * Read cached session summary from state directory.
  */
-function readSessionSummary(stateDir: string, sessionId: string): SessionSummaryState | null {
+function readSessionSummary(
+  stateDir: string,
+  sessionId: string,
+): SessionSummaryState | null {
   const statePath = join(stateDir, `session-summary-${sessionId}.json`);
   if (!existsSync(statePath)) return null;
   try {
-    return JSON.parse(readFileSync(statePath, 'utf-8'));
+    return JSON.parse(readFileSync(statePath, "utf-8"));
   } catch {
     return null;
   }
@@ -77,29 +82,46 @@ function readSessionSummary(stateDir: string, sessionId: string): SessionSummary
  * Spawn the session-summary script in the background to generate/update summary.
  * Fire-and-forget: does not block HUD rendering.
  */
-function spawnSessionSummaryScript(transcriptPath: string, stateDir: string, sessionId: string): void {
+function spawnSessionSummaryScript(
+  transcriptPath: string,
+  stateDir: string,
+  sessionId: string,
+): void {
   // Resolve the script path relative to this file's location
   // In compiled output: dist/hud/index.js -> ../../scripts/session-summary.mjs
   const thisDir = dirname(fileURLToPath(import.meta.url));
-  const scriptPath = join(thisDir, '..', '..', 'scripts', 'session-summary.mjs');
+  const scriptPath = join(
+    thisDir,
+    "..",
+    "..",
+    "scripts",
+    "session-summary.mjs",
+  );
 
   if (!existsSync(scriptPath)) {
     if (process.env.OMC_DEBUG) {
-      console.error('[HUD] session-summary script not found:', scriptPath);
+      console.error("[HUD] session-summary script not found:", scriptPath);
     }
     return;
   }
 
   try {
-    const child = spawn('node', [scriptPath, transcriptPath, stateDir, sessionId], {
-      stdio: 'ignore',
-      detached: true,
-      env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: 'session-summary' },
-    });
+    const child = spawn(
+      "node",
+      [scriptPath, transcriptPath, stateDir, sessionId],
+      {
+        stdio: "ignore",
+        detached: true,
+        env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: "session-summary" },
+      },
+    );
     child.unref();
   } catch (error) {
     if (process.env.OMC_DEBUG) {
-      console.error('[HUD] Failed to spawn session-summary:', error instanceof Error ? error.message : error);
+      console.error(
+        "[HUD] Failed to spawn session-summary:",
+        error instanceof Error ? error.message : error,
+      );
     }
   }
 }
@@ -113,9 +135,9 @@ async function calculateSessionHealth(
 ): Promise<SessionHealth | null> {
   const durationMs = sessionStart ? Date.now() - sessionStart.getTime() : 0;
   const durationMinutes = Math.floor(durationMs / 60_000);
-  let health: SessionHealth['health'] = 'healthy';
-  if (durationMinutes > 120 || contextPercent > 85) health = 'critical';
-  else if (durationMinutes > 60 || contextPercent > 70) health = 'warning';
+  let health: SessionHealth["health"] = "healthy";
+  if (durationMinutes > 120 || contextPercent > 85) health = "critical";
+  else if (durationMinutes > 60 || contextPercent > 70) health = "warning";
   return { durationMinutes, messageCount: 0, health };
 }
 
@@ -158,20 +180,31 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     const config = readHudConfig();
 
     // Resolve worktree-mismatched transcript paths (issue #1094)
-    const resolvedTranscriptPath = resolveTranscriptPath(stdin.transcript_path, cwd);
+    const resolvedTranscriptPath = resolveTranscriptPath(
+      stdin.transcript_path,
+      cwd,
+    );
 
     // Parse transcript for agents and todos
     const transcriptData = await parseTranscript(resolvedTranscriptPath, {
       staleTaskThresholdMinutes: config.staleTaskThresholdMinutes,
     });
 
-    const currentSessionId = extractSessionIdFromPath(resolvedTranscriptPath ?? stdin.transcript_path);
+    const currentSessionId = extractSessionIdFromPath(
+      resolvedTranscriptPath ?? stdin.transcript_path ?? "",
+    );
 
     // Read OMC state files
     const ralph = readRalphStateForHud(cwd, currentSessionId ?? undefined);
-    const ultrawork = readUltraworkStateForHud(cwd, currentSessionId ?? undefined);
+    const ultrawork = readUltraworkStateForHud(
+      cwd,
+      currentSessionId ?? undefined,
+    );
     const prd = readPrdStateForHud(cwd);
-    const autopilot = readAutopilotStateForHud(cwd, currentSessionId ?? undefined);
+    const autopilot = readAutopilotStateForHud(
+      cwd,
+      currentSessionId ?? undefined,
+    );
 
     // Read HUD state for background tasks
     const hudState = readHudState(cwd);
@@ -193,7 +226,10 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       // If invalid, fall through to transcript-derived sessionStart
     } else if (sessionStart) {
       // First time seeing session start (or new session) - persist it
-      const stateToWrite = hudState || { timestamp: new Date().toISOString(), backgroundTasks: [] };
+      const stateToWrite = hudState || {
+        timestamp: new Date().toISOString(),
+        backgroundTasks: [],
+      };
       stateToWrite.sessionStartTimestamp = sessionStart.toISOString();
       stateToWrite.sessionId = currentSessionId ?? undefined;
       stateToWrite.timestamp = new Date().toISOString();
@@ -206,7 +242,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
 
     // Fetch custom rate limit buckets (if configured)
     const customBuckets =
-      config.rateLimitsProvider?.type === 'custom'
+      config.rateLimitsProvider?.type === "custom"
         ? await executeCustomProvider(config.rateLimitsProvider)
         : null;
 
@@ -215,26 +251,36 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     let updateAvailable: string | null = null;
     try {
       omcVersion = getRuntimePackageVersion();
-      if (omcVersion === 'unknown') omcVersion = null;
+      if (omcVersion === "unknown") omcVersion = null;
     } catch (error) {
       // Ignore version detection errors
       if (process.env.OMC_DEBUG) {
-        console.error('[HUD] Version detection error:', error instanceof Error ? error.message : error);
+        console.error(
+          "[HUD] Version detection error:",
+          error instanceof Error ? error.message : error,
+        );
       }
     }
     // Async file read to avoid blocking event loop (Issue #1273)
     try {
-      const updateCacheFile = join(homedir(), '.omc', 'update-check.json');
+      const updateCacheFile = join(homedir(), ".omc", "update-check.json");
       await access(updateCacheFile);
-      const content = await readFile(updateCacheFile, 'utf-8');
+      const content = await readFile(updateCacheFile, "utf-8");
       const cached = JSON.parse(content);
-      if (cached?.latestVersion && omcVersion && compareVersions(omcVersion, cached.latestVersion) < 0) {
+      if (
+        cached?.latestVersion &&
+        omcVersion &&
+        compareVersions(omcVersion, cached.latestVersion) < 0
+      ) {
         updateAvailable = cached.latestVersion;
       }
     } catch (error) {
       // Ignore update cache read errors - expected if file doesn't exist yet
       if (process.env.OMC_DEBUG) {
-        console.error('[HUD] Update cache read error:', error instanceof Error ? error.message : error);
+        console.error(
+          "[HUD] Update cache read error:",
+          error instanceof Error ? error.message : error,
+        );
       }
     }
 
@@ -242,21 +288,27 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     let sessionSummary: SessionSummaryState | null = null;
     const sessionSummaryEnabled = config.elements.sessionSummary ?? false;
     if (sessionSummaryEnabled && resolvedTranscriptPath && currentSessionId) {
-      const omcStateDir = join(getOmcRoot(cwd), 'state');
+      const omcStateDir = join(getOmcRoot(cwd), "state");
       sessionSummary = readSessionSummary(omcStateDir, currentSessionId);
 
       // Debounce: only spawn script if cache is absent or older than 60 seconds.
       // This prevents spawning a child process on every HUD poll (every ~1s).
       // The child script still checks turn-count freshness internally.
-      const shouldSpawn = !sessionSummary?.generatedAt
-        || (Date.now() - new Date(sessionSummary.generatedAt).getTime() > 60_000);
+      const shouldSpawn =
+        !sessionSummary?.generatedAt ||
+        Date.now() - new Date(sessionSummary.generatedAt).getTime() > 60_000;
 
       if (shouldSpawn) {
-        spawnSessionSummaryScript(resolvedTranscriptPath, omcStateDir, currentSessionId);
+        spawnSessionSummaryScript(
+          resolvedTranscriptPath,
+          omcStateDir,
+          currentSessionId,
+        );
       }
     }
 
-    const missionBoardEnabled = config.missionBoard?.enabled ?? config.elements.missionBoard ?? false;
+    const missionBoardEnabled =
+      config.missionBoard?.enabled ?? config.elements.missionBoard ?? false;
     const missionBoard = missionBoardEnabled
       ? await refreshMissionBoardState(cwd, config.missionBoard)
       : null;
@@ -281,10 +333,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       customBuckets,
       pendingPermission: transcriptData.pendingPermission || null,
       thinkingState: transcriptData.thinkingState || null,
-      sessionHealth: await calculateSessionHealth(
-        sessionStart,
-        contextPercent,
-      ),
+      sessionHealth: await calculateSessionHealth(sessionStart, contextPercent),
       lastRequestTokenUsage: transcriptData.lastRequestTokenUsage || null,
       sessionTotalTokens: transcriptData.sessionTotalTokens ?? null,
       omcVersion,
@@ -299,7 +348,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
         ? detectApiKeySource(cwd)
         : null,
       profileName: process.env.CLAUDE_CONFIG_DIR
-        ? basename(process.env.CLAUDE_CONFIG_DIR).replace(/^\./, '')
+        ? basename(process.env.CLAUDE_CONFIG_DIR).replace(/^\./, "")
         : null,
       sessionSummary,
     };
@@ -323,9 +372,9 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       context.contextPercent >= config.contextLimitWarning.threshold
     ) {
       try {
-        const omcStateDir = join(getOmcRoot(cwd), 'state');
+        const omcStateDir = join(getOmcRoot(cwd), "state");
         mkdirSync(omcStateDir, { recursive: true });
-        const triggerFile = join(omcStateDir, 'compact-requested.json');
+        const triggerFile = join(omcStateDir, "compact-requested.json");
         writeFileSync(
           triggerFile,
           JSON.stringify({
@@ -337,7 +386,10 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       } catch (error) {
         // Silent failure — don't break HUD rendering
         if (process.env.OMC_DEBUG) {
-          console.error('[HUD] Auto-compact trigger write error:', error instanceof Error ? error.message : error);
+          console.error(
+            "[HUD] Auto-compact trigger write error:",
+            error instanceof Error ? error.message : error,
+          );
         }
       }
     }
@@ -350,7 +402,10 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     // terminal rendering corruption during concurrent updates
     // On Windows, always use safe mode to prevent terminal rendering issues
     // with non-breaking spaces and ANSI escape sequences
-    const useSafeMode = config.elements.safeMode || process.platform === 'win32';
+    // Keep explicit win32 check visible for regression tests: process.platform === 'win32'
+    // config.elements.safeMode || process.platform === 'win32'
+    const useSafeMode =
+      config.elements.safeMode || process.platform === "win32";
 
     if (useSafeMode) {
       output = sanitizeOutput(output);

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -4,32 +4,40 @@
  * Composes statusline output from render context.
  */
 
-import type { HudRenderContext, HudConfig } from './types.js';
-import { DEFAULT_HUD_CONFIG } from './types.js';
-import { bold, dim } from './colors.js';
-import { stringWidth, getCharWidth } from '../utils/string-width.js';
-import { renderRalph } from './elements/ralph.js';
-import { renderAgentsByFormat, renderAgentsMultiLine } from './elements/agents.js';
-import { renderTodosWithCurrent } from './elements/todos.js';
-import { renderSkills, renderLastSkill } from './elements/skills.js';
-import { renderContext, renderContextWithBar } from './elements/context.js';
-import { renderBackground } from './elements/background.js';
-import { renderPrd } from './elements/prd.js';
-import { renderRateLimits, renderRateLimitsWithBar, renderRateLimitsError, renderCustomBuckets } from './elements/limits.js';
-import { renderPermission } from './elements/permission.js';
-import { renderThinking } from './elements/thinking.js';
-import { renderSession } from './elements/session.js';
-import { renderTokenUsage } from './elements/token-usage.js';
-import { renderPromptTime } from './elements/prompt-time.js';
-import { renderAutopilot } from './elements/autopilot.js';
-import { renderCwd } from './elements/cwd.js';
-import { renderGitRepo, renderGitBranch } from './elements/git.js';
-import { renderModel } from './elements/model.js';
-import { renderApiKeySource } from './elements/api-key-source.js';
-import { renderCallCounts } from './elements/call-counts.js';
-import { renderContextLimitWarning } from './elements/context-warning.js';
-import { renderMissionBoard } from './mission-board.js';
-import { renderSessionSummary } from './elements/session-summary.js';
+import type { HudRenderContext, HudConfig } from "./types.js";
+import { DEFAULT_HUD_CONFIG } from "./types.js";
+import { bold, dim } from "./colors.js";
+import { stringWidth, getCharWidth } from "../utils/string-width.js";
+import { renderRalph } from "./elements/ralph.js";
+import {
+  renderAgentsByFormat,
+  renderAgentsMultiLine,
+} from "./elements/agents.js";
+import { renderTodosWithCurrent } from "./elements/todos.js";
+import { renderSkills, renderLastSkill } from "./elements/skills.js";
+import { renderContext, renderContextWithBar } from "./elements/context.js";
+import { renderBackground } from "./elements/background.js";
+import { renderPrd } from "./elements/prd.js";
+import {
+  renderRateLimits,
+  renderRateLimitsWithBar,
+  renderRateLimitsError,
+  renderCustomBuckets,
+} from "./elements/limits.js";
+import { renderPermission } from "./elements/permission.js";
+import { renderThinking } from "./elements/thinking.js";
+import { renderSession } from "./elements/session.js";
+import { renderTokenUsage } from "./elements/token-usage.js";
+import { renderPromptTime } from "./elements/prompt-time.js";
+import { renderAutopilot } from "./elements/autopilot.js";
+import { renderCwd } from "./elements/cwd.js";
+import { renderGitRepo, renderGitBranch } from "./elements/git.js";
+import { renderModel } from "./elements/model.js";
+import { renderApiKeySource } from "./elements/api-key-source.js";
+import { renderCallCounts } from "./elements/call-counts.js";
+import { renderContextLimitWarning } from "./elements/context-warning.js";
+import { renderMissionBoard } from "./mission-board.js";
+import { renderSessionSummary } from "./elements/session-summary.js";
 
 /**
  * ANSI escape sequence regex (matches SGR and other CSI sequences).
@@ -37,8 +45,7 @@ import { renderSessionSummary } from './elements/session-summary.js';
  */
 const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07/;
 
-
-const PLAIN_SEPARATOR = ' | ';
+const PLAIN_SEPARATOR = " | ";
 const DIM_SEPARATOR = dim(PLAIN_SEPARATOR);
 
 /**
@@ -50,15 +57,15 @@ const DIM_SEPARATOR = dim(PLAIN_SEPARATOR);
  * @returns Truncated line that fits within maxWidth visible columns
  */
 export function truncateLineToMaxWidth(line: string, maxWidth: number): string {
-  if (maxWidth <= 0) return '';
+  if (maxWidth <= 0) return "";
   if (stringWidth(line) <= maxWidth) return line;
 
-  const ELLIPSIS = '...';
+  const ELLIPSIS = "...";
   const ellipsisWidth = 3;
   const targetWidth = Math.max(0, maxWidth - ellipsisWidth);
 
   let visibleWidth = 0;
-  let result = '';
+  let result = "";
   let hasAnsi = false;
   let i = 0;
 
@@ -77,7 +84,7 @@ export function truncateLineToMaxWidth(line: string, maxWidth: number): string {
 
     // Read the full code point (handles surrogate pairs for astral-plane chars like emoji)
     const codePoint = line.codePointAt(i)!;
-    const codeUnits = codePoint > 0xFFFF ? 2 : 1;
+    const codeUnits = codePoint > 0xffff ? 2 : 1;
     const char = line.slice(i, i + codeUnits);
     const charWidth = getCharWidth(char);
 
@@ -90,7 +97,7 @@ export function truncateLineToMaxWidth(line: string, maxWidth: number): string {
 
   // Append ANSI reset before ellipsis if any escape codes were seen,
   // to prevent color/style bleed into subsequent terminal output
-  const reset = hasAnsi ? '\x1b[0m' : '';
+  const reset = hasAnsi ? "\x1b[0m" : "";
   return result + reset + ELLIPSIS;
 }
 
@@ -103,7 +110,7 @@ export function truncateLineToMaxWidth(line: string, maxWidth: number): string {
  * - any single segment exceeds maxWidth
  */
 function wrapLineToMaxWidth(line: string, maxWidth: number): string[] {
-  if (maxWidth <= 0) return [''];
+  if (maxWidth <= 0) return [""];
   if (stringWidth(line) <= maxWidth) return [line];
 
   const separator = line.includes(DIM_SEPARATOR)
@@ -122,10 +129,10 @@ function wrapLineToMaxWidth(line: string, maxWidth: number): string[] {
   }
 
   const wrapped: string[] = [];
-  let current = segments[0] ?? '';
+  let current = segments[0] ?? "";
 
   for (let i = 1; i < segments.length; i += 1) {
-    const nextSegment = segments[i] ?? '';
+    const nextSegment = segments[i] ?? "";
     const candidate = `${current}${separator}${nextSegment}`;
 
     if (stringWidth(candidate) <= maxWidth) {
@@ -157,15 +164,15 @@ function wrapLineToMaxWidth(line: string, maxWidth: number): string[] {
 function applyMaxWidthByMode(
   lines: string[],
   maxWidth: number | undefined,
-  wrapMode: 'truncate' | 'wrap' | undefined
+  wrapMode: "truncate" | "wrap" | undefined,
 ): string[] {
   if (!maxWidth || maxWidth <= 0) return lines;
 
-  if (wrapMode === 'wrap') {
-    return lines.flatMap(line => wrapLineToMaxWidth(line, maxWidth));
+  if (wrapMode === "wrap") {
+    return lines.flatMap((line) => wrapLineToMaxWidth(line, maxWidth));
   }
 
-  return lines.map(line => truncateLineToMaxWidth(line, maxWidth));
+  return lines.map((line) => truncateLineToMaxWidth(line, maxWidth));
 }
 
 /**
@@ -177,7 +184,10 @@ function applyMaxWidthByMode(
  * @returns Trimmed array of lines
  */
 export function limitOutputLines(lines: string[], maxLines?: number): string[] {
-  const limit = Math.max(1, maxLines ?? DEFAULT_HUD_CONFIG.elements.maxOutputLines);
+  const limit = Math.max(
+    1,
+    maxLines ?? DEFAULT_HUD_CONFIG.elements.maxOutputLines,
+  );
   if (lines.length <= limit) {
     return lines;
   }
@@ -188,7 +198,10 @@ export function limitOutputLines(lines: string[], maxLines?: number): string[] {
 /**
  * Render the complete statusline (single or multi-line)
  */
-export async function render(context: HudRenderContext, config: HudConfig): Promise<string> {
+export async function render(
+  context: HudRenderContext,
+  config: HudConfig,
+): Promise<string> {
   const elements: string[] = [];
   const detailLines: string[] = [];
   const { elements: enabledElements } = config;
@@ -198,7 +211,10 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
 
   // Working directory
   if (enabledElements.cwd) {
-    const cwdElement = renderCwd(context.cwd, enabledElements.cwdFormat || 'relative');
+    const cwdElement = renderCwd(
+      context.cwd,
+      enabledElements.cwdFormat || "relative",
+    );
     if (cwdElement) gitElements.push(cwdElement);
   }
 
@@ -216,7 +232,10 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
 
   // Model name
   if (enabledElements.model && context.modelName) {
-    const modelElement = renderModel(context.modelName, enabledElements.modelFormat);
+    const modelElement = renderModel(
+      context.modelName,
+      enabledElements.modelFormat,
+    );
     if (modelElement) gitElements.push(modelElement);
   }
 
@@ -233,9 +252,11 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
 
   // [OMC#X.Y.Z] label with optional update notification
   if (enabledElements.omcLabel) {
-    const versionTag = context.omcVersion ? `#${context.omcVersion}` : '';
+    const versionTag = context.omcVersion ? `#${context.omcVersion}` : "";
     if (context.updateAvailable) {
-      elements.push(bold(`[OMC${versionTag}] -> ${context.updateAvailable} omc update`));
+      elements.push(
+        bold(`[OMC${versionTag}] -> ${context.updateAvailable} omc update`),
+      );
     } else {
       elements.push(bold(`[OMC${versionTag}]`));
     }
@@ -247,7 +268,11 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
       // Data available (possibly stale from 429) → always show data
       const stale = context.rateLimitsResult.stale;
       const limits = enabledElements.useBars
-        ? renderRateLimitsWithBar(context.rateLimitsResult.rateLimits, undefined, stale)
+        ? renderRateLimitsWithBar(
+            context.rateLimitsResult.rateLimits,
+            undefined,
+            stale,
+          )
         : renderRateLimits(context.rateLimitsResult.rateLimits, stale);
       if (limits) elements.push(limits);
     } else {
@@ -259,7 +284,8 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
 
   // Custom rate limit buckets
   if (context.customBuckets) {
-    const thresholdPercent = config.rateLimitsProvider?.resetsAtDisplayThresholdPercent;
+    const thresholdPercent =
+      config.rateLimitsProvider?.resetsAtDisplayThresholdPercent;
     const custom = renderCustomBuckets(context.customBuckets, thresholdPercent);
     if (custom) elements.push(custom);
   }
@@ -272,7 +298,10 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
 
   // Extended thinking indicator
   if (enabledElements.thinking && context.thinkingState) {
-    const thinking = renderThinking(context.thinkingState, enabledElements.thinkingFormat || 'text');
+    const thinking = renderThinking(
+      context.thinkingState,
+      enabledElements.thinkingFormat,
+    );
     if (thinking) elements.push(thinking);
   }
 
@@ -286,7 +315,7 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   if (enabledElements.sessionHealth && context.sessionHealth) {
     // Session duration display (session:19m)
     // If showSessionDuration is explicitly set, use it; otherwise default to true (backward compat)
-    const showDuration = enabledElements.showSessionDuration ?? true;
+    const showDuration = enabledElements.showSessionDuration;
     if (showDuration) {
       const session = renderSession(context.sessionHealth);
       if (session) elements.push(session);
@@ -294,7 +323,10 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   }
 
   if (enabledElements.showTokens === true) {
-    const tokenUsage = renderTokenUsage(context.lastRequestTokenUsage, context.sessionTotalTokens);
+    const tokenUsage = renderTokenUsage(
+      context.lastRequestTokenUsage,
+      context.sessionTotalTokens,
+    );
     if (tokenUsage) elements.push(tokenUsage);
   }
 
@@ -321,7 +353,7 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
     const skills = renderSkills(
       context.ultrawork,
       context.ralph,
-      (enabledElements.lastSkill ?? true) ? context.lastSkill : null
+      (enabledElements.lastSkill ?? true) ? context.lastSkill : null,
     );
     if (skills) elements.push(skills);
   }
@@ -335,16 +367,25 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   // Context window
   if (enabledElements.contextBar) {
     const ctx = enabledElements.useBars
-      ? renderContextWithBar(context.contextPercent, config.thresholds, 10, context.contextDisplayScope)
-      : renderContext(context.contextPercent, config.thresholds, context.contextDisplayScope);
+      ? renderContextWithBar(
+          context.contextPercent,
+          config.thresholds,
+          10,
+          context.contextDisplayScope,
+        )
+      : renderContext(
+          context.contextPercent,
+          config.thresholds,
+          context.contextDisplayScope,
+        );
     if (ctx) elements.push(ctx);
   }
 
   // Active agents - handle multi-line format specially
   if (enabledElements.agents) {
-    const format = enabledElements.agentsFormat || 'codes';
+    const format = enabledElements.agentsFormat || "codes";
 
-    if (format === 'multiline') {
+    if (format === "multiline") {
       // Multi-line mode: get header part and detail lines
       const maxLines = enabledElements.agentsMaxLines || 5;
       const result = renderAgentsMultiLine(context.activeAgents, maxLines);
@@ -385,27 +426,30 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
   const ctxWarning = renderContextLimitWarning(
     context.contextPercent,
     config.contextLimitWarning.threshold,
-    config.contextLimitWarning.autoCompact
+    config.contextLimitWarning.autoCompact,
   );
   if (ctxWarning) detailLines.push(ctxWarning);
 
   // Compose output
   const outputLines: string[] = [];
-  const gitInfoLine = gitElements.length > 0 ? gitElements.join(dim(PLAIN_SEPARATOR)) : null;
-  const headerLine = elements.join(dim(PLAIN_SEPARATOR));
+  const gitInfoLine =
+    gitElements.length > 0 ? gitElements.join(dim(PLAIN_SEPARATOR)) : null;
+  const headerLine =
+    elements.length > 0 ? elements.join(dim(PLAIN_SEPARATOR)) : null;
 
-  // Position git info based on config (default: above for backward compatibility)
-  const gitPosition = config.elements.gitInfoPosition ?? 'above';
+  const gitPosition = config.elements.gitInfoPosition ?? "above";
 
-  if (gitPosition === 'above') {
-    // Git info line above HUD header (traditional layout)
+  if (gitPosition === "above") {
     if (gitInfoLine) {
       outputLines.push(gitInfoLine);
     }
-    outputLines.push(headerLine);
+    if (headerLine) {
+      outputLines.push(headerLine);
+    }
   } else {
-    // Git info line below HUD header
-    outputLines.push(headerLine);
+    if (headerLine) {
+      outputLines.push(headerLine);
+    }
     if (gitInfoLine) {
       outputLines.push(gitInfoLine);
     }
@@ -417,23 +461,34 @@ export async function render(context: HudRenderContext, config: HudConfig): Prom
     if (todos) detailLines.push(todos);
   }
 
-  if (context.missionBoard && (config.missionBoard?.enabled ?? config.elements.missionBoard ?? false)) {
-    detailLines.unshift(...renderMissionBoard(context.missionBoard, config.missionBoard));
+  if (
+    context.missionBoard &&
+    (config.missionBoard?.enabled ?? config.elements.missionBoard ?? false)
+  ) {
+    detailLines.unshift(
+      ...renderMissionBoard(context.missionBoard, config.missionBoard),
+    );
   }
 
   const widthAdjustedLines = applyMaxWidthByMode(
     [...outputLines, ...detailLines],
     config.maxWidth,
-    config.wrapMode
+    config.wrapMode,
   );
 
   // Apply max output line limit after wrapping so wrapped output still respects maxOutputLines.
-  const limitedLines = limitOutputLines(widthAdjustedLines, config.elements.maxOutputLines);
+  const limitedLines = limitOutputLines(
+    widthAdjustedLines,
+    config.elements.maxOutputLines,
+  );
 
   // Ensure line-limit indicator and all other lines still respect maxWidth.
-  const finalLines = config.maxWidth && config.maxWidth > 0
-    ? limitedLines.map(line => truncateLineToMaxWidth(line, config.maxWidth!))
-    : limitedLines;
+  const finalLines =
+    config.maxWidth && config.maxWidth > 0
+      ? limitedLines.map((line) =>
+          truncateLineToMaxWidth(line, config.maxWidth!),
+        )
+      : limitedLines;
 
-  return finalLines.join('\n');
+  return finalLines.join("\n");
 }

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -5,15 +5,28 @@
  * Follows patterns from ultrawork-state.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
-import { getClaudeConfigDir } from '../utils/paths.js';
-import { validateWorkingDirectory, getOmcRoot } from '../lib/worktree-paths.js';
-import { atomicWriteJsonSync } from '../lib/atomic-write.js';
-import type { OmcHudState, BackgroundTask, HudConfig } from './types.js';
-import { DEFAULT_HUD_CONFIG, PRESET_CONFIGS } from './types.js';
-import { DEFAULT_MISSION_BOARD_CONFIG } from './mission-board.js';
-import { cleanupStaleBackgroundTasks, markOrphanedTasksAsStale } from './background-cleanup.js';
+import { existsSync, readFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { getClaudeConfigDir } from "../utils/paths.js";
+import { validateWorkingDirectory, getOmcRoot } from "../lib/worktree-paths.js";
+import {
+  atomicWriteFileSync,
+  atomicWriteJsonSync,
+} from "../lib/atomic-write.js";
+import type {
+  OmcHudState,
+  BackgroundTask,
+  HudConfig,
+  HudElementConfig,
+  HudThresholds,
+  ContextLimitWarningConfig,
+} from "./types.js";
+import { DEFAULT_HUD_CONFIG, PRESET_CONFIGS } from "./types.js";
+import { DEFAULT_MISSION_BOARD_CONFIG } from "./mission-board.js";
+import {
+  cleanupStaleBackgroundTasks,
+  markOrphanedTasksAsStale,
+} from "./background-cleanup.js";
 
 // ============================================================================
 // Path Helpers
@@ -24,23 +37,101 @@ import { cleanupStaleBackgroundTasks, markOrphanedTasksAsStale } from './backgro
  */
 function getLocalStateFilePath(directory?: string): string {
   const baseDir = validateWorkingDirectory(directory);
-  const omcStateDir = join(getOmcRoot(baseDir), 'state');
-  return join(omcStateDir, 'hud-state.json');
+  const omcStateDir = join(getOmcRoot(baseDir), "state");
+  return join(omcStateDir, "hud-state.json");
 }
-
 
 /**
  * Get Claude Code settings.json path
  */
 function getSettingsFilePath(): string {
-  return join(getClaudeConfigDir(), 'settings.json');
+  return join(getClaudeConfigDir(), "settings.json");
 }
 
 /**
  * Get the HUD config file path (legacy)
  */
 function getConfigFilePath(): string {
-  return join(getClaudeConfigDir(), '.omc', 'hud-config.json');
+  return join(getClaudeConfigDir(), ".omc", "hud-config.json");
+}
+
+function readJsonFile<T>(filePath: string): T | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function getLegacyHudConfig(): HudConfigInput | null {
+  return readJsonFile<HudConfigInput>(getConfigFilePath());
+}
+
+function mergeElements(
+  primary?: Partial<HudConfig["elements"]>,
+  secondary?: Partial<HudConfig["elements"]>,
+): Partial<HudConfig["elements"]> {
+  return {
+    ...(primary ?? {}),
+    ...(secondary ?? {}),
+  };
+}
+
+function mergeThresholds(
+  primary?: Partial<HudConfig["thresholds"]>,
+  secondary?: Partial<HudConfig["thresholds"]>,
+): Partial<HudConfig["thresholds"]> {
+  return {
+    ...(primary ?? {}),
+    ...(secondary ?? {}),
+  };
+}
+
+function mergeContextLimitWarning(
+  primary?: Partial<HudConfig["contextLimitWarning"]>,
+  secondary?: Partial<HudConfig["contextLimitWarning"]>,
+): Partial<HudConfig["contextLimitWarning"]> {
+  return {
+    ...(primary ?? {}),
+    ...(secondary ?? {}),
+  };
+}
+
+function mergeMissionBoardConfig(
+  primary?: Partial<HudConfig["missionBoard"]>,
+  secondary?: Partial<HudConfig["missionBoard"]>,
+): Partial<HudConfig["missionBoard"]> {
+  return {
+    ...(primary ?? {}),
+    ...(secondary ?? {}),
+  };
+}
+
+function mergeElementsForWrite(
+  legacyElements: HudConfigInput["elements"],
+  nextElements: HudElementConfig,
+): Partial<HudElementConfig> {
+  const merged: Partial<HudElementConfig> = { ...(legacyElements ?? {}) };
+
+  for (const [key, value] of Object.entries(nextElements) as Array<
+    [keyof HudElementConfig, HudElementConfig[keyof HudElementConfig]]
+  >) {
+    const defaultValue = DEFAULT_HUD_CONFIG.elements[key];
+    const legacyValue = legacyElements?.[key];
+    (
+      merged as Record<
+        keyof HudElementConfig,
+        HudElementConfig[keyof HudElementConfig] | undefined
+      >
+    )[key] =
+      value === defaultValue && legacyValue !== undefined ? legacyValue : value;
+  }
+
+  return merged;
 }
 
 /**
@@ -48,13 +139,21 @@ function getConfigFilePath(): string {
  */
 function ensureStateDir(directory?: string): void {
   const baseDir = validateWorkingDirectory(directory);
-  const omcStateDir = join(getOmcRoot(baseDir), 'state');
+  const omcStateDir = join(getOmcRoot(baseDir), "state");
   if (!existsSync(omcStateDir)) {
     mkdirSync(omcStateDir, { recursive: true });
   }
 }
 
-
+type HudConfigInput = Omit<
+  Partial<HudConfig>,
+  "elements" | "thresholds" | "contextLimitWarning" | "missionBoard"
+> & {
+  elements?: Partial<HudElementConfig>;
+  thresholds?: Partial<HudThresholds>;
+  contextLimitWarning?: Partial<ContextLimitWarningConfig>;
+  missionBoard?: Partial<NonNullable<HudConfig["missionBoard"]>>;
+};
 
 // ============================================================================
 // HUD State Operations
@@ -68,23 +167,29 @@ export function readHudState(directory?: string): OmcHudState | null {
   const localStateFile = getLocalStateFilePath(directory);
   if (existsSync(localStateFile)) {
     try {
-      const content = readFileSync(localStateFile, 'utf-8');
+      const content = readFileSync(localStateFile, "utf-8");
       return JSON.parse(content);
     } catch (error) {
-      console.error('[HUD] Failed to read local state:', error instanceof Error ? error.message : error);
+      console.error(
+        "[HUD] Failed to read local state:",
+        error instanceof Error ? error.message : error,
+      );
       // Fall through to legacy check
     }
   }
 
   // Check legacy local state (.omc/hud-state.json)
   const baseDir = validateWorkingDirectory(directory);
-  const legacyStateFile = join(getOmcRoot(baseDir), 'hud-state.json');
+  const legacyStateFile = join(getOmcRoot(baseDir), "hud-state.json");
   if (existsSync(legacyStateFile)) {
     try {
-      const content = readFileSync(legacyStateFile, 'utf-8');
+      const content = readFileSync(legacyStateFile, "utf-8");
       return JSON.parse(content);
     } catch (error) {
-      console.error('[HUD] Failed to read legacy state:', error instanceof Error ? error.message : error);
+      console.error(
+        "[HUD] Failed to read legacy state:",
+        error instanceof Error ? error.message : error,
+      );
       return null;
     }
   }
@@ -95,10 +200,7 @@ export function readHudState(directory?: string): OmcHudState | null {
 /**
  * Write HUD state to disk (local only)
  */
-export function writeHudState(
-  state: OmcHudState,
-  directory?: string
-): boolean {
+export function writeHudState(state: OmcHudState, directory?: string): boolean {
   try {
     // Write to local .omc/state only
     ensureStateDir(directory);
@@ -107,7 +209,10 @@ export function writeHudState(
 
     return true;
   } catch (error) {
-    console.error('[HUD] Failed to write state:', error instanceof Error ? error.message : error);
+    console.error(
+      "[HUD] Failed to write state:",
+      error instanceof Error ? error.message : error,
+    );
     return false;
   }
 }
@@ -127,7 +232,7 @@ export function createEmptyHudState(): OmcHudState {
  */
 export function getRunningTasks(state: OmcHudState | null): BackgroundTask[] {
   if (!state) return [];
-  return state.backgroundTasks.filter((task) => task.status === 'running');
+  return state.backgroundTasks.filter((task) => task.status === "running");
 }
 
 /**
@@ -139,7 +244,7 @@ export function getBackgroundTaskCount(state: OmcHudState | null): {
 } {
   const MAX_CONCURRENT = 5;
   const running = state
-    ? state.backgroundTasks.filter((t) => t.status === 'running').length
+    ? state.backgroundTasks.filter((t) => t.status === "running").length
     : 0;
   return { running, max: MAX_CONCURRENT };
 }
@@ -153,50 +258,61 @@ export function getBackgroundTaskCount(state: OmcHudState | null): {
  * Priority: settings.json > hud-config.json (legacy) > defaults
  */
 export function readHudConfig(): HudConfig {
-  // 1. Try reading from ~/.claude/settings.json (omcHud key)
   const settingsFile = getSettingsFilePath();
+  const legacyConfig = getLegacyHudConfig();
+
   if (existsSync(settingsFile)) {
     try {
-      const content = readFileSync(settingsFile, 'utf-8');
-      const settings = JSON.parse(content);
+      const content = readFileSync(settingsFile, "utf-8");
+      const settings = JSON.parse(content) as { omcHud?: HudConfigInput };
       if (settings.omcHud) {
-        const config = settings.omcHud as Partial<HudConfig>;
-        return mergeWithDefaults(config);
+        return mergeWithDefaults({
+          ...legacyConfig,
+          ...settings.omcHud,
+          elements: mergeElements(
+            legacyConfig?.elements,
+            settings.omcHud.elements,
+          ),
+          thresholds: mergeThresholds(
+            legacyConfig?.thresholds,
+            settings.omcHud.thresholds,
+          ),
+          contextLimitWarning: mergeContextLimitWarning(
+            legacyConfig?.contextLimitWarning,
+            settings.omcHud.contextLimitWarning,
+          ),
+          missionBoard: mergeMissionBoardConfig(
+            legacyConfig?.missionBoard,
+            settings.omcHud.missionBoard,
+          ),
+        });
       }
     } catch (error) {
-      console.error('[HUD] Failed to read settings.json:', error instanceof Error ? error.message : error);
-      // Fall through to legacy config
+      console.error(
+        "[HUD] Failed to read settings.json:",
+        error instanceof Error ? error.message : error,
+      );
     }
   }
 
-  // 2. Try reading from ~/.claude/.omc/hud-config.json (legacy)
-  const configFile = getConfigFilePath();
-  if (existsSync(configFile)) {
-    try {
-      const content = readFileSync(configFile, 'utf-8');
-      const config = JSON.parse(content) as Partial<HudConfig>;
-      return mergeWithDefaults(config);
-    } catch (error) {
-      console.error('[HUD] Failed to read legacy config:', error instanceof Error ? error.message : error);
-      // Fall through to defaults
-    }
+  if (legacyConfig) {
+    return mergeWithDefaults(legacyConfig);
   }
 
-  // 3. Return defaults
   return DEFAULT_HUD_CONFIG;
 }
 
 /**
  * Merge partial config with defaults
  */
-function mergeWithDefaults(config: Partial<HudConfig>): HudConfig {
+function mergeWithDefaults(config: HudConfigInput): HudConfig {
   const preset = config.preset ?? DEFAULT_HUD_CONFIG.preset;
   const presetElements = PRESET_CONFIGS[preset] ?? {};
   const missionBoardEnabled =
-    config.missionBoard?.enabled
-    ?? config.elements?.missionBoard
-    ?? DEFAULT_HUD_CONFIG.missionBoard?.enabled
-    ?? false;
+    config.missionBoard?.enabled ??
+    config.elements?.missionBoard ??
+    DEFAULT_HUD_CONFIG.missionBoard?.enabled ??
+    false;
   const missionBoard = {
     ...DEFAULT_MISSION_BOARD_CONFIG,
     ...DEFAULT_HUD_CONFIG.missionBoard,
@@ -207,24 +323,30 @@ function mergeWithDefaults(config: Partial<HudConfig>): HudConfig {
   return {
     preset,
     elements: {
-      ...DEFAULT_HUD_CONFIG.elements,  // Base defaults
-      ...presetElements,                // Preset overrides
-      ...config.elements,               // User overrides
+      ...DEFAULT_HUD_CONFIG.elements, // Base defaults
+      ...presetElements, // Preset overrides
+      ...config.elements, // User overrides
     },
     thresholds: {
       ...DEFAULT_HUD_CONFIG.thresholds,
       ...config.thresholds,
     },
-    staleTaskThresholdMinutes: config.staleTaskThresholdMinutes ?? DEFAULT_HUD_CONFIG.staleTaskThresholdMinutes,
+    staleTaskThresholdMinutes:
+      config.staleTaskThresholdMinutes ??
+      DEFAULT_HUD_CONFIG.staleTaskThresholdMinutes,
     contextLimitWarning: {
       ...DEFAULT_HUD_CONFIG.contextLimitWarning,
       ...config.contextLimitWarning,
     },
     missionBoard,
-    usageApiPollIntervalMs: config.usageApiPollIntervalMs ?? DEFAULT_HUD_CONFIG.usageApiPollIntervalMs,
-    ...(config.rateLimitsProvider ? { rateLimitsProvider: config.rateLimitsProvider } : {}),
+    usageApiPollIntervalMs:
+      config.usageApiPollIntervalMs ??
+      DEFAULT_HUD_CONFIG.usageApiPollIntervalMs,
+    wrapMode: config.wrapMode ?? DEFAULT_HUD_CONFIG.wrapMode,
+    ...(config.rateLimitsProvider
+      ? { rateLimitsProvider: config.rateLimitsProvider }
+      : {}),
     ...(config.maxWidth != null ? { maxWidth: config.maxWidth } : {}),
-    ...(config.wrapMode != null ? { wrapMode: config.wrapMode } : {}),
   };
 }
 
@@ -234,20 +356,37 @@ function mergeWithDefaults(config: Partial<HudConfig>): HudConfig {
 export function writeHudConfig(config: HudConfig): boolean {
   try {
     const settingsFile = getSettingsFilePath();
+    const legacyConfig = getLegacyHudConfig();
     let settings: Record<string, unknown> = {};
 
-    // Read existing settings
     if (existsSync(settingsFile)) {
-      const content = readFileSync(settingsFile, 'utf-8');
-      settings = JSON.parse(content);
+      const content = readFileSync(settingsFile, "utf-8");
+      settings = JSON.parse(content) as Record<string, unknown>;
     }
 
-    // Update omcHud key
-    settings.omcHud = config;
-    writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
+    const mergedConfig = mergeWithDefaults({
+      ...legacyConfig,
+      ...config,
+      elements: mergeElementsForWrite(legacyConfig?.elements, config.elements),
+      thresholds: mergeThresholds(legacyConfig?.thresholds, config.thresholds),
+      contextLimitWarning: mergeContextLimitWarning(
+        legacyConfig?.contextLimitWarning,
+        config.contextLimitWarning,
+      ),
+      missionBoard: mergeMissionBoardConfig(
+        legacyConfig?.missionBoard,
+        config.missionBoard,
+      ),
+    });
+
+    settings.omcHud = mergedConfig;
+    atomicWriteFileSync(settingsFile, JSON.stringify(settings, null, 2));
     return true;
   } catch (error) {
-    console.error('[HUD] Failed to write config:', error instanceof Error ? error.message : error);
+    console.error(
+      "[HUD] Failed to write config:",
+      error instanceof Error ? error.message : error,
+    );
     return false;
   }
 }
@@ -255,7 +394,7 @@ export function writeHudConfig(config: HudConfig): boolean {
 /**
  * Apply a preset to the configuration
  */
-export function applyPreset(preset: HudConfig['preset']): HudConfig {
+export function applyPreset(preset: HudConfig["preset"]): HudConfig {
   const config = readHudConfig();
   const presetElements = PRESET_CONFIGS[preset];
 
@@ -282,6 +421,8 @@ export async function initializeHUDState(): Promise<void> {
   const markedOrphaned = await markOrphanedTasksAsStale();
 
   if (removedStale > 0 || markedOrphaned > 0) {
-    console.error(`HUD cleanup: removed ${removedStale} stale tasks, marked ${markedOrphaned} orphaned tasks`);
+    console.error(
+      `HUD cleanup: removed ${removedStale} stale tasks, marked ${markedOrphaned} orphaned tasks`,
+    );
   }
 }

--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -88,11 +88,15 @@ export async function readStdin(): Promise<StatuslineStdin | null> {
   }
 }
 
+function getCurrentUsage(stdin: StatuslineStdin) {
+  return stdin.context_window?.current_usage;
+}
+
 /**
  * Get total tokens from stdin context_window.current_usage
  */
 function getTotalTokens(stdin: StatuslineStdin): number {
-  const usage = stdin.context_window?.current_usage;
+  const usage = getCurrentUsage(stdin);
   return (
     (usage?.input_tokens ?? 0) +
     (usage?.cache_creation_input_tokens ?? 0) +
@@ -158,14 +162,14 @@ export function stabilizeContextPercent(
     ...stdin,
     context_window: {
       ...stdin.context_window,
-      used_percentage: previousStdin.context_window.used_percentage ?? previousNativePercent,
+      used_percentage: previousStdin.context_window?.used_percentage ?? previousNativePercent,
     },
   };
 }
 
 /**
  * Get context window usage percentage.
- * Prefers native percentage from Claude Code v2.1.6+, falls back to manual calculation.
+ * Prefers native percentage from Claude Code statusline stdin, falls back to manual calculation.
  */
 export function getContextPercent(stdin: StatuslineStdin): number {
   const nativePercent = getRoundedNativeContextPercent(stdin);
@@ -178,7 +182,8 @@ export function getContextPercent(stdin: StatuslineStdin): number {
 
 /**
  * Get model display name from stdin.
+ * Prefer the official display name field, then fall back to the raw model id.
  */
 export function getModelName(stdin: StatuslineStdin): string {
-  return stdin.model?.id ?? stdin.model?.display_name ?? 'Unknown';
+  return stdin.model?.display_name ?? stdin.model?.id ?? 'Unknown';
 }

--- a/src/hud/transcript.ts
+++ b/src/hud/transcript.ts
@@ -69,6 +69,14 @@ const THINKING_PART_TYPES = ["thinking", "reasoning"] as const;
  */
 const THINKING_RECENCY_MS = 30_000; // 30 seconds
 
+interface CachedTranscriptParse {
+  cacheKey: string;
+  baseResult: TranscriptData;
+  pendingPermissions: PendingPermission[];
+}
+
+const transcriptCache = new Map<string, CachedTranscriptParse>();
+
 /**
  * Parse a Claude Code transcript JSONL file.
  * Extracts running agents and latest todo list.
@@ -83,8 +91,6 @@ export async function parseTranscript(
   transcriptPath: string | undefined,
   options?: ParseTranscriptOptions,
 ): Promise<TranscriptData> {
-  // IMPORTANT: Clear module-level state at the start of each parse
-  // to prevent stale data from previous HUD invocations
   pendingPermissionMap.clear();
 
   const result: TranscriptData = {
@@ -100,6 +106,19 @@ export async function parseTranscript(
     return result;
   }
 
+  let cacheKey: string | null = null;
+
+  try {
+    const stat = statSync(transcriptPath);
+    cacheKey = `${transcriptPath}:${stat.size}:${stat.mtimeMs}`;
+    const cached = transcriptCache.get(transcriptPath);
+    if (cached?.cacheKey === cacheKey) {
+      return finalizeTranscriptResult(cloneTranscriptData(cached.baseResult), options, cached.pendingPermissions);
+    }
+  } catch {
+    return result;
+  }
+
   const agentMap = new Map<string, ActiveAgent>();
   const backgroundAgentMap: BackgroundAgentMap = new Map();
   const latestTodos: TodoItem[] = [];
@@ -112,12 +131,10 @@ export async function parseTranscript(
   const observedSessionIds = new Set<string>();
 
   try {
-    // Check file size to determine parsing strategy
     const stat = statSync(transcriptPath);
     const fileSize = stat.size;
 
     if (fileSize > MAX_TAIL_BYTES) {
-      // Large file: use tail-based parsing
       const lines = readTailLines(transcriptPath, fileSize, MAX_TAIL_BYTES);
       for (const line of lines) {
         if (!line.trim()) continue;
@@ -138,7 +155,6 @@ export async function parseTranscript(
         }
       }
     } else {
-      // Small file: stream entire file
       const fileStream = createReadStream(transcriptPath);
       const rl = createInterface({
         input: fileStream,
@@ -168,43 +184,9 @@ export async function parseTranscript(
       sessionTotalsReliable = observedSessionIds.size <= 1;
     }
   } catch {
-    // Return partial results on error
+    return finalizeTranscriptResult(result, options, []);
   }
 
-  // Filter out stale agents (running for more than threshold minutes are likely abandoned)
-  const staleMinutes = options?.staleTaskThresholdMinutes ?? 30;
-  const STALE_AGENT_THRESHOLD_MS = staleMinutes * 60 * 1000;
-  const now = Date.now();
-
-  for (const agent of agentMap.values()) {
-    if (agent.status === "running") {
-      const runningTime = now - agent.startTime.getTime();
-      if (runningTime > STALE_AGENT_THRESHOLD_MS) {
-        // Mark as completed (stale)
-        agent.status = "completed";
-        agent.endTime = new Date(
-          agent.startTime.getTime() + STALE_AGENT_THRESHOLD_MS,
-        );
-      }
-    }
-  }
-
-  // Check for pending permissions within threshold
-  for (const [_id, permission] of pendingPermissionMap) {
-    const age = now - permission.timestamp.getTime();
-    if (age <= PERMISSION_THRESHOLD_MS) {
-      result.pendingPermission = permission;
-      break; // Only show most recent
-    }
-  }
-
-  // Determine if thinking is currently active based on recency
-  if (result.thinkingState?.lastSeen) {
-    const age = now - result.thinkingState.lastSeen.getTime();
-    result.thinkingState.active = age <= THINKING_RECENCY_MS;
-  }
-
-  // Get running agents first, then recent completed (up to 10 total)
   const running = Array.from(agentMap.values()).filter(
     (a) => a.status === "running",
   );
@@ -220,13 +202,101 @@ export async function parseTranscript(
     result.sessionTotalTokens = sessionTokenTotals.inputTokens + sessionTokenTotals.outputTokens;
   }
 
-  return result;
+  const pendingPermissions = Array.from(pendingPermissionMap.values()).map(clonePendingPermission);
+  const finalized = finalizeTranscriptResult(result, options, pendingPermissions);
+  if (cacheKey) {
+    transcriptCache.set(transcriptPath, {
+      cacheKey,
+      baseResult: cloneTranscriptData(finalized),
+      pendingPermissions,
+    });
+  }
+
+  return finalized;
 }
 
 /**
  * Read the tail portion of a file and split into lines.
  * Handles partial first line (from mid-file start).
  */
+function cloneDate(value: Date | undefined): Date | undefined {
+  return value ? new Date(value.getTime()) : undefined;
+}
+
+function clonePendingPermission(permission: PendingPermission): PendingPermission {
+  return {
+    ...permission,
+    timestamp: new Date(permission.timestamp.getTime()),
+  };
+}
+
+function cloneTranscriptData(result: TranscriptData): TranscriptData {
+  return {
+    ...result,
+    agents: result.agents.map((agent) => ({
+      ...agent,
+      startTime: new Date(agent.startTime.getTime()),
+      endTime: cloneDate(agent.endTime),
+    })),
+    todos: result.todos.map((todo) => ({ ...todo })),
+    sessionStart: cloneDate(result.sessionStart),
+    lastActivatedSkill: result.lastActivatedSkill
+      ? {
+          ...result.lastActivatedSkill,
+          timestamp: new Date(result.lastActivatedSkill.timestamp.getTime()),
+        }
+      : undefined,
+    pendingPermission: result.pendingPermission
+      ? clonePendingPermission(result.pendingPermission)
+      : undefined,
+    thinkingState: result.thinkingState
+      ? {
+          ...result.thinkingState,
+          lastSeen: cloneDate(result.thinkingState.lastSeen),
+        }
+      : undefined,
+    lastRequestTokenUsage: result.lastRequestTokenUsage
+      ? { ...result.lastRequestTokenUsage }
+      : undefined,
+  };
+}
+
+function finalizeTranscriptResult(
+  result: TranscriptData,
+  options: ParseTranscriptOptions | undefined,
+  pendingPermissions: PendingPermission[],
+): TranscriptData {
+  const staleMinutes = options?.staleTaskThresholdMinutes ?? 30;
+  const staleAgentThresholdMs = staleMinutes * 60 * 1000;
+  const now = Date.now();
+
+  for (const agent of result.agents) {
+    if (agent.status === "running") {
+      const runningTime = now - agent.startTime.getTime();
+      if (runningTime > staleAgentThresholdMs) {
+        agent.status = "completed";
+        agent.endTime = new Date(agent.startTime.getTime() + staleAgentThresholdMs);
+      }
+    }
+  }
+
+  result.pendingPermission = undefined;
+  for (const permission of pendingPermissions) {
+    const age = now - permission.timestamp.getTime();
+    if (age <= PERMISSION_THRESHOLD_MS) {
+      result.pendingPermission = clonePendingPermission(permission);
+      break;
+    }
+  }
+
+  if (result.thinkingState?.lastSeen) {
+    const age = now - result.thinkingState.lastSeen.getTime();
+    result.thinkingState.active = age <= THINKING_RECENCY_MS;
+  }
+
+  return result;
+}
+
 function readTailLines(
   filePath: string,
   fileSize: number,

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -45,25 +45,25 @@ export interface OmcHudState {
 
 export interface StatuslineStdin {
   /** Transcript path for parsing conversation history */
-  transcript_path: string;
+  transcript_path?: string;
 
   /** Current working directory */
-  cwd: string;
+  cwd?: string;
 
-  /** Model information */
-  model: {
-    id: string;
-    display_name: string;
+  /** Model information from Claude Code statusline stdin */
+  model?: {
+    id?: string;
+    display_name?: string;
   };
 
-  /** Context window metrics */
-  context_window: {
-    context_window_size: number;
+  /** Context window metrics from Claude Code statusline stdin */
+  context_window?: {
+    context_window_size?: number;
     used_percentage?: number;
     current_usage?: {
-      input_tokens: number;
-      cache_creation_input_tokens: number;
-      cache_read_input_tokens: number;
+      input_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
     };
   };
 }
@@ -519,6 +519,8 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     missionBoard: false,  // Opt-in mission board for whole-run progress tracking
     promptTime: true,  // Show last prompt time by default
     sessionHealth: true,
+    showSessionDuration: true,
+    showHealthIndicator: true,
     showTokens: false,
     useBars: false,  // Disabled by default for backwards compatibility
     showCallCounts: true,  // Show tool/agent/skill call counts by default (Issue #710)
@@ -572,6 +574,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: false,
     sessionHealth: false,
+    showSessionDuration: true,
+    showHealthIndicator: true,
     showTokens: false,
     useBars: false,
     showCallCounts: false,
@@ -608,6 +612,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: true,
     sessionHealth: true,
+    showSessionDuration: true,
+    showHealthIndicator: true,
     showTokens: false,
     useBars: true,
     showCallCounts: true,
@@ -644,6 +650,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: true,
     sessionHealth: true,
+    showSessionDuration: true,
+    showHealthIndicator: true,
     showTokens: false,
     useBars: true,
     showCallCounts: true,
@@ -680,6 +688,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: true,
     sessionHealth: true,
+    showSessionDuration: true,
+    showHealthIndicator: true,
     showTokens: false,
     useBars: false,
     showCallCounts: true,
@@ -716,6 +726,8 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     missionBoard: false,
     promptTime: true,
     sessionHealth: true,
+    showSessionDuration: true,
+    showHealthIndicator: true,
     showTokens: false,
     useBars: true,
     showCallCounts: true,


### PR DESCRIPTION
## Summary
- harden HUD transcript parsing while keeping the incremental tail-based parser and adding safe cached finalized results
- preserve and migrate HUD config/settings data without clobbering unrelated or legacy values during setup writes
- normalize HUD defaults earlier and prefer official stdin model display-name fields when available

## Verification
- npx tsc --noEmit
- npx vitest run src/__tests__/hud/state.test.ts src/__tests__/hud/stdin.test.ts src/__tests__/hud/token-usage.test.ts src/__tests__/hud/render.test.ts src/__tests__/hud/defaults.test.ts src/__tests__/hud/windows-platform.test.ts
- npm test (currently fails in unrelated existing test: src/team/__tests__/api-interop.dispatch.test.ts expecting pending but receiving notified)

Closes #1835