### PR TITLE
fix(hooks): return fresh:false for missing heartbeat file

### DIFF
--- a/src/hooks/__tests__/team-worker-heartbeat.test.ts
+++ b/src/hooks/__tests__/team-worker-heartbeat.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression test for: missing heartbeat file should return fresh:false
+ *
+ * Bug: readWorkerHeartbeatSnapshot returned fresh:true when the heartbeat file
+ * didn't exist, causing false "all workers idle" notifications.
+ *
+ * Fix: VAL-SPLIT-001 — missing heartbeat must return fresh:false.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { maybeNotifyLeaderAllWorkersIdle, type TmuxRunner } from '../team-worker-hook.js';
+
+describe('team-worker-hook heartbeat missing file', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  const teamName = 'test-team';
+  const workerName = 'worker-1';
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'heartbeat-test-'));
+    stateDir = join(tmpDir, '.omc', 'state');
+
+    // Set up minimal team config so readTeamWorkersForIdleCheck works
+    const teamDir = join(stateDir, 'team', teamName);
+    mkdirSync(teamDir, { recursive: true });
+    writeFileSync(
+      join(teamDir, 'config.json'),
+      JSON.stringify({
+        workers: [{ name: workerName }],
+        tmux_session: 'test-session',
+        leader_pane_id: '%99',
+      }),
+    );
+
+    // Set up worker status as idle + fresh
+    const workerDir = join(teamDir, 'workers', workerName);
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      join(workerDir, 'status.json'),
+      JSON.stringify({
+        state: 'idle',
+        updated_at: new Date().toISOString(),
+      }),
+    );
+
+    // Explicitly do NOT create heartbeat.json — this is the missing file scenario
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('should NOT send all-workers-idle notification when heartbeat file is missing', async () => {
+    const sendKeysCalls: Array<{ target: string; text: string }> = [];
+    const mockTmux: TmuxRunner = {
+      async sendKeys(target: string, text: string) {
+        sendKeysCalls.push({ target, text });
+      },
+    };
+
+    await maybeNotifyLeaderAllWorkersIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName, workerName },
+      tmux: mockTmux,
+    });
+
+    // With the bug (fresh:true for missing heartbeat), tmux.sendKeys would be called.
+    // After the fix (fresh:false), the function should return early and NOT notify.
+    expect(sendKeysCalls).toHaveLength(0);
+  });
+
+  it('should send all-workers-idle notification when heartbeat file exists and is fresh', async () => {
+    // Create a fresh heartbeat file
+    const workerDir = join(stateDir, 'team', teamName, 'workers', workerName);
+    writeFileSync(
+      join(workerDir, 'heartbeat.json'),
+      JSON.stringify({
+        pid: process.pid,
+        last_turn_at: new Date().toISOString(),
+        turn_count: 1,
+        alive: true,
+      }),
+    );
+
+    const sendKeysCalls: Array<{ target: string; text: string }> = [];
+    const mockTmux: TmuxRunner = {
+      async sendKeys(target: string, text: string) {
+        sendKeysCalls.push({ target, text });
+      },
+    };
+
+    await maybeNotifyLeaderAllWorkersIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName, workerName },
+      tmux: mockTmux,
+    });
+
+    // With a fresh heartbeat file, the notification SHOULD fire
+    expect(sendKeysCalls.length).toBeGreaterThan(0);
+    expect(sendKeysCalls[0]!.text).toContain('All');
+    expect(sendKeysCalls[0]!.text).toContain('idle');
+  });
+});

--- a/src/hooks/team-worker-hook.ts
+++ b/src/hooks/team-worker-hook.ts
@@ -186,7 +186,7 @@ async function readWorkerHeartbeatSnapshot(
 ): Promise<WorkerHeartbeatSnapshot> {
   const heartbeatPath = join(stateDir, 'team', teamName, 'workers', workerName, 'heartbeat.json');
   try {
-    if (!existsSync(heartbeatPath)) return { last_turn_at: null, fresh: true, missing: true };
+    if (!existsSync(heartbeatPath)) return { last_turn_at: null, fresh: false, missing: true };
     const raw = await readFile(heartbeatPath, 'utf-8');
     const parsed = JSON.parse(raw);
     const lastTurnAt = parsed && typeof parsed.last_turn_at === 'string' ? parsed.last_turn_at : null;


### PR DESCRIPTION
## Bug

`readWorkerHeartbeatSnapshot` in `src/hooks/team-worker-hook.ts` returned `fresh: true` when the heartbeat file did not exist:

```typescript
if (!existsSync(heartbeatPath)) return { last_turn_at: null, fresh: true, missing: true };
```

This caused workers that had never written a heartbeat to be treated as having **fresh** activity. The downstream effect was that `maybeNotifyLeaderAllWorkersIdle` incorrectly considered these workers as active and fresh, leading to **false "all workers idle" notifications** when all workers' status was idle but some had never written a heartbeat file.

## Fix

Changed `fresh: true` to `fresh: false` for missing heartbeat files:

```typescript
if (!existsSync(heartbeatPath)) return { last_turn_at: null, fresh: false, missing: true };
```

A missing heartbeat file means the worker has never reported activity, so it should not be considered "fresh".

## Test

Added `src/hooks/__tests__/team-worker-heartbeat.test.ts` with two regression tests:

1. **Missing heartbeat → no notification**: Verifies that `maybeNotifyLeaderAllWorkersIdle` does NOT send a tmux notification when the heartbeat file is missing (the fix)
2. **Fresh heartbeat → notification fires**: Verifies that when a fresh heartbeat file exists, the notification correctly fires (ensures no over-correction)

## Validation

- `npx tsc --noEmit` — 0 errors
- `npx vitest run` — 7082 passed (1 pre-existing failure in `session-start-script-context.test.ts` unrelated to this change)
- `npm run build` — success