### PR TITLE
feat(hud): add worktree indicator element (wt:<name>)

### DIFF
--- a/src/hud/elements/__tests__/worktree.test.ts
+++ b/src/hud/elements/__tests__/worktree.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, execSync: vi.fn() };
+});
+
+import { execSync } from 'node:child_process';
+import { getWorktreeName, renderWorktree, resetWorktreeCache } from '../worktree.js';
+
+beforeEach(() => {
+  resetWorktreeCache();
+  vi.resetAllMocks();
+});
+
+describe('getWorktreeName', () => {
+  it('returns worktree name when git-dir contains .git/worktrees/<name>', () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      '/home/user/project/.git/worktrees/issue-1858\n'
+    );
+    expect(getWorktreeName('/some/worktree')).toBe('issue-1858');
+  });
+
+  it('returns null in the main working tree (.git directory)', () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue('.git\n');
+    expect(getWorktreeName('/some/repo')).toBeNull();
+  });
+
+  it('returns null when git-dir is an absolute path without worktrees segment', () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue('/home/user/project/.git\n');
+    expect(getWorktreeName('/some/repo')).toBeNull();
+  });
+
+  it('returns null when not in a git repo', () => {
+    (execSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('not a git repository');
+    });
+    expect(getWorktreeName('/not/a/repo')).toBeNull();
+  });
+
+  it('caches the result and calls execSync only once for the same cwd', () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      '/home/user/project/.git/worktrees/feat-my-feature\n'
+    );
+    getWorktreeName('/cached/path');
+    getWorktreeName('/cached/path');
+    expect(execSync).toHaveBeenCalledOnce();
+  });
+});
+
+describe('renderWorktree', () => {
+  it('renders wt:<name> when inside a linked worktree', () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      '/home/user/project/.git/worktrees/issue-1858\n'
+    );
+    const result = renderWorktree('/some/worktree');
+    expect(result).toContain('issue-1858');
+    expect(result).toContain('wt:');
+  });
+
+  it('returns null when in the main repo', () => {
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue('.git\n');
+    expect(renderWorktree('/some/repo')).toBeNull();
+  });
+});

--- a/src/hud/elements/index.ts
+++ b/src/hud/elements/index.ts
@@ -23,3 +23,4 @@ export { renderPromptTime } from './prompt-time.js';
 export { detectApiKeySource, renderApiKeySource, type ApiKeySource } from './api-key-source.js';
 export { renderMissionBoard } from './mission-board.js';
 export { renderSessionSummary, type SessionSummaryState } from './session-summary.js';
+export { renderWorktree, getWorktreeName, resetWorktreeCache } from './worktree.js';

--- a/src/hud/elements/worktree.ts
+++ b/src/hud/elements/worktree.ts
@@ -1,0 +1,80 @@
+/**
+ * OMC HUD - Worktree Element
+ *
+ * Displays the current git worktree name when running inside a linked worktree
+ * (created via `git worktree add` or `omc teleport`). Returns null in the main repo.
+ */
+
+import { execSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { dim, yellow } from '../colors.js';
+
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const worktreeCache = new Map<string, CacheEntry<string | null>>();
+
+/**
+ * Clear worktree cache. Call in tests beforeEach to ensure a clean slate.
+ */
+export function resetWorktreeCache(): void {
+  worktreeCache.clear();
+}
+
+/**
+ * Detect whether the cwd is inside a linked git worktree and return its name.
+ *
+ * A linked worktree has a git-dir of the form:
+ *   /path/to/main-repo/.git/worktrees/<name>
+ *
+ * The main working tree has a git-dir of simply `.git` (relative) or
+ * `/path/to/repo/.git` (absolute) with no `worktrees/` segment.
+ *
+ * @param cwd - Working directory to check (defaults to process.cwd())
+ * @returns Worktree name, or null when in the main repo or not in git
+ */
+export function getWorktreeName(cwd?: string): string | null {
+  const key = cwd ? resolve(cwd) : process.cwd();
+  const cached = worktreeCache.get(key);
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.value;
+  }
+
+  let result: string | null = null;
+  try {
+    const gitDir = execSync('git rev-parse --git-dir', {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 1000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
+    }).trim();
+
+    // Linked worktrees have a git-dir ending in .git/worktrees/<name>
+    const match = gitDir.match(/[/\\]\.git[/\\]worktrees[/\\]([^/\\]+)$/);
+    result = match ? match[1] : null;
+  } catch {
+    result = null;
+  }
+
+  worktreeCache.set(key, { value: result, expiresAt: Date.now() + CACHE_TTL_MS });
+  return result;
+}
+
+/**
+ * Render the worktree indicator element.
+ *
+ * Shows `wt:<name>` when inside a linked worktree, null otherwise.
+ *
+ * @param cwd - Working directory
+ * @returns Formatted worktree indicator or null
+ */
+export function renderWorktree(cwd?: string): string | null {
+  const name = getWorktreeName(cwd);
+  if (!name) return null;
+  return `${dim('wt:')}${yellow(name)}`;
+}

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -32,6 +32,7 @@ import { renderPromptTime } from "./elements/prompt-time.js";
 import { renderAutopilot } from "./elements/autopilot.js";
 import { renderCwd } from "./elements/cwd.js";
 import { renderGitRepo, renderGitBranch } from "./elements/git.js";
