### PR TITLE
fix(auto-slash-command): include builtin skills directory in command discovery

### DIFF
--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -6,22 +6,33 @@
  * Adapted from oh-my-opencode's auto-slash-command hook.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'fs';
-import { join, basename } from 'path';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join, basename } from "path";
+import { getClaudeConfigDir } from "../../utils/paths.js";
 import type {
   ParsedSlashCommand,
   CommandInfo,
   CommandMetadata,
   CommandScope,
   ExecuteResult,
-} from './types.js';
-import { resolveLiveData } from './live-data.js';
-import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
-import { formatOmcCliInvocation, rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
-import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
-import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
-import { renderSkillRuntimeGuidance } from '../../features/builtin-skills/runtime-guidance.js';
+} from "./types.js";
+import { resolveLiveData } from "./live-data.js";
+import {
+  parseFrontmatter,
+  parseFrontmatterAliases,
+  stripOptionalQuotes,
+} from "../../utils/frontmatter.js";
+import {
+  formatOmcCliInvocation,
+  rewriteOmcCliInvocations,
+} from "../../utils/omc-cli-rendering.js";
+import {
+  parseSkillPipelineMetadata,
+  renderSkillPipelineGuidance,
+} from "../../utils/skill-pipeline.js";
+import { renderSkillResourcesGuidance } from "../../utils/skill-resources.js";
+import { renderSkillRuntimeGuidance } from "../../features/builtin-skills/runtime-guidance.js";
+import { getSkillsDir } from "../../features/builtin-skills/skills.js";
 
 /** Claude config directory */
 const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
