### PR TITLE
fix(notifications): remove Slack fallback to prevent unrelated session injection

### DIFF
--- a/src/__tests__/slack-fallback-removal.test.ts
+++ b/src/__tests__/slack-fallback-removal.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+
+// ============================================================================
+// BUG 2: Slack fallback does not inject into unrelated sessions
+// ============================================================================
+describe('BUG 2: Slack fallback removal', () => {
+  it('reply-listener does not contain fallback to last mapping for Slack', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/notifications/reply-listener.ts'),
+      'utf-8',
+    );
+
+    // The old pattern: `mappings[mappings.length - 1].tmuxPaneId`
+    expect(source).not.toContain('mappings[mappings.length - 1]');
+
+    // The comment about skipping should be present
+    expect(source).toContain(
+      'skip injection to avoid sending to an unrelated session',
+    );
+  });
+});

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -30,7 +30,6 @@ import {
 } from '../features/rate-limit-wait/tmux-detector.js';
 import {
   lookupByMessageId,
-  loadAllMappings,
   removeMessagesByPane,
   pruneStale,
 } from './session-registry.js';
@@ -801,13 +800,8 @@ async function pollLoop(): Promise<void> {
               }
             }
 
-            // No thread match: use most recent registered pane
-            if (!targetPaneId) {
-              const mappings = loadAllMappings();
-              if (mappings.length > 0) {
-                targetPaneId = mappings[mappings.length - 1].tmuxPaneId;
-              }
-            }
+            // No thread match: skip injection to avoid sending to an unrelated session.
+            // Discord and Telegram already skip when no match is found.
 
             if (!targetPaneId) {
               log('WARN: No target pane found for Slack message, skipping');


### PR DESCRIPTION
## Summary
- Remove `loadAllMappings` import and fallback to last registered pane for Slack
- Skip injection when no thread match found (matches Discord/Telegram behavior)

## Test plan
- `npx vitest run src/__tests__/slack-fallback-removal.test.ts`