+import { renderWorktree } from "./elements/worktree.js";
 import { renderModel } from "./elements/model.js";
 import { renderApiKeySource } from "./elements/api-key-source.js";
 import { renderCallCounts } from "./elements/call-counts.js";
@@ -228,6 +229,12 @@ export async function render(
   if (enabledElements.gitBranch) {
     const gitBranchElement = renderGitBranch(context.cwd);
     if (gitBranchElement) gitElements.push(gitBranchElement);
+  }
+
+  // Worktree indicator
+  if (enabledElements.worktree) {
+    const worktreeElement = renderWorktree(context.cwd);
+    if (worktreeElement) gitElements.push(worktreeElement);
   }
 
   // Model name

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -415,6 +415,7 @@ export interface HudElementConfig {
   cwdFormat: CwdFormat;      // Path display format
   gitRepo: boolean;          // Show git repository name
   gitBranch: boolean;        // Show git branch
+  worktree: boolean;         // Show current worktree name (wt:<name>) when inside a linked worktree
   gitInfoPosition: 'above' | 'below';  // Position of git info relative to main HUD line
   model: boolean;            // Show current model name
   modelFormat: ModelFormat;   // Model name verbosity level
@@ -495,6 +496,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     cwdFormat: 'relative',
     gitRepo: false,           // Disabled by default for backward compatibility
     gitBranch: false,         // Disabled by default for backward compatibility
+    worktree: false,          // Disabled by default for backward compatibility
     gitInfoPosition: 'above',  // Git info above main HUD line (backward compatible)
     model: false,             // Disabled by default for backward compatibility
     modelFormat: 'short',     // Short names by default for backward compatibility
@@ -550,6 +552,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'folder',
     gitRepo: false,
     gitBranch: false,
+    worktree: false,
     gitInfoPosition: 'above',
     model: false,
     modelFormat: 'short',
@@ -588,6 +591,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'relative',
     gitRepo: false,
     gitBranch: true,
+    worktree: true,
     gitInfoPosition: 'above',
     model: false,
     modelFormat: 'short',
@@ -626,6 +630,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'relative',
     gitRepo: true,
     gitBranch: true,
+    worktree: true,
     gitInfoPosition: 'above',
     model: false,
     modelFormat: 'short',
@@ -664,6 +669,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'relative',
     gitRepo: false,
     gitBranch: true,
+    worktree: true,
     gitInfoPosition: 'above',
     model: false,
     modelFormat: 'short',
@@ -702,6 +708,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     cwdFormat: 'relative',
     gitRepo: true,
     gitBranch: true,
+    worktree: true,
     gitInfoPosition: 'above',
     model: false,
     modelFormat: 'short',


### PR DESCRIPTION
## Summary

- Adds a `wt:<name>` element to the HUD that shows the current git worktree name when running inside a linked worktree (e.g. one created by `omc teleport`)
- Returns `null` in the main repo — no noise for the common case
- Enabled by default in `focused`, `full`, `opencode`, and `dense` presets; off in `minimal`
- Follows the same pattern as `git.ts`: `git rev-parse --git-dir`, parse the `worktrees/<name>` segment, 30s TTL cache

## Test plan

- [x] Returns worktree name when git-dir contains `.git/worktrees/<name>`
- [x] Returns null in main repo (git-dir is `.git`)
- [x] Returns null when not in a git repo
- [x] Caches result — `execSync` called only once per cwd
- [x] `renderWorktree` formats as `wt:<name>` with correct colors
- [x] All 7 tests pass