### PR TITLE
fix: track and clean up child processes on exit (#1724)

### DIFF
--- a/src/__tests__/child-process-tracker.test.ts
+++ b/src/__tests__/child-process-tracker.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { spawn } from 'child_process';
+import {
+  trackChildProcess,
+  untrackChildProcess,
+  killAllTrackedProcesses,
+  getTrackedProcessCount,
+} from '../platform/child-process-tracker.js';
+
+describe('child-process-tracker', () => {
+  beforeEach(() => {
+    // Kill any leftover tracked processes from prior tests
+    killAllTrackedProcesses();
+  });
+
+  it('tracks a spawned child process and auto-removes on exit', async () => {
+    const child = spawn('node', ['-e', 'setTimeout(() => {}, 100)'], {
+      stdio: 'ignore',
+    });
+
+    trackChildProcess(child, 'test-short-lived');
+    expect(getTrackedProcessCount()).toBeGreaterThanOrEqual(1);
+
+    // Wait for the child to exit naturally
+    await new Promise<void>((resolve) => {
+      child.on('exit', () => resolve());
+    });
+
+    // After natural exit, it should be untracked
+    expect(getTrackedProcessCount()).toBe(0);
+  });
+
+  it('killAllTrackedProcesses terminates a long-running child', async () => {
+    const child = spawn('node', ['-e', 'setTimeout(() => {}, 60000)'], {
+      stdio: 'ignore',
+    });
+
+    trackChildProcess(child, 'test-long-lived');
+    expect(getTrackedProcessCount()).toBeGreaterThanOrEqual(1);
+
+    killAllTrackedProcesses();
+    expect(getTrackedProcessCount()).toBe(0);
+
+    // Wait for actual process exit
+    await new Promise<void>((resolve) => {
+      child.on('exit', () => resolve());
+      // Safety timeout
+      setTimeout(resolve, 3000);
+    });
+  });
+
+  it('untrackChildProcess removes a process from tracking', () => {
+    const child = spawn('node', ['-e', 'setTimeout(() => {}, 60000)'], {
+      stdio: 'ignore',
+    });
+
+    trackChildProcess(child, 'test-untrack');
+    const pid = child.pid!;
+    expect(getTrackedProcessCount()).toBeGreaterThanOrEqual(1);
+
+    untrackChildProcess(pid);
+    expect(getTrackedProcessCount()).toBe(0);
+
+    // Clean up the process manually
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // already dead
+    }
+  });
+
+  it('handles process that failed to spawn (no pid)', () => {
+    // Create a mock ChildProcess-like object with no pid
+    const fakeProc = {
+      pid: undefined,
+      on: vi.fn(),
+    } as any;
+
+    const result = trackChildProcess(fakeProc, 'no-pid');
+    expect(result).toBe(fakeProc);
+    expect(getTrackedProcessCount()).toBe(0);
+  });
+});

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { trackChildProcess } from '../platform/child-process-tracker.js';
 import { readFile, rm } from 'fs/promises';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
@@ -384,6 +385,8 @@ export async function startTeamJob(input: TeamStartInput): Promise<TeamStartResu
   child.stdin?.write(JSON.stringify(payload));
   child.stdin?.end();
   child.unref();
