### PR TITLE
fix: replace 40+ silent .catch(() => {}) with debug logging

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -954,9 +954,9 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
                 sessionId,
                 projectPath: directory,
                 profileName: process.env.OMC_NOTIFY_PROFILE,
-              }).catch(() => {}),
+              }).catch(err => console.debug('Failed to send session-idle notification:', err)),
             )
-            .catch(() => {});
+            .catch(err => console.debug('Failed to import notifications module:', err));
         }
       }
 
@@ -1046,9 +1046,9 @@ async function processSessionStart(input: HookInput): Promise<HookOutput> {
           sessionId,
           projectPath: directory,
           profileName: process.env.OMC_NOTIFY_PROFILE,
-        }).catch(() => {}),
+        }).catch(err => console.debug('Failed to send session-start notification:', err)),
       )
-      .catch(() => {});
+      .catch(err => console.debug('Failed to import notifications module:', err));
     // Wake OpenClaw gateway for session-start (non-blocking)
     _openclaw.wake("session-start", { sessionId, projectPath: directory });
   }
@@ -1078,7 +1078,7 @@ async function processSessionStart(input: HookInput): Promise<HookOutput> {
           });
         },
       )
-      .catch(() => {});
+      .catch(err => console.debug('Failed to start reply listener:', err));
   }
 
   const messages: string[] = [];
@@ -1281,9 +1281,9 @@ export function dispatchAskUserQuestionNotification(
         projectPath: directory,
         question: questionText,
         profileName: process.env.OMC_NOTIFY_PROFILE,
-      }).catch(() => {}),
+      }).catch(err => console.debug('Failed to send ask-user-question notification:', err)),
     )
-    .catch(() => {});
+    .catch(err => console.debug('Failed to import notifications module:', err));
 }
 
 /** @internal Object wrapper so tests can spy on the dispatch call. */
@@ -1306,8 +1306,8 @@ export const _openclaw = {
   ) => {
     if (process.env.OMC_OPENCLAW !== "1") return;
     import("../openclaw/index.js")
-      .then(({ wakeOpenClaw }) => wakeOpenClaw(event, context).catch(() => {}))
-      .catch(() => {});
+      .then(({ wakeOpenClaw }) => wakeOpenClaw(event, context).catch(err => console.debug('Failed to wake OpenClaw:', err)))
+      .catch(err => console.debug('Failed to import OpenClaw module:', err));
   },
 };
 
@@ -1522,9 +1522,9 @@ function processPreToolUse(input: HookInput): HookOutput {
           agentName,
           agentType,
           profileName: process.env.OMC_NOTIFY_PROFILE,
-        }).catch(() => {}),
+        }).catch(err => console.debug('Failed to send agent-call notification:', err)),
       )
-      .catch(() => {});
+      .catch(err => console.debug('Failed to import notifications module:', err));
   }
 
   // Warn about pkill -f self-termination risk (issue #210)

--- a/src/hooks/team-dispatch-hook.ts
+++ b/src/hooks/team-dispatch-hook.ts
@@ -389,7 +389,7 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
   const shouldTypePrompt = attemptCountAtStart === 0 || !preCaptureHasTrigger;
   if (shouldTypePrompt) {
     if (attemptCountAtStart >= 1) {
-      await runProcess('tmux', ['send-keys', '-t', paneTarget, 'C-u'], 1000).catch(() => {});
+      await runProcess('tmux', ['send-keys', '-t', paneTarget, 'C-u'], 1000).catch(err => console.debug('Failed to send tmux C-u:', err));
       await new Promise((r) => setTimeout(r, 50));
     }
     await runProcess('tmux', ['send-keys', '-t', paneTarget, '-l', request.trigger_message], 3000);
@@ -423,7 +423,7 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
     } catch { /* capture failed; retry */ }
 
     for (let i = 0; i < submitKeyPresses; i++) {
-      await runProcess('tmux', ['send-keys', '-t', paneTarget, 'C-m'], 3000).catch(() => {});
+      await runProcess('tmux', ['send-keys', '-t', paneTarget, 'C-m'], 3000).catch(err => console.debug('Failed to send tmux C-m:', err));
     }
   }
 
