### PR TITLE
feat(teleport): symlink node_modules from repo root instead of running npm install

### DIFF
--- a/src/cli/commands/__tests__/teleport.test.ts
+++ b/src/cli/commands/__tests__/teleport.test.ts
@@ -8,6 +8,7 @@ vi.mock('fs', async (importOriginal) => {
     ...actual,
     existsSync: vi.fn(),
     mkdirSync: vi.fn(),
+    symlinkSync: vi.fn(),
   };
 });
 
@@ -26,7 +27,8 @@ vi.mock('../../../providers/index.js', () => ({
   getProvider: vi.fn(),
 }));
 
-import { existsSync } from 'fs';
+import { existsSync, symlinkSync } from 'fs';
+import { execSync } from 'child_process';
 import { teleportCommand } from '../teleport.js';
 
 describe('createWorktree — no shell injection via execFileSync', () => {
@@ -122,5 +124,83 @@ describe('createWorktree — no shell injection via execFileSync', () => {
       );
     });
     expect(gitShellCalls).toHaveLength(0);
+  });
+});
+
+describe('symlinkNodeModules — node_modules symlink after worktree creation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
+  });
+
+  const setupProviderMocks = async () => {
+    const { parseRemoteUrl, getProvider } = await import('../../../providers/index.js');
+    (parseRemoteUrl as ReturnType<typeof vi.fn>).mockReturnValue({
+      owner: 'owner',
+      repo: 'repo',
+      provider: 'github',
+    });
+    (getProvider as ReturnType<typeof vi.fn>).mockReturnValue({
+      displayName: 'GitHub',
+      getRequiredCLI: () => 'gh',
+      viewPR: () => null,
+      viewIssue: () => ({ title: 'test issue' }),
+      prRefspec: null,
+    });
+    // getCurrentRepo() uses execSync for git rev-parse and remote get-url
+    (execSync as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+      if (cmd.includes('rev-parse --show-toplevel')) return '/repo/root';
+      if (cmd.includes('remote get-url')) return 'https://github.com/owner/repo.git';
+      return '';
+    });
+  };
+
+  it('symlinks node_modules from repo root when source exists and target does not', async () => {
+    await setupProviderMocks();
+
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
+      if (typeof p !== 'string') return false;
+      if (p.includes('issue')) return false;           // worktree path does not exist yet
+      if (p.endsWith('node_modules')) return true;     // source node_modules exists in repo root
+      return true;                                      // parent dirs exist
+    });
+
+    await teleportCommand('#3', { base: 'main' });
+
+    expect(symlinkSync).toHaveBeenCalledOnce();
+    const [src, dest] = (symlinkSync as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(src).toMatch(/node_modules$/);
+    expect(dest).toMatch(/node_modules$/);
+    expect(src).not.toBe(dest);
+  });
+
+  it('skips symlink when source node_modules does not exist', async () => {
+    await setupProviderMocks();
+
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
+      if (typeof p !== 'string') return false;
+      if (p.includes('issue')) return false;
+      if (p.endsWith('node_modules')) return false;    // no node_modules in repo root
+      return true;
+    });
+
+    await teleportCommand('#4', { base: 'main' });
+
+    expect(symlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('skips symlink when target node_modules already exists in worktree', async () => {
+    await setupProviderMocks();
+
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
+      if (typeof p !== 'string') return false;
+      if (p.endsWith('node_modules')) return true;     // both source and target exist
+      if (p.includes('issue')) return false;
+      return true;
+    });
+
+    await teleportCommand('#5', { base: 'main' });
+
+    expect(symlinkSync).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/teleport.ts
+++ b/src/cli/commands/teleport.ts
@@ -7,7 +7,7 @@
 
 import chalk from 'chalk';
 import { execSync, execFileSync } from 'child_process';
-import { existsSync, mkdirSync, rmSync, readdirSync, statSync } from 'fs';
+import { existsSync, mkdirSync, rmSync, readdirSync, statSync, symlinkSync } from 'fs';
 import { homedir } from 'os';
 import { join, basename, isAbsolute, relative } from 'path';
 import { parseRemoteUrl, getProvider } from '../../providers/index.js';
@@ -293,6 +293,24 @@ function createWorktree(
 }
 
 /**
+ * Symlink node_modules from the parent repo into a newly created worktree.
+ * Avoids a full `npm install` in the worktree when the parent already has dependencies installed.
+ */
+function symlinkNodeModules(repoRoot: string, worktreePath: string): void {
+  const sourceNodeModules = join(repoRoot, 'node_modules');
+  const targetNodeModules = join(worktreePath, 'node_modules');
+  if (!existsSync(sourceNodeModules) || existsSync(targetNodeModules)) {
+    return;
+  }
+  try {
+    const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
+    symlinkSync(sourceNodeModules, targetNodeModules, symlinkType);
+  } catch {
+    // Non-fatal: user can still run npm install manually
+  }
+}
+
+/**
  * Main teleport command
  */
 export async function teleportCommand(
@@ -437,6 +455,8 @@ export async function teleportCommand(
     }
     return { success: false, error: result.error };
   }
+
+  symlinkNodeModules(repoRoot, worktreePath);
 
   if (!options.json) {
     console.log('');


### PR DESCRIPTION
## Summary

- Fixes #1858
- Adds `symlinkNodeModules()` to `teleport.ts` — mirrors the existing `ensureAutoresearchWorktreeDependencies()` pattern in `autoresearch/runtime.ts`
- After a worktree is created, `node_modules` is symlinked from the repo root into the worktree (junction on Windows, `dir` symlink elsewhere)
- No-op when source `node_modules` is absent or a target already exists — fully non-breaking

## Test plan

- [x] `symlinkSync` called when source exists and target does not
- [x] `symlinkSync` skipped when source `node_modules` absent
- [x] `symlinkSync` skipped when target `node_modules` already exists
- [x] All 5 existing + new tests pass (`vitest`)