### PR TITLE
fix: resolve 6 verified bugs across MCP, hooks, CLI, and utils

### DIFF
--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -364,6 +364,7 @@ export function deepMerge<T extends Record<string, unknown>>(
   const result = { ...target };
 
   for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
     const sourceValue = source[key as keyof T];
     const targetValue = target[key as keyof T];
 

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -506,9 +506,9 @@ describe('extractDiscordFlag', () => {
 // extractOpenClawFlag
 // ---------------------------------------------------------------------------
 describe('extractOpenClawFlag', () => {
-  it('returns openclawEnabled=false with no --openclaw flag', () => {
+  it('returns openclawEnabled=undefined with no --openclaw flag', () => {
     const result = extractOpenClawFlag(['--madmax']);
-    expect(result.openclawEnabled).toBe(false);
+    expect(result.openclawEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual(['--madmax']);
   });
 
@@ -560,9 +560,9 @@ describe('extractOpenClawFlag', () => {
     expect(result.openclawEnabled).toBe(false);
   });
 
-  it('returns openclawEnabled=false for empty args', () => {
+  it('returns openclawEnabled=undefined for empty args', () => {
     const result = extractOpenClawFlag([]);
-    expect(result.openclawEnabled).toBe(false);
+    expect(result.openclawEnabled).toBeUndefined();
     expect(result.remainingArgs).toEqual([]);
   });
 

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -67,8 +67,8 @@ export function extractNotifyFlag(args: string[]): { notifyEnabled: boolean; rem
  * Does NOT consume the next positional arg (no space-separated value).
  * This flag is stripped before passing args to Claude CLI.
  */
-export function extractOpenClawFlag(args: string[]): { openclawEnabled: boolean; remainingArgs: string[] } {
-  let openclawEnabled = false;
+export function extractOpenClawFlag(args: string[]): { openclawEnabled: boolean | undefined; remainingArgs: string[] } {
+  let openclawEnabled: boolean | undefined = undefined;
   const remainingArgs: string[] = [];
 
   for (const arg of args) {

--- a/src/hooks/autopilot/state.ts
+++ b/src/hooks/autopilot/state.ts
@@ -29,6 +29,7 @@ import { loadConfig } from "../../config/loader.js";
 import { resolvePlanOutputAbsolutePath } from "../../config/plan-output.js";
 import {
   readRalphState,
+  writeRalphState,
   clearRalphState,
   clearLinkedUltraworkState,
 } from "../ralph/index.js";
@@ -415,35 +416,38 @@ export function transitionRalphToUltraQA(
     };
   }
 
-  // Step 2: Cleanly terminate Ralph (and linked Ultrawork)
+  // Step 2: Deactivate Ralph (set active=false) so UltraQA's mutual exclusion
+  // check passes, but keep state file on disk for rollback if UltraQA fails.
+  if (ralphState) {
+    writeRalphState(directory, { ...ralphState, active: false }, sessionId);
+  }
   if (ralphState?.linked_ultrawork) {
     clearLinkedUltraworkState(directory, sessionId);
-  }
-  const ralphCleared = clearRalphState(directory, sessionId);
-
-  if (!ralphCleared) {
-    return {
-      success: false,
-      error: "Failed to clear Ralph state",
-    };
   }
 
   // Step 3: Transition to QA phase
   const newState = transitionPhase(directory, "qa", sessionId);
   if (!newState) {
+    // Rollback: re-activate Ralph
+    if (ralphState) {
+      writeRalphState(directory, ralphState, sessionId);
+    }
     return {
       success: false,
       error: "Failed to transition to QA phase",
     };
   }
 
-  // Step 4: Start UltraQA
+  // Step 4: Start UltraQA (Ralph is deactivated, mutual exclusion passes)
   const qaResult = startUltraQA(directory, "tests", sessionId, {
     maxCycles: 5,
   });
 
   if (!qaResult.success) {
-    // Rollback on failure - restore execution phase
+    // Rollback: restore Ralph state and execution phase
+    if (ralphState) {
+      writeRalphState(directory, ralphState, sessionId);
+    }
     transitionPhase(directory, "execution", sessionId);
     updateExecution(directory, { ralph_completed_at: undefined }, sessionId);
 
@@ -452,6 +456,9 @@ export function transitionRalphToUltraQA(
       error: qaResult.error || "Failed to start UltraQA",
     };
   }
+
+  // Step 5: UltraQA started — clear Ralph state fully (best-effort)
+  clearRalphState(directory, sessionId);
 
   return {
     success: true,

--- a/src/lib/shared-memory.ts
+++ b/src/lib/shared-memory.ts
@@ -180,9 +180,16 @@ export function writeEntry(
     entry.expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
   }
 
-  const tmpPath = filePath + '.tmp';
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
   writeFileSync(tmpPath, JSON.stringify(entry, null, 2), 'utf-8');
   renameSync(tmpPath, filePath);
+
+  // Clean up legacy .tmp file (old constant-suffix scheme) if it exists
+  try {
+    const legacyTmp = filePath + '.tmp';
+    if (existsSync(legacyTmp)) unlinkSync(legacyTmp);
+  } catch { /* best-effort cleanup */ }
+
   return entry;
 }
 

--- a/src/mcp/standalone-server.ts
+++ b/src/mcp/standalone-server.ts
@@ -34,7 +34,7 @@ interface ToolDef {
   description: string;
   annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean; idempotentHint?: boolean; openWorldHint?: boolean };
   schema: z.ZodRawShape | z.ZodObject<z.ZodRawShape>;
-  handler: (args: unknown) => Promise<{ content: Array<{ type: 'text'; text: string }> }>;
+  handler: (args: unknown) => Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }>;
 }
 
 // Aggregate all tools - AST tools gracefully degrade if @ast-grep/napi is unavailable
@@ -177,7 +177,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const result = await tool.handler((args ?? {}) as unknown);
     return {
       content: result.content,
-      isError: false,
+      isError: result.isError ?? false,
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -522,19 +522,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
-  if (isDeprecatedTeamToolName(name)) {
-    return createDeprecatedCliOnlyEnvelopeWithArgs(name, args);
-  }
 
+  // Dispatch live handlers first. The deprecation guard below currently overlaps
+  // with these same tool names but is kept as a safety net for future tool
+  // renames — if a tool name is removed from this dispatch block, the
+  // deprecation guard will catch stale callers and return a migration hint.
   try {
     if (name === 'omc_run_team_start') return await handleStart(args ?? {});
     if (name === 'omc_run_team_status') return await handleStatus(args ?? {});
     if (name === 'omc_run_team_wait') return await handleWait(args ?? {});
     if (name === 'omc_run_team_cleanup') return await handleCleanup(args ?? {});
-    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
   } catch (error) {
     return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
   }
+
+  if (isDeprecatedTeamToolName(name)) {
+    return createDeprecatedCliOnlyEnvelopeWithArgs(name, args);
+  }
+
+  return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
 });
 
 async function main() {


### PR DESCRIPTION
## Summary

Fixes 6 bugs identified through deep codebase review (5 parallel Sonnet agents + Opus verification):

- **fix(mcp)**: Pass through tool handler `isError` flag instead of hardcoding `false` — prevents silent tool failures from being reported as success to MCP clients
- **fix(mcp)**: Dispatch live team handlers before deprecation guard — makes `handleStart/Status/Wait/Cleanup` reachable instead of blocked by deprecation intercept
- **fix(hooks)**: Clear Ralph state only after UltraQA starts successfully — prevents orphaned session state when UltraQA fails to start
- **fix(cli)**: Init `openclawEnabled` as `undefined` instead of `false` — distinguishes "not specified" from "explicitly disabled", prevents `OMC_OPENCLAW=0` on every normal launch
- **fix(lib)**: Use unique tmp paths in shared-memory writes — prevents race condition where concurrent writers clobber each other via constant `.tmp` suffix
- **fix(agents)**: Add prototype pollution guard to `deepMerge` — skips `__proto__`, `constructor`, `prototype` keys to match existing guard in `config/loader.ts`

## Changed files (7 files, +40/-29)

| File | Change |
|------|--------|
| `src/mcp/standalone-server.ts` | `isError: result.isError ?? false` + type update |
| `src/mcp/team-server.ts` | Reorder handler dispatch before deprecation guard |
| `src/hooks/autopilot/state.ts` | Move `clearRalphState` after `startUltraQA` |
| `src/cli/launch.ts` | `openclawEnabled` init `undefined`, type `boolean \| undefined` |
| `src/lib/shared-memory.ts` | Unique tmp path + legacy `.tmp` cleanup |
| `src/agents/utils.ts` | Prototype pollution guard in `deepMerge` |
| `src/cli/__tests__/launch.test.ts` | Update 2 tests to expect `undefined` |

## Verification (local)

- TypeScript: `npx tsc --noEmit` — 0 errors
- Tests: 7055 passed, 0 failed
- Build: success

## Test plan

- [x] All 7055 existing tests pass
- [x] Updated 2 `extractOpenClawFlag` tests to match correct `undefined` behavior
- [x] TypeScript type check clean
- [x] Full build succeeds
- [ ] CI pipeline passes on upstream