### PR TITLE
feat(hud): show cache token hit rate in token usage display

### DIFF
--- a/src/hud/elements/token-usage.ts
+++ b/src/hud/elements/token-usage.ts
@@ -2,10 +2,15 @@
  * OMC HUD - Token Usage Element
  *
  * Renders last-request input/output token usage from transcript metadata.
+ * Format: tok:i45k/o2k [r2k] [cr:38k(84%)] [cw:1k] [s120k]
  */
 
 import type { LastRequestTokenUsage } from '../types.js';
 import { formatTokenCount } from '../../cli/utils/formatting.js';
+
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+const GREEN = '\x1b[32m';
 
 export function renderTokenUsage(
   usage: LastRequestTokenUsage | null | undefined,
@@ -17,15 +22,26 @@ export function renderTokenUsage(
   if (!hasUsage) return null;
 
   const parts = [
-    `tok:i${formatTokenCount(usage.inputTokens)}/o${formatTokenCount(usage.outputTokens)}`,
+    `${DIM}tok:${RESET}i${formatTokenCount(usage.inputTokens)}/o${formatTokenCount(usage.outputTokens)}`,
   ];
 
   if (usage.reasoningTokens && usage.reasoningTokens > 0) {
     parts.push(`r${formatTokenCount(usage.reasoningTokens)}`);
   }
 
+  if (usage.cacheReadTokens && usage.cacheReadTokens > 0) {
+    const pct = usage.inputTokens > 0
+      ? Math.round((usage.cacheReadTokens / usage.inputTokens) * 100)
+      : 0;
+    parts.push(`${GREEN}cr:${formatTokenCount(usage.cacheReadTokens)}(${pct}%)${RESET}`);
+  }
+
+  if (usage.cacheCreationTokens && usage.cacheCreationTokens > 0) {
+    parts.push(`${DIM}cw:${formatTokenCount(usage.cacheCreationTokens)}${RESET}`);
+  }
+
   if (sessionTotalTokens && sessionTotalTokens > 0) {
-    parts.push(`s${formatTokenCount(sessionTotalTokens)}`);
+    parts.push(`${DIM}s${formatTokenCount(sessionTotalTokens)}${RESET}`);
   }
 
   return parts.join(' ');

--- a/src/hud/transcript.ts
+++ b/src/hud/transcript.ts
@@ -670,6 +670,16 @@ function extractLastRequestTokenUsage(usage: TranscriptUsage | undefined): LastR
     normalized.reasoningTokens = Math.max(0, Math.round(reasoningTokens));
   }
 
+  const cacheReadTokens = getNumericUsageValue(usage.cache_read_input_tokens);
+  if (cacheReadTokens != null && cacheReadTokens > 0) {
+    normalized.cacheReadTokens = Math.max(0, Math.round(cacheReadTokens));
+  }
+
+  const cacheCreationTokens = getNumericUsageValue(usage.cache_creation_input_tokens);
+  if (cacheCreationTokens != null && cacheCreationTokens > 0) {
+    normalized.cacheCreationTokens = Math.max(0, Math.round(cacheCreationTokens));
+  }
+
   return normalized;
 }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -115,6 +115,8 @@ export interface LastRequestTokenUsage {
   inputTokens: number;
   outputTokens: number;
   reasoningTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
 }
 
 export interface TranscriptData {


### PR DESCRIPTION
## Summary

Surfaces prompt cache effectiveness directly in the HUD status line by parsing and displaying cache token fields from the Claude API response.

## Changes

### `src/hud/types.ts`
Extend `LastRequestTokenUsage` interface with two optional fields:
- `cacheReadTokens?` — tokens served from prompt cache
- `cacheCreationTokens?` — tokens written to prompt cache

### `src/hud/transcript.ts`
Parse `cache_read_input_tokens` and `cache_creation_input_tokens` from the raw usage object in `extractLastRequestTokenUsage()`. These fields were already present in Claude API responses but were silently dropped.

### `src/hud/elements/token-usage.ts`
Render the new fields:
- `cr:38k(84%)` — **green**, cache reads + hit rate relative to total input. High % = cost savings.
- `cw:1k` — **dim**, cache writes (one-time cost)

## Output format

```
tok: i45k/o2k cr:38k(84%) cw:1k s120k
```

Fields are only shown when non-zero — users without caching see no change.