### PR TITLE
fix(team): strip tmux- prefix and add claude to provider type

### DIFF
--- a/src/__tests__/team-status-tmux-provider.test.ts
+++ b/src/__tests__/team-status-tmux-provider.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+
+// ============================================================================
+// BUG 6: team-status provider type handles tmux workers
+// ============================================================================
+describe('BUG 6: team-status provider type for tmux workers', () => {
+  it('source strips both mcp- and tmux- prefixes', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/team/team-status.ts'),
+      'utf-8',
+    );
+
+    // Should use a regex that strips both prefixes
+    expect(source).toMatch(/replace\(.*mcp.*tmux/s);
+    // Should include 'claude' in the provider union type
+    expect(source).toContain("'claude'");
+  });
+
+  it('WorkerStatus interface includes claude in provider union', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/team/team-status.ts'),
+      'utf-8',
+    );
+
+    // The interface should have claude in the union
+    const interfaceMatch = source.match(
+      /interface WorkerStatus[\s\S]*?provider:\s*([^;]+);/,
+    );
+    expect(interfaceMatch).not.toBeNull();
+    expect(interfaceMatch![1]).toContain("'claude'");
+    expect(interfaceMatch![1]).toContain("'codex'");
+    expect(interfaceMatch![1]).toContain("'gemini'");
+  });
+
+  it('regex correctly strips mcp- prefix', () => {
+    const regex = /^(?:mcp|tmux)-/;
+    expect('mcp-codex'.replace(regex, '')).toBe('codex');
+  });
+
+  it('regex correctly strips tmux- prefix', () => {
+    const regex = /^(?:mcp|tmux)-/;
+    expect('tmux-claude'.replace(regex, '')).toBe('claude');
+  });
+
+  it('regex correctly strips tmux-codex to codex', () => {
+    const regex = /^(?:mcp|tmux)-/;
+    expect('tmux-codex'.replace(regex, '')).toBe('codex');
+  });
+});

--- a/src/team/team-status.ts
+++ b/src/team/team-status.ts
@@ -59,7 +59,7 @@ function peekRecentOutboxMessages(
 
 export interface WorkerStatus {
   workerName: string;
-  provider: 'codex' | 'gemini';
+  provider: 'claude' | 'codex' | 'gemini';
   heartbeat: HeartbeatData | null;
   isAlive: boolean;
   currentTask: TaskFile | null;
@@ -133,7 +133,7 @@ export function getTeamStatus(
     };
 
     const currentTask = workerTasks.find(t => t.status === 'in_progress') || null;
-    const provider = w.agentType.replace('mcp-', '') as 'codex' | 'gemini';
+    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini';
 
     return {
       workerName: w.name,


### PR DESCRIPTION
## Summary
- Update regex to strip both mcp- and tmux- prefixes
- Add claude to WorkerStatus.provider union type

## Test plan
- npx vitest run src/__tests__/team-status-tmux-provider.test.ts