### PR TITLE
Fix non-interactive ralplan pausing between consensus stages

### DIFF
--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -298,6 +298,84 @@ describe('processHook - Routing Matrix', () => {
       }
     });
 
+    it('activates ralplan state when Skill tool invokes ralplan directly', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-ralplan-skill-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'ralplan-skill-session';
+
+        const result = await processHook('pre-tool-use', {
+          sessionId,
+          toolName: 'Skill',
+          toolInput: { skill: 'oh-my-claudecode:ralplan' },
+          directory: tempDir,
+        });
+
+        expect(result.continue).toBe(true);
+
+        const ralplanPath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralplan-state.json');
+        expect(existsSync(ralplanPath)).toBe(true);
+
+        const ralplanState = JSON.parse(readFileSync(ralplanPath, 'utf-8')) as {
+          active?: boolean;
+          session_id?: string;
+          current_phase?: string;
+          awaiting_confirmation?: boolean;
+        };
+
+        expect(ralplanState.active).toBe(true);
+        expect(ralplanState.session_id).toBe(sessionId);
+        expect(ralplanState.current_phase).toBe('ralplan');
+        expect(ralplanState.awaiting_confirmation).toBeUndefined();
+
+        const stopResult = await processHook('persistent-mode', {
+          sessionId,
+          directory: tempDir,
+          stop_reason: 'end_turn',
+        } as HookInput);
+
+        expect(stopResult.continue).toBe(false);
+        expect(stopResult.message).toContain('ralplan-continuation');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('activates ralplan state when Skill tool invokes omc-plan in consensus mode', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-plan-consensus-skill-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'plan-consensus-skill-session';
+
+        const result = await processHook('pre-tool-use', {
+          sessionId,
+          toolName: 'Skill',
+          toolInput: {
+            skill: 'oh-my-claudecode:omc-plan',
+            args: '--consensus issue #1926',
+          },
+          directory: tempDir,
+        });
+
+        expect(result.continue).toBe(true);
+
+        const ralplanPath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralplan-state.json');
+        expect(existsSync(ralplanPath)).toBe(true);
+
+        const ralplanState = JSON.parse(readFileSync(ralplanPath, 'utf-8')) as {
+          active?: boolean;
+          session_id?: string;
+          current_phase?: string;
+        };
+
+        expect(ralplanState.active).toBe(true);
+        expect(ralplanState.session_id).toBe(sessionId);
+        expect(ralplanState.current_phase).toBe('ralplan');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('should handle session-start and return continue:true', async () => {
       const input: HookInput = {
         sessionId: 'test-session',

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -24,6 +24,7 @@ import {
 } from "fs";
 import { dirname, join } from "path";
 import { resolveToWorktreeRoot, getOmcRoot } from "../lib/worktree-paths.js";
+import { writeModeState } from "../lib/mode-state-io.js";
 import { formatOmcCliInvocation } from "../utils/omc-cli-rendering.js";
 import { createSwallowedErrorLogger } from "../lib/swallowed-error.js";
 
@@ -241,6 +242,56 @@ function confirmSkillModeStates(directory: string, skillName: string, sessionId?
   for (const modeName of MODE_CONFIRMATION_SKILL_MAP[skillName] ?? []) {
     updateModeAwaitingConfirmation(directory, modeName, sessionId, false);
   }
+}
+
+function getSkillInvocationArgs(toolInput: unknown): string {
+  if (!toolInput || typeof toolInput !== "object") {
+    return "";
+  }
+
+  const input = toolInput as Record<string, unknown>;
+  const candidates = [
+    input.args,
+    input.arguments,
+    input.argument,
+    input.skill_args,
+    input.skillArgs,
+    input.prompt,
+    input.description,
+    input.input,
+  ];
+
+  return candidates.find((value): value is string => typeof value === "string" && value.trim().length > 0)?.trim() ?? "";
+}
+
+function isConsensusPlanningSkillInvocation(skillName: string | null, toolInput: unknown): boolean {
+  if (!skillName) {
+    return false;
+  }
+
+  if (skillName === "ralplan") {
+    return true;
+  }
+
+  if (skillName !== "omc-plan" && skillName !== "plan") {
+    return false;
+  }
+
+  return getSkillInvocationArgs(toolInput).toLowerCase().includes("--consensus");
+}
+
+function activateRalplanState(directory: string, sessionId?: string): void {
+  writeModeState(
+    "ralplan",
+    {
+      active: true,
+      session_id: sessionId,
+      current_phase: "ralplan",
+      started_at: new Date().toISOString(),
+    },
+    directory,
+    sessionId,
+  );
 }
 
 interface TeamStagedState {
@@ -1512,6 +1563,9 @@ function processPreToolUse(input: HookInput): HookOutput {
       try {
         writeSkillActiveState(directory, skillName, input.sessionId, rawSkillName);
         confirmSkillModeStates(directory, skillName, input.sessionId);
+        if (isConsensusPlanningSkillInvocation(skillName, input.toolInput)) {
+          activateRalplanState(directory, input.sessionId);
+        }
       } catch {
         // Skill-state/state-sync writes are best-effort; don't fail the hook on error.
       }


### PR DESCRIPTION
## Summary
- activate ralplan mode state as soon as the Skill tool invokes `ralplan`
- treat `omc-plan` / `plan` skill invocations with `--consensus` as the same protected consensus workflow
- add regression tests proving the stop hook blocks `end_turn` once consensus planning starts

## Problem
Non-interactive ralplan was pausing after intermediate plain-text summaries because the runtime never armed standalone `ralplan` stop-hook enforcement for Skill-based consensus planning entrypoints.

## Testing
- `npx vitest run src/hooks/__tests__/bridge-routing.test.ts src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts src/hooks/skill-state/__tests__/skill-state.test.ts`
- `npx tsc --noEmit`

Closes #1926
