### PR TITLE
fix(security): add warnings for unsafe regex in live-data policy

### DIFF
--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -173,6 +173,7 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
         if (!safe(pat)) {
           // Unsafe regex in deny list: block the command to fail closed.
           // A ReDoS-capable pattern is treated as a blanket deny.
+          console.warn(`[live-data] Unsafe denied_pattern skipped (possible ReDoS): ${pat}`);
           return { allowed: false, reason: `unsafe regex rejected: ${pat}` };
         }
         if (new RegExp(pat).test(command)) {
@@ -218,6 +219,7 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
           // Unsafe regex in allow list: skip to fail closed.
           // The pattern cannot grant access — remaining patterns
           // or allowed_commands may still match.
+          console.warn(`[live-data] Unsafe allowed_pattern skipped (possible ReDoS): ${pat}`);
           continue;
         }
         if (new RegExp(pat).test(command)) {


### PR DESCRIPTION
## Summary

- Adds `console.warn()` calls when `safe-regex` rejects a ReDoS-capable pattern in `denied_patterns` or `allowed_patterns` within `src/hooks/auto-slash-command/live-data.ts`
- Gives operators visibility into which policy-file patterns are being silently skipped or blocked, complementing the existing `safe-regex` validation and `escapeRegExp` guards already in place

Closes #1758

## Test plan

- [ ] Add a catastrophic backtracking pattern (e.g. `(a+)+$`) to `denied_patterns` in a local `live-data-policy.json` and verify a warning is printed to stderr
- [ ] Add the same pattern to `allowed_patterns` and verify the warning appears and the pattern is skipped (command not granted access)
- [ ] Verify normal safe patterns continue to work without warnings