### PR TITLE
test: add unit tests for utility modules

### DIFF
--- a/src/lib/__tests__/mode-names.test.ts
+++ b/src/lib/__tests__/mode-names.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MODE_NAMES,
+  DEPRECATED_MODE_NAMES,
+  ALL_MODE_NAMES,
+  MODE_STATE_FILE_MAP,
+  SESSION_END_MODE_STATE_FILES,
+  SESSION_METRICS_MODE_FILES,
+} from '../mode-names.js';
+
+describe('MODE_NAMES', () => {
+  it('contains all expected mode identifiers', () => {
+    expect(MODE_NAMES.AUTOPILOT).toBe('autopilot');
+    expect(MODE_NAMES.TEAM).toBe('team');
+    expect(MODE_NAMES.RALPH).toBe('ralph');
+    expect(MODE_NAMES.ULTRAWORK).toBe('ultrawork');
+    expect(MODE_NAMES.ULTRAQA).toBe('ultraqa');
+  });
+
+  it('has exactly 5 modes', () => {
+    expect(Object.keys(MODE_NAMES)).toHaveLength(5);
+  });
+});
+
+describe('DEPRECATED_MODE_NAMES', () => {
+  it('contains deprecated mode identifiers', () => {
+    expect(DEPRECATED_MODE_NAMES.ULTRAPILOT).toBe('ultrapilot');
+    expect(DEPRECATED_MODE_NAMES.SWARM).toBe('swarm');
+    expect(DEPRECATED_MODE_NAMES.PIPELINE).toBe('pipeline');
+  });
+
+  it('does not overlap with active MODE_NAMES', () => {
+    const activeValues = new Set(Object.values(MODE_NAMES));
+    for (const deprecated of Object.values(DEPRECATED_MODE_NAMES)) {
+      expect(activeValues.has(deprecated as any)).toBe(false);
+    }
+  });
+});
+
+describe('ALL_MODE_NAMES', () => {
+  it('contains all MODE_NAMES values', () => {
+    for (const mode of Object.values(MODE_NAMES)) {
+      expect(ALL_MODE_NAMES).toContain(mode);
+    }
+  });
+
+  it('has the same length as MODE_NAMES keys', () => {
+    expect(ALL_MODE_NAMES).toHaveLength(Object.keys(MODE_NAMES).length);
+  });
+
+  it('is readonly (frozen-like array)', () => {
+    // TypeScript enforces readonly at compile time; at runtime verify it is an array
+    expect(Array.isArray(ALL_MODE_NAMES)).toBe(true);
+  });
+});
+
+describe('MODE_STATE_FILE_MAP', () => {
+  it('has an entry for every mode in MODE_NAMES', () => {
+    for (const mode of Object.values(MODE_NAMES)) {
+      expect(MODE_STATE_FILE_MAP[mode]).toBeDefined();
+    }
+  });
+
+  it('maps each mode to a -state.json filename', () => {
+    for (const [mode, filename] of Object.entries(MODE_STATE_FILE_MAP)) {
+      expect(filename).toMatch(/^.+-state\.json$/);
+      expect(filename).toContain(mode);
+    }
+  });
+
+  it('produces unique filenames', () => {
+    const filenames = Object.values(MODE_STATE_FILE_MAP);
+    expect(new Set(filenames).size).toBe(filenames.length);
+  });
+});
+
+describe('SESSION_END_MODE_STATE_FILES', () => {
+  it('contains entries for all standard modes', () => {
+    const modes = SESSION_END_MODE_STATE_FILES.map((e) => e.mode);
+    for (const mode of Object.values(MODE_NAMES)) {
+      expect(modes).toContain(mode);
+    }
+  });
+
+  it('includes skill-active entry', () => {
+    const modes = SESSION_END_MODE_STATE_FILES.map((e) => e.mode);
+    expect(modes).toContain('skill-active');
+  });
+
+  it('has valid file fields', () => {
+    for (const entry of SESSION_END_MODE_STATE_FILES) {
+      expect(entry.file).toBeTruthy();
+      expect(entry.mode).toBeTruthy();
+    }
+  });
+});
+
+describe('SESSION_METRICS_MODE_FILES', () => {
+  it('is a subset of SESSION_END_MODE_STATE_FILES modes', () => {
+    const endModes = new Set(SESSION_END_MODE_STATE_FILES.map((e) => e.mode));
+    for (const entry of SESSION_METRICS_MODE_FILES) {
+      expect(endModes.has(entry.mode)).toBe(true);
+    }
+  });
+
+  it('contains autopilot, ralph, and ultrawork', () => {
+    const modes = SESSION_METRICS_MODE_FILES.map((e) => e.mode);
+    expect(modes).toContain(MODE_NAMES.AUTOPILOT);
+    expect(modes).toContain(MODE_NAMES.RALPH);
+    expect(modes).toContain(MODE_NAMES.ULTRAWORK);
+  });
+});

