### PR TITLE
fix(lib): guard against prototype pollution in deepMerge

### DIFF
--- a/src/__tests__/project-memory-merge.test.ts
+++ b/src/__tests__/project-memory-merge.test.ts
@@ -107,6 +107,25 @@ describe('deepMerge', () => {
     );
     expect(result.items).toEqual([1, 2, 3, 4, 5]);
   });
+
+  it('should skip __proto__ keys to prevent prototype pollution', () => {
+    const base = { a: 1 } as Record<string, unknown>;
+    const malicious = JSON.parse('{"__proto__": {"polluted": true}, "b": 2}');
+    const result = deepMerge(base, malicious);
+    expect(result.b).toBe(2);
+    expect(result).not.toHaveProperty('__proto__', { polluted: true });
+    // Ensure Object.prototype was not polluted
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('should skip constructor and prototype keys', () => {
+    const base = { a: 1 } as Record<string, unknown>;
+    const malicious = { constructor: { polluted: true }, prototype: { evil: true }, b: 2 } as Record<string, unknown>;
+    const result = deepMerge(base, malicious);
+    expect(result.b).toBe(2);
+    expect(result).not.toHaveProperty('constructor');
+    expect(result).not.toHaveProperty('prototype');
+  });
 });
 
 // ===========================================================================

--- a/src/lib/project-memory-merge.ts
+++ b/src/lib/project-memory-merge.ts
@@ -46,6 +46,7 @@ export function deepMerge<T extends Record<string, unknown>>(
   const result: Record<string, unknown> = { ...base };
 
   for (const key of Object.keys(incoming)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
     const baseVal = (base as Record<string, unknown>)[key];
     const incomingVal = (incoming as Record<string, unknown>)[key];
 


### PR DESCRIPTION
## Summary
- Guard against prototype pollution by skipping `__proto__`, `constructor`, and `prototype` keys in `deepMerge`
- Add 2 regression tests verifying Object.prototype remains unpolluted

## Test plan
- `npx vitest run src/__tests__/project-memory-merge.test.ts`