### PR TITLE
Fix codex team worker registration lookups for claim-task

### DIFF
--- a/src/team/__tests__/api-interop.cwd-resolution.test.ts
+++ b/src/team/__tests__/api-interop.cwd-resolution.test.ts
@@ -82,4 +82,28 @@ describe('team api working-directory resolution', () => {
     if (!claimResult.ok) return;
     expect(typeof (claimResult.data as { claimToken?: string }).claimToken).toBe('string');
   });
+
+
+  it('claims tasks using config workers even when manifest workers are stale', async () => {
+    const teamStateRoot = await seedTeamState();
+    await writeFile(join(teamStateRoot, 'manifest.json'), JSON.stringify({
+      schema_version: 2,
+      name: teamName,
+      task: 'resolution test',
+      worker_count: 0,
+      workers: [],
+      created_at: '2026-03-06T00:00:00.000Z',
+      team_state_root: teamStateRoot,
+    }, null, 2));
+
+    const claimResult = await executeTeamApiOperation('claim-task', {
+      team_name: teamName,
+      task_id: '1',
+      worker: 'worker-1',
+    }, cwd);
+    expect(claimResult.ok).toBe(true);
+    if (!claimResult.ok) return;
+    expect((claimResult.data as { ok?: boolean }).ok).toBe(true);
+    expect(typeof (claimResult.data as { claimToken?: string }).claimToken).toBe('string');
+  });
 });

--- a/src/team/__tests__/api-interop.dispatch.test.ts
+++ b/src/team/__tests__/api-interop.dispatch.test.ts
@@ -144,6 +144,36 @@ describe('team api dispatch-aware messaging', () => {
     expect(requests[0]?.trigger_message).toContain('report progress');
   });
 
