### PR TITLE
Fix ralplan stop-hook stale subagent consensus bypass

### DIFF
--- a/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
@@ -435,6 +435,10 @@ describe('team pipeline standalone stop enforcement', () => {
 // Ralplan Standalone Tests
 // ===========================================================================
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('ralplan standalone stop enforcement', () => {
   it('blocks stop when ralplan state is active', async () => {
     const sessionId = 'session-ralplan-block-1';
@@ -624,6 +628,10 @@ describe('ralplan standalone stop enforcement', () => {
   it('allows orchestrator idle when ralplan is active but delegated subagents are still running', async () => {
     const sessionId = 'session-ralplan-active-subagents';
     const tempDir = makeTempProject();
+    const now = new Date('2026-03-28T18:00:00.000Z');
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
 
     try {
       writeRalplanState(tempDir, sessionId);
@@ -640,6 +648,41 @@ describe('ralplan standalone stop enforcement', () => {
       const result = await checkPersistentModes(sessionId, tempDir);
       expect(result.shouldBlock).toBe(false);
       expect(result.mode).toBe('ralplan');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks stop when the active subagent count is stale beyond the recency window', async () => {
+    const sessionId = 'session-ralplan-stale-subagent-count';
+    const tempDir = makeTempProject();
+    const now = new Date('2026-03-28T18:05:00.000Z');
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    try {
+      writeRalplanState(tempDir, sessionId);
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: 'agent-1930-stale',
+          agent_type: 'architect',
+          started_at: new Date(now.getTime() - 60_000).toISOString(),
+          parent_mode: 'ralplan',
+          status: 'running',
+        },
+      ]);
+
+      const staleUpdatedAt = new Date(now.getTime() - 10_000).toISOString();
+      const trackingPath = join(tempDir, '.omc', 'state', 'subagent-tracking.json');
+      const tracking = JSON.parse(readFileSync(trackingPath, 'utf-8')) as { last_updated?: string };
+      tracking.last_updated = staleUpdatedAt;
+      writeFileSync(trackingPath, JSON.stringify(tracking, null, 2));
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(true);
+      expect(result.mode).toBe('ralplan');
+      expect(result.message).toContain('ralplan-continuation');
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -48,7 +48,7 @@ import {
 import { checkAutopilot } from '../autopilot/enforcement.js';
 import { readTeamPipelineState } from '../team-pipeline/state.js';
 import type { TeamPipelinePhase } from '../team-pipeline/types.js';
-import { getActiveAgentCount } from '../subagent-tracker/index.js';
+import { getActiveAgentSnapshot } from '../subagent-tracker/index.js';
 
 export interface ToolErrorState {
   tool_name: string;
@@ -851,6 +851,7 @@ When done, run \`/oh-my-claudecode:cancel\` to cleanly exit.
 
 const RALPLAN_STOP_BLOCKER_MAX = 30;
 const RALPLAN_STOP_BLOCKER_TTL_MS = 45 * 60 * 1000; // 45 min
+const RALPLAN_ACTIVE_AGENT_RECENCY_WINDOW_MS = 5_000;
 
 interface RalplanState {
   active: boolean;
@@ -903,10 +904,18 @@ async function checkRalplan(
     };
   }
 
-  // Orchestrators are allowed to go idle while delegated work is still active.
-  // Delegation waits are expected, so clear any accumulated breaker budget and
-  // let enforcement resume from a clean slate after the running subagents finish.
-  if (getActiveAgentCount(workingDir) > 0) {
+  // Orchestrators are allowed to go idle while delegated work is still active,
+  // but the raw running-agent count can lag behind the real lifecycle because
+  // SubagentStop/post-tool-use bookkeeping lands after the stop event. Only
+  // trust the bypass when the tracker itself was updated recently enough to
+  // look live; otherwise fail closed and keep consensus enforcement active.
+  const activeAgents = getActiveAgentSnapshot(workingDir);
+  const activeAgentStateUpdatedAt = activeAgents.lastUpdatedAt ? new Date(activeAgents.lastUpdatedAt).getTime() : NaN;
+  const hasFreshActiveAgentState =
+    Number.isFinite(activeAgentStateUpdatedAt)
+    && Date.now() - activeAgentStateUpdatedAt <= RALPLAN_ACTIVE_AGENT_RECENCY_WINDOW_MS;
+
+  if (activeAgents.count > 0 && hasFreshActiveAgentState) {
     writeStopBreaker(workingDir, 'ralplan', 0, sessionId);
     return {
       shouldBlock: false,

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -790,9 +790,21 @@ export function cleanupStaleAgents(directory: string): number {
 /**
  * Get count of active (running) agents
  */
-export function getActiveAgentCount(directory: string): number {
+export interface ActiveAgentSnapshot {
+  count: number;
+  lastUpdatedAt?: string;
+}
+
+export function getActiveAgentSnapshot(directory: string): ActiveAgentSnapshot {
   const state = readTrackingState(directory);
-  return state.agents.filter((a) => a.status === "running").length;
+  return {
+    count: state.agents.filter((a) => a.status === "running").length,
+    lastUpdatedAt: state.last_updated,
+  };
+}
+
+export function getActiveAgentCount(directory: string): number {
+  return getActiveAgentSnapshot(directory).count;
 }
 
 /**


### PR DESCRIPTION
## Summary
- fail closed when ralplan sees a stale active-subagent count during stop-hook enforcement
- expose a subagent-tracker snapshot API with both running count and last update time
- add regression coverage for fresh in-flight subagents vs stale-count race behavior

## Why this approach
Issue #1930 proposed either:
- **A. timestamp-based staleness check with a recency window**
- **B. phase-aware bypass**

I chose **A**.

The current standalone ralplan stop-hook path only has coarse phase information (`current_phase` is typically just `ralplan` in this path), so a phase-aware bypass would require broader lifecycle/state production changes before it could reliably distinguish a legitimate delegated wait from a stale count. The bug itself is specifically a tracker-timing race, so the smallest safe fix is to make the bypass trust the subagent count only when the tracker was updated recently enough to be credible.

## Testing
- `npm run test:run -- src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts src/hooks/subagent-tracker/__tests__/index.test.ts`
- `npx eslint src/hooks/persistent-mode/index.ts src/hooks/subagent-tracker/index.ts src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts`
- `npm run build`

Closes #1930
