### PR TITLE
Fix silent catch observability gaps in team/hooks hot paths

### DIFF
--- a/src/hooks/__tests__/bridge-openclaw.test.ts
+++ b/src/hooks/__tests__/bridge-openclaw.test.ts
@@ -37,6 +37,30 @@ describe("_openclaw.wake", () => {
     vi.doUnmock("../../openclaw/index.js");
   });
 
+  it("logs when wakeOpenClaw rejects but does not throw", async () => {
+    vi.stubEnv("OMC_OPENCLAW", "1");
+    vi.resetModules();
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.doMock("../../openclaw/index.js", () => ({
+      wakeOpenClaw: vi.fn().mockRejectedValue(new Error('gateway down')),
+    }));
+
+    const { _openclaw: freshOpenClaw } = await import("../bridge.js");
+
+    expect(() => {
+      freshOpenClaw.wake("session-start", { sessionId: "sid-1" });
+    }).not.toThrow();
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[omc] hooks.bridge openclaw wake failed for session-start: gateway down',
+    );
+
+    vi.doUnmock("../../openclaw/index.js");
+  });
+
   it("does not throw when OMC_OPENCLAW === '1' and import fails", async () => {
     vi.stubEnv("OMC_OPENCLAW", "1");
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -25,6 +25,7 @@ import {
 import { dirname, join } from "path";
 import { resolveToWorktreeRoot, getOmcRoot } from "../lib/worktree-paths.js";
 import { formatOmcCliInvocation } from "../utils/omc-cli-rendering.js";
+import { createSwallowedErrorLogger } from "../lib/swallowed-error.js";
 
 // Hot-path imports: needed on every/most hook invocations (keyword-detector, pre/post-tool-use)
 import {
@@ -951,15 +952,18 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
         const stateDir = join(getOmcRoot(directory), "state");
         if (shouldSendIdleNotification(stateDir, sessionId)) {
           recordIdleNotificationSent(stateDir, sessionId);
+          const logSessionIdleNotifyFailure = createSwallowedErrorLogger(
+            'hooks.bridge session-idle notification failed',
+          );
           import("../notifications/index.js")
             .then(({ notify }) =>
               notify("session-idle", {
                 sessionId,
                 projectPath: directory,
                 profileName: process.env.OMC_NOTIFY_PROFILE,
-              }).catch(() => {}),
+              }).catch(logSessionIdleNotifyFailure),
             )
-            .catch(() => {});
+            .catch(logSessionIdleNotifyFailure);
         }
       }
 
@@ -1043,15 +1047,18 @@ async function processSessionStart(input: HookInput): Promise<HookOutput> {
 
   // Send session-start notification (non-blocking, swallows errors)
   if (sessionId) {
+    const logSessionStartNotifyFailure = createSwallowedErrorLogger(
+      'hooks.bridge session-start notification failed',
+    );
     import("../notifications/index.js")
       .then(({ notify }) =>
         notify("session-start", {
           sessionId,
           projectPath: directory,
           profileName: process.env.OMC_NOTIFY_PROFILE,
-        }).catch(() => {}),
+        }).catch(logSessionStartNotifyFailure),
       )
-      .catch(() => {});
+      .catch(logSessionStartNotifyFailure);
     // Wake OpenClaw gateway for session-start (non-blocking)
     _openclaw.wake("session-start", { sessionId, projectPath: directory });
   }
@@ -1277,6 +1284,10 @@ export function dispatchAskUserQuestionNotification(
       .filter(Boolean)
       .join("; ") || "User input requested";
 
+  const logAskUserQuestionNotifyFailure = createSwallowedErrorLogger(
+    'hooks.bridge ask-user-question notification failed',
+  );
+
   import("../notifications/index.js")
     .then(({ notify }) =>
       notify("ask-user-question", {
@@ -1284,9 +1295,9 @@ export function dispatchAskUserQuestionNotification(
         projectPath: directory,
         question: questionText,
         profileName: process.env.OMC_NOTIFY_PROFILE,
-      }).catch(() => {}),
+      }).catch(logAskUserQuestionNotifyFailure),
     )
