### PR TITLE
fix(interop): add file locking to updateSharedTask

### DIFF
--- a/src/__tests__/shared-state-locking.test.ts
+++ b/src/__tests__/shared-state-locking.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression tests for race condition bug fixes.
+ *
+ * BUG 1: shared-state updateSharedTask has no file locking
+ * BUG 2: git-worktree removeWorkerWorktree has unlocked metadata update
+ * BUG 3: team-ops teamCreateTask has race on task ID generation
+ * BUG 4: generateJobId not collision-safe
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+
+describe('shared-state updateSharedTask locking', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'shared-state-lock-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('updateSharedTask uses withFileLockSync for read-modify-write', async () => {
+    // Verify the source code contains the locking pattern
+    const sourcePath = join(__dirname, '..', 'interop', 'shared-state.ts');
+    const source = readFileSync(sourcePath, 'utf-8');
+
+    // Must import withFileLockSync
+    expect(source).toContain("import { withFileLockSync } from '../lib/file-lock.js'");
+
+    // The updateSharedTask function must use withFileLockSync
+    const fnMatch = source.match(/export function updateSharedTask[\s\S]*?^}/m);
+    expect(fnMatch).toBeTruthy();
+    const fnBody = fnMatch![0];
+    expect(fnBody).toContain('withFileLockSync');
+    expect(fnBody).toContain("taskPath + '.lock'");
+  });
+
+  it('updateSharedTask functionally updates a task with locking', async () => {
+    const { addSharedTask, updateSharedTask, initInteropSession } = await import(
+      '../interop/shared-state.js'
+    );
+
+    initInteropSession('test-session', tempDir);
+
+    const task = addSharedTask(tempDir, {
+      source: 'omc',
+      target: 'omx',
+      type: 'analyze',
+      description: 'test task for locking',
+    });
+
+    const updated = updateSharedTask(tempDir, task.id, {
+      status: 'completed',
+      result: 'done',
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe('completed');
+    expect(updated!.result).toBe('done');
+    expect(updated!.completedAt).toBeTruthy();
+
+    // Verify lock file does not persist after operation
+    const lockPath = join(
+      tempDir, '.omc', 'state', 'interop', 'tasks', `${task.id}.json.lock`,
+    );
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BUG 2: git-worktree removeWorkerWorktree must use file locking
+// ---------------------------------------------------------------------------
+

--- a/src/interop/shared-state.ts
+++ b/src/interop/shared-state.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from 'fs';
 import { z } from 'zod';
 import { atomicWriteJsonSync } from '../lib/atomic-write.js';
+import { withFileLockSync } from '../lib/file-lock.js';
 
 export interface InteropConfig {
   sessionId: string;
@@ -220,27 +221,29 @@ export function updateSharedTask(
   }
 
   try {
-    const content = readFileSync(taskPath, 'utf-8');
-    const parsed = SharedTaskSchema.safeParse(JSON.parse(content));
-    if (!parsed.success) return null;
-    const task = parsed.data;
+    return withFileLockSync(taskPath + '.lock', () => {
+      const content = readFileSync(taskPath, 'utf-8');
+      const parsed = SharedTaskSchema.safeParse(JSON.parse(content));
+      if (!parsed.success) return null;
+      const task = parsed.data;
 
-    const updatedTask: SharedTask = {
-      ...task,
-      ...updates,
-    };
+      const updatedTask: SharedTask = {
+        ...task,
+        ...updates,
+      };
 
-    // Set completedAt if status changed to completed/failed
-    if (
-      (updates.status === 'completed' || updates.status === 'failed') &&
-      !updatedTask.completedAt
-    ) {
-      updatedTask.completedAt = new Date().toISOString();
-    }
+      // Set completedAt if status changed to completed/failed
+      if (
+        (updates.status === 'completed' || updates.status === 'failed') &&
+        !updatedTask.completedAt
+      ) {
+        updatedTask.completedAt = new Date().toISOString();
+      }
 
-    atomicWriteJsonSync(taskPath, updatedTask);
+      atomicWriteJsonSync(taskPath, updatedTask);
 
-    return updatedTask;
+      return updatedTask;
+    });
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Wrap `updateSharedTask` read-modify-write with `withFileLockSync` to prevent race conditions
- Lock file is cleaned up after operation completes
- Add regression tests verifying locking behavior

## Test plan
- `npx vitest run src/__tests__/shared-state-locking.test.ts`