### PR TITLE
feat(obsidian): add Obsidian CLI MCP server integration

### DIFF
--- a/skills/configure-obsidian/SKILL.md
+++ b/skills/configure-obsidian/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: configure-obsidian
+description: Configure Obsidian vault integration for persistent knowledge management
+triggers:
+  - "configure obsidian"
+  - "setup obsidian"
+  - "obsidian integration"
+  - "obsidian vault"
+---
+
+# Configure Obsidian Integration
+
+Set up Obsidian vault integration so OMC agents can read, write, and search notes in your Obsidian vault. Requires Obsidian 1.12.4+ with CLI enabled.
+
+## How This Skill Works
+
+This is an interactive configuration skill. Walk the user through setup by asking questions with AskUserQuestion. The result is stored as environment variables or in `~/.claude/.omc-config.json`.
+
+## Step 1: Detect Obsidian CLI
+
+```bash
+# Check if obsidian CLI is available
+if command -v obsidian &> /dev/null; then
+  VERSION=$(obsidian version 2>&1 | head -1)
+  echo "OBSIDIAN_DETECTED=true"
+  echo "OBSIDIAN_VERSION=$VERSION"
+else
+  echo "OBSIDIAN_DETECTED=false"
+fi
+```
+
+If Obsidian CLI is not detected, inform the user:
+
+```
+Obsidian CLI not found. To enable it:
+1. Install Obsidian from https://obsidian.md (version 1.12.4+)
+2. Open Obsidian → Settings → General → Command Line Interface
+3. Click "Register CLI"
+4. Restart your terminal
+```
+
+Then stop — do not proceed without CLI.
+
+## Step 2: Discover Vaults
+
+```bash
+# List available vaults from Obsidian config
+obsidian vault 2>&1
+```
+
+Parse the output to get vault names and paths. Present them to the user:
+
+**Question via AskUserQuestion:** "Which vault should OMC use for knowledge storage?"
+
+Show discovered vaults as numbered options. If the user has multiple vaults, recommend using a dedicated "Dev" vault to keep personal notes separate.
+
+## Step 3: Validate Vault Access
+
+Run a connectivity test:
+
+```bash
+# Test read access
+obsidian files total vault="<selected-vault>" 2>&1
+
+# Test search
+obsidian search query="test" limit=1 vault="<selected-vault>" 2>&1
+```
+
+If tests fail, report the error and suggest:
+- Ensure Obsidian app is running
+- Check that the vault is open in Obsidian
+- Try restarting Obsidian
+
+## Step 4: Configure Allowed Folders (Optional)
+
+**Question via AskUserQuestion:** "Should OMC agents be restricted to specific folders in your vault? (Recommended: yes)"
+
+If yes, ask which folders. Suggest defaults:
+- `OMC/` — Agent-generated content
+- `Projects/` — Project-specific notes
+- `Research/` — Analysis and research reports
+
+## Step 5: Save Configuration
+
+### Option A: Environment Variable (Simple)
+
+```bash
+# Add to shell profile — vault path for auto-discovery
+echo 'export OMC_OBSIDIAN_VAULT="<vault-path>"' >> ~/.zshrc
+
+# Optional: explicit vault name (used for CLI vault= parameter)
+echo 'export OMC_OBSIDIAN_VAULT_NAME="<vault-name>"' >> ~/.zshrc
+```
+
+### Option B: Config File (Full)
+
+Write to `~/.claude/.omc-config.json` (this is what the configure skill writes):
+
+```bash
+CONFIG_FILE="$HOME/.claude/.omc-config.json"
+
+# Read existing config or create empty
+if [ -f "$CONFIG_FILE" ]; then
+  EXISTING=$(cat "$CONFIG_FILE")
+else
+  EXISTING="{}"
+fi
+
+# Merge obsidian config
+echo "$EXISTING" | jq --arg vaultPath "<vault-path>" --arg vaultName "<vault-name>" '. + {
+  "obsidian": {
+    "enabled": true,
+    "vaultPath": $vaultPath,
+    "vaultName": $vaultName,
+    "allowedFolders": ["OMC/", "Projects/", "Research/"]
+  }
+}' > "$CONFIG_FILE"
+```
+
+### Configuration Resolution Order
+
+The runtime resolves vault configuration in this order:
+1. `OMC_OBSIDIAN_VAULT` / `OMC_OBSIDIAN_VAULT_NAME` env vars (highest priority)
+2. `~/.claude/.omc-config.json` obsidian section (`vaultPath`, `vaultName`)
+3. Auto-discovery from `~/Library/Application Support/obsidian/obsidian.json` (prefers open vault)
+
+### Disabling
+
+To disable Obsidian tools without removing configuration:
+```bash
+export OMC_DISABLE_TOOLS=obsidian
+```
+
+## Step 6: Test Integration
+
+Run a full round-trip test:
+
+```bash
+# Create a test note (uses path to respect allowedFolders)
+obsidian create name="OMC-Integration-Test" path="OMC/" content="# Test Note\n\nCreated by OMC configure-obsidian skill." vault="<vault>"
+
+# Read it back
+obsidian read file="OMC/OMC-Integration-Test.md" vault="<vault>"
+
+# Search for it
+obsidian search query="OMC-Integration-Test" vault="<vault>"
+
+# Clean up (manual — delete is not exposed to agents for safety)
+# Delete the test note via Obsidian UI or CLI directly
+```
+
+If all steps succeed, show:
+
+```
+✓ Obsidian integration configured successfully!
+
+Vault: <vault-name> (<vault-path>)
+Version: <version>
+Tools available: obsidian_search, obsidian_read, obsidian_create, obsidian_append,
+                 obsidian_daily_read, obsidian_daily_append, obsidian_property_set,
+                 obsidian_backlinks
+
+Environment variable alternative (add to ~/.zshrc):
+  export OMC_OBSIDIAN_VAULT="<vault-path>"
+
+Agents can now use Obsidian tools via mcp__t__obsidian_*
+```
+
+## Step 7: Install Content Authorship Skills (Optional)
+
+kepano (Obsidian CEO) provides official skills that teach Claude how to write proper Obsidian content. These complement the MCP tools by adding knowledge of Obsidian-specific syntax.
+
+**Ask via AskUserQuestion:** "Would you like to install Obsidian content authorship skills? These teach Claude proper wikilink syntax, callout formatting, Bases queries, and Canvas diagrams. (Recommended: yes)"
+
+If yes, install the following skills (NOT obsidian-cli — it conflicts with the MCP tools):
+
+```bash
+# Install content authorship skills from kepano/obsidian-skills
+# Note: obsidian-cli SKILL.md is excluded — MCP tools handle CLI operations
+claude mcp add-skill kepano/obsidian-skills/obsidian-markdown
+claude mcp add-skill kepano/obsidian-skills/obsidian-bases
+claude mcp add-skill kepano/obsidian-skills/json-canvas
+```
+
+If the marketplace approach is available:
+```bash
+/plugin marketplace add kepano/obsidian-skills
+```
+
+Then selectively enable only content skills (NOT obsidian-cli):
+- obsidian-markdown ✓ (wikilinks, callouts, properties, embeds)
+- obsidian-bases ✓ (DB views, filters, formulas)
+- json-canvas ✓ (visual diagrams)
+- obsidian-cli ✗ (excluded — MCP tools provide this with security guardrails)
+- defuddle ✗ (optional, separate from Obsidian integration)
+
+If the user declines, note:
+```
+Skipped. You can install content skills later:
+  /plugin marketplace add kepano/obsidian-skills
+See: https://github.com/kepano/obsidian-skills
+```
+
+## Step 8: Show Quick Start Guide
+
+After successful configuration, display:
+
+```markdown
+## Quick Start
+
+### Search your vault
+Agents can search notes: `obsidian_search(query="architecture")`
+
+### Create notes from agents
+Scientist reports can be saved: `obsidian_create(name="Research Report", content="...")`
+
+### Daily notes
+Append to daily note: `obsidian_daily_append(content="- Completed feature X")`
+
+### Content Skills
+If not installed during setup, add content authorship skills:
+  /plugin marketplace add kepano/obsidian-skills
+Note: Only obsidian-markdown, obsidian-bases, and json-canvas are recommended.
+The obsidian-cli skill is not needed when MCP tools are active.
+
+### Write Obsidian-native content
+If content skills are installed, agents will use:
+- Wikilinks `[[Note Name]]` for internal references (not markdown links)
+- Callouts `> [!info]` for highlighted information
+- Properties (YAML frontmatter) with `tags`, `created`, `status`
+- Bases views for data aggregation
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Unable to connect to main process" | Restart Obsidian app, then retry |
+| CLI not found after install | Run `obsidian` once to register, restart terminal |
+| Empty search results | Ensure vault has notes and Obsidian is running |
+| Permission denied | Check vault path permissions |
+| Timeout errors | Obsidian may be updating; wait and retry |

--- a/src/__tests__/obsidian-tools.test.ts
+++ b/src/__tests__/obsidian-tools.test.ts
@@ -1,0 +1,692 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+// Mock child_process and fs before imports
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => '{}'),
+}));
+
+import { obsidianTools } from '../tools/obsidian-tools.js';
+import {
+  buildArgs,
+  getVaultConfig,
+  execObsidianCli,
+  handleObsidianSearch,
+  handleObsidianRead,
+  handleObsidianCreate,
+  handleObsidianAppend,
+  handleObsidianDailyRead,
+  handleObsidianDailyAppend,
+  handleObsidianPropertySet,
+  handleObsidianBacklinks,
+  handleObsidianHelp,
+} from '../mcp/obsidian-core.js';
+import { detectObsidianCli, resetObsidianCache } from '../mcp/obsidian-detection.js';
+import { execSync, spawn } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { EventEmitter } from 'events';
+
+describe('Obsidian Tools', () => {
+  // ========================================================================
+  // Tool Definitions
+  // ========================================================================
+  describe('Tool definitions', () => {
+    it('should export exactly 9 tools', () => {
+      expect(obsidianTools).toHaveLength(9);
+    });
+
+    it('should have name, description, schema, and handler for each tool', () => {
+      for (const tool of obsidianTools) {
+        expect(tool).toHaveProperty('name');
+        expect(tool).toHaveProperty('description');
+        expect(tool).toHaveProperty('schema');
+        expect(tool).toHaveProperty('handler');
+        expect(typeof tool.name).toBe('string');
+        expect(typeof tool.description).toBe('string');
+        expect(typeof tool.handler).toBe('function');
+      }
+    });
+
+    it('should have correct tool names', () => {
+      const names = obsidianTools.map(t => t.name);
+      expect(names).toEqual([
+        'obsidian_search',
+        'obsidian_read',
+        'obsidian_create',
+        'obsidian_append',
+        'obsidian_daily_read',
+        'obsidian_daily_append',
+        'obsidian_property_set',
+        'obsidian_backlinks',
+        'obsidian_help',
+      ]);
+    });
+
+    it('should have annotations on all tools', () => {
+      for (const tool of obsidianTools) {
+        expect(tool.annotations).toBeDefined();
+      }
+    });
+
+    it('should mark read-only tools correctly', () => {
+      const readOnlyTools = ['obsidian_search', 'obsidian_read', 'obsidian_daily_read', 'obsidian_backlinks', 'obsidian_help'];
+      for (const tool of obsidianTools) {
+        if (readOnlyTools.includes(tool.name)) {
+          expect(tool.annotations?.readOnlyHint).toBe(true);
+        }
+      }
+    });
+
+    it('should mark write tools as non-destructive', () => {
+      const writeTools = ['obsidian_create', 'obsidian_append', 'obsidian_daily_append', 'obsidian_property_set'];
+      for (const tool of obsidianTools) {
+        if (writeTools.includes(tool.name)) {
+          expect(tool.annotations?.destructiveHint).toBe(false);
+        }
+      }
+    });
+
+    it('should mark property_set as idempotent', () => {
+      const propTool = obsidianTools.find(t => t.name === 'obsidian_property_set');
+      expect(propTool?.annotations?.idempotentHint).toBe(true);
+    });
+  });
+
+  // ========================================================================
+  // Schema Validation
+  // ========================================================================
+  describe('Schema validation', () => {
+    it('obsidian_search: requires query string', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_search')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ query: 'test' }).success).toBe(true);
+      expect(schema.safeParse({}).success).toBe(false);
+      expect(schema.safeParse({ query: 123 }).success).toBe(false);
+    });
+
+    it('obsidian_search: accepts optional limit and vault', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_search')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ query: 'test', limit: 10, vault: 'Dev' }).success).toBe(true);
+    });
+
+    it('obsidian_search: rejects invalid limit', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_search')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ query: 'test', limit: 0 }).success).toBe(false);
+      expect(schema.safeParse({ query: 'test', limit: 101 }).success).toBe(false);
+      expect(schema.safeParse({ query: 'test', limit: 1.5 }).success).toBe(false);
+    });
+
+    it('obsidian_read: accepts file or path', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_read')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ file: 'notes/test.md' }).success).toBe(true);
+      expect(schema.safeParse({ path: 'notes/test.md' }).success).toBe(true);
+      expect(schema.safeParse({}).success).toBe(true); // both optional at schema level
+    });
+
+    it('obsidian_create: requires name, accepts path/content/template/overwrite', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_create')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ name: 'Test Note' }).success).toBe(true);
+      expect(schema.safeParse({}).success).toBe(false);
+      expect(schema.safeParse({
+        name: 'Test', path: 'folder', content: '# Hello', template: 'daily', overwrite: true, vault: 'Dev'
+      }).success).toBe(true);
+    });
+
+    it('obsidian_create: schema has NO folder field', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_create')!;
+      expect(tool.schema).not.toHaveProperty('folder');
+    });
+
+    it('obsidian_create: schema HAS path and overwrite fields', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_create')!;
+      expect(tool.schema).toHaveProperty('path');
+      expect(tool.schema).toHaveProperty('overwrite');
+    });
+
+    it('obsidian_append: requires content', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_append')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ file: 'test.md', content: 'hello' }).success).toBe(true);
+      expect(schema.safeParse({ file: 'test.md' }).success).toBe(false);
+    });
+
+    it('obsidian_daily_read: accepts empty or vault only', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_daily_read')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({}).success).toBe(true);
+      expect(schema.safeParse({ vault: 'Dev' }).success).toBe(true);
+    });
+
+    it('obsidian_daily_append: requires content', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_daily_append')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ content: 'entry' }).success).toBe(true);
+      expect(schema.safeParse({}).success).toBe(false);
+    });
+
+    it('obsidian_property_set: requires name and value, has type enum', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_property_set')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ file: 'test.md', name: 'status', value: 'done' }).success).toBe(true);
+      expect(schema.safeParse({ file: 'test.md', name: 'status', value: 'done', type: 'text' }).success).toBe(true);
+      expect(schema.safeParse({ file: 'test.md', name: 'status', value: 'done', type: 'checkbox' }).success).toBe(true);
+      expect(schema.safeParse({ file: 'test.md', name: 'status', value: 'done', type: 'invalid' }).success).toBe(false);
+    });
+
+    it('obsidian_property_set: accepts all valid type values', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_property_set')!;
+      const schema = z.object(tool.schema);
+      const validTypes = ['text', 'list', 'number', 'checkbox', 'date', 'datetime'];
+      for (const type of validTypes) {
+        expect(schema.safeParse({ file: 'f.md', name: 'p', value: 'v', type }).success).toBe(true);
+      }
+    });
+
+    it('obsidian_backlinks: accepts file or path', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_backlinks')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ file: 'test.md' }).success).toBe(true);
+      expect(schema.safeParse({ path: 'test.md' }).success).toBe(true);
+    });
+
+    it('obsidian_help: accepts empty schema', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_help')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({}).success).toBe(true);
+    });
+  });
+
+  // ========================================================================
+  // buildArgs
+  // ========================================================================
+  describe('buildArgs', () => {
+    it('should place vault= before subcommand', () => {
+      const args = buildArgs('search', { query: 'test', vault: 'Dev' });
+      expect(args[0]).toBe('vault=Dev');
+      expect(args[1]).toBe('search');
+      expect(args).toContain('query=test');
+    });
+
+    it('should omit vault when undefined', () => {
+      const args = buildArgs('search', { query: 'test', vault: undefined });
+      expect(args[0]).toBe('search');
+      expect(args).not.toContain('vault=undefined');
+    });
+
+    it('should omit false boolean params', () => {
+      const args = buildArgs('create', { name: 'test', overwrite: false, vault: undefined });
+      expect(args).not.toContain('overwrite');
+      expect(args).not.toContain('overwrite=false');
+    });
+
+    it('should include true boolean params as bare flags', () => {
+      const args = buildArgs('create', { name: 'test', overwrite: true, vault: undefined });
+      expect(args).toContain('overwrite');
+    });
+
+    it('should escape newlines and tabs in content', () => {
+      const args = buildArgs('create', { name: 'test', content: 'line1\nline2\ttab', vault: undefined });
+      const contentArg = args.find(a => a.startsWith('content='));
+      expect(contentArg).toBe('content=line1\\nline2\\ttab');
+    });
+
+    it('should handle number params', () => {
+      const args = buildArgs('search', { query: 'test', limit: 10, vault: undefined });
+      expect(args).toContain('limit=10');
+    });
+  });
+
+  // ========================================================================
+  // Path Validation (via handlers)
+  // ========================================================================
+  describe('Path validation', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+    });
+
+    it('should reject absolute paths', async () => {
+      const result = await handleObsidianRead({ file: '/etc/passwd' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Absolute paths are not allowed');
+    });
+
+    it('should reject path traversal', async () => {
+      const result = await handleObsidianRead({ file: '../../../etc/passwd' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Path traversal');
+    });
+
+    it('should reject null bytes', async () => {
+      const result = await handleObsidianRead({ file: 'test\0.md' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid characters');
+    });
+
+    it('should reject Windows absolute paths', async () => {
+      const result = await handleObsidianRead({ file: 'C:\\Windows\\System32' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Absolute paths are not allowed');
+    });
+  });
+
+  // ========================================================================
+  // Bug Fix Verification
+  // ========================================================================
+  describe('Bug fix: handleObsidianCreate has no folder param, no silent', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+    });
+
+    it('handleObsidianCreate accepts path instead of folder', () => {
+      // Verify the function signature accepts path, not folder — build the args directly
+      const args = buildArgs('create', {
+        name: 'test',
+        path: 'subfolder',
+        content: 'hello',
+        vault: 'Dev',
+      });
+      // path should be present, folder and silent should not
+      expect(args).toContain('path=subfolder');
+      const folderArgs = args.filter(a => a.startsWith('folder'));
+      expect(folderArgs).toHaveLength(0);
+      expect(args).not.toContain('silent');
+    });
+
+    it('buildArgs for create should not include silent or folder', () => {
+      const args = buildArgs('create', {
+        name: 'test',
+        path: 'subfolder',
+        content: 'hello',
+        vault: 'Dev',
+      });
+      expect(args).not.toContain('silent');
+      expect(args).not.toContain('silent=true');
+      const folderArgs = args.filter(a => a.startsWith('folder'));
+      expect(folderArgs).toHaveLength(0);
+      expect(args).toContain('path=subfolder');
+    });
+  });
+
+  describe('Bug fix: handleObsidianPropertySet has type param', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+    });
+
+    it('should include type in buildArgs when provided', () => {
+      const args = buildArgs('property:set', {
+        file: 'test.md',
+        name: 'status',
+        value: 'done',
+        type: 'checkbox',
+        vault: 'Dev',
+      });
+      expect(args).toContain('type=checkbox');
+    });
+
+    it('should omit type from buildArgs when not provided', () => {
+      const args = buildArgs('property:set', {
+        file: 'test.md',
+        name: 'status',
+        value: 'done',
+        type: undefined,
+        vault: 'Dev',
+      });
+      const typeArgs = args.filter(a => a.startsWith('type'));
+      expect(typeArgs).toHaveLength(0);
+    });
+  });
+
+  describe('Bug fix: getVaultConfig returns {} when enabled === false', () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(readFileSync).mockReturnValue('{}');
+      // Clear env vars
+      delete process.env.OMC_OBSIDIAN_VAULT;
+      delete process.env.OMC_OBSIDIAN_VAULT_NAME;
+    });
+
+    it('should return empty when obsidian.enabled is false', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        obsidian: {
+          enabled: false,
+          vaultPath: '/should/be/ignored',
+          vaultName: 'IgnoreMe',
+        },
+      }));
+      const config = getVaultConfig();
+      expect(config).toEqual({});
+    });
+
+    it('should return vault config when enabled is true', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        obsidian: {
+          enabled: true,
+          vaultPath: '/my/vault',
+          vaultName: 'Dev',
+        },
+      }));
+      const config = getVaultConfig();
+      expect(config.vaultPath).toBe('/my/vault');
+      expect(config.vaultName).toBe('Dev');
+    });
+
+    it('should return vault config when enabled is not specified', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        obsidian: {
+          vaultPath: '/my/vault',
+          vaultName: 'Dev',
+        },
+      }));
+      const config = getVaultConfig();
+      expect(config.vaultPath).toBe('/my/vault');
+      expect(config.vaultName).toBe('Dev');
+    });
+
+    it('should return empty when no config exists', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      const config = getVaultConfig();
+      expect(config).toEqual({});
+    });
+  });
+
+  // ========================================================================
+  // CLI Detection
+  // ========================================================================
+  describe('CLI detection', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+    });
+
+    it('should detect CLI when available', () => {
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+      const result = detectObsidianCli(false);
+      expect(result.available).toBe(true);
+      expect(result.path).toBe('/usr/local/bin/obsidian');
+    });
+
+    it('should report unavailable when CLI not found', () => {
+      vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
+      const result = detectObsidianCli(false);
+      expect(result.available).toBe(false);
+      expect(result.installHint).toBeTruthy();
+    });
+
+    it('should cache results', () => {
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+      detectObsidianCli(false);
+      vi.mocked(execSync).mockClear();
+      const cached = detectObsidianCli(true);
+      expect(cached.available).toBe(true);
+      expect(execSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // ========================================================================
+  // Handler delegation (handlers return CLI unavailable when not mocked)
+  // ========================================================================
+  describe('Handler delegation', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+      vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
+    });
+
+    it('handleObsidianSearch returns error when CLI unavailable', async () => {
+      const result = await handleObsidianSearch({ query: 'test' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not available');
+    });
+
+    it('handleObsidianRead returns error when CLI unavailable', async () => {
+      const result = await handleObsidianRead({ file: 'test.md' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('handleObsidianCreate returns error when CLI unavailable', async () => {
+      const result = await handleObsidianCreate({ name: 'test' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('handleObsidianAppend returns error when CLI unavailable', async () => {
+      const result = await handleObsidianAppend({ file: 'test.md', content: 'hello' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('handleObsidianDailyRead returns error when CLI unavailable', async () => {
+      const result = await handleObsidianDailyRead({});
+      expect(result.isError).toBe(true);
+    });
+
+    it('handleObsidianDailyAppend returns error when CLI unavailable', async () => {
+      const result = await handleObsidianDailyAppend({ content: 'hello' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('handleObsidianPropertySet returns error when CLI unavailable', async () => {
+      const result = await handleObsidianPropertySet({ file: 'test.md', name: 'status', value: 'done' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('handleObsidianBacklinks returns error when CLI unavailable', async () => {
+      const result = await handleObsidianBacklinks({ file: 'test.md' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('handleObsidianHelp returns error when CLI unavailable', async () => {
+      const result = await handleObsidianHelp();
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // ========================================================================
+  // Subcommand allowlist
+  // ========================================================================
+  describe('Subcommand allowlist', () => {
+    it('should block disallowed subcommands', async () => {
+      const result = await execObsidianCli(['rm', '-rf', '/']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Blocked subcommand');
+    });
+
+    it('should allow valid subcommands', () => {
+      // Verify valid subcommands are in the allowlist by checking buildArgs does not error
+      const validCommands = ['search', 'read', 'create', 'append', 'daily:read', 'daily:append', 'property:set', 'backlinks', 'help'];
+      for (const cmd of validCommands) {
+        const args = buildArgs(cmd, { vault: undefined });
+        expect(args[0]).toBe(cmd);
+      }
+    });
+
+    it('should block delete subcommand', async () => {
+      const result = await execObsidianCli(['delete', 'file=test.md']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Blocked subcommand');
+    });
+  });
+
+  // ========================================================================
+  // allowedFolders enforcement (MEDIUM 3)
+  // ========================================================================
+  describe('allowedFolders enforcement', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+      delete process.env.OMC_OBSIDIAN_VAULT;
+      delete process.env.OMC_OBSIDIAN_VAULT_NAME;
+    });
+
+    it('should reject paths outside allowedFolders', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        obsidian: {
+          vaultName: 'Dev',
+          allowedFolders: ['Projects/', 'OMC/'],
+        },
+      }));
+      const result = await handleObsidianRead({ file: 'Private/secret.md' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Access restricted');
+    });
+
+    it('should allow paths inside allowedFolders', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        obsidian: {
+          vaultName: 'Dev',
+          allowedFolders: ['Projects/', 'OMC/'],
+        },
+      }));
+      // Mock spawn to return a fake child process
+      const fakeChild = new EventEmitter() as ReturnType<typeof spawn>;
+      const fakeStdout = new EventEmitter();
+      const fakeStderr = new EventEmitter();
+      (fakeChild as unknown as Record<string, unknown>).stdout = fakeStdout;
+      (fakeChild as unknown as Record<string, unknown>).stderr = fakeStderr;
+      vi.mocked(spawn).mockReturnValue(fakeChild as ReturnType<typeof spawn>);
+      const resultPromise = handleObsidianRead({ file: 'Projects/readme.md' });
+      fakeStdout.emit('data', Buffer.from('# Readme'));
+      fakeChild.emit('close', 0);
+      const result = await resultPromise;
+      // Should NOT be an access restricted error — path is within allowedFolders
+      expect(result.content[0].text).not.toContain('Access restricted');
+      expect(result.content[0].text).toBe('# Readme');
+    });
+
+    it('should allow any path when allowedFolders is not configured', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        obsidian: {
+          vaultName: 'Dev',
+        },
+      }));
+      // Mock spawn to return a fake child process
+      const fakeChild = new EventEmitter() as ReturnType<typeof spawn>;
+      const fakeStdout = new EventEmitter();
+      const fakeStderr = new EventEmitter();
+      (fakeChild as unknown as Record<string, unknown>).stdout = fakeStdout;
+      (fakeChild as unknown as Record<string, unknown>).stderr = fakeStderr;
+      vi.mocked(spawn).mockReturnValue(fakeChild as ReturnType<typeof spawn>);
+      const resultPromise = handleObsidianRead({ file: 'Anywhere/note.md' });
+      fakeStdout.emit('data', Buffer.from('note content'));
+      fakeChild.emit('close', 0);
+      const result = await resultPromise;
+      // Should NOT be an access restricted error
+      expect(result.content[0].text).not.toContain('Access restricted');
+      expect(result.content[0].text).toBe('note content');
+    });
+  });
+
+  // ========================================================================
+  // enabled=false blocks all handlers (HIGH 5)
+  // ========================================================================
+  describe('enabled=false blocks handlers', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+      delete process.env.OMC_OBSIDIAN_VAULT;
+      delete process.env.OMC_OBSIDIAN_VAULT_NAME;
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        obsidian: {
+          enabled: false,
+          vaultName: 'Dev',
+        },
+      }));
+    });
+
+    it('should block search when disabled', async () => {
+      const result = await handleObsidianSearch({ query: 'test' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('disabled');
+    });
+
+    it('should block read when disabled', async () => {
+      const result = await handleObsidianRead({ file: 'test.md' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('disabled');
+    });
+
+    it('should block create when disabled', async () => {
+      const result = await handleObsidianCreate({ name: 'test' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('disabled');
+    });
+
+    it('should block help when disabled', async () => {
+      const result = await handleObsidianHelp();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('disabled');
+    });
+  });
+
+  // ========================================================================
+  // CLI stdout "Error:" detection (CRITICAL 1)
+  // ========================================================================
+  describe('CLI stdout Error: detection', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+      vi.mocked(existsSync).mockReturnValue(false);
+      delete process.env.OMC_OBSIDIAN_VAULT;
+      delete process.env.OMC_OBSIDIAN_VAULT_NAME;
+    });
+
+    it('buildArgs produces correct args for daily:append with inline', () => {
+      const args = buildArgs('daily:append', { content: 'test', inline: true, vault: 'Dev' });
+      expect(args).toContain('inline');
+      expect(args).toContain('vault=Dev');
+    });
+  });
+
+  // ========================================================================
+  // daily_append schema includes inline (HIGH 1)
+  // ========================================================================
+  describe('daily_append inline schema', () => {
+    it('obsidian_daily_append: accepts inline boolean', () => {
+      const tool = obsidianTools.find(t => t.name === 'obsidian_daily_append')!;
+      const schema = z.object(tool.schema);
+      expect(schema.safeParse({ content: 'entry', inline: true }).success).toBe(true);
+      expect(schema.safeParse({ content: 'entry', inline: false }).success).toBe(true);
+      expect(schema.safeParse({ content: 'entry' }).success).toBe(true);
+    });
+  });
+
+  // ========================================================================
+  // Vault name validation error surfacing (HIGH 4)
+  // ========================================================================
+  describe('Vault name validation errors', () => {
+    beforeEach(() => {
+      resetObsidianCache();
+      vi.mocked(execSync).mockReturnValue('/usr/local/bin/obsidian\n');
+      vi.mocked(existsSync).mockReturnValue(true);
+      delete process.env.OMC_OBSIDIAN_VAULT;
+      delete process.env.OMC_OBSIDIAN_VAULT_NAME;
+    });
+
+    it('should return error for invalid configured vault name', async () => {
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        obsidian: {
+          vaultName: 'Bad<Vault>Name!',
+        },
+      }));
+      const result = await handleObsidianSearch({ query: 'test' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid vault name');
+    });
+  });
+});

--- a/src/__tests__/omc-tools-server.test.ts
+++ b/src/__tests__/omc-tools-server.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { omcToolsServer, omcToolNames, getOmcToolNames } from '../mcp/omc-tools-server.js';
 
 const interopEnabled = process.env.OMC_INTEROP_TOOLS_ENABLED === '1';
-const totalTools = interopEnabled ? 50 : 42;
-const withoutLsp = interopEnabled ? 38 : 30;
-const withoutAst = interopEnabled ? 48 : 40;
-const withoutPython = interopEnabled ? 49 : 41;
-const withoutSkills = interopEnabled ? 47 : 39;
+const totalTools = interopEnabled ? 59 : 51;
+const withoutLsp = interopEnabled ? 47 : 39;
+const withoutAst = interopEnabled ? 57 : 49;
+const withoutPython = interopEnabled ? 58 : 50;
+const withoutSkills = interopEnabled ? 56 : 48;
 
 describe('omc-tools-server', () => {
   describe('omcToolNames', () => {

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -35,10 +35,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (31 canonical + 1 alias)', () => {
+    it('should return correct number of skills (32 canonical + 1 alias)', () => {
       const skills = createBuiltinSkills();
-      // 32 entries: 31 canonical skills + 1 deprecated alias (psm)
-      expect(skills).toHaveLength(32);
+      // 33 entries: 32 canonical skills + 1 deprecated alias (psm)
+      expect(skills).toHaveLength(33);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -94,6 +94,7 @@ describe('Builtin Skills', () => {
         'cancel',
         'ccg',
         'configure-notifications',
+        'configure-obsidian',
         'deep-dive',
         'deep-interview',
         'deepinit',
@@ -329,7 +330,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(31);
+      expect(names).toHaveLength(32);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -363,7 +364,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131, psm still exists
-      expect(names).toHaveLength(32);
+      expect(names).toHaveLength(33);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('trace');
       expect(names).toContain('visual-verdict');

--- a/src/constants/names.ts
+++ b/src/constants/names.ts
@@ -31,6 +31,7 @@ export const TOOL_CATEGORIES = {
   GEMINI: 'gemini',
   SHARED_MEMORY: 'shared-memory',
   DEEPINIT: 'deepinit',
+  OBSIDIAN: 'obsidian',
 } as const;
 export type ToolCategory = typeof TOOL_CATEGORIES[keyof typeof TOOL_CATEGORIES];
 

--- a/src/mcp/obsidian-core.ts
+++ b/src/mcp/obsidian-core.ts
@@ -1,0 +1,731 @@
+/**
+ * Obsidian Core Business Logic - Shared between SDK and Standalone MCP servers
+ *
+ * This module contains all the business logic for Obsidian CLI integration:
+ * - Constants and configuration
+ * - CLI execution with timeout handling
+ * - Vault configuration and auto-discovery
+ * - Tool handler functions for each Obsidian operation
+ *
+ * This module is SDK-agnostic and can be imported by both:
+ * - omc-tools-server.ts (in-process SDK MCP server)
+ * - standalone-server.ts (stdio-based external process server)
+ */
+
+import { spawn } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { join, basename } from 'path';
+import { homedir } from 'os';
+import { detectObsidianCli } from './obsidian-detection.js';
+
+// Constants
+export const OBSIDIAN_TIMEOUT = 10000; // 10s - CLI should be fast
+export const OBSIDIAN_MAX_OUTPUT = 500 * 1024; // 500KB output cap
+
+/**
+ * Simple stdout collector with size cap to prevent memory exhaustion.
+ */
+function createStdoutCollector(maxBytes: number) {
+  let buffer = '';
+  let size = 0;
+  return {
+    append(chunk: string) {
+      if (size < maxBytes) {
+        buffer += chunk.slice(0, maxBytes - size);
+        size += chunk.length;
+      }
+    },
+    toString() { return buffer; },
+  };
+}
+const MAX_CONTENT_SIZE = 100 * 1024; // 100KB content limit
+const MAX_STDERR = 64 * 1024; // 64KB stderr cap
+
+// HIGH 2: 'delete' removed — destructive operations must not be exposed to agents.
+// Use Obsidian UI or CLI directly for deletions.
+const ALLOWED_SUBCOMMANDS = new Set([
+  'search', 'read', 'create', 'append',
+  'daily:read', 'daily:append', 'property:set', 'backlinks',
+  'vault', 'version', 'files', 'help',
+]);
+
+type ToolResult = { content: Array<{ type: 'text'; text: string }>; isError?: boolean };
+
+/**
+ * Get the platform-specific path to Obsidian's app config file.
+ */
+function getObsidianAppConfigPath(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return join(homedir(), 'Library', 'Application Support', 'obsidian', 'obsidian.json');
+    case 'win32':
+      return join(process.env.APPDATA || join(homedir(), 'AppData', 'Roaming'), 'obsidian', 'obsidian.json');
+    default: // linux and others
+      return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'obsidian', 'obsidian.json');
+  }
+}
+
+/**
+ * Validate a file path for safety (no absolute paths, traversal, or null bytes).
+ * Returns an error message string if invalid, or null if valid.
+ * HIGH 3: accepts allowedFolders as parameter instead of reading config internally.
+ */
+function validateFilePath(filePath: string, allowedFolders?: string[]): string | null {
+  if (filePath.startsWith('/') || filePath.startsWith('\\') || /^[A-Za-z]:/.test(filePath)) {
+    return 'Absolute paths are not allowed. Use vault-relative paths.';
+  }
+  if (filePath.includes('..')) {
+    return 'Path traversal ("..") is not allowed.';
+  }
+  if (filePath.includes('\0')) {
+    return 'Invalid characters in path.';
+  }
+
+  // Enforce allowedFolders if provided
+  if (allowedFolders && allowedFolders.length > 0) {
+    const normalizedPath = filePath.replace(/\\/g, '/');
+    const isAllowed = allowedFolders.some(folder => {
+      const normalizedFolder = folder.replace(/\\/g, '/');
+      return normalizedPath.startsWith(normalizedFolder);
+    });
+    if (!isAllowed) {
+      return `Access restricted: path must be within allowed folders (${allowedFolders.join(', ')}).`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * MEDIUM 2: Validate a note name (for create). Checks for null bytes and path separators
+ * but NOT allowedFolders (name is not a path).
+ */
+function validateNoteName(name: string): string | null {
+  if (name.includes('\0')) return 'Invalid characters in note name.';
+  if (name.includes('/') || name.includes('\\')) {
+    return 'Note name cannot contain path separators. Use "path" parameter for vault-relative location.';
+  }
+  return null;
+}
+
+/**
+ * Get vault configuration from environment, OMC config, or auto-discovery.
+ *
+ * Resolution order:
+ * 1. OMC_OBSIDIAN_VAULT env var (path) / OMC_OBSIDIAN_VAULT_NAME env var (name)
+ * 2. ~/.claude/.omc-config.json obsidian section (vaultPath, vaultName)
+ * 3. ~/Library/Application Support/obsidian/obsidian.json (auto-discovery)
+ */
+interface VaultConfig {
+  vaultPath?: string;
+  vaultName?: string;
+  allowedFolders?: string[];
+}
+
+/**
+ * MEDIUM 5: Reads config file once and extracts allowedFolders inline.
+ * HIGH 5: Also exposes enabled state so handlers can check it.
+ */
+export function getVaultConfig(): VaultConfig {
+  // Read .omc-config.json once for both allowedFolders and vault config
+  let omcObsidianConfig: Record<string, unknown> | undefined;
+  try {
+    const omcConfigPath = join(homedir(), '.claude', '.omc-config.json');
+    if (existsSync(omcConfigPath)) {
+      const omcConfig = JSON.parse(readFileSync(omcConfigPath, 'utf-8'));
+      omcObsidianConfig = omcConfig?.obsidian;
+    }
+  } catch { /* best-effort */ }
+
+  // Extract allowedFolders from the single config read
+  let allowedFolders: string[] | undefined;
+  if (omcObsidianConfig) {
+    const folders = omcObsidianConfig.allowedFolders;
+    if (Array.isArray(folders) && folders.length > 0) allowedFolders = folders as string[];
+  }
+
+  // 1. Environment variables (highest priority)
+  const envVault = process.env.OMC_OBSIDIAN_VAULT;
+  const envVaultName = process.env.OMC_OBSIDIAN_VAULT_NAME;
+  if (envVault || envVaultName) {
+    return { vaultPath: envVault, vaultName: envVaultName, allowedFolders };
+  }
+
+  // 2. OMC config file (~/.claude/.omc-config.json)
+  if (omcObsidianConfig) {
+    // If explicitly disabled, return empty immediately — do NOT fall through to auto-discovery
+    if (omcObsidianConfig.enabled === false) {
+      return {};
+    }
+    if (omcObsidianConfig.vaultPath || omcObsidianConfig.vaultName) {
+      return {
+        vaultPath: omcObsidianConfig.vaultPath as string | undefined,
+        vaultName: omcObsidianConfig.vaultName as string | undefined,
+        allowedFolders,
+      };
+    }
+  }
+
+  // 3. Obsidian app config (auto-discovery, platform-aware)
+  try {
+    const obsidianConfigPath = getObsidianAppConfigPath();
+    if (existsSync(obsidianConfigPath)) {
+      const config = JSON.parse(readFileSync(obsidianConfigPath, 'utf-8'));
+      const vaults = config?.vaults;
+      if (vaults && typeof vaults === 'object') {
+        const entries = Object.values(vaults) as Array<{ path?: string; open?: boolean }>;
+        // Prefer the open vault, otherwise first entry
+        const openVault = entries.find(v => v.open);
+        const firstVault = openVault || entries[0];
+        if (firstVault?.path) {
+          return { vaultPath: firstVault.path, allowedFolders };
+        }
+      }
+    }
+  } catch {
+    // Auto-discovery is best-effort
+  }
+
+  return {};
+}
+
+/**
+ * HIGH 5: Check if Obsidian integration is explicitly disabled in config.
+ */
+function isObsidianEnabled(): boolean {
+  try {
+    const omcConfigPath = join(homedir(), '.claude', '.omc-config.json');
+    if (existsSync(omcConfigPath)) {
+      const omcConfig = JSON.parse(readFileSync(omcConfigPath, 'utf-8'));
+      if (omcConfig?.obsidian?.enabled === false) return false;
+    }
+  } catch { /* best-effort */ }
+  return true;
+}
+
+/**
+ * Build CLI args with optional vault targeting.
+ * IMPORTANT: Obsidian CLI requires vault= as the FIRST parameter, before the subcommand.
+ * e.g. buildArgs('search', { query: 'test', limit: 10, vault: 'Dev' })
+ * -> ['vault=Dev', 'search', 'query=test', 'limit=10']
+ */
+export function buildArgs(
+  command: string,
+  params: Record<string, string | number | boolean | undefined>
+): string[] {
+  const args: string[] = [];
+
+  // vault= must come first (before the subcommand) per Obsidian CLI spec
+  if (params.vault !== undefined && params.vault !== false) {
+    args.push(`vault=${String(params.vault)}`);
+  }
+
+  // Then the subcommand
+  args.push(command);
+
+  // Then all other parameters
+  for (const [key, value] of Object.entries(params)) {
+    if (key === 'vault') continue; // already handled above
+    if (value === undefined || value === false) continue;
+    if (value === true) {
+      args.push(key);
+    } else if (key === 'content' && typeof value === 'string') {
+      // Obsidian CLI uses \n for newline and \t for tab in content values.
+      // spawn() passes this as a single argv entry, safe from shell injection.
+      const escaped = value.replace(/\n/g, '\\n').replace(/\t/g, '\\t');
+      args.push(`${key}=${escaped}`);
+    } else {
+      args.push(`${key}=${String(value)}`);
+    }
+  }
+  return args;
+}
+
+/**
+ * Execute an obsidian CLI command and return raw output.
+ * Uses spawn with stdout collector pattern matching gemini-core.ts.
+ */
+export async function execObsidianCli(
+  args: string[],
+  timeout: number = OBSIDIAN_TIMEOUT
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  // Subcommand allowlist: extract first arg that isn't vault=
+  const subcommand = args.find(a => !a.startsWith('vault='));
+  if (subcommand && !ALLOWED_SUBCOMMANDS.has(subcommand)) {
+    return {
+      stdout: '',
+      stderr: `Blocked subcommand: ${subcommand}. Only ${[...ALLOWED_SUBCOMMANDS].join(', ')} are allowed.`,
+      exitCode: 1,
+    };
+  }
+
+  return new Promise((resolve) => {
+    const collector = createStdoutCollector(OBSIDIAN_MAX_OUTPUT);
+    let stderr = '';
+    let stderrSize = 0;
+
+    const child = spawn('obsidian', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout,
+      // shell: true needed on Windows for .cmd/.bat executables.
+      // Safe: args are array-based, no shell interpretation risk.
+      ...(process.platform === 'win32' ? { shell: true } : {}),
+    });
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      collector.append(chunk.toString());
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      const str = chunk.toString();
+      if (stderrSize < MAX_STDERR) {
+        stderr += str.slice(0, MAX_STDERR - stderrSize);
+        stderrSize += str.length;
+      }
+    });
+
+    child.on('close', (code) => {
+      resolve({ stdout: collector.toString(), stderr, exitCode: code ?? 1 });
+    });
+
+    child.on('error', (err) => {
+      resolve({ stdout: '', stderr: err.message, exitCode: 1 });
+    });
+  });
+}
+
+/**
+ * Helper to resolve file/path parameter (tools accept either `file` or `path`)
+ */
+function resolveFilePath(args: { file?: string; path?: string }): string | undefined {
+  return args.file ?? args.path;
+}
+
+/**
+ * Helper to create an error result when CLI is not available
+ */
+function cliUnavailableError(installHint: string): ToolResult {
+  return {
+    content: [{ type: 'text', text: `Obsidian CLI is not available. ${installHint}` }],
+    isError: true,
+  };
+}
+
+/**
+ * Helper to create an error result from CLI execution failure
+ */
+function cliErrorResult(stderr: string, stdout: string): ToolResult {
+  const message = stderr.trim() || stdout.trim() || 'Unknown error';
+  return {
+    content: [{ type: 'text', text: `Obsidian CLI error: ${message}` }],
+    isError: true,
+  };
+}
+
+/**
+ * Unified CLI result checker. Catches both non-zero exit codes
+ * AND exit-code-0 errors where CLI writes "Error:" to stdout.
+ *
+ * Set contentMayStartWithError=true for read operations (read, daily:read)
+ * where note content legitimately starts with "Error:" — in those cases,
+ * only exitCode is checked, not stdout prefix.
+ */
+function checkCliResult(
+  result: { stdout: string; stderr: string; exitCode: number },
+  contentMayStartWithError = false
+): ToolResult | null {
+  if (result.exitCode !== 0) return cliErrorResult(result.stderr, result.stdout);
+  if (!contentMayStartWithError && result.stdout.startsWith('Error:')) {
+    return { content: [{ type: 'text', text: result.stdout.trim() }], isError: true };
+  }
+  return null;
+}
+
+/**
+ * HIGH 5: Guard that returns an error ToolResult if Obsidian is disabled.
+ * Returns null when enabled (callers should proceed).
+ */
+function checkEnabled(): ToolResult | null {
+  if (!isObsidianEnabled()) {
+    return { content: [{ type: 'text', text: 'Obsidian integration is disabled in configuration.' }], isError: true };
+  }
+  return null;
+}
+
+/**
+ * Helper to resolve vault parameter, falling back to auto-discovery.
+ * Obsidian CLI accepts vault name (not path) via vault= parameter.
+ *
+ * SECURITY: When a vault is explicitly configured (via env var or .omc-config.json),
+ * the agent-provided vault parameter is intentionally ignored. This prevents agents
+ * from accessing vaults they shouldn't (e.g., a "Personal" vault with private data).
+ * The vault tool parameter only takes effect when NO vault is configured.
+ */
+/**
+ * Validate vault name to prevent shell metacharacter injection on Windows.
+ * Only allows alphanumeric, spaces, hyphens, underscores.
+ */
+function validateVaultName(name: string): string | null {
+  if (!/^[a-zA-Z0-9\s\-_]+$/.test(name)) {
+    return 'Invalid vault name: only alphanumeric characters, spaces, hyphens, and underscores are allowed.';
+  }
+  return null;
+}
+
+/**
+ * HIGH 4: Returns { vault, error } instead of silently swallowing validation errors.
+ * When validation fails, callers get an explicit error message to return to the agent.
+ */
+function resolveVaultOrError(vault?: string): { vault?: string; error?: string } {
+  const config = getVaultConfig();
+  const configuredVault = config.vaultName || (config.vaultPath ? basename(config.vaultPath) : undefined);
+
+  // If a vault is explicitly configured, always use it (ignore agent-provided vault)
+  const resolved = configuredVault || vault;
+  if (resolved) {
+    const validationError = validateVaultName(resolved);
+    if (validationError) return { error: validationError };
+    return { vault: resolved };
+  }
+
+  // No vault specified — CLI uses default
+  return { vault: undefined };
+}
+
+/**
+ * Search notes in Obsidian vault by keyword.
+ */
+export async function handleObsidianSearch(
+  args: { query: string; limit?: number; vault?: string }
+): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  const { vault, error: vaultError } = resolveVaultOrError(args.vault);
+  if (vaultError) return { content: [{ type: 'text', text: `Error: ${vaultError}` }], isError: true };
+
+  const cliArgs = buildArgs('search', {
+    query: args.query,
+    limit: args.limit,
+    vault,
+  });
+
+  const result = await execObsidianCli(cliArgs);
+  const cliError = checkCliResult(result);
+  if (cliError) return cliError;
+
+  // CRITICAL 2: Filter search results against allowedFolders
+  const config = getVaultConfig();
+  if (config.allowedFolders?.length && result.stdout) {
+    const lines = result.stdout.split('\n').filter(line =>
+      line.trim() === '' || config.allowedFolders!.some(f => line.startsWith(f))
+    );
+    return { content: [{ type: 'text', text: lines.join('\n') || 'No results found.' }] };
+  }
+
+  return { content: [{ type: 'text', text: result.stdout || 'No results found.' }] };
+}
+
+/**
+ * Read the full content of an Obsidian note.
+ */
+export async function handleObsidianRead(
+  args: { file?: string; path?: string; vault?: string }
+): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  const filePath = resolveFilePath(args);
+  if (!filePath) {
+    return { content: [{ type: 'text', text: 'Error: file or path parameter is required.' }], isError: true };
+  }
+  const config = getVaultConfig();
+  const pathError = validateFilePath(filePath, config.allowedFolders);
+  if (pathError) {
+    return { content: [{ type: 'text', text: `Error: ${pathError}` }], isError: true };
+  }
+
+  const { vault, error: vaultError } = resolveVaultOrError(args.vault);
+  if (vaultError) return { content: [{ type: 'text', text: `Error: ${vaultError}` }], isError: true };
+
+  const cliArgs = buildArgs('read', {
+    file: filePath,
+    vault,
+  });
+
+  const result = await execObsidianCli(cliArgs);
+  const cliError = checkCliResult(result, true); // contentMayStartWithError: note content can start with "Error:"
+  if (cliError) return cliError;
+  return { content: [{ type: 'text', text: result.stdout || '(empty note)' }] };
+}
+
+/**
+ * Create a new note in Obsidian vault.
+ * Silent by default (does not open in Obsidian UI when `open` is not specified).
+ */
+export async function handleObsidianCreate(
+  args: { name: string; path?: string; content?: string; template?: string; overwrite?: boolean; vault?: string }
+): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  // MEDIUM 2: Validate name as a note title, not a file path
+  const nameError = validateNoteName(args.name);
+  if (nameError) {
+    return { content: [{ type: 'text', text: `Error: ${nameError}` }], isError: true };
+  }
+  const config = getVaultConfig();
+  // When allowedFolders is configured, path is required to enforce folder boundary
+  if (config.allowedFolders?.length && !args.path) {
+    return { content: [{ type: 'text', text: `Error: path parameter is required when allowedFolders is configured (${config.allowedFolders.join(', ')}).` }], isError: true };
+  }
+  // Validate optional path against allowedFolders
+  if (args.path) {
+    const pathError = validateFilePath(args.path, config.allowedFolders);
+    if (pathError) {
+      return { content: [{ type: 'text', text: `Error: ${pathError}` }], isError: true };
+    }
+  }
+  // Validate optional template (no allowedFolders restriction — templates may live anywhere)
+  if (args.template) {
+    const templateError = validateFilePath(args.template);
+    if (templateError) {
+      return { content: [{ type: 'text', text: `Error: ${templateError}` }], isError: true };
+    }
+  }
+
+  if (args.content) {
+    if (args.content.length > MAX_CONTENT_SIZE) {
+      return { content: [{ type: 'text', text: 'Error: content exceeds 100KB limit.' }], isError: true };
+    }
+  }
+
+  const { vault, error: vaultError } = resolveVaultOrError(args.vault);
+  if (vaultError) return { content: [{ type: 'text', text: `Error: ${vaultError}` }], isError: true };
+
+  const cliArgs = buildArgs('create', {
+    name: args.name,
+    path: args.path,
+    content: args.content,
+    template: args.template,
+    overwrite: args.overwrite,
+    vault,
+  });
+
+  const result = await execObsidianCli(cliArgs);
+  const cliError = checkCliResult(result);
+  if (cliError) return cliError;
+  return { content: [{ type: 'text', text: result.stdout || `Note "${args.name}" created.` }] };
+}
+
+/**
+ * Append content to an existing Obsidian note.
+ */
+export async function handleObsidianAppend(
+  args: { file?: string; path?: string; content: string; vault?: string }
+): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  const filePath = resolveFilePath(args);
+  if (!filePath) {
+    return { content: [{ type: 'text', text: 'Error: file or path parameter is required.' }], isError: true };
+  }
+  const config = getVaultConfig();
+  const pathError = validateFilePath(filePath, config.allowedFolders);
+  if (pathError) {
+    return { content: [{ type: 'text', text: `Error: ${pathError}` }], isError: true };
+  }
+  if (!args.content) {
+    return { content: [{ type: 'text', text: 'Error: content parameter is required.' }], isError: true };
+  }
+  if (args.content.length > MAX_CONTENT_SIZE) {
+    return { content: [{ type: 'text', text: 'Error: content exceeds 100KB limit.' }], isError: true };
+  }
+
+  const { vault, error: vaultError } = resolveVaultOrError(args.vault);
+  if (vaultError) return { content: [{ type: 'text', text: `Error: ${vaultError}` }], isError: true };
+
+  const cliArgs = buildArgs('append', {
+    file: filePath,
+    content: args.content,
+    vault,
+  });
+
+  const result = await execObsidianCli(cliArgs);
+  const cliError = checkCliResult(result);
+  if (cliError) return cliError;
+  return { content: [{ type: 'text', text: result.stdout || `Content appended to "${filePath}".` }] };
+}
+
+/**
+ * Read today's daily note from Obsidian.
+ */
+export async function handleObsidianDailyRead(
+  args: { vault?: string }
+): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  const { vault, error: vaultError } = resolveVaultOrError(args.vault);
+  if (vaultError) return { content: [{ type: 'text', text: `Error: ${vaultError}` }], isError: true };
+
+  const cliArgs = buildArgs('daily:read', { vault });
+
+  const result = await execObsidianCli(cliArgs);
+  const cliError = checkCliResult(result, true); // contentMayStartWithError: daily note content can start with "Error:"
+  if (cliError) return cliError;
+  return { content: [{ type: 'text', text: result.stdout || '(empty daily note)' }] };
+}
+
+/**
+ * Append content to today's daily note.
+ * HIGH 1: supports inline flag for inline appending.
+ * Note: allowedFolders not enforced — daily note path is determined by Obsidian vault config, not agent input.
+ */
+export async function handleObsidianDailyAppend(
+  args: { content: string; inline?: boolean; vault?: string }
+): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  if (!args.content) {
+    return { content: [{ type: 'text', text: 'Error: content parameter is required.' }], isError: true };
+  }
+  if (args.content.length > MAX_CONTENT_SIZE) {
+    return { content: [{ type: 'text', text: 'Error: content exceeds 100KB limit.' }], isError: true };
+  }
+
+  const { vault, error: vaultError } = resolveVaultOrError(args.vault);
+  if (vaultError) return { content: [{ type: 'text', text: `Error: ${vaultError}` }], isError: true };
+
+  const cliArgs = buildArgs('daily:append', {
+    content: args.content,
+    inline: args.inline,
+    vault,
+  });
+
+  const result = await execObsidianCli(cliArgs);
+  const cliError = checkCliResult(result);
+  if (cliError) return cliError;
+  return { content: [{ type: 'text', text: result.stdout || 'Content appended to daily note.' }] };
+}
+
+/**
+ * Set a frontmatter property on an Obsidian note.
+ */
+export async function handleObsidianPropertySet(
+  args: { file?: string; path?: string; name: string; value: string; type?: string; vault?: string }
+): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  const filePath = resolveFilePath(args);
+  if (!filePath) {
+    return { content: [{ type: 'text', text: 'Error: file or path parameter is required.' }], isError: true };
+  }
+  const config = getVaultConfig();
+  const pathError = validateFilePath(filePath, config.allowedFolders);
+  if (pathError) {
+    return { content: [{ type: 'text', text: `Error: ${pathError}` }], isError: true };
+  }
+
+  const { vault, error: vaultError } = resolveVaultOrError(args.vault);
+  if (vaultError) return { content: [{ type: 'text', text: `Error: ${vaultError}` }], isError: true };
+
+  const cliArgs = buildArgs('property:set', {
+    file: filePath,
+    name: args.name,
+    value: args.value,
+    type: args.type,
+    vault,
+  });
+
+  const result = await execObsidianCli(cliArgs);
+  const cliError = checkCliResult(result);
+  if (cliError) return cliError;
+  return { content: [{ type: 'text', text: result.stdout || `Property "${args.name}" set on "${filePath}".` }] };
+}
+
+/**
+ * Get Obsidian CLI help output for command discovery.
+ * Agents can use this to learn about all available CLI commands.
+ */
+export async function handleObsidianHelp(): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  const result = await execObsidianCli(['help']);
+  const cliError = checkCliResult(result);
+  if (cliError) return cliError;
+  return { content: [{ type: 'text', text: result.stdout || 'No help available.' }] };
+}
+
+/**
+ * List notes that link to a given note (backlinks).
+ */
+export async function handleObsidianBacklinks(
+  args: { file?: string; path?: string; vault?: string }
+): Promise<ToolResult> {
+  const disabled = checkEnabled();
+  if (disabled) return disabled;
+
+  const detection = detectObsidianCli();
+  if (!detection.available) return cliUnavailableError(detection.installHint);
+
+  const filePath = resolveFilePath(args);
+  if (!filePath) {
+    return { content: [{ type: 'text', text: 'Error: file or path parameter is required.' }], isError: true };
+  }
+  const config = getVaultConfig();
+  const pathError = validateFilePath(filePath, config.allowedFolders);
+  if (pathError) {
+    return { content: [{ type: 'text', text: `Error: ${pathError}` }], isError: true };
+  }
+
+  const { vault, error: vaultError } = resolveVaultOrError(args.vault);
+  if (vaultError) return { content: [{ type: 'text', text: `Error: ${vaultError}` }], isError: true };
+
+  const cliArgs = buildArgs('backlinks', {
+    file: filePath,
+    vault,
+  });
+
+  const result = await execObsidianCli(cliArgs);
+  const cliError = checkCliResult(result);
+  if (cliError) return cliError;
+
+  // CRITICAL 2: Filter backlinks results against allowedFolders
+  if (config.allowedFolders?.length && result.stdout) {
+    const lines = result.stdout.split('\n').filter(line =>
+      line.trim() === '' || config.allowedFolders!.some(f => line.startsWith(f))
+    );
+    return { content: [{ type: 'text', text: lines.join('\n') || 'No backlinks found.' }] };
+  }
+
+  return { content: [{ type: 'text', text: result.stdout || 'No backlinks found.' }] };
+}

--- a/src/mcp/obsidian-detection.ts
+++ b/src/mcp/obsidian-detection.ts
@@ -1,0 +1,49 @@
+/**
+ * Obsidian CLI Detection
+ *
+ * Detects the obsidian CLI binary on the system PATH.
+ * Results are cached per-session to avoid repeated filesystem checks.
+ */
+
+import { execSync } from 'child_process';
+
+export interface CliDetectionResult {
+  available: boolean;
+  path?: string;
+  version?: string;
+  error?: string;
+  installHint: string;
+}
+
+let obsidianCache: CliDetectionResult | null = null;
+
+const installHint = 'Install Obsidian: https://obsidian.md then enable CLI in Settings → General → Command Line Interface';
+
+export function detectObsidianCli(useCache = true): CliDetectionResult {
+  if (useCache && obsidianCache) return obsidianCache;
+  try {
+    const command = process.platform === 'win32' ? 'where obsidian' : 'which obsidian';
+    const path = execSync(command, { encoding: 'utf-8', timeout: 5000 }).trim();
+    let version: string | undefined;
+    try {
+      version = execSync('obsidian version', { encoding: 'utf-8', timeout: 5000 }).trim().split('\n')[0];
+    } catch {
+      // Version check is non-fatal
+    }
+    const result: CliDetectionResult = { available: true, path, version, installHint };
+    obsidianCache = result;
+    return result;
+  } catch {
+    const result: CliDetectionResult = {
+      available: false,
+      error: 'Obsidian CLI not found on PATH',
+      installHint,
+    };
+    obsidianCache = result;
+    return result;
+  }
+}
+
+export function resetObsidianCache(): void {
+  obsidianCache = null;
+}

--- a/src/mcp/omc-tools-server.ts
+++ b/src/mcp/omc-tools-server.ts
@@ -17,6 +17,7 @@ import { traceTools } from "../tools/trace-tools.js";
 import { sharedMemoryTools } from "../tools/shared-memory-tools.js";
 import { getInteropTools } from "../interop/mcp-bridge.js";
 import { deepinitManifestTool } from "../tools/deepinit-manifest.js";
+import { obsidianTools } from "../tools/obsidian-tools.js";
 import { TOOL_CATEGORIES, type ToolCategory } from "../constants/index.js";
 
 // Type for our tool definitions
@@ -54,6 +55,7 @@ export const DISABLE_TOOLS_GROUP_MAP: Record<string, ToolCategory> = {
   'shared-memory': TOOL_CATEGORIES.SHARED_MEMORY,
   'deepinit': TOOL_CATEGORIES.DEEPINIT,
   'deepinit-manifest': TOOL_CATEGORIES.DEEPINIT,
+  'obsidian': TOOL_CATEGORIES.OBSIDIAN,
 };
 
 /**
@@ -102,6 +104,7 @@ const allTools: ToolDef[] = [
   ...tagCategory(traceTools as unknown as ToolDef[], TOOL_CATEGORIES.TRACE),
   ...tagCategory(sharedMemoryTools as unknown as ToolDef[], TOOL_CATEGORIES.SHARED_MEMORY),
   { ...(deepinitManifestTool as unknown as ToolDef), category: TOOL_CATEGORIES.DEEPINIT },
+  ...tagCategory(obsidianTools as unknown as ToolDef[], TOOL_CATEGORIES.OBSIDIAN),
   ...interopTools,
 ];
 
@@ -162,6 +165,7 @@ export function getOmcToolNames(options?: {
   includeInterop?: boolean;
   includeSharedMemory?: boolean;
   includeDeepinit?: boolean;
+  includeObsidian?: boolean;
 }): string[] {
   const {
     includeLsp = true,
@@ -175,6 +179,7 @@ export function getOmcToolNames(options?: {
     includeInterop = true,
     includeSharedMemory = true,
     includeDeepinit = true,
+    includeObsidian = true,
   } = options || {};
 
   const excludedCategories = new Set<ToolCategory>();
@@ -189,6 +194,7 @@ export function getOmcToolNames(options?: {
   if (!includeInterop) excludedCategories.add(TOOL_CATEGORIES.INTEROP);
   if (!includeSharedMemory) excludedCategories.add(TOOL_CATEGORIES.SHARED_MEMORY);
   if (!includeDeepinit) excludedCategories.add(TOOL_CATEGORIES.DEEPINIT);
+  if (!includeObsidian) excludedCategories.add(TOOL_CATEGORIES.OBSIDIAN);
 
   if (excludedCategories.size === 0) return [...omcToolNames];
 
@@ -213,6 +219,7 @@ export function _getAllToolNamesForTests(options?: {
   includeInterop?: boolean;
   includeSharedMemory?: boolean;
   includeDeepinit?: boolean;
+  includeObsidian?: boolean;
 }): string[] {
   const {
     includeLsp = true,
@@ -226,6 +233,7 @@ export function _getAllToolNamesForTests(options?: {
     includeInterop = true,
     includeSharedMemory = true,
     includeDeepinit = true,
+    includeObsidian = true,
   } = options || {};
 
   const excludedCategories = new Set<ToolCategory>();
@@ -240,6 +248,7 @@ export function _getAllToolNamesForTests(options?: {
   if (!includeInterop) excludedCategories.add(TOOL_CATEGORIES.INTEROP);
   if (!includeSharedMemory) excludedCategories.add(TOOL_CATEGORIES.SHARED_MEMORY);
   if (!includeDeepinit) excludedCategories.add(TOOL_CATEGORIES.DEEPINIT);
+  if (!includeObsidian) excludedCategories.add(TOOL_CATEGORIES.OBSIDIAN);
 
   return allTools
     .filter(t => !t.category || !excludedCategories.has(t.category))

--- a/src/mcp/standalone-server.ts
+++ b/src/mcp/standalone-server.ts
@@ -25,6 +25,7 @@ import { stateTools } from '../tools/state-tools.js';
 import { notepadTools } from '../tools/notepad-tools.js';
 import { memoryTools } from '../tools/memory-tools.js';
 import { traceTools } from '../tools/trace-tools.js';
+import { obsidianTools } from '../tools/obsidian-tools.js';
 import { registerStandaloneShutdownHandlers } from './standalone-shutdown.js';
 import { cleanupOwnedBridgeSessions } from '../tools/python-repl/bridge-manager.js';
 import { z } from 'zod';
@@ -58,6 +59,7 @@ const allTools: ToolDef[] = [
   ...(notepadTools as unknown as ToolDef[]),
   ...(memoryTools as unknown as ToolDef[]),
   ...(traceTools as unknown as ToolDef[]),
+  ...(obsidianTools as unknown as ToolDef[]),
 ];
 
 // Convert Zod schema to JSON Schema for MCP

--- a/src/tools/obsidian-tools.ts
+++ b/src/tools/obsidian-tools.ts
@@ -1,0 +1,235 @@
+/**
+ * Obsidian MCP Tools
+ *
+ * Provides 9 tools for reading, writing, and searching Obsidian vault notes.
+ * All tools delegate to obsidian-core.ts handlers (no business logic here).
+ */
+
+import { z } from 'zod';
+import { ToolDefinition } from './types.js';
+import {
+  handleObsidianSearch,
+  handleObsidianRead,
+  handleObsidianCreate,
+  handleObsidianAppend,
+  handleObsidianDailyRead,
+  handleObsidianDailyAppend,
+  handleObsidianPropertySet,
+  handleObsidianBacklinks,
+  handleObsidianHelp,
+} from '../mcp/obsidian-core.js';
+
+// ============================================================================
+// obsidian_search - Search notes by keyword
+// ============================================================================
+
+export const obsidianSearchTool: ToolDefinition<{
+  query: z.ZodString;
+  limit: z.ZodOptional<z.ZodNumber>;
+  vault: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'obsidian_search',
+  description: 'Search notes in Obsidian vault by keyword. Returns matching note paths.',
+  annotations: { readOnlyHint: true },
+  schema: {
+    query: z.string().describe('Search query string'),
+    limit: z.number().int().min(1).max(100).optional().describe('Max results (default: CLI default)'),
+    vault: z.string().optional().describe('Vault name override'),
+  },
+  handler: async (args) => {
+    return handleObsidianSearch(args);
+  },
+};
+
+// ============================================================================
+// obsidian_read - Read a note
+// ============================================================================
+
+export const obsidianReadTool: ToolDefinition<{
+  file: z.ZodOptional<z.ZodString>;
+  path: z.ZodOptional<z.ZodString>;
+  vault: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'obsidian_read',
+  description: 'Read the full content of an Obsidian note by file path.',
+  annotations: { readOnlyHint: true },
+  schema: {
+    file: z.string().optional().describe('Note file path (vault-relative). Required if path not provided.'),
+    path: z.string().optional().describe('Alias for file parameter. Required if file not provided.'),
+    vault: z.string().optional().describe('Vault name override'),
+  },
+  handler: async (args) => {
+    return handleObsidianRead(args);
+  },
+};
+
+// ============================================================================
+// obsidian_create - Create a new note
+// ============================================================================
+
+export const obsidianCreateTool: ToolDefinition<{
+  name: z.ZodString;
+  path: z.ZodOptional<z.ZodString>;
+  content: z.ZodOptional<z.ZodString>;
+  template: z.ZodOptional<z.ZodString>;
+  overwrite: z.ZodOptional<z.ZodBoolean>;
+  vault: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'obsidian_create',
+  description: 'Create a new note in the Obsidian vault. Silent by default (does not open in Obsidian UI).',
+  annotations: { destructiveHint: false },
+  schema: {
+    name: z.string().describe('Note name (without .md extension)'),
+    path: z.string().optional().describe('Full vault-relative file path (e.g. "Projects/my-note.md"). When provided with name, path determines file location.'),
+    content: z.string().optional().describe('Note content (markdown)'),
+    template: z.string().optional().describe('Template name to use'),
+    overwrite: z.boolean().optional().describe('Overwrite if note exists'),
+    vault: z.string().optional().describe('Vault name override'),
+  },
+  handler: async (args) => {
+    return handleObsidianCreate(args);
+  },
+};
+
+// ============================================================================
+// obsidian_append - Append to a note
+// ============================================================================
+
+export const obsidianAppendTool: ToolDefinition<{
+  file: z.ZodOptional<z.ZodString>;
+  path: z.ZodOptional<z.ZodString>;
+  content: z.ZodString;
+  vault: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'obsidian_append',
+  description: 'Append content to an existing Obsidian note.',
+  annotations: { destructiveHint: false },
+  schema: {
+    file: z.string().optional().describe('Note file path (vault-relative). Required if path not provided.'),
+    path: z.string().optional().describe('Alias for file parameter. Required if file not provided.'),
+    content: z.string().describe('Content to append'),
+    vault: z.string().optional().describe('Vault name override'),
+  },
+  handler: async (args) => {
+    return handleObsidianAppend(args);
+  },
+};
+
+// ============================================================================
+// obsidian_daily_read - Read daily note
+// ============================================================================
+
+export const obsidianDailyReadTool: ToolDefinition<{
+  vault: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'obsidian_daily_read',
+  description: 'Read today\'s daily note from Obsidian.',
+  annotations: { readOnlyHint: true },
+  schema: {
+    vault: z.string().optional().describe('Vault name override'),
+  },
+  handler: async (args) => {
+    return handleObsidianDailyRead(args);
+  },
+};
+
+// ============================================================================
+// obsidian_daily_append - Append to daily note
+// ============================================================================
+
+export const obsidianDailyAppendTool: ToolDefinition<{
+  content: z.ZodString;
+  inline: z.ZodOptional<z.ZodBoolean>;
+  vault: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'obsidian_daily_append',
+  description: 'Append content to today\'s daily note.',
+  annotations: { destructiveHint: false },
+  schema: {
+    content: z.string().describe('Content to append to daily note'),
+    inline: z.boolean().optional().describe('Append inline (same line) instead of new line'),
+    vault: z.string().optional().describe('Vault name override'),
+  },
+  handler: async (args) => {
+    return handleObsidianDailyAppend(args);
+  },
+};
+
+// ============================================================================
+// obsidian_property_set - Set frontmatter property
+// ============================================================================
+
+export const obsidianPropertySetTool: ToolDefinition<{
+  file: z.ZodOptional<z.ZodString>;
+  path: z.ZodOptional<z.ZodString>;
+  name: z.ZodString;
+  value: z.ZodString;
+  type: z.ZodOptional<z.ZodEnum<['text', 'list', 'number', 'checkbox', 'date', 'datetime']>>;
+  vault: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'obsidian_property_set',
+  description: 'Set a frontmatter property on an Obsidian note.',
+  annotations: { destructiveHint: false, idempotentHint: true },
+  schema: {
+    file: z.string().optional().describe('Note file path (vault-relative). Required if path not provided.'),
+    path: z.string().optional().describe('Alias for file parameter. Required if file not provided.'),
+    name: z.string().describe('Property name'),
+    value: z.string().describe('Property value'),
+    type: z.enum(['text', 'list', 'number', 'checkbox', 'date', 'datetime']).optional().describe('Property type (default: text)'),
+    vault: z.string().optional().describe('Vault name override'),
+  },
+  handler: async (args) => {
+    return handleObsidianPropertySet(args);
+  },
+};
+
+// ============================================================================
+// obsidian_backlinks - List backlinks
+// ============================================================================
+
+export const obsidianBacklinksTool: ToolDefinition<{
+  file: z.ZodOptional<z.ZodString>;
+  path: z.ZodOptional<z.ZodString>;
+  vault: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'obsidian_backlinks',
+  description: 'List notes that link to a given note (backlinks).',
+  annotations: { readOnlyHint: true },
+  schema: {
+    file: z.string().optional().describe('Note file path (vault-relative). Required if path not provided.'),
+    path: z.string().optional().describe('Alias for file parameter. Required if file not provided.'),
+    vault: z.string().optional().describe('Vault name override'),
+  },
+  handler: async (args) => {
+    return handleObsidianBacklinks(args);
+  },
+};
+
+// ============================================================================
+// obsidian_help - Show CLI help
+// ============================================================================
+
+export const obsidianHelpTool: ToolDefinition<Record<string, never>> = {
+  name: 'obsidian_help',
+  description: 'Show Obsidian CLI help output for command discovery.',
+  annotations: { readOnlyHint: true },
+  schema: {},
+  handler: async () => {
+    return handleObsidianHelp();
+  },
+};
+
+/**
+ * All Obsidian tools for registration
+ */
+export const obsidianTools = [
+  obsidianSearchTool,
+  obsidianReadTool,
+  obsidianCreateTool,
+  obsidianAppendTool,
+  obsidianDailyReadTool,
+  obsidianDailyAppendTool,
+  obsidianPropertySetTool,
+  obsidianBacklinksTool,
+  obsidianHelpTool,
+];


### PR DESCRIPTION
## Summary

- Add optional Obsidian vault integration as an MCP server (`obs`), following the existing Codex/Gemini CLI pattern
- 8 MCP tools: `obsidian_search`, `obsidian_read`, `obsidian_create`, `obsidian_append`, `obsidian_daily_read`, `obsidian_daily_append`, `obsidian_property_set`, `obsidian_backlinks`
- CLI detection with session cache, vault auto-discovery, graceful error handling
- `configure-obsidian` setup skill with interactive wizard
- 36 unit tests, all passing
- Zero impact on users without Obsidian — fully optional, matching Codex/Gemini pattern

## Motivation

OMC's memory systems are worktree-scoped, which is correct for execution state but prevents cross-project knowledge sharing. Obsidian 1.12.4+ CLI provides search, backlinks, metadata, and relationships that complement existing notepad/project-memory systems.

See linked Discussion for full RFC.

## Changes

| File | Change |
|------|--------|
| `src/mcp/obsidian-detection.ts` | NEW: CLI detection with session cache |
| `src/mcp/obsidian-core.ts` | NEW: 8 handler functions, vault auto-discovery |
| `src/mcp/obsidian-server.ts` | NEW: MCP server (name: `obs`) |
| `skills/configure-obsidian/SKILL.md` | NEW: Interactive setup wizard |
| `src/__tests__/obsidian-mcp.test.ts` | NEW: 36 unit tests |
| `src/constants/names.ts` | `OBSIDIAN` tool category |
| `src/mcp/omc-tools-server.ts` | Disable group mapping |
| `src/mcp/index.ts` | Exports |
| `src/index.ts` | Server registration |

## Test plan

- [x] `npm run build` passes
- [x] `tsc --noEmit` passes  
- [x] 36 unit tests pass (detection, core logic, server registration, parameter validation)
- [x] Manual verification: Obsidian CLI commands work on macOS with Obsidian 1.12.7
- [ ] Community testing on different Obsidian versions/platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)