### PR TITLE
fix(lib): accept dots in extractRepoSlug for repos like next.js

### DIFF
--- a/src/__tests__/repo-slug-dots.test.ts
+++ b/src/__tests__/repo-slug-dots.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+
+describe('BUG 5: extractRepoSlug accepts dots', () => {
+  it('parses repo with dots: next.js', async () => {
+    const { extractRepoSlug } = await import(
+      '../lib/featured-contributors.js'
+    );
+    expect(extractRepoSlug('https://github.com/vercel/next.js')).toBe(
+      'vercel/next.js',
+    );
+  });
+
+  it('parses repo with dots: socket.io.git', async () => {
+    const { extractRepoSlug } = await import(
+      '../lib/featured-contributors.js'
+    );
+    expect(extractRepoSlug('https://github.com/socketio/socket.io.git')).toBe(
+      'socketio/socket.io',
+    );
+  });
+
+  it('parses repo with dots: vue.js.git', async () => {
+    const { extractRepoSlug } = await import(
+      '../lib/featured-contributors.js'
+    );
+    expect(extractRepoSlug('https://github.com/vuejs/vue.js.git')).toBe(
+      'vuejs/vue.js',
+    );
+  });
+
+  it('still parses standard repos without dots', async () => {
+    const { extractRepoSlug } = await import(
+      '../lib/featured-contributors.js'
+    );
+    expect(extractRepoSlug('https://github.com/facebook/react')).toBe(
+      'facebook/react',
+    );
+  });
+
+  it('still parses SSH URLs', async () => {
+    const { extractRepoSlug } = await import(
+      '../lib/featured-contributors.js'
+    );
+    expect(extractRepoSlug('git@github.com:vuejs/vue.js.git')).toBe(
+      'vuejs/vue.js',
+    );
+  });
+});

--- a/src/lib/featured-contributors.ts
+++ b/src/lib/featured-contributors.ts
@@ -167,7 +167,7 @@ async function fetchAllPages<T>(url: string): Promise<T[]> {
 }
 
 export function extractRepoSlug(repositoryUrl: string): string {
-  const match = repositoryUrl.match(/github\.com[/:]([^/]+\/[^/.]+)(?:\.git)?$/i);
+  const match = repositoryUrl.match(/github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/i);
   if (!match?.[1]) {
     throw new Error(`Could not determine GitHub repository slug from: ${repositoryUrl}`);
   }


### PR DESCRIPTION
## Summary
- Update extractRepoSlug regex to allow dots in repo names
- Add 5 regression tests for dotted repo names

## Test plan
- `npx vitest run src/__tests__/repo-slug-dots.test.ts`