### PR TITLE
fix: guard standalone MCP CallToolRequestSchema registration against TS2589

### DIFF
--- a/src/mcp/standalone-server.ts
+++ b/src/mcp/standalone-server.ts
@@ -14,6 +14,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { lspTools } from '../tools/lsp-tools.js';
 import { astTools } from '../tools/ast-tools.js';
 // IMPORTANT: Import from tool.js, NOT index.js!
@@ -36,6 +37,15 @@ interface ToolDef {
   schema: z.ZodRawShape | z.ZodObject<z.ZodRawShape>;
   handler: (args: unknown) => Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }>;
 }
+
+type StandaloneCallToolHandler = (
+  request: CallToolRequest,
+) => Promise<CallToolResult>;
+
+type StandaloneCallToolRequestRegistrar = (
+  schema: typeof CallToolRequestSchema,
+  handler: StandaloneCallToolHandler,
+) => void;
 
 // Aggregate all tools - AST tools gracefully degrade if @ast-grep/napi is unavailable
 // Team runtime tools (omc_run_team_start, omc_run_team_status) live in the
@@ -162,7 +172,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 });
 
 // Handle tool calls
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+const setStandaloneCallToolRequestHandler =
+  server.setRequestHandler as unknown as StandaloneCallToolRequestRegistrar;
+
+setStandaloneCallToolRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
   const tool = allTools.find(t => t.name === name);


### PR DESCRIPTION
## Summary
- harden the standalone MCP `CallToolRequestSchema` registration behind a narrow local registrar type
- keep the workaround scoped to the historical TS2589 hotspot instead of casting the whole `server` as `any`
- preserve current `dev` behavior, including tool `isError` propagation and the rest of the standalone server logic

## Context
Closed PR #1892 documented a reproducible `TS2589: Type instantiation is excessively deep and possibly infinite` failure at:

- `src/mcp/standalone-server.ts`
- `server.setRequestHandler(CallToolRequestSchema, async (request) => ...)`

In this worktree, current `dev` built cleanly, so this PR ports the same protection as a narrower compatibility shim rather than the broader historical `(server as any)` cast.

## Verification
- `npx tsc --pretty false --noEmit`
- `npx -p typescript@5.7.2 tsc --pretty false --noEmit`
- `npm run build`
- `npx vitest run src/__tests__/standalone-server.test.ts`