-    .catch(() => {});
+    .catch(logAskUserQuestionNotifyFailure);
 }
 
 /** @internal Object wrapper so tests can spy on the dispatch call. */
@@ -1308,9 +1319,12 @@ export const _openclaw = {
     context: import("../openclaw/types.js").OpenClawContext,
   ) => {
     if (process.env.OMC_OPENCLAW !== "1") return;
+    const logOpenClawWakeFailure = createSwallowedErrorLogger(
+      `hooks.bridge openclaw wake failed for ${event}`,
+    );
     import("../openclaw/index.js")
-      .then(({ wakeOpenClaw }) => wakeOpenClaw(event, context).catch(() => {}))
-      .catch(() => {});
+      .then(({ wakeOpenClaw }) => wakeOpenClaw(event, context).catch(logOpenClawWakeFailure))
+      .catch(logOpenClawWakeFailure);
   },
 };
 
@@ -1517,6 +1531,9 @@ function processPreToolUse(input: HookInput): HookOutput {
     const agentName = agentType?.includes(":")
       ? agentType.split(":").pop()
       : agentType;
+    const logAgentCallNotifyFailure = createSwallowedErrorLogger(
+      'hooks.bridge agent-call notification failed',
+    );
     import("../notifications/index.js")
       .then(({ notify }) =>
         notify("agent-call", {
@@ -1525,9 +1542,9 @@ function processPreToolUse(input: HookInput): HookOutput {
           agentName,
           agentType,
           profileName: process.env.OMC_NOTIFY_PROFILE,
-        }).catch(() => {}),
+        }).catch(logAgentCallNotifyFailure),
       )
-      .catch(() => {});
+      .catch(logAgentCallNotifyFailure);
   }
 
   // Warn about pkill -f self-termination risk (issue #210)