+  // Track for cleanup on parent exit (#1724)
+  trackChildProcess(child, `team-runtime[${input.teamName}]`);
 
   if (child.pid != null) {
     job.pid = child.pid;

--- a/src/features/rate-limit-wait/daemon.ts
+++ b/src/features/rate-limit-wait/daemon.ts
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { spawn } from 'child_process';
 import { resolveDaemonModulePath } from '../../utils/daemon-module-path.js';
+import { trackChildProcess } from '../../platform/child-process-tracker.js';
 import {
   checkRateLimitStatus,
   formatRateLimitStatus,
@@ -501,6 +502,8 @@ export function startDaemon(config?: DaemonConfig): DaemonResponse {
     });
 
     child.unref();
+    // Track for cleanup on parent exit (#1724)
+    trackChildProcess(child, 'rate-limit-wait-daemon');
 
     const pid = child.pid;
     if (pid) {

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -49,6 +49,7 @@ import { homedir } from "os";
 import { spawn } from "child_process";
 import { fileURLToPath } from "url";
 import { getOmcRoot } from "../lib/worktree-paths.js";
+import { trackChildProcess } from "../platform/child-process-tracker.js";
 
 /**
  * Extract session ID (UUID) from a transcript path.
@@ -97,6 +98,8 @@ function spawnSessionSummaryScript(transcriptPath: string, stateDir: string, ses
       env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: 'session-summary' },
     });
     child.unref();
+    // Track for cleanup on parent exit (#1724)
+    trackChildProcess(child, `session-summary[${sessionId}]`);
   } catch (error) {
     if (process.env.OMC_DEBUG) {
       console.error('[HUD] Failed to spawn session-summary:', error instanceof Error ? error.message : error);

--- a/src/mcp/standalone-server.ts
+++ b/src/mcp/standalone-server.ts
@@ -192,6 +192,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 // The MCP server process owns the LSP child processes (spawned via
 // child_process.spawn in LspClient.connect), so cleanup must happen here.
 import { disconnectAll as disconnectAllLsp } from '../tools/lsp/index.js';
+import { killAllTrackedProcesses } from '../platform/child-process-tracker.js';
 
 async function gracefulShutdown(signal: string): Promise<void> {
   // Hard deadline: exit even if cleanup hangs (e.g. unresponsive LSP server)
@@ -200,6 +201,12 @@ async function gracefulShutdown(signal: string): Promise<void> {
 
   console.error(`OMC MCP Server: received ${signal}, disconnecting LSP servers...`);
 
+  // Kill all tracked child processes first (#1724)
+  try {
+    killAllTrackedProcesses();
+  } catch {
+    // Best-effort
+  }
   try {
     await cleanupOwnedBridgeSessions();
   } catch {

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -23,6 +23,7 @@ import { homedir } from 'os';
 import { spawn } from 'child_process';
 import { request as httpsRequest } from 'https';
 import { resolveDaemonModulePath } from '../utils/daemon-module-path.js';
+import { trackChildProcess } from '../platform/child-process-tracker.js';
 import {
   capturePaneContent,
   sendToPane,
@@ -956,6 +957,8 @@ export function startReplyListener(_config: ReplyListenerDaemonConfig): DaemonRe
     });
 
     child.unref();
+    // Track for cleanup on parent exit (#1724)
+    trackChildProcess(child, 'reply-listener-daemon');
 
     const pid = child.pid;
     if (pid) {

--- a/src/platform/child-process-tracker.ts
+++ b/src/platform/child-process-tracker.ts
@@ -1,0 +1,121 @@
+/**
+ * Child Process Tracker
+ *
+ * Centralized tracking and cleanup of spawned child processes.
+ * Prevents orphaned processes (PPID 1) from accumulating when
+ * the parent Claude Code session exits without forwarding signals.
+ *
+ * Issue: #1724
+ */
+
+import { ChildProcess } from 'child_process';
+
+interface TrackedProcess {
+  proc: ChildProcess;
+  pid: number;
+  label: string;
+  spawnedAt: number;
+}
+
+const trackedProcesses = new Map<number, TrackedProcess>();
+let cleanupRegistered = false;
+
+/**
+ * Track a spawned child process for cleanup on exit.
+ *
+ * @param proc - The ChildProcess returned by spawn/fork/exec
+ * @param label - Human-readable label for debugging (e.g., 'gyoshu_bridge', 'session-summary')
+ * @returns The same ChildProcess (for chaining)
+ */
+export function trackChildProcess(proc: ChildProcess, label: string): ChildProcess {
+  if (!proc.pid) {
+    // Process failed to spawn; nothing to track
+    return proc;
+  }
+
+  const entry: TrackedProcess = {
+    proc,
+    pid: proc.pid,
+    label,
+    spawnedAt: Date.now(),
+  };
+
+  trackedProcesses.set(proc.pid, entry);
+
+  // Auto-remove when process exits naturally
+  proc.on('exit', () => {
+    trackedProcesses.delete(entry.pid);
+  });
+  proc.on('error', () => {
+    trackedProcesses.delete(entry.pid);
+  });
+
+  ensureCleanupHandlers();
+
+  return proc;
+}
+
+/**
+ * Untrack a child process (e.g., when it is managed by another subsystem).
+ */
+export function untrackChildProcess(pid: number): void {
+  trackedProcesses.delete(pid);
+}
+
+/**
+ * Kill all tracked child processes.
+ * Called automatically on exit/SIGTERM/SIGINT, but can also be invoked manually.
+ *
+ * Uses process group kill (negative PID) when possible to clean up
+ * any grandchild processes spawned by detached children.
+ */
+export function killAllTrackedProcesses(): void {
+  for (const [pid, entry] of trackedProcesses) {
+    try {
+      // Try process group kill first (catches grandchildren)
+      if (process.platform !== 'win32') {
+        try {
+          process.kill(-pid, 'SIGTERM');
+        } catch {
+          // Process group kill failed; fall back to direct kill
+          process.kill(pid, 'SIGTERM');
+        }
+      } else {
+        process.kill(pid, 'SIGTERM');
+      }
+    } catch {
+      // Process already dead — ignore
+    }
+    trackedProcesses.delete(pid);
+  }
+}
+
+/**
+ * Get the count of currently tracked (alive) processes.
+ * Useful for diagnostics.
+ */
+export function getTrackedProcessCount(): number {
+  return trackedProcesses.size;
+}
+
+/**
+ * Register process exit handlers exactly once.
+ * Handles: exit, SIGTERM, SIGINT, SIGHUP.
+ */
+function ensureCleanupHandlers(): void {
+  if (cleanupRegistered) return;
+  cleanupRegistered = true;
+
+  // 'exit' fires synchronously — we can only do sync work here
+  process.on('exit', () => {
+    killAllTrackedProcesses();
+  });
+
+  // For signals, kill children but do NOT call process.exit().
+  // Other signal handlers (LSP cleanup, bridge cleanup, etc.) may still need to run.
+  for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP'] as const) {
+    process.on(sig, () => {
+      killAllTrackedProcesses();
+    });
+  }
+}

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -51,3 +51,4 @@ export function isWSL(): boolean {
 
 // Re-exports
 export * from './process-utils.js';
+export * from './child-process-tracker.js';

--- a/src/tools/python-repl/bridge-manager.ts
+++ b/src/tools/python-repl/bridge-manager.ts
@@ -20,6 +20,7 @@ import { BridgeMeta, PythonEnvInfo } from './types.js';
 import { getRuntimeDir, getSessionDir, getBridgeSocketPath, getBridgeMetaPath, getBridgePortPath, getSessionLockPath } from './paths.js';
 import { atomicWriteJson, safeReadJson, ensureDirSync } from '../../lib/atomic-write.js';
 import { getProcessStartTime, isProcessAlive } from '../../platform/index.js';
+import { trackChildProcess } from '../../platform/child-process-tracker.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -395,6 +396,9 @@ export async function spawnBridgeServer(
   });
 
   proc.unref();
