### PR TITLE
fix(session-start): warn when silentAutoUpdate is inoperative in plugin mode

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -399,6 +399,17 @@ async function main() {
       }
     } catch {}
 
+    // Warn if silentAutoUpdate is enabled but running in plugin mode (#1773)
+    if (process.env.CLAUDE_PLUGIN_ROOT) {
+      try {
+        const omcConfigPath = join(configDir, '.omc-config.json');
+        const omcConfig = readJsonFile(omcConfigPath);
+        if (omcConfig?.silentAutoUpdate) {
+          messages.push(`<session-restore>\n\n[OMC] silentAutoUpdate is enabled in .omc-config.json but has no effect in plugin mode.\nTo update, use: /plugin marketplace update omc && /omc-setup\nOr run manually: omc update\n\n</session-restore>\n\n---\n`);
+        }
+      } catch {}
+    }
+
     // Check HUD installation (one-time setup guidance)
     const hudCheck = await checkHudInstallation();
     if (!hudCheck.installed) {


### PR DESCRIPTION
## Summary
- Detect when `silentAutoUpdate: true` is set in `.omc-config.json` but OMC is running as a plugin
- Show a session-start warning directing users to the correct update method

## Problem
`silentAutoUpdate` has no effect in plugin mode:
1. `session-start.mjs` never calls `initSilentAutoUpdate()`
2. `performUpdate()` blocks on `isRunningAsPlugin()`

## Fix
Add a check after the npm update check in `session-start.mjs`. When `CLAUDE_PLUGIN_ROOT` is set and `silentAutoUpdate: true`, inject a session-restore warning.

## Changes
- `scripts/session-start.mjs`: +11 lines, minimal insertion, zero formatting changes

## Testing
- `hud-build-guidance.test.ts`: 3/3 passing (previously failed due to formatting changes in v2)

Fixes #1773