### PR TITLE
fix(team): revert task to pending when tmux pane creation fails

### DIFF
--- a/src/__tests__/runtime-task-orphan.test.ts
+++ b/src/__tests__/runtime-task-orphan.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Regression test: when tmux pane creation fails (empty paneId),
+ * spawnWorkerForTask must revert the task from in_progress back to pending
+ * instead of leaving it orphaned.
+ */
+
+// --- Mocks ---
+
+const mockExecFileAsync = vi.fn();
+
+vi.mock('child_process', () => {
+  const execFile = Object.assign(vi.fn(), {
+    [Symbol.for('nodejs.util.promisify.custom')]: mockExecFileAsync,
+  });
+  return { execFile };
+});
+
+vi.mock('../team/model-contract.js', () => ({
+  buildWorkerArgv: vi.fn(() => ['/usr/bin/claude', '--flag']),
+  resolveValidatedBinaryPath: vi.fn(() => '/usr/bin/claude'),
+  getWorkerEnv: vi.fn(() => ({})),
+  isPromptModeAgent: vi.fn(() => false),
+  getPromptModeArgs: vi.fn(() => []),
+  resolveClaudeWorkerModel: vi.fn(() => undefined),
+}));
+
+vi.mock('../team/tmux-session.js', () => ({
+  createTeamSession: vi.fn(),
+  spawnWorkerInPane: vi.fn(),
+  sendToWorker: vi.fn(() => Promise.resolve(true)),
+  isWorkerAlive: vi.fn(() => Promise.resolve(true)),
+  killTeamSession: vi.fn(),
+  resolveSplitPaneWorkerPaneIds: vi.fn(() => []),
+  waitForPaneReady: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock('../team/worker-bootstrap.js', () => ({
+  composeInitialInbox: vi.fn(),
+  ensureWorkerStateDir: vi.fn(),
+  writeWorkerOverlay: vi.fn(),
+  generateTriggerMessage: vi.fn(() => 'trigger'),
+}));
+
+vi.mock('../team/git-worktree.js', () => ({
+  cleanupTeamWorktrees: vi.fn(),
+}));
+
+vi.mock('../team/task-file-ops.js', () => ({
+  withTaskLock: vi.fn(async (_team: string, _taskId: string, fn: () => unknown) => fn()),
+  writeTaskFailure: vi.fn(() => ({ retryCount: 0 })),
+  DEFAULT_MAX_TASK_RETRIES: 3,
+}));
+
+describe('spawnWorkerForTask task orphan prevention', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'runtime-task-orphan-'));
+    mockExecFileAsync.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reverts task to pending when tmux pane creation returns empty paneId', async () => {
+    const { spawnWorkerForTask } = await import('../team/runtime.js');
+
+    const teamName = 'testteam';
+    const taskIndex = 0;
+    const taskId = String(taskIndex + 1);
+
+    // Create task directory and initial task file (status: pending)
+    const tasksDir = join(tmpDir, '.omc', 'state', 'team', teamName, 'tasks');
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, `${taskId}.json`), JSON.stringify({
+      id: taskId,
+      subject: 'Test task',
+      description: 'Test description',
+      status: 'pending',
+      owner: null,
+      result: null,
+      createdAt: new Date().toISOString(),
+    }));
+
+    // Mock tmux split-window to return empty stdout (pane creation failure)
+    mockExecFileAsync.mockResolvedValue({ stdout: '\n', stderr: '' });
+
+    const runtime = {
+      teamName,
+      sessionName: 'test-session',
+      leaderPaneId: '%0',
+      config: {
+        teamName,
+        workerCount: 1,
+        agentTypes: ['claude' as const],
+        tasks: [{ subject: 'Test task', description: 'Test description' }],
+        cwd: tmpDir,
+      },
+      workerNames: ['worker-1'],
+      workerPaneIds: [] as string[],
+      activeWorkers: new Map(),
+      cwd: tmpDir,
+      resolvedBinaryPaths: { claude: '/usr/bin/claude' },
+    };
+
+    const result = await spawnWorkerForTask(runtime, 'worker-1', taskIndex);
+
+    // Should return empty string (failure indicator)
+    expect(result).toBe('');
+
+    // Task must be reverted back to pending (not orphaned as in_progress)
+    const taskFile = JSON.parse(readFileSync(join(tasksDir, `${taskId}.json`), 'utf-8'));
+    expect(taskFile.status).toBe('pending');
+    expect(taskFile.owner).toBeNull();
+  });
+});

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -696,7 +696,14 @@ export async function spawnWorkerForTask(
     '-c', runtime.cwd,
   ]);
   const paneId = splitResult.stdout.split('\n')[0]?.trim();
-  if (!paneId) return '';
+  if (!paneId) {
+    try {
+      await resetTaskToPending(root, taskId, runtime.teamName, runtime.cwd);
+    } catch {
+      // best-effort revert
+    }
+    return '';
+  }
 
   const workerIndex = parseWorkerIndex(workerNameValue);
   const agentType = runtime.config.agentTypes[workerIndex % runtime.config.agentTypes.length]


### PR DESCRIPTION
## Bug

In `src/team/runtime.ts`, `spawnWorkerForTask` marks a task as `in_progress` via `markTaskInProgress` before attempting tmux pane creation. When `tmux split-window` fails and returns an empty `paneId`, the function returns early (`return '`) but the task remains stuck as `in_progress` forever — no one resets it.

## Fix

After the pane creation attempt, if `paneId` is empty/falsy, call `resetTaskToPending(root, taskId, runtime.teamName, runtime.cwd)` wrapped in a try/catch (best-effort revert) before returning early. This ensures the task goes back to `pending` so it can be picked up by another worker.

## Changes

- **`src/team/runtime.ts`**: Added task revert logic in `spawnWorkerForTask` when tmux pane creation fails (empty paneId)
- **`src/__tests__/runtime-task-orphan.test.ts`**: Regression test verifying task reverts to pending on pane creation failure

## Verification

- `npx tsc --noEmit` — 0 errors
- `npx vitest run` — 7081 passed (1 pre-existing failure in `session-start-script-context.test.ts` unrelated to this change)
- `npm run build` — success