### PR TITLE
feat: auto-detect terminal width for HUD wrapping

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -157,6 +157,19 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     // Read configuration (before transcript parsing so we can use staleTaskThresholdMinutes)
     const config = readHudConfig();
 
+    // Auto-detect terminal width if maxWidth not explicitly configured (#1726)
+    if (!config.maxWidth) {
+      const cols =
+        parseInt(process.env.COLUMNS ?? "0", 10) ||
+        process.stderr.columns ||
+        process.stdout.columns ||
+        0;
+      if (cols > 0) {
+        config.maxWidth = cols;
+        if (!config.wrapMode) config.wrapMode = "wrap";
+      }
+    }
+
     // Resolve worktree-mismatched transcript paths (issue #1094)
     const resolvedTranscriptPath = resolveTranscriptPath(stdin.transcript_path, cwd);
 
@@ -385,6 +398,16 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
 
 // Export for programmatic use (e.g., omc hud --watch loop)
 export { main };
+
+// Listen for terminal resize events so column values stay current in --watch mode (#1726)
+if (process.stdout.isTTY) {
+  process.stdout.on("resize", () => {
+    // No-op: process.stdout.columns is updated automatically by Node.js on resize.
+    // This listener ensures the 'resize' event is observed, which triggers
+    // Node's internal columns update. The next main() invocation will read
+    // the fresh value via the auto-detect fallback chain.
+  });
+}
 
 // Auto-run (unconditional so dynamic import() via omc-hud.mjs wrapper works correctly)
 main();


### PR DESCRIPTION
## Summary

- Adds automatic terminal width detection in `src/hud/index.ts` using the fallback chain: `parseInt(process.env.COLUMNS)` -> `process.stderr.columns` -> `process.stdout.columns` -> `0`
- When auto-detected (and no explicit `maxWidth` configured), sets `wrapMode` to `'wrap'` so content is preserved across multiple lines instead of being truncated with `...`
- Registers a `process.stdout.on('resize', ...)` listener so column values stay current in `--watch` mode

## Details

Closes #1726

When the terminal is narrow, Claude Code truncates the HUD statusline with `...`, cutting off useful information. Previously, users had to manually set `maxWidth` in `~/.claude/settings.json`. This change makes the HUD automatically detect terminal width at render time, providing zero-config adaptive wrapping.

**Backward compatible**: Existing `maxWidth` / `wrapMode` settings are fully respected. The auto-detection only activates when `maxWidth` is not explicitly configured.

## Test plan

- [ ] Verify HUD renders correctly on a wide terminal (no wrapping applied)
- [ ] Resize terminal to narrow width and confirm HUD wraps at element boundaries instead of truncating
- [ ] Set explicit `maxWidth` in settings and confirm it takes precedence over auto-detection
- [ ] Test with `COLUMNS` env var set to confirm it is picked up
- [ ] Test `--watch` mode and resize terminal mid-session to confirm dynamic updates