### PR TITLE
fix(team): add locking to teamCreateTask for safe concurrent task creation

### DIFF
--- a/src/__tests__/team-ops-task-locking.test.ts
+++ b/src/__tests__/team-ops-task-locking.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ---------------------------------------------------------------------------
+// BUG 3: team-ops teamCreateTask must use locking for task ID generation
+// ---------------------------------------------------------------------------
+
+describe('team-ops teamCreateTask locking', () => {
+  let tempDir: string;
+  const teamName = 'lock-test-team';
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'team-ops-lock-test-'));
+    // Set up minimal team config
+    const root = join(tempDir, '.omc', 'state', 'team', teamName);
+    mkdirSync(join(root, 'tasks'), { recursive: true });
+    writeFileSync(join(root, 'config.json'), JSON.stringify({
+      name: teamName,
+      task: 'test',
+      agent_type: 'executor',
+      worker_count: 1,
+      max_workers: 20,
+      tmux_session: 'test-session',
+      workers: [{ name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] }],
+      created_at: new Date().toISOString(),
+      next_task_id: 1,
+      leader_pane_id: null,
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+    }));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('teamCreateTask source uses locking around task creation', () => {
+    const { readFileSync } = require('fs');
+    const sourcePath = join(__dirname, '..', 'team', 'team-ops.ts');
+    const source = readFileSync(sourcePath, 'utf-8');
+
+    // Extract the teamCreateTask function
+    const fnStart = source.indexOf('export async function teamCreateTask');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = source.slice(fnStart, fnStart + 2000);
+
+    // Must use locking (either withLock or withFileLockSync)
+    expect(fnBody).toContain('withLock');
+    expect(fnBody).toContain('lock-create-task');
+  });
+
+  it('two sequential task creations produce different IDs', async () => {
+    const { teamCreateTask } = await import('../team/team-ops.js');
+
+    const task1 = await teamCreateTask(
+      teamName,
+      { subject: 'Task A', description: 'first', status: 'pending' as const },
+      tempDir,
+    );
+
+    const task2 = await teamCreateTask(
+      teamName,
+      { subject: 'Task B', description: 'second', status: 'pending' as const },
+      tempDir,
+    );
+
+    expect(task1.id).not.toBe(task2.id);
+    expect(Number(task1.id)).toBeLessThan(Number(task2.id));
+  });
+
+  it('concurrent task creations produce different IDs', async () => {
+    const { teamCreateTask } = await import('../team/team-ops.js');
+
+    const results = await Promise.all([
+      teamCreateTask(teamName, { subject: 'Task 1', description: 'c1', status: 'pending' as const }, tempDir),
+      teamCreateTask(teamName, { subject: 'Task 2', description: 'c2', status: 'pending' as const }, tempDir),
+      teamCreateTask(teamName, { subject: 'Task 3', description: 'c3', status: 'pending' as const }, tempDir),
+    ]);
+
+    const ids = results.map(t => t.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(3);
+  });
+});

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -312,28 +312,42 @@ export async function teamCreateTask(
   task: Omit<TeamTask, 'id' | 'created_at'>,
   cwd: string,
 ): Promise<TeamTaskV2> {
-  const cfg = await teamReadConfig(teamName, cwd);
-  if (!cfg) throw new Error(`Team ${teamName} not found`);
+  const lockDir = join(teamDir(teamName, cwd), '.lock-create-task');
+  const timeoutMs = 5_000;
+  const deadline = Date.now() + timeoutMs;
+  let delayMs = 20;
 
-  const nextId = String(cfg.next_task_id ?? 1);
+  while (Date.now() < deadline) {
+    const result = await withLock(lockDir, async () => {
+      const cfg = await teamReadConfig(teamName, cwd);
+      if (!cfg) throw new Error(`Team ${teamName} not found`);
 
-  const created: TeamTaskV2 = {
-    ...task,
-    id: nextId,
-    status: task.status ?? 'pending',
-    depends_on: task.depends_on ?? task.blocked_by ?? [],
-    version: 1,
-    created_at: new Date().toISOString(),
-  };
+      const nextId = String(cfg.next_task_id ?? 1);
 
-  const taskPath = absPath(cwd, TeamPaths.tasks(teamName));
-  await mkdir(taskPath, { recursive: true });
-  await writeAtomic(join(taskPath, `task-${nextId}.json`), JSON.stringify(created, null, 2));
+      const created: TeamTaskV2 = {
+        ...task,
+        id: nextId,
+        status: task.status ?? 'pending',
+        depends_on: task.depends_on ?? task.blocked_by ?? [],
+        version: 1,
+        created_at: new Date().toISOString(),
+      };
 
-  // Advance counter
-  cfg.next_task_id = Number(nextId) + 1;
-  await writeAtomic(absPath(cwd, TeamPaths.config(teamName)), JSON.stringify(cfg, null, 2));
-  return created;
+      const taskPath = absPath(cwd, TeamPaths.tasks(teamName));
+      await mkdir(taskPath, { recursive: true });
+      await writeAtomic(join(taskPath, `task-${nextId}.json`), JSON.stringify(created, null, 2));
+
+      // Advance counter
+      cfg.next_task_id = Number(nextId) + 1;
+      await writeAtomic(absPath(cwd, TeamPaths.config(teamName)), JSON.stringify(cfg, null, 2));
+      return created;
+    });
+    if (result.ok) return result.value;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    delayMs = Math.min(delayMs * 2, 200);
+  }
+
+  throw new Error(`Failed to acquire task creation lock for team ${teamName} after ${timeoutMs}ms`);
 }
 
 export async function teamReadTask(teamName: string, taskId: string, cwd: string): Promise<TeamTask | null> {


### PR DESCRIPTION
## Summary
- Add directory-based locking around task creation in `teamCreateTask`
- Retry with exponential backoff on lock contention (5s timeout)
- Prevent duplicate task IDs from concurrent agent operations

## Test plan
- `npx vitest run src/__tests__/team-ops-task-locking.test.ts`