@@ -492,8 +492,8 @@ async function updateMailboxNotified(stateDir: string, teamName: string, workerN
 
 async function appendDispatchLog(logsDir: string, event: Record<string, unknown>): Promise<void> {
   const path = join(logsDir, `team-dispatch-${new Date().toISOString().slice(0, 10)}.jsonl`);
-  await mkdir(logsDir, { recursive: true }).catch(() => {});
-  await appendFile(path, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
+  await mkdir(logsDir, { recursive: true }).catch(err => console.debug('Failed to create dispatch logs directory:', err));
+  await appendFile(path, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(err => console.debug('Failed to append dispatch log entry:', err));
 }
 
 async function appendLeaderNotificationDeferredEvent(params: {
@@ -516,8 +516,8 @@ async function appendLeaderNotificationDeferredEvent(params: {
     request_id: params.request.request_id,
     ...(params.request.message_id ? { message_id: params.request.message_id } : {}),
   };
-  await mkdir(eventsDir, { recursive: true }).catch(() => {});
-  await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(() => {});
+  await mkdir(eventsDir, { recursive: true }).catch(err => console.debug('Failed to create events directory:', err));
+  await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(err => console.debug('Failed to append leader notification deferred event:', err));
 }
 
 // ── Main export ────────────────────────────────────────────────────────────
@@ -697,7 +697,7 @@ export async function drainPendingTeamDispatch(options: {
           request.notified_at = nowIso;
           request.last_reason = result.reason;
           if (request.kind === 'mailbox' && request.message_id) {
-            await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(() => {});
+            await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(err => console.debug('Failed to update mailbox notified status:', err));
           }
           processed += 1;
           mutated = true;

--- a/src/hooks/team-leader-nudge-hook.ts
+++ b/src/hooks/team-leader-nudge-hook.ts
@@ -44,7 +44,7 @@ async function readJsonSafe<T>(path: string, fallback: T): Promise<T> {
 
 async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
   const dir = join(path, '..');
-  await mkdir(dir, { recursive: true }).catch(() => {});
+  await mkdir(dir, { recursive: true }).catch(err => console.debug('Failed to create directory for atomic write:', err));
   const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}`;
   await writeFile(tmpPath, JSON.stringify(value, null, 2));
   await rename(tmpPath, path);
@@ -354,14 +354,14 @@ export async function maybeNudgeLeader(params: {
       nudge_count: nudgeState.nudge_count + 1,
       last_nudge_at_ms: nowMs,
       last_nudge_at: nowIso,
-    }).catch(() => {});
+    }).catch(err => console.debug('Failed to write nudge state:', err));
     await appendTeamEvent(teamName, {
       type: 'team_leader_nudge',
       worker: 'leader-fixed',
       reason: guidance.reason,
       next_action: guidance.nextAction,
       message: guidance.message,
-    }, params.cwd).catch(() => {});
+    }, params.cwd).catch(err => console.debug('Failed to append team leader nudge event:', err));
 
     return { nudged: true, reason: guidance.reason };
   } catch {

--- a/src/hooks/team-worker-hook.ts
+++ b/src/hooks/team-worker-hook.ts
@@ -105,7 +105,7 @@ async function readJsonIfExists<T>(path: string, fallback: T): Promise<T> {
 
 async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
   const dir = join(path, '..');
-  await mkdir(dir, { recursive: true }).catch(() => {});
+  await mkdir(dir, { recursive: true }).catch(err => console.debug('Failed to create directory for atomic write:', err));
   const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}`;
   await writeFile(tmpPath, JSON.stringify(value, null, 2));
   await rename(tmpPath, path);
@@ -238,7 +238,7 @@ export async function updateWorkerHeartbeat(
     turn_count: turnCount + 1,
     alive: true,
   };
-  await mkdir(join(stateDir, 'team', teamName, 'workers', workerName), { recursive: true }).catch(() => {});
+  await mkdir(join(stateDir, 'team', teamName, 'workers', workerName), { recursive: true }).catch(err => console.debug('Failed to create worker heartbeat directory:', err));
   await writeJsonAtomic(heartbeatPath, heartbeat);
 }
 
@@ -346,7 +346,7 @@ export async function maybeNotifyLeaderWorkerIdle(params: {
       last_notified_at_ms: nowMs,
       last_notified_at: nowIso,
       prev_state: prevState,
-    }).catch(() => {});
+    }).catch(err => console.debug('Failed to write idle cooldown state:', err));
 
     // Append event
     const eventsDir = join(stateDir, 'team', teamName, 'events');
@@ -427,7 +427,7 @@ export async function maybeNotifyLeaderAllWorkersIdle(params: {
       last_notified_at_ms: nowMs,
       last_notified_at: nowIso,
       worker_count: N,
-    }).catch(() => {});
+    }).catch(err => console.debug('Failed to write idle state:', err));
 
     // Append event
     const eventsDir = join(stateDir, 'team', teamName, 'events');

--- a/src/lib/atomic-write.ts
+++ b/src/lib/atomic-write.ts
@@ -86,7 +86,7 @@ export async function atomicWriteJson(
   } finally {
     // Clean up temp file on error
     if (!success) {
-      await fs.unlink(tempPath).catch(() => {});
+      await fs.unlink(tempPath).catch(err => console.debug('Failed to clean up temp file:', tempPath, err));
     }
   }
 }

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -434,7 +434,7 @@ async function syncMailboxDispatchNotified(
     requestId,
     { message_id: messageId, last_reason: 'mailbox_mark_notified' },
     cwd,
-  ).catch(() => {});
+  ).catch(err => console.debug('Failed to mark dispatch request notified:', err));
 }
 
 async function syncMailboxDispatchDelivered(
@@ -451,13 +451,13 @@ async function syncMailboxDispatchDelivered(
     requestId,
     { message_id: messageId, last_reason: 'mailbox_mark_delivered' },
     cwd,
-  ).catch(() => {});
+  ).catch(err => console.debug('Failed to mark dispatch request notified:', err));
   await markDispatchRequestDelivered(
     teamName,
     requestId,
     { message_id: messageId, last_reason: 'mailbox_mark_delivered' },
     cwd,
-  ).catch(() => {});
+  ).catch(err => console.debug('Failed to mark dispatch request delivered:', err));
 }
 
 function validateCommonFields(args: Record<string, unknown>): void {

--- a/src/team/events.ts
+++ b/src/team/events.ts
@@ -106,7 +106,7 @@ export async function emitMonitorDerivedEvents(
         worker: 'leader-fixed',
         task_id: task.id,
         reason: `status_transition:${prevStatus}->${task.status}`,
-      }, cwd).catch(() => {});
+      }, cwd).catch(err => console.debug('Failed to append team event:', err));
       completedEventTaskIds[task.id] = true;
     } else if (task.status === 'failed') {
       await appendTeamEvent(teamName, {
@@ -114,7 +114,7 @@ export async function emitMonitorDerivedEvents(
         worker: 'leader-fixed',
         task_id: task.id,
         reason: `status_transition:${prevStatus}->${task.status}`,
-      }, cwd).catch(() => {});
+      }, cwd).catch(err => console.debug('Failed to append team event:', err));
     }
   }
 