+
+  it('routes mailbox notifications using config workers when manifest workers are stale', async () => {
+    const base = join(cwd, '.omc', 'state', 'team', teamName);
+    await writeFile(join(base, 'manifest.json'), JSON.stringify({
+      schema_version: 2,
+      name: teamName,
+      task: 'dispatch',
+      worker_count: 0,
+      workers: [],
+      created_at: '2026-03-06T00:00:00.000Z',
+      team_state_root: base,
+    }, null, 2));
+
+    const sendResult = await executeTeamApiOperation('send-message', {
+      team_name: teamName,
+      from_worker: 'leader-fixed',
+      to_worker: 'worker-1',
+      body: 'Please continue',
+    }, cwd);
+
+    expect(sendResult.ok).toBe(true);
+    if (!sendResult.ok) return;
+    const messageId = (sendResult.data as { message?: { message_id?: string } }).message?.message_id;
+    expect(typeof messageId).toBe('string');
+
+    const requests = await listDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: 'worker-1' });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.message_id).toBe(messageId);
+  });
+
   it('uses the canonical worker pane when duplicate worker records exist', async () => {
     const configPath = join(cwd, '.omc', 'state', 'team', teamName, 'config.json');
     await writeFile(configPath, JSON.stringify({

--- a/src/team/__tests__/state-paths.test.ts
+++ b/src/team/__tests__/state-paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { TeamPaths, normalizeTaskFileStem } from '../state-paths.js';
+import { TeamPaths, absPath, normalizeTaskFileStem } from '../state-paths.js';
 
 describe('state-paths task/mailbox normalization', () => {
   it('normalizes numeric task ids to task-<id>.json', () => {
@@ -14,5 +14,9 @@ describe('state-paths task/mailbox normalization', () => {
 
   it('uses canonical JSON mailbox path', () => {
     expect(TeamPaths.mailbox('demo', 'worker-1')).toBe('.omc/state/team/demo/mailbox/worker-1.json');
+  });
+
+  it('preserves absolute paths when resolving team state files', () => {
+    expect(absPath('/workspace', '/already/absolute/path')).toBe('/already/absolute/path');
   });
 });

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -274,8 +274,10 @@ function resolveTeamWorkingDirectoryFromMetadata(
   const fromConfig = readTeamStateRootFromFile(join(teamRoot, 'config.json'));
   if (fromConfig) return stateRootToWorkingDirectory(fromConfig);
 
-  const fromManifest = readTeamStateRootFromFile(join(teamRoot, 'manifest.v2.json'));
-  if (fromManifest) return stateRootToWorkingDirectory(fromManifest);
+  for (const manifestName of ['manifest.json', 'manifest.v2.json']) {
+    const fromManifest = readTeamStateRootFromFile(join(teamRoot, manifestName));
+    if (fromManifest) return stateRootToWorkingDirectory(fromManifest);
+  }
 
   return null;
 }

--- a/src/team/monitor.ts
+++ b/src/team/monitor.ts
@@ -57,9 +57,47 @@ async function writeAtomic(filePath: string, data: string): Promise<void> {
 // Config / Manifest readers
 // ---------------------------------------------------------------------------
 
+function configFromManifest(manifest: TeamManifestV2): TeamConfig {
+  return {
+    name: manifest.name,
+    task: manifest.task,
+    agent_type: 'claude',
+    policy: manifest.policy,
+    governance: manifest.governance,
+    worker_launch_mode: manifest.policy.worker_launch_mode,
+    worker_count: manifest.worker_count,
+    max_workers: 20,
+    workers: manifest.workers,
+    created_at: manifest.created_at,
+    tmux_session: manifest.tmux_session,
+    next_task_id: manifest.next_task_id,
+    leader_cwd: manifest.leader_cwd,
+    team_state_root: manifest.team_state_root,
+    workspace_mode: manifest.workspace_mode,
+    leader_pane_id: manifest.leader_pane_id,
+    hud_pane_id: manifest.hud_pane_id,
+    resize_hook_name: manifest.resize_hook_name,
+    resize_hook_target: manifest.resize_hook_target,
+    next_worker_index: manifest.next_worker_index,
+  };
+}
+
 export async function readTeamConfig(teamName: string, cwd: string): Promise<TeamConfig | null> {
-  const config = await readJsonSafe<TeamConfig>(absPath(cwd, TeamPaths.config(teamName)));
-  return config ? canonicalizeTeamConfigWorkers(config) : null;
+  const [config, manifest] = await Promise.all([
+    readJsonSafe<TeamConfig>(absPath(cwd, TeamPaths.config(teamName))),
+    readTeamManifest(teamName, cwd),
+  ]);
+  if (!config && !manifest) return null;
+  if (!manifest) return config ? canonicalizeTeamConfigWorkers(config) : null;
+  if (!config) return canonicalizeTeamConfigWorkers(configFromManifest(manifest));
+  return canonicalizeTeamConfigWorkers({
+    ...configFromManifest(manifest),
+    ...config,
+    workers: [...(config.workers ?? []), ...(manifest.workers ?? [])],
+    worker_count: Math.max(config.worker_count ?? 0, manifest.worker_count ?? 0),
+    next_task_id: Math.max(config.next_task_id ?? 1, manifest.next_task_id ?? 1),
+    max_workers: Math.max(config.max_workers ?? 0, 20),
+  });
 }
 
 export async function readTeamManifest(teamName: string, cwd: string): Promise<TeamManifestV2 | null> {

--- a/src/team/state-paths.ts
+++ b/src/team/state-paths.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 
 /**
  * Typed path builders for all team state files.
@@ -124,7 +124,7 @@ export const TeamPaths = {
  * Get absolute path for a team state file.
  */
 export function absPath(cwd: string, relativePath: string): string {
-  return join(cwd, relativePath);
+  return isAbsolute(relativePath) ? relativePath : join(cwd, relativePath);
 }
 
 /**

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -191,37 +191,52 @@ async function withMailboxLock<T>(teamName: string, workerName: string, cwd: str
 // Team lifecycle
 // ---------------------------------------------------------------------------
 
-export async function teamReadConfig(teamName: string, cwd: string): Promise<TeamConfig | null> {
-  // Try manifest first, fall back to config.json
-  const manifest = await teamReadManifest(teamName, cwd);
-  if (manifest) {
-    return canonicalizeTeamConfigWorkers({
-      name: manifest.name,
-      task: manifest.task,
-      agent_type: 'claude',
-      policy: manifest.policy,
-      governance: manifest.governance,
-      worker_launch_mode: manifest.policy.worker_launch_mode,
-      worker_count: manifest.worker_count,
-      max_workers: 20,
-      workers: manifest.workers,
-      created_at: manifest.created_at,
-      tmux_session: manifest.tmux_session,
-      next_task_id: manifest.next_task_id,
-      leader_cwd: manifest.leader_cwd,
-      team_state_root: manifest.team_state_root,
-      workspace_mode: manifest.workspace_mode,
-      leader_pane_id: manifest.leader_pane_id,
-      hud_pane_id: manifest.hud_pane_id,
-      resize_hook_name: manifest.resize_hook_name,
-      resize_hook_target: manifest.resize_hook_target,
-      next_worker_index: manifest.next_worker_index,
-    });
-  }
+function configFromManifest(manifest: TeamManifestV2): TeamConfig {
+  return {
+    name: manifest.name,
+    task: manifest.task,
+    agent_type: 'claude',
+    policy: manifest.policy,
+    governance: manifest.governance,
+    worker_launch_mode: manifest.policy.worker_launch_mode,
+    worker_count: manifest.worker_count,
+    max_workers: 20,
+    workers: manifest.workers,
+    created_at: manifest.created_at,
+    tmux_session: manifest.tmux_session,
+    next_task_id: manifest.next_task_id,
+    leader_cwd: manifest.leader_cwd,
+    team_state_root: manifest.team_state_root,
+    workspace_mode: manifest.workspace_mode,
+    leader_pane_id: manifest.leader_pane_id,
+    hud_pane_id: manifest.hud_pane_id,
+    resize_hook_name: manifest.resize_hook_name,
+    resize_hook_target: manifest.resize_hook_target,
+    next_worker_index: manifest.next_worker_index,
+  };
+}
 
-  const configPath = absPath(cwd, TeamPaths.config(teamName));
-  const config = await readJsonSafe<TeamConfig>(configPath);
-  return config ? canonicalizeTeamConfigWorkers(config) : null;
+function mergeTeamConfigSources(config: TeamConfig | null, manifest: TeamManifestV2 | null): TeamConfig | null {
+  if (!config && !manifest) return null;
+  if (!manifest) return config ? canonicalizeTeamConfigWorkers(config) : null;
+  if (!config) return canonicalizeTeamConfigWorkers(configFromManifest(manifest));
+
+  return canonicalizeTeamConfigWorkers({
+    ...configFromManifest(manifest),
+    ...config,
+    workers: [...(config.workers ?? []), ...(manifest.workers ?? [])],
+    worker_count: Math.max(config.worker_count ?? 0, manifest.worker_count ?? 0),
+    next_task_id: Math.max(config.next_task_id ?? 1, manifest.next_task_id ?? 1),
+    max_workers: Math.max(config.max_workers ?? 0, 20),
+  });
+}
+
+export async function teamReadConfig(teamName: string, cwd: string): Promise<TeamConfig | null> {
+  const [manifest, config] = await Promise.all([
+    teamReadManifest(teamName, cwd),
+    readJsonSafe<TeamConfig>(absPath(cwd, TeamPaths.config(teamName))),
+  ]);
+  return mergeTeamConfigSources(config, manifest);
 }
 
 export async function teamReadManifest(teamName: string, cwd: string): Promise<TeamManifestV2 | null> {


### PR DESCRIPTION
## Summary
- merge `config.json` and manifest worker sources so stale manifests do not hide valid codex workers from `claim-task` or mailbox dispatch
- preserve absolute team-state paths to avoid doubled workspace prefixes in mailbox/dispatch path handling
- support both `manifest.json` and legacy `manifest.v2.json` when resolving team working directories

## Testing
- `npx tsc --noEmit`
- `npx eslint src/team/team-ops.ts src/team/monitor.ts src/team/state-paths.ts src/team/api-interop.ts src/team/__tests__/api-interop.cwd-resolution.test.ts src/team/__tests__/api-interop.dispatch.test.ts src/team/__tests__/state-paths.test.ts`
- `npx vitest run src/team/__tests__/api-interop.cwd-resolution.test.ts src/team/__tests__/api-interop.dispatch.test.ts src/team/__tests__/state-paths.test.ts src/team/__tests__/phase1-foundation.test.ts`

Closes #1872.
