### PR TITLE
fix(builtin-skills): resolve correct skills directory in bundled CLI mode

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -66455,10 +66455,27 @@ init_context_injector();
 var import_fs81 = require("fs");
 var import_path96 = require("path");
 var import_url12 = require("url");
-var __filename3 = (0, import_url12.fileURLToPath)(importMetaUrl);
-var __dirname2 = (0, import_path96.dirname)(__filename3);
-var PROJECT_ROOT = (0, import_path96.join)(__dirname2, "..", "..", "..");
-var SKILLS_DIR2 = (0, import_path96.join)(PROJECT_ROOT, "skills");
+function getPackageDir5() {
+  if (typeof __dirname !== "undefined" && __dirname) {
+    const currentDirName = (0, import_path96.basename)(__dirname);
+    const parentDirName = (0, import_path96.basename)((0, import_path96.dirname)(__dirname));
+    const grandparentDirName = (0, import_path96.basename)((0, import_path96.dirname)((0, import_path96.dirname)(__dirname)));
+    if (currentDirName === "bridge") {
+      return (0, import_path96.join)(__dirname, "..");
+    }
+    if (currentDirName === "builtin-skills" && parentDirName === "features" && (grandparentDirName === "src" || grandparentDirName === "dist")) {
+      return (0, import_path96.join)(__dirname, "..", "..", "..");
+    }
+  }
+  try {
+    const __filename3 = (0, import_url12.fileURLToPath)(importMetaUrl);
+    const __dirname2 = (0, import_path96.dirname)(__filename3);
+    return (0, import_path96.join)(__dirname2, "..", "..", "..");
+  } catch {
+    return process.cwd();
+  }
+}
+var SKILLS_DIR2 = (0, import_path96.join)(getPackageDir5(), "skills");
 var CC_NATIVE_COMMANDS = /* @__PURE__ */ new Set([
   "review",
   "plan",

--- a/src/__tests__/package-dir-resolution-regression.test.ts
+++ b/src/__tests__/package-dir-resolution-regression.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { loadAgentPrompt } from '../agents/utils.js';
+import { clearSkillsCache, getBuiltinSkill, getSkillsDir } from '../features/builtin-skills/skills.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -21,6 +22,7 @@ describe('package dir resolution regression (#1322, #1324)', () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    clearSkillsCache();
   });
 
   it('src/agents/utils.ts checks __dirname before import.meta.url', () => {
@@ -47,6 +49,18 @@ describe('package dir resolution regression (#1322, #1324)', () => {
     );
   });
 
+  it('src/features/builtin-skills/skills.ts checks __dirname before import.meta.url', () => {
+    const source = readFileSync(join(REPO_ROOT, 'src', 'features', 'builtin-skills', 'skills.ts'), 'utf-8');
+    const snippet = getSnippetByMarker(source, 'function getPackageDir(): string {');
+
+    expect(snippet).toContain("typeof __dirname !== 'undefined'");
+    expect(snippet).toContain("currentDirName === 'bridge'");
+    expect(snippet).toContain('fileURLToPath(import.meta.url)');
+    expect(snippet.indexOf("typeof __dirname !== 'undefined'")).toBeLessThan(
+      snippet.indexOf('fileURLToPath(import.meta.url)'),
+    );
+  });
+
   it('bridge/runtime-cli.cjs keeps __dirname branch ahead of fileURLToPath(import_meta.url)', () => {
     const source = readFileSync(join(REPO_ROOT, 'bridge', 'runtime-cli.cjs'), 'utf-8');
     const snippet = getSnippetByMarker(source, 'function getPackageDir() {');
@@ -59,6 +73,20 @@ describe('package dir resolution regression (#1322, #1324)', () => {
     );
   });
 
+  it('bridge/cli.cjs keeps builtin skills package-dir resolution bridge-aware', () => {
+    const source = readFileSync(join(REPO_ROOT, 'bridge', 'cli.cjs'), 'utf-8');
+    const skillsDirIndex = source.indexOf('var SKILLS_DIR2 =');
+    const helperIndex = source.lastIndexOf('function getPackageDir', skillsDirIndex);
+    const snippet = helperIndex === -1 ? '' : source.slice(helperIndex, helperIndex + 1400);
+
+    expect(snippet).toContain('typeof __dirname !== "undefined"');
+    expect(snippet).toContain('currentDirName === "bridge"');
+    expect(snippet).toContain('fileURLToPath)(importMetaUrl)');
+    expect(snippet.indexOf('typeof __dirname !== "undefined"')).toBeLessThan(
+      snippet.indexOf('fileURLToPath)(importMetaUrl)'),
+    );
+  });
+
   it('loadAgentPrompt resolves prompts even when cwd is unrelated', () => {
     const sandboxDir = mkdtempSync(join(tmpdir(), 'omc-agents-path-resolution-'));
     process.chdir(sandboxDir);
@@ -66,6 +94,20 @@ describe('package dir resolution regression (#1322, #1324)', () => {
     const prompt = loadAgentPrompt('architect');
     expect(prompt).not.toContain('Prompt unavailable');
     expect(prompt.length).toBeGreaterThan(100);
+  });
+
+
+  it('builtin skills resolve skills directory and load skills even when cwd is unrelated', () => {
+    const sandboxDir = mkdtempSync(join(tmpdir(), 'omc-builtin-skills-path-resolution-'));
+    process.chdir(sandboxDir);
+
+    const skillsDir = getSkillsDir();
+    const skill = getBuiltinSkill('ralph');
+
+    expect(skillsDir).toBe(join(REPO_ROOT, 'skills'));
+    expect(skill).toBeDefined();
+    expect(skill?.name).toBe('ralph');
+    expect(skill?.template.length).toBeGreaterThan(100);
   });
 
   it('getValidAgentRoles resolves agents directory even when cwd is unrelated', async () => {

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -10,7 +10,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import type { BuiltinSkill } from './types.js';
 import { parseFrontmatter, parseFrontmatterAliases } from '../../utils/frontmatter.js';
@@ -19,11 +19,35 @@ import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../u
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from './runtime-guidance.js';
 
-// Get the project root directory (go up from src/features/builtin-skills/)
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const PROJECT_ROOT = join(__dirname, '..', '..', '..');
-const SKILLS_DIR = join(PROJECT_ROOT, 'skills');
+function getPackageDir(): string {
+  if (typeof __dirname !== 'undefined' && __dirname) {
+    const currentDirName = basename(__dirname);
+    const parentDirName = basename(dirname(__dirname));
+    const grandparentDirName = basename(dirname(dirname(__dirname)));
+
+    if (currentDirName === 'bridge') {
+      return join(__dirname, '..');
+    }
+
+    if (
+      currentDirName === 'builtin-skills'
+      && parentDirName === 'features'
+      && (grandparentDirName === 'src' || grandparentDirName === 'dist')
+    ) {
+      return join(__dirname, '..', '..', '..');
+    }
+  }
+
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    return join(__dirname, '..', '..', '..');
+  } catch {
+    return process.cwd();
+  }
+}
+
+const SKILLS_DIR = join(getPackageDir(), 'skills');
 
 /**
  * Claude Code native commands that must not be shadowed by OMC skill short names.


### PR DESCRIPTION
## Summary
- make builtin-skills package-dir resolution bridge-aware so bundled `bridge/cli.cjs` resolves the packaged `skills/` directory correctly
- extend the existing package-dir regression suite to cover builtin-skills source logic, bundled CLI output, and cwd-independent builtin skill loading
- update the bundled `bridge/cli.cjs` artifact to ship the fix

## Testing
- `npx vitest run src/__tests__/package-dir-resolution-regression.test.ts`

## Notes
- `src/__tests__/skills.test.ts` times out in this environment without surfacing a failing assertion, so it was not used as a completion gate for this targeted regression fix.
- Fixes #1914