@@ -128,7 +128,7 @@ export async function emitMonitorDerivedEvents(
         type: 'worker_stopped',
         worker: worker.name,
         reason: 'pane_exited',
-      }, cwd).catch(() => {});
+      }, cwd).catch(err => console.debug('Failed to append team event:', err));
     }
 
     if (prevState === 'working' && worker.status.state === 'idle') {
@@ -136,7 +136,7 @@ export async function emitMonitorDerivedEvents(
         type: 'worker_idle',
         worker: worker.name,
         reason: `state_transition:${prevState}->${worker.status.state}`,
-      }, cwd).catch(() => {});
+      }, cwd).catch(err => console.debug('Failed to append team event:', err));
     }
   }
 }

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -111,7 +111,7 @@ async function markImmediateDispatchFailure(params: {
       last_reason: reason,
     },
     cwd,
-  ).catch(() => {});
+  ).catch(err => console.debug('Failed to transition dispatch request:', err));
 }
 
 async function markLeaderPaneMissingDeferred(params: {
@@ -135,7 +135,7 @@ async function markLeaderPaneMissingDeferred(params: {
       last_reason: 'leader_pane_missing_deferred',
     },
     cwd,
-  ).catch(() => {});
+  ).catch(err => console.debug('Failed to transition dispatch request:', err));
 }
 
 // ── Public API ─────────────────────────────────────────────────────────────

--- a/src/team/monitor.ts
+++ b/src/team/monitor.ts
@@ -383,7 +383,7 @@ export async function withScalingLock<T>(
       try {
         return await fn();
       } finally {
-        await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+        await rm(lockDir, { recursive: true, force: true }).catch(err => console.debug('Failed to remove lock directory:', lockDir, err));
       }
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -399,7 +399,7 @@ async function main(): Promise<void> {
           reason: leaderGuidance.reason,
           next_action: leaderGuidance.nextAction,
           message: leaderGuidance.message,
-        }, cwd).catch(() => {});
+        }, cwd).catch(err => console.debug('Failed to append team leader nudge event:', err));
         lastLeaderNudgeReason = leaderGuidance.reason;
       }
 

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -928,7 +928,7 @@ export async function requeueDeadWorkerTasks(
       worker: 'leader-fixed',
       task_id: task.id,
       reason: `requeue_dead_worker:${task.owner}`,
-    }, cwd).catch(() => {});
+    }, cwd).catch(err => console.debug('Failed to append team event:', err));
   }
 
   return requeued;
@@ -1165,7 +1165,7 @@ export async function shutdownTeamV2(
       type: 'shutdown_gate',
       worker: 'leader-fixed',
       reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed}${ralph ? ' policy=ralph' : ''}`,
-    }, cwd).catch(() => {});
+    }, cwd).catch(err => console.debug('Failed to append team event:', err));
 
     if (!gate.allowed) {
       const hasActiveWork = gate.pending > 0 || gate.blocked > 0 || gate.in_progress > 0;
@@ -1174,14 +1174,14 @@ export async function shutdownTeamV2(
           type: 'team_leader_nudge',
           worker: 'leader-fixed',
           reason: `cleanup_override_bypassed:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
