### PR TITLE
Fix flaky session-start project-memory assertion

### DIFF
--- a/src/__tests__/session-start-script-context.test.ts
+++ b/src/__tests__/session-start-script-context.test.ts
@@ -144,9 +144,13 @@ describe('session-start.mjs regression #1386', () => {
     const context = output.hookSpecificOutput?.additionalContext || '';
 
     expect(output.continue).toBe(true);
+    expect(context).toContain('<project-memory-context>');
     expect(context).toContain('[PROJECT MEMORY]');
     expect(context).toContain('Preserve project memory directives at session start');
-    expect(context).toContain('[Project Environment] TypeScript | using pnpm | Build: pnpm build | Test: pnpm test');
+    expect(context).toContain('[Project Environment]');
+    expect(context).toContain('- TypeScript | pkg:pnpm | node');
+    expect(context).toContain('- build=pnpm build | test=pnpm test');
     expect(context).toContain('[env] Requires LOCAL_API_BASE for smoke tests');
+    expect(context).toContain('</project-memory-context>');
   });
 });


### PR DESCRIPTION
## Summary\n- update the session-start regression test to assert the current project-memory wrapper format\n- check the structured environment and build/test lines instead of the old inline summary\n- verify the targeted Vitest file passes\n\n## Testing\n- npx vitest run src/__tests__/session-start-script-context.test.ts --reporter=verbose