--- a/src/utils/__tests__/jsonc.test.ts
+++ b/src/utils/__tests__/jsonc.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { parseJsonc, stripJsoncComments } from '../jsonc.js';
+
+describe('stripJsoncComments', () => {
+  it('returns plain JSON unchanged', () => {
+    const input = '{"key": "value"}';
+    expect(stripJsoncComments(input)).toBe(input);
+  });
+
+  it('strips single-line comments', () => {
+    const input = '{\n  // this is a comment\n  "key": "value"\n}';
+    const result = stripJsoncComments(input);
+    expect(result).not.toContain('//');
+    expect(result).toContain('"key": "value"');
+  });
+
+  it('strips multi-line comments', () => {
+    const input = '{\n  /* multi\n     line */\n  "key": "value"\n}';
+    const result = stripJsoncComments(input);
+    expect(result).not.toContain('/*');
+    expect(result).not.toContain('*/');
+    expect(result).toContain('"key": "value"');
+  });
+
+  it('preserves comment-like content inside strings', () => {
+    const input = '{"url": "http://example.com"}';
+    expect(stripJsoncComments(input)).toBe(input);
+  });
+
+  it('preserves double-slash inside string values', () => {
+    const input = '{"path": "a // b"}';
+    expect(stripJsoncComments(input)).toBe(input);
+  });
+
+  it('preserves block-comment-like content inside strings', () => {
+    const input = '{"note": "/* not a comment */"}';
+    expect(stripJsoncComments(input)).toBe(input);
+  });
+
+  it('handles escaped quotes inside strings', () => {
+    const input = '{"msg": "say \\"hello\\""}';
+    const result = stripJsoncComments(input);
+    expect(result).toBe(input);
+  });
+
+  it('strips trailing single-line comment after value', () => {
+    const input = '{"key": 42 // trailing comment\n}';
+    const result = stripJsoncComments(input);
+    expect(result).toContain('"key": 42 ');
+    expect(result).not.toContain('trailing comment');
+  });
+
+  it('handles empty input', () => {
+    expect(stripJsoncComments('')).toBe('');
+  });
+
+  it('handles input with only comments', () => {
+    const result = stripJsoncComments('// just a comment');
+    expect(result.trim()).toBe('');
+  });
+});
+
+describe('parseJsonc', () => {
+  it('parses plain JSON', () => {
+    expect(parseJsonc('{"a": 1}')).toEqual({ a: 1 });
+  });
+
+  it('parses JSON with single-line comments', () => {
+    const input = '{\n  // comment\n  "a": 1\n}';
+    expect(parseJsonc(input)).toEqual({ a: 1 });
+  });
+
+  it('parses JSON with multi-line comments', () => {
+    const input = '{\n  /* comment */\n  "a": 1\n}';
+    expect(parseJsonc(input)).toEqual({ a: 1 });
+  });
+
+  it('parses JSON with trailing commas stripped via comment removal', () => {
+    // This tests that comment stripping works before JSON.parse
+    const input = '{\n  "a": 1\n  // "b": 2\n}';
+    expect(parseJsonc(input)).toEqual({ a: 1 });
+  });
+
+  it('throws on invalid JSON after comment stripping', () => {
+    expect(() => parseJsonc('{invalid}')).toThrow();
+  });
+
+  it('handles arrays with comments', () => {
+    const input = '[\n  1, // first\n  2  // second\n]';
+    expect(parseJsonc(input)).toEqual([1, 2]);
+  });
+
+  it('handles nested objects with comments', () => {
+    const input = `{
+      // top-level comment
+      "config": {
+        /* nested comment */
+        "enabled": true
+      }
+    }`;
+    expect(parseJsonc(input)).toEqual({ config: { enabled: true } });
+  });
+});

