### PR TITLE
fix(hud): add PID tracking to prevent session-summary process accumulation

### DIFF
--- a/src/__tests__/session-summary-pid-tracking.test.ts
+++ b/src/__tests__/session-summary-pid-tracking.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+
+describe('BUG 1: session summary spawn guard with PID tracking', () => {
+  it('source has spawn timestamp guard preventing duplicate processes', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/hud/index.ts'),
+      'utf-8',
+    );
+
+    // Should track the last spawn timestamp
+    expect(source).toContain('lastSummarySpawnTimestamp');
+
+    // Should check elapsed time before spawning
+    expect(source).toMatch(/now\s*-\s*lastSummarySpawnTimestamp/);
+
+    // Should have a guard window (120s)
+    expect(source).toContain('120_000');
+  });
+
+  it('source tracks spawned process PID', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/hud/index.ts'),
+      'utf-8',
+    );
+
+    // Should have a module-level PID tracking variable
+    expect(source).toContain('summaryProcessPid');
+
+    // Should check PID liveness with process.kill(pid, 0)
+    expect(source).toMatch(/process\.kill\(summaryProcessPid,\s*0\)/);
+
+    // Should store child.pid after spawn
+    expect(source).toContain('summaryProcessPid = child.pid');
+  });
+
+  it('source exports _resetSummarySpawnTimestamp for testing', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/hud/index.ts'),
+      'utf-8',
+    );
+
+    expect(source).toContain('export function _resetSummarySpawnTimestamp');
+  });
+
+  it('source exports _getSummaryProcessPid for testing', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/hud/index.ts'),
+      'utf-8',
+    );
+
+    expect(source).toContain('export function _getSummaryProcessPid');
+  });
+
+  it('guard returns early before spawn when within window', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/hud/index.ts'),
+      'utf-8',
+    );
+
+    // The function should return early if within the window
+    const fnStart = source.indexOf('function spawnSessionSummaryScript');
+    const fnBody = source.slice(fnStart, fnStart + 800);
+    expect(fnBody).toContain('return;');
+    expect(fnBody).toContain('lastSummarySpawnTimestamp = now');
+  });
+
+  it('PID liveness check prevents second spawn when process is alive', () => {
+    // Simulate the PID tracking logic with the current process (alive)
+    let pid: number | null = process.pid;
+    let spawnAllowed = true;
+
+    if (pid !== null) {
+      try {
+        process.kill(pid, 0);
+        // Process is still alive — skip spawn
+        spawnAllowed = false;
+      } catch {
+        pid = null;
+      }
+    }
+
+    expect(spawnAllowed).toBe(false);
+  });
+
+  it('dead PID allows respawn', () => {
+    // Use a PID that is almost certainly dead
+    let pid: number | null = 2147483647;
+    let spawnAllowed = true;
+
+    if (pid !== null) {
+      try {
+        process.kill(pid, 0);
+        // Process alive — block
+        spawnAllowed = false;
+      } catch {
+        // Process dead — allow respawn
+        pid = null;
+      }
+    }
+
+    expect(spawnAllowed).toBe(true);
+    expect(pid).toBeNull();
+  });
+
+  it('null PID allows spawn (no previous process tracked)', () => {
+    let pid: number | null = null;
+    let spawnAllowed = true;
+
+    if (pid !== null) {
+      try {
+        process.kill(pid, 0);
+        spawnAllowed = false;
+      } catch {
+        pid = null;
+      }
+    }
+
+    // No PID tracked, should allow spawn
+    expect(spawnAllowed).toBe(true);
+  });
+
+  it('PID is cleared on spawn failure in source', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/hud/index.ts'),
+      'utf-8',
+    );
+
+    // Find the catch block in spawn section
+    const fnStart = source.indexOf('function spawnSessionSummaryScript');
+    const fnBody = source.slice(fnStart, fnStart + 1500);
+
+    // The catch block should clear summaryProcessPid
+    expect(fnBody).toMatch(/catch[\s\S]*?summaryProcessPid\s*=\s*null/);
+  });
+});

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -79,14 +79,60 @@ function readSessionSummary(
 }
 
 /**
+ * Track the timestamp of the last spawned session-summary process to prevent
+ * unbounded accumulation of detached processes when summarization takes >60s.
+ */
+let lastSummarySpawnTimestamp = 0;
+
+/**
+ * Track the PID of the spawned session-summary child process.
+ * Before spawning a new process, we check if this PID is still alive
+ * using process.kill(pid, 0). This prevents process accumulation even
+ * when summarization runs longer than the timestamp-based throttle window.
+ */
+let summaryProcessPid: number | null = null;
+
+/** @internal Reset spawn guard — used by tests only. */
+export function _resetSummarySpawnTimestamp(): void {
+  lastSummarySpawnTimestamp = 0;
+  summaryProcessPid = null;
+}
+
+/** @internal Get the tracked summary process PID — used by tests only. */
+export function _getSummaryProcessPid(): number | null {
+  return summaryProcessPid;
+}
+
+/**
  * Spawn the session-summary script in the background to generate/update summary.
  * Fire-and-forget: does not block HUD rendering.
+ * Guards against duplicate spawns by tracking the last spawn timestamp.
  */
 function spawnSessionSummaryScript(
   transcriptPath: string,
   stateDir: string,
   sessionId: string,
 ): void {
+  // Check if a previously spawned summary process is still alive.
+  // This prevents accumulation of detached processes when summarization
+  // takes longer than the timestamp-based throttle window.
+  if (summaryProcessPid !== null) {
+    try {
+      process.kill(summaryProcessPid, 0);
+      // Process is still alive — skip spawning a new one
+      return;
+    } catch {
+      // Process is dead (ESRCH) — clear PID and allow respawn
+      summaryProcessPid = null;
+    }
+  }
+
+  // Secondary guard: prevent rapid re-spawns via timestamp (within 120s).
+  const now = Date.now();
+  if (now - lastSummarySpawnTimestamp < 120_000) {
+    return;
+  }
+  lastSummarySpawnTimestamp = now;
   // Resolve the script path relative to this file's location
   // In compiled output: dist/hud/index.js -> ../../scripts/session-summary.mjs
   const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -115,8 +161,10 @@ function spawnSessionSummaryScript(
         env: { ...process.env, CLAUDE_CODE_ENTRYPOINT: "session-summary" },
       },
     );
+    summaryProcessPid = child.pid ?? null;
     child.unref();
   } catch (error) {
+    summaryProcessPid = null;
     if (process.env.OMC_DEBUG) {
       console.error(
         "[HUD] Failed to spawn session-summary:",


### PR DESCRIPTION
## Summary
- Track PID of spawned session-summary process via `summaryProcessPid`
- Check PID liveness with `process.kill(pid, 0)` before respawning
- Add 120s timestamp throttle as secondary guard
- Export test helpers `_resetSummarySpawnTimestamp` and `_getSummaryProcessPid`

## Test plan
- `npx vitest run src/__tests__/session-summary-pid-tracking.test.ts`