### PR TITLE
fix(model-routing): replace require() with ESM import to prevent crash

### DIFF
--- a/src/__tests__/model-routing-esm.test.ts
+++ b/src/__tests__/model-routing-esm.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { routeAndAdaptTask } from '../features/model-routing/index.js';
+
+describe('model-routing ESM compatibility', () => {
+  it('routeAndAdaptTask should work without require() (ESM-safe)', () => {
+    // This test verifies BUG FIX: routeAndAdaptTask used require() calls
+    // inside an ESM module, causing ReferenceError at runtime.
+    // The fix replaces require() with already-imported ESM re-exports.
+    const result = routeAndAdaptTask('Find the config file');
+
+    expect(result).toBeDefined();
+    expect(result.decision).toBeDefined();
+    expect(result.decision.tier).toBeDefined();
+    expect(typeof result.adaptedPrompt).toBe('string');
+  });
+
+  it('routeAndAdaptTask should handle optional parameters', () => {
+    const result = routeAndAdaptTask('Complex architecture refactoring', 'architect', 2);
+
+    expect(result).toBeDefined();
+    expect(result.decision).toBeDefined();
+    expect(result.decision.tier).toBeDefined();
+    expect(typeof result.adaptedPrompt).toBe('string');
+  });
+
+  it('routeAndAdaptTask should return valid routing decision with tier', () => {
+    const result = routeAndAdaptTask('Simple search task');
+
+    expect(['LOW', 'MEDIUM', 'HIGH', 'EXPLICIT']).toContain(result.decision.tier);
+  });
+});

--- a/src/features/model-routing/index.ts
+++ b/src/features/model-routing/index.ts
@@ -91,6 +91,10 @@ export {
   TIER_TASK_INSTRUCTIONS,
 } from './prompts/index.js';
 
+// Local imports for routeAndAdaptTask convenience function
+import { routeWithEscalation } from './router.js';
+import { adaptPromptForTier } from './prompts/index.js';
+
 /**
  * Convenience function to route and adapt prompt in one call
  */
@@ -99,9 +103,6 @@ export function routeAndAdaptTask(
   agentType?: string,
   previousFailures?: number
 ): { decision: import('./types.js').RoutingDecision; adaptedPrompt: string } {
-  const { routeWithEscalation } = require('./router.js');
-  const { adaptPromptForTier } = require('./prompts/index.js');
-
   const decision = routeWithEscalation({
     taskPrompt,
     agentType,


### PR DESCRIPTION
## Summary
- Replace `require()` with static ESM imports in `routeAndAdaptTask`
- Prevent `ReferenceError: require is not defined` in ESM context
- Add 3 regression tests

## Test plan
- `npx vitest run src/__tests__/model-routing-esm.test.ts`