--- a/src/utils/__tests__/skill-pipeline.test.ts
+++ b/src/utils/__tests__/skill-pipeline.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../skill-pipeline.js';
+
+describe('parseSkillPipelineMetadata', () => {
+  it('returns undefined when no pipeline fields are present', () => {
+    expect(parseSkillPipelineMetadata({})).toBeUndefined();
+  });
+
+  it('returns undefined for empty string values', () => {
+    expect(parseSkillPipelineMetadata({ pipeline: '', 'next-skill': '' })).toBeUndefined();
+  });
+
+  it('parses a simple pipeline list', () => {
+    const result = parseSkillPipelineMetadata({ pipeline: '[plan, implement, review]' });
+    expect(result).toBeDefined();
+    expect(result!.steps).toEqual(['plan', 'implement', 'review']);
+  });
+
+  it('deduplicates pipeline steps (case-insensitive)', () => {
+    const result = parseSkillPipelineMetadata({ pipeline: '[plan, Plan, PLAN]' });
+    expect(result!.steps).toEqual(['plan']);
+  });
+
+  it('parses next-skill field', () => {
+    const result = parseSkillPipelineMetadata({ 'next-skill': 'review' });
+    expect(result).toBeDefined();
+    expect(result!.nextSkill).toBe('review');
+  });
+
+  it('normalizes oh-my-claudecode: prefix from next-skill', () => {
+    const result = parseSkillPipelineMetadata({ 'next-skill': 'oh-my-claudecode:review' });
+    expect(result!.nextSkill).toBe('review');
+  });
+
+  it('normalizes /oh-my-claudecode: prefix from next-skill', () => {
+    const result = parseSkillPipelineMetadata({ 'next-skill': '/oh-my-claudecode:review' });
+    expect(result!.nextSkill).toBe('review');
+  });
+
+  it('normalizes leading slash from next-skill', () => {
+    const result = parseSkillPipelineMetadata({ 'next-skill': '/review' });
+    expect(result!.nextSkill).toBe('review');
+  });
+
+  it('parses next-skill-args field', () => {
+    const result = parseSkillPipelineMetadata({
+      'next-skill': 'review',
+      'next-skill-args': '--strict',
+    });
+    expect(result!.nextSkillArgs).toBe('--strict');
+  });
+
+  it('strips quotes from next-skill-args', () => {
+    const result = parseSkillPipelineMetadata({
+      'next-skill': 'review',
+      'next-skill-args': '"--strict"',
+    });
+    expect(result!.nextSkillArgs).toBe('--strict');
+  });
+
+  it('parses handoff field', () => {
+    const result = parseSkillPipelineMetadata({ handoff: '.omc/handoff.md' });
+    expect(result).toBeDefined();
+    expect(result!.handoff).toBe('.omc/handoff.md');
+  });
+
+  it('parses all fields together', () => {
+    const result = parseSkillPipelineMetadata({
+      pipeline: '[plan, implement]',
+      'next-skill': 'review',
+      'next-skill-args': '--verbose',
+      handoff: '.omc/handoff.md',
+    });
+    expect(result).toEqual({
+      steps: ['plan', 'implement'],
+      nextSkill: 'review',
+      nextSkillArgs: '--verbose',
+      handoff: '.omc/handoff.md',
+    });
+  });
+});
+
+describe('renderSkillPipelineGuidance', () => {
+  it('returns empty string when pipeline is undefined', () => {
+    expect(renderSkillPipelineGuidance('test', undefined)).toBe('');
+  });
+
+  it('renders current stage info', () => {
+    const pipeline = { steps: ['plan', 'implement'], nextSkill: undefined, handoff: undefined, nextSkillArgs: undefined };
+    const result = renderSkillPipelineGuidance('plan', pipeline);
+    expect(result).toContain('Current stage: `plan`');
+    expect(result).toContain('## Skill Pipeline');
+  });
+
+  it('renders terminal stage message when no next-skill', () => {
+    const pipeline = { steps: ['plan'], nextSkill: undefined, handoff: undefined, nextSkillArgs: undefined };
+    const result = renderSkillPipelineGuidance('plan', pipeline);
+    expect(result).toContain('terminal stage');
+  });
+
+  it('renders next skill invocation when next-skill is set', () => {
+    const pipeline = { steps: ['plan'], nextSkill: 'review', handoff: undefined, nextSkillArgs: undefined };
+    const result = renderSkillPipelineGuidance('plan', pipeline);
+    expect(result).toContain('Next skill: `review`');
+    expect(result).toContain('oh-my-claudecode:review');
+    expect(result).toContain('When this stage completes');
+  });
+
+  it('renders handoff artifact instruction', () => {
+    const pipeline = { steps: [], nextSkill: 'review', handoff: '.omc/handoff.md', nextSkillArgs: undefined };
+    const result = renderSkillPipelineGuidance('plan', pipeline);
+    expect(result).toContain('Handoff artifact: `.omc/handoff.md`');
+    expect(result).toContain('Write or update the handoff artifact');
+  });
+
+  it('renders pipeline step sequence', () => {
+    const pipeline = { steps: ['plan', 'implement'], nextSkill: 'review', handoff: undefined, nextSkillArgs: undefined };
+    const result = renderSkillPipelineGuidance('plan', pipeline);
+    // Should show steps connected with arrows
+    expect(result).toContain('\u2192');
+  });
+
+  it('normalizes skill name prefix in current stage', () => {
+    const pipeline = { steps: [], nextSkill: 'review', handoff: undefined, nextSkillArgs: undefined };
+    const result = renderSkillPipelineGuidance('oh-my-claudecode:plan', pipeline);
+    expect(result).toContain('Current stage: `plan`');
+  });
+});

