### PR TITLE
fix(hooks): resolve [1m] model suffix deadlock for Bedrock sub-agents

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -10,8 +10,9 @@ import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, ren
 import { dirname, join, resolve } from 'path';
 import { execSync } from 'child_process';
 import { homedir } from 'os';
-import { pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { readStdin } from './lib/stdin.mjs';
+import { isSubagentSafeModelId, hasExtendedContextSuffix } from '../dist/config/models.js';
 
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 const MODE_STATE_FILES = [
@@ -546,21 +547,60 @@ async function main() {
           : '';
     const modeActive = hasActiveMode(directory, sessionId);
 
-    // Force-inherit check: deny Task/Agent calls with model param when forceInherit is enabled
-    // (Bedrock, Vertex, CC Switch, etc.) - issues #1135, #1201
+    // Force-inherit check: deny Task/Agent calls with invalid model param when forceInherit is
+    // enabled (Bedrock, Vertex, CC Switch, etc.) - issues #1135, #1201, #1767, #1868
+    //
+    // New behaviour (issue #1868 — [1m] suffix deadlock):
+    //   ALLOW explicit valid provider-specific model IDs (full Bedrock/Vertex format, no [1m])
+    //   DENY  tier names (sonnet/opus/haiku) and [1m]-suffixed IDs
+    //   DENY  no-model calls when the session model itself has [1m] — guide to OMC_SUBAGENT_MODEL
     if (toolName === 'Task' || toolName === 'Agent') {
       const toolInput = data.toolInput || data.tool_input || {};
       const toolModel = toolInput.model;
-      if (toolModel && isForceInheritEnabled()) {
-        console.log(JSON.stringify({
-          continue: true,
-          hookSpecificOutput: {
-            hookEventName: 'PreToolUse',
-            permissionDecision: 'deny',
-            permissionDecisionReason: `[MODEL ROUTING] This environment uses a non-standard provider (Bedrock/Vertex/proxy). Do NOT pass the \`model\` parameter on ${toolName} calls — remove \`model\` and retry so agents inherit the parent session's model. The model "${toolModel}" is not valid for this provider.`
+      if (isForceInheritEnabled()) {
+        const sessionModel = process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || '';
+        const sessionHasLmSuffix = hasExtendedContextSuffix(sessionModel);
+
+        if (toolModel) {
+          // Allow explicit valid provider-specific IDs (full Bedrock/Vertex format) without a
+          // [1m] suffix — blocking these leaves no escape hatch when the inherited session model
+          // is itself invalid. Reject tier names (sonnet/opus/haiku) and [1m]-suffixed IDs.
+          if (!isSubagentSafeModelId(toolModel)) {
+            const subagentModel = process.env.OMC_SUBAGENT_MODEL || '';
+            const guidance = subagentModel
+              ? `Pass model="${subagentModel}" (your configured OMC_SUBAGENT_MODEL value).`
+              : `Remove the \`model\` parameter, or set OMC_SUBAGENT_MODEL=<valid-bedrock-id> and pass that value explicitly.`;
+            console.log(JSON.stringify({
+              continue: true,
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: 'deny',
+                permissionDecisionReason: `[MODEL ROUTING] This environment uses a non-standard provider (Bedrock/Vertex/proxy). ${guidance} The model "${toolModel}" is not valid for this provider.`
+              }
+            }));
+            return;
           }
-        }));
-        return;
+          // else: valid provider-specific model ID — fall through to continue.
+        } else if (sessionHasLmSuffix) {
+          // No model param, but the session model has a [1m] context-window suffix.
+          // Sub-agents would inherit it and fail — the runtime strips [1m] to a bare
+          // Anthropic model ID (e.g. claude-sonnet-4-6) which is invalid on Bedrock.
+          const subagentModel = process.env.OMC_SUBAGENT_MODEL || '';
+          const suggestion = subagentModel
+            ? `Pass model="${subagentModel}" (your configured OMC_SUBAGENT_MODEL) explicitly on this ${toolName} call.`
+            : `Set OMC_SUBAGENT_MODEL=<valid-bedrock-id> in your environment (use the model ID from the 400 error message, e.g. "us.anthropic.claude-sonnet-4-5-20250929-v1:0"), then pass that value as the model parameter.`;
+          console.log(JSON.stringify({
+            continue: true,
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              permissionDecision: 'deny',
+              permissionDecisionReason: `[MODEL ROUTING] Your session model "${sessionModel}" has a context-window suffix ([1m]) that sub-agents cannot inherit — the runtime strips it to a bare Anthropic model ID which is invalid on Bedrock. ${suggestion}`
+            }
+          }));
+          return;
+        }
+        // else: no model param and no [1m] on session model → normal forceInherit,
+        // agents inherit the parent session's model cleanly.
       }
     }
 

--- a/src/__tests__/bedrock-lm-suffix-hook.test.ts
+++ b/src/__tests__/bedrock-lm-suffix-hook.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the forceInherit hook's handling of [1m]-suffixed Bedrock model IDs.
+ *
+ * These tests verify the decision functions that underpin the updated forceInherit
+ * block in scripts/pre-tool-enforcer.mjs. The hook uses isSubagentSafeModelId()
+ * to decide whether to allow or deny an explicit `model` param, and
+ * hasExtendedContextSuffix() to detect when the session model would cause a
+ * silent sub-agent failure on Bedrock.
+ *
+ * Manual hook verification (stdin test):
+ *   echo '{"tool_name":"Agent","toolInput":{},"cwd":"/tmp"}' | \
+ *     ANTHROPIC_MODEL='global.anthropic.claude-sonnet-4-6[1m]' \
+ *     OMC_ROUTING_FORCE_INHERIT=true \
+ *     node scripts/pre-tool-enforcer.mjs
+ *   → expect: deny with [1m] suffix guidance and OMC_SUBAGENT_MODEL mention
+ *
+ *   echo '{"tool_name":"Agent","toolInput":{"model":"us.anthropic.claude-sonnet-4-5-20250929-v1:0"},"cwd":"/tmp"}' | \
+ *     ANTHROPIC_MODEL='global.anthropic.claude-sonnet-4-6[1m]' \
+ *     OMC_ROUTING_FORCE_INHERIT=true \
+ *     node scripts/pre-tool-enforcer.mjs
+ *   → expect: continue (allowed through as valid Bedrock ID)
+ */
+
+import { spawnSync } from 'child_process';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  hasExtendedContextSuffix,
+  isSubagentSafeModelId,
+  isProviderSpecificModelId,
+} from '../config/models.js';
+import { saveAndClear, restore } from '../config/__tests__/test-helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOK_PATH = resolve(__dirname, '../../scripts/pre-tool-enforcer.mjs');
+
+const ENV_KEYS = ['ANTHROPIC_MODEL', 'CLAUDE_MODEL', 'OMC_ROUTING_FORCE_INHERIT', 'OMC_SUBAGENT_MODEL'] as const;
+
+// ---------------------------------------------------------------------------
+// Hook ALLOW path: explicit model param is a valid provider-specific ID
+// ---------------------------------------------------------------------------
+describe('hook allow path — isSubagentSafeModelId(model) === true', () => {
+  it('allows global. cross-region Bedrock profile (the standard escape hatch)', () => {
+    expect(isSubagentSafeModelId('global.anthropic.claude-sonnet-4-6-v1:0')).toBe(true);
+  });
+
+  it('allows us. regional Bedrock cross-region inference profile', () => {
+    expect(isSubagentSafeModelId('us.anthropic.claude-sonnet-4-5-20250929-v1:0')).toBe(true);
+  });
+
+  it('allows ap. regional Bedrock profile', () => {
+    expect(isSubagentSafeModelId('ap.anthropic.claude-sonnet-4-6-v1:0')).toBe(true);
+  });
+
+  it('allows Bedrock ARN inference-profile format', () => {
+    expect(isSubagentSafeModelId(
+      'arn:aws:bedrock:us-east-2:123456789012:inference-profile/global.anthropic.claude-opus-4-6-v1:0'
+    )).toBe(true);
+  });
+
+  it('allows Vertex AI model ID', () => {
+    expect(isSubagentSafeModelId('vertex_ai/claude-sonnet-4-6@20250514')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook DENY path: explicit model param is invalid for sub-agents
+// ---------------------------------------------------------------------------
+describe('hook deny path — explicit model param is invalid', () => {
+  it('denies [1m]-suffixed model ID (the core bug case)', () => {
+    expect(isSubagentSafeModelId('global.anthropic.claude-sonnet-4-6[1m]')).toBe(false);
+  });
+
+  it('denies [200k]-suffixed model ID', () => {
+    expect(isSubagentSafeModelId('global.anthropic.claude-sonnet-4-6[200k]')).toBe(false);
+  });
+
+  it('denies tier alias "sonnet"', () => {
+    expect(isSubagentSafeModelId('sonnet')).toBe(false);
+  });
+
+  it('denies tier alias "opus"', () => {
+    expect(isSubagentSafeModelId('opus')).toBe(false);
+  });
+
+  it('denies tier alias "haiku"', () => {
+    expect(isSubagentSafeModelId('haiku')).toBe(false);
+  });
+
+  it('denies bare Anthropic model ID (invalid on Bedrock)', () => {
+    expect(isSubagentSafeModelId('claude-sonnet-4-6')).toBe(false);
+    expect(isSubagentSafeModelId('claude-opus-4-6')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session model [1m] detection — the no-model-param deny path
+// ---------------------------------------------------------------------------
+describe('session model [1m] detection — hasExtendedContextSuffix', () => {
+  it('detects [1m] on the exact model from the bug report', () => {
+    expect(hasExtendedContextSuffix('global.anthropic.claude-sonnet-4-6[1m]')).toBe(true);
+  });
+
+  it('detects [200k] on hypothetical future variant', () => {
+    expect(hasExtendedContextSuffix('global.anthropic.claude-sonnet-4-6[200k]')).toBe(true);
+  });
+
+  it('does NOT flag the standard Bedrock profile without suffix', () => {
+    expect(hasExtendedContextSuffix('global.anthropic.claude-sonnet-4-6-v1:0')).toBe(false);
+  });
+
+  it('does NOT flag the opus env var from the bug report env', () => {
+    // ANTHROPIC_DEFAULT_OPUS_MODEL=global.anthropic.claude-opus-4-6-v1 (no [1m])
+    expect(hasExtendedContextSuffix('global.anthropic.claude-opus-4-6-v1')).toBe(false);
+  });
+
+  it('does NOT flag the haiku env var from the bug report env', () => {
+    // ANTHROPIC_DEFAULT_HAIKU_MODEL=global.anthropic.claude-haiku-4-5-20251001-v1:0
+    expect(hasExtendedContextSuffix('global.anthropic.claude-haiku-4-5-20251001-v1:0')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider-specific check still correct for Bedrock IDs used in guidance
+// ---------------------------------------------------------------------------
+describe('isProviderSpecificModelId — Bedrock IDs used in OMC_SUBAGENT_MODEL guidance', () => {
+  it('accepts the model from the 400 error message', () => {
+    expect(isProviderSpecificModelId('us.anthropic.claude-sonnet-4-5-20250929-v1:0')).toBe(true);
+  });
+
+  it('accepts [1m]-suffixed model as provider-specific (but it is NOT subagent-safe)', () => {
+    // isProviderSpecificModelId detects the Bedrock prefix — the [1m] is a secondary check
+    expect(isProviderSpecificModelId('global.anthropic.claude-sonnet-4-6[1m]')).toBe(true);
+    // But isSubagentSafeModelId combines both checks and rejects it
+    expect(isSubagentSafeModelId('global.anthropic.claude-sonnet-4-6[1m]')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Environment-based session model detection (simulates hook reading env vars)
+// ---------------------------------------------------------------------------
+describe('environment-based session model detection', () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => { saved = saveAndClear(ENV_KEYS); });
+  afterEach(() => { restore(saved); });
+
+  it('detects [1m] session model via ANTHROPIC_MODEL env var', () => {
+    process.env.ANTHROPIC_MODEL = 'global.anthropic.claude-sonnet-4-6[1m]';
+    const sessionModel = process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || '';
+    expect(hasExtendedContextSuffix(sessionModel)).toBe(true);
+  });
+
+  it('detects [1m] session model via CLAUDE_MODEL env var', () => {
+    process.env.CLAUDE_MODEL = 'global.anthropic.claude-sonnet-4-6[1m]';
+    const sessionModel = process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || '';
+    expect(hasExtendedContextSuffix(sessionModel)).toBe(true);
+  });
+
+  it('does not flag missing env vars', () => {
+    const sessionModel = process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || '';
+    expect(hasExtendedContextSuffix(sessionModel)).toBe(false);
+  });
+
+  it('does not flag a valid Bedrock model in env vars', () => {
+    process.env.ANTHROPIC_MODEL = 'global.anthropic.claude-opus-4-6-v1';
+    const sessionModel = process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || '';
+    expect(hasExtendedContextSuffix(sessionModel)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook integration tests — spawn the hook and verify stdin→stdout behaviour
+// ---------------------------------------------------------------------------
+
+function runHook(
+  toolInput: Record<string, unknown>,
+  env: Record<string, string>,
+): { denied: boolean; reason?: string } {
+  const stdin = JSON.stringify({
+    tool_name: 'Agent',
+    toolInput,
+    cwd: '/tmp',
+    session_id: 'test-hook-integration',
+  });
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdin,
+    encoding: 'utf8',
+    env: { ...process.env, ...env, OMC_ROUTING_FORCE_INHERIT: 'true' },
+    timeout: 10000,
+  });
+  const lines = (result.stdout || '').split('\n').filter(Boolean);
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed?.hookSpecificOutput?.permissionDecision === 'deny') {
+        return { denied: true, reason: parsed.hookSpecificOutput.permissionDecisionReason };
+      }
+    } catch {
+      // non-JSON line — skip
+    }
+  }
+  return { denied: false };
+}
+
+describe('hook integration — force-inherit + [1m] scenarios', () => {
+  it('denies [1m]-suffixed explicit model param', () => {
+    const result = runHook(
+      { model: 'global.anthropic.claude-sonnet-4-6[1m]' },
+      { ANTHROPIC_MODEL: 'global.anthropic.claude-sonnet-4-6[1m]' },
+    );
+    expect(result.denied).toBe(true);
+    expect(result.reason).toMatch(/\[1m\]/);
+    expect(result.reason).toMatch(/MODEL ROUTING/);
+  });
+
+  it('allows valid Bedrock cross-region profile through without denying', () => {
+    const result = runHook(
+      { model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0' },
+      { ANTHROPIC_MODEL: 'global.anthropic.claude-sonnet-4-6[1m]' },
+    );
+    expect(result.denied).toBe(false);
+  });
+
+  it('denies no-model call when session model has [1m] suffix and guides to OMC_SUBAGENT_MODEL', () => {
+    const result = runHook(
+      {},
+      { ANTHROPIC_MODEL: 'global.anthropic.claude-sonnet-4-6[1m]' },
+    );
+    expect(result.denied).toBe(true);
+    expect(result.reason).toMatch(/OMC_SUBAGENT_MODEL/);
+    expect(result.reason).toMatch(/global\.anthropic\.claude-sonnet-4-6\[1m\]/);
+  });
+
+  it('includes configured OMC_SUBAGENT_MODEL value in guidance when set', () => {
+    const result = runHook(
+      {},
+      {
+        ANTHROPIC_MODEL: 'global.anthropic.claude-sonnet-4-6[1m]',
+        OMC_SUBAGENT_MODEL: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+      },
+    );
+    expect(result.denied).toBe(true);
+    expect(result.reason).toMatch(/us\.anthropic\.claude-sonnet-4-5-20250929-v1:0/);
+  });
+});

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -5,6 +5,8 @@ import {
   isNonClaudeProvider,
   isProviderSpecificModelId,
   resolveClaudeFamily,
+  hasExtendedContextSuffix,
+  isSubagentSafeModelId,
 } from '../models.js';
 import { saveAndClear, restore } from './test-helpers.js';
 
@@ -240,5 +242,89 @@ describe('resolveClaudeFamily() — Bedrock inference profile IDs', () => {
   it('returns null for non-Claude model IDs', () => {
     expect(resolveClaudeFamily('gpt-4o')).toBeNull();
     expect(resolveClaudeFamily('gemini-1.5-pro')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasExtendedContextSuffix() — issue: [1m] suffix breaks Bedrock sub-agents
+// ---------------------------------------------------------------------------
+describe('hasExtendedContextSuffix()', () => {
+  it('detects [1m] suffix (1M context window annotation)', () => {
+    expect(hasExtendedContextSuffix('global.anthropic.claude-sonnet-4-6[1m]')).toBe(true);
+  });
+
+  it('detects [200k] suffix (200k context window annotation)', () => {
+    expect(hasExtendedContextSuffix('global.anthropic.claude-sonnet-4-6[200k]')).toBe(true);
+  });
+
+  it('detects [100k] suffix', () => {
+    expect(hasExtendedContextSuffix('us.anthropic.claude-opus-4-6[100k]')).toBe(true);
+  });
+
+  it('returns false for standard Bedrock cross-region profile ID', () => {
+    expect(hasExtendedContextSuffix('global.anthropic.claude-sonnet-4-6-v1:0')).toBe(false);
+  });
+
+  it('returns false for versioned Bedrock ID without suffix', () => {
+    expect(hasExtendedContextSuffix('global.anthropic.claude-opus-4-6-v1')).toBe(false);
+  });
+
+  it('returns false for bare Anthropic model ID', () => {
+    expect(hasExtendedContextSuffix('claude-sonnet-4-6')).toBe(false);
+  });
+
+  it('returns false for tier aliases', () => {
+    expect(hasExtendedContextSuffix('sonnet')).toBe(false);
+    expect(hasExtendedContextSuffix('opus')).toBe(false);
+    expect(hasExtendedContextSuffix('haiku')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSubagentSafeModelId() — safe to pass as `model` param on Bedrock/Vertex
+// ---------------------------------------------------------------------------
+describe('isSubagentSafeModelId()', () => {
+  it('accepts global. cross-region Bedrock profile without suffix', () => {
+    expect(isSubagentSafeModelId('global.anthropic.claude-sonnet-4-6-v1:0')).toBe(true);
+  });
+
+  it('accepts us. regional Bedrock profile', () => {
+    expect(isSubagentSafeModelId('us.anthropic.claude-sonnet-4-5-20250929-v1:0')).toBe(true);
+  });
+
+  it('accepts eu. regional Bedrock profile', () => {
+    expect(isSubagentSafeModelId('eu.anthropic.claude-haiku-4-5-v1:0')).toBe(true);
+  });
+
+  it('accepts Bedrock ARN format', () => {
+    expect(isSubagentSafeModelId('arn:aws:bedrock:us-east-2:123456789012:inference-profile/global.anthropic.claude-opus-4-6-v1:0')).toBe(true);
+  });
+
+  it('accepts Vertex AI model ID', () => {
+    expect(isSubagentSafeModelId('vertex_ai/claude-sonnet-4-6@20250514')).toBe(true);
+  });
+
+  it('rejects [1m]-suffixed model ID — the core bug case', () => {
+    expect(isSubagentSafeModelId('global.anthropic.claude-sonnet-4-6[1m]')).toBe(false);
+  });
+
+  it('rejects [200k]-suffixed model ID', () => {
+    expect(isSubagentSafeModelId('global.anthropic.claude-sonnet-4-6[200k]')).toBe(false);
+  });
+
+  it('rejects bare Anthropic model ID (not provider-specific)', () => {
+    expect(isSubagentSafeModelId('claude-sonnet-4-6')).toBe(false);
+  });
+
+  it('rejects tier alias "sonnet"', () => {
+    expect(isSubagentSafeModelId('sonnet')).toBe(false);
+  });
+
+  it('rejects tier alias "opus"', () => {
+    expect(isSubagentSafeModelId('opus')).toBe(false);
+  });
+
+  it('rejects tier alias "haiku"', () => {
+    expect(isSubagentSafeModelId('haiku')).toBe(false);
   });
 });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -220,6 +220,31 @@ export function isProviderSpecificModelId(modelId: string): boolean {
 }
 
 /**
+ * Detect whether a model ID has a Claude Code extended-context window suffix
+ * (e.g., `[1m]`, `[200k]`) that is NOT a valid Bedrock API identifier.
+ *
+ * The `[1m]` suffix is a Claude Code internal annotation for the 1M context
+ * window variant. It is valid for the parent session's API path but is
+ * rejected by the sub-agent spawning runtime, which strips it to a bare
+ * Anthropic model ID (e.g., `claude-sonnet-4-6`) that is invalid on Bedrock.
+ */
+export function hasExtendedContextSuffix(modelId: string): boolean {
+  return /\[\d+[mk]\]$/i.test(modelId);
+}
+
+/**
+ * Check whether a model ID is safe to pass as the `model` parameter when
+ * spawning sub-agents on non-standard providers (Bedrock, Vertex AI).
+ *
+ * A model ID is sub-agent safe if it is provider-specific (full Bedrock or
+ * Vertex AI format) AND does not carry a Claude Code context-window suffix
+ * like `[1m]` that the sub-agent runtime cannot handle.
+ */
+export function isSubagentSafeModelId(modelId: string): boolean {
+  return isProviderSpecificModelId(modelId) && !hasExtendedContextSuffix(modelId);
+}
+
+/**
  * Detect whether Claude Code is running on Google Vertex AI.
  *
  * Claude Code sets CLAUDE_CODE_USE_VERTEX=1 when configured for Vertex AI.


### PR DESCRIPTION
## Problem

On AWS Bedrock, the parent session model includes a Claude Code context-window annotation (e.g. `global.anthropic.claude-sonnet-4-6[1m]`). Sub-agents inherit this value, but the sub-agent runtime strips `[1m]` to a bare Anthropic API model ID (`claude-sonnet-4-6`), which Bedrock rejects with a 400 error.

The existing `forceInherit` hook made this worse by blocking *all* explicit `model` parameters — including valid Bedrock IDs — leaving no escape hatch. Result: every sub-agent spawn failed immediately, making `/team`, `/ralph`, `/ultrawork`, and all multi-agent skills completely non-functional on Bedrock with 1M-context models.

## Approach

- Add `hasExtendedContextSuffix()` and `isSubagentSafeModelId()` to the model utilities so the distinction between "valid Bedrock ID" and "broken `[1m]` ID" is testable and reusable
- Update the `forceInherit` hook to **allow** explicit valid Bedrock/Vertex model IDs through (the escape hatch), while continuing to block tier names (`sonnet`/`opus`/`haiku`) and `[1m]`-suffixed values
- When no `model` param is provided and the session model has `[1m]`, the hook denies with actionable guidance pointing to the new `OMC_SUBAGENT_MODEL` env var
- Hook imports `isSubagentSafeModelId()` and `hasExtendedContextSuffix()` from `dist/config/models.js` directly (no inline regex duplication)
- Remove misleading `strippedModel` fallback hint — stripping `[1m]` yields an unversioned ID that Bedrock rejects
- Use `CLAUDE_MODEL || ANTHROPIC_MODEL` precedence (matches existing order in `src/config/models.ts`)
- Add integration tests that spawn the hook process via stdin to cover all three new code paths end-to-end

## User action required after upgrade

Set `OMC_SUBAGENT_MODEL=<valid-bedrock-id>` in `~/.claude/settings.json` env (e.g. `us.anthropic.claude-sonnet-4-5-20250929-v1:0`). The hook will then guide each Agent/Task call to use that value explicitly.

## Changes

- `src/config/models.ts` — `hasExtendedContextSuffix()`, `isSubagentSafeModelId()` exports
- `scripts/pre-tool-enforcer.mjs` — updated forceInherit block; imports from dist; fixed env var precedence
- `src/__tests__/bedrock-lm-suffix-hook.test.ts` — hook integration tests
- `src/config/__tests__/models.test.ts` — unit tests for new exports

Closes #1868