### PR TITLE
chore: remove broken ask:codex and ask:gemini script entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,6 @@
     "build:cli": "node scripts/build-cli.mjs",
     "build:runtime-cli": "node scripts/build-runtime-cli.mjs",
     "build:team-server": "node scripts/build-team-server.mjs",
-    "ask:codex": "./scripts/ask-codex.sh",
-    "ask:gemini": "./scripts/ask-gemini.sh",
     "compose-docs": "node scripts/compose-docs.mjs",
     "dev": "tsc --watch",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary

Remove two broken script entries from `package.json` that reference non-existent files.

## Bug

The `scripts` section in `package.json` contained:
```json
"ask:codex": "./scripts/ask-codex.sh",
"ask:gemini": "./scripts/ask-gemini.sh"
```

But `scripts/ask-codex.sh` and `scripts/ask-gemini.sh` do not exist in the repository. Running `npm run ask:codex` or `npm run ask:gemini` would fail with a file-not-found error.

## Fix

Removed the two broken script entries. This is a 2-line deletion with no behavioral impact on any working functionality.

## Verification

- `ls scripts/ask-*.sh` → confirms files don't exist
- `npx tsc --noEmit` → 0 errors
- `npx vitest run` → 7081 tests passed
- `npm run build` → success

Part of PR#1896 split (6/6).