### PR TITLE
fix(notifications): move clearTimeout to finally block in sendCustomWebhook

### DIFF
--- a/src/__tests__/webhook-timeout-cleanup.test.ts
+++ b/src/__tests__/webhook-timeout-cleanup.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+
+// ============================================================================
+// BUG 3: Dispatcher webhook timeout leak
+// ============================================================================
+describe('BUG 3: sendCustomWebhook clears timeout on error', () => {
+  it('source uses finally block to clear timeout', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/notifications/dispatcher.ts'),
+      'utf-8',
+    );
+
+    // Find the sendCustomWebhook function
+    const fnStart = source.indexOf('export async function sendCustomWebhook');
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const fnBody = source.slice(fnStart, fnStart + 2000);
+    // clearTimeout should appear inside a finally block
+    expect(fnBody).toMatch(/finally\s*\{[\s\S]*?clearTimeout/);
+  });
+});

--- a/src/notifications/dispatcher.ts
+++ b/src/notifications/dispatcher.ts
@@ -758,27 +758,29 @@ export async function sendCustomWebhook(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), config.timeout);
     
-    const response = await fetch(url, {
-      method: config.method,
-      headers,
-      body: config.method !== 'GET' ? body : undefined,
-      signal: controller.signal,
-    });
-    
-    clearTimeout(timeout);
-    
-    if (!response.ok) {
+    try {
+      const response = await fetch(url, {
+        method: config.method,
+        headers,
+        body: config.method !== 'GET' ? body : undefined,
+        signal: controller.signal,
+      });
+      
+      if (!response.ok) {
+        return {
+          platform: "webhook",
+          success: false,
+          error: `HTTP ${response.status}: ${response.statusText}`,
+        };
+      }
+      
       return {
         platform: "webhook",
-        success: false,
-        error: `HTTP ${response.status}: ${response.statusText}`,
+        success: true,
       };
+    } finally {
+      clearTimeout(timeout);
     }
-    
-    return {
-      platform: "webhook",
-      success: true,
-    };
   } catch (error) {
     return {
       platform: "webhook",


### PR DESCRIPTION
## Summary
- Move clearTimeout to finally block in sendCustomWebhook
- Prevents timer leaks on network errors

## Test plan
- npx vitest run src/__tests__/webhook-timeout-cleanup.test.ts