@@ -32,16 +43,16 @@ const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
  * with `omc-` to avoid overriding built-in CC slash commands.
  */
 const CC_NATIVE_COMMANDS = new Set([
-  'review',
-  'plan',
-  'security-review',
-  'init',
-  'doctor',
-  'help',
-  'config',
-  'clear',
-  'compact',
-  'memory',
+  "review",
+  "plan",
+  "security-review",
+  "init",
+  "doctor",
+  "help",
+  "config",
+  "clear",
+  "compact",
+  "memory",
 ]);
 
 function toSafeSkillName(name: string): string {
@@ -66,7 +77,7 @@ function getFrontmatterString(
  */
 function discoverCommandsFromDir(
   commandsDir: string,
-  scope: CommandScope
+  scope: CommandScope,
 ): CommandInfo[] {
   if (!existsSync(commandsDir)) {
     return [];
@@ -83,19 +94,19 @@ function discoverCommandsFromDir(
 
   for (const entry of entries) {
     // Only process .md files
-    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
 
     const commandPath = join(commandsDir, entry.name);
-    const commandName = basename(entry.name, '.md');
+    const commandName = basename(entry.name, ".md");
 
     try {
-      const content = readFileSync(commandPath, 'utf-8');
+      const content = readFileSync(commandPath, "utf-8");
       const { metadata: fm, body } = parseFrontmatter(content);
 
       const commandMetadata: CommandMetadata = {
         name: commandName,
-        description: fm.description || '',
-        argumentHint: fm['argument-hint'],
+        description: fm.description || "",
+        argumentHint: fm["argument-hint"],
         model: fm.model,
         agent: fm.agent,
       };
@@ -127,25 +138,30 @@ function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
     for (const dir of skillDirs) {
       if (!dir.isDirectory()) continue;
 
-      const skillPath = join(skillsDir, dir.name, 'SKILL.md');
+      const skillPath = join(skillsDir, dir.name, "SKILL.md");
       if (!existsSync(skillPath)) continue;
 
       try {
-        const content = readFileSync(skillPath, 'utf-8');
+        const content = readFileSync(skillPath, "utf-8");
         const { metadata: fm, body } = parseFrontmatter(content);
 
-        const rawName = getFrontmatterString(fm, 'name') || dir.name;
+        const rawName = getFrontmatterString(fm, "name") || dir.name;
         const canonicalName = toSafeSkillName(rawName);
-        const aliases = Array.from(new Set(
-          parseFrontmatterAliases(fm.aliases)
-            .map((alias: string) => toSafeSkillName(alias))
-            .filter((alias: string) => alias.toLowerCase() !== canonicalName.toLowerCase())
-        ));
+        const aliases = Array.from(
+          new Set(
+            parseFrontmatterAliases(fm.aliases)
+              .map((alias: string) => toSafeSkillName(alias))
+              .filter(
+                (alias: string) =>
+                  alias.toLowerCase() !== canonicalName.toLowerCase(),
+              ),
+          ),
+        );
         const commandNames = [canonicalName, ...aliases];
-        const description = getFrontmatterString(fm, 'description') || '';
-        const argumentHint = getFrontmatterString(fm, 'argument-hint');
-        const model = getFrontmatterString(fm, 'model');
-        const agent = getFrontmatterString(fm, 'agent');
+        const description = getFrontmatterString(fm, "description") || "";
+        const argumentHint = getFrontmatterString(fm, "argument-hint");
+        const model = getFrontmatterString(fm, "model");
+        const agent = getFrontmatterString(fm, "agent");
         const pipeline = parseSkillPipelineMetadata(fm);
 
         for (const commandName of commandNames) {
@@ -170,7 +186,7 @@ function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
             path: skillPath,
             metadata,
             content: body,
-            scope: 'skill',
+            scope: "skill",
           });
         }
       } catch {
@@ -188,25 +204,31 @@ function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
  * Discover all available commands from multiple sources
  */
 export function discoverAllCommands(): CommandInfo[] {
-  const userCommandsDir = join(CLAUDE_CONFIG_DIR, 'commands');
-  const projectCommandsDir = join(process.cwd(), '.claude', 'commands');
-  const projectOmcSkillsDir = join(process.cwd(), '.omc', 'skills');
-  const projectAgentSkillsDir = join(process.cwd(), '.agents', 'skills');
-  const userSkillsDir = join(CLAUDE_CONFIG_DIR, 'skills');
+  const userCommandsDir = join(CLAUDE_CONFIG_DIR, "commands");
+  const projectCommandsDir = join(process.cwd(), ".claude", "commands");
+  const projectOmcSkillsDir = join(process.cwd(), ".omc", "skills");
+  const projectAgentSkillsDir = join(process.cwd(), ".agents", "skills");
+  const userSkillsDir = join(CLAUDE_CONFIG_DIR, "skills");
+  const builtinSkillsDir = getSkillsDir();
 
-  const userCommands = discoverCommandsFromDir(userCommandsDir, 'user');
-  const projectCommands = discoverCommandsFromDir(projectCommandsDir, 'project');
+  const userCommands = discoverCommandsFromDir(userCommandsDir, "user");
+  const projectCommands = discoverCommandsFromDir(
+    projectCommandsDir,
+    "project",
+  );
   const projectOmcSkills = discoverSkillsFromDir(projectOmcSkillsDir);
   const projectAgentSkills = discoverSkillsFromDir(projectAgentSkillsDir);
   const userSkills = discoverSkillsFromDir(userSkillsDir);
+  const builtinSkills = discoverSkillsFromDir(builtinSkillsDir);
 
-  // Priority: project commands > user commands > project OMC skills > project compatibility skills > user skills
+  // Priority: project commands > user commands > project OMC skills > project compatibility skills > user skills > builtin skills
   const prioritized = [
     ...projectCommands,
     ...userCommands,
     ...projectOmcSkills,
     ...projectAgentSkills,
     ...userSkills,
+    ...builtinSkills,
   ];
   const seen = new Set<string>();
 
@@ -225,7 +247,7 @@ export function findCommand(commandName: string): CommandInfo | null {
   const allCommands = discoverAllCommands();
   return (
     allCommands.find(
-      (cmd) => cmd.name.toLowerCase() === commandName.toLowerCase()
+      (cmd) => cmd.name.toLowerCase() === commandName.toLowerCase(),
     ) ?? null
   );
 }
@@ -234,41 +256,41 @@ export function findCommand(commandName: string): CommandInfo | null {
  * Resolve $ARGUMENTS placeholder in command content
  */
 function resolveArguments(content: string, args: string): string {
-  return content.replace(/\$ARGUMENTS/g, args || '(no arguments provided)');
+  return content.replace(/\$ARGUMENTS/g, args || "(no arguments provided)");
 }
 
 function hasInvocationFlag(args: string, flag: string): boolean {
-  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(`(^|\\s)${escaped}(?=\\s|$)`).test(args);
 }
 
 function stripInvocationFlag(args: string, flag: string): string {
-  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return args
-    .replace(new RegExp(`(^|\\s)${escaped}(?=\\s|$)`, 'g'), ' ')
-    .replace(/\s+/g, ' ')
+    .replace(new RegExp(`(^|\\s)${escaped}(?=\\s|$)`, "g"), " ")
+    .replace(/\s+/g, " ")
     .trim();
 }
 
 function renderDeepInterviewAutoresearchGuidance(args: string): string {
-  const missionSeed = stripInvocationFlag(args, '--autoresearch');
+  const missionSeed = stripInvocationFlag(args, "--autoresearch");
   const lines = [
-    '## Autoresearch Setup Mode',
-    `This deep-interview invocation was launched as the zero-learning-curve setup lane for \`${formatOmcCliInvocation('autoresearch')}\`.`,
-    '',
-    'Required behavior in this mode:',
+    "## Autoresearch Setup Mode",
+    `This deep-interview invocation was launched as the zero-learning-curve setup lane for \`${formatOmcCliInvocation("autoresearch")}\`.`,
+    "",
+    "Required behavior in this mode:",
     '- If the mission is not already clear, start by asking: "What should autoresearch improve or prove for this repo?"',
-    '- Treat evaluator clarity as a required readiness gate before launch.',
-    '- When the mission and evaluator are ready, launch direct execution with:',
+    "- Treat evaluator clarity as a required readiness gate before launch.",
+    "- When the mission and evaluator are ready, launch direct execution with:",
     `  \`${formatOmcCliInvocation('autoresearch --mission "<mission>" --eval "<evaluator>" [--keep-policy <policy>] [--slug <slug>]')}\``,
-    '- Do **not** hand off to `omc-plan`, `autopilot`, `ralph`, or `team` in this mode.',
+    "- Do **not** hand off to `omc-plan`, `autopilot`, `ralph`, or `team` in this mode.",
   ];
 
   if (missionSeed) {
-    lines.push('', `Mission seed from invocation: \`${missionSeed}\``);
+    lines.push("", `Mission seed from invocation: \`${missionSeed}\``);
   }
 
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 /**
@@ -276,11 +298,12 @@ function renderDeepInterviewAutoresearchGuidance(args: string): string {
  */
 function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   const sections: string[] = [];
-  const isDeepInterviewAutoresearch = cmd.scope === 'skill'
-    && cmd.metadata.name.toLowerCase() === 'deep-interview'
-    && hasInvocationFlag(args, '--autoresearch');
+  const isDeepInterviewAutoresearch =
+    cmd.scope === "skill" &&
+    cmd.metadata.name.toLowerCase() === "deep-interview" &&
+    hasInvocationFlag(args, "--autoresearch");
   const displayArgs = isDeepInterviewAutoresearch
-    ? stripInvocationFlag(args, '--autoresearch')
+    ? stripInvocationFlag(args, "--autoresearch")
     : args;
 
   sections.push(`<command-name>/${cmd.name}</command-name>\n`);
@@ -305,40 +328,51 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
 
   if (cmd.metadata.aliasOf) {
     sections.push(
-      `⚠️ **Deprecated Alias**: \`/${cmd.name}\` is deprecated and will be removed in a future release. Use \`/${cmd.metadata.aliasOf}\` instead.\n`
+      `⚠️ **Deprecated Alias**: \`/${cmd.name}\` is deprecated and will be removed in a future release. Use \`/${cmd.metadata.aliasOf}\` instead.\n`,
     );
   }
 
-  sections.push('---\n');
+  sections.push("---\n");
 
   // Resolve arguments in content, then execute any live-data commands
-  const resolvedContent = resolveArguments(cmd.content || '', displayArgs);
-  const injectedContent = rewriteOmcCliInvocations(resolveLiveData(resolvedContent));
-  const runtimeGuidance = cmd.scope === 'skill' && !isDeepInterviewAutoresearch
-    ? renderSkillRuntimeGuidance(cmd.metadata.name)
-    : '';
-  const pipelineGuidance = cmd.scope === 'skill' && !isDeepInterviewAutoresearch
-    ? renderSkillPipelineGuidance(cmd.metadata.name, cmd.metadata.pipeline)
-    : '';
-  const resourceGuidance = cmd.scope === 'skill' && cmd.path
-    ? renderSkillResourcesGuidance(cmd.path)
-    : '';
+  const resolvedContent = resolveArguments(cmd.content || "", displayArgs);
+  const injectedContent = rewriteOmcCliInvocations(
+    resolveLiveData(resolvedContent),
+  );
+  const runtimeGuidance =
+    cmd.scope === "skill" && !isDeepInterviewAutoresearch
+      ? renderSkillRuntimeGuidance(cmd.metadata.name)
+      : "";
+  const pipelineGuidance =
+    cmd.scope === "skill" && !isDeepInterviewAutoresearch
+      ? renderSkillPipelineGuidance(cmd.metadata.name, cmd.metadata.pipeline)
+      : "";
+  const resourceGuidance =
+    cmd.scope === "skill" && cmd.path
+      ? renderSkillResourcesGuidance(cmd.path)
+      : "";
   const invocationGuidance = isDeepInterviewAutoresearch
     ? renderDeepInterviewAutoresearchGuidance(args)
-    : '';
+    : "";
   sections.push(
-    [injectedContent.trim(), invocationGuidance, runtimeGuidance, pipelineGuidance, resourceGuidance]
+    [
+      injectedContent.trim(),
+      invocationGuidance,
+      runtimeGuidance,
+      pipelineGuidance,
+      resourceGuidance,
+    ]
       .filter((section) => section.trim().length > 0)
-      .join('\n\n')
+      .join("\n\n"),
   );
 
-  if (displayArgs && !cmd.content?.includes('$ARGUMENTS')) {
-    sections.push('\n\n---\n');
-    sections.push('## User Request\n');
+  if (displayArgs && !cmd.content?.includes("$ARGUMENTS")) {
+    sections.push("\n\n---\n");
+    sections.push("## User Request\n");
     sections.push(displayArgs);
   }
 
-  return sections.join('\n');
+  return sections.join("\n");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `getSkillsDir()` to `discoverAllCommands()` at lowest priority so builtin skill aliases (e.g. `/psm` for `project-session-manager`) are discoverable via the auto-slash-command hook.

## Problem
`discoverAllCommands()` in `src/hooks/auto-slash-command/executor.ts` searches user commands, project commands, and user skills directories — but **never** includes the package's own builtin skills directory (`skills/`). This causes all builtin skill aliases defined via `aliases:` in SKILL.md frontmatter to be broken as slash commands.

## Fix
Import `getSkillsDir()` from `src/features/builtin-skills/skills.ts` and add the builtin skills directory as the last (lowest priority) source in the discovery pipeline. The existing deduplication logic ensures user/project skills can still override builtin ones.

## Changes
- `src/hooks/auto-slash-command/executor.ts`: Import `getSkillsDir`, discover builtin skills, append at lowest priority

Fixes #1831