### PR TITLE
feat(hud): show elapsed time since prompt instead of clock timestamp

### DIFF
--- a/src/hud/elements/prompt-time.ts
+++ b/src/hud/elements/prompt-time.ts
@@ -1,19 +1,42 @@
 /**
  * OMC HUD - Prompt Time Element
  *
- * Renders the timestamp of the last user prompt submission.
+ * Renders elapsed time since the last user prompt submission.
  * Recorded by the keyword-detector hook on UserPromptSubmit.
  */
 
 import { dim } from '../colors.js';
 
 /**
- * Render prompt submission time.
- *
- * Format: prompt:HH:MM:SS
+ * Format elapsed milliseconds as human-readable duration.
+ * < 60s  → 13s
+ * < 1h   → 1m23s
+ * >= 1h  → 2h3m
  */
-export function renderPromptTime(promptTime: Date | null): string | null {
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m${totalSeconds % 60}s`;
+  const hours = Math.floor(totalMinutes / 60);
+  return `${hours}h${totalMinutes % 60}m`;
+}
+
+/**
+ * Render elapsed time since prompt submission.
+ *
+ * Format: ⏱13s  or  ⏱1m23s  or  ⏱2h3m
+ * Falls back to HH:MM:SS timestamp if now is not provided.
+ */
+export function renderPromptTime(promptTime: Date | null, now?: Date): string | null {
   if (!promptTime) return null;
+
+  if (now) {
+    const elapsed = now.getTime() - promptTime.getTime();
+    if (elapsed >= 0) {
+      return `${dim('⏱')}${formatElapsed(elapsed)}`;
+    }
+  }
 
   const hours = String(promptTime.getHours()).padStart(2, '0');
   const minutes = String(promptTime.getMinutes()).padStart(2, '0');

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -307,7 +307,7 @@ export async function render(
 
   // Prompt submission time
   if (enabledElements.promptTime) {
-    const prompt = renderPromptTime(context.promptTime);
+    const prompt = renderPromptTime(context.promptTime, new Date());
     if (prompt) elements.push(prompt);
   }
 


### PR DESCRIPTION
## Summary

Replace the static clock timestamp (`prompt:14:32:05`) with a live elapsed counter showing how long since the last user prompt was submitted (e.g. `⏱1m23s`).

## Changes

### `src/hud/elements/prompt-time.ts`
- Add `formatElapsed(ms)` helper that formats milliseconds as:
  - `13s` — under 1 minute
  - `1m23s` — under 1 hour
  - `2h3m` — 1 hour or more
- Accept optional `now?: Date` parameter in `renderPromptTime()`
- When `now` is provided and `elapsed >= 0`: render as `⏱{elapsed}`
- Falls back to original `HH:MM:SS` timestamp when `now` is not provided (fully backward compatible)

### `src/hud/render.ts`
Pass `new Date()` as the second argument to `renderPromptTime()` so elapsed time is calculated at each render tick.

## Output examples

```
⏱8s      — 8 seconds after prompt
⏱1m23s   — 1 minute 23 seconds
⏱2h3m    — 2 hours 3 minutes
```

The `⏱` icon is dim-styled; the elapsed value is full-brightness for quick glancing.

## Why elapsed over clock time

The elapsed format answers the user's actual question: "how long is this taking?" rather than "what time did I send the message?". It's directly actionable — if you see `⏱3m45s` you know the response is running long.