### PR TITLE
Improve project-memory injection with progressive disclosure

### DIFF
--- a/src/hooks/project-memory/__tests__/formatter.test.ts
+++ b/src/hooks/project-memory/__tests__/formatter.test.ts
@@ -2,20 +2,45 @@
  * Tests for Project Memory Formatter
  */
 
-import { describe, it, expect } from 'vitest';
-import { formatContextSummary, formatFullContext } from '../formatter.js';
-import { ProjectMemory } from '../types.js';
-import { SCHEMA_VERSION } from '../constants.js';
+import { describe, it, expect } from "vitest";
+import { formatContextSummary, formatFullContext } from "../formatter.js";
+import { ProjectMemory } from "../types.js";
+import { SCHEMA_VERSION } from "../constants.js";
+
+const NOW = Date.parse("2026-03-24T15:00:00Z");
 
 // Helper to create base memory with all required fields
-const createBaseMemory = (overrides: Partial<ProjectMemory> = {}): ProjectMemory => ({
+const createBaseMemory = (
+  overrides: Partial<ProjectMemory> = {},
+): ProjectMemory => ({
   version: SCHEMA_VERSION,
-  lastScanned: Date.now(),
-  projectRoot: '/test',
-  techStack: { languages: [], frameworks: [], packageManager: null, runtime: null },
-  build: { buildCommand: null, testCommand: null, lintCommand: null, devCommand: null, scripts: {} },
-  conventions: { namingStyle: null, importStyle: null, testPattern: null, fileOrganization: null },
-  structure: { isMonorepo: false, workspaces: [], mainDirectories: [], gitBranches: null },
+  lastScanned: NOW,
+  projectRoot: "/test",
+  techStack: {
+    languages: [],
+    frameworks: [],
+    packageManager: null,
+    runtime: null,
+  },
+  build: {
+    buildCommand: null,
+    testCommand: null,
+    lintCommand: null,
+    devCommand: null,
+    scripts: {},
+  },
+  conventions: {
+    namingStyle: null,
+    importStyle: null,
+    testPattern: null,
+    fileOrganization: null,
+  },
+  structure: {
+    isMonorepo: false,
+    workspaces: [],
+    mainDirectories: [],
+    gitBranches: null,
+  },
   customNotes: [],
   directoryMap: {},
   hotPaths: [],
@@ -23,303 +48,305 @@ const createBaseMemory = (overrides: Partial<ProjectMemory> = {}): ProjectMemory
   ...overrides,
 });
 
-describe('Project Memory Formatter', () => {
-  describe('formatContextSummary', () => {
-    it('should format TypeScript/React project summary', () => {
+describe("Project Memory Formatter", () => {
+  describe("formatContextSummary", () => {
+    it("formats the summary in progressive disclosure order", () => {
       const memory = createBaseMemory({
         techStack: {
           languages: [
-            { name: 'TypeScript', version: '5.0.0', confidence: 'high', markers: ['tsconfig.json'] },
+            {
+              name: "TypeScript",
+              version: "5.0.0",
+              confidence: "high",
+              markers: ["tsconfig.json"],
+            },
           ],
           frameworks: [
-            { name: 'react', version: '18.2.0', category: 'frontend' },
-            { name: 'vite', version: '5.0.0', category: 'build' },
+            { name: "next", version: "14.0.0", category: "fullstack" },
           ],
-          packageManager: 'pnpm',
-          runtime: 'Node.js 20.0.0',
+          packageManager: "pnpm",
+          runtime: "Node.js 20.0.0",
         },
         build: {
-          buildCommand: 'pnpm build',
-          testCommand: 'pnpm test',
-          lintCommand: null,
+          buildCommand: "pnpm build",
+          testCommand: "pnpm test",
+          lintCommand: "pnpm lint",
           devCommand: null,
           scripts: {},
         },
-        conventions: {
-          namingStyle: null,
-          importStyle: null,
-          testPattern: null,
-          fileOrganization: null,
-        },
-        structure: {
-          isMonorepo: false,
-          workspaces: [],
-          mainDirectories: [],
-          gitBranches: null,
-        },
-        customNotes: [],
-      });
-
-      const summary = formatContextSummary(memory);
-
-      expect(summary).toContain('TypeScript');
-      expect(summary).toContain('react');
-      expect(summary).toContain('pnpm');
-      expect(summary).toContain('Build: pnpm build');
-      expect(summary).toContain('Test: pnpm test');
-      expect(summary.length).toBeLessThan(300);
-    });
-
-    it('should prioritize fullstack frameworks over frontend', () => {
-      const memory = createBaseMemory({
-        techStack: {
-          languages: [{ name: 'TypeScript', version: null, confidence: 'high', markers: ['tsconfig.json'] }],
-          frameworks: [
-            { name: 'react', version: '18.2.0', category: 'frontend' },
-            { name: 'next', version: '14.0.0', category: 'fullstack' },
-          ],
-          packageManager: 'npm',
-          runtime: null,
-        },
-        build: {
-          buildCommand: 'npm run build',
-          testCommand: null,
-          lintCommand: null,
-          devCommand: null,
-          scripts: {},
-        },
-        conventions: {
-          namingStyle: null,
-          importStyle: null,
-          testPattern: null,
-          fileOrganization: null,
-        },
-        structure: {
-          isMonorepo: false,
-          workspaces: [],
-          mainDirectories: [],
-          gitBranches: null,
-        },
-        customNotes: [],
-      });
-
-      const summary = formatContextSummary(memory);
-
-      expect(summary).toContain('next');
-      expect(summary).not.toContain('react');
-    });
-
-    it('should handle minimal project with no frameworks', () => {
-      const memory = createBaseMemory({
-        techStack: {
-          languages: [{ name: 'Rust', version: null, confidence: 'high', markers: ['Cargo.toml'] }],
-          frameworks: [],
-          packageManager: 'cargo',
-          runtime: null,
-        },
-        build: {
-          buildCommand: 'cargo build',
-          testCommand: 'cargo test',
-          lintCommand: null,
-          devCommand: null,
-          scripts: {},
-        },
-        conventions: {
-          namingStyle: null,
-          importStyle: null,
-          testPattern: null,
-          fileOrganization: null,
-        },
-        structure: {
-          isMonorepo: false,
-          workspaces: [],
-          mainDirectories: [],
-          gitBranches: null,
-        },
-        customNotes: [],
-      });
-
-      const summary = formatContextSummary(memory);
-
-      expect(summary).toContain('Rust');
-      expect(summary).toContain('cargo');
-      expect(summary).toContain('Build: cargo build');
-    });
-
-    it('should truncate long summaries', () => {
-      const memory = createBaseMemory({
-        techStack: {
-          languages: [{ name: 'TypeScript', version: '5.0.0', confidence: 'high', markers: ['tsconfig.json'] }],
-          frameworks: [
-            { name: 'react', version: '18.2.0', category: 'frontend' },
-            { name: 'vite', version: '5.0.0', category: 'build' },
-            { name: 'vitest', version: '1.0.0', category: 'testing' },
-          ],
-          packageManager: 'pnpm',
-          runtime: 'Node.js 20.0.0',
-        },
-        build: {
-          buildCommand: 'pnpm build --mode production --minify',
-          testCommand: 'pnpm test --coverage --verbose',
-          lintCommand: 'pnpm lint --fix',
-          devCommand: 'pnpm dev --host 0.0.0.0',
-          scripts: {},
-        },
-        conventions: {
-          namingStyle: null,
-          importStyle: null,
-          testPattern: null,
-          fileOrganization: null,
-        },
-        structure: {
-          isMonorepo: false,
-          workspaces: [],
-          mainDirectories: [],
-          gitBranches: null,
-        },
-        customNotes: [],
-      });
-
-      const summary = formatContextSummary(memory);
-
-      expect(summary.length).toBeLessThan(300);
-      expect(summary).toContain('[Project Environment]');
-    });
-
-    it('should include customNotes in context summary', () => {
-      const memory = createBaseMemory({
-        techStack: {
-          languages: [{ name: 'TypeScript', version: null, confidence: 'high', markers: ['tsconfig.json'] }],
-          frameworks: [],
-          packageManager: null,
-          runtime: null,
-        },
+        hotPaths: [
+          {
+            path: "src/hooks/project-memory/index.ts",
+            accessCount: 5,
+            lastAccessed: NOW,
+            type: "file",
+          },
+        ],
+        userDirectives: [
+          {
+            timestamp: NOW,
+            directive: "Keep changes in src/hooks/project-memory",
+            context: "",
+            source: "explicit",
+            priority: "high",
+          },
+        ],
         customNotes: [
-          { timestamp: Date.now(), source: 'learned', category: 'env', content: 'Requires NODE_ENV=production' },
-          { timestamp: Date.now(), source: 'manual', category: 'deploy', content: 'Uses Docker for deployment' },
+          {
+            timestamp: NOW,
+            source: "learned",
+            category: "runtime",
+            content: "Node.js v20.10.0",
+          },
         ],
       });
 
-      const summary = formatContextSummary(memory);
+      const summary = formatContextSummary(memory, {
+        workingDirectory: "src/hooks/project-memory",
+        now: NOW,
+      });
 
-      expect(summary).toContain('**Notes:**');
-      expect(summary).toContain('[env] Requires NODE_ENV=production');
-      expect(summary).toContain('[deploy] Uses Docker for deployment');
+      expect(summary.indexOf("[Project Environment]")).toBeLessThan(
+        summary.indexOf("[Hot Paths]"),
+      );
+      expect(summary.indexOf("[Hot Paths]")).toBeLessThan(
+        summary.indexOf("[Directives]"),
+      );
+      expect(summary.indexOf("[Directives]")).toBeLessThan(
+        summary.indexOf("[Recent Learnings]"),
+      );
     });
 
-    it('should limit customNotes to 5 in context summary', () => {
-      const notes = Array.from({ length: 8 }, (_, i) => ({
-        timestamp: Date.now(),
-        source: 'learned' as const,
-        category: 'test',
-        content: `Note ${i + 1}`,
-      }));
+    it("keeps the summary bounded", () => {
+      const memory = createBaseMemory({
+        techStack: {
+          languages: [
+            {
+              name: "TypeScript",
+              version: "5.0.0",
+              confidence: "high",
+              markers: ["tsconfig.json"],
+            },
+          ],
+          frameworks: [
+            { name: "next", version: "14.0.0", category: "fullstack" },
+            { name: "vitest", version: "2.0.0", category: "testing" },
+          ],
+          packageManager: "pnpm",
+          runtime: "Node.js 20.0.0",
+        },
+        build: {
+          buildCommand:
+            "pnpm build --mode production --minify --long-flag really-long-value",
+          testCommand: "pnpm test --runInBand --coverage --reporter verbose",
+          lintCommand: "pnpm lint --max-warnings=0 --fix",
+          devCommand: "pnpm dev",
+          scripts: {},
+        },
+        hotPaths: Array.from({ length: 6 }, (_, index) => ({
+          path: `src/feature-${index}/very/deep/file-${index}.ts`,
+          accessCount: 10 - index,
+          lastAccessed: NOW - index * 1000,
+          type: "file" as const,
+        })),
+        userDirectives: Array.from({ length: 5 }, (_, index) => ({
+          timestamp: NOW - index,
+          directive: `Critical directive ${index} with verbose explanation`,
+          context: "",
+          source: "explicit" as const,
+          priority: index === 0 ? ("high" as const) : ("normal" as const),
+        })),
+        customNotes: Array.from({ length: 5 }, (_, index) => ({
+          timestamp: NOW - index * 1000,
+          source: "learned" as const,
+          category: "env",
+          content: `Learning ${index} with lots of additional detail to stress output truncation`,
+        })),
+      });
 
-      const memory = createBaseMemory({ customNotes: notes });
-      const summary = formatContextSummary(memory);
+      const summary = formatContextSummary(memory, { now: NOW });
 
-      expect(summary).toContain('Note 5');
-      expect(summary).not.toContain('Note 6');
+      expect(summary.length).toBeLessThanOrEqual(650);
+      expect(summary).toContain("[Project Environment]");
     });
 
-    it('should not include Notes section when customNotes is empty', () => {
-      const memory = createBaseMemory({ customNotes: [] });
-      const summary = formatContextSummary(memory);
+    it("prefers hot paths near the current working directory", () => {
+      const memory = createBaseMemory({
+        hotPaths: [
+          {
+            path: "docs/guide.md",
+            accessCount: 20,
+            lastAccessed: NOW - 60_000,
+            type: "file",
+          },
+          {
+            path: "src/hooks/project-memory/formatter.ts",
+            accessCount: 5,
+            lastAccessed: NOW - 60_000,
+            type: "file",
+          },
+          {
+            path: "src/hooks/project-memory/index.ts",
+            accessCount: 4,
+            lastAccessed: NOW - 60_000,
+            type: "file",
+          },
+        ],
+      });
 
-      expect(summary).not.toContain('**Notes:**');
+      const summary = formatContextSummary(memory, {
+        workingDirectory: "src/hooks/project-memory",
+        now: NOW,
+      });
+
+      const hotPathsSection = summary.split("[Hot Paths]")[1] ?? "";
+      expect(
+        hotPathsSection.indexOf("src/hooks/project-memory/formatter.ts"),
+      ).toBeLessThan(hotPathsSection.indexOf("docs/guide.md"));
+    });
+
+    it("prioritizes high priority directives and recent learnings", () => {
+      const memory = createBaseMemory({
+        userDirectives: [
+          {
+            timestamp: NOW - 10_000,
+            directive: "use concise output",
+            context: "",
+            source: "explicit",
+            priority: "normal",
+          },
+          {
+            timestamp: NOW - 20_000,
+            directive: "stay inside src/hooks/project-memory",
+            context: "",
+            source: "explicit",
+            priority: "high",
+          },
+        ],
+        customNotes: [
+          {
+            timestamp: NOW - 50_000,
+            source: "learned",
+            category: "test",
+            content: "Old test note",
+          },
+          {
+            timestamp: NOW - 1_000,
+            source: "learned",
+            category: "env",
+            content: "Fresh env note",
+          },
+        ],
+      });
+
+      const summary = formatContextSummary(memory, { now: NOW });
+      const directivesSection =
+        summary.split("[Directives]")[1]?.split("[Recent Learnings]")[0] ?? "";
+      const learningsSection = summary.split("[Recent Learnings]")[1] ?? "";
+
+      expect(
+        directivesSection.indexOf("stay inside src/hooks/project-memory"),
+      ).toBeLessThan(directivesSection.indexOf("use concise output"));
+      expect(learningsSection.indexOf("Fresh env note")).toBeLessThan(
+        learningsSection.indexOf("Old test note"),
+      );
+    });
+
+    it("skips empty tiers without leaving extra headings", () => {
+      const memory = createBaseMemory({
+        techStack: {
+          languages: [
+            {
+              name: "Rust",
+              version: null,
+              confidence: "high",
+              markers: ["Cargo.toml"],
+            },
+          ],
+          frameworks: [],
+          packageManager: "cargo",
+          runtime: null,
+        },
+        build: {
+          buildCommand: "cargo build",
+          testCommand: "cargo test",
+          lintCommand: null,
+          devCommand: null,
+          scripts: {},
+        },
+      });
+
+      const summary = formatContextSummary(memory, { now: NOW });
+
+      expect(summary).toContain("[Project Environment]");
+      expect(summary).not.toContain("[Hot Paths]");
+      expect(summary).not.toContain("[Directives]");
+      expect(summary).not.toContain("[Recent Learnings]");
     });
   });
 
-  describe('formatFullContext', () => {
-    it('should format complete project details', () => {
+  describe("formatFullContext", () => {
+    it("should format complete project details", () => {
       const memory = createBaseMemory({
         techStack: {
           languages: [
-            { name: 'TypeScript', version: '5.0.0', confidence: 'high', markers: ['tsconfig.json'] },
+            {
+              name: "TypeScript",
+              version: "5.0.0",
+              confidence: "high",
+              markers: ["tsconfig.json"],
+            },
           ],
           frameworks: [
-            { name: 'react', version: '18.2.0', category: 'frontend' },
+            { name: "react", version: "18.2.0", category: "frontend" },
           ],
-          packageManager: 'pnpm',
-          runtime: 'Node.js 20.0.0',
+          packageManager: "pnpm",
+          runtime: "Node.js 20.0.0",
         },
         build: {
-          buildCommand: 'pnpm build',
-          testCommand: 'pnpm test',
-          lintCommand: 'pnpm lint',
-          devCommand: 'pnpm dev',
+          buildCommand: "pnpm build",
+          testCommand: "pnpm test",
+          lintCommand: "pnpm lint",
+          devCommand: "pnpm dev",
           scripts: {},
         },
         conventions: {
-          namingStyle: 'camelCase',
-          importStyle: 'ES modules',
-          testPattern: '*.test.ts',
-          fileOrganization: 'feature-based',
+          namingStyle: "camelCase",
+          importStyle: "ES modules",
+          testPattern: "*.test.ts",
+          fileOrganization: "feature-based",
         },
         structure: {
           isMonorepo: true,
-          workspaces: ['packages/*'],
-          mainDirectories: ['src', 'tests'],
-          gitBranches: { defaultBranch: 'main', branchingStrategy: null },
+          workspaces: ["packages/*"],
+          mainDirectories: ["src", "tests"],
+          gitBranches: { defaultBranch: "main", branchingStrategy: null },
         },
         customNotes: [
-          { timestamp: Date.now(), source: 'learned', category: 'env', content: 'Requires NODE_ENV' },
+          {
+            timestamp: NOW,
+            source: "learned",
+            category: "env",
+            content: "Requires NODE_ENV",
+          },
         ],
       });
 
       const full = formatFullContext(memory);
 
-      expect(full).toContain('<project-memory>');
-      expect(full).toContain('## Project Environment');
-      expect(full).toContain('**Languages:**');
-      expect(full).toContain('TypeScript (5.0.0)');
-      expect(full).toContain('**Frameworks:**');
-      expect(full).toContain('react (18.2.0) [frontend]');
-      expect(full).toContain('**Commands:**');
-      expect(full).toContain('Build: `pnpm build`');
-      expect(full).toContain('**Code Style:** camelCase');
-      expect(full).toContain('**Structure:** Monorepo');
-      expect(full).toContain('**Custom Notes:**');
-      expect(full).toContain('[env] Requires NODE_ENV');
-      expect(full).toContain('</project-memory>');
-    });
-
-    it('should handle empty sections gracefully', () => {
-      const memory = createBaseMemory({
-        techStack: {
-          languages: [],
-          frameworks: [],
-          packageManager: null,
-          runtime: null,
-        },
-        build: {
-          buildCommand: null,
-          testCommand: null,
-          lintCommand: null,
-          devCommand: null,
-          scripts: {},
-        },
-        conventions: {
-          namingStyle: null,
-          importStyle: null,
-          testPattern: null,
-          fileOrganization: null,
-        },
-        structure: {
-          isMonorepo: false,
-          workspaces: [],
-          mainDirectories: [],
-          gitBranches: null,
-        },
-        customNotes: [],
-      });
-
-      const full = formatFullContext(memory);
-
-      expect(full).toContain('<project-memory>');
-      expect(full).not.toContain('**Languages:**');
-      expect(full).not.toContain('**Frameworks:**');
-      expect(full).not.toContain('**Commands:**');
+      expect(full).toContain("<project-memory>");
+      expect(full).toContain("## Project Environment");
+      expect(full).toContain("**Languages:**");
+      expect(full).toContain("TypeScript (5.0.0)");
+      expect(full).toContain("**Frameworks:**");
+      expect(full).toContain("react (18.2.0) [frontend]");
+      expect(full).toContain("**Commands:**");
+      expect(full).toContain("Build: `pnpm build`");
+      expect(full).toContain("**Code Style:** camelCase");
+      expect(full).toContain("**Structure:** Monorepo");
+      expect(full).toContain("**Custom Notes:**");
+      expect(full).toContain("[env] Requires NODE_ENV");
+      expect(full).toContain("</project-memory>");
     });
   });
 });

--- a/src/hooks/project-memory/__tests__/integration.test.ts
+++ b/src/hooks/project-memory/__tests__/integration.test.ts
@@ -2,264 +2,369 @@
  * Integration Tests for Project Memory Hook
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import fs from 'fs/promises';
-import path from 'path';
-import os from 'os';
-import { registerProjectMemoryContext, clearProjectMemorySession } from '../index.js';
-import { loadProjectMemory, getMemoryPath } from '../storage.js';
-import { learnFromToolOutput } from '../learner.js';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { contextCollector } from "../../../features/context-injector/collector.js";
+import {
+  registerProjectMemoryContext,
+  clearProjectMemorySession,
+} from "../index.js";
+import { loadProjectMemory, getMemoryPath } from "../storage.js";
+import { learnFromToolOutput } from "../learner.js";
 
-describe('Project Memory Integration', () => {
+describe("Project Memory Integration", () => {
   let tempDir: string;
 
   beforeEach(async () => {
     delete process.env.OMC_STATE_DIR;
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'integration-test-'));
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "integration-test-"));
   });
 
   afterEach(async () => {
     delete process.env.OMC_STATE_DIR;
+    contextCollector.clear("test-session-1");
+    contextCollector.clear("test-session-2");
+    contextCollector.clear("test-session-3a");
+    contextCollector.clear("test-session-3b");
+    contextCollector.clear("test-session-4");
+    contextCollector.clear("test-session-5");
+    contextCollector.clear("test-session-6");
+    contextCollector.clear("test-session-7");
+    contextCollector.clear("test-session-8");
+    contextCollector.clear("test-session-scope");
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
-  describe('End-to-end SessionStart flow', () => {
-    it('should detect, persist, and inject context on first session', async () => {
-      // Create a TypeScript project
+  describe("End-to-end SessionStart flow", () => {
+    it("should detect, persist, and inject context on first session", async () => {
       const packageJson = {
-        name: 'test-app',
+        name: "test-app",
         scripts: {
-          build: 'tsc',
-          test: 'vitest',
+          build: "tsc",
+          test: "vitest",
         },
         dependencies: {
-          react: '^18.2.0',
+          react: "^18.2.0",
         },
         devDependencies: {
-          typescript: '^5.0.0',
+          typescript: "^5.0.0",
         },
       };
 
-      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson, null, 2));
-      await fs.writeFile(path.join(tempDir, 'tsconfig.json'), '{}');
-      await fs.writeFile(path.join(tempDir, 'pnpm-lock.yaml'), '');
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson, null, 2),
+      );
+      await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
+      await fs.writeFile(path.join(tempDir, "pnpm-lock.yaml"), "");
 
-      // Simulate SessionStart hook
-      const sessionId = 'test-session-1';
+      const sessionId = "test-session-1";
       const registered = await registerProjectMemoryContext(sessionId, tempDir);
 
       expect(registered).toBe(true);
 
-      // Verify memory file was created
       const memory = await loadProjectMemory(tempDir);
       expect(memory).not.toBeNull();
-      expect(memory?.techStack.packageManager).toBe('pnpm');
-      expect(memory?.build.buildCommand).toBe('pnpm build');
+      expect(memory?.techStack.packageManager).toBe("pnpm");
+      expect(memory?.build.buildCommand).toBe("pnpm build");
 
-      // Verify .omc directory structure
-      const omcDir = path.join(tempDir, '.omc');
+      const omcDir = path.join(tempDir, ".omc");
       const omcStat = await fs.stat(omcDir);
       expect(omcStat.isDirectory()).toBe(true);
+
+      const pending = contextCollector.getPending(sessionId);
+      expect(pending.merged).toContain("[Project Environment]");
     });
 
-    it('should persist to centralized state dir without creating local .omc when OMC_STATE_DIR is set', async () => {
-      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'integration-state-'));
+    it("should persist to centralized state dir without creating local .omc when OMC_STATE_DIR is set", async () => {
+      const stateDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "integration-state-"),
+      );
       try {
         process.env.OMC_STATE_DIR = stateDir;
 
         const packageJson = {
-          name: 'test-app',
-          scripts: { build: 'tsc' },
-          devDependencies: { typescript: '^5.0.0' },
+          name: "test-app",
+          scripts: { build: "tsc" },
+          devDependencies: { typescript: "^5.0.0" },
         };
 
-        await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson, null, 2));
-        await fs.writeFile(path.join(tempDir, 'tsconfig.json'), '{}');
+        await fs.writeFile(
+          path.join(tempDir, "package.json"),
+          JSON.stringify(packageJson, null, 2),
+        );
+        await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
 
-        const registered = await registerProjectMemoryContext('test-session-centralized', tempDir);
+        const registered = await registerProjectMemoryContext(
+          "test-session-centralized",
+          tempDir,
+        );
         expect(registered).toBe(true);
 
         const memoryPath = getMemoryPath(tempDir);
-        const content = await fs.readFile(memoryPath, 'utf-8');
+        const content = await fs.readFile(memoryPath, "utf-8");
         expect(JSON.parse(content).projectRoot).toBe(tempDir);
-        await expect(fs.access(path.join(tempDir, '.omc', 'project-memory.json'))).rejects.toThrow();
+        await expect(
+          fs.access(path.join(tempDir, ".omc", "project-memory.json")),
+        ).rejects.toThrow();
       } finally {
         delete process.env.OMC_STATE_DIR;
+        contextCollector.clear("test-session-centralized");
         await fs.rm(stateDir, { recursive: true, force: true });
       }
     });
 
-    it('should not inject duplicate context in same session', async () => {
-      const packageJson = { name: 'test' };
-      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson));
+    it("should not inject duplicate context in same session and same scope", async () => {
+      const packageJson = {
+        name: "test",
+        scripts: { build: "tsc" },
+        devDependencies: { typescript: "^5.0.0" },
+      };
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson),
+      );
+      await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
 
-      const sessionId = 'test-session-2';
-
-      // First registration
+      const sessionId = "test-session-2";
       const first = await registerProjectMemoryContext(sessionId, tempDir);
-      expect(first).toBe(true);
-
-      // Second registration in same session
       const second = await registerProjectMemoryContext(sessionId, tempDir);
-      expect(second).toBe(false); // Should skip duplicate
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+      expect(contextCollector.getEntryCount(sessionId)).toBe(1);
     });
 
-    it('should inject again for different session', async () => {
-      const packageJson = { name: 'test' };
-      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson));
+    it("should inject again for different session", async () => {
+      const packageJson = {
+        name: "test",
+        scripts: { build: "tsc" },
+        devDependencies: { typescript: "^5.0.0" },
+      };
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson),
+      );
+      await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
 
-      // Session 1
-      const session1 = 'test-session-3a';
+      const session1 = "test-session-3a";
       const first = await registerProjectMemoryContext(session1, tempDir);
-      expect(first).toBe(true);
 
-      // Session 2
-      const session2 = 'test-session-3b';
+      const session2 = "test-session-3b";
       const second = await registerProjectMemoryContext(session2, tempDir);
+
+      expect(first).toBe(true);
       expect(second).toBe(true);
     });
 
-    it('should not inject if project has no useful info', async () => {
-      // Empty directory with no config files — add .git so findProjectRoot
-      // stops here instead of walking up to the real repo root
-      await fs.mkdir(path.join(tempDir, '.git'));
-      const sessionId = 'test-session-4';
+    it("should allow reinjection for a new scope in the same session", async () => {
+      const packageJson = {
+        name: "test",
+        scripts: { build: "tsc" },
+        devDependencies: { typescript: "^5.0.0" },
+      };
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson),
+      );
+      await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
+      await fs.mkdir(path.join(tempDir, "src", "hooks", "project-memory"), {
+        recursive: true,
+      });
+
+      const sessionId = "test-session-scope";
+      const first = await registerProjectMemoryContext(sessionId, tempDir);
+      const second = await registerProjectMemoryContext(
+        sessionId,
+        path.join(tempDir, "src", "hooks", "project-memory"),
+      );
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(contextCollector.getEntryCount(sessionId)).toBe(1);
+      expect(
+        contextCollector.getPending(sessionId).entries[0]?.metadata?.scopeKey,
+      ).toBe("src/hooks/project-memory");
+    });
+
+    it("should not inject if project has no useful info", async () => {
+      await fs.mkdir(path.join(tempDir, ".git"));
+      const sessionId = "test-session-4";
       const registered = await registerProjectMemoryContext(sessionId, tempDir);
 
       expect(registered).toBe(false);
     });
   });
 
-  describe('Rescan preserves user-contributed data', () => {
-    it('should preserve customNotes and userDirectives after rescan', async () => {
-      const packageJson = { name: 'test', scripts: { build: 'tsc' }, devDependencies: { typescript: '^5.0.0' } };
-      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson));
-      await fs.writeFile(path.join(tempDir, 'tsconfig.json'), '{}');
+  describe("Rescan preserves user-contributed data", () => {
+    it("should preserve customNotes, userDirectives, and hotPaths after rescan", async () => {
+      const packageJson = {
+        name: "test",
+        scripts: { build: "tsc" },
+        devDependencies: { typescript: "^5.0.0" },
+      };
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson),
+      );
+      await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
 
-      // Initial scan
-      const sessionId = 'test-session-rescan';
+      const sessionId = "test-session-rescan";
       await registerProjectMemoryContext(sessionId, tempDir);
 
-      // Add custom notes and directives to the persisted memory
       const memory = await loadProjectMemory(tempDir);
       expect(memory).not.toBeNull();
       memory!.customNotes = [
-        { timestamp: Date.now(), source: 'manual', category: 'deploy', content: 'Uses Docker' },
+        {
+          timestamp: Date.now(),
+          source: "manual",
+          category: "deploy",
+          content: "Uses Docker",
+        },
       ];
       memory!.userDirectives = [
-        { timestamp: Date.now(), directive: 'Always use strict mode', context: '', source: 'explicit', priority: 'high' },
+        {
+          timestamp: Date.now(),
+          directive: "Always use strict mode",
+          context: "",
+          source: "explicit",
+          priority: "high",
+        },
       ];
-      // Set lastScanned to 25 hours ago to trigger rescan
+      memory!.hotPaths = [
+        {
+          path: "src/index.ts",
+          accessCount: 3,
+          lastAccessed: Date.now(),
+          type: "file",
+        },
+      ];
       memory!.lastScanned = Date.now() - 25 * 60 * 60 * 1000;
       const memoryPath = getMemoryPath(tempDir);
       await fs.writeFile(memoryPath, JSON.stringify(memory, null, 2));
 
-      // Clear session cache and re-register (triggers rescan)
       clearProjectMemorySession(sessionId);
       await registerProjectMemoryContext(sessionId, tempDir);
 
-      // Verify user-contributed data survived
       const updated = await loadProjectMemory(tempDir);
       expect(updated).not.toBeNull();
       expect(updated!.customNotes).toHaveLength(1);
-      expect(updated!.customNotes[0].content).toBe('Uses Docker');
+      expect(updated!.customNotes[0].content).toBe("Uses Docker");
       expect(updated!.userDirectives).toHaveLength(1);
-      expect(updated!.userDirectives[0].directive).toBe('Always use strict mode');
-      // Verify lastScanned was updated (rescan happened)
+      expect(updated!.userDirectives[0].directive).toBe(
+        "Always use strict mode",
+      );
+      expect(updated!.hotPaths).toHaveLength(1);
+      expect(updated!.hotPaths[0].path).toBe("src/index.ts");
       const age = Date.now() - updated!.lastScanned;
       expect(age).toBeLessThan(5000);
+      contextCollector.clear(sessionId);
     });
   });
 
-  describe('End-to-end PostToolUse learning flow', () => {
-    it('should learn build command from Bash execution', async () => {
-      // Create initial project
-      const packageJson = { name: 'test', scripts: {} };
-      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson));
+  describe("End-to-end PostToolUse learning flow", () => {
+    it("should learn build command from Bash execution", async () => {
+      const packageJson = { name: "test", scripts: {} };
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson),
+      );
 
-      // Initial detection (no build command)
-      const sessionId = 'test-session-5';
+      const sessionId = "test-session-5";
       await registerProjectMemoryContext(sessionId, tempDir);
 
       let memory = await loadProjectMemory(tempDir);
       expect(memory?.build.buildCommand).toBeNull();
 
-      // Simulate user running build command
-      await learnFromToolOutput('Bash', { command: 'npm run build' }, '', tempDir);
+      await learnFromToolOutput(
+        "Bash",
+        { command: "npm run build" },
+        "",
+        tempDir,
+      );
 
-      // Verify learning
       memory = await loadProjectMemory(tempDir);
-      expect(memory?.build.buildCommand).toBe('npm run build');
+      expect(memory?.build.buildCommand).toBe("npm run build");
     });
 
-    it('should learn environment hints from command output', async () => {
-      // Create initial project
-      const packageJson = { name: 'test' };
-      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson));
+    it("should learn environment hints from command output", async () => {
+      const packageJson = { name: "test" };
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson),
+      );
 
-      // Initial detection
-      const sessionId = 'test-session-6';
+      const sessionId = "test-session-6";
       await registerProjectMemoryContext(sessionId, tempDir);
 
-      // Simulate command with Node.js version in output
-      const output = 'Node.js v20.10.0\nnpm v10.2.0';
-      await learnFromToolOutput('Bash', { command: 'node --version' }, output, tempDir);
+      const output = `Node.js v20.10.0\nnpm v10.2.0`;
+      await learnFromToolOutput(
+        "Bash",
+        { command: "node --version" },
+        output,
+        tempDir,
+      );
 
-      // Verify learning
       const memory = await loadProjectMemory(tempDir);
       expect(memory?.customNotes.length).toBeGreaterThan(0);
-      expect(memory?.customNotes[0].category).toBe('runtime');
-      expect(memory?.customNotes[0].content).toContain('Node.js');
+      expect(memory?.customNotes[0].category).toBe("runtime");
+      expect(memory?.customNotes[0].content).toContain("Node.js");
     });
   });
 
-  describe('Session cleanup', () => {
-    it('should clear session cache', async () => {
-      const packageJson = { name: 'test' };
-      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson));
+  describe("Session cleanup", () => {
+    it("should clear session cache", async () => {
+      const packageJson = {
+        name: "test",
+        scripts: { build: "tsc" },
+        devDependencies: { typescript: "^5.0.0" },
+      };
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson),
+      );
+      await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
 
-      const sessionId = 'test-session-7';
-
-      // Register
+      const sessionId = "test-session-7";
       await registerProjectMemoryContext(sessionId, tempDir);
-
-      // Clear cache
       clearProjectMemorySession(sessionId);
-
-      // Should register again (cache cleared)
       const registered = await registerProjectMemoryContext(sessionId, tempDir);
       expect(registered).toBe(true);
     });
   });
 
-  describe('Cache expiry', () => {
-    it('should rescan if cache is stale', async () => {
-      const packageJson = { name: 'test', version: '1.0.0' };
-      await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify(packageJson));
+  describe("Cache expiry", () => {
+    it("should rescan if cache is stale", async () => {
+      const packageJson = {
+        name: "test",
+        version: "1.0.0",
+        scripts: { build: "tsc" },
+        devDependencies: { typescript: "^5.0.0" },
+      };
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify(packageJson),
+      );
+      await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
 
-      // Initial scan
-      const sessionId = 'test-session-8';
+      const sessionId = "test-session-8";
       await registerProjectMemoryContext(sessionId, tempDir);
 
-      // Load and manually set lastScanned to 25 hours ago
       const memory = await loadProjectMemory(tempDir);
       expect(memory).not.toBeNull();
       memory!.lastScanned = Date.now() - 25 * 60 * 60 * 1000;
 
-      // Save with old timestamp
       const memoryPath = getMemoryPath(tempDir);
       await fs.writeFile(memoryPath, JSON.stringify(memory, null, 2));
 
-      // Clear session cache to allow re-registration
       clearProjectMemorySession(sessionId);
-
-      // Register again - should trigger rescan
       await registerProjectMemoryContext(sessionId, tempDir);
 
-      // Verify lastScanned was updated
       const updated = await loadProjectMemory(tempDir);
       const age = Date.now() - updated!.lastScanned;
-      expect(age).toBeLessThan(5000); // Less than 5 seconds old
+      expect(age).toBeLessThan(5000);
     });
   });
 });

--- a/src/hooks/project-memory/__tests__/pre-compact.test.ts
+++ b/src/hooks/project-memory/__tests__/pre-compact.test.ts
@@ -2,34 +2,56 @@
  * Tests for Project Memory PreCompact Handler
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { processPreCompact, PreCompactInput } from '../pre-compact.js';
-import { ProjectMemory } from '../types.js';
-import { SCHEMA_VERSION } from '../constants.js';
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { processPreCompact, PreCompactInput } from "../pre-compact.js";
+import { ProjectMemory } from "../types.js";
+import { SCHEMA_VERSION } from "../constants.js";
 
-// Mock dependencies
-vi.mock('../../rules-injector/finder.js', () => ({
+vi.mock("../../rules-injector/finder.js", () => ({
   findProjectRoot: vi.fn(),
 }));
 
-vi.mock('../storage.js', () => ({
+vi.mock("../storage.js", () => ({
   loadProjectMemory: vi.fn(),
 }));
 
-import { findProjectRoot } from '../../rules-injector/finder.js';
-import { loadProjectMemory } from '../storage.js';
+import { findProjectRoot } from "../../rules-injector/finder.js";
+import { loadProjectMemory } from "../storage.js";
 
 const mockedFindProjectRoot = vi.mocked(findProjectRoot);
 const mockedLoadProjectMemory = vi.mocked(loadProjectMemory);
 
-const createBaseMemory = (overrides: Partial<ProjectMemory> = {}): ProjectMemory => ({
+const createBaseMemory = (
+  overrides: Partial<ProjectMemory> = {},
+): ProjectMemory => ({
   version: SCHEMA_VERSION,
   lastScanned: Date.now(),
-  projectRoot: '/test',
-  techStack: { languages: [], frameworks: [], packageManager: null, runtime: null },
-  build: { buildCommand: null, testCommand: null, lintCommand: null, devCommand: null, scripts: {} },
-  conventions: { namingStyle: null, importStyle: null, testPattern: null, fileOrganization: null },
-  structure: { isMonorepo: false, workspaces: [], mainDirectories: [], gitBranches: null },
+  projectRoot: "/test",
+  techStack: {
+    languages: [],
+    frameworks: [],
+    packageManager: null,
+    runtime: null,
+  },
+  build: {
+    buildCommand: null,
+    testCommand: null,
+    lintCommand: null,
+    devCommand: null,
+    scripts: {},
+  },
+  conventions: {
+    namingStyle: null,
+    importStyle: null,
+    testPattern: null,
+    fileOrganization: null,
+  },
+  structure: {
+    isMonorepo: false,
+    workspaces: [],
+    mainDirectories: [],
+    gitBranches: null,
+  },
   customNotes: [],
   directoryMap: {},
   hotPaths: [],
@@ -38,25 +60,59 @@ const createBaseMemory = (overrides: Partial<ProjectMemory> = {}): ProjectMemory
 });
 
 const baseInput: PreCompactInput = {
-  session_id: 'test-session',
-  transcript_path: '/tmp/transcript',
-  cwd: '/test',
-  permission_mode: 'default',
-  hook_event_name: 'PreCompact',
-  trigger: 'auto',
+  session_id: "test-session",
+  transcript_path: "/tmp/transcript",
+  cwd: "/test",
+  permission_mode: "default",
+  hook_event_name: "PreCompact",
+  trigger: "auto",
 };
 
-describe('Project Memory PreCompact Handler', () => {
+describe("Project Memory PreCompact Handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should treat customNotes as critical info and inject system message', async () => {
-    mockedFindProjectRoot.mockReturnValue('/test');
+  it("should treat customNotes as critical info and inject system message", async () => {
+    mockedFindProjectRoot.mockReturnValue("/test");
     mockedLoadProjectMemory.mockResolvedValue(
       createBaseMemory({
+        techStack: {
+          languages: [
+            {
+              name: "TypeScript",
+              version: null,
+              confidence: "high",
+              markers: ["tsconfig.json"],
+            },
+          ],
+          frameworks: [],
+          packageManager: "pnpm",
+          runtime: null,
+        },
+        build: {
+          buildCommand: "pnpm build",
+          testCommand: "pnpm test",
+          lintCommand: null,
+          devCommand: null,
+          scripts: {},
+        },
         customNotes: [
-          { timestamp: Date.now(), source: 'learned', category: 'env', content: 'Requires NODE_ENV' },
+          {
+            timestamp: Date.now(),
+            source: "learned",
+            category: "env",
+            content: "Requires NODE_ENV",
+          },
+        ],
+        userDirectives: [
+          {
+            timestamp: Date.now(),
+            directive: "Stay in scope",
+            context: "",
+            source: "explicit",
+            priority: "high",
+          },
         ],
       }),
     );
@@ -65,12 +121,14 @@ describe('Project Memory PreCompact Handler', () => {
 
     expect(result.continue).toBe(true);
     expect(result.systemMessage).toBeDefined();
-    expect(result.systemMessage).toContain('Project Memory');
-    expect(result.systemMessage).toContain('[env] Requires NODE_ENV');
+    expect(result.systemMessage).toContain("Project Memory");
+    expect(result.systemMessage).toContain("[Project Environment]");
+    expect(result.systemMessage).toContain("[Directives]");
+    expect(result.systemMessage).toContain("[Recent Learnings]");
   });
 
-  it('should not inject when memory has no critical info', async () => {
-    mockedFindProjectRoot.mockReturnValue('/test');
+  it("should not inject when memory has no critical info", async () => {
+    mockedFindProjectRoot.mockReturnValue("/test");
     mockedLoadProjectMemory.mockResolvedValue(createBaseMemory());
 
     const result = await processPreCompact(baseInput);

--- a/src/hooks/project-memory/formatter.ts
+++ b/src/hooks/project-memory/formatter.ts
@@ -3,96 +3,38 @@
  * Generates context strings for injection
  */
 
-import { ProjectMemory, FrameworkDetection } from './types.js';
-import { formatDirectivesForContext } from './directive-detector.js';
-import { getTopHotPaths } from './hot-path-tracker.js';
+import path from "path";
+import {
+  ProjectMemory,
+  FrameworkDetection,
+  ProjectMemoryContext,
+  CustomNote,
+  UserDirective,
+} from "./types.js";
+import { getTopHotPaths } from "./hot-path-tracker.js";
+
+const SUMMARY_CHAR_BUDGET = 650;
+const MAX_HOT_PATH_ITEMS = 3;
+const MAX_DIRECTIVE_ITEMS = 3;
+const MAX_LEARNING_ITEMS = 3;
 
 /**
  * Format project memory as a concise summary
  * Used for context injection (includes directives for compaction resilience)
  */
-export function formatContextSummary(memory: ProjectMemory): string {
+export function formatContextSummary(
+  memory: ProjectMemory,
+  context: ProjectMemoryContext = {},
+): string {
   const lines: string[] = [];
+  const pushTier = createBoundedTierWriter(lines);
 
-  // Always include user directives at the top (critical for compaction resilience)
-  if (memory.userDirectives.length > 0) {
-    const directivesText = formatDirectivesForContext(memory.userDirectives);
-    lines.push(directivesText);
-    lines.push('');
-  }
+  pushTier(formatEnvironmentTier(memory));
+  pushTier(formatHotPathsTier(memory, context));
+  pushTier(formatDirectivesTier(memory));
+  pushTier(formatLearningsTier(memory, context));
 
-  // Tech stack summary
-  const parts: string[] = [];
-
-  // Primary language
-  const primaryLang = memory.techStack.languages
-    .filter(l => l.confidence === 'high')
-    .sort((a, b) => b.markers.length - a.markers.length)[0];
-
-  if (primaryLang) {
-    parts.push(primaryLang.name);
-  }
-
-  // Primary framework (prefer frontend/fullstack)
-  const primaryFramework = getPrimaryFramework(memory.techStack.frameworks);
-  if (primaryFramework) {
-    parts.push(primaryFramework.name);
-  }
-
-  // Package manager
-  if (memory.techStack.packageManager) {
-    parts.push(`using ${memory.techStack.packageManager}`);
-  }
-
-  // Build command
-  if (memory.build.buildCommand) {
-    parts.push(`Build: ${memory.build.buildCommand}`);
-  }
-
-  // Test command
-  if (memory.build.testCommand) {
-    parts.push(`Test: ${memory.build.testCommand}`);
-  }
-
-  const techSummary = parts.join(' | ');
-
-  // Add tech summary
-  if (techSummary) {
-    lines.push(`[Project Environment] ${techSummary}`);
-  }
-
-  // Add hot paths if available
-  const topPaths = getTopHotPaths(memory.hotPaths, 5);
-  if (topPaths.length > 0) {
-    lines.push('');
-    lines.push('**Frequently Accessed:**');
-    for (const hp of topPaths) {
-      lines.push(`- ${hp.path} (${hp.accessCount}x)`);
-    }
-  }
-
-  // Add key directories
-  const keyDirs = Object.values(memory.directoryMap)
-    .filter(d => d.purpose)
-    .slice(0, 5);
-  if (keyDirs.length > 0) {
-    lines.push('');
-    lines.push('**Key Directories:**');
-    for (const dir of keyDirs) {
-      lines.push(`- ${dir.path}: ${dir.purpose}`);
-    }
-  }
-
-  // Add custom notes
-  if (memory.customNotes.length > 0) {
-    lines.push('');
-    lines.push('**Notes:**');
-    for (const note of memory.customNotes.slice(0, 5)) {
-      lines.push(`- [${note.category}] ${note.content}`);
-    }
-  }
-
-  return lines.join('\n');
+  return trimToBudget(lines.join("\n"), SUMMARY_CHAR_BUDGET);
 }
 
 /**
@@ -101,35 +43,35 @@ export function formatContextSummary(memory: ProjectMemory): string {
 export function formatFullContext(memory: ProjectMemory): string {
   const lines: string[] = [];
 
-  lines.push('<project-memory>');
-  lines.push('');
-  lines.push('## Project Environment');
-  lines.push('');
+  lines.push("<project-memory>");
+  lines.push("");
+  lines.push("## Project Environment");
+  lines.push("");
 
-  // Languages
   if (memory.techStack.languages.length > 0) {
-    lines.push('**Languages:**');
+    lines.push("**Languages:**");
     for (const lang of memory.techStack.languages) {
-      const version = lang.version ? ` (${lang.version})` : '';
+      const version = lang.version ? ` (${lang.version})` : "";
       lines.push(`- ${lang.name}${version}`);
     }
-    lines.push('');
+    lines.push("");
   }
 
-  // Frameworks
   if (memory.techStack.frameworks.length > 0) {
-    lines.push('**Frameworks:**');
+    lines.push("**Frameworks:**");
     for (const fw of memory.techStack.frameworks) {
-      const version = fw.version ? ` (${fw.version})` : '';
+      const version = fw.version ? ` (${fw.version})` : "";
       lines.push(`- ${fw.name}${version} [${fw.category}]`);
     }
-    lines.push('');
+    lines.push("");
   }
 
-  // Commands
-  const hasCommands = memory.build.buildCommand || memory.build.testCommand || memory.build.lintCommand;
+  const hasCommands =
+    memory.build.buildCommand ||
+    memory.build.testCommand ||
+    memory.build.lintCommand;
   if (hasCommands) {
-    lines.push('**Commands:**');
+    lines.push("**Commands:**");
     if (memory.build.buildCommand) {
       lines.push(`- Build: \`${memory.build.buildCommand}\``);
     }
@@ -142,11 +84,13 @@ export function formatFullContext(memory: ProjectMemory): string {
     if (memory.build.devCommand) {
       lines.push(`- Dev: \`${memory.build.devCommand}\``);
     }
-    lines.push('');
+    lines.push("");
   }
 
-  // Conventions
-  const hasConventions = memory.conventions.namingStyle || memory.conventions.importStyle || memory.conventions.testPattern;
+  const hasConventions =
+    memory.conventions.namingStyle ||
+    memory.conventions.importStyle ||
+    memory.conventions.testPattern;
   if (hasConventions) {
     if (memory.conventions.namingStyle) {
       lines.push(`**Code Style:** ${memory.conventions.namingStyle}`);
@@ -157,44 +101,216 @@ export function formatFullContext(memory: ProjectMemory): string {
     if (memory.conventions.testPattern) {
       lines.push(`**Test Pattern:** ${memory.conventions.testPattern}`);
     }
-    lines.push('');
+    lines.push("");
   }
 
-  // Structure
   if (memory.structure.isMonorepo) {
-    lines.push('**Structure:** Monorepo');
+    lines.push("**Structure:** Monorepo");
     if (memory.structure.workspaces.length > 0) {
-      lines.push(`- Workspaces: ${memory.structure.workspaces.slice(0, 3).join(', ')}`);
+      lines.push(
+        `- Workspaces: ${memory.structure.workspaces.slice(0, 3).join(", ")}`,
+      );
     }
-    lines.push('');
+    lines.push("");
   }
 
-  // Custom notes
   if (memory.customNotes.length > 0) {
-    lines.push('**Custom Notes:**');
+    lines.push("**Custom Notes:**");
     for (const note of memory.customNotes.slice(0, 5)) {
       lines.push(`- [${note.category}] ${note.content}`);
     }
-    lines.push('');
+    lines.push("");
   }
 
-  lines.push('</project-memory>');
+  lines.push("</project-memory>");
 
-  return lines.join('\n');
+  return lines.join("\n");
+}
+
+function formatEnvironmentTier(memory: ProjectMemory): string[] {
+  const lines: string[] = [];
+  const parts: string[] = [];
+
+  const primaryLang =
+    memory.techStack.languages
+      .filter((l) => l.confidence === "high")
+      .sort((a, b) => b.markers.length - a.markers.length)[0] ??
+    memory.techStack.languages[0];
+
+  if (primaryLang) {
+    parts.push(primaryLang.name);
+  }
+
+  const primaryFramework = getPrimaryFramework(memory.techStack.frameworks);
+  if (primaryFramework) {
+    parts.push(primaryFramework.name);
+  }
+
+  if (memory.techStack.packageManager) {
+    parts.push(`pkg:${memory.techStack.packageManager}`);
+  }
+
+  if (memory.techStack.runtime) {
+    parts.push(memory.techStack.runtime);
+  }
+
+  if (parts.length === 0) {
+    return lines;
+  }
+
+  lines.push("[Project Environment]");
+  lines.push(`- ${parts.join(" | ")}`);
+
+  const commands: string[] = [];
+  if (memory.build.buildCommand)
+    commands.push(`build=${memory.build.buildCommand}`);
+  if (memory.build.testCommand)
+    commands.push(`test=${memory.build.testCommand}`);
+  if (memory.build.lintCommand)
+    commands.push(`lint=${memory.build.lintCommand}`);
+  if (commands.length > 0) {
+    lines.push(`- ${commands.join(" | ")}`);
+  }
+
+  return lines;
+}
+
+function formatHotPathsTier(
+  memory: ProjectMemory,
+  context: ProjectMemoryContext,
+): string[] {
+  const topPaths = getTopHotPaths(memory.hotPaths, MAX_HOT_PATH_ITEMS, context);
+  if (topPaths.length === 0) {
+    return [];
+  }
+
+  const lines = ["[Hot Paths]"];
+  for (const hotPath of topPaths) {
+    lines.push(`- ${hotPath.path} (${hotPath.accessCount}x)`);
+  }
+  return lines;
+}
+
+function formatDirectivesTier(memory: ProjectMemory): string[] {
+  const directives = [...memory.userDirectives]
+    .sort((a, b) => scoreDirective(b) - scoreDirective(a))
+    .slice(0, MAX_DIRECTIVE_ITEMS);
+
+  if (directives.length === 0) {
+    return [];
+  }
+
+  const lines = ["[Directives]"];
+  for (const directive of directives) {
+    const priority = directive.priority === "high" ? "critical" : "note";
+    lines.push(`- ${priority}: ${directive.directive}`);
+  }
+  return lines;
+}
+
+function formatLearningsTier(
+  memory: ProjectMemory,
+  context: ProjectMemoryContext,
+): string[] {
+  const notes = [...memory.customNotes]
+    .sort((a, b) => scoreLearning(b, context) - scoreLearning(a, context))
+    .slice(0, MAX_LEARNING_ITEMS);
+
+  if (notes.length === 0) {
+    return [];
+  }
+
+  const lines = ["[Recent Learnings]"];
+  for (const note of notes) {
+    lines.push(`- [${note.category}] ${note.content}`);
+  }
+  return lines;
+}
+
+function createBoundedTierWriter(lines: string[]) {
+  return (tierLines: string[]): void => {
+    if (tierLines.length === 0) {
+      return;
+    }
+
+    if (lines.length > 0) {
+      lines.push("");
+    }
+
+    lines.push(...tierLines);
+  };
+}
+
+function trimToBudget(summary: string, budget: number): string {
+  if (summary.length <= budget) {
+    return summary;
+  }
+
+  return `${summary.slice(0, budget - 1).trimEnd()}…`;
+}
+
+function scoreDirective(directive: UserDirective): number {
+  return (
+    (directive.priority === "high" ? 1_000_000_000_000 : 0) +
+    directive.timestamp
+  );
+}
+
+function scoreLearning(
+  note: CustomNote,
+  context: ProjectMemoryContext,
+): number {
+  const categoryWeight: Record<string, number> = {
+    env: 60,
+    runtime: 50,
+    dependency: 40,
+    deploy: 30,
+    test: 20,
+  };
+
+  const now = context.now ?? Date.now();
+  const ageHours = Math.floor(
+    Math.max(0, now - note.timestamp) / (60 * 60 * 1000),
+  );
+  const recencyWeight = Math.max(0, 100 - ageHours);
+  const scopePath = normalizeScopePath(context.workingDirectory);
+  const scopeBoost =
+    scopePath && note.content.includes(scopePath.split("/").pop() ?? "")
+      ? 10
+      : 0;
+
+  return recencyWeight + (categoryWeight[note.category] ?? 10) + scopeBoost;
+}
+
+function normalizeScopePath(workingDirectory?: string): string | null {
+  if (!workingDirectory) {
+    return null;
+  }
+
+  const normalized = path
+    .normalize(workingDirectory)
+    .replace(/^\.[/\\]?/, "")
+    .replace(/\\/g, "/");
+  if (normalized === "" || normalized === ".") {
+    return null;
+  }
+
+  return normalized;
 }
 
 /**
  * Get the primary framework to highlight
  * Prefers frontend/fullstack, then by popularity
  */
-function getPrimaryFramework(frameworks: FrameworkDetection[]): FrameworkDetection | null {
+function getPrimaryFramework(
+  frameworks: FrameworkDetection[],
+): FrameworkDetection | null {
   if (frameworks.length === 0) return null;
 
-  // Priority order: fullstack > frontend > backend > testing > build
-  const priority = ['fullstack', 'frontend', 'backend', 'testing', 'build'];
+  const priority = ["fullstack", "frontend", "backend", "testing", "build"];
 
   for (const category of priority) {
-    const match = frameworks.find(f => f.category === category);
+    const match = frameworks.find((f) => f.category === category);
     if (match) return match;
   }
 

--- a/src/hooks/project-memory/hot-path-tracker.ts
+++ b/src/hooks/project-memory/hot-path-tracker.ts
@@ -3,8 +3,8 @@
  * Tracks frequently accessed files and directories
  */
 
-import path from 'path';
-import { HotPath } from './types.js';
+import path from "path";
+import { HotPath, ProjectMemoryContext } from "./types.js";
 
 const MAX_HOT_PATHS = 50;
 
@@ -15,20 +15,17 @@ export function trackAccess(
   hotPaths: HotPath[],
   filePath: string,
   projectRoot: string,
-  type: 'file' | 'directory'
+  type: "file" | "directory",
 ): HotPath[] {
-  // Make path relative to project root
   const relativePath = path.isAbsolute(filePath)
     ? path.relative(projectRoot, filePath)
     : filePath;
 
-  // Skip if path is outside project or in ignored directories
-  if (relativePath.startsWith('..') || shouldIgnorePath(relativePath)) {
+  if (relativePath.startsWith("..") || shouldIgnorePath(relativePath)) {
     return hotPaths;
   }
 
-  // Find existing entry
-  const existing = hotPaths.find(hp => hp.path === relativePath);
+  const existing = hotPaths.find((hp) => hp.path === relativePath);
 
   if (existing) {
     existing.accessCount++;
@@ -42,7 +39,6 @@ export function trackAccess(
     });
   }
 
-  // Sort by access count and keep top entries
   hotPaths.sort((a, b) => b.accessCount - a.accessCount);
 
   if (hotPaths.length > MAX_HOT_PATHS) {
@@ -52,31 +48,41 @@ export function trackAccess(
   return hotPaths;
 }
 
-/**
- * Check if path should be ignored
- */
 function shouldIgnorePath(relativePath: string): boolean {
   const ignorePatterns = [
-    'node_modules',
-    '.git',
-    '.omc',
-    'dist',
-    'build',
-    '.cache',
-    '.next',
-    '.nuxt',
-    'coverage',
-    '.DS_Store',
+    "node_modules",
+    ".git",
+    ".omc",
+    "dist",
+    "build",
+    ".cache",
+    ".next",
+    ".nuxt",
+    "coverage",
+    ".DS_Store",
   ];
 
-  return ignorePatterns.some(pattern => relativePath.includes(pattern));
+  return ignorePatterns.some((pattern) => relativePath.includes(pattern));
 }
 
 /**
  * Get top hot paths for display
  */
-export function getTopHotPaths(hotPaths: HotPath[], limit: number = 10): HotPath[] {
-  return hotPaths.slice(0, limit);
+export function getTopHotPaths(
+  hotPaths: HotPath[],
+  limit: number = 10,
+  context?: ProjectMemoryContext,
+): HotPath[] {
+  const now = context?.now ?? Date.now();
+  const scopePath = normalizeScopePath(context?.workingDirectory);
+
+  return [...hotPaths]
+    .filter((hp) => !shouldIgnorePath(hp.path))
+    .sort(
+      (a, b) =>
+        scoreHotPath(b, scopePath, now) - scoreHotPath(a, scopePath, now),
+    )
+    .slice(0, limit);
 }
 
 /**
@@ -87,13 +93,80 @@ export function decayHotPaths(hotPaths: HotPath[]): HotPath[] {
   const dayInMs = 24 * 60 * 60 * 1000;
 
   return hotPaths
-    .map(hp => {
+    .map((hp) => {
       const age = now - hp.lastAccessed;
       if (age > dayInMs * 7) {
-        // Older than 7 days, reduce count
-        return { ...hp, accessCount: Math.max(1, Math.floor(hp.accessCount / 2)) };
+        return {
+          ...hp,
+          accessCount: Math.max(1, Math.floor(hp.accessCount / 2)),
+        };
       }
       return hp;
     })
-    .filter(hp => hp.accessCount > 0);
+    .filter((hp) => hp.accessCount > 0);
+}
+
+function scoreHotPath(
+  hotPath: HotPath,
+  scopePath: string | null,
+  now: number,
+): number {
+  const ageMs = Math.max(0, now - hotPath.lastAccessed);
+  const recencyScore = Math.max(0, 120 - Math.floor(ageMs / (60 * 60 * 1000)));
+  const accessScore = hotPath.accessCount * 10;
+  const typeBonus = hotPath.type === "file" ? 6 : 3;
+  const scopeBonus = getScopeAffinityScore(hotPath.path, scopePath);
+
+  return accessScore + recencyScore + typeBonus + scopeBonus;
+}
+
+function getScopeAffinityScore(
+  hotPath: string,
+  scopePath: string | null,
+): number {
+  if (!scopePath || scopePath === "." || scopePath.length === 0) {
+    return 0;
+  }
+
+  if (hotPath === scopePath) {
+    return 400;
+  }
+
+  if (hotPath.startsWith(`${scopePath}/`)) {
+    return 320;
+  }
+
+  if (scopePath.startsWith(`${hotPath}/`)) {
+    return 220;
+  }
+
+  const hotSegments = hotPath.split("/");
+  const scopeSegments = scopePath.split("/");
+  let sharedSegments = 0;
+
+  while (
+    sharedSegments < hotSegments.length &&
+    sharedSegments < scopeSegments.length &&
+    hotSegments[sharedSegments] === scopeSegments[sharedSegments]
+  ) {
+    sharedSegments++;
+  }
+
+  return sharedSegments * 60;
+}
+
+function normalizeScopePath(workingDirectory?: string): string | null {
+  if (!workingDirectory) {
+    return null;
+  }
+
+  const normalized = path
+    .normalize(workingDirectory)
+    .replace(/^\.[/\\]?/, "")
+    .replace(/\\/g, "/");
+  if (normalized === "" || normalized === ".") {
+    return null;
+  }
+
+  return normalized;
 }

--- a/src/hooks/project-memory/index.ts
+++ b/src/hooks/project-memory/index.ts
@@ -3,6 +3,7 @@
  * Main orchestrator for auto-detecting and injecting project context
  */
 
+import path from "path";
 import { contextCollector } from "../../features/context-injector/collector.js";
 import { findProjectRoot } from "../rules-injector/finder.js";
 import {
@@ -14,34 +15,26 @@ import { detectProjectEnvironment } from "./detector.js";
 import { formatContextSummary } from "./formatter.js";
 
 /**
- * Session caches to prevent duplicate injection
- * Map<sessionId, Set<projectRoot>>
+ * Session caches to prevent duplicate injection.
+ * Map<sessionId, Set<projectRoot:scopeKey>>
  * Bounded to MAX_SESSIONS entries to prevent memory leaks in long-running MCP processes.
  */
 const sessionCaches = new Map<string, Set<string>>();
 const MAX_SESSIONS = 100;
 
-/**
- * Register project memory context for a session
- * Called from SessionStart hook
- *
- * @param sessionId - Current session ID
- * @param workingDirectory - Current working directory
- * @returns true if context was registered, false otherwise
- */
 export async function registerProjectMemoryContext(
   sessionId: string,
   workingDirectory: string,
 ): Promise<boolean> {
-  // Find project root
   const projectRoot = findProjectRoot(workingDirectory);
   if (!projectRoot) {
     return false;
   }
 
-  // Check session cache (avoid duplicate injection)
+  const scopeKey = getScopeKey(projectRoot, workingDirectory);
+  const cacheKey = `${projectRoot}:${scopeKey}`;
+
   if (!sessionCaches.has(sessionId)) {
-    // Evict oldest entry if cache is at capacity
     if (sessionCaches.size >= MAX_SESSIONS) {
       const firstKey = sessionCaches.keys().next().value;
       if (firstKey !== undefined) {
@@ -50,90 +43,87 @@ export async function registerProjectMemoryContext(
     }
     sessionCaches.set(sessionId, new Set());
   }
+
   const cache = sessionCaches.get(sessionId)!;
-  if (cache.has(projectRoot)) {
+  if (cache.has(cacheKey)) {
     return false;
   }
 
   try {
-    // Load or detect memory
     let memory = await loadProjectMemory(projectRoot);
 
-    // Rescan if memory doesn't exist or is stale
     if (!memory || shouldRescan(memory)) {
       const existing = memory;
       memory = await detectProjectEnvironment(projectRoot);
-      // Preserve user-contributed data that detection cannot reproduce
       if (existing) {
         memory.customNotes = existing.customNotes;
         memory.userDirectives = existing.userDirectives;
+        memory.hotPaths = existing.hotPaths;
       }
       await saveProjectMemory(projectRoot, memory);
     }
 
-    // Only inject if we have useful information
-    const hasUsefulInfo =
-      memory.techStack.languages.length > 0 ||
-      memory.techStack.frameworks.length > 0 ||
-      memory.build.buildCommand !== null;
+    const content = formatContextSummary(memory, {
+      workingDirectory: path.relative(projectRoot, workingDirectory),
+      scopeKey,
+    });
 
-    if (!hasUsefulInfo) {
+    if (!content.trim()) {
       return false;
     }
 
-    // Register context with high priority
     contextCollector.register(sessionId, {
       id: "project-environment",
       source: "project-memory",
-      content: formatContextSummary(memory),
+      content,
       priority: "high",
       metadata: {
         projectRoot,
+        scopeKey,
         languages: memory.techStack.languages.map((l) => l.name),
         lastScanned: memory.lastScanned,
       },
     });
 
-    // Mark as injected for this session
-    cache.add(projectRoot);
+    cache.add(cacheKey);
     return true;
   } catch (error) {
-    // Silently fail - we don't want to break the session
     console.error("Error registering project memory context:", error);
     return false;
   }
 }
 
-/**
- * Clear project memory session cache
- * Called when session ends
- *
- * @param sessionId - Session ID to clear
- */
 export function clearProjectMemorySession(sessionId: string): void {
   sessionCaches.delete(sessionId);
 }
 
-/**
- * Force rescan of project environment
- * Useful for manual refresh
- *
- * @param projectRoot - Project root directory
- */
 export async function rescanProjectEnvironment(
   projectRoot: string,
 ): Promise<void> {
   const existing = await loadProjectMemory(projectRoot);
   const memory = await detectProjectEnvironment(projectRoot);
-  // Preserve user-contributed data that detection cannot reproduce
   if (existing) {
     memory.customNotes = existing.customNotes;
     memory.userDirectives = existing.userDirectives;
+    memory.hotPaths = existing.hotPaths;
   }
   await saveProjectMemory(projectRoot, memory);
 }
 
-// Re-export utilities for use in other modules
+function getScopeKey(projectRoot: string, workingDirectory: string): string {
+  const relative = path.relative(projectRoot, workingDirectory);
+  if (!relative || relative === "") {
+    return ".";
+  }
+
+  const normalized = relative.replace(/\\/g, "/");
+  if (normalized.startsWith("..")) {
+    return ".";
+  }
+
+  return normalized;
+}
+
 export {
   loadProjectMemory,
   saveProjectMemory,

--- a/src/hooks/project-memory/types.ts
+++ b/src/hooks/project-memory/types.ts
@@ -27,14 +27,14 @@ export interface TechStack {
 export interface LanguageDetection {
   name: string;
   version: string | null;
-  confidence: 'high' | 'medium' | 'low';
+  confidence: "high" | "medium" | "low";
   markers: string[];
 }
 
 export interface FrameworkDetection {
   name: string;
   version: string | null;
-  category: 'frontend' | 'backend' | 'fullstack' | 'testing' | 'build';
+  category: "frontend" | "backend" | "fullstack" | "testing" | "build";
 }
 
 export interface BuildInfo {
@@ -66,7 +66,7 @@ export interface GitBranchPattern {
 
 export interface CustomNote {
   timestamp: number;
-  source: 'manual' | 'learned';
+  source: "manual" | "learned";
   category: string;
   content: string;
 }
@@ -98,7 +98,7 @@ export interface HotPath {
   path: string;
   accessCount: number;
   lastAccessed: number;
-  type: 'file' | 'directory';
+  type: "file" | "directory";
 }
 
 /**
@@ -108,6 +108,12 @@ export interface UserDirective {
   timestamp: number;
   directive: string;
   context: string;
-  source: 'explicit' | 'inferred';
-  priority: 'high' | 'normal';
+  source: "explicit" | "inferred";
+  priority: "high" | "normal";
+}
+
+export interface ProjectMemoryContext {
+  workingDirectory?: string;
+  scopeKey?: string;
+  now?: number;
 }


### PR DESCRIPTION
## Summary\n- compress project-memory injection into bounded progressive-disclosure tiers\n- rank hot paths and recent learnings with current scope affinity for better session/worktree recall\n- preserve fail-open behavior while allowing scope-aware reinjection in the same session\n\n## Testing\n- npx tsc --noEmit\n- npm test *(fails due to pre-existing unrelated failure in : expected pending, received notified)*\n\nCloses #1834