### PR TITLE
feat(i18n): cross-script skill trigger matching for Korean

### DIFF
--- a/src/__tests__/hooks/learner/transliteration-map.test.ts
+++ b/src/__tests__/hooks/learner/transliteration-map.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for Transliteration Map Module
+ *
+ * Validates:
+ * - Korean transliteration mappings are correct
+ * - expandTriggers() correctly expands trigger arrays
+ * - Original triggers are preserved after expansion
+ * - Deduplication works correctly
+ * - Architecture is extensible (locale registry structure)
+ *
+ * @see https://github.com/Yeachan-Heo/oh-my-claudecode/issues/1820
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  expandTriggers,
+  getLocaleRegistry,
+} from "../../../hooks/learner/transliteration-map.js";
+
+describe("Transliteration Map Module", () => {
+  describe("expandTriggers", () => {
+    it("should expand English triggers with Korean variants", () => {
+      const triggers = ["deep dive"];
+      const expanded = expandTriggers(triggers);
+
+      expect(expanded).toContain("deep dive");
+      expect(expanded).toContain("딥다이브");
+      expect(expanded).toContain("딥 다이브");
+    });
+
+    it("should handle multiple triggers", () => {
+      const triggers = ["deep dive", "debug"];
+      const expanded = expandTriggers(triggers);
+
+      expect(expanded).toContain("deep dive");
+      expect(expanded).toContain("딥다이브");
+      expect(expanded).toContain("debug");
+      expect(expanded).toContain("디버그");
+      expect(expanded).toContain("디버깅");
+    });
+
+    it("should preserve original triggers that have no mapping", () => {
+      const triggers = ["some-custom-trigger", "deploy"];
+      const expanded = expandTriggers(triggers);
+
+      expect(expanded).toContain("some-custom-trigger");
+      expect(expanded).toContain("deploy");
+      expect(expanded).toContain("디플로이");
+    });
+
+    it("should deduplicate variants", () => {
+      // Both "deep dive" and "deep-dive" map to "딥다이브"
+      const triggers = ["deep dive", "deep-dive"];
+      const expanded = expandTriggers(triggers);
+
+      const occurrences = expanded.filter((t) => t === "딥다이브");
+      expect(occurrences).toHaveLength(1);
+    });
+
+    it("should return all strings in lowercase", () => {
+      const triggers = ["deploy"];
+      const expanded = expandTriggers(triggers);
+
+      for (const trigger of expanded) {
+        expect(trigger).toBe(trigger.toLowerCase());
+      }
+    });
+
+    it("should return unchanged array when no mappings match", () => {
+      const triggers = ["unmapped-trigger-xyz"];
+      const expanded = expandTriggers(triggers);
+
+      expect(expanded).toEqual(["unmapped-trigger-xyz"]);
+    });
+
+    it("should handle empty input", () => {
+      const expanded = expandTriggers([]);
+      expect(expanded).toEqual([]);
+    });
+  });
+
+  describe("Locale Registry", () => {
+    it("should have Korean (ko) locale registered", () => {
+      const registry = getLocaleRegistry();
+      expect(registry).toHaveProperty("ko");
+    });
+
+    it("should have non-empty Korean map", () => {
+      const registry = getLocaleRegistry();
+      const koEntries = Object.keys(registry.ko);
+      expect(koEntries.length).toBeGreaterThan(10);
+    });
+
+    it("should have array values for all Korean entries", () => {
+      const registry = getLocaleRegistry();
+      for (const [key, variants] of Object.entries(registry.ko)) {
+        expect(Array.isArray(variants)).toBe(true);
+        expect(variants.length).toBeGreaterThan(0);
+        for (const variant of variants) {
+          expect(typeof variant).toBe("string");
+          expect(variant.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe("Cross-script matching integration", () => {
+    it("should enable Korean input to match English deep-dive trigger", () => {
+      // Simulates the matching pipeline in bridge.ts
+      const skillTriggers = ["deep dive", "deep-dive", "trace and interview", "investigate deeply"];
+      const expanded = expandTriggers(skillTriggers.map((t) => t.toLowerCase()));
+
+      const koreanInput = "해당 문제에 대해서 딥다이브 해주세요".toLowerCase();
+
+      const matched = expanded.some((trigger) => koreanInput.includes(trigger));
+      expect(matched).toBe(true);
+    });
+
+    it("should enable Korean input to match English deploy trigger", () => {
+      const skillTriggers = ["deploy"];
+      const expanded = expandTriggers(skillTriggers.map((t) => t.toLowerCase()));
+
+      const koreanInput = "프로덕션에 디플로이 해주세요";
+
+      const matched = expanded.some((trigger) => koreanInput.includes(trigger));
+      expect(matched).toBe(true);
+    });
+
+    it("should still match English input after expansion", () => {
+      const skillTriggers = ["deep dive"];
+      const expanded = expandTriggers(skillTriggers.map((t) => t.toLowerCase()));
+
+      const englishInput = "please do a deep dive on this issue";
+
+      const matched = expanded.some((trigger) => englishInput.includes(trigger));
+      expect(matched).toBe(true);
+    });
+  });
+});

--- a/src/hooks/learner/bridge.ts
+++ b/src/hooks/learner/bridge.ts
@@ -19,6 +19,7 @@ import {
 import { join, dirname, basename } from "path";
 import { homedir } from "os";
 import { OmcPaths } from "../../lib/worktree-paths.js";
+import { expandTriggers } from "./transliteration-map.js";
 
 // Re-export constants
 export const USER_SKILLS_DIR = join(
@@ -133,7 +134,7 @@ function getSkillMetadataCache(projectRoot: string): CachedSkillData[] {
         path: candidate.path,
         name,
         triggers,
-        triggersLower: triggers.map((t) => t.toLowerCase()),
+        triggersLower: expandTriggers(triggers.map((t) => t.toLowerCase())),
         matching: parsed.metadata.matching,
         content: parsed.content,
         scope: candidate.scope,

--- a/src/hooks/learner/transliteration-map.ts
+++ b/src/hooks/learner/transliteration-map.ts
@@ -1,0 +1,169 @@
+/**
+ * Transliteration Map Module
+ *
+ * Provides static mappings from English trigger terms to their transliterated
+ * equivalents in other languages. Used by bridge.ts to expand trigger words
+ * at cache load time so that the existing `includes()` matching works
+ * automatically for non-Latin input.
+ *
+ * Architecture:
+ * - Each locale has its own mapping object (English key -> array of locale variants)
+ * - Adding a new locale requires only adding a new map and registering it
+ * - No changes to bridge.ts or matching logic needed for new locales
+ *
+ * @see https://github.com/Yeachan-Heo/oh-my-claudecode/issues/1820
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** A mapping from lowercase English terms to their transliterated variants */
+export type TransliterationMap = Record<string, string[]>;
+
+/** Registry of all locale maps */
+export interface LocaleRegistry {
+  [locale: string]: TransliterationMap;
+}
+
+// =============================================================================
+// Korean (ko) Transliteration Map
+// =============================================================================
+
+/**
+ * Korean transliterations of common English terms used in skill triggers.
+ *
+ * Keys are lowercase English terms. Values are arrays of Korean variants
+ * (including spacing variants, e.g., "딥다이브" and "딥 다이브").
+ *
+ * To add new entries: add the English term as key and Korean variants as values.
+ */
+const koMap: TransliterationMap = {
+  // Development workflow terms
+  "deep dive": ["딥다이브", "딥 다이브"],
+  "deep-dive": ["딥다이브", "딥 다이브"],
+  debug: ["디버그", "디버깅"],
+  debugging: ["디버깅"],
+  deploy: ["디플로이", "배포"],
+  deployment: ["디플로이먼트", "배포"],
+  refactor: ["리팩토링", "리팩터"],
+  refactoring: ["리팩토링"],
+  review: ["리뷰"],
+  "code review": ["코드 리뷰", "코드리뷰"],
+  commit: ["커밋"],
+  merge: ["머지"],
+  rollback: ["롤백"],
+  hotfix: ["핫픽스"],
+  release: ["릴리스", "릴리즈"],
+
+  // Architecture & design
+  architecture: ["아키텍처"],
+  design: ["디자인"],
+  "design pattern": ["디자인 패턴", "디자인패턴"],
+  microservice: ["마이크로서비스"],
+  monolith: ["모놀리스"],
+  api: ["에이피아이"],
+  endpoint: ["엔드포인트"],
+  database: ["데이터베이스"],
+  schema: ["스키마"],
+  migration: ["마이그레이션"],
+
+  // Testing
+  test: ["테스트"],
+  testing: ["테스팅"],
+  "unit test": ["유닛 테스트", "유닛테스트", "단위 테스트"],
+  "integration test": ["통합 테스트", "통합테스트", "인테그레이션 테스트"],
+  benchmark: ["벤치마크"],
+  coverage: ["커버리지"],
+
+  // Analysis & investigation
+  analyze: ["분석"],
+  analysis: ["분석"],
+  investigate: ["조사"],
+  "investigate deeply": ["깊이 조사", "심층 분석"],
+  trace: ["트레이스", "추적"],
+  "trace and interview": ["트레이스 앤 인터뷰"],
+  profile: ["프로파일"],
+  profiling: ["프로파일링"],
+  optimize: ["최적화", "옵티마이즈"],
+  optimization: ["최적화", "옵티마이제이션"],
+  performance: ["퍼포먼스", "성능"],
+
+  // Infrastructure
+  docker: ["도커"],
+  kubernetes: ["쿠버네티스"],
+  pipeline: ["파이프라인"],
+  ci: ["씨아이"],
+  cd: ["씨디"],
+  monitoring: ["모니터링"],
+  logging: ["로깅"],
+
+  // General
+  setup: ["셋업", "설정"],
+  config: ["설정", "컨피그"],
+  configuration: ["설정", "컨피규레이션"],
+  scaffold: ["스캐폴드"],
+  template: ["템플릿", "템플릿"],
+  boilerplate: ["보일러플레이트"],
+  documentation: ["문서화", "도큐멘테이션"],
+  tutorial: ["튜토리얼"],
+  explain: ["설명"],
+  summarize: ["요약"],
+  simplify: ["단순화", "심플리파이"],
+};
+
+// =============================================================================
+// Locale Registry
+// =============================================================================
+
+/**
+ * Registry of all available locale transliteration maps.
+ *
+ * To add a new locale:
+ * 1. Create a new map (e.g., `jaMap` for Japanese) following the same pattern
+ * 2. Add it to this registry with the appropriate locale key
+ */
+const localeRegistry: LocaleRegistry = {
+  ko: koMap,
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Expand an array of trigger strings with transliterated variants from all
+ * registered locales.
+ *
+ * Given triggers like ["deep dive", "deep-dive"], returns an expanded array
+ * that includes the originals plus any transliterated variants:
+ * ["deep dive", "deep-dive", "딥다이브", "딥 다이브"]
+ *
+ * All returned strings are lowercase.
+ *
+ * @param triggersLower - Array of lowercase trigger strings
+ * @returns Expanded array with original triggers + transliterated variants (deduped)
+ */
+export function expandTriggers(triggersLower: string[]): string[] {
+  const expanded = new Set<string>(triggersLower);
+
+  for (const localeMap of Object.values(localeRegistry)) {
+    for (const trigger of triggersLower) {
+      const variants = localeMap[trigger];
+      if (variants) {
+        for (const variant of variants) {
+          expanded.add(variant.toLowerCase());
+        }
+      }
+    }
+  }
+
+  return Array.from(expanded);
+}
+
+/**
+ * Get the locale registry (for testing/inspection).
+ */
+export function getLocaleRegistry(): Readonly<LocaleRegistry> {
+  return localeRegistry;
+}


### PR DESCRIPTION
## Summary

- Adds a static transliteration map (`src/hooks/learner/transliteration-map.ts`) that maps ~30 common English skill terms to their Korean transliterated equivalents (e.g., "deep dive" -> "딥다이브")
- Integrates with `getSkillMetadataCache()` in `bridge.ts` to expand `triggersLower` with Korean variants at cache load time, so the existing `promptLower.includes(triggerLower)` matching works automatically for Korean input
- Architecture is extensible to other locales: adding Japanese, Chinese, etc. requires only a new map object in `transliteration-map.ts` -- no changes to `bridge.ts` or matching logic

## Changes

| File | Change |
|------|--------|
| `src/hooks/learner/transliteration-map.ts` | **New** - static Korean-English mapping + `expandTriggers()` API |
| `src/hooks/learner/bridge.ts` | Import `expandTriggers`, call it when building `triggersLower` in cache |
| `src/__tests__/hooks/learner/transliteration-map.test.ts` | **New** - 13 tests covering expansion, dedup, cross-script matching |

## How it works

\`\`\`
Before: triggersLower = ["deep dive", "deep-dive"]
After:  triggersLower = ["deep dive", "deep-dive", "딥다이브", "딥 다이브"]

User types: "해당 문제에 대해서 딥다이브 해주세요"
-> promptLower.includes("딥다이브") -> match!
\`\`\`

Expansion happens once per cache refresh (30s TTL), so runtime matching cost is unchanged.

## Test plan

- [x] All 13 new transliteration tests pass
- [x] All 18 existing bridge tests pass (no regressions)
- [x] Korean input "딥다이브" matches English trigger "deep dive"
- [x] English triggers continue to work unchanged
- [x] Duplicate variants are deduplicated

Closes #1820