### PR TITLE
feat(hud): auto-detect terminal width for responsive wrapping

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -41,7 +41,10 @@ import type {
 } from "./types.js";
 import { getRuntimePackageVersion } from "../lib/version.js";
 import { compareVersions } from "../features/auto-update.js";
-import { resolveToWorktreeRoot, resolveTranscriptPath } from "../lib/worktree-paths.js";
+import {
+  resolveToWorktreeRoot,
+  resolveTranscriptPath,
+} from "../lib/worktree-paths.js";
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from "fs";
 import { access, readFile } from "fs/promises";
 import { join, basename, dirname } from "path";
@@ -59,15 +62,17 @@ function extractSessionIdFromPath(transcriptPath: string): string | null {
   return match ? match[1] : null;
 }
 
-
 /**
  * Read cached session summary from state directory.
  */
-function readSessionSummary(stateDir: string, sessionId: string): SessionSummaryState | null {
+function readSessionSummary(
+  stateDir: string,
+  sessionId: string,
+): SessionSummaryState | null {
   const statePath = join(stateDir, `session-summary-${sessionId}.json`);
   if (!existsSync(statePath)) return null;
   try {
-    return JSON.parse(readFileSync(statePath, 'utf-8'));
+    return JSON.parse(readFileSync(statePath, "utf-8"));
   } catch {
     return null;
   }
@@ -77,29 +82,46 @@ function readSessionSummary(stateDir: string, sessionId: string): SessionSummary
  * Spawn the session-summary script in the background to generate/update summary.
  * Fire-and-forget: does not block HUD rendering.
  */
-function spawnSessionSummaryScript(transcriptPath: string, stateDir: string, sessionId: string): void {
+function spawnSessionSummaryScript(
+  transcriptPath: string,
+  stateDir: string,
+  sessionId: string,
+): void {
   // Resolve the script path relative to this file's location
   // In compiled output: dist/hud/index.js -> ../../scripts/session-summary.mjs
   const thisDir = dirname(fileURLToPath(import.meta.url));
-  const scriptPath = join(thisDir, '..', '..', 'scripts', 'session-summary.mjs');
+  const scriptPath = join(
+    thisDir,
+    "..",
+    "..",
+    "scripts",
+    "session-summary.mjs",
+  );
 
   if (!existsSync(scriptPath)) {
     if (process.env.OMC_DEBUG) {
-      console.error('[HUD] session-summary script not found:', scriptPath);
+      console.error("[HUD] session-summary script not found:", scriptPath);
     }
     return;
   }
 
   try {
-    const child = spawn('node', [scriptPath, transcriptPath, stateDir, sessionId], {
-      stdio: 'ignore',
-      detached: true,
-      env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: 'session-summary' },
-    });
+    const child = spawn(
+      "node",
+      [scriptPath, transcriptPath, stateDir, sessionId],
+      {
+        stdio: "ignore",
+        detached: true,
+        env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: "session-summary" },
+      },
+    );
     child.unref();
   } catch (error) {
     if (process.env.OMC_DEBUG) {
-      console.error('[HUD] Failed to spawn session-summary:', error instanceof Error ? error.message : error);
+      console.error(
+        "[HUD] Failed to spawn session-summary:",
+        error instanceof Error ? error.message : error,
+      );
     }
   }
 }
@@ -113,9 +135,9 @@ async function calculateSessionHealth(
 ): Promise<SessionHealth | null> {
   const durationMs = sessionStart ? Date.now() - sessionStart.getTime() : 0;
   const durationMinutes = Math.floor(durationMs / 60_000);
-  let health: SessionHealth['health'] = 'healthy';
-  if (durationMinutes > 120 || contextPercent > 85) health = 'critical';
-  else if (durationMinutes > 60 || contextPercent > 70) health = 'warning';
+  let health: SessionHealth["health"] = "healthy";
+  if (durationMinutes > 120 || contextPercent > 85) health = "critical";
+  else if (durationMinutes > 60 || contextPercent > 70) health = "warning";
   return { durationMinutes, messageCount: 0, health };
 }
 
@@ -157,21 +179,45 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     // Read configuration (before transcript parsing so we can use staleTaskThresholdMinutes)
     const config = readHudConfig();
 
+    // Auto-detect terminal width if not explicitly configured (#1726)
+    if (config.maxWidth === undefined) {
+      const cols =
+        parseInt(process.env.COLUMNS ?? "0", 10) ||
+        process.stderr.columns ||
+        process.stdout.columns ||
+        0;
+      if (cols > 0) {
+        config.maxWidth = cols;
+        if (!config.wrapMode) config.wrapMode = "wrap";
+      }
+    }
+
     // Resolve worktree-mismatched transcript paths (issue #1094)
-    const resolvedTranscriptPath = resolveTranscriptPath(stdin.transcript_path, cwd);
+    const resolvedTranscriptPath = resolveTranscriptPath(
+      stdin.transcript_path,
+      cwd,
+    );
 
     // Parse transcript for agents and todos
     const transcriptData = await parseTranscript(resolvedTranscriptPath, {
       staleTaskThresholdMinutes: config.staleTaskThresholdMinutes,
     });
 
-    const currentSessionId = extractSessionIdFromPath(resolvedTranscriptPath ?? stdin.transcript_path);
+    const currentSessionId = extractSessionIdFromPath(
+      resolvedTranscriptPath ?? stdin.transcript_path,
+    );
 
     // Read OMC state files
     const ralph = readRalphStateForHud(cwd, currentSessionId ?? undefined);
-    const ultrawork = readUltraworkStateForHud(cwd, currentSessionId ?? undefined);
+    const ultrawork = readUltraworkStateForHud(
+      cwd,
+      currentSessionId ?? undefined,
+    );
     const prd = readPrdStateForHud(cwd);
-    const autopilot = readAutopilotStateForHud(cwd, currentSessionId ?? undefined);
+    const autopilot = readAutopilotStateForHud(
+      cwd,
+      currentSessionId ?? undefined,
+    );
 
     // Read HUD state for background tasks
     const hudState = readHudState(cwd);
@@ -193,7 +239,10 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       // If invalid, fall through to transcript-derived sessionStart
     } else if (sessionStart) {
       // First time seeing session start (or new session) - persist it
-      const stateToWrite = hudState || { timestamp: new Date().toISOString(), backgroundTasks: [] };
+      const stateToWrite = hudState || {
+        timestamp: new Date().toISOString(),
+        backgroundTasks: [],
+      };
       stateToWrite.sessionStartTimestamp = sessionStart.toISOString();
       stateToWrite.sessionId = currentSessionId ?? undefined;
       stateToWrite.timestamp = new Date().toISOString();
@@ -206,7 +255,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
 
     // Fetch custom rate limit buckets (if configured)
     const customBuckets =
-      config.rateLimitsProvider?.type === 'custom'
+      config.rateLimitsProvider?.type === "custom"
         ? await executeCustomProvider(config.rateLimitsProvider)
         : null;
 
@@ -215,26 +264,36 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     let updateAvailable: string | null = null;
     try {
       omcVersion = getRuntimePackageVersion();
-      if (omcVersion === 'unknown') omcVersion = null;
+      if (omcVersion === "unknown") omcVersion = null;
     } catch (error) {
       // Ignore version detection errors
       if (process.env.OMC_DEBUG) {
-        console.error('[HUD] Version detection error:', error instanceof Error ? error.message : error);
+        console.error(
+          "[HUD] Version detection error:",
+          error instanceof Error ? error.message : error,
+        );
       }
     }
     // Async file read to avoid blocking event loop (Issue #1273)
     try {
-      const updateCacheFile = join(homedir(), '.omc', 'update-check.json');
+      const updateCacheFile = join(homedir(), ".omc", "update-check.json");
       await access(updateCacheFile);
-      const content = await readFile(updateCacheFile, 'utf-8');
+      const content = await readFile(updateCacheFile, "utf-8");
       const cached = JSON.parse(content);
-      if (cached?.latestVersion && omcVersion && compareVersions(omcVersion, cached.latestVersion) < 0) {
+      if (
+        cached?.latestVersion &&
+        omcVersion &&
+        compareVersions(omcVersion, cached.latestVersion) < 0
+      ) {
         updateAvailable = cached.latestVersion;
       }
     } catch (error) {
       // Ignore update cache read errors - expected if file doesn't exist yet
       if (process.env.OMC_DEBUG) {
-        console.error('[HUD] Update cache read error:', error instanceof Error ? error.message : error);
+        console.error(
+          "[HUD] Update cache read error:",
+          error instanceof Error ? error.message : error,
+        );
       }
     }
 
@@ -242,21 +301,27 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     let sessionSummary: SessionSummaryState | null = null;
     const sessionSummaryEnabled = config.elements.sessionSummary ?? false;
     if (sessionSummaryEnabled && resolvedTranscriptPath && currentSessionId) {
-      const omcStateDir = join(getOmcRoot(cwd), 'state');
+      const omcStateDir = join(getOmcRoot(cwd), "state");
       sessionSummary = readSessionSummary(omcStateDir, currentSessionId);
 
       // Debounce: only spawn script if cache is absent or older than 60 seconds.
       // This prevents spawning a child process on every HUD poll (every ~1s).
       // The child script still checks turn-count freshness internally.
-      const shouldSpawn = !sessionSummary?.generatedAt
-        || (Date.now() - new Date(sessionSummary.generatedAt).getTime() > 60_000);
+      const shouldSpawn =
+        !sessionSummary?.generatedAt ||
+        Date.now() - new Date(sessionSummary.generatedAt).getTime() > 60_000;
 
       if (shouldSpawn) {
-        spawnSessionSummaryScript(resolvedTranscriptPath, omcStateDir, currentSessionId);
+        spawnSessionSummaryScript(
+          resolvedTranscriptPath,
+          omcStateDir,
+          currentSessionId,
+        );
       }
     }
 
-    const missionBoardEnabled = config.missionBoard?.enabled ?? config.elements.missionBoard ?? false;
+    const missionBoardEnabled =
+      config.missionBoard?.enabled ?? config.elements.missionBoard ?? false;
     const missionBoard = missionBoardEnabled
       ? await refreshMissionBoardState(cwd, config.missionBoard)
       : null;
@@ -281,10 +346,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       customBuckets,
       pendingPermission: transcriptData.pendingPermission || null,
       thinkingState: transcriptData.thinkingState || null,
-      sessionHealth: await calculateSessionHealth(
-        sessionStart,
-        contextPercent,
-      ),
+      sessionHealth: await calculateSessionHealth(sessionStart, contextPercent),
       lastRequestTokenUsage: transcriptData.lastRequestTokenUsage || null,
       sessionTotalTokens: transcriptData.sessionTotalTokens ?? null,
       omcVersion,
@@ -299,7 +361,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
         ? detectApiKeySource(cwd)
         : null,
       profileName: process.env.CLAUDE_CONFIG_DIR
-        ? basename(process.env.CLAUDE_CONFIG_DIR).replace(/^\./, '')
+        ? basename(process.env.CLAUDE_CONFIG_DIR).replace(/^\./, "")
         : null,
       sessionSummary,
     };
@@ -323,9 +385,9 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       context.contextPercent >= config.contextLimitWarning.threshold
     ) {
       try {
-        const omcStateDir = join(getOmcRoot(cwd), 'state');
+        const omcStateDir = join(getOmcRoot(cwd), "state");
         mkdirSync(omcStateDir, { recursive: true });
-        const triggerFile = join(omcStateDir, 'compact-requested.json');
+        const triggerFile = join(omcStateDir, "compact-requested.json");
         writeFileSync(
           triggerFile,
           JSON.stringify({
@@ -337,7 +399,10 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       } catch (error) {
         // Silent failure — don't break HUD rendering
         if (process.env.OMC_DEBUG) {
-          console.error('[HUD] Auto-compact trigger write error:', error instanceof Error ? error.message : error);
+          console.error(
+            "[HUD] Auto-compact trigger write error:",
+            error instanceof Error ? error.message : error,
+          );
         }
       }
     }
@@ -350,7 +415,8 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     // terminal rendering corruption during concurrent updates
     // On Windows, always use safe mode to prevent terminal rendering issues
     // with non-breaking spaces and ANSI escape sequences
-    const useSafeMode = config.elements.safeMode || process.platform === 'win32';
+    const useSafeMode =
+      config.elements.safeMode || process.platform === "win32";
 
     if (useSafeMode) {
       output = sanitizeOutput(output);


### PR DESCRIPTION
## Summary
- Auto-detect terminal width when `maxWidth` is not explicitly configured, using fallback chain: `COLUMNS` env -> `stderr.columns` -> `stdout.columns`
- Default `wrapMode` to `'wrap'` (instead of `'truncate'`) when width is auto-detected, preserving content across multiple lines

## Problem
When the terminal is resized to a narrow width, the HUD statusline gets truncated by Claude Code with `...`, cutting off useful information. Users must manually configure `maxWidth` in `~/.claude/settings.json` — without it, no width-aware formatting happens.

## Fix
After `readHudConfig()` in `src/hud/index.ts`, add terminal width auto-detection:
- `process.env.COLUMNS` — shell-exported terminal width (most common)
- `process.stderr.columns` — stderr is often still a TTY even when stdout is piped
- `process.stdout.columns` — available when stdout is a TTY

When auto-detected, `wrapMode` defaults to `'wrap'` so content is preserved rather than cut with `...`.

## Behavior
- Zero config change needed for users
- Existing `maxWidth` / `wrapMode` settings are fully respected (no behavior change)
- HUD becomes responsive to terminal resizing

Fixes #1726