### PR TITLE
fix(hooks): clear timeout in finally block for session-start scripts

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -256,13 +256,12 @@ async function checkNpmUpdate(currentVersion) {
   } catch {}
 
   // Fetch from npm registry with 2s timeout
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 2000);
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 2000);
     const response = await fetch('https://registry.npmjs.org/oh-my-claude-sisyphus/latest', {
       signal: controller.signal
     });
-    clearTimeout(timeoutId);
     if (!response.ok) return null;
 
     const data = await response.json();
@@ -277,7 +276,7 @@ async function checkNpmUpdate(currentVersion) {
     } catch {}
 
     return updateAvailable ? { currentVersion, latestVersion } : null;
-  } catch { return null; }
+  } catch { return null; } finally { clearTimeout(timeoutId); }
 }
 
 // Check if HUD is properly installed (with retry for race conditions)

--- a/src/__tests__/session-start-timeout-cleanup.test.ts
+++ b/src/__tests__/session-start-timeout-cleanup.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+
+describe('BUG 4: session-start hooks clear timeout in finally', () => {
+  it('templates/hooks/session-start.mjs uses finally for clearTimeout', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'templates/hooks/session-start.mjs'),
+      'utf-8',
+    );
+
+    // Find the checkForUpdates function
+    const fnStart = source.indexOf('async function checkForUpdates');
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart, fnStart + 1500);
+    expect(fnBody).toMatch(/finally\s*\{[\s\S]*?clearTimeout/);
+  });
+
+  it('scripts/session-start.mjs uses finally for clearTimeout', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'scripts/session-start.mjs'),
+      'utf-8',
+    );
+
+    // The checkNpmUpdate function should use finally for clearTimeout
+    // Look for the npm fetch section
+    const fetchSection = source.indexOf('registry.npmjs.org');
+    expect(fetchSection).toBeGreaterThan(-1);
+
+    // Find the surrounding try/finally block
+    const surroundingCode = source.slice(
+      Math.max(0, fetchSection - 300),
+      fetchSection + 800,
+    );
+    expect(surroundingCode).toMatch(/finally\s*\{[\s\S]*?clearTimeout/);
+  });
+});

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -65,14 +65,12 @@ async function checkForUpdates(currentVersion) {
   }
 
   // Fetch latest version from npm
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 2000);
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 2000);
-
     const response = await fetch('https://registry.npmjs.org/oh-my-claude-sisyphus/latest', {
       signal: controller.signal
     });
-    clearTimeout(timeoutId);
 
     if (!response.ok) {
       throw new Error('Network response was not ok');
@@ -96,7 +94,7 @@ async function checkForUpdates(currentVersion) {
   } catch (error) {
     // Silent fail - network unavailable or timeout
     return null;
-  }
+  } finally { clearTimeout(timeoutId); }
 }
 
 function compareVersions(v1, v2) {


### PR DESCRIPTION
## Summary
- Move `clearTimeout` to `finally` block in `scripts/session-start.mjs`
- Same fix in `templates/hooks/session-start.mjs`
- Prevents timer leaks on fetch abort/error

## Test plan
- `npx vitest run src/__tests__/session-start-timeout-cleanup.test.ts`