### PR TITLE
fix(ask): strip CLAUDECODE env from advisor spawns

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -79,15 +79,22 @@ function parseArgs(argv) {
   return { provider, prompt: rest.join(' ').trim() };
 }
 
+// Strip Claude session markers so provider advisors do not detect or inherit the active Claude Code session.
+const CLAUDE_SESSION_STRIPPED_ENV_VARS = new Set([
+  'CLAUDECODE',
+  'CLAUDE_SESSION_ID',
+  'CLAUDECODE_SESSION_ID',
+  'CLAUDE_CODE_ENTRYPOINT',
+]);
 const CODEX_STRIPPED_ENV_VARS = new Set(['RUST_LOG', 'RUST_BACKTRACE', 'RUST_LIB_BACKTRACE']);
 
 function buildProviderEnv(provider, env = process.env) {
-  if (provider !== 'codex') {
-    return env;
-  }
+  const strippedEnvVars = provider === 'codex'
+    ? new Set([...CLAUDE_SESSION_STRIPPED_ENV_VARS, ...CODEX_STRIPPED_ENV_VARS])
+    : CLAUDE_SESSION_STRIPPED_ENV_VARS;
 
   return Object.fromEntries(
-    Object.entries(env).filter(([key]) => !CODEX_STRIPPED_ENV_VARS.has(key)),
+    Object.entries(env).filter(([key]) => !strippedEnvVars.has(key)),
   );
 }
 

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -37,7 +37,7 @@ function buildChildEnv(
 }
 
 function runCli(
-  args: string[],
+  args: readonly string[],
   cwd: string,
   envOverrides: Record<string, string> = {},
   options: RunOptions = {},
@@ -57,7 +57,7 @@ function runCli(
 }
 
 function runAdvisorScript(
-  args: string[],
+  args: readonly string[],
   cwd: string,
   envOverrides: Record<string, string> = {},
   options: RunOptions = {},
@@ -78,7 +78,7 @@ function runAdvisorScript(
 
 function runAdvisorScriptWithPrelude(
   preludePath: string,
-  args: string[],
+  args: readonly string[],
   cwd: string,
   envOverrides: Record<string, string> = {},
   options: RunOptions = {},
@@ -155,6 +155,14 @@ function writeSpawnSyncCapturePrelude(dir: string): string {
       "      encoding: options.encoding ?? null,",
       "      stdio: options.stdio ?? null,",
       "      input: options.input ?? null,",
+      '      env: {',
+      "        CLAUDECODE: options.env?.CLAUDECODE ?? null,",
+      "        CLAUDE_SESSION_ID: options.env?.CLAUDE_SESSION_ID ?? null,",
+      "        CLAUDECODE_SESSION_ID: options.env?.CLAUDECODE_SESSION_ID ?? null,",
+      "        CLAUDE_CODE_ENTRYPOINT: options.env?.CLAUDE_CODE_ENTRYPOINT ?? null,",
+      "        RUST_LOG: options.env?.RUST_LOG ?? null,",
+      "        RUST_BACKTRACE: options.env?.RUST_BACKTRACE ?? null,",
+      '      },',
       '    },',
       '  });',
       "  if (mode === 'missing' && command === 'where') {",
@@ -422,6 +430,58 @@ describe('run-provider-advisor script contract', () => {
       const artifactPath = result.stdout.trim();
       const artifact = readFileSync(artifactPath, 'utf8');
       expect(artifact).toContain('## Original task\n\nlegacy original task');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['claude', ['claude', '--prompt', 'nested claude prompt']],
+    ['codex', ['codex', '--prompt', 'nested codex prompt']],
+    ['gemini', ['gemini', '--prompt', 'nested gemini prompt']],
+  ] as const)('strips Claude session env vars for %s advisor spawns', (provider, args) => {
+    const wd = mkdtempSync(join(tmpdir(), `omc-ask-${provider}-advisor-env-`));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        args,
+        wd,
+        {
+          SPAWN_CAPTURE_PATH: capturePath,
+          CLAUDECODE: '1',
+          CLAUDE_SESSION_ID: 'session-123',
+          CLAUDECODE_SESSION_ID: 'session-legacy',
+          CLAUDE_CODE_ENTRYPOINT: 'plugin',
+        },
+        { preserveClaudeSessionEnv: true },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+        options: {
+          shell: boolean;
+          encoding: string | null;
+          stdio: string | null;
+          input: string | null;
+          env: Record<string, string | null>;
+        };
+      }>;
+
+      expect(calls).toHaveLength(2);
+      for (const call of calls) {
+        expect(call.options.env).toMatchObject({
+          CLAUDECODE: null,
+          CLAUDE_SESSION_ID: null,
+          CLAUDECODE_SESSION_ID: null,
+          CLAUDE_CODE_ENTRYPOINT: null,
+        });
+      }
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- strip Claude Code session env markers from advisor subprocess environments for all providers
- preserve existing Codex-specific Rust env sanitization
- add regression coverage to assert advisor spawns do not inherit Claude session env vars

## Testing
- npx vitest run src/cli/__tests__/ask.test.ts
- npm test -- --run