--- a/src/hooks/team-dispatch-hook.ts
+++ b/src/hooks/team-dispatch-hook.ts
@@ -16,6 +16,7 @@
 import { readFile, writeFile, mkdir, readdir, appendFile, rename, rm, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { dirname, join, resolve } from 'path';
+import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -563,6 +564,9 @@ export async function drainPendingTeamDispatch(options: {
   let processed = 0;
   let skipped = 0;
   let failed = 0;
+  const logMailboxSyncFailure = createSwallowedErrorLogger(
+    'hooks.team-dispatch drainPendingTeamDispatch mailbox notification sync failed',
+  );
   const issueCooldownMs = resolveIssueDispatchCooldownMs();
   const triggerCooldownMs = resolveDispatchTriggerCooldownMs();
 
@@ -697,7 +701,7 @@ export async function drainPendingTeamDispatch(options: {
           request.notified_at = nowIso;
           request.last_reason = result.reason;
           if (request.kind === 'mailbox' && request.message_id) {
-            await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(() => {});
+            await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(logMailboxSyncFailure);
           }
           processed += 1;
           mutated = true;

--- a/src/hooks/team-leader-nudge-hook.ts
+++ b/src/hooks/team-leader-nudge-hook.ts
@@ -14,6 +14,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { appendTeamEvent } from '../team/events.js';
 import { deriveTeamLeaderGuidance } from '../team/leader-nudge-guidance.js';
+import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -341,6 +342,9 @@ export async function maybeNudgeLeader(params: {
 
   // Send nudge
   const message = `[OMC] Leader nudge (${guidance.nextAction}): ${guidance.message} ${INJECT_MARKER}`;
+  const logNudgePersistenceFailure = createSwallowedErrorLogger(
+    'hooks.team-leader-nudge maybeNudgeLeader persistence failed',
+  );
 
   try {
     await tmux.sendKeys(leaderPaneId, message, true);
@@ -354,14 +358,14 @@ export async function maybeNudgeLeader(params: {
       nudge_count: nudgeState.nudge_count + 1,
       last_nudge_at_ms: nowMs,
       last_nudge_at: nowIso,
-    }).catch(() => {});
+    }).catch(logNudgePersistenceFailure);
     await appendTeamEvent(teamName, {
       type: 'team_leader_nudge',
       worker: 'leader-fixed',
       reason: guidance.reason,
       next_action: guidance.nextAction,
       message: guidance.message,
-    }, params.cwd).catch(() => {});
+    }, params.cwd).catch(logNudgePersistenceFailure);
 
     return { nudged: true, reason: guidance.reason };
   } catch {

--- a/src/hooks/team-worker-hook.ts
+++ b/src/hooks/team-worker-hook.ts
@@ -16,6 +16,7 @@
 import { readFile, writeFile, mkdir, appendFile, rename, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 // ── Env helpers ────────────────────────────────────────────────────────────
 
@@ -333,6 +334,9 @@ export async function maybeNotifyLeaderWorkerIdle(params: {
   if (currentTaskId) parts.push(`task: ${currentTaskId}`);
   if (currentReason) parts.push(`reason: ${currentReason}`);
   const message = `${parts.join('. ')}. ${DEFAULT_MARKER}`;
+  const logWorkerIdlePersistenceFailure = createSwallowedErrorLogger(
+    'hooks.team-worker maybeNotifyLeaderWorkerIdle persistence failed',
+  );
 
   try {
     await tmux.sendKeys(leaderPaneId, message, true);
@@ -346,7 +350,7 @@ export async function maybeNotifyLeaderWorkerIdle(params: {
       last_notified_at_ms: nowMs,
       last_notified_at: nowIso,
       prev_state: prevState,
-    }).catch(() => {});
+    }).catch(logWorkerIdlePersistenceFailure);
 
     // Append event
     const eventsDir = join(stateDir, 'team', teamName, 'events');
@@ -414,6 +418,9 @@ export async function maybeNotifyLeaderAllWorkersIdle(params: {
 
   const N = workers.length;
   const message = `[OMC] All ${N} worker${N === 1 ? '' : 's'} idle. Ready for next instructions. ${DEFAULT_MARKER}`;
+  const logAllWorkersIdlePersistenceFailure = createSwallowedErrorLogger(
+    'hooks.team-worker maybeNotifyLeaderAllWorkersIdle persistence failed',
+  );
 
   try {
     await tmux.sendKeys(leaderPaneId, message, true);
@@ -427,7 +434,7 @@ export async function maybeNotifyLeaderAllWorkersIdle(params: {
       last_notified_at_ms: nowMs,
       last_notified_at: nowIso,
       worker_count: N,
-    }).catch(() => {});
+    }).catch(logAllWorkersIdlePersistenceFailure);
 
     // Append event
     const eventsDir = join(stateDir, 'team', teamName, 'events');

--- a/src/lib/__tests__/swallowed-error.test.ts
+++ b/src/lib/__tests__/swallowed-error.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { createSwallowedErrorLogger, formatSwallowedError } from '../swallowed-error.js';
+
+describe('swallowed-error helper', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('formats Error instances and non-Error values safely', () => {
+    expect(formatSwallowedError(new Error('boom'))).toBe('boom');
+    expect(formatSwallowedError('plain')).toBe('plain');
+    expect(formatSwallowedError({ code: 42 })).toBe('{"code":42}');
+  });
+
+  it('logs swallowed failures without throwing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const log = createSwallowedErrorLogger('test context');
+
+    expect(() => log(new Error('boom'))).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith('[omc] test context: boom');
+  });
+});

--- a/src/lib/swallowed-error.ts
+++ b/src/lib/swallowed-error.ts
@@ -1,0 +1,23 @@
+export function formatSwallowedError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function logSwallowedError(context: string, error: unknown): void {
+  try {
+    console.warn(`[omc] ${context}: ${formatSwallowedError(error)}`);
+  } catch {
+    // Never let logging a swallowed error throw.
+  }
+}
+
+export function createSwallowedErrorLogger(context: string): (error: unknown) => void {
+  return (error: unknown) => {
+    logSwallowedError(context, error);
+  };
+}

--- a/src/team/__tests__/events.swallowed-error.test.ts
+++ b/src/team/__tests__/events.swallowed-error.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const fsMocks = vi.hoisted(() => ({
+  appendFile: vi.fn(),
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return {
+    ...actual,
+    appendFile: fsMocks.appendFile,
+    mkdir: fsMocks.mkdir,
+    readFile: fsMocks.readFile,
+  };
+});
+
+describe('emitMonitorDerivedEvents swallowed error logging', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    fsMocks.appendFile.mockReset();
+    fsMocks.mkdir.mockReset();
+    fsMocks.readFile.mockReset();
+  });
+
+  it('logs appendTeamEvent failures without throwing', async () => {
+    fsMocks.mkdir.mockResolvedValue(undefined);
+    fsMocks.appendFile.mockRejectedValue(new Error('disk full'));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { emitMonitorDerivedEvents } = await import('../events.js');
+
+    await expect(emitMonitorDerivedEvents(
+      'demo-team',
+      [{ id: 'task-1', status: 'completed' }],
+      [],
+      { taskStatusById: { 'task-1': 'in_progress' } },
+      '/tmp/demo-team',
+    )).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[omc] team.events.emitMonitorDerivedEvents appendTeamEvent failed: disk full',
+    );
+  });
+});

--- a/src/team/__tests__/team-leader-nudge-hook.logging.test.ts
+++ b/src/team/__tests__/team-leader-nudge-hook.logging.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+
+const { appendTeamEventMock } = vi.hoisted(() => ({
+  appendTeamEventMock: vi.fn(async () => {
+    throw new Error('event write failed');
+  }),
+}));
+
+vi.mock('../../team/events.js', () => ({
+  appendTeamEvent: appendTeamEventMock,
+}));
+
+import { maybeNudgeLeader } from '../../hooks/team-leader-nudge-hook.js';
+
+describe('team leader nudge hook logging', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-team-leader-nudge-logging-'));
+    appendTeamEventMock.mockClear();
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  async function writeJson(relativePath: string, value: unknown): Promise<void> {
+    const fullPath = join(cwd, relativePath);
+    await mkdir(dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, JSON.stringify(value, null, 2), 'utf-8');
+  }
+
+  it('logs appendTeamEvent persistence failures without failing the nudge', async () => {
+    await writeJson('.omc/state/team/demo-team/config.json', {
+      workers: [{ name: 'worker-1' }],
+      leader_pane_id: '%1',
+    });
+    await writeJson('.omc/state/team/demo-team/workers/worker-1/status.json', {
+      state: 'idle',
+      updated_at: new Date().toISOString(),
+    });
+    await writeJson('.omc/state/team/demo-team/workers/worker-1/heartbeat.json', {
+      alive: true,
+      last_turn_at: new Date().toISOString(),
+    });
+    await writeJson('.omc/state/team/demo-team/tasks/task-1.json', {
+      status: 'pending',
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sent: string[] = [];
+
+    const result = await maybeNudgeLeader({
+      cwd,
+      stateDir: join(cwd, '.omc', 'state'),
+      teamName: 'demo-team',
+      tmux: {
+        async sendKeys(_target, text) {
+          sent.push(text);
+        },
+      },
+    });
+
+    expect(result.nudged).toBe(true);
+    expect(sent[0]).toContain('Leader nudge');
+    expect(appendTeamEventMock).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[omc] hooks.team-leader-nudge maybeNudgeLeader persistence failed: event write failed',
+    );
+  });
+});

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -48,6 +48,7 @@ import { listDispatchRequests, markDispatchRequestDelivered, markDispatchRequest
 import { generateMailboxTriggerMessage } from './worker-bootstrap.js';
 import { shutdownTeam } from './runtime.js';
 import { shutdownTeamV2 } from './runtime-v2.js';
+import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 const TEAM_UPDATE_TASK_MUTABLE_FIELDS = new Set(['subject', 'description', 'blocked_by', 'requires_code_change']);
 const TEAM_UPDATE_TASK_REQUEST_FIELDS = new Set(['team_name', 'task_id', 'workingDirectory', ...TEAM_UPDATE_TASK_MUTABLE_FIELDS]);
@@ -428,6 +429,9 @@ async function syncMailboxDispatchNotified(
   messageId: string,
   cwd: string,
 ): Promise<void> {
+  const logDispatchSyncFailure = createSwallowedErrorLogger(
+    'team.api-interop syncMailboxDispatchNotified dispatch state sync failed',
+  );
   const requestId = await findMailboxDispatchRequestId(teamName, workerName, messageId, cwd);
   if (!requestId) return;
   await markDispatchRequestNotified(
@@ -435,7 +439,7 @@ async function syncMailboxDispatchNotified(
     requestId,
     { message_id: messageId, last_reason: 'mailbox_mark_notified' },
     cwd,
-  ).catch(() => {});
+  ).catch(logDispatchSyncFailure);
 }
 
 async function syncMailboxDispatchDelivered(
@@ -444,6 +448,9 @@ async function syncMailboxDispatchDelivered(
   messageId: string,
   cwd: string,
 ): Promise<void> {
+  const logDispatchSyncFailure = createSwallowedErrorLogger(
+    'team.api-interop syncMailboxDispatchDelivered dispatch state sync failed',
+  );
   const requestId = await findMailboxDispatchRequestId(teamName, workerName, messageId, cwd);
   if (!requestId) return;
 
@@ -452,13 +459,13 @@ async function syncMailboxDispatchDelivered(
     requestId,
     { message_id: messageId, last_reason: 'mailbox_mark_delivered' },
     cwd,
-  ).catch(() => {});
+  ).catch(logDispatchSyncFailure);
   await markDispatchRequestDelivered(
     teamName,
     requestId,
     { message_id: messageId, last_reason: 'mailbox_mark_delivered' },
     cwd,
-  ).catch(() => {});
+  ).catch(logDispatchSyncFailure);
 }
 
 function validateCommonFields(args: Record<string, unknown>): void {

--- a/src/team/events.ts
+++ b/src/team/events.ts
@@ -15,6 +15,7 @@ import { existsSync } from 'fs';
 import { TeamPaths, absPath } from './state-paths.js';
 import type { TeamEventType } from './contracts.js';
 import type { TeamEvent } from './types.js';
+import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 /**
  * Append a team event to the JSONL event log.
@@ -93,6 +94,10 @@ export async function emitMonitorDerivedEvents(
 ): Promise<void> {
   if (!previousSnapshot) return;
 
+  const logDerivedEventFailure = createSwallowedErrorLogger(
+    'team.events.emitMonitorDerivedEvents appendTeamEvent failed',
+  );
+
   const completedEventTaskIds = { ...(previousSnapshot.completedEventTaskIds ?? {}) };
 
   // Detect task status transitions
@@ -106,7 +111,7 @@ export async function emitMonitorDerivedEvents(
         worker: 'leader-fixed',
         task_id: task.id,
         reason: `status_transition:${prevStatus}->${task.status}`,
-      }, cwd).catch(() => {});
+      }, cwd).catch(logDerivedEventFailure);
       completedEventTaskIds[task.id] = true;
     } else if (task.status === 'failed') {
       await appendTeamEvent(teamName, {
@@ -114,7 +119,7 @@ export async function emitMonitorDerivedEvents(
         worker: 'leader-fixed',
         task_id: task.id,
         reason: `status_transition:${prevStatus}->${task.status}`,
-      }, cwd).catch(() => {});
+      }, cwd).catch(logDerivedEventFailure);
     }
   }
 
@@ -128,7 +133,7 @@ export async function emitMonitorDerivedEvents(
         type: 'worker_stopped',
         worker: worker.name,
         reason: 'pane_exited',
-      }, cwd).catch(() => {});
+      }, cwd).catch(logDerivedEventFailure);
     }
 
     if (prevState === 'working' && worker.status.state === 'idle') {
@@ -136,7 +141,7 @@ export async function emitMonitorDerivedEvents(
         type: 'worker_idle',
         worker: worker.name,
         reason: `state_transition:${prevState}->${worker.status.state}`,
-      }, cwd).catch(() => {});
+      }, cwd).catch(logDerivedEventFailure);
     }
   }
 }

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -19,6 +19,7 @@ import {
   type TeamDispatchRequest,
   type TeamDispatchRequestInput,
 } from './dispatch-queue.js';
+import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -96,6 +97,9 @@ async function markImmediateDispatchFailure(params: {
 }): Promise<void> {
   const { teamName, request, reason, messageId, cwd } = params;
   if (request.transport_preference === 'hook_preferred_with_fallback') return;
+  const logTransitionFailure = createSwallowedErrorLogger(
+    'team.mcp-comm.markImmediateDispatchFailure transitionDispatchRequest failed',
+  );
 
   const current = await readDispatchRequest(teamName, request.request_id, cwd);
   if (!current) return;
@@ -111,7 +115,7 @@ async function markImmediateDispatchFailure(params: {
       last_reason: reason,
     },
     cwd,
-  ).catch(() => {});
+  ).catch(logTransitionFailure);
 }
 
 async function markLeaderPaneMissingDeferred(params: {
@@ -121,6 +125,9 @@ async function markLeaderPaneMissingDeferred(params: {
   messageId?: string;
 }): Promise<void> {
   const { teamName, request, cwd, messageId } = params;
+  const logTransitionFailure = createSwallowedErrorLogger(
+    'team.mcp-comm.markLeaderPaneMissingDeferred transitionDispatchRequest failed',
+  );
   const current = await readDispatchRequest(teamName, request.request_id, cwd);
   if (!current) return;
   if (current.status !== 'pending') return;
@@ -135,7 +142,7 @@ async function markLeaderPaneMissingDeferred(params: {
       last_reason: 'leader_pane_missing_deferred',
     },
     cwd,
-  ).catch(() => {});
+  ).catch(logTransitionFailure);
 }
 
 // ── Public API ─────────────────────────────────────────────────────────────

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -16,6 +16,7 @@ import { deriveTeamLeaderGuidance } from './leader-nudge-guidance.js';
 import { waitForSentinelReadiness } from './sentinel-gate.js';
 import { isRuntimeV2Enabled, startTeamV2, monitorTeamV2, shutdownTeamV2 } from './runtime-v2.js';
 import type { TeamSnapshotV2 } from './runtime-v2.js';
+import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 interface CliInput {
   teamName: string;
@@ -170,6 +171,9 @@ function collectTaskResults(stateRoot: string): TaskResult[] {
 
 async function main(): Promise<void> {
   const startTime = Date.now();
+  const logLeaderNudgeEventFailure = createSwallowedErrorLogger(
+    'team.runtime-cli main appendTeamEvent failed',
+  );
 
   // Read stdin
   const chunks: Buffer[] = [];
@@ -399,7 +403,7 @@ async function main(): Promise<void> {
           reason: leaderGuidance.reason,
           next_action: leaderGuidance.nextAction,
           message: leaderGuidance.message,
-        }, cwd).catch(() => {});
+        }, cwd).catch(logLeaderNudgeEventFailure);
         lastLeaderNudgeReason = leaderGuidance.reason;
       }
 

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -73,6 +73,7 @@ import {
 import { queueInboxInstruction, type DispatchOutcome } from './mcp-comm.js';
 import { cleanupTeamWorktrees } from './git-worktree.js';
 import { formatOmcCliInvocation } from '../utils/omc-cli-rendering.js';
+import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 // ---------------------------------------------------------------------------
 // Feature flag
@@ -889,6 +890,9 @@ export async function requeueDeadWorkerTasks(
   deadWorkerNames: string[],
   cwd: string,
 ): Promise<string[]> {
+  const logEventFailure = createSwallowedErrorLogger(
+    'team.runtime-v2.requeueDeadWorkerTasks appendTeamEvent failed',
+  );
   const sanitized = sanitizeTeamName(teamName);
   const tasks = await listTasksFromFiles(sanitized, cwd);
   const requeued: string[] = [];
@@ -937,7 +941,7 @@ export async function requeueDeadWorkerTasks(
       worker: 'leader-fixed',
       task_id: task.id,
       reason: `requeue_dead_worker:${task.owner}`,
-    }, cwd).catch(() => {});
+    }, cwd).catch(logEventFailure);
   }
 
   return requeued;
@@ -1142,6 +1146,9 @@ export async function shutdownTeamV2(
   cwd: string,
   options: ShutdownOptionsV2 = {},
 ): Promise<void> {
+  const logEventFailure = createSwallowedErrorLogger(
+    'team.runtime-v2.shutdownTeamV2 appendTeamEvent failed',
+  );
   const force = options.force === true;
   const ralph = options.ralph === true;
   const timeoutMs = options.timeoutMs ?? 15_000;
@@ -1174,7 +1181,7 @@ export async function shutdownTeamV2(
       type: 'shutdown_gate',
       worker: 'leader-fixed',
       reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed}${ralph ? ' policy=ralph' : ''}`,
-    }, cwd).catch(() => {});
+    }, cwd).catch(logEventFailure);
 
     if (!gate.allowed) {
       const hasActiveWork = gate.pending > 0 || gate.blocked > 0 || gate.in_progress > 0;
@@ -1183,14 +1190,14 @@ export async function shutdownTeamV2(
           type: 'team_leader_nudge',
           worker: 'leader-fixed',
           reason: `cleanup_override_bypassed:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
-        }, cwd).catch(() => {});
+        }, cwd).catch(logEventFailure);
       } else if (ralph && !hasActiveWork) {
         // Ralph policy: bypass on failure-only scenarios
         await appendTeamEvent(sanitized, {
           type: 'team_leader_nudge',
           worker: 'leader-fixed',
           reason: `gate_bypassed:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
-        }, cwd).catch(() => {});
+        }, cwd).catch(logEventFailure);
       } else {
         throw new Error(
           `shutdown_gate_blocked:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
@@ -1204,7 +1211,7 @@ export async function shutdownTeamV2(
       type: 'shutdown_gate_forced',
       worker: 'leader-fixed',
       reason: 'force_bypass',
-    }, cwd).catch(() => {});
+    }, cwd).catch(logEventFailure);
   }
 
   // 2. Send shutdown request to each worker
@@ -1237,7 +1244,7 @@ export async function shutdownTeamV2(
           type: 'shutdown_ack',
           worker: w.name,
           reason: ack.status === 'reject' ? `reject:${ack.reason || 'no_reason'}` : 'accept',
-        }, cwd).catch(() => {});
+        }, cwd).catch(logEventFailure);
         if (ack.status === 'reject') {
           rejected.push({ worker: w.name, reason: ack.reason || 'no_reason' });
         }
@@ -1301,7 +1308,7 @@ export async function shutdownTeamV2(
       type: 'team_leader_nudge',
       worker: 'leader-fixed',
       reason: `ralph_cleanup_summary: total=${finalTasks.length} completed=${completed} failed=${failed} pending=${pending} force=${force}`,
-    }, cwd).catch(() => {});
+    }, cwd).catch(logEventFailure);
   }
 
   // 6. Clean up state


### PR DESCRIPTION
## Summary
- add a shared swallowed-error logger for best-effort background failures
- replace observability-critical silent catches in team/hooks hot paths with contextual logging
- add focused regression tests for the helper, team event logging, team leader nudge persistence, and OpenClaw wake failures

## Scope notes
- intentionally left cleanup-only lock removal, mkdir preconditions, and tmux retry noise silent
- targeted notification delivery, event emission, dispatch/mailbox state sync, and post-success persistence paths

## Verification
- `npx vitest run src/lib/__tests__/swallowed-error.test.ts src/team/__tests__/events.swallowed-error.test.ts src/team/__tests__/team-leader-nudge-hook.logging.test.ts src/hooks/__tests__/bridge-openclaw.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/lib/swallowed-error.ts src/lib/__tests__/swallowed-error.test.ts src/hooks/bridge.ts src/hooks/__tests__/bridge-openclaw.test.ts src/hooks/team-dispatch-hook.ts src/hooks/team-leader-nudge-hook.ts src/hooks/team-worker-hook.ts src/team/api-interop.ts src/team/events.ts src/team/mcp-comm.ts src/team/runtime-cli.ts src/team/runtime-v2.ts src/team/__tests__/events.swallowed-error.test.ts src/team/__tests__/team-leader-nudge-hook.logging.test.ts`
