### PR TITLE
feat(hud): add OSC 8 terminal hyperlinks for cwd element

### DIFF
--- a/src/hud/elements/cwd.ts
+++ b/src/hud/elements/cwd.ts
@@ -2,6 +2,7 @@
  * OMC HUD - CWD Element
  *
  * Renders current working directory with configurable format.
+ * Supports OSC 8 terminal hyperlinks for supported terminals (iTerm2, WezTerm, etc.)
  */
 
 import { homedir } from 'node:os';
@@ -10,15 +11,40 @@ import { dim } from '../colors.js';
 import type { CwdFormat } from '../types.js';
 
 /**
+ * Wrap text in an OSC 8 terminal hyperlink.
+ * Supported by: iTerm2, WezTerm, Kitty, Hyper, Windows Terminal, VTE-based terminals.
+ * Format: ESC]8;;URL ESC\ TEXT ESC]8;; ESC\
+ */
+function osc8Link(url: string, text: string): string {
+  return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
+}
+
+/**
+ * Convert an absolute filesystem path to a file:// URL.
+ * Handles Windows paths (C:\path -> file:///C:/path).
+ */
+function pathToFileUrl(absPath: string): string {
+  // Normalize backslashes on Windows
+  const normalized = absPath.replace(/\\/g, '/');
+  // Windows absolute path (e.g. C:/...)
+  if (/^[A-Za-z]:\//.test(normalized)) {
+    return `file:///${normalized}`;
+  }
+  return `file://${normalized}`;
+}
+
+/**
  * Render current working directory based on format.
  *
  * @param cwd - Absolute path to current working directory
  * @param format - Display format (relative, absolute, folder)
+ * @param useHyperlinks - Wrap in OSC 8 hyperlink (file:// URL)
  * @returns Formatted path string or null if empty
  */
 export function renderCwd(
   cwd: string | undefined,
-  format: CwdFormat = 'relative'
+  format: CwdFormat = 'relative',
+  useHyperlinks = false
 ): string | null {
   if (!cwd) return null;
 
@@ -42,5 +68,12 @@ export function renderCwd(
       displayPath = cwd;
   }
 
-  return `${dim(displayPath)}`;
+  const rendered = `${dim(displayPath)}`;
+
+  if (useHyperlinks) {
+    const url = pathToFileUrl(cwd);
+    return osc8Link(url, rendered);
+  }
+
+  return rendered;
 }

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -214,6 +214,7 @@ export async function render(
     const cwdElement = renderCwd(
       context.cwd,
       enabledElements.cwdFormat || "relative",
+      enabledElements.useHyperlinks ?? false,
     );
     if (cwdElement) gitElements.push(cwdElement);
   }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -413,6 +413,7 @@ export type ModelFormat = 'short' | 'versioned' | 'full';
 export interface HudElementConfig {
   cwd: boolean;              // Show working directory
   cwdFormat: CwdFormat;      // Path display format
+  useHyperlinks?: boolean;   // Wrap cwd/paths in OSC 8 terminal hyperlinks (clickable in supported terminals)
   gitRepo: boolean;          // Show git repository name
   gitBranch: boolean;        // Show git branch
   gitInfoPosition: 'above' | 'below';  // Position of git info relative to main HUD line
@@ -493,6 +494,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
   elements: {
     cwd: false,               // Disabled by default for backward compatibility
     cwdFormat: 'relative',
+    useHyperlinks: false,
     gitRepo: false,           // Disabled by default for backward compatibility
     gitBranch: false,         // Disabled by default for backward compatibility
     gitInfoPosition: 'above',  // Git info above main HUD line (backward compatible)
@@ -548,6 +550,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
   minimal: {
     cwd: false,
     cwdFormat: 'folder',
+    useHyperlinks: false,
     gitRepo: false,
     gitBranch: false,
     gitInfoPosition: 'above',
@@ -586,6 +589,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
   focused: {
     cwd: false,
     cwdFormat: 'relative',
+    useHyperlinks: false,
     gitRepo: false,
     gitBranch: true,
     gitInfoPosition: 'above',
@@ -624,6 +628,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
   full: {
     cwd: false,
     cwdFormat: 'relative',
+    useHyperlinks: false,
     gitRepo: true,
     gitBranch: true,
     gitInfoPosition: 'above',
@@ -662,6 +667,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
   opencode: {
     cwd: false,
     cwdFormat: 'relative',
+    useHyperlinks: false,
     gitRepo: false,
     gitBranch: true,
     gitInfoPosition: 'above',
@@ -700,6 +706,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
   dense: {
     cwd: false,
     cwdFormat: 'relative',
+    useHyperlinks: false,
     gitRepo: true,
     gitBranch: true,
     gitInfoPosition: 'above',


### PR DESCRIPTION
## Summary

Adds support for [OSC 8 terminal hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) in the cwd HUD element, inspired by [ccstatusline](https://github.com/sirmalloc/ccstatusline) which uses them extensively.

When enabled, the working directory is wrapped in a clickable `file://` hyperlink — click it in your terminal to open the directory in your file manager or editor.

## Supported terminals

OSC 8 works in: **iTerm2**, **WezTerm**, **Kitty**, **Hyper**, **Windows Terminal**, **GNOME Terminal**, **Konsole**, and other VTE-based terminals.

## Changes

- **`src/hud/elements/cwd.ts`**: Added `osc8Link(url, text)` helper, `pathToFileUrl()` for cross-platform `file://` URLs (handles Windows `C:\path`), and `useHyperlinks` parameter to `renderCwd()`
- **`src/hud/types.ts`**: Added `useHyperlinks?: boolean` to `HudElementConfig` + `useHyperlinks: false` in all 6 preset objects
- **`src/hud/render.ts`**: Passes `enabledElements.useHyperlinks ?? false` to `renderCwd()`

## Configuration

```json
{
  "elements": {
    "useHyperlinks": true
  }
}
```

## Opt-in

Defaults to `false` in all presets to avoid breaking terminals that render OSC 8 as garbage text.