### PR TITLE
fix(lib): add RALPLAN to mode name maps

### DIFF
--- a/src/__tests__/mode-names-ralplan.test.ts
+++ b/src/__tests__/mode-names-ralplan.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MODE_NAMES,
+  ALL_MODE_NAMES,
+  MODE_STATE_FILE_MAP,
+  SESSION_END_MODE_STATE_FILES,
+  SESSION_METRICS_MODE_FILES,
+} from '../lib/mode-names.js';
+
+describe('mode-names ralplan', () => {
+  it('MODE_NAMES should include RALPLAN', () => {
+    // BUG FIX: MODE_NAMES was documented as 'single source of truth' but was
+    // missing RALPLAN which exists in src/constants/names.ts.
+    expect(MODE_NAMES.RALPLAN).toBe('ralplan');
+  });
+
+  it('ALL_MODE_NAMES should include ralplan', () => {
+    expect(ALL_MODE_NAMES).toContain('ralplan');
+  });
+
+  it('MODE_STATE_FILE_MAP should have ralplan entry', () => {
+    expect(MODE_STATE_FILE_MAP['ralplan']).toBe('ralplan-state.json');
+  });
+
+  it('SESSION_END_MODE_STATE_FILES should include ralplan', () => {
+    const ralplanEntry = SESSION_END_MODE_STATE_FILES.find(
+      entry => entry.mode === 'ralplan'
+    );
+    expect(ralplanEntry).toBeDefined();
+    expect(ralplanEntry!.file).toBe('ralplan-state.json');
+  });
+
+  it('SESSION_METRICS_MODE_FILES should include ralplan', () => {
+    const ralplanEntry = SESSION_METRICS_MODE_FILES.find(
+      entry => entry.mode === 'ralplan'
+    );
+    expect(ralplanEntry).toBeDefined();
+    expect(ralplanEntry!.file).toBe('ralplan-state.json');
+  });
+
+  it('total mode count should be consistent', () => {
+    const modeCount = Object.keys(MODE_NAMES).length;
+    expect(ALL_MODE_NAMES.length).toBe(modeCount);
+    expect(Object.keys(MODE_STATE_FILE_MAP).length).toBe(modeCount);
+  });
+});

--- a/src/lib/mode-names.ts
+++ b/src/lib/mode-names.ts
@@ -13,6 +13,7 @@ export const MODE_NAMES = {
   RALPH: 'ralph',
   ULTRAWORK: 'ultrawork',
   ULTRAQA: 'ultraqa',
+  RALPLAN: 'ralplan',
 } as const;
 
 /**
@@ -38,6 +39,7 @@ export const ALL_MODE_NAMES: readonly ModeName[] = [
   MODE_NAMES.RALPH,
   MODE_NAMES.ULTRAWORK,
   MODE_NAMES.ULTRAQA,
+  MODE_NAMES.RALPLAN,
 ] as const;
 
 /**
@@ -50,6 +52,7 @@ export const MODE_STATE_FILE_MAP: Readonly<Record<ModeName, string>> = {
   [MODE_NAMES.RALPH]: 'ralph-state.json',
   [MODE_NAMES.ULTRAWORK]: 'ultrawork-state.json',
   [MODE_NAMES.ULTRAQA]: 'ultraqa-state.json',
+  [MODE_NAMES.RALPLAN]: 'ralplan-state.json',
 };
 
 /**
@@ -62,6 +65,7 @@ export const SESSION_END_MODE_STATE_FILES: readonly { file: string; mode: string
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.RALPH], mode: MODE_NAMES.RALPH },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAWORK], mode: MODE_NAMES.ULTRAWORK },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAQA], mode: MODE_NAMES.ULTRAQA },
+  { file: MODE_STATE_FILE_MAP[MODE_NAMES.RALPLAN], mode: MODE_NAMES.RALPLAN },
   { file: 'skill-active-state.json', mode: 'skill-active' },
 ];
 
@@ -72,4 +76,5 @@ export const SESSION_METRICS_MODE_FILES: readonly { file: string; mode: string }
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.AUTOPILOT], mode: MODE_NAMES.AUTOPILOT },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.RALPH], mode: MODE_NAMES.RALPH },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAWORK], mode: MODE_NAMES.ULTRAWORK },
+  { file: MODE_STATE_FILE_MAP[MODE_NAMES.RALPLAN], mode: MODE_NAMES.RALPLAN },
 ];


### PR DESCRIPTION
## Summary
- Add `RALPLAN` to all mode name constants and mappings
- Fix missing mode causing cleanup/metrics to skip ralplan state files
- Add 6 regression tests verifying all maps include ralplan

## Test plan
- `npx vitest run src/__tests__/mode-names-ralplan.test.ts`