--- a/src/utils/__tests__/ssrf-guard.test.ts
+++ b/src/utils/__tests__/ssrf-guard.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { validateUrlForSSRF, validateAnthropicBaseUrl } from '../ssrf-guard.js';
+
+/**
+ * Additional SSRF guard tests supplementing src/__tests__/ssrf-guard.test.ts.
+ * Focuses on edge cases: encoding tricks, cloud metadata paths, and credentials.
+ */
+
+describe('validateUrlForSSRF - encoding bypass attempts', () => {
+  it('blocks hex-encoded IP addresses (resolved by URL constructor to loopback)', () => {
+    // Node's URL constructor resolves 0x7f000001 to 127.0.0.1
+    const result = validateUrlForSSRF('http://0x7f000001/');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('blocks decimal-encoded IP addresses (resolved by URL constructor to loopback)', () => {
+    // 2130706433 = 127.0.0.1; URL constructor resolves it
+    const result = validateUrlForSSRF('http://2130706433/');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('blocks octal-encoded IP addresses (resolved by URL constructor to loopback)', () => {
+    // 0177.0.0.1 = 127.0.0.1; URL constructor resolves it
+    const result = validateUrlForSSRF('http://0177.0.0.1/');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('allows short numeric hostnames that are not IP encoding', () => {
+    // Short numeric strings (3 digits or less) are allowed as they could be valid hostnames
+    const result = validateUrlForSSRF('http://123/');
+    // 123 has length 3, so it should NOT match the decimal IP check (>3)
+    // but it will try URL parse - depends on URL constructor behavior
+    expect(typeof result.allowed).toBe('boolean');
+  });
+});
+
+describe('validateUrlForSSRF - cloud metadata paths', () => {
+  it('blocks AWS metadata endpoint path', () => {
+    const result = validateUrlForSSRF('http://example.com/latest/meta-data/iam/credentials');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('cloud metadata');
+  });
+
+  it('does not block /computeMetadata due to case mismatch (known limitation)', () => {
+    // The code lowercases pathLower but compares against mixed-case '/computeMetadata',
+    // so '/computemetadata/...' (lowercased) never startsWith '/computeMetadata'.
+    // This documents the current behavior.
+    const result = validateUrlForSSRF('http://example.com/computeMetadata/v1/instance');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('blocks /metadata path', () => {
+    const result = validateUrlForSSRF('http://example.com/metadata');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('cloud metadata');
+  });
+
+  it('blocks /meta-data path', () => {
+    const result = validateUrlForSSRF('http://example.com/meta-data');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('cloud metadata');
+  });
+
+  it('allows paths that merely contain metadata as a substring', () => {
+    const result = validateUrlForSSRF('http://example.com/api/v1/metadata-service');
+    // /api/v1/metadata-service does NOT start with /metadata
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe('validateUrlForSSRF - credentials in URL', () => {
+  it('blocks URLs with username', () => {
+    const result = validateUrlForSSRF('http://admin@example.com/');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('credentials');
+  });
+
+  it('blocks URLs with username and password', () => {
+    const result = validateUrlForSSRF('http://admin:secret@example.com/');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('credentials');
+  });
+});
+
+describe('validateUrlForSSRF - protocol restrictions', () => {
+  it('blocks file:// protocol', () => {
+    const result = validateUrlForSSRF('file:///etc/passwd');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('Protocol');
+  });
+
+  it('blocks ftp:// protocol', () => {
+    const result = validateUrlForSSRF('ftp://example.com/file');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('Protocol');
+  });
+
+  it('blocks javascript: protocol', () => {
+    // URL constructor may or may not parse this
+    const result = validateUrlForSSRF('javascript:alert(1)');
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe('validateUrlForSSRF - IPv6 variants', () => {
+  it('blocks IPv6 loopback', () => {
+    const result = validateUrlForSSRF('http://[::1]/');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('blocks IPv6 unique local (fc00:)', () => {
+    const result = validateUrlForSSRF('http://[fc00::1]/');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('blocks IPv6 link-local (fe80:)', () => {
+    const result = validateUrlForSSRF('http://[fe80::1]/');
+    expect(result.allowed).toBe(false);
+  });
+});
+
+describe('validateUrlForSSRF - edge cases', () => {
+  it('rejects empty string', () => {
+    expect(validateUrlForSSRF('').allowed).toBe(false);
+  });
+
+  it('rejects non-URL string', () => {
+    expect(validateUrlForSSRF('not a url').allowed).toBe(false);
+  });
+
+  it('allows valid public HTTPS URL', () => {
+    expect(validateUrlForSSRF('https://api.anthropic.com/v1/messages').allowed).toBe(true);
+  });
+
+  it('allows valid public HTTP URL', () => {
+    expect(validateUrlForSSRF('http://example.com/api').allowed).toBe(true);
+  });
+});
+
+describe('validateAnthropicBaseUrl', () => {
+  it('allows valid HTTPS anthropic URL', () => {
+    expect(validateAnthropicBaseUrl('https://api.anthropic.com').allowed).toBe(true);
+  });
+
+  it('rejects private IP addresses', () => {
+    expect(validateAnthropicBaseUrl('http://192.168.1.1/api').allowed).toBe(false);
+  });
+
+  it('rejects invalid URL format', () => {
+    expect(validateAnthropicBaseUrl('not-a-url').allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **75 unit tests** across 4 new test files for pure utility modules that previously lacked dedicated test coverage
- All tests pass with `vitest run` and follow the project's existing test conventions (co-located `__tests__/` directories, vitest globals)

## Modules tested

| File | Module | Tests | What's covered |
|------|--------|-------|----------------|
| `src/utils/__tests__/jsonc.test.ts` | `jsonc.ts` | 17 | JSONC comment stripping (single-line, multi-line, inside strings, escaped quotes), `parseJsonc` with nested objects and arrays |
| `src/utils/__tests__/skill-pipeline.test.ts` | `skill-pipeline.ts` | 19 | Pipeline metadata parsing, skill reference normalization (`oh-my-claudecode:` prefix stripping), deduplication, guidance rendering with handoff artifacts |
| `src/lib/__tests__/mode-names.test.ts` | `mode-names.ts` | 15 | Mode name constants, deprecated mode separation, `ALL_MODE_NAMES` completeness, `MODE_STATE_FILE_MAP` uniqueness, session-end and metrics file entries |
| `src/utils/__tests__/ssrf-guard.test.ts` | `ssrf-guard.ts` | 24 | Encoding bypass attempts (hex/decimal/octal IPs), cloud metadata path blocking, credential rejection, protocol restrictions, IPv6 variants, edge cases. Documents a case-sensitivity limitation in `/computeMetadata` matching |

## Test plan

- [x] `npx vitest run` passes for all 4 new test files (75/75 green)
- [x] No modifications to source code -- tests only
- [x] Tests are pure (no filesystem/network side effects)