### PR TITLE
fix(hooks): prevent one-shot skills from blocking stop hook

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -1009,41 +1009,58 @@ async function main() {
     // Priority 9: Skill Active State (issue #1033)
     // Skills like code-review, plan, ralplan, tdd, etc. write skill-active-state.json
     // when invoked via the Skill tool. This prevents premature stops mid-skill.
+    //
+    // One-shot skills (ccg, ask, cancel, note, learner, etc.) are stateless and
+    // should never block the stop hook. They complete within the same turn.
     {
+      // One-shot skills that should never block stop
+      const ONESHOT_SKILLS = new Set([
+        "ccg", "ask", "ask-codex", "ask-gemini", "cancel", "note", "learner",
+        "hud", "omc-doctor", "omc-help", "omc-setup", "mcp-setup", "skill",
+        "configure-notifications", "learn-about-omc", "release", "trace",
+        "writer-memory", "ralph-init", "project-session-manager",
+      ]);
+
       const skillState = readStateFileWithSession(stateDir, "skill-active-state.json", sessionId);
       if (skillState.state?.active) {
-        // Staleness check (per-skill TTL)
-        const sLastChecked = skillState.state.last_checked_at ? new Date(skillState.state.last_checked_at).getTime() : 0;
-        const sStartedAt = skillState.state.started_at ? new Date(skillState.state.started_at).getTime() : 0;
-        const sMostRecent = Math.max(sLastChecked, sStartedAt);
-        const sTtl = skillState.state.stale_ttl_ms || 5 * 60 * 1000;
-        const sAge = sMostRecent > 0 ? Date.now() - sMostRecent : Infinity;
-        const isStale = sMostRecent === 0 || sAge > sTtl;
+        const skillName = skillState.state.skill_name || "unknown";
 
-        if (!isStale && isSessionMatch(skillState.state, sessionId)) {
-          const count = skillState.state.reinforcement_count || 0;
-          const maxReinforcements = skillState.state.max_reinforcements || 3;
+        // Skip blocking for one-shot skills — they don't have persistent state
+        if (ONESHOT_SKILLS.has(skillName)) {
+          try { if (skillState.path && existsSync(skillState.path)) unlinkSync(skillState.path); } catch {}
+          // Fall through to allow stop
+        } else {
+          // Staleness check: use started_at ONLY — last_checked_at must not
+          // reset the TTL clock (otherwise the skill never goes stale).
+          const sStartedAt = skillState.state.started_at ? new Date(skillState.state.started_at).getTime() : 0;
+          const sTtl = skillState.state.stale_ttl_ms || 5 * 60 * 1000;
+          const sAge = sStartedAt > 0 ? Date.now() - sStartedAt : Infinity;
+          const isStale = sStartedAt === 0 || sAge > sTtl;
 
-          if (count < maxReinforcements) {
-            if (getActiveSubagentCount(stateDir) > 0) {
-              console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+          if (!isStale && isSessionMatch(skillState.state, sessionId)) {
+            const count = skillState.state.reinforcement_count || 0;
+            const maxReinforcements = skillState.state.max_reinforcements || 3;
+
+            if (count < maxReinforcements) {
+              if (getActiveSubagentCount(stateDir) > 0) {
+                console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+                return;
+              }
+
+              skillState.state.reinforcement_count = count + 1;
+              skillState.state.last_checked_at = new Date().toISOString();
+              writeJsonFile(skillState.path, skillState.state);
+
+              const skillActiveReason = `[SKILL ACTIVE: ${skillName}] The "${skillName}" skill is still executing (reinforcement ${count + 1}/${maxReinforcements}). Continue working on the skill's instructions. Do not stop until the skill completes its workflow.`;
+              console.log(JSON.stringify({
+                decision: "block",
+                reason: skillActiveReason,
+              }));
               return;
+            } else {
+              // Reinforcement limit reached - clear state and allow stop
+              try { if (skillState.path && existsSync(skillState.path)) unlinkSync(skillState.path); } catch {}
             }
-
-            skillState.state.reinforcement_count = count + 1;
-            skillState.state.last_checked_at = new Date().toISOString();
-            writeJsonFile(skillState.path, skillState.state);
-
-            const skillName = skillState.state.skill_name || "unknown";
-            const skillActiveReason = `[SKILL ACTIVE: ${skillName}] The "${skillName}" skill is still executing (reinforcement ${count + 1}/${maxReinforcements}). Continue working on the skill's instructions. Do not stop until the skill completes its workflow.`;
-            console.log(JSON.stringify({
-              decision: "block",
-              reason: skillActiveReason,
-            }));
-            return;
-          } else {
-            // Reinforcement limit reached - clear state and allow stop
-            try { if (skillState.path && existsSync(skillState.path)) unlinkSync(skillState.path); } catch {}
           }
         }
       }


### PR DESCRIPTION
## Problem

Two bugs in `persistent-mode.cjs` Priority 9 (skill-active-state) cause one-shot skills like `ccg`, `ask`, `cancel`, `note` to block the stop hook up to 5 times before finally allowing the session to stop.

### Bug 1: TTL self-refresh defeats staleness check

`last_checked_at` is updated on every hook check (line 1034), resetting the staleness clock. This means the TTL (`stale_ttl_ms`) never actually expires — the skill state stays "fresh" indefinitely because each reinforcement check refreshes the timestamp.

**Before:** `sMostRecent = Math.max(sLastChecked, sStartedAt)` — `sLastChecked` always wins since it's just updated.
**After:** `sAge = Date.now() - sStartedAt` — TTL calculated from `started_at` only, `last_checked_at` no longer resets the clock.

### Bug 2: One-shot skills never write `active: false`

Stateless skills (ccg, ask, cancel, note, learner, hud, etc.) write `active: true` when invoked via the Skill tool, but they have no completion hook to write `active: false`. They run within a single turn and complete naturally — there's no persistent state to track.

The only escape path was `reinforcement_count >= max_reinforcements` (default 5), meaning 5 consecutive stop blocks before the session could actually stop.

**Fix:** Added `ONESHOT_SKILLS` set containing 19 stateless utility skills. When the hook detects one of these, it auto-clears the state file and falls through to allow stop immediately.

## Changes

- `scripts/persistent-mode.cjs`: +47/-30 lines
  - Added `ONESHOT_SKILLS` set (19 skills that should never block stop)
  - TTL now uses `started_at` only, not `Math.max(last_checked_at, started_at)`
  - One-shot skills auto-clear their state file on first stop check

## Testing

Verified locally: after invoking `/ccg` and completing the workflow, the stop hook no longer blocks. Previously it blocked 5 times with `[SKILL ACTIVE: ccg]` messages.

## Related

- Issue #1033 (skill-active-state feature)
- Issue #1878 (omc-hub-rs memory overhead — same contributor)