### PR TITLE
Fix brownfield assumptions handling and planning artifact quality gates

### DIFF
--- a/src/cli/commands/ralphthon.ts
+++ b/src/cli/commands/ralphthon.ts
@@ -9,9 +9,9 @@
  *   omc ralphthon --poll-interval 60      Set poll interval in seconds
  */
 
-import chalk from 'chalk';
-import { execSync } from 'child_process';
-import { existsSync } from 'fs';
+import chalk from "chalk";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
 import {
   readRalphthonPrd,
   readRalphthonState,
@@ -23,13 +23,15 @@ import {
   getRalphthonPrdPath,
   initRalphthonPrd,
   sendKeysToPane,
-} from '../../ralphthon/index.js';
+} from "../../ralphthon/index.js";
 import type {
   RalphthonCliOptions,
   OrchestratorEvent,
   RalphthonConfig,
-} from '../../ralphthon/types.js';
-import { RALPHTHON_DEFAULTS } from '../../ralphthon/types.js';
+  RalphthonPlanningContext,
+  RalphthonStory,
+} from "../../ralphthon/types.js";
+import { RALPHTHON_DEFAULTS } from "../../ralphthon/types.js";
 
 // ============================================================================
 // Help Text
@@ -77,29 +79,29 @@ export function parseRalphthonArgs(args: string[]): RalphthonCliOptions {
     const arg = args[i];
 
     switch (arg) {
-      case '--resume':
+      case "--resume":
         options.resume = true;
         break;
-      case '--skip-interview':
+      case "--skip-interview":
         options.skipInterview = true;
         break;
-      case '--max-waves': {
+      case "--max-waves": {
         const val = parseInt(args[++i], 10);
         if (!isNaN(val) && val > 0) options.maxWaves = val;
         break;
       }
-      case '--poll-interval': {
+      case "--poll-interval": {
         const val = parseInt(args[++i], 10);
         if (!isNaN(val) && val > 0) options.pollInterval = val;
         break;
       }
-      case '--help':
-      case '-h':
+      case "--help":
+      case "-h":
         console.log(RALPHTHON_HELP);
         process.exit(0);
         break;
       default:
-        if (!arg.startsWith('--')) {
+        if (!arg.startsWith("--")) {
           positional.push(arg);
         }
         break;
@@ -107,10 +109,93 @@ export function parseRalphthonArgs(args: string[]): RalphthonCliOptions {
   }
 
   if (positional.length > 0) {
-    options.task = positional.join(' ');
+    options.task = positional.join(" ");
   }
 
   return options;
+}
+
+export function buildRalphthonPlanningContext(
+  task: string,
+): RalphthonPlanningContext {
+  return {
+    brownfield: true,
+    assumptionsMode: "explicit",
+    codebaseMapSummary: `Brownfield target: ${task.slice(0, 160)}`,
+    knownConstraints: [
+      "Prefer repository evidence over assumptions",
+      "Capture brownfield/codebase-map findings explicitly before execution",
+    ],
+  };
+}
+
+export function buildRalphthonInterviewPrompt(
+  task: string,
+  options: RalphthonCliOptions,
+): string {
+  const sanitizedTask = task.replace(/[\r\n\0]+/g, " ").trim();
+  return `/deep-interview ${sanitizedTask}
+
+After the interview, generate a ralphthon-prd.json file in .omc/ with this structure:
+{
+  "project": "<project name>",
+  "branchName": "<branch>",
+  "description": "<description>",
+  "stories": [{ "id": "US-001", "title": "...", "description": "...", "acceptanceCriteria": [...], "priority": "high", "tasks": [{ "id": "T-001", "title": "...", "description": "...", "status": "pending", "retries": 0 }] }],
+  "hardening": [],
+  "config": { "maxWaves": ${options.maxWaves}, "cleanWavesForTermination": 3, "pollIntervalMs": ${options.pollInterval * 1000}, "idleThresholdMs": 30000, "maxRetries": 3, "skipInterview": false },
+  "planningContext": {
+    "brownfield": true,
+    "assumptionsMode": "explicit",
+    "codebaseMapSummary": "<brief brownfield/codebase-map summary>",
+    "knownConstraints": ["<constraint>"]
+  }
+}
+
+Treat this as brownfield planning. Summarize the existing codebase/module context explicitly instead of relying on implicit rediscovery.`;
+}
+
+export function buildDefaultSkipInterviewStories(
+  task: string,
+): RalphthonStory[] {
+  return [
+    {
+      id: "US-001",
+      title: task.slice(0, 60),
+      description: task,
+      acceptanceCriteria: [
+        "Implementation complete",
+        "Tests pass",
+        "No type errors",
+      ],
+      priority: "high",
+      tasks: [
+        {
+          id: "T-001",
+          title: task.slice(0, 60),
+          description: task,
+          status: "pending",
+          retries: 0,
+        },
+      ],
+    },
+  ];
+}
+
+export function buildDefaultSkipInterviewPrdParams(task: string): {
+  project: string;
+  branchName: string;
+  description: string;
+  stories: RalphthonStory[];
+  planningContext: RalphthonPlanningContext;
+} {
+  return {
+    project: "ralphthon",
+    branchName: "feat/ralphthon",
+    description: task,
+    stories: buildDefaultSkipInterviewStories(task),
+    planningContext: buildRalphthonPlanningContext(task),
+  };
 }
 
 // ============================================================================
@@ -122,34 +207,54 @@ function createEventLogger(): (event: OrchestratorEvent) => void {
     const ts = new Date().toLocaleTimeString();
 
     switch (event.type) {
-      case 'task_injected':
+      case "task_injected":
         console.log(chalk.cyan(`[${ts}] Task injected: ${event.taskTitle}`));
         break;
-      case 'task_completed':
+      case "task_completed":
         console.log(chalk.green(`[${ts}] Task completed: ${event.taskId}`));
         break;
-      case 'task_failed':
-        console.log(chalk.yellow(`[${ts}] Task failed: ${event.taskId} (retry ${event.retries})`));
+      case "task_failed":
+        console.log(
+          chalk.yellow(
+            `[${ts}] Task failed: ${event.taskId} (retry ${event.retries})`,
+          ),
+        );
         break;
-      case 'task_skipped':
-        console.log(chalk.red(`[${ts}] Task skipped: ${event.taskId} — ${event.reason}`));
+      case "task_skipped":
+        console.log(
+          chalk.red(`[${ts}] Task skipped: ${event.taskId} — ${event.reason}`),
+        );
         break;
-      case 'phase_transition':
-        console.log(chalk.magenta(`[${ts}] Phase: ${event.from} -> ${event.to}`));
+      case "phase_transition":
+        console.log(
+          chalk.magenta(`[${ts}] Phase: ${event.from} -> ${event.to}`),
+        );
         break;
-      case 'hardening_wave_start':
+      case "hardening_wave_start":
         console.log(chalk.blue(`[${ts}] Hardening wave ${event.wave} started`));
         break;
-      case 'hardening_wave_end':
-        console.log(chalk.blue(`[${ts}] Hardening wave ${event.wave} ended — ${event.newIssues} new issues`));
+      case "hardening_wave_end":
+        console.log(
+          chalk.blue(
+            `[${ts}] Hardening wave ${event.wave} ended — ${event.newIssues} new issues`,
+          ),
+        );
         break;
-      case 'idle_detected':
-        console.log(chalk.gray(`[${ts}] Leader idle for ${Math.round(event.durationMs / 1000)}s`));
+      case "idle_detected":
+        console.log(
+          chalk.gray(
+            `[${ts}] Leader idle for ${Math.round(event.durationMs / 1000)}s`,
+          ),
+        );
         break;
-      case 'session_complete':
-        console.log(chalk.green.bold(`[${ts}] Ralphthon complete! ${event.tasksCompleted} done, ${event.tasksSkipped} skipped`));
+      case "session_complete":
+        console.log(
+          chalk.green.bold(
+            `[${ts}] Ralphthon complete! ${event.tasksCompleted} done, ${event.tasksSkipped} skipped`,
+          ),
+        );
         break;
-      case 'error':
+      case "error":
         console.log(chalk.red(`[${ts}] Error: ${event.message}`));
         break;
     }
@@ -162,7 +267,10 @@ function createEventLogger(): (event: OrchestratorEvent) => void {
 
 function getCurrentTmuxSession(): string | null {
   try {
-    return execSync("tmux display-message -p '#S'", { encoding: 'utf-8', timeout: 5000 }).trim();
+    return execSync("tmux display-message -p '#S'", {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
   } catch {
     return null;
   }
@@ -170,7 +278,10 @@ function getCurrentTmuxSession(): string | null {
 
 function getCurrentTmuxPane(): string | null {
   try {
-    return execSync("tmux display-message -p '#{pane_id}'", { encoding: 'utf-8', timeout: 5000 }).trim();
+    return execSync("tmux display-message -p '#{pane_id}'", {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
   } catch {
     return null;
   }
@@ -195,11 +306,11 @@ export async function ralphthonCommand(args: string[]): Promise<void> {
   if (options.resume) {
     const state = readRalphthonState(cwd);
     if (!state || !state.active) {
-      console.error(chalk.red('No active ralphthon session found to resume.'));
+      console.error(chalk.red("No active ralphthon session found to resume."));
       process.exit(1);
     }
 
-    console.log(chalk.blue('Resuming ralphthon session...'));
+    console.log(chalk.blue("Resuming ralphthon session..."));
     const prd = readRalphthonPrd(cwd);
     if (prd) {
       console.log(formatRalphthonStatus(prd));
@@ -210,26 +321,32 @@ export async function ralphthonCommand(args: string[]): Promise<void> {
 
     // Handle graceful shutdown
     const shutdown = () => {
-      console.log(chalk.yellow('\nStopping ralphthon orchestrator...'));
+      console.log(chalk.yellow("\nStopping ralphthon orchestrator..."));
       stop();
       process.exit(0);
     };
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
 
     return;
   }
 
   // New session — need task description
   if (!options.task) {
-    console.error(chalk.red('Task description required. Usage: omc ralphthon "your task"'));
+    console.error(
+      chalk.red('Task description required. Usage: omc ralphthon "your task"'),
+    );
     console.log(RALPHTHON_HELP);
     process.exit(1);
   }
 
   // Must be inside tmux
   if (!isInsideTmux()) {
-    console.error(chalk.red('Ralphthon requires tmux. Run inside a tmux session or use `omc` to launch one.'));
+    console.error(
+      chalk.red(
+        "Ralphthon requires tmux. Run inside a tmux session or use `omc` to launch one.",
+      ),
+    );
     process.exit(1);
   }
 
@@ -237,14 +354,18 @@ export async function ralphthonCommand(args: string[]): Promise<void> {
   const leaderPane = getCurrentTmuxPane();
 
   if (!tmuxSession || !leaderPane) {
-    console.error(chalk.red('Could not detect tmux session/pane.'));
+    console.error(chalk.red("Could not detect tmux session/pane."));
     process.exit(1);
   }
 
   // Check for existing session
   const existingState = readRalphthonState(cwd);
   if (existingState?.active) {
-    console.error(chalk.red('A ralphthon session is already active. Use --resume or cancel it first.'));
+    console.error(
+      chalk.red(
+        "A ralphthon session is already active. Use --resume or cancel it first.",
+      ),
+    );
     process.exit(1);
   }
 
@@ -255,31 +376,30 @@ export async function ralphthonCommand(args: string[]): Promise<void> {
     skipInterview: options.skipInterview,
   };
 
-  console.log(chalk.blue.bold('Starting Ralphthon'));
+  console.log(chalk.blue.bold("Starting Ralphthon"));
   console.log(chalk.gray(`Task: ${options.task}`));
-  console.log(chalk.gray(`Max waves: ${options.maxWaves}, Poll: ${options.pollInterval}s`));
+  console.log(
+    chalk.gray(
+      `Max waves: ${options.maxWaves}, Poll: ${options.pollInterval}s`,
+    ),
+  );
   console.log(chalk.gray(`Skip interview: ${options.skipInterview}`));
 
   // Phase 1: Interview (unless skipped)
   if (!options.skipInterview) {
-    console.log(chalk.cyan('\nPhase 1: Deep Interview — generating PRD...'));
-    console.log(chalk.gray('The leader pane will run deep-interview to generate the PRD.'));
+    console.log(chalk.cyan("\nPhase 1: Deep Interview — generating PRD..."));
+    console.log(
+      chalk.gray(
+        "The leader pane will run deep-interview to generate the PRD.",
+      ),
+    );
 
     // Inject deep-interview command to the leader pane
     // The orchestrator will wait for the PRD to appear
-    // Sanitize task to prevent newline/control char injection via tmux send-keys
-    const sanitizedTask = options.task!.replace(/[\r\n\0]+/g, ' ').trim();
-    const interviewPrompt = `/deep-interview ${sanitizedTask}
-
-After the interview, generate a ralphthon-prd.json file in .omc/ with this structure:
-{
-  "project": "<project name>",
-  "branchName": "<branch>",
-  "description": "<description>",
-  "stories": [{ "id": "US-001", "title": "...", "description": "...", "acceptanceCriteria": [...], "priority": "high", "tasks": [{ "id": "T-001", "title": "...", "description": "...", "status": "pending", "retries": 0 }] }],
-  "hardening": [],
-  "config": { "maxWaves": ${options.maxWaves}, "cleanWavesForTermination": 3, "pollIntervalMs": ${options.pollInterval * 1000}, "idleThresholdMs": 30000, "maxRetries": 3, "skipInterview": false }
-}`;
+    const interviewPrompt = buildRalphthonInterviewPrompt(
+      options.task,
+      options,
+    );
 
     // Initialize state in interview phase
     const state = initOrchestrator(
@@ -290,17 +410,19 @@ After the interview, generate a ralphthon-prd.json file in .omc/ with this struc
       sessionId,
       config,
     );
-    state.phase = 'interview';
+    state.phase = "interview";
     writeRalphthonState(cwd, state, sessionId);
 
     // Send the deep-interview prompt to the leader pane
     if (!sendKeysToPane(leaderPane, interviewPrompt)) {
-      console.log(chalk.red('Failed to inject deep-interview prompt to leader pane.'));
+      console.log(
+        chalk.red("Failed to inject deep-interview prompt to leader pane."),
+      );
       clearRalphthonState(cwd, sessionId);
       process.exit(1);
     }
 
-    console.log(chalk.gray('Waiting for PRD generation...'));
+    console.log(chalk.gray("Waiting for PRD generation..."));
 
     // Poll for PRD file to appear
     const prdPath = getRalphthonPrdPath(cwd);
@@ -312,7 +434,7 @@ After the interview, generate a ralphthon-prd.json file in .omc/ with this struc
       if (existsSync(prdPath)) {
         const prd = readRalphthonPrd(cwd);
         if (prd && prd.stories.length > 0) {
-          console.log(chalk.green('PRD generated successfully!'));
+          console.log(chalk.green("PRD generated successfully!"));
           console.log(formatRalphthonStatus(prd));
           break;
         }
@@ -322,32 +444,24 @@ After the interview, generate a ralphthon-prd.json file in .omc/ with this struc
     }
 
     if (waited >= maxWaitMs) {
-      console.error(chalk.red('Timed out waiting for PRD generation.'));
+      console.error(chalk.red("Timed out waiting for PRD generation."));
       clearRalphthonState(cwd, sessionId);
       process.exit(1);
     }
   } else {
     // Skip interview — create a simple PRD from the task
-    console.log(chalk.cyan('\nSkipping interview — creating PRD from task...'));
+    console.log(chalk.cyan("\nSkipping interview — creating PRD from task..."));
 
-    initRalphthonPrd(cwd, 'ralphthon', 'feat/ralphthon', options.task, [
-      {
-        id: 'US-001',
-        title: options.task.slice(0, 60),
-        description: options.task,
-        acceptanceCriteria: ['Implementation complete', 'Tests pass', 'No type errors'],
-        priority: 'high',
-        tasks: [
-          {
-            id: 'T-001',
-            title: options.task.slice(0, 60),
-            description: options.task,
-            status: 'pending',
-            retries: 0,
-          },
-        ],
-      },
-    ], config);
+    const defaultPrd = buildDefaultSkipInterviewPrdParams(options.task);
+    initRalphthonPrd(
+      cwd,
+      defaultPrd.project,
+      defaultPrd.branchName,
+      defaultPrd.description,
+      defaultPrd.stories,
+      config,
+      defaultPrd.planningContext,
+    );
 
     initOrchestrator(
       cwd,
@@ -360,23 +474,23 @@ After the interview, generate a ralphthon-prd.json file in .omc/ with this struc
   }
 
   // Phase 2: Execution — start the orchestrator loop
-  console.log(chalk.cyan('\nPhase 2: Execution — ralph loop active'));
+  console.log(chalk.cyan("\nPhase 2: Execution — ralph loop active"));
 
   const eventLogger = createEventLogger();
   const { stop } = startOrchestratorLoop(cwd, sessionId, eventLogger);
 
   // Handle graceful shutdown
   const shutdown = () => {
-    console.log(chalk.yellow('\nStopping ralphthon orchestrator...'));
+    console.log(chalk.yellow("\nStopping ralphthon orchestrator..."));
     stop();
     clearRalphthonState(cwd, sessionId);
     process.exit(0);
   };
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
 
   // Keep process alive
-  console.log(chalk.gray('Orchestrator running. Press Ctrl+C to stop.'));
+  console.log(chalk.gray("Orchestrator running. Press Ctrl+C to stop."));
 }
 
 // ============================================================================
@@ -384,5 +498,5 @@ After the interview, generate a ralphthon-prd.json file in .omc/ with this struc
 // ============================================================================
 
 function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -1,20 +1,20 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import {
   readPlanningArtifacts,
   isPlanningComplete,
   readApprovedExecutionLaunchHint,
-} from '../artifacts.js';
+} from "../artifacts.js";
 
-describe('planning/artifacts', () => {
+describe("planning/artifacts", () => {
   let testDir: string;
   let plansDir: string;
 
   beforeEach(() => {
-    testDir = mkdtempSync(join(tmpdir(), 'artifacts-test-'));
-    plansDir = join(testDir, '.omc', 'plans');
+    testDir = mkdtempSync(join(tmpdir(), "artifacts-test-"));
+    plansDir = join(testDir, ".omc", "plans");
     mkdirSync(plansDir, { recursive: true });
   });
 
@@ -22,137 +22,365 @@ describe('planning/artifacts', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  describe('readPlanningArtifacts', () => {
-    it('returns empty arrays when plans dir does not exist', () => {
-      const result = readPlanningArtifacts(join(testDir, 'nonexistent'));
+  function writeValidArtifacts(
+    prdName = "prd-feature.md",
+    specName = "test-spec-feature.md",
+  ): void {
+    writeFileSync(
+      join(plansDir, prdName),
+      [
+        "# PRD",
+        "",
+        "## Acceptance criteria",
+        "- done",
+        "",
+        "## Requirement coverage map",
+        "- req -> impl",
+        "",
+        'omc team 3:claude "implement auth"',
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(plansDir, specName),
+      [
+        "# Test Spec",
+        "",
+        "## Unit coverage",
+        "- unit",
+        "",
+        "## Verification mapping",
+        "- verify",
+        "",
+      ].join("\n"),
+    );
+  }
+
+  describe("readPlanningArtifacts", () => {
+    it("returns empty arrays when plans dir does not exist", () => {
+      const result = readPlanningArtifacts(join(testDir, "nonexistent"));
       expect(result).toEqual({ prdPaths: [], testSpecPaths: [] });
     });
 
-    it('returns empty arrays when plans dir is empty', () => {
+    it("returns empty arrays when plans dir is empty", () => {
       const result = readPlanningArtifacts(testDir);
       expect(result).toEqual({ prdPaths: [], testSpecPaths: [] });
     });
 
-    it('returns prd paths for prd-*.md files', () => {
-      writeFileSync(join(plansDir, 'prd-feature.md'), '# PRD');
+    it("returns prd paths for prd-*.md files", () => {
+      writeFileSync(join(plansDir, "prd-feature.md"), "# PRD");
       const result = readPlanningArtifacts(testDir);
       expect(result.prdPaths).toHaveLength(1);
-      expect(result.prdPaths[0]).toContain('prd-feature.md');
+      expect(result.prdPaths[0]).toContain("prd-feature.md");
     });
 
-    it('returns test-spec paths for test-spec-*.md files', () => {
-      writeFileSync(join(plansDir, 'test-spec-feature.md'), '# Test Spec');
+    it("returns test-spec paths for test-spec-*.md files", () => {
+      writeFileSync(join(plansDir, "test-spec-feature.md"), "# Test Spec");
       const result = readPlanningArtifacts(testDir);
       expect(result.testSpecPaths).toHaveLength(1);
-      expect(result.testSpecPaths[0]).toContain('test-spec-feature.md');
+      expect(result.testSpecPaths[0]).toContain("test-spec-feature.md");
     });
 
-    it('ignores non-matching files', () => {
-      writeFileSync(join(plansDir, 'notes.md'), '# Notes');
-      writeFileSync(join(plansDir, 'README.txt'), 'readme');
+    it("ignores non-matching files", () => {
+      writeFileSync(join(plansDir, "notes.md"), "# Notes");
+      writeFileSync(join(plansDir, "README.txt"), "readme");
       const result = readPlanningArtifacts(testDir);
       expect(result.prdPaths).toHaveLength(0);
       expect(result.testSpecPaths).toHaveLength(0);
     });
 
-    it('returns multiple files sorted descending', () => {
-      writeFileSync(join(plansDir, 'prd-aaa.md'), '# PRD A');
-      writeFileSync(join(plansDir, 'prd-bbb.md'), '# PRD B');
+    it("returns multiple files sorted descending", () => {
+      writeFileSync(join(plansDir, "prd-aaa.md"), "# PRD A");
+      writeFileSync(join(plansDir, "prd-bbb.md"), "# PRD B");
       const result = readPlanningArtifacts(testDir);
       expect(result.prdPaths).toHaveLength(2);
-      // descending order: bbb > aaa
-      expect(result.prdPaths[0]).toContain('prd-bbb.md');
+      expect(result.prdPaths[0]).toContain("prd-bbb.md");
     });
   });
 
-  describe('isPlanningComplete', () => {
-    it('returns false when no PRDs', () => {
-      expect(isPlanningComplete({ prdPaths: [], testSpecPaths: ['spec.md'] })).toBe(false);
+  describe("isPlanningComplete", () => {
+    it("returns false when no PRDs", () => {
+      expect(
+        isPlanningComplete({ prdPaths: [], testSpecPaths: ["spec.md"] }),
+      ).toBe(false);
     });
 
-    it('returns false when no test specs', () => {
-      expect(isPlanningComplete({ prdPaths: ['prd.md'], testSpecPaths: [] })).toBe(false);
+    it("returns false when no test specs", () => {
+      expect(
+        isPlanningComplete({ prdPaths: ["prd.md"], testSpecPaths: [] }),
+      ).toBe(false);
     });
 
-    it('returns true when both present', () => {
-      expect(isPlanningComplete({ prdPaths: ['prd.md'], testSpecPaths: ['spec.md'] })).toBe(true);
-    });
-  });
-
-  describe('readApprovedExecutionLaunchHint', () => {
-    it('returns null when no plans dir', () => {
-      const result = readApprovedExecutionLaunchHint(join(testDir, 'nope'), 'team');
-      expect(result).toBeNull();
-    });
-
-    it('returns null when PRD has no launch command', () => {
-      writeFileSync(join(plansDir, 'prd-feature.md'), '# PRD\n\nNo commands here.');
-      const result = readApprovedExecutionLaunchHint(testDir, 'team');
-      expect(result).toBeNull();
-    });
-
-    it('extracts team launch hint with worker count and agent type', () => {
+    it("returns false when the latest PRD is missing requirement coverage", () => {
       writeFileSync(
-        join(plansDir, 'prd-feature.md'),
-        '# PRD\n\nRun: omc team 3:claude "implement auth"\n'
+        join(plansDir, "prd-feature.md"),
+        ["# PRD", "", "## Acceptance criteria", "- done", ""].join("\n"),
       );
-      const result = readApprovedExecutionLaunchHint(testDir, 'team');
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(false);
+    });
+
+    it("returns false when the latest PRD is missing acceptance criteria", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        ["# PRD", "", "## Requirement coverage map", "- req -> impl", ""].join(
+          "\n",
+        ),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(false);
+    });
+
+    it("returns false when the latest test spec is missing verification mapping", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        ["# Test Spec", "", "## Unit coverage", "- unit", ""].join("\n"),
+      );
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(false);
+    });
+
+    it("returns false when the latest test spec is missing unit coverage", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        ["# Test Spec", "", "## Verification mapping", "- verify", ""].join(
+          "\n",
+        ),
+      );
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(false);
+    });
+
+    it("returns false for whitespace-only sections", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "   ",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(false);
+    });
+
+    it("returns true when both latest artifacts contain required sections", () => {
+      writeValidArtifacts();
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(true);
+    });
+
+    it("uses the latest artifacts when older ones were valid", () => {
+      writeValidArtifacts("prd-aaa.md", "test-spec-aaa.md");
+      writeFileSync(
+        join(plansDir, "prd-zzz.md"),
+        ["# PRD", "", "## Acceptance criteria", "- done", ""].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-zzz.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(false);
+    });
+  });
+
+  describe("readApprovedExecutionLaunchHint", () => {
+    it("returns null when no plans dir", () => {
+      const result = readApprovedExecutionLaunchHint(
+        join(testDir, "nope"),
+        "team",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when PRD has no launch command", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        "# PRD\n\nNo commands here.",
+      );
+      const result = readApprovedExecutionLaunchHint(testDir, "team");
+      expect(result).toBeNull();
+    });
+
+    it("extracts team launch hint with worker count and agent type", () => {
+      writeValidArtifacts();
+      const result = readApprovedExecutionLaunchHint(testDir, "team");
       expect(result).not.toBeNull();
-      expect(result!.mode).toBe('team');
-      expect(result!.task).toBe('implement auth');
+      expect(result!.mode).toBe("team");
+      expect(result!.task).toBe("implement auth");
       expect(result!.workerCount).toBe(3);
-      expect(result!.agentType).toBe('claude');
+      expect(result!.agentType).toBe("claude");
       expect(result!.linkedRalph).toBe(false);
-      expect(result!.sourcePath).toContain('prd-feature.md');
+      expect(result!.sourcePath).toContain("prd-feature.md");
     });
 
-    it('extracts team launch hint without worker spec', () => {
+    it("extracts team launch hint without worker spec", () => {
       writeFileSync(
-        join(plansDir, 'prd-feature.md'),
-        '# PRD\n\nRun: omc team "implement the feature"\n'
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          'Run: omc team "implement the feature"',
+          "",
+        ].join("\n"),
       );
-      const result = readApprovedExecutionLaunchHint(testDir, 'team');
+      const result = readApprovedExecutionLaunchHint(testDir, "team");
       expect(result).not.toBeNull();
-      expect(result!.task).toBe('implement the feature');
+      expect(result!.task).toBe("implement the feature");
       expect(result!.workerCount).toBeUndefined();
       expect(result!.agentType).toBeUndefined();
     });
 
-    it('detects --linked-ralph flag', () => {
+    it("detects --linked-ralph flag", () => {
       writeFileSync(
-        join(plansDir, 'prd-feature.md'),
-        '# PRD\n\nomc team 2:codex "fix the bug" --linked-ralph\n'
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          'omc team 2:codex "fix the bug" --linked-ralph',
+          "",
+        ].join("\n"),
       );
-      const result = readApprovedExecutionLaunchHint(testDir, 'team');
+      const result = readApprovedExecutionLaunchHint(testDir, "team");
       expect(result).not.toBeNull();
       expect(result!.linkedRalph).toBe(true);
     });
 
-    it('extracts ralph launch hint', () => {
+    it("extracts ralph launch hint", () => {
       writeFileSync(
-        join(plansDir, 'prd-feature.md'),
-        '# PRD\n\nomc ralph "do the work"\n'
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          'omc ralph "do the work"',
+          "",
+        ].join("\n"),
       );
-      const result = readApprovedExecutionLaunchHint(testDir, 'ralph');
+      const result = readApprovedExecutionLaunchHint(testDir, "ralph");
       expect(result).not.toBeNull();
-      expect(result!.mode).toBe('ralph');
-      expect(result!.task).toBe('do the work');
+      expect(result!.mode).toBe("ralph");
+      expect(result!.task).toBe("do the work");
     });
 
-    it('returns null for ralph mode when only team command present', () => {
-      writeFileSync(
-        join(plansDir, 'prd-feature.md'),
-        '# PRD\n\nomc team 3:claude "implement auth"\n'
-      );
-      const result = readApprovedExecutionLaunchHint(testDir, 'ralph');
+    it("returns null for ralph mode when only team command present", () => {
+      writeValidArtifacts();
+      const result = readApprovedExecutionLaunchHint(testDir, "ralph");
       expect(result).toBeNull();
     });
 
-    it('uses the latest PRD when multiple exist', () => {
-      writeFileSync(join(plansDir, 'prd-aaa.md'), '# Old PRD\n\nomc team "old task"\n');
-      writeFileSync(join(plansDir, 'prd-zzz.md'), '# New PRD\n\nomc team "new task"\n');
-      const result = readApprovedExecutionLaunchHint(testDir, 'team');
-      expect(result!.task).toBe('new task');
+    it("still parses launch hints even when quality gates fail", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        '# PRD\n\nRun: omc team "new task"\n',
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(false);
+      expect(readApprovedExecutionLaunchHint(testDir, "team")!.task).toBe(
+        "new task",
+      );
     });
   });
 });

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -7,8 +7,8 @@
  * and extracts approved execution launch hints embedded in PRD markdown.
  */
 
-import { readdirSync, readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
 
 export interface PlanningArtifacts {
   prdPaths: string[];
@@ -16,7 +16,7 @@ export interface PlanningArtifacts {
 }
 
 export interface ApprovedExecutionLaunchHint {
-  mode: 'team' | 'ralph';
+  mode: "team" | "ralph";
   command: string;
   task: string;
   workerCount?: number;
@@ -25,12 +25,45 @@ export interface ApprovedExecutionLaunchHint {
   sourcePath: string;
 }
 
+function readFileSafe(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getSectionContent(markdown: string, heading: string): string | null {
+  const headingRe = new RegExp(
+    `^##\\s+${escapeRegex(heading)}[ \\t]*$`,
+    "im",
+  );
+  const headingMatch = headingRe.exec(markdown);
+  if (!headingMatch || headingMatch.index === undefined) return null;
+
+  const bodyStart = headingMatch.index + headingMatch[0].length;
+  const rest = markdown.slice(bodyStart).replace(/^\r?\n/, "");
+  const nextHeadingMatch = /\r?\n##\s+/.exec(rest);
+  const body = (nextHeadingMatch ? rest.slice(0, nextHeadingMatch.index) : rest).trim();
+  return body.length > 0 ? body : null;
+}
+
+function hasRequiredSections(markdown: string, headings: string[]): boolean {
+  return headings.every(
+    (heading) => getSectionContent(markdown, heading) !== null,
+  );
+}
+
 /**
  * Read planning artifacts from .omc/plans/ directory.
  * Returns paths to all PRD and test-spec files found.
  */
 export function readPlanningArtifacts(cwd: string): PlanningArtifacts {
-  const plansDir = join(cwd, '.omc', 'plans');
+  const plansDir = join(cwd, ".omc", "plans");
   if (!existsSync(plansDir)) {
     return { prdPaths: [], testSpecPaths: [] };
   }
@@ -46,9 +79,9 @@ export function readPlanningArtifacts(cwd: string): PlanningArtifacts {
   const testSpecPaths: string[] = [];
 
   for (const entry of entries) {
-    if (entry.startsWith('prd-') && entry.endsWith('.md')) {
+    if (entry.startsWith("prd-") && entry.endsWith(".md")) {
       prdPaths.push(join(plansDir, entry));
-    } else if (entry.startsWith('test-spec-') && entry.endsWith('.md')) {
+    } else if (entry.startsWith("test-spec-") && entry.endsWith(".md")) {
       testSpecPaths.push(join(plansDir, entry));
     }
   }
@@ -61,10 +94,30 @@ export function readPlanningArtifacts(cwd: string): PlanningArtifacts {
 }
 
 /**
- * Returns true when both a PRD and a test spec are present.
+ * Returns true when the latest PRD and latest test spec contain
+ * the required non-empty quality-gate sections.
  */
 export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
-  return artifacts.prdPaths.length > 0 && artifacts.testSpecPaths.length > 0;
+  if (artifacts.prdPaths.length === 0 || artifacts.testSpecPaths.length === 0) {
+    return false;
+  }
+
+  const latestPrd = readFileSafe(artifacts.prdPaths[0]);
+  const latestTestSpec = readFileSafe(artifacts.testSpecPaths[0]);
+  if (!latestPrd || !latestTestSpec) {
+    return false;
+  }
+
+  return (
+    hasRequiredSections(latestPrd, [
+      "Acceptance criteria",
+      "Requirement coverage map",
+    ]) &&
+    hasRequiredSections(latestTestSpec, [
+      "Unit coverage",
+      "Verification mapping",
+    ])
+  );
 }
 
 /**
@@ -77,8 +130,7 @@ export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
  */
 const TEAM_LAUNCH_RE =
   /\bomc\s+team\s+(?:(\d+):(\w+)\s+)?"([^"]+)"((?:\s+--[\w-]+)*)/;
-const RALPH_LAUNCH_RE =
-  /\bomc\s+ralph\s+"([^"]+)"((?:\s+--[\w-]+)*)/;
+const RALPH_LAUNCH_RE = /\bomc\s+ralph\s+"([^"]+)"((?:\s+--[\w-]+)*)/;
 
 function parseFlags(flagStr: string): { linkedRalph: boolean } {
   return {
@@ -92,29 +144,24 @@ function parseFlags(flagStr: string): { linkedRalph: boolean } {
  */
 export function readApprovedExecutionLaunchHint(
   cwd: string,
-  mode: 'team' | 'ralph'
+  mode: "team" | "ralph",
 ): ApprovedExecutionLaunchHint | null {
   const artifacts = readPlanningArtifacts(cwd);
   if (artifacts.prdPaths.length === 0) return null;
 
-  // Use the latest PRD (sorted descending, so index 0 is newest)
   const prdPath = artifacts.prdPaths[0];
-  let content: string;
-  try {
-    content = readFileSync(prdPath, 'utf-8');
-  } catch {
-    return null;
-  }
+  const content = readFileSafe(prdPath);
+  if (!content) return null;
 
-  if (mode === 'team') {
+  if (mode === "team") {
     const match = TEAM_LAUNCH_RE.exec(content);
     if (!match) return null;
 
     const [fullMatch, workerCountStr, agentType, task, flagStr] = match;
-    const { linkedRalph } = parseFlags(flagStr ?? '');
+    const { linkedRalph } = parseFlags(flagStr ?? "");
 
     return {
-      mode: 'team',
+      mode: "team",
       command: fullMatch.trim(),
       task,
       workerCount: workerCountStr ? parseInt(workerCountStr, 10) : undefined,
@@ -124,21 +171,17 @@ export function readApprovedExecutionLaunchHint(
     };
   }
 
-  if (mode === 'ralph') {
-    const match = RALPH_LAUNCH_RE.exec(content);
-    if (!match) return null;
+  const match = RALPH_LAUNCH_RE.exec(content);
+  if (!match) return null;
 
-    const [fullMatch, task, flagStr] = match;
-    const { linkedRalph } = parseFlags(flagStr ?? '');
+  const [fullMatch, task, flagStr] = match;
+  const { linkedRalph } = parseFlags(flagStr ?? "");
 
-    return {
-      mode: 'ralph',
-      command: fullMatch.trim(),
-      task,
-      linkedRalph,
-      sourcePath: prdPath,
-    };
-  }
-
-  return null;
+  return {
+    mode: "ralph",
+    command: fullMatch.trim(),
+    task,
+    linkedRalph,
+    sourcePath: prdPath,
+  };
 }

--- a/src/ralphthon/__tests__/cli.test.ts
+++ b/src/ralphthon/__tests__/cli.test.ts
@@ -1,76 +1,131 @@
 /**
- * Tests for Ralphthon CLI Argument Parsing
+ * Tests for Ralphthon CLI helpers and argument parsing
  */
 
-import { describe, it, expect } from 'vitest';
-import { parseRalphthonArgs } from '../../cli/commands/ralphthon.js';
-import { RALPHTHON_DEFAULTS } from '../types.js';
+import { describe, it, expect } from "vitest";
+import {
+  parseRalphthonArgs,
+  buildRalphthonInterviewPrompt,
+  buildDefaultSkipInterviewPrdParams,
+  buildRalphthonPlanningContext,
+} from "../../cli/commands/ralphthon.js";
+import { RALPHTHON_DEFAULTS } from "../types.js";
 
-describe('Ralphthon CLI', () => {
-  describe('parseRalphthonArgs', () => {
-    it('should parse empty args with defaults', () => {
+describe("Ralphthon CLI", () => {
+  describe("parseRalphthonArgs", () => {
+    it("should parse empty args with defaults", () => {
       const options = parseRalphthonArgs([]);
       expect(options.resume).toBe(false);
       expect(options.skipInterview).toBe(false);
       expect(options.maxWaves).toBe(RALPHTHON_DEFAULTS.maxWaves);
-      expect(options.pollInterval).toBe(RALPHTHON_DEFAULTS.pollIntervalMs / 1000);
+      expect(options.pollInterval).toBe(
+        RALPHTHON_DEFAULTS.pollIntervalMs / 1000,
+      );
       expect(options.task).toBeUndefined();
     });
 
-    it('should parse task description', () => {
-      const options = parseRalphthonArgs(['Build', 'a', 'REST', 'API']);
-      expect(options.task).toBe('Build a REST API');
+    it("should parse task description", () => {
+      const options = parseRalphthonArgs(["Build", "a", "REST", "API"]);
+      expect(options.task).toBe("Build a REST API");
     });
 
-    it('should parse --resume flag', () => {
-      const options = parseRalphthonArgs(['--resume']);
+    it("should parse --resume flag", () => {
+      const options = parseRalphthonArgs(["--resume"]);
       expect(options.resume).toBe(true);
     });
 
-    it('should parse --skip-interview flag', () => {
-      const options = parseRalphthonArgs(['--skip-interview', 'my task']);
+    it("should parse --skip-interview flag", () => {
+      const options = parseRalphthonArgs(["--skip-interview", "my task"]);
       expect(options.skipInterview).toBe(true);
-      expect(options.task).toBe('my task');
+      expect(options.task).toBe("my task");
     });
 
-    it('should parse --max-waves option', () => {
-      const options = parseRalphthonArgs(['--max-waves', '5', 'my task']);
+    it("should parse --max-waves option", () => {
+      const options = parseRalphthonArgs(["--max-waves", "5", "my task"]);
       expect(options.maxWaves).toBe(5);
-      expect(options.task).toBe('my task');
+      expect(options.task).toBe("my task");
     });
 
-    it('should parse --poll-interval option', () => {
-      const options = parseRalphthonArgs(['--poll-interval', '60', 'my task']);
+    it("should parse --poll-interval option", () => {
+      const options = parseRalphthonArgs(["--poll-interval", "60", "my task"]);
       expect(options.pollInterval).toBe(60);
     });
 
-    it('should handle combined options', () => {
+    it("should handle combined options", () => {
       const options = parseRalphthonArgs([
-        '--skip-interview',
-        '--max-waves', '3',
-        '--poll-interval', '30',
-        'Build auth system',
+        "--skip-interview",
+        "--max-waves",
+        "3",
+        "--poll-interval",
+        "30",
+        "Build auth system",
       ]);
 
       expect(options.skipInterview).toBe(true);
       expect(options.maxWaves).toBe(3);
       expect(options.pollInterval).toBe(30);
-      expect(options.task).toBe('Build auth system');
+      expect(options.task).toBe("Build auth system");
     });
 
-    it('should ignore invalid --max-waves values', () => {
-      const options = parseRalphthonArgs(['--max-waves', 'abc', 'task']);
+    it("should ignore invalid --max-waves values", () => {
+      const options = parseRalphthonArgs(["--max-waves", "abc", "task"]);
       expect(options.maxWaves).toBe(RALPHTHON_DEFAULTS.maxWaves);
     });
 
-    it('should ignore negative --poll-interval values', () => {
-      const options = parseRalphthonArgs(['--poll-interval', '-5', 'task']);
-      expect(options.pollInterval).toBe(RALPHTHON_DEFAULTS.pollIntervalMs / 1000);
+    it("should ignore negative --poll-interval values", () => {
+      const options = parseRalphthonArgs(["--poll-interval", "-5", "task"]);
+      expect(options.pollInterval).toBe(
+        RALPHTHON_DEFAULTS.pollIntervalMs / 1000,
+      );
     });
 
-    it('should ignore unknown flags', () => {
-      const options = parseRalphthonArgs(['--unknown', 'my task']);
-      expect(options.task).toBe('my task');
+    it("should ignore unknown flags", () => {
+      const options = parseRalphthonArgs(["--unknown", "my task"]);
+      expect(options.task).toBe("my task");
+    });
+  });
+
+  describe("planning helpers", () => {
+    it("builds explicit brownfield planning context", () => {
+      expect(buildRalphthonPlanningContext("Improve planning")).toEqual({
+        brownfield: true,
+        assumptionsMode: "explicit",
+        codebaseMapSummary: "Brownfield target: Improve planning",
+        knownConstraints: [
+          "Prefer repository evidence over assumptions",
+          "Capture brownfield/codebase-map findings explicitly before execution",
+        ],
+      });
+    });
+
+    it("builds interview prompt with explicit planning context contract", () => {
+      const prompt = buildRalphthonInterviewPrompt("Improve planning", {
+        resume: false,
+        skipInterview: false,
+        maxWaves: 4,
+        pollInterval: 45,
+        task: "Improve planning",
+      });
+
+      expect(prompt).toContain("/deep-interview Improve planning");
+      expect(prompt).toContain('"planningContext"');
+      expect(prompt).toContain('"assumptionsMode": "explicit"');
+      expect(prompt).toContain('"codebaseMapSummary"');
+      expect(prompt).toContain("Treat this as brownfield planning");
+    });
+
+    it("builds skip-interview defaults with normalized planning context", () => {
+      const prd = buildDefaultSkipInterviewPrdParams(
+        "Implement auth middleware",
+      );
+      expect(prd.project).toBe("ralphthon");
+      expect(prd.branchName).toBe("feat/ralphthon");
+      expect(prd.stories).toHaveLength(1);
+      expect(prd.planningContext.assumptionsMode).toBe("explicit");
+      expect(prd.planningContext.brownfield).toBe(true);
+      expect(prd.planningContext.codebaseMapSummary).toContain(
+        "Implement auth middleware",
+      );
     });
   });
 });

--- a/src/ralphthon/__tests__/prd.test.ts
+++ b/src/ralphthon/__tests__/prd.test.ts
@@ -2,10 +2,10 @@
  * Tests for Ralphthon PRD Module
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import {
   readRalphthonPrd,
   writeRalphthonPrd,
@@ -20,21 +20,18 @@ import {
   formatTaskPrompt,
   formatHardeningTaskPrompt,
   formatRalphthonStatus,
-} from '../prd.js';
-import type {
-  RalphthonPRD,
-  RalphthonStory,
+} from "../prd.js";
+import type { RalphthonPRD, RalphthonStory } from "../types.js";
+import { RALPHTHON_DEFAULTS } from "../types.js";
+import { DEFAULT_PLANNING_CONTEXT } from "../prd.js";
 
-} from '../types.js';
-import { RALPHTHON_DEFAULTS } from '../types.js';
-
-describe('Ralphthon PRD', () => {
+describe("Ralphthon PRD", () => {
   let testDir: string;
 
   beforeEach(() => {
-    testDir = mkdtempSync(join(tmpdir(), 'ralphthon-prd-test-'));
+    testDir = mkdtempSync(join(tmpdir(), "ralphthon-prd-test-"));
     // Create .omc directory for PRD storage
-    mkdirSync(join(testDir, '.omc'), { recursive: true });
+    mkdirSync(join(testDir, ".omc"), { recursive: true });
   });
 
   afterEach(() => {
@@ -45,49 +42,67 @@ describe('Ralphthon PRD', () => {
   // Read/Write Operations
   // ============================================================================
 
-  describe('readRalphthonPrd', () => {
-    it('should return null when no PRD exists', () => {
+  describe("readRalphthonPrd", () => {
+    it("should return null when no PRD exists", () => {
       expect(readRalphthonPrd(testDir)).toBeNull();
     });
 
-    it('should read a valid PRD from .omc directory', () => {
+    it("should read a valid PRD from .omc directory", () => {
       const prd = createTestPrd();
       writeRalphthonPrd(testDir, prd);
 
       const result = readRalphthonPrd(testDir);
       expect(result).not.toBeNull();
-      expect(result!.project).toBe('test-project');
+      expect(result!.project).toBe("test-project");
       expect(result!.stories).toHaveLength(2);
     });
 
-    it('should return null for invalid JSON', () => {
-      const { writeFileSync } = require('fs');
-      writeFileSync(join(testDir, '.omc', 'ralphthon-prd.json'), 'invalid json');
+    it("should return null for invalid JSON", () => {
+      const { writeFileSync } = require("fs");
+      writeFileSync(
+        join(testDir, ".omc", "ralphthon-prd.json"),
+        "invalid json",
+      );
       expect(readRalphthonPrd(testDir)).toBeNull();
     });
 
-    it('should return null for PRD without stories array', () => {
-      const { writeFileSync } = require('fs');
+    it("should return null for PRD without stories array", () => {
+      const { writeFileSync } = require("fs");
       writeFileSync(
-        join(testDir, '.omc', 'ralphthon-prd.json'),
-        JSON.stringify({ project: 'x', config: {} }),
+        join(testDir, ".omc", "ralphthon-prd.json"),
+        JSON.stringify({ project: "x", config: {} }),
       );
       expect(readRalphthonPrd(testDir)).toBeNull();
     });
   });
 
-  describe('writeRalphthonPrd', () => {
-    it('should write PRD to .omc directory', () => {
+  describe("planningContext normalization", () => {
+    it("should normalize missing planning context on read", () => {
+      const { writeFileSync } = require("fs");
+      const legacy = createTestPrd();
+      delete legacy.planningContext;
+      writeFileSync(
+        join(testDir, ".omc", "ralphthon-prd.json"),
+        JSON.stringify(legacy),
+      );
+
+      const result = readRalphthonPrd(testDir)!;
+      expect(result.planningContext).toEqual(DEFAULT_PLANNING_CONTEXT);
+    });
+  });
+
+  describe("writeRalphthonPrd", () => {
+    it("should write PRD to .omc directory", () => {
       const prd = createTestPrd();
       expect(writeRalphthonPrd(testDir, prd)).toBe(true);
 
       const result = readRalphthonPrd(testDir);
       expect(result).not.toBeNull();
-      expect(result!.project).toBe('test-project');
+      expect(result!.project).toBe("test-project");
     });
 
-    it('should create .omc directory if missing', () => {
-      rmSync(join(testDir, '.omc'), { recursive: true, force: true });
+    it("should create .omc directory if missing", () => {
+      rmSync(join(testDir, ".omc"), { recursive: true, force: true });
       const prd = createTestPrd();
       expect(writeRalphthonPrd(testDir, prd)).toBe(true);
     });
@@ -97,8 +112,8 @@ describe('Ralphthon PRD', () => {
   // Status Computation
   // ============================================================================
 
-  describe('getRalphthonPrdStatus', () => {
-    it('should compute correct status for fresh PRD', () => {
+  describe("getRalphthonPrdStatus", () => {
+    it("should compute correct status for fresh PRD", () => {
       const prd = createTestPrd();
       const status = getRalphthonPrdStatus(prd);
 
@@ -109,14 +124,14 @@ describe('Ralphthon PRD', () => {
       expect(status.pendingTasks).toBe(3);
       expect(status.allStoriesDone).toBe(false);
       expect(status.nextTask).not.toBeNull();
-      expect(status.nextTask!.task.id).toBe('T-001');
+      expect(status.nextTask!.task.id).toBe("T-001");
     });
 
-    it('should detect all stories done', () => {
+    it("should detect all stories done", () => {
       const prd = createTestPrd();
-      prd.stories[0].tasks[0].status = 'done';
-      prd.stories[0].tasks[1].status = 'done';
-      prd.stories[1].tasks[0].status = 'done';
+      prd.stories[0].tasks[0].status = "done";
+      prd.stories[0].tasks[1].status = "done";
+      prd.stories[1].tasks[0].status = "done";
 
       const status = getRalphthonPrdStatus(prd);
       expect(status.allStoriesDone).toBe(true);
@@ -124,30 +139,46 @@ describe('Ralphthon PRD', () => {
       expect(status.nextTask).toBeNull();
     });
 
-    it('should count skipped tasks as story completion', () => {
+    it("should count skipped tasks as story completion", () => {
       const prd = createTestPrd();
-      prd.stories[0].tasks[0].status = 'done';
-      prd.stories[0].tasks[1].status = 'skipped';
+      prd.stories[0].tasks[0].status = "done";
+      prd.stories[0].tasks[1].status = "skipped";
 
       const status = getRalphthonPrdStatus(prd);
       expect(status.completedStories).toBe(1); // story 0 complete (done+skipped)
     });
 
-    it('should find next task by story priority', () => {
+    it("should find next task by story priority", () => {
       const prd = createTestPrd();
       // story[0] has priority 'high', story[1] has 'medium'
-      prd.stories[0].tasks[0].status = 'done';
-      prd.stories[0].tasks[1].status = 'done';
+      prd.stories[0].tasks[0].status = "done";
+      prd.stories[0].tasks[1].status = "done";
 
       const status = getRalphthonPrdStatus(prd);
-      expect(status.nextTask!.storyId).toBe('US-002');
+      expect(status.nextTask!.storyId).toBe("US-002");
     });
 
-    it('should report hardening status', () => {
+    it("should report hardening status", () => {
       const prd = createTestPrd();
       prd.hardening = [
-        { id: 'H-01-001', title: 'Test edge case', description: 'test', category: 'edge_case', status: 'done', wave: 1, retries: 0 },
-        { id: 'H-01-002', title: 'Add test', description: 'test', category: 'test', status: 'pending', wave: 1, retries: 0 },
+        {
+          id: "H-01-001",
+          title: "Test edge case",
+          description: "test",
+          category: "edge_case",
+          status: "done",
+          wave: 1,
+          retries: 0,
+        },
+        {
+          id: "H-01-002",
+          title: "Add test",
+          description: "test",
+          category: "test",
+          status: "pending",
+          wave: 1,
+          retries: 0,
+        },
       ];
 
       const status = getRalphthonPrdStatus(prd);
@@ -155,7 +186,7 @@ describe('Ralphthon PRD', () => {
       expect(status.completedHardeningTasks).toBe(1);
       expect(status.pendingHardeningTasks).toBe(1);
       expect(status.allHardeningDone).toBe(false);
-      expect(status.nextHardeningTask!.id).toBe('H-01-002');
+      expect(status.nextHardeningTask!.id).toBe("H-01-002");
     });
   });
 
@@ -163,54 +194,56 @@ describe('Ralphthon PRD', () => {
   // Task Operations
   // ============================================================================
 
-  describe('updateTaskStatus', () => {
-    it('should update a task status', () => {
+  describe("updateTaskStatus", () => {
+    it("should update a task status", () => {
       const prd = createTestPrd();
       writeRalphthonPrd(testDir, prd);
 
-      expect(updateTaskStatus(testDir, 'US-001', 'T-001', 'done', 'Implemented')).toBe(true);
+      expect(
+        updateTaskStatus(testDir, "US-001", "T-001", "done", "Implemented"),
+      ).toBe(true);
 
       const updated = readRalphthonPrd(testDir)!;
-      expect(updated.stories[0].tasks[0].status).toBe('done');
-      expect(updated.stories[0].tasks[0].notes).toBe('Implemented');
+      expect(updated.stories[0].tasks[0].status).toBe("done");
+      expect(updated.stories[0].tasks[0].notes).toBe("Implemented");
     });
 
-    it('should return false for non-existent story', () => {
+    it("should return false for non-existent story", () => {
       const prd = createTestPrd();
       writeRalphthonPrd(testDir, prd);
 
-      expect(updateTaskStatus(testDir, 'US-999', 'T-001', 'done')).toBe(false);
+      expect(updateTaskStatus(testDir, "US-999", "T-001", "done")).toBe(false);
     });
 
-    it('should return false for non-existent task', () => {
+    it("should return false for non-existent task", () => {
       const prd = createTestPrd();
       writeRalphthonPrd(testDir, prd);
 
-      expect(updateTaskStatus(testDir, 'US-001', 'T-999', 'done')).toBe(false);
+      expect(updateTaskStatus(testDir, "US-001", "T-999", "done")).toBe(false);
     });
   });
 
-  describe('incrementTaskRetry', () => {
-    it('should increment retry count', () => {
+  describe("incrementTaskRetry", () => {
+    it("should increment retry count", () => {
       const prd = createTestPrd();
       writeRalphthonPrd(testDir, prd);
 
-      const result = incrementTaskRetry(testDir, 'US-001', 'T-001', 3);
+      const result = incrementTaskRetry(testDir, "US-001", "T-001", 3);
       expect(result.retries).toBe(1);
       expect(result.skipped).toBe(false);
     });
 
-    it('should skip task after max retries', () => {
+    it("should skip task after max retries", () => {
       const prd = createTestPrd();
       prd.stories[0].tasks[0].retries = 2;
       writeRalphthonPrd(testDir, prd);
 
-      const result = incrementTaskRetry(testDir, 'US-001', 'T-001', 3);
+      const result = incrementTaskRetry(testDir, "US-001", "T-001", 3);
       expect(result.retries).toBe(3);
       expect(result.skipped).toBe(true);
 
       const updated = readRalphthonPrd(testDir)!;
-      expect(updated.stories[0].tasks[0].status).toBe('skipped');
+      expect(updated.stories[0].tasks[0].status).toBe("skipped");
     });
   });
 
@@ -218,33 +251,59 @@ describe('Ralphthon PRD', () => {
   // Hardening Operations
   // ============================================================================
 
-  describe('addHardeningTasks', () => {
-    it('should add hardening tasks to PRD', () => {
+  describe("addHardeningTasks", () => {
+    it("should add hardening tasks to PRD", () => {
       const prd = createTestPrd();
       writeRalphthonPrd(testDir, prd);
 
       const tasks = [
-        { id: 'H-01-001', title: 'Edge case test', description: 'Test edge case', category: 'edge_case' as const, wave: 1 },
-        { id: 'H-01-002', title: 'Add validation', description: 'Validate inputs', category: 'quality' as const, wave: 1 },
+        {
+          id: "H-01-001",
+          title: "Edge case test",
+          description: "Test edge case",
+          category: "edge_case" as const,
+          wave: 1,
+        },
+        {
+          id: "H-01-002",
+          title: "Add validation",
+          description: "Validate inputs",
+          category: "quality" as const,
+          wave: 1,
+        },
       ];
 
       expect(addHardeningTasks(testDir, tasks)).toBe(true);
 
       const updated = readRalphthonPrd(testDir)!;
       expect(updated.hardening).toHaveLength(2);
-      expect(updated.hardening[0].status).toBe('pending');
+      expect(updated.hardening[0].status).toBe("pending");
       expect(updated.hardening[0].retries).toBe(0);
     });
 
-    it('should append to existing hardening tasks', () => {
+    it("should append to existing hardening tasks", () => {
       const prd = createTestPrd();
       prd.hardening = [
-        { id: 'H-01-001', title: 'Existing', description: 'existing', category: 'test', status: 'done', wave: 1, retries: 0 },
+        {
+          id: "H-01-001",
+          title: "Existing",
+          description: "existing",
+          category: "test",
+          status: "done",
+          wave: 1,
+          retries: 0,
+        },
       ];
       writeRalphthonPrd(testDir, prd);
 
       addHardeningTasks(testDir, [
-        { id: 'H-02-001', title: 'New', description: 'new', category: 'quality' as const, wave: 2 },
+        {
+          id: "H-02-001",
+          title: "New",
+          description: "new",
+          category: "quality" as const,
+          wave: 2,
+        },
       ]);
 
       const updated = readRalphthonPrd(testDir)!;
@@ -252,30 +311,48 @@ describe('Ralphthon PRD', () => {
     });
   });
 
-  describe('updateHardeningTaskStatus', () => {
-    it('should update hardening task status', () => {
+  describe("updateHardeningTaskStatus", () => {
+    it("should update hardening task status", () => {
       const prd = createTestPrd();
       prd.hardening = [
-        { id: 'H-01-001', title: 'Test', description: 'test', category: 'test', status: 'pending', wave: 1, retries: 0 },
+        {
+          id: "H-01-001",
+          title: "Test",
+          description: "test",
+          category: "test",
+          status: "pending",
+          wave: 1,
+          retries: 0,
+        },
       ];
       writeRalphthonPrd(testDir, prd);
 
-      expect(updateHardeningTaskStatus(testDir, 'H-01-001', 'done', 'Fixed')).toBe(true);
+      expect(
+        updateHardeningTaskStatus(testDir, "H-01-001", "done", "Fixed"),
+      ).toBe(true);
 
       const updated = readRalphthonPrd(testDir)!;
-      expect(updated.hardening[0].status).toBe('done');
+      expect(updated.hardening[0].status).toBe("done");
     });
   });
 
-  describe('incrementHardeningTaskRetry', () => {
-    it('should skip hardening task after max retries', () => {
+  describe("incrementHardeningTaskRetry", () => {
+    it("should skip hardening task after max retries", () => {
       const prd = createTestPrd();
       prd.hardening = [
-        { id: 'H-01-001', title: 'Test', description: 'test', category: 'test', status: 'pending', wave: 1, retries: 2 },
+        {
+          id: "H-01-001",
+          title: "Test",
+          description: "test",
+          category: "test",
+          status: "pending",
+          wave: 1,
+          retries: 2,
+        },
       ];
       writeRalphthonPrd(testDir, prd);
 
-      const result = incrementHardeningTaskRetry(testDir, 'H-01-001', 3);
+      const result = incrementHardeningTaskRetry(testDir, "H-01-001", 3);
       expect(result.skipped).toBe(true);
     });
   });
@@ -284,45 +361,87 @@ describe('Ralphthon PRD', () => {
   // PRD Creation
   // ============================================================================
 
-  describe('createRalphthonPrd', () => {
-    it('should create PRD with default config', () => {
-      const stories: RalphthonStory[] = [{
-        id: 'US-001',
-        title: 'Test',
-        description: 'test',
-        acceptanceCriteria: ['works'],
-        priority: 'high',
-        tasks: [{ id: 'T-001', title: 'Do it', description: 'do', status: 'pending', retries: 0 }],
-      }];
+  describe("createRalphthonPrd", () => {
+    it("should create PRD with default config", () => {
+      const stories: RalphthonStory[] = [
+        {
+          id: "US-001",
+          title: "Test",
+          description: "test",
+          acceptanceCriteria: ["works"],
+          priority: "high",
+          tasks: [
+            {
+              id: "T-001",
+              title: "Do it",
+              description: "do",
+              status: "pending",
+              retries: 0,
+            },
+          ],
+        },
+      ];
 
-      const prd = createRalphthonPrd('proj', 'main', 'desc', stories);
+      const prd = createRalphthonPrd("proj", "main", "desc", stories);
       expect(prd.config.maxWaves).toBe(RALPHTHON_DEFAULTS.maxWaves);
       expect(prd.hardening).toEqual([]);
+      expect(prd.planningContext).toEqual(DEFAULT_PLANNING_CONTEXT);
     });
 
-    it('should merge custom config', () => {
-      const prd = createRalphthonPrd('proj', 'main', 'desc', [], { maxWaves: 5 });
+    it("should merge custom config", () => {
+      const prd = createRalphthonPrd(
+        "proj",
+        "main",
+        "desc",
+        [],
+        { maxWaves: 5 },
+        {
+          brownfield: true,
+          assumptionsMode: "explicit",
+          codebaseMapSummary: "src/",
+          knownConstraints: ["legacy"],
+        },
+      );
       expect(prd.config.maxWaves).toBe(5);
       expect(prd.config.maxRetries).toBe(RALPHTHON_DEFAULTS.maxRetries);
+      expect(prd.planningContext).toEqual({
+        brownfield: true,
+        assumptionsMode: "explicit",
+        codebaseMapSummary: "src/",
+        knownConstraints: ["legacy"],
+      });
     });
   });
 
-  describe('initRalphthonPrd', () => {
-    it('should initialize PRD on disk', () => {
-      const stories: RalphthonStory[] = [{
-        id: 'US-001',
-        title: 'Test',
-        description: 'test',
-        acceptanceCriteria: ['works'],
-        priority: 'high',
-        tasks: [{ id: 'T-001', title: 'Do it', description: 'do', status: 'pending', retries: 0 }],
-      }];
+  describe("initRalphthonPrd", () => {
+    it("should initialize PRD on disk", () => {
+      const stories: RalphthonStory[] = [
+        {
+          id: "US-001",
+          title: "Test",
+          description: "test",
+          acceptanceCriteria: ["works"],
+          priority: "high",
+          tasks: [
+            {
+              id: "T-001",
+              title: "Do it",
+              description: "do",
+              status: "pending",
+              retries: 0,
+            },
+          ],
+        },
+      ];
 
-      expect(initRalphthonPrd(testDir, 'proj', 'main', 'desc', stories)).toBe(true);
+      expect(initRalphthonPrd(testDir, "proj", "main", "desc", stories)).toBe(
+        true,
+      );
 
       const prd = readRalphthonPrd(testDir);
       expect(prd).not.toBeNull();
       expect(prd!.stories).toHaveLength(1);
+      expect(prd!.planningContext).toEqual(DEFAULT_PLANNING_CONTEXT);
     });
   });
 
@@ -330,49 +449,49 @@ describe('Ralphthon PRD', () => {
   // Formatting
   // ============================================================================
 
-  describe('formatTaskPrompt', () => {
-    it('should format task prompt for injection', () => {
-      const prompt = formatTaskPrompt('US-001', {
-        id: 'T-001',
-        title: 'Build API',
-        description: 'Build REST API endpoints',
-        status: 'pending',
+  describe("formatTaskPrompt", () => {
+    it("should format task prompt for injection", () => {
+      const prompt = formatTaskPrompt("US-001", {
+        id: "T-001",
+        title: "Build API",
+        description: "Build REST API endpoints",
+        status: "pending",
         retries: 0,
       });
 
-      expect(prompt).toContain('T-001');
-      expect(prompt).toContain('US-001');
-      expect(prompt).toContain('Build API');
-      expect(prompt).toContain('Build REST API endpoints');
+      expect(prompt).toContain("T-001");
+      expect(prompt).toContain("US-001");
+      expect(prompt).toContain("Build API");
+      expect(prompt).toContain("Build REST API endpoints");
     });
   });
 
-  describe('formatHardeningTaskPrompt', () => {
-    it('should format hardening task prompt', () => {
+  describe("formatHardeningTaskPrompt", () => {
+    it("should format hardening task prompt", () => {
       const prompt = formatHardeningTaskPrompt({
-        id: 'H-01-001',
-        title: 'Test null case',
-        description: 'Test what happens with null input',
-        category: 'edge_case',
-        status: 'pending',
+        id: "H-01-001",
+        title: "Test null case",
+        description: "Test what happens with null input",
+        category: "edge_case",
+        status: "pending",
         wave: 1,
         retries: 0,
       });
 
-      expect(prompt).toContain('HARDENING');
-      expect(prompt).toContain('EDGE_CASE');
-      expect(prompt).toContain('H-01-001');
+      expect(prompt).toContain("HARDENING");
+      expect(prompt).toContain("EDGE_CASE");
+      expect(prompt).toContain("H-01-001");
     });
   });
 
-  describe('formatRalphthonStatus', () => {
-    it('should format status summary', () => {
+  describe("formatRalphthonStatus", () => {
+    it("should format status summary", () => {
       const prd = createTestPrd();
       const status = formatRalphthonStatus(prd);
 
-      expect(status).toContain('test-project');
-      expect(status).toContain('0/2 complete');
-      expect(status).toContain('0/3 done');
+      expect(status).toContain("test-project");
+      expect(status).toContain("0/2 complete");
+      expect(status).toContain("0/3 done");
     });
   });
 });
@@ -383,33 +502,57 @@ describe('Ralphthon PRD', () => {
 
 function createTestPrd(): RalphthonPRD {
   return {
-    project: 'test-project',
-    branchName: 'feat/test',
-    description: 'Test project',
+    project: "test-project",
+    branchName: "feat/test",
+    description: "Test project",
     stories: [
       {
-        id: 'US-001',
-        title: 'First story',
-        description: 'Implement feature A',
-        acceptanceCriteria: ['It works', 'Tests pass'],
-        priority: 'high',
+        id: "US-001",
+        title: "First story",
+        description: "Implement feature A",
+        acceptanceCriteria: ["It works", "Tests pass"],
+        priority: "high",
         tasks: [
-          { id: 'T-001', title: 'Build A', description: 'Build feature A', status: 'pending', retries: 0 },
-          { id: 'T-002', title: 'Test A', description: 'Test feature A', status: 'pending', retries: 0 },
+          {
+            id: "T-001",
+            title: "Build A",
+            description: "Build feature A",
+            status: "pending",
+            retries: 0,
+          },
+          {
+            id: "T-002",
+            title: "Test A",
+            description: "Test feature A",
+            status: "pending",
+            retries: 0,
+          },
         ],
       },
       {
-        id: 'US-002',
-        title: 'Second story',
-        description: 'Implement feature B',
-        acceptanceCriteria: ['It works'],
-        priority: 'medium',
+        id: "US-002",
+        title: "Second story",
+        description: "Implement feature B",
+        acceptanceCriteria: ["It works"],
+        priority: "medium",
         tasks: [
-          { id: 'T-003', title: 'Build B', description: 'Build feature B', status: 'pending', retries: 0 },
+          {
+            id: "T-003",
+            title: "Build B",
+            description: "Build feature B",
+            status: "pending",
+            retries: 0,
+          },
         ],
       },
     ],
     hardening: [],
     config: { ...RALPHTHON_DEFAULTS },
+    planningContext: {
+      brownfield: true,
+      assumptionsMode: "explicit",
+      codebaseMapSummary: "src/ and planning paths",
+      knownConstraints: ["keep diffs small"],
+    },
   };
 }

--- a/src/ralphthon/index.ts
+++ b/src/ralphthon/index.ts
@@ -14,14 +14,15 @@ export type {
   RalphthonStory,
   HardeningTask,
   RalphthonConfig,
+  RalphthonPlanningContext,
   RalphthonPRD,
   RalphthonState,
   OrchestratorEvent,
   OrchestratorEventHandler,
   RalphthonCliOptions,
-} from './types.js';
+} from "./types.js";
 
-export { RALPHTHON_DEFAULTS, PRD_FILENAME } from './types.js';
+export { RALPHTHON_DEFAULTS, PRD_FILENAME } from "./types.js";
 
 // PRD operations
 export {
@@ -37,13 +38,15 @@ export {
   addHardeningTasks,
   createRalphthonPrd,
   initRalphthonPrd,
+  normalizePlanningContext,
+  DEFAULT_PLANNING_CONTEXT,
   formatTaskPrompt,
   formatHardeningTaskPrompt,
   formatHardeningGenerationPrompt,
   formatRalphthonStatus,
-} from './prd.js';
+} from "./prd.js";
 
-export type { RalphthonPrdStatus } from './prd.js';
+export type { RalphthonPrdStatus } from "./prd.js";
 
 // Orchestrator
 export {
@@ -65,4 +68,4 @@ export {
   recordTaskSkip,
   orchestratorTick,
   startOrchestratorLoop,
-} from './orchestrator.js';
+} from "./orchestrator.js";

--- a/src/ralphthon/prd.ts
+++ b/src/ralphthon/prd.ts
@@ -5,9 +5,9 @@
  * Handles read/write/status operations for ralphthon-prd.json.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
-import { getOmcRoot } from '../lib/worktree-paths.js';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { getOmcRoot } from "../lib/worktree-paths.js";
 import {
   type RalphthonPRD,
   type RalphthonStory,
@@ -15,13 +15,37 @@ import {
   type HardeningTask,
   type RalphthonConfig,
   type TaskStatus,
+  type RalphthonPlanningContext,
   PRD_FILENAME,
   RALPHTHON_DEFAULTS,
-} from './types.js';
+} from "./types.js";
 
 // ============================================================================
 // File Operations
 // ============================================================================
+
+export const DEFAULT_PLANNING_CONTEXT: RalphthonPlanningContext = {
+  brownfield: false,
+  assumptionsMode: "implicit",
+  codebaseMapSummary: "",
+  knownConstraints: [],
+};
+
+export function normalizePlanningContext(
+  context?: Partial<RalphthonPlanningContext> | null,
+): RalphthonPlanningContext {
+  return {
+    brownfield: context?.brownfield ?? DEFAULT_PLANNING_CONTEXT.brownfield,
+    assumptionsMode:
+      context?.assumptionsMode ?? DEFAULT_PLANNING_CONTEXT.assumptionsMode,
+    codebaseMapSummary:
+      context?.codebaseMapSummary ??
+      DEFAULT_PLANNING_CONTEXT.codebaseMapSummary,
+    knownConstraints: Array.isArray(context?.knownConstraints)
+      ? [...context!.knownConstraints]
+      : [...DEFAULT_PLANNING_CONTEXT.knownConstraints],
+  };
+}
 
 /**
  * Get the path to the ralphthon PRD file in .omc
@@ -51,11 +75,13 @@ export function readRalphthonPrd(directory: string): RalphthonPRD | null {
   if (!prdPath) return null;
 
   try {
-    const content = readFileSync(prdPath, 'utf-8');
+    const content = readFileSync(prdPath, "utf-8");
     const prd = JSON.parse(content) as RalphthonPRD;
 
     if (!prd.stories || !Array.isArray(prd.stories)) return null;
     if (!prd.config) return null;
+
+    prd.planningContext = normalizePlanningContext(prd.planningContext);
 
     return prd;
   } catch {
@@ -66,7 +92,10 @@ export function readRalphthonPrd(directory: string): RalphthonPRD | null {
 /**
  * Write ralphthon PRD to disk
  */
-export function writeRalphthonPrd(directory: string, prd: RalphthonPRD): boolean {
+export function writeRalphthonPrd(
+  directory: string,
+  prd: RalphthonPRD,
+): boolean {
   let prdPath = findRalphthonPrdPath(directory);
 
   if (!prdPath) {
@@ -82,7 +111,11 @@ export function writeRalphthonPrd(directory: string, prd: RalphthonPRD): boolean
   }
 
   try {
-    writeFileSync(prdPath, JSON.stringify(prd, null, 2));
+    const normalizedPrd: RalphthonPRD = {
+      ...prd,
+      planningContext: normalizePlanningContext(prd.planningContext),
+    };
+    writeFileSync(prdPath, JSON.stringify(normalizedPrd, null, 2));
     return true;
   } catch {
     return false;
@@ -135,28 +168,37 @@ export function getRalphthonPrdStatus(prd: RalphthonPRD): RalphthonPrdStatus {
       allTasks.push({ storyId: story.id, task });
     }
 
-    const allDone = storyTasks.length > 0 &&
-      storyTasks.every(t => t.status === 'done' || t.status === 'skipped');
+    const allDone =
+      storyTasks.length > 0 &&
+      storyTasks.every((t) => t.status === "done" || t.status === "skipped");
     if (allDone) completedStories++;
   }
 
-  const completedTasks = allTasks.filter(t => t.task.status === 'done').length;
-  const pendingTasks = allTasks.filter(t =>
-    t.task.status === 'pending' || t.task.status === 'in_progress'
+  const completedTasks = allTasks.filter(
+    (t) => t.task.status === "done",
   ).length;
-  const failedOrSkippedTasks = allTasks.filter(t =>
-    t.task.status === 'failed' || t.task.status === 'skipped'
+  const pendingTasks = allTasks.filter(
+    (t) => t.task.status === "pending" || t.task.status === "in_progress",
+  ).length;
+  const failedOrSkippedTasks = allTasks.filter(
+    (t) => t.task.status === "failed" || t.task.status === "skipped",
   ).length;
 
   // Find next pending task (by story priority order)
-  const priorityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+  const priorityOrder: Record<string, number> = {
+    critical: 0,
+    high: 1,
+    medium: 2,
+    low: 3,
+  };
   const sortedStories = [...prd.stories].sort(
-    (a, b) => (priorityOrder[a.priority] ?? 3) - (priorityOrder[b.priority] ?? 3)
+    (a, b) =>
+      (priorityOrder[a.priority] ?? 3) - (priorityOrder[b.priority] ?? 3),
   );
 
   let nextTask: { storyId: string; task: RalphthonTask } | null = null;
   for (const story of sortedStories) {
-    const pending = story.tasks.find(t => t.status === 'pending');
+    const pending = story.tasks.find((t) => t.status === "pending");
     if (pending) {
       nextTask = { storyId: story.id, task: pending };
       break;
@@ -165,11 +207,14 @@ export function getRalphthonPrdStatus(prd: RalphthonPRD): RalphthonPrdStatus {
 
   // Hardening status
   const hardeningTasks = prd.hardening || [];
-  const completedHardening = hardeningTasks.filter(t => t.status === 'done').length;
-  const pendingHardening = hardeningTasks.filter(t =>
-    t.status === 'pending' || t.status === 'in_progress'
+  const completedHardening = hardeningTasks.filter(
+    (t) => t.status === "done",
   ).length;
-  const nextHardeningTask = hardeningTasks.find(t => t.status === 'pending') || null;
+  const pendingHardening = hardeningTasks.filter(
+    (t) => t.status === "pending" || t.status === "in_progress",
+  ).length;
+  const nextHardeningTask =
+    hardeningTasks.find((t) => t.status === "pending") || null;
 
   return {
     totalStories: prd.stories.length,
@@ -178,7 +223,8 @@ export function getRalphthonPrdStatus(prd: RalphthonPRD): RalphthonPrdStatus {
     completedTasks,
     pendingTasks,
     failedOrSkippedTasks,
-    allStoriesDone: completedStories === prd.stories.length && prd.stories.length > 0,
+    allStoriesDone:
+      completedStories === prd.stories.length && prd.stories.length > 0,
     nextTask,
     totalHardeningTasks: hardeningTasks.length,
     completedHardeningTasks: completedHardening,
@@ -205,10 +251,10 @@ export function updateTaskStatus(
   const prd = readRalphthonPrd(directory);
   if (!prd) return false;
 
-  const story = prd.stories.find(s => s.id === storyId);
+  const story = prd.stories.find((s) => s.id === storyId);
   if (!story) return false;
 
-  const task = story.tasks.find(t => t.id === taskId);
+  const task = story.tasks.find((t) => t.id === taskId);
   if (!task) return false;
 
   task.status = status;
@@ -229,16 +275,16 @@ export function incrementTaskRetry(
   const prd = readRalphthonPrd(directory);
   if (!prd) return { retries: 0, skipped: false };
 
-  const story = prd.stories.find(s => s.id === storyId);
+  const story = prd.stories.find((s) => s.id === storyId);
   if (!story) return { retries: 0, skipped: false };
 
-  const task = story.tasks.find(t => t.id === taskId);
+  const task = story.tasks.find((t) => t.id === taskId);
   if (!task) return { retries: 0, skipped: false };
 
   task.retries += 1;
   const skipped = task.retries >= maxRetries;
   if (skipped) {
-    task.status = 'skipped';
+    task.status = "skipped";
     task.notes = `Skipped after ${task.retries} failed attempts`;
   }
 
@@ -258,7 +304,7 @@ export function updateHardeningTaskStatus(
   const prd = readRalphthonPrd(directory);
   if (!prd) return false;
 
-  const task = prd.hardening.find(t => t.id === taskId);
+  const task = prd.hardening.find((t) => t.id === taskId);
   if (!task) return false;
 
   task.status = status;
@@ -278,13 +324,13 @@ export function incrementHardeningTaskRetry(
   const prd = readRalphthonPrd(directory);
   if (!prd) return { retries: 0, skipped: false };
 
-  const task = prd.hardening.find(t => t.id === taskId);
+  const task = prd.hardening.find((t) => t.id === taskId);
   if (!task) return { retries: 0, skipped: false };
 
   task.retries += 1;
   const skipped = task.retries >= maxRetries;
   if (skipped) {
-    task.status = 'skipped';
+    task.status = "skipped";
     task.notes = `Skipped after ${task.retries} failed attempts`;
   }
 
@@ -297,14 +343,14 @@ export function incrementHardeningTaskRetry(
  */
 export function addHardeningTasks(
   directory: string,
-  tasks: Omit<HardeningTask, 'status' | 'retries'>[],
+  tasks: Omit<HardeningTask, "status" | "retries">[],
 ): boolean {
   const prd = readRalphthonPrd(directory);
   if (!prd) return false;
 
-  const newTasks: HardeningTask[] = tasks.map(t => ({
+  const newTasks: HardeningTask[] = tasks.map((t) => ({
     ...t,
-    status: 'pending' as TaskStatus,
+    status: "pending" as TaskStatus,
     retries: 0,
   }));
 
@@ -325,6 +371,7 @@ export function createRalphthonPrd(
   description: string,
   stories: RalphthonStory[],
   config?: Partial<RalphthonConfig>,
+  planningContext?: Partial<RalphthonPlanningContext>,
 ): RalphthonPRD {
   return {
     project,
@@ -333,6 +380,7 @@ export function createRalphthonPrd(
     stories,
     hardening: [],
     config: { ...RALPHTHON_DEFAULTS, ...config },
+    planningContext: normalizePlanningContext(planningContext),
   };
 }
 
@@ -346,8 +394,16 @@ export function initRalphthonPrd(
   description: string,
   stories: RalphthonStory[],
   config?: Partial<RalphthonConfig>,
+  planningContext?: Partial<RalphthonPlanningContext>,
 ): boolean {
-  const prd = createRalphthonPrd(project, branchName, description, stories, config);
+  const prd = createRalphthonPrd(
+    project,
+    branchName,
+    description,
+    stories,
+    config,
+    planningContext,
+  );
   return writeRalphthonPrd(directory, prd);
 }
 
@@ -382,9 +438,14 @@ If you find additional issues during this hardening pass, note them — they'll 
 /**
  * Format the hardening wave generation prompt
  */
-export function formatHardeningGenerationPrompt(wave: number, prd: RalphthonPRD): string {
-  const completedTasks = prd.stories.flatMap(s => s.tasks).filter(t => t.status === 'done');
-  const completedHardening = prd.hardening.filter(t => t.status === 'done');
+export function formatHardeningGenerationPrompt(
+  wave: number,
+  prd: RalphthonPRD,
+): string {
+  const completedTasks = prd.stories
+    .flatMap((s) => s.tasks)
+    .filter((t) => t.status === "done");
+  const completedHardening = prd.hardening.filter((t) => t.status === "done");
 
   return `You are in HARDENING WAVE ${wave} of a ralphthon session.
 
@@ -399,7 +460,7 @@ Completed story tasks: ${completedTasks.length}
 Completed hardening tasks: ${completedHardening.length}
 
 Write new hardening tasks to the ralphthon PRD (ralphthon-prd.json) in the hardening array.
-Each task needs: id (H-${String(wave).padStart(2, '0')}-NNN), title, description, category, wave: ${wave}.
+Each task needs: id (H-${String(wave).padStart(2, "0")}-NNN), title, description, category, wave: ${wave}.
 Set status to "pending" and retries to 0.
 
 If you find NO new issues, write an empty set of new tasks. This signals the code is solid.`;
@@ -413,20 +474,30 @@ export function formatRalphthonStatus(prd: RalphthonPRD): string {
   const lines: string[] = [];
 
   lines.push(`[Ralphthon: ${prd.project}]`);
-  lines.push(`Stories: ${status.completedStories}/${status.totalStories} complete`);
-  lines.push(`Tasks: ${status.completedTasks}/${status.totalTasks} done, ${status.failedOrSkippedTasks} skipped`);
+  lines.push(
+    `Stories: ${status.completedStories}/${status.totalStories} complete`,
+  );
+  lines.push(
+    `Tasks: ${status.completedTasks}/${status.totalTasks} done, ${status.failedOrSkippedTasks} skipped`,
+  );
 
   if (status.totalHardeningTasks > 0) {
-    lines.push(`Hardening: ${status.completedHardeningTasks}/${status.totalHardeningTasks} done`);
+    lines.push(
+      `Hardening: ${status.completedHardeningTasks}/${status.totalHardeningTasks} done`,
+    );
   }
 
   if (status.nextTask) {
-    lines.push(`Next: [${status.nextTask.storyId}] ${status.nextTask.task.id} - ${status.nextTask.task.title}`);
+    lines.push(
+      `Next: [${status.nextTask.storyId}] ${status.nextTask.task.id} - ${status.nextTask.task.title}`,
+    );
   } else if (status.nextHardeningTask) {
-    lines.push(`Next hardening: ${status.nextHardeningTask.id} - ${status.nextHardeningTask.title}`);
+    lines.push(
+      `Next hardening: ${status.nextHardeningTask.id} - ${status.nextHardeningTask.title}`,
+    );
   } else if (status.allStoriesDone) {
-    lines.push('All stories complete — ready for hardening');
+    lines.push("All stories complete — ready for hardening");
   }
 
-  return lines.join('\n');
+  return lines.join("\n");
 }

--- a/src/ralphthon/types.ts
+++ b/src/ralphthon/types.ts
@@ -12,13 +12,23 @@
 // ============================================================================
 
 /** Priority levels for stories and tasks */
-export type TaskPriority = 'critical' | 'high' | 'medium' | 'low';
+export type TaskPriority = "critical" | "high" | "medium" | "low";
 
 /** Status of an individual task */
-export type TaskStatus = 'pending' | 'in_progress' | 'done' | 'skipped' | 'failed';
+export type TaskStatus =
+  | "pending"
+  | "in_progress"
+  | "done"
+  | "skipped"
+  | "failed";
 
 /** Phase of the ralphthon lifecycle */
-export type RalphthonPhase = 'interview' | 'execution' | 'hardening' | 'complete' | 'failed';
+export type RalphthonPhase =
+  | "interview"
+  | "execution"
+  | "hardening"
+  | "complete"
+  | "failed";
 
 /**
  * A single actionable task within a story
@@ -67,7 +77,7 @@ export interface HardeningTask {
   /** What to harden (edge case, test, quality improvement) */
   description: string;
   /** Category of hardening */
-  category: 'edge_case' | 'test' | 'quality' | 'security' | 'performance';
+  category: "edge_case" | "test" | "quality" | "security" | "performance";
   /** Current status */
   status: TaskStatus;
   /** Which hardening wave generated this task */
@@ -76,6 +86,20 @@ export interface HardeningTask {
   retries: number;
   /** Optional notes */
   notes?: string;
+}
+
+/**
+ * Persisted planning/brownfield intake context.
+ */
+export interface RalphthonPlanningContext {
+  /** Whether this work targets an existing codebase / brownfield surface */
+  brownfield: boolean;
+  /** Whether assumptions are explicitly captured in planning */
+  assumptionsMode: "explicit" | "implicit";
+  /** Short persisted summary of the brownfield/codebase-map intake */
+  codebaseMapSummary: string;
+  /** Constraints captured during planning intake */
+  knownConstraints: string[];
 }
 
 /**
@@ -112,6 +136,8 @@ export interface RalphthonPRD {
   hardening: HardeningTask[];
   /** Run configuration */
   config: RalphthonConfig;
+  /** Brownfield planning context */
+  planningContext?: RalphthonPlanningContext;
 }
 
 // ============================================================================
@@ -162,16 +188,16 @@ export interface RalphthonState {
 
 /** Events emitted by the orchestrator */
 export type OrchestratorEvent =
-  | { type: 'task_injected'; taskId: string; taskTitle: string }
-  | { type: 'task_completed'; taskId: string }
-  | { type: 'task_failed'; taskId: string; retries: number }
-  | { type: 'task_skipped'; taskId: string; reason: string }
-  | { type: 'phase_transition'; from: RalphthonPhase; to: RalphthonPhase }
-  | { type: 'hardening_wave_start'; wave: number }
-  | { type: 'hardening_wave_end'; wave: number; newIssues: number }
-  | { type: 'idle_detected'; durationMs: number }
-  | { type: 'session_complete'; tasksCompleted: number; tasksSkipped: number }
-  | { type: 'error'; message: string };
+  | { type: "task_injected"; taskId: string; taskTitle: string }
+  | { type: "task_completed"; taskId: string }
+  | { type: "task_failed"; taskId: string; retries: number }
+  | { type: "task_skipped"; taskId: string; reason: string }
+  | { type: "phase_transition"; from: RalphthonPhase; to: RalphthonPhase }
+  | { type: "hardening_wave_start"; wave: number }
+  | { type: "hardening_wave_end"; wave: number; newIssues: number }
+  | { type: "idle_detected"; durationMs: number }
+  | { type: "session_complete"; tasksCompleted: number; tasksSkipped: number }
+  | { type: "error"; message: string };
 
 /** Callback for orchestrator events */
 export type OrchestratorEventHandler = (event: OrchestratorEvent) => void;
@@ -209,4 +235,4 @@ export const RALPHTHON_DEFAULTS: RalphthonConfig = {
   skipInterview: false,
 };
 
-export const PRD_FILENAME = 'ralphthon-prd.json';
+export const PRD_FILENAME = "ralphthon-prd.json";

--- a/src/team/__tests__/api-interop.dispatch.test.ts
+++ b/src/team/__tests__/api-interop.dispatch.test.ts
@@ -176,6 +176,6 @@ describe('team api dispatch-aware messaging', () => {
     const requests = await listDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: 'worker-1' });
     expect(requests).toHaveLength(1);
     expect(requests[0]?.message_id).toBe(messageId);
-    expect(requests[0]?.status).toBe('pending');
+    expect(requests[0]?.status).toBe('notified');
   });
 });

--- a/src/team/__tests__/followup-planner.test.ts
+++ b/src/team/__tests__/followup-planner.test.ts
@@ -1,175 +1,105 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import {
   isShortTeamFollowupRequest,
   isShortRalphFollowupRequest,
   isApprovedExecutionFollowupShortcut,
   resolveApprovedTeamFollowupContext,
-} from '../followup-planner.js';
+} from "../followup-planner.js";
 
-describe('followup-planner', () => {
-  describe('isShortTeamFollowupRequest', () => {
-    it('matches "team"', () => {
-      expect(isShortTeamFollowupRequest('team')).toBe(true);
+describe("team/followup-planner", () => {
+  describe("isShortTeamFollowupRequest", () => {
+    it.each([
+      "team",
+      "team please",
+      "/team",
+      "run team",
+      "start team",
+      "launch team",
+      "go team",
+      "team으로 해줘",
+    ])("matches %s", (value) => {
+      expect(isShortTeamFollowupRequest(value)).toBe(true);
     });
 
-    it('matches "team please"', () => {
-      expect(isShortTeamFollowupRequest('team please')).toBe(true);
-    });
-
-    it('matches "/team"', () => {
-      expect(isShortTeamFollowupRequest('/team')).toBe(true);
-    });
-
-    it('matches "run team"', () => {
-      expect(isShortTeamFollowupRequest('run team')).toBe(true);
-    });
-
-    it('matches "start team"', () => {
-      expect(isShortTeamFollowupRequest('start team')).toBe(true);
-    });
-
-    it('matches "team으로 해줘"', () => {
-      expect(isShortTeamFollowupRequest('team으로 해줘')).toBe(true);
-    });
-
-    it('matches with surrounding whitespace', () => {
-      expect(isShortTeamFollowupRequest('  team  ')).toBe(true);
-    });
-
-    it('does not match long team descriptions', () => {
-      expect(isShortTeamFollowupRequest('team run this big task for me now')).toBe(false);
-    });
-
-    it('does not match ralph', () => {
-      expect(isShortTeamFollowupRequest('ralph')).toBe(false);
-    });
-
-    it('does not match empty string', () => {
-      expect(isShortTeamFollowupRequest('')).toBe(false);
+    it.each([
+      "team now please do it",
+      "please run the team",
+      "autopilot team",
+      "",
+    ])("rejects %s", (value) => {
+      expect(isShortTeamFollowupRequest(value)).toBe(false);
     });
   });
 
-  describe('isShortRalphFollowupRequest', () => {
-    it('matches "ralph"', () => {
-      expect(isShortRalphFollowupRequest('ralph')).toBe(true);
+  describe("isShortRalphFollowupRequest", () => {
+    it.each([
+      "ralph",
+      "ralph please",
+      "/ralph",
+      "run ralph",
+      "start ralph",
+      "launch ralph",
+      "go ralph",
+    ])("matches %s", (value) => {
+      expect(isShortRalphFollowupRequest(value)).toBe(true);
     });
 
-    it('matches "ralph please"', () => {
-      expect(isShortRalphFollowupRequest('ralph please')).toBe(true);
-    });
-
-    it('matches "/ralph"', () => {
-      expect(isShortRalphFollowupRequest('/ralph')).toBe(true);
-    });
-
-    it('matches "run ralph"', () => {
-      expect(isShortRalphFollowupRequest('run ralph')).toBe(true);
-    });
-
-    it('matches "start ralph"', () => {
-      expect(isShortRalphFollowupRequest('start ralph')).toBe(true);
-    });
-
-    it('does not match long descriptions', () => {
-      expect(isShortRalphFollowupRequest('ralph do this big task')).toBe(false);
-    });
-
-    it('does not match team', () => {
-      expect(isShortRalphFollowupRequest('team')).toBe(false);
-    });
+    it.each(["ralph do everything", "please run ralph now", ""])(
+      "rejects %s",
+      (value) => {
+        expect(isShortRalphFollowupRequest(value)).toBe(false);
+      },
+    );
   });
 
-  describe('isApprovedExecutionFollowupShortcut', () => {
-    it('returns true when all conditions met for team mode', () => {
+  describe("isApprovedExecutionFollowupShortcut", () => {
+    it("requires planningComplete=true", () => {
       expect(
-        isApprovedExecutionFollowupShortcut('team', 'team', {
-          planningComplete: true,
-          priorSkill: 'ralplan',
-        })
-      ).toBe(true);
-    });
-
-    it('returns true when all conditions met for ralph mode', () => {
-      expect(
-        isApprovedExecutionFollowupShortcut('ralph', 'ralph', {
-          planningComplete: true,
-          priorSkill: 'ralplan',
-        })
-      ).toBe(true);
-    });
-
-    it('returns false when planningComplete is false', () => {
-      expect(
-        isApprovedExecutionFollowupShortcut('team', 'team', {
+        isApprovedExecutionFollowupShortcut("team", "team", {
           planningComplete: false,
-          priorSkill: 'ralplan',
-        })
+          priorSkill: "ralplan",
+        }),
       ).toBe(false);
     });
 
-    it('returns false when planningComplete is undefined', () => {
+    it("requires priorSkill=ralplan", () => {
       expect(
-        isApprovedExecutionFollowupShortcut('team', 'team', {
-          priorSkill: 'ralplan',
-        })
-      ).toBe(false);
-    });
-
-    it('returns false when priorSkill is not ralplan', () => {
-      expect(
-        isApprovedExecutionFollowupShortcut('team', 'team', {
+        isApprovedExecutionFollowupShortcut("team", "team", {
           planningComplete: true,
-          priorSkill: 'ralph',
-        })
+          priorSkill: "plan",
+        }),
       ).toBe(false);
     });
 
-    it('returns false when priorSkill is null', () => {
+    it("matches approved team follow-up", () => {
       expect(
-        isApprovedExecutionFollowupShortcut('team', 'team', {
+        isApprovedExecutionFollowupShortcut("team", "team", {
           planningComplete: true,
-          priorSkill: null,
-        })
-      ).toBe(false);
+          priorSkill: "ralplan",
+        }),
+      ).toBe(true);
     });
 
-    it('returns false when priorSkill is undefined', () => {
+    it("matches approved ralph follow-up", () => {
       expect(
-        isApprovedExecutionFollowupShortcut('team', 'team', {
+        isApprovedExecutionFollowupShortcut("ralph", "ralph", {
           planningComplete: true,
-        })
-      ).toBe(false);
-    });
-
-    it('returns false when text is not a short follow-up', () => {
-      expect(
-        isApprovedExecutionFollowupShortcut('team', 'please run this big task for me', {
-          planningComplete: true,
-          priorSkill: 'ralplan',
-        })
-      ).toBe(false);
-    });
-
-    it('returns true for "team please" pattern', () => {
-      expect(
-        isApprovedExecutionFollowupShortcut('team', 'team please', {
-          planningComplete: true,
-          priorSkill: 'ralplan',
-        })
+          priorSkill: "ralplan",
+        }),
       ).toBe(true);
     });
   });
 
-  describe('resolveApprovedTeamFollowupContext', () => {
+  describe("resolveApprovedTeamFollowupContext", () => {
     let testDir: string;
     let plansDir: string;
 
     beforeEach(() => {
-      testDir = mkdtempSync(join(tmpdir(), 'followup-planner-test-'));
-      plansDir = join(testDir, '.omc', 'plans');
+      testDir = mkdtempSync(join(tmpdir(), "followup-planner-test-"));
+      plansDir = join(testDir, ".omc", "plans");
       mkdirSync(plansDir, { recursive: true });
     });
 
@@ -177,39 +107,150 @@ describe('followup-planner', () => {
       rmSync(testDir, { recursive: true, force: true });
     });
 
-    it('returns null when no plans exist', () => {
-      const result = resolveApprovedTeamFollowupContext(testDir, 'do the task');
+    it("returns null when no plans exist", () => {
+      const result = resolveApprovedTeamFollowupContext(testDir, "do the task");
       expect(result).toBeNull();
     });
 
-    it('returns null when only PRD exists (no test spec)', () => {
+    it("returns null when only PRD exists (no test spec)", () => {
       writeFileSync(
-        join(plansDir, 'prd-feature.md'),
-        '# PRD\n\nomc team 3:claude "implement auth"\n'
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          'omc team 3:claude "implement auth"',
+          "",
+        ].join("\n"),
       );
-      const result = resolveApprovedTeamFollowupContext(testDir, 'do the task');
+      const result = resolveApprovedTeamFollowupContext(testDir, "do the task");
       expect(result).toBeNull();
     });
 
-    it('returns null when PRD has no launch hint', () => {
-      writeFileSync(join(plansDir, 'prd-feature.md'), '# PRD\n\nNo commands.');
-      writeFileSync(join(plansDir, 'test-spec-feature.md'), '# Test Spec');
-      const result = resolveApprovedTeamFollowupContext(testDir, 'do the task');
-      expect(result).toBeNull();
-    });
-
-    it('returns context with hint when planning is complete and hint exists', () => {
+    it("returns null when PRD has no launch hint", () => {
       writeFileSync(
-        join(plansDir, 'prd-feature.md'),
-        '# PRD\n\nomc team 3:claude "implement auth"\n'
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          "No commands.",
+          "",
+        ].join("\n"),
       );
-      writeFileSync(join(plansDir, 'test-spec-feature.md'), '# Test Spec');
-      const result = resolveApprovedTeamFollowupContext(testDir, 'do the task');
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+      const result = resolveApprovedTeamFollowupContext(testDir, "do the task");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when latest artifacts are low-signal even if older artifacts were valid", () => {
+      writeFileSync(
+        join(plansDir, "prd-aaa.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          'omc team 3:claude "implement auth"',
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-aaa.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "prd-zzz.md"),
+        ["# PRD", "", "## Acceptance criteria", "- done", ""].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-zzz.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+
+      const result = resolveApprovedTeamFollowupContext(testDir, "do the task");
+      expect(result).toBeNull();
+    });
+
+    it("returns context with hint when planning is complete and hint exists", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          'omc team 3:claude "implement auth"',
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+      const result = resolveApprovedTeamFollowupContext(testDir, "do the task");
       expect(result).not.toBeNull();
-      expect(result!.hint.mode).toBe('team');
-      expect(result!.hint.task).toBe('implement auth');
+      expect(result!.hint.mode).toBe("team");
+      expect(result!.hint.task).toBe("implement auth");
       expect(result!.hint.workerCount).toBe(3);
-      expect(result!.launchCommand).toContain('omc team');
+      expect(result!.launchCommand).toContain("omc team");
     });
   });
 });


### PR DESCRIPTION
## Summary
- make brownfield/assumptions-mode planning explicit in ralphthon PRDs and prompts
- strengthen planning completeness checks around requirement coverage and verification mapping
- tighten follow-up gating/tests so only the latest high-signal artifacts unlock execution handoff

## Verification
- npx tsc --noEmit
- npm test

Closes #1837