+
+  // Track for cleanup on parent exit (#1724)
+  trackChildProcess(proc, `gyoshu_bridge[${sessionId}]`);
 
   // Capture stderr for error reporting (capped at 64KB)
   const MAX_STDERR_CHARS = 64 * 1024;


### PR DESCRIPTION
## Summary

- Adds a centralized `ChildProcessTracker` module (`src/platform/child-process-tracker.ts`) that registers `process.on('exit')`, `SIGTERM`, `SIGINT`, and `SIGHUP` handlers to kill all tracked child processes when the parent terminates
- Wires `trackChildProcess()` into all 5 spawn sites that use `detached: true` + `unref()`: `gyoshu_bridge.py`, `session-summary`, `reply-listener-daemon`, `rate-limit-wait-daemon`, and `team-runtime`
- Integrates `killAllTrackedProcesses()` into the MCP standalone server's graceful shutdown path, ensuring cleanup runs even on explicit signal-based shutdown
- Uses process group kill (`-pid`) on Unix to also terminate grandchild processes

Fixes #1724

## Test plan

- [ ] Run `npx vitest run src/__tests__/child-process-tracker.test.ts` -- 4 tests verify tracking, auto-removal on exit, manual untrack, and kill-all behavior
- [ ] Start a Claude Code session with OMC, use python_repl tool, then exit -- verify `gyoshu_bridge.py` processes are terminated
- [ ] Monitor `ps aux | grep gyoshu_bridge` across multiple session starts/stops to confirm no orphaned processes accumulate
- [ ] Verify `omx hud --watch` child processes are cleaned up on session exit