### PR TITLE
fix(team): parse only complete lines in outbox-reader

### DIFF
--- a/src/__tests__/outbox-reader-partial-lines.test.ts
+++ b/src/__tests__/outbox-reader-partial-lines.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+
+// ============================================================================
+// BUG 7: outbox-reader only parses complete lines
+// ============================================================================
+describe('BUG 7: outbox-reader partial line handling', () => {
+  it('source only parses lines from completePortion', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const source = readFileSync(
+      join(process.cwd(), 'src/team/outbox-reader.ts'),
+      'utf-8',
+    );
+
+    // The fix introduces a `completePortion` variable
+    expect(source).toContain('completePortion');
+
+    // Lines should be split from completePortion, not from chunk directly
+    expect(source).toMatch(/completePortion\.split/);
+  });
+
+  it('does not parse partial trailing line when chunk lacks trailing newline', () => {
+    // Simulate the logic from the fix
+    const chunk = '{"msg":"line1"}\n{"msg":"line2"}\n{"msg":"partial';
+    let completePortion = chunk;
+    if (!chunk.endsWith('\n')) {
+      const lastNewline = chunk.lastIndexOf('\n');
+      completePortion = lastNewline >= 0 ? chunk.slice(0, lastNewline + 1) : '';
+    }
+
+    const lines = completePortion.split('\n').filter((l: string) => l.trim());
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe('{"msg":"line1"}');
+    expect(lines[1]).toBe('{"msg":"line2"}');
+  });
+
+  it('parses all lines when chunk ends with newline', () => {
+    const chunk = '{"msg":"line1"}\n{"msg":"line2"}\n';
+    let completePortion = chunk;
+    if (!chunk.endsWith('\n')) {
+      const lastNewline = chunk.lastIndexOf('\n');
+      completePortion = lastNewline >= 0 ? chunk.slice(0, lastNewline + 1) : '';
+    }
+
+    const lines = completePortion.split('\n').filter((l: string) => l.trim());
+    expect(lines).toHaveLength(2);
+  });
+
+  it('returns empty when chunk is a single partial line with no newline', () => {
+    const chunk = '{"msg":"partial';
+    let completePortion = chunk;
+    if (!chunk.endsWith('\n')) {
+      const lastNewline = chunk.lastIndexOf('\n');
+      completePortion = lastNewline >= 0 ? chunk.slice(0, lastNewline + 1) : '';
+    }
+
+    const lines = completePortion.split('\n').filter((l: string) => l.trim());
+    expect(lines).toHaveLength(0);
+  });
+});

--- a/src/team/outbox-reader.ts
+++ b/src/team/outbox-reader.ts
@@ -73,22 +73,26 @@ export function readNewOutboxMessages(
   }
 
   const chunk = buf.toString('utf-8');
-  const lines = chunk.split('\n').filter(l => l.trim());
-  const messages: OutboxMessage[] = [];
-  for (const line of lines) {
-    try {
-      messages.push(JSON.parse(line));
-    } catch { /* skip malformed lines */ }
-  }
 
-  // If the buffer ends mid-line (no trailing newline), backtrack the cursor
-  // to the start of that partial line so it is retried on the next read.
+  // Only parse complete lines (up to the last newline) so that a partial
+  // trailing line is not delivered prematurely and then re-delivered on
+  // the next read when the cursor backtracks.
   let consumed = bytesToRead;
+  let completePortion = chunk;
   if (!chunk.endsWith('\n')) {
     const lastNewline = chunk.lastIndexOf('\n');
     consumed = lastNewline >= 0
       ? Buffer.byteLength(chunk.slice(0, lastNewline + 1), 'utf-8')
       : 0;
+    completePortion = lastNewline >= 0 ? chunk.slice(0, lastNewline + 1) : '';
+  }
+
+  const lines = completePortion.split('\n').filter(l => l.trim());
+  const messages: OutboxMessage[] = [];
+  for (const line of lines) {
+    try {
+      messages.push(JSON.parse(line));
+    } catch { /* skip malformed lines */ }
   }
 
   // Update cursor atomically to prevent corruption on crash


### PR DESCRIPTION
## Summary
- Parse only complete JSONL lines from read chunk
- Prevents premature delivery of partial trailing lines

## Test plan
- npx vitest run src/__tests__/outbox-reader-partial-lines.test.ts