### PR TITLE
fix: bind server context in standalone MCP handler registration

### DIFF
--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -25704,7 +25704,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     }))
   };
 });
-var setStandaloneCallToolRequestHandler = server.setRequestHandler;
+var setStandaloneCallToolRequestHandler = server.setRequestHandler.bind(server);
 setStandaloneCallToolRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
   const tool = allTools.find((t) => t.name === name);

--- a/src/mcp/standalone-server.ts
+++ b/src/mcp/standalone-server.ts
@@ -173,7 +173,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 
 // Handle tool calls
 const setStandaloneCallToolRequestHandler =
-  server.setRequestHandler as unknown as StandaloneCallToolRequestRegistrar;
+  (server.setRequestHandler as unknown as StandaloneCallToolRequestRegistrar).bind(server);
 
 setStandaloneCallToolRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;


### PR DESCRIPTION
## Problem

The MCP bridge server (`plugin:oh-my-claudecode:t`) crashes immediately on startup with:

```
TypeError: Cannot read properties of undefined (reading 'assertRequestHandlerCapability')
```

In `src/mcp/standalone-server.ts` (lines 175–178), `server.setRequestHandler` is extracted into a local variable without `.bind(server)`. The `as unknown as StandaloneCallToolRequestRegistrar` cast (added in `7150e61c` to fix TS2589) is compile-time only — it does not preserve `this` binding at runtime. When called as a plain function in strict mode, `this` is `undefined`, causing the crash.

## Fix

Added `.bind(server)` to preserve the `this` context when extracting `setRequestHandler`:

```ts
// Before (broken)
const setStandaloneCallToolRequestHandler =
  server.setRequestHandler as unknown as StandaloneCallToolRequestRegistrar;

// After (fixed)
const setStandaloneCallToolRequestHandler =
  (server.setRequestHandler as unknown as StandaloneCallToolRequestRegistrar).bind(server);
```

Applied to both the TypeScript source and the pre-built `bridge/mcp-server.cjs` bundle.

## Impact

Without this fix:
- `plugin:oh-my-claudecode:t` shows `✗ Failed to connect` in `claude mcp list`
- All bridge MCP tools are unavailable (`state_clear`, `state_list_active`, `lsp_diagnostics`)
- Beads context injection (`registerBeadsContext`) cannot persist across hook invocations

## Verification

After the fix, bridge starts successfully:
```
$ node bridge/mcp-server.cjs
OMC Tools MCP Server running on stdio
```

## Environment

- oh-my-claudecode: v4.9.2
- Node.js: v24.12.0
- @modelcontextprotocol/sdk: ^1.26.0
- OS: macOS Darwin 25.2.0