### PR TITLE
fix(cli): increase generateJobId entropy from 4 to 8 hex chars

### DIFF
--- a/src/__tests__/jobid-collision-safety.test.ts
+++ b/src/__tests__/jobid-collision-safety.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression tests for race condition bug fixes.
+ *
+ * BUG 1: shared-state updateSharedTask has no file locking
+ * BUG 2: git-worktree removeWorkerWorktree has unlocked metadata update
+ * BUG 3: team-ops teamCreateTask has race on task ID generation
+ * BUG 4: generateJobId not collision-safe
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+
+// ---------------------------------------------------------------------------
+describe('generateJobId collision safety', () => {
+  it('generateJobId includes randomness for uniqueness', () => {
+    const sourcePath = join(__dirname, '..', 'cli', 'team.ts');
+    const source = readFileSync(sourcePath, 'utf-8');
+
+    // Extract the generateJobId function
+    const fnMatch = source.match(/function generateJobId[\s\S]*?\n}/);
+    expect(fnMatch).toBeTruthy();
+    const fnBody = fnMatch![0];
+
+    // Must include randomness (randomUUID or similar)
+    expect(fnBody).toContain('randomUUID');
+  });
+
+  it('100 rapid calls produce 100 unique IDs', async () => {
+    const { generateJobId } = await import('../cli/team.js');
+
+    const ids = new Set<string>();
+    const fixedTime = Date.now();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateJobId(fixedTime));
+    }
+
+    expect(ids.size).toBe(100);
+  });
+
+  it('generated IDs match the updated JOB_ID_PATTERN', async () => {
+    const { generateJobId } = await import('../cli/team.js');
+    const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
+
+    for (let i = 0; i < 50; i++) {
+      const id = generateJobId();
+      expect(JOB_ID_PATTERN.test(id)).toBe(true);
+    }
+  });
+
+  it('generateJobId uses 8+ hex chars of randomness', async () => {
+    const { generateJobId } = await import('../cli/team.js');
+
+    const fixedTime = Date.now();
+    const id = generateJobId(fixedTime);
+    const prefix = `omc-${fixedTime.toString(36)}`;
+    const randomPart = id.slice(prefix.length);
+
+    // Must have at least 8 chars of randomness
+    expect(randomPart.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/src/__tests__/team-server-validation.test.ts
+++ b/src/__tests__/team-server-validation.test.ts
@@ -48,11 +48,11 @@ vi.mock('../team/tmux-session.js', () => ({
 // re-exporting internals.
 // ---------------------------------------------------------------------------
 
-const VALID_JOB_ID_RE = /^omc-[a-z0-9]{1,12}$/;
+const VALID_JOB_ID_RE = /^omc-[a-z0-9]{1,16}$/;
 
 function validateJobId(job_id: string): void {
   if (!VALID_JOB_ID_RE.test(job_id)) {
-    throw new Error(`Invalid job_id: "${job_id}". Must match /^omc-[a-z0-9]{1,12}$/`);
+    throw new Error(`Invalid job_id: "${job_id}". Must match /^omc-[a-z0-9]{1,16}$/`);
   }
 }
 
@@ -69,7 +69,7 @@ describe('validateJobId', () => {
       'omc-',
       'omc-UPPERCASE',
       'omc-has spaces',
-      'omc-' + 'a'.repeat(13), // 13 chars — exceeds 12-char limit
+      'omc-' + 'a'.repeat(17), // 17 chars — exceeds 16-char limit
       'notprefixed',
       'omc_underscore',
       'omc-abc!@#',
@@ -86,9 +86,10 @@ describe('validateJobId', () => {
     const validIds = [
       'omc-abc123',
       'omc-a',
-      'omc-123456789012', // exactly 12 chars
+      'omc-123456789012', // 12 chars
       'omc-1',
       'omc-abcdefghijkl', // 12 lowercase letters
+      'omc-abcdefghijklmnop', // exactly 16 chars
     ];
 
     for (const id of validIds) {
@@ -111,7 +112,7 @@ describe('team-server handler validation integration', () => {
   it('production validateJobId regex matches test regex', async () => {
     const nodeFs = (await vi.importActual('fs')) as typeof import('fs');
     const src = nodeFs.readFileSync(SOURCE_PATH, 'utf-8');
-    expect(src).toContain('/^omc-[a-z0-9]{1,12}$/');
+    expect(src).toContain('/^omc-[a-z0-9]{1,16}$/');
   });
 
   it('handleStatus and handleWait both call validateJobId before disk access', async () => {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -98,7 +98,7 @@ describe('team cli', () => {
     });
 
     expect(result.status).toBe('running');
-    expect(result.jobId).toMatch(/^omc-[a-z0-9]{1,12}$/);
+    expect(result.jobId).toMatch(/^omc-[a-z0-9]{1,16}$/);
     expect(result.pid).toBe(4242);
 
     expect(mocks.spawn).toHaveBeenCalledWith(
@@ -155,7 +155,7 @@ describe('team cli', () => {
       status: string;
       pid: number;
     };
-    expect(output.jobId).toMatch(/^omc-[a-z0-9]{1,12}$/);
+    expect(output.jobId).toMatch(/^omc-[a-z0-9]{1,16}$/);
     expect(output.status).toBe('running');
     expect(output.pid).toBe(7777);
 

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { spawn } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { readFile, rm } from 'fs/promises';
@@ -12,7 +13,7 @@ import { readTeamConfig } from '../team/monitor.js';
 import { isProcessAlive } from '../platform/index.js';
 import { getGlobalOmcStatePath } from '../utils/paths.js';
 
-const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,12}$/;
+const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
 const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini']);
 const SUBCOMMANDS = new Set(['start', 'status', 'wait', 'cleanup', 'resume', 'shutdown', 'api', 'help', '--help', '-h']);
 
@@ -254,8 +255,8 @@ function buildStatus(jobId: string, job: TeamJobRecord): TeamJobStatus {
   };
 }
 
-function generateJobId(now = Date.now()): string {
-  return `omc-${now.toString(36)}`;
+export function generateJobId(now = Date.now()): string {
+  return `omc-${now.toString(36)}${randomUUID().slice(0, 8)}`;
 }
 
 function convergeWithResultArtifact(jobId: string, job: TeamJobRecord, jobsDir: string): TeamJobRecord {

--- a/src/mcp/__tests__/team-cleanup.test.ts
+++ b/src/mcp/__tests__/team-cleanup.test.ts
@@ -157,10 +157,10 @@ describe('killTeamSession', () => {
 
 // ─── validateJobId regex ──────────────────────────────────────────────────────
 
-// Re-test the regex rule from team-server.ts (spec: /^omc-[a-z0-9]{1,12}$/)
-const JOB_ID_RE = /^omc-[a-z0-9]{1,12}$/;
+// Re-test the regex rule from team-server.ts (spec: /^omc-[a-z0-9]{1,16}$/)
+const JOB_ID_RE = /^omc-[a-z0-9]{1,16}$/;
 
-describe('validateJobId regex (/^omc-[a-z0-9]{1,12}$/)', () => {
+describe('validateJobId regex (/^omc-[a-z0-9]{1,16}$/)', () => {
   it('accepts valid job IDs', () => {
     expect(JOB_ID_RE.test('omc-abc123')).toBe(true);
     expect(JOB_ID_RE.test('omc-a')).toBe(true);
@@ -178,8 +178,8 @@ describe('validateJobId regex (/^omc-[a-z0-9]{1,12}$/)', () => {
     expect(JOB_ID_RE.test('job-abc123')).toBe(false);
   });
 
-  it('rejects IDs longer than 12 chars after prefix', () => {
-    expect(JOB_ID_RE.test('omc-' + 'a'.repeat(13))).toBe(false);
+  it('rejects IDs longer than 16 chars after prefix', () => {
+    expect(JOB_ID_RE.test('omc-' + 'a'.repeat(17))).toBe(false);
   });
 
   it('rejects empty suffix', () => {

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -178,8 +178,8 @@ async function loadPaneIds(jobId: string): Promise<{ paneIds: string[]; leaderPa
 }
 
 function validateJobId(job_id: string): void {
-  if (!/^omc-[a-z0-9]{1,12}$/.test(job_id)) {
-    throw new Error(`Invalid job_id: "${job_id}". Must match /^omc-[a-z0-9]{1,12}$/`);
+  if (!/^omc-[a-z0-9]{1,16}$/.test(job_id)) {
+    throw new Error(`Invalid job_id: "${job_id}". Must match /^omc-[a-z0-9]{1,16}$/`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `randomUUID().slice(0, 8)` suffix to `generateJobId` for collision safety
- Update `JOB_ID_PATTERN` regex from `{1,12}` to `{1,16}` in cli, mcp-server, and tests
- Export `generateJobId` for testing
- Add regression tests: 100 rapid calls produce unique IDs

## Test plan
- `npx vitest run src/__tests__/jobid-collision-safety.test.ts`
- `npx vitest run src/__tests__/team-server-validation.test.ts`
- `npx vitest run src/cli/__tests__/team.test.ts`