### PR TITLE
feat(hud): auto-detect terminal width for responsive wrapping

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -177,7 +177,22 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     const cwd = resolveToWorktreeRoot(stdin.cwd || undefined);
 
     // Read configuration (before transcript parsing so we can use staleTaskThresholdMinutes)
-    const config = readHudConfig();
+    // Clone to avoid mutating shared DEFAULT_HUD_CONFIG when applying runtime width detection
+    const config = { ...readHudConfig() };
+
+    // Auto-detect terminal width if not explicitly configured (#1726)
+    // Prefer live TTY columns (responds to resize) over static COLUMNS env var
+    if (config.maxWidth === undefined) {
+      const cols =
+        process.stderr.columns ||
+        process.stdout.columns ||
+        parseInt(process.env.COLUMNS ?? "0", 10) ||
+        0;
+      if (cols > 0) {
+        config.maxWidth = cols;
+        if (!config.wrapMode) config.wrapMode = "wrap";
+      }
+    }
 
     // Resolve worktree-mismatched transcript paths (issue #1094)
     const resolvedTranscriptPath = resolveTranscriptPath(


### PR DESCRIPTION
## Summary
- Auto-detect terminal width when `maxWidth` is not explicitly configured
- Default `wrapMode` to `'wrap'` when width is auto-detected, preserving content across multiple lines

## Problem
When the terminal is resized to a narrow width, the HUD statusline gets truncated by Claude Code with `...`, cutting off useful information. Users must manually configure `maxWidth` in `~/.claude/settings.json`.

## Fix
After `readHudConfig()` in `src/hud/index.ts`, add terminal width auto-detection with two key improvements based on review feedback from #1866:

1. **Clone config before mutating** — Use `{ ...readHudConfig() }` to avoid mutating the shared `DEFAULT_HUD_CONFIG` object, which would break re-detection on subsequent ticks in `--watch` mode.

2. **Prefer live TTY width over static COLUMNS** — Fallback order is now `stderr.columns` → `stdout.columns` → `COLUMNS` env, so the HUD responds to terminal resizing in watch mode rather than using a stale startup value.

## Behavior
- Zero config change needed for users
- Existing `maxWidth` / `wrapMode` settings are fully respected (no behavior change)
- HUD becomes responsive to terminal resizing
- Watch mode correctly re-detects width on each tick

Fixes #1726