### PR TITLE
feat(teleport): symlink node_modules from parent repo in worktrees

### DIFF
--- a/src/cli/commands/teleport.ts
+++ b/src/cli/commands/teleport.ts
@@ -5,13 +5,21 @@
  * Default worktree location: ~/Workspace/omc-worktrees/
  */
 
-import chalk from 'chalk';
-import { execSync, execFileSync } from 'child_process';
-import { existsSync, mkdirSync, rmSync, readdirSync, statSync } from 'fs';
-import { homedir } from 'os';
-import { join, basename, isAbsolute, relative } from 'path';
-import { parseRemoteUrl, getProvider } from '../../providers/index.js';
-import type { ProviderName, GitProvider } from '../../providers/types.js';
+import chalk from "chalk";
+import { execSync, execFileSync } from "child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  rmSync,
+  readdirSync,
+  statSync,
+  symlinkSync,
+} from "fs";
+import { homedir } from "os";
+import { join, basename, isAbsolute, relative } from "path";
+import { parseRemoteUrl, getProvider } from "../../providers/index.js";
+import type { ProviderName, GitProvider } from "../../providers/types.js";
 
 export interface TeleportOptions {
   worktree?: boolean;
@@ -29,14 +37,14 @@ export interface TeleportResult {
 }
 
 // Default worktree root directory
-const DEFAULT_WORKTREE_ROOT = join(homedir(), 'Workspace', 'omc-worktrees');
+const DEFAULT_WORKTREE_ROOT = join(homedir(), "Workspace", "omc-worktrees");
 
 /**
  * Parse a reference string into components
  * Supports: omc#123, owner/repo#123, #123, URLs, feature names
  */
 function parseRef(ref: string): {
-  type: 'issue' | 'pr' | 'feature';
+  type: "issue" | "pr" | "feature";
   owner?: string;
   repo?: string;
   number?: number;
@@ -44,103 +52,117 @@ function parseRef(ref: string): {
   provider?: ProviderName;
 } {
   // GitHub PR URL: github.com/owner/repo/pull/N
-  const ghPrUrlMatch = ref.match(/^https?:\/\/[^/]*github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[?#].*)?$/);
+  const ghPrUrlMatch = ref.match(
+    /^https?:\/\/[^/]*github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[?#].*)?$/,
+  );
   if (ghPrUrlMatch) {
     return {
-      type: 'pr',
+      type: "pr",
       owner: ghPrUrlMatch[1],
       repo: ghPrUrlMatch[2],
       number: parseInt(ghPrUrlMatch[3], 10),
-      provider: 'github',
+      provider: "github",
     };
   }
 
   // GitHub Issue URL: github.com/owner/repo/issues/N
-  const ghIssueUrlMatch = ref.match(/^https?:\/\/[^/]*github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)(?:[?#].*)?$/);
+  const ghIssueUrlMatch = ref.match(
+    /^https?:\/\/[^/]*github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)(?:[?#].*)?$/,
+  );
   if (ghIssueUrlMatch) {
     return {
-      type: 'issue',
+      type: "issue",
       owner: ghIssueUrlMatch[1],
       repo: ghIssueUrlMatch[2],
       number: parseInt(ghIssueUrlMatch[3], 10),
-      provider: 'github',
+      provider: "github",
     };
   }
 
   // GitLab MR URL: gitlab.*/namespace/-/merge_requests/N (supports nested groups and self-hosted)
-  const glMrUrlMatch = ref.match(/^https?:\/\/[^/]*gitlab[^/]*\/(.+)\/-\/merge_requests\/(\d+)(?:[?#].*)?$/);
+  const glMrUrlMatch = ref.match(
+    /^https?:\/\/[^/]*gitlab[^/]*\/(.+)\/-\/merge_requests\/(\d+)(?:[?#].*)?$/,
+  );
   if (glMrUrlMatch) {
-    const namespaceParts = glMrUrlMatch[1].split('/');
+    const namespaceParts = glMrUrlMatch[1].split("/");
     const repo = namespaceParts.pop()!;
-    const owner = namespaceParts.join('/');
+    const owner = namespaceParts.join("/");
     return {
-      type: 'pr',
+      type: "pr",
       owner,
       repo,
       number: parseInt(glMrUrlMatch[2], 10),
-      provider: 'gitlab',
+      provider: "gitlab",
     };
   }
 
   // GitLab Issue URL: gitlab.*/namespace/-/issues/N (supports nested groups and self-hosted)
-  const glIssueUrlMatch = ref.match(/^https?:\/\/[^/]*gitlab[^/]*\/(.+)\/-\/issues\/(\d+)(?:[?#].*)?$/);
+  const glIssueUrlMatch = ref.match(
+    /^https?:\/\/[^/]*gitlab[^/]*\/(.+)\/-\/issues\/(\d+)(?:[?#].*)?$/,
+  );
   if (glIssueUrlMatch) {
-    const namespaceParts = glIssueUrlMatch[1].split('/');
+    const namespaceParts = glIssueUrlMatch[1].split("/");
     const repo = namespaceParts.pop()!;
-    const owner = namespaceParts.join('/');
+    const owner = namespaceParts.join("/");
     return {
-      type: 'issue',
+      type: "issue",
       owner,
       repo,
       number: parseInt(glIssueUrlMatch[2], 10),
-      provider: 'gitlab',
+      provider: "gitlab",
     };
   }
 
   // Bitbucket PR URL: bitbucket.org/workspace/repo/pull-requests/N
-  const bbPrUrlMatch = ref.match(/^https?:\/\/[^/]*bitbucket\.org\/([^/]+)\/([^/]+)\/pull-requests\/(\d+)(?:[?#].*)?$/);
+  const bbPrUrlMatch = ref.match(
+    /^https?:\/\/[^/]*bitbucket\.org\/([^/]+)\/([^/]+)\/pull-requests\/(\d+)(?:[?#].*)?$/,
+  );
   if (bbPrUrlMatch) {
     return {
-      type: 'pr',
+      type: "pr",
       owner: bbPrUrlMatch[1],
       repo: bbPrUrlMatch[2],
       number: parseInt(bbPrUrlMatch[3], 10),
-      provider: 'bitbucket',
+      provider: "bitbucket",
     };
   }
 
   // Bitbucket Issue URL: bitbucket.org/workspace/repo/issues/N
-  const bbIssueUrlMatch = ref.match(/^https?:\/\/[^/]*bitbucket\.org\/([^/]+)\/([^/]+)\/issues\/(\d+)(?:[?#].*)?$/);
+  const bbIssueUrlMatch = ref.match(
+    /^https?:\/\/[^/]*bitbucket\.org\/([^/]+)\/([^/]+)\/issues\/(\d+)(?:[?#].*)?$/,
+  );
   if (bbIssueUrlMatch) {
     return {
-      type: 'issue',
+      type: "issue",
       owner: bbIssueUrlMatch[1],
       repo: bbIssueUrlMatch[2],
       number: parseInt(bbIssueUrlMatch[3], 10),
-      provider: 'bitbucket',
+      provider: "bitbucket",
     };
   }
 
   // Azure DevOps PR URL: dev.azure.com/org/project/_git/repo/pullrequest/N
-  const azPrUrlMatch = ref.match(/^https?:\/\/[^/]*dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)(?:[?#].*)?$/);
+  const azPrUrlMatch = ref.match(
+    /^https?:\/\/[^/]*dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)(?:[?#].*)?$/,
+  );
   if (azPrUrlMatch) {
     return {
-      type: 'pr',
+      type: "pr",
       owner: `${azPrUrlMatch[1]}/${azPrUrlMatch[2]}`,
       repo: azPrUrlMatch[3],
       number: parseInt(azPrUrlMatch[4], 10),
-      provider: 'azure-devops',
+      provider: "azure-devops",
     };
   }
 
   // Azure DevOps legacy: https://{org}.visualstudio.com/{project}/_git/{repo}/pullrequest/{id}
   const azureLegacyPrMatch = ref.match(
-    /^https?:\/\/([^.]+)\.visualstudio\.com\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)/i
+    /^https?:\/\/([^.]+)\.visualstudio\.com\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)/i,
   );
   if (azureLegacyPrMatch) {
     return {
-      type: 'pr',
-      provider: 'azure-devops',
+      type: "pr",
+      provider: "azure-devops",
       owner: `${azureLegacyPrMatch[1]}/${azureLegacyPrMatch[2]}`,
       repo: azureLegacyPrMatch[3],
       number: parseInt(azureLegacyPrMatch[4], 10),
@@ -151,11 +173,11 @@ function parseRef(ref: string): {
   const gitlabShorthand = ref.match(/^(.+?)\/([^!/]+)!(\d+)$/);
   if (gitlabShorthand) {
     return {
-      type: 'pr',
+      type: "pr",
       owner: gitlabShorthand[1],
       repo: gitlabShorthand[2],
       number: parseInt(gitlabShorthand[3], 10),
-      provider: 'gitlab',
+      provider: "gitlab",
     };
   }
 
@@ -163,7 +185,7 @@ function parseRef(ref: string): {
   const fullRefMatch = ref.match(/^(.+)\/([^/#]+)#(\d+)$/);
   if (fullRefMatch) {
     return {
-      type: 'issue', // Will be refined by provider CLI
+      type: "issue", // Will be refined by provider CLI
       owner: fullRefMatch[1],
       repo: fullRefMatch[2],
       number: parseInt(fullRefMatch[3], 10),
@@ -174,7 +196,7 @@ function parseRef(ref: string): {
   const aliasMatch = ref.match(/^([a-zA-Z][a-zA-Z0-9_-]*)#(\d+)$/);
   if (aliasMatch) {
     return {
-      type: 'issue',
+      type: "issue",
       name: aliasMatch[1], // Alias to resolve
       number: parseInt(aliasMatch[2], 10),
     };
@@ -184,14 +206,14 @@ function parseRef(ref: string): {
   const numberMatch = ref.match(/^#?(\d+)$/);
   if (numberMatch) {
     return {
-      type: 'issue',
+      type: "issue",
       number: parseInt(numberMatch[1], 10),
     };
   }
 
   // Feature name (anything else)
   return {
-    type: 'feature',
+    type: "feature",
     name: ref,
   };
 }
@@ -202,21 +224,37 @@ function parseRef(ref: string): {
 function sanitize(str: string, maxLen: number = 30): string {
   return str
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
     .slice(0, maxLen);
 }
 
 /**
  * Get current git repo info
  */
-function getCurrentRepo(): { owner: string; repo: string; root: string; provider: ProviderName } | null {
+function getCurrentRepo(): {
+  owner: string;
+  repo: string;
+  root: string;
+  provider: ProviderName;
+} | null {
   try {
-    const root = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8', timeout: 5000 }).trim();
-    const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf-8', timeout: 5000 }).trim();
+    const root = execSync("git rev-parse --show-toplevel", {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+    const remoteUrl = execSync("git remote get-url origin", {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
     const parsed = parseRemoteUrl(remoteUrl);
     if (parsed) {
-      return { owner: parsed.owner, repo: parsed.repo, root, provider: parsed.provider };
+      return {
+        owner: parsed.owner,
+        repo: parsed.repo,
+        root,
+        provider: parsed.provider,
+      };
     }
   } catch {
     // Not in a git repo or no origin
@@ -228,13 +266,13 @@ function getCurrentRepo(): { owner: string; repo: string; root: string; provider
  * Fetch issue/PR info via provider abstraction
  */
 function fetchProviderInfo(
-  type: 'issue' | 'pr',
+  type: "issue" | "pr",
   number: number,
   provider: GitProvider,
   owner?: string,
-  repo?: string
+  repo?: string,
 ): { title: string; branch?: string } | null {
-  if (type === 'pr') {
+  if (type === "pr") {
     const pr = provider.viewPR(number, owner, repo);
     return pr ? { title: pr.title, branch: pr.headBranch } : null;
   }
@@ -249,41 +287,46 @@ function createWorktree(
   repoRoot: string,
   worktreePath: string,
   branchName: string,
-  baseBranch: string
+  baseBranch: string,
 ): { success: boolean; error?: string } {
   try {
     // Ensure worktree parent directory exists
-    const parentDir = join(worktreePath, '..');
+    const parentDir = join(worktreePath, "..");
     if (!existsSync(parentDir)) {
       mkdirSync(parentDir, { recursive: true });
     }
 
     // Check if worktree already exists
     if (existsSync(worktreePath)) {
-      return { success: false, error: `Worktree already exists at ${worktreePath}` };
+      return {
+        success: false,
+        error: `Worktree already exists at ${worktreePath}`,
+      };
     }
 
     // Fetch latest from origin
-    execFileSync('git', ['fetch', 'origin', baseBranch], {
+    execFileSync("git", ["fetch", "origin", baseBranch], {
       cwd: repoRoot,
-      stdio: 'pipe',
+      stdio: "pipe",
     });
 
     // Create branch from base if it doesn't exist
     try {
-      execFileSync('git', ['branch', branchName, `origin/${baseBranch}`], {
+      execFileSync("git", ["branch", branchName, `origin/${baseBranch}`], {
         cwd: repoRoot,
-        stdio: 'pipe',
+        stdio: "pipe",
       });
     } catch {
       // Branch might already exist, that's OK
     }
 
     // Create the worktree
-    execFileSync('git', ['worktree', 'add', worktreePath, branchName], {
+    execFileSync("git", ["worktree", "add", worktreePath, branchName], {
       cwd: repoRoot,
-      stdio: 'pipe',
+      stdio: "pipe",
     });
+
+    symlinkNodeModules(repoRoot, worktreePath);
 
     return { success: true };
   } catch (err) {
@@ -292,21 +335,55 @@ function createWorktree(
   }
 }
 
+function symlinkNodeModules(repoRoot: string, worktreePath: string): void {
+  const sourceNodeModules = join(repoRoot, "node_modules");
+  const targetNodeModules = join(worktreePath, "node_modules");
+
+  if (!existsSync(sourceNodeModules)) {
+    return;
+  }
+
+  try {
+    if (existsSync(targetNodeModules)) {
+      return;
+    }
+
+    try {
+      lstatSync(targetNodeModules);
+      return;
+    } catch {
+      // Path does not exist, continue.
+    }
+
+    symlinkSync(
+      sourceNodeModules,
+      targetNodeModules,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      chalk.yellow(`Warning: Failed to symlink node_modules: ${message}`),
+    );
+  }
+}
+
 /**
  * Main teleport command
  */
 export async function teleportCommand(
   ref: string,
-  options: TeleportOptions
+  options: TeleportOptions,
 ): Promise<TeleportResult> {
   const parsed = parseRef(ref);
-  const baseBranch = options.base || 'main';
+  const baseBranch = options.base || "main";
   const worktreeRoot = options.worktreePath || DEFAULT_WORKTREE_ROOT;
 
   // Get current repo info
   const currentRepo = getCurrentRepo();
   if (!currentRepo) {
-    const error = 'Not in a git repository. Run this command from within a git repo.';
+    const error =
+      "Not in a git repository. Run this command from within a git repo.";
     if (!options.json) {
       console.error(chalk.red(error));
     }
@@ -323,9 +400,9 @@ export async function teleportCommand(
   let worktreeDirName: string;
   let title: string | undefined;
 
-  if (parsed.type === 'feature') {
+  if (parsed.type === "feature") {
     // Feature branch
-    const safeName = sanitize(parsed.name || 'feature');
+    const safeName = sanitize(parsed.name || "feature");
     branchName = `feat/${safeName}`;
     worktreeDirName = `feat/${repoName}-${safeName}`;
     title = parsed.name;
@@ -339,7 +416,7 @@ export async function teleportCommand(
     const resolvedRepo = parsed.repo || repo;
 
     if (!parsed.number) {
-      const error = 'Could not parse issue/PR number from reference';
+      const error = "Could not parse issue/PR number from reference";
       if (!options.json) {
         console.error(chalk.red(error));
       }
@@ -355,9 +432,21 @@ export async function teleportCommand(
     }
 
     // Try to detect if it's a PR or issue
-    const prInfo = fetchProviderInfo('pr', parsed.number, provider, resolvedOwner, resolvedRepo);
+    const prInfo = fetchProviderInfo(
+      "pr",
+      parsed.number,
+      provider,
+      resolvedOwner,
+      resolvedRepo,
+    );
     const issueInfo = !prInfo
-      ? fetchProviderInfo('issue', parsed.number, provider, resolvedOwner, resolvedRepo)
+      ? fetchProviderInfo(
+          "issue",
+          parsed.number,
+          provider,
+          resolvedOwner,
+          resolvedRepo,
+        )
       : null;
 
     const info = prInfo || issueInfo;
@@ -365,7 +454,7 @@ export async function teleportCommand(
 
     if (!info) {
       const cli = provider.getRequiredCLI();
-      const error = `Could not fetch info for #${parsed.number} from ${provider.displayName}. ${cli ? `Make sure ${cli} CLI is installed and authenticated.` : 'Check your authentication credentials and network connection.'}`;
+      const error = `Could not fetch info for #${parsed.number} from ${provider.displayName}. ${cli ? `Make sure ${cli} CLI is installed and authenticated.` : "Check your authentication credentials and network connection."}`;
       if (!options.json) {
         console.error(chalk.red(error));
       }
@@ -381,19 +470,24 @@ export async function teleportCommand(
       worktreeDirName = `pr/${repoName}-${parsed.number}`;
 
       if (!options.json) {
-        console.log(chalk.blue(`Creating PR review worktree: #${parsed.number} - ${title}`));
+        console.log(
+          chalk.blue(
+            `Creating PR review worktree: #${parsed.number} - ${title}`,
+          ),
+        );
       }
 
       // Fetch the PR branch using provider-specific refspec or head branch
       if (provider.prRefspec) {
         try {
           const refspec = provider.prRefspec
-            .replace('{number}', String(parsed.number))
-            .replace('{branch}', branchName);
-          execFileSync(
-            'git', ['fetch', 'origin', refspec],
-            { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30000 }
-          );
+            .replace("{number}", String(parsed.number))
+            .replace("{branch}", branchName);
+          execFileSync("git", ["fetch", "origin", refspec], {
+            cwd: repoRoot,
+            stdio: ["pipe", "pipe", "pipe"],
+            timeout: 30000,
+          });
         } catch {
           // Branch might already exist
         }
@@ -402,8 +496,9 @@ export async function teleportCommand(
         // fetch the PR's head branch from origin
         try {
           execFileSync(
-            'git', ['fetch', 'origin', `${info.branch}:${branchName}`],
-            { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30000 }
+            "git",
+            ["fetch", "origin", `${info.branch}:${branchName}`],
+            { cwd: repoRoot, stdio: ["pipe", "pipe", "pipe"], timeout: 30000 },
           );
         } catch {
           // Branch might already exist locally
@@ -415,7 +510,11 @@ export async function teleportCommand(
       worktreeDirName = `issue/${repoName}-${parsed.number}`;
 
       if (!options.json) {
-        console.log(chalk.blue(`Creating issue fix worktree: #${parsed.number} - ${title}`));
+        console.log(
+          chalk.blue(
+            `Creating issue fix worktree: #${parsed.number} - ${title}`,
+          ),
+        );
       }
     }
   }
@@ -439,24 +538,30 @@ export async function teleportCommand(
   }
 
   if (!options.json) {
-    console.log('');
-    console.log(chalk.green('Worktree created successfully!'));
-    console.log('');
-    console.log(chalk.bold('To start working:'));
+    console.log("");
+    console.log(chalk.green("Worktree created successfully!"));
+    console.log("");
+    console.log(chalk.bold("To start working:"));
     console.log(chalk.cyan(`  cd ${worktreePath}`));
-    console.log('');
+    console.log("");
     if (title) {
       console.log(chalk.gray(`Title: ${title}`));
     }
   }
 
   if (options.json) {
-    console.log(JSON.stringify({
-      success: true,
-      worktreePath,
-      branch: branchName,
-      title,
-    }, null, 2));
+    console.log(
+      JSON.stringify(
+        {
+          success: true,
+          worktreePath,
+          branch: branchName,
+          title,
+        },
+        null,
+        2,
+      ),
+    );
   }
 
   return {
@@ -469,7 +574,11 @@ export async function teleportCommand(
 /**
  * Find worktree directories by scanning for .git files (not directories)
  */
-function findWorktreeDirs(dir: string, maxDepth: number = 3, currentDepth: number = 0): string[] {
+function findWorktreeDirs(
+  dir: string,
+  maxDepth: number = 3,
+  currentDepth: number = 0,
+): string[] {
   if (currentDepth >= maxDepth) return [];
   const results: string[] = [];
   try {
@@ -478,7 +587,7 @@ function findWorktreeDirs(dir: string, maxDepth: number = 3, currentDepth: numbe
       if (!entry.isDirectory()) continue;
       const fullPath = join(dir, entry.name);
       try {
-        const gitPath = join(fullPath, '.git');
+        const gitPath = join(fullPath, ".git");
         const stat = statSync(gitPath);
         if (stat.isFile()) {
           results.push(fullPath);
@@ -498,28 +607,30 @@ function findWorktreeDirs(dir: string, maxDepth: number = 3, currentDepth: numbe
 /**
  * List existing worktrees in the default location
  */
-export async function teleportListCommand(options: { json?: boolean }): Promise<void> {
+export async function teleportListCommand(options: {
+  json?: boolean;
+}): Promise<void> {
   const worktreeRoot = DEFAULT_WORKTREE_ROOT;
 
   if (!existsSync(worktreeRoot)) {
     if (options.json) {
       console.log(JSON.stringify({ worktrees: [] }));
     } else {
-      console.log(chalk.gray('No worktrees found.'));
+      console.log(chalk.gray("No worktrees found."));
     }
     return;
   }
 
   const worktreeDirs = findWorktreeDirs(worktreeRoot);
 
-  const worktrees = worktreeDirs.map(worktreePath => {
+  const worktrees = worktreeDirs.map((worktreePath) => {
     const relativePath = relative(worktreeRoot, worktreePath);
 
-    let branch = 'unknown';
+    let branch = "unknown";
     try {
-      branch = execSync('git branch --show-current', {
+      branch = execSync("git branch --show-current", {
         cwd: worktreePath,
-        encoding: 'utf-8',
+        encoding: "utf-8",
       }).trim();
     } catch {
       // Ignore
@@ -532,18 +643,18 @@ export async function teleportListCommand(options: { json?: boolean }): Promise<
     console.log(JSON.stringify({ worktrees }, null, 2));
   } else {
     if (worktrees.length === 0) {
-      console.log(chalk.gray('No worktrees found.'));
+      console.log(chalk.gray("No worktrees found."));
       return;
     }
 
-    console.log(chalk.bold('\nOMC Worktrees:\n'));
-    console.log(chalk.gray('─'.repeat(60)));
+    console.log(chalk.bold("\nOMC Worktrees:\n"));
+    console.log(chalk.gray("─".repeat(60)));
 
     for (const wt of worktrees) {
       console.log(`  ${chalk.cyan(wt.relativePath)}`);
       console.log(`    Branch: ${chalk.yellow(wt.branch)}`);
       console.log(`    Path: ${chalk.gray(wt.path)}`);
-      console.log('');
+      console.log("");
     }
   }
 }
@@ -554,7 +665,7 @@ export async function teleportListCommand(options: { json?: boolean }): Promise<
  */
 export async function teleportRemoveCommand(
   pathOrName: string,
-  options: { force?: boolean; json?: boolean }
+  options: { force?: boolean; json?: boolean },
 ): Promise<number> {
   const worktreeRoot = DEFAULT_WORKTREE_ROOT;
 
@@ -576,7 +687,7 @@ export async function teleportRemoveCommand(
 
   // Safety check: must be under worktree root
   const rel = relative(worktreeRoot, worktreePath);
-  if (rel.startsWith('..') || isAbsolute(rel)) {
+  if (rel.startsWith("..") || isAbsolute(rel)) {
     const error = `Refusing to remove worktree outside of ${worktreeRoot}`;
     if (options.json) {
       console.log(JSON.stringify({ success: false, error }));
@@ -589,13 +700,14 @@ export async function teleportRemoveCommand(
   try {
     // Check for uncommitted changes
     if (!options.force) {
-      const status = execSync('git status --porcelain', {
+      const status = execSync("git status --porcelain", {
         cwd: worktreePath,
-        encoding: 'utf-8',
+        encoding: "utf-8",
       });
 
       if (status.trim()) {
-        const error = 'Worktree has uncommitted changes. Use --force to remove anyway.';
+        const error =
+          "Worktree has uncommitted changes. Use --force to remove anyway.";
         if (options.json) {
           console.log(JSON.stringify({ success: false, error }));
         } else {
@@ -606,9 +718,9 @@ export async function teleportRemoveCommand(
     }
 
     // Find the main repo to run git worktree remove
-    const gitDir = execSync('git rev-parse --git-dir', {
+    const gitDir = execSync("git rev-parse --git-dir", {
       cwd: worktreePath,
-      encoding: 'utf-8',
+      encoding: "utf-8",
     }).trim();
 
     // The git-dir will be something like /path/to/main/.git/worktrees/name
@@ -618,11 +730,11 @@ export async function teleportRemoveCommand(
 
     if (mainRepo) {
       const args = options.force
-        ? ['worktree', 'remove', '--force', worktreePath]
-        : ['worktree', 'remove', worktreePath];
-      execFileSync('git', args, {
+        ? ["worktree", "remove", "--force", worktreePath]
+        : ["worktree", "remove", worktreePath];
+      execFileSync("git", args, {
         cwd: mainRepo,
-        stdio: 'pipe',
+        stdio: "pipe",
       });
     } else {
       // Fallback: just remove the directory


### PR DESCRIPTION
## Summary
- Add `symlinkNodeModules(repoRoot, worktreePath)` to `src/cli/commands/teleport.ts`.
- After `git worktree add` succeeds, symlink parent repo `node_modules` into the new worktree.
- Use platform-aware symlink type (`junction` on Windows, `dir` on Unix) and keep failures non-fatal with warning output.

## Why
Creating worktrees currently requires reinstalling dependencies in each worktree. Reusing the parent `node_modules` avoids repeated installs, reducing setup time and network usage.

Closes #1858