-        }, cwd).catch(() => {});
+        }, cwd).catch(err => console.debug('Failed to append team event:', err));
       } else if (ralph && !hasActiveWork) {
         // Ralph policy: bypass on failure-only scenarios
         await appendTeamEvent(sanitized, {
           type: 'team_leader_nudge',
           worker: 'leader-fixed',
           reason: `gate_bypassed:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
-        }, cwd).catch(() => {});
+        }, cwd).catch(err => console.debug('Failed to append team event:', err));
       } else {
         throw new Error(
           `shutdown_gate_blocked:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
@@ -1195,7 +1195,7 @@ export async function shutdownTeamV2(
       type: 'shutdown_gate_forced',
       worker: 'leader-fixed',
       reason: 'force_bypass',
-    }, cwd).catch(() => {});
+    }, cwd).catch(err => console.debug('Failed to append team event:', err));
   }
 
   // 2. Send shutdown request to each worker
@@ -1228,7 +1228,7 @@ export async function shutdownTeamV2(
           type: 'shutdown_ack',
           worker: w.name,
           reason: ack.status === 'reject' ? `reject:${ack.reason || 'no_reason'}` : 'accept',
-        }, cwd).catch(() => {});
+        }, cwd).catch(err => console.debug('Failed to append team event:', err));
         if (ack.status === 'reject') {
           rejected.push({ worker: w.name, reason: ack.reason || 'no_reason' });
         }
@@ -1292,7 +1292,7 @@ export async function shutdownTeamV2(
       type: 'team_leader_nudge',
       worker: 'leader-fixed',
       reason: `ralph_cleanup_summary: total=${finalTasks.length} completed=${completed} failed=${failed} pending=${pending} force=${force}`,
-    }, cwd).catch(() => {});
+    }, cwd).catch(err => console.debug('Failed to append team event:', err));
   }
 
   // 6. Clean up state

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -162,7 +162,7 @@ async function withLock<T>(lockDir: string, fn: () => Promise<T>): Promise<{ ok:
     const result = await fn();
     return { ok: true, value: result };
   } finally {
-    await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+    await rm(lockDir, { recursive: true, force: true }).catch(err => console.debug('Failed to remove lock directory:', lockDir, err));
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaced 40+ instances of `.catch(() => {})` across 12 source files with `.catch(err => console.debug('...', err))` to make previously invisible failures traceable
- Preserves fire-and-forget semantics (no crash on failure) while leaving a debug trail
- Covers all affected areas: event persistence, dispatch state transitions, notification dispatch, filesystem operations, tmux key sending, and MCP worker communication

## Affected Files

| File | Changes | Context |
|------|---------|---------|
| `src/team/events.ts` | 4 catches | Team event persistence |
| `src/team/runtime-v2.ts` | 7 catches | Event publishing during shutdown/cleanup |
| `src/hooks/bridge.ts` | 11 catches | Notification dispatch (session-idle, session-start, ask-user-question, agent-call, OpenClaw) |
| `src/team/api-interop.ts` | 3 catches | Dispatch state transitions (notified/delivered) |
| `src/team/mcp-comm.ts` | 2 catches | MCP dispatch request transitions |
| `src/hooks/team-dispatch-hook.ts` | 7 catches | Tmux key sending, dispatch logging, mailbox updates |
| `src/hooks/team-worker-hook.ts` | 4 catches | Worker heartbeat dirs, idle state writes |
| `src/hooks/team-leader-nudge-hook.ts` | 3 catches | Nudge state writes, event appends |
| `src/team/runtime-cli.ts` | 1 catch | Leader nudge event |
| `src/team/monitor.ts` | 1 catch | Lock directory cleanup |
| `src/team/team-ops.ts` | 1 catch | Lock directory cleanup |
| `src/lib/atomic-write.ts` | 1 catch | Temp file cleanup |

## Approach

Used `console.debug()` with contextual messages describing the failed operation. This was chosen because:
1. Each module in the project defines its own local `debugLog` (env-gated, file-appending) -- adding that to 12 more files would be heavyweight
2. `console.debug` is lightweight, universally available, and can be filtered by log level
3. Each message describes *what* failed (e.g., "Failed to append team event:", "Failed to send session-idle notification:") for easy grep-ability

Test files with `.catch(() => {})` (cleanup in test teardown) were intentionally left unchanged.

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit` passes)
- [x] Only test files retain silent catches (verified via grep)
- [ ] Existing test suite passes (no behavioral changes -- all catches still swallow errors, just with logging)

Closes #1901