### PR TITLE
fix(hud): propagate directory parameter to initializeHUDState

### DIFF
--- a/src/__tests__/background-cleanup-directory.test.ts
+++ b/src/__tests__/background-cleanup-directory.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Track calls to readHudState/writeHudState to verify directory propagation
+const readHudStateMock = vi.fn();
+const writeHudStateMock = vi.fn();
+
+vi.mock('../hud/state.js', () => ({
+  readHudState: (...args: unknown[]) => readHudStateMock(...args),
+  writeHudState: (...args: unknown[]) => writeHudStateMock(...args),
+  initializeHUDState: vi.fn(),
+}));
+
+import {
+  cleanupStaleBackgroundTasks,
+  markOrphanedTasksAsStale,
+} from '../hud/background-cleanup.js';
+
+describe('background-cleanup directory propagation', () => {
+  beforeEach(() => {
+    readHudStateMock.mockReset();
+    writeHudStateMock.mockReset();
+  });
+
+  it('cleanupStaleBackgroundTasks should pass directory to readHudState', async () => {
+    // BUG FIX: cleanupStaleBackgroundTasks called readHudState() without directory,
+    // defaulting to process.cwd() instead of the actual project directory.
+    readHudStateMock.mockReturnValue(null);
+
+    await cleanupStaleBackgroundTasks(undefined, '/custom/project/dir');
+
+    expect(readHudStateMock).toHaveBeenCalledWith('/custom/project/dir');
+  });
+
+  it('cleanupStaleBackgroundTasks should pass directory to writeHudState when cleaning', async () => {
+    const staleTask = {
+      id: 'task-1',
+      status: 'running',
+      startedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
+    };
+    readHudStateMock.mockReturnValue({ backgroundTasks: [staleTask] });
+
+    await cleanupStaleBackgroundTasks(undefined, '/custom/project/dir');
+
+    expect(writeHudStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ backgroundTasks: expect.any(Array) }),
+      '/custom/project/dir'
+    );
+  });
+
+  it('markOrphanedTasksAsStale should pass directory to readHudState', async () => {
+    readHudStateMock.mockReturnValue(null);
+
+    await markOrphanedTasksAsStale('/custom/project/dir');
+
+    expect(readHudStateMock).toHaveBeenCalledWith('/custom/project/dir');
+  });
+
+  it('markOrphanedTasksAsStale should pass directory to writeHudState when marking', async () => {
+    const orphanedTask = {
+      id: 'task-orphan',
+      status: 'running',
+      startedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(), // 3 hours ago
+    };
+    readHudStateMock.mockReturnValue({ backgroundTasks: [orphanedTask] });
+
+    await markOrphanedTasksAsStale('/custom/project/dir');
+
+    expect(writeHudStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ backgroundTasks: expect.any(Array) }),
+      '/custom/project/dir'
+    );
+  });
+
+  it('functions should default to no directory when not provided', async () => {
+    readHudStateMock.mockReturnValue(null);
+
+    await cleanupStaleBackgroundTasks();
+    expect(readHudStateMock).toHaveBeenCalledWith(undefined);
+
+    readHudStateMock.mockReset();
+    await markOrphanedTasksAsStale();
+    expect(readHudStateMock).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/__tests__/hud/watch-mode-init.test.ts
+++ b/src/__tests__/hud/watch-mode-init.test.ts
@@ -156,6 +156,16 @@ describe('HUD watch mode initialization', () => {
     expect(initializeHUDState).toHaveBeenCalledTimes(1);
   });
 
+  it('passes resolved cwd to initializeHUDState instead of defaulting to process.cwd()', async () => {
+    const hud = await importHudModule();
+    initializeHUDState.mockClear();
+
+    await hud.main(true, false);
+
+    // initializeHUDState must receive the resolved cwd from stdin, not undefined/process.cwd()
+    expect(initializeHUDState).toHaveBeenCalledWith('/tmp/worktree');
+  });
+
   it('passes the current session id to OMC state readers', async () => {
     const hud = await importHudModule();
     fakeStdin.transcript_path = '/tmp/worktree/transcripts/123e4567-e89b-12d3-a456-426614174000.jsonl';

--- a/src/hud/background-cleanup.ts
+++ b/src/hud/background-cleanup.ts
@@ -17,9 +17,10 @@ const STALE_TASK_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes default
  * @returns Number of tasks removed
  */
 export async function cleanupStaleBackgroundTasks(
-  thresholdMs: number = STALE_TASK_THRESHOLD_MS
+  thresholdMs: number = STALE_TASK_THRESHOLD_MS,
+  directory?: string
 ): Promise<number> {
-  const state = readHudState();
+  const state = readHudState(directory);
 
   if (!state || !state.backgroundTasks) {
     return 0;
@@ -47,7 +48,7 @@ export async function cleanupStaleBackgroundTasks(
   const removedCount = originalCount - state.backgroundTasks.length;
 
   if (removedCount > 0) {
-    writeHudState(state);
+    writeHudState(state, directory);
   }
 
   return removedCount;
@@ -59,8 +60,8 @@ export async function cleanupStaleBackgroundTasks(
  *
  * @returns Array of orphaned tasks
  */
-export async function detectOrphanedTasks(): Promise<BackgroundTask[]> {
-  const state = readHudState();
+export async function detectOrphanedTasks(directory?: string): Promise<BackgroundTask[]> {
+  const state = readHudState(directory);
 
   if (!state || !state.backgroundTasks) {
     return [];
@@ -91,14 +92,14 @@ export async function detectOrphanedTasks(): Promise<BackgroundTask[]> {
  *
  * @returns Number of tasks marked
  */
-export async function markOrphanedTasksAsStale(): Promise<number> {
-  const state = readHudState();
+export async function markOrphanedTasksAsStale(directory?: string): Promise<number> {
+  const state = readHudState(directory);
 
   if (!state || !state.backgroundTasks) {
     return 0;
   }
 
-  const orphaned = await detectOrphanedTasks();
+  const orphaned = await detectOrphanedTasks(directory);
   let marked = 0;
 
   for (const orphanedTask of orphaned) {
@@ -110,7 +111,7 @@ export async function markOrphanedTasksAsStale(): Promise<number> {
   }
 
   if (marked > 0) {
-    writeHudState(state);
+    writeHudState(state, directory);
   }
 
   return marked;

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -147,11 +147,6 @@ async function calculateSessionHealth(
  */
 async function main(watchMode = false, skipInit = false): Promise<void> {
   try {
-    // Initialize HUD state (cleanup stale/orphaned tasks)
-    if (!skipInit) {
-      await initializeHUDState();
-    }
-
     // Read stdin from Claude Code
     const previousStdinCache = readStdinCache();
     let stdin = await readStdin();
@@ -175,6 +170,12 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     }
 
     const cwd = resolveToWorktreeRoot(stdin.cwd || undefined);
+
+    // Initialize HUD state (cleanup stale/orphaned tasks)
+    // Must happen after cwd resolution so cleanup targets the correct project directory
+    if (!skipInit) {
+      await initializeHUDState(cwd);
+    }
 
     // Read configuration (before transcript parsing so we can use staleTaskThresholdMinutes)
     // Clone to avoid mutating shared DEFAULT_HUD_CONFIG when applying runtime width detection

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -415,10 +415,10 @@ export function applyPreset(preset: HudConfig["preset"]): HudConfig {
  * Initialize HUD state with cleanup of stale/orphaned tasks.
  * Should be called on HUD startup.
  */
-export async function initializeHUDState(): Promise<void> {
+export async function initializeHUDState(directory?: string): Promise<void> {
   // Clean up stale background tasks from previous sessions
-  const removedStale = await cleanupStaleBackgroundTasks();
-  const markedOrphaned = await markOrphanedTasksAsStale();
+  const removedStale = await cleanupStaleBackgroundTasks(undefined, directory);
+  const markedOrphaned = await markOrphanedTasksAsStale(directory);
 
   if (removedStale > 0 || markedOrphaned > 0) {
     console.error(


### PR DESCRIPTION
## Summary
- Move `initializeHUDState()` call after cwd resolution in HUD main
- Add `directory` parameter to `initializeHUDState`, `cleanupStaleBackgroundTasks`, `markOrphanedTasksAsStale`, `detectOrphanedTasks`
- Prevent cleanup from targeting wrong directory
- Add 6 regression tests for directory propagation

## Test plan
- `npx vitest run src/__tests__/background-cleanup-directory.test.ts`
- `npx vitest run src/__tests__/hud/watch-mode-init.test.ts`