### PR TITLE
fix(agents): respect forceInherit when resolving subagent_type model

### DIFF
--- a/src/__tests__/routing-force-inherit.test.ts
+++ b/src/__tests__/routing-force-inherit.test.ts
@@ -15,6 +15,7 @@ import {
   processPreToolUse,
   type AgentInput,
 } from '../features/delegation-enforcer.js';
+import { getAgentDefinitions } from '../agents/definitions.js';
 
 // Mock loadConfig to control forceInherit
 vi.mock('../config/loader.js', async (importOriginal) => {
@@ -278,5 +279,83 @@ describe('routing.forceInherit (issue #1135)', () => {
 
       expect(result.modifiedInput).toEqual(toolInput);
     });
+  });
+});
+
+describe('getAgentDefinitions with forceInherit (issue #1989)', () => {
+  let originalClaudeModel: string | undefined;
+  let originalAnthropicModel: string | undefined;
+
+  beforeEach(() => {
+    originalClaudeModel = process.env.CLAUDE_MODEL;
+    originalAnthropicModel = process.env.ANTHROPIC_MODEL;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalClaudeModel === undefined) delete process.env.CLAUDE_MODEL;
+    else process.env.CLAUDE_MODEL = originalClaudeModel;
+
+    if (originalAnthropicModel === undefined) delete process.env.ANTHROPIC_MODEL;
+    else process.env.ANTHROPIC_MODEL = originalAnthropicModel;
+  });
+
+  it('uses parent CLAUDE_MODEL for all agents when forceInherit is true', () => {
+    process.env.CLAUDE_MODEL = 'accounts/fireworks/routers/kimi-k2p5-turbo';
+    mockedLoadConfig.mockReturnValue({
+      ...DEFAULT_CONFIG,
+      routing: { ...DEFAULT_CONFIG.routing, forceInherit: true },
+    } as ReturnType<typeof loadConfig>);
+
+    const defs = getAgentDefinitions();
+
+    // Every agent should use the parent model, not its hardcoded default
+    for (const [name, def] of Object.entries(defs)) {
+      expect(def.model, `agent "${name}" should inherit parent model`).toBe(
+        'accounts/fireworks/routers/kimi-k2p5-turbo'
+      );
+    }
+  });
+
+  it('falls back to ANTHROPIC_MODEL when CLAUDE_MODEL is unset and forceInherit is true', () => {
+    delete process.env.CLAUDE_MODEL;
+    process.env.ANTHROPIC_MODEL = 'claude-opus-4-6';
+    mockedLoadConfig.mockReturnValue({
+      ...DEFAULT_CONFIG,
+      routing: { ...DEFAULT_CONFIG.routing, forceInherit: true },
+    } as ReturnType<typeof loadConfig>);
+
+    const defs = getAgentDefinitions();
+    for (const def of Object.values(defs)) {
+      expect(def.model).toBe('claude-opus-4-6');
+    }
+  });
+
+  it('uses hardcoded agent defaults when forceInherit is false', () => {
+    process.env.CLAUDE_MODEL = 'accounts/fireworks/routers/kimi-k2p5-turbo';
+    mockedLoadConfig.mockReturnValue({
+      ...DEFAULT_CONFIG,
+      routing: { ...DEFAULT_CONFIG.routing, forceInherit: false },
+    } as ReturnType<typeof loadConfig>);
+
+    const defs = getAgentDefinitions();
+
+    // At least some agents should NOT use the env model (they have their own defaults)
+    const modelsUsed = new Set(Object.values(defs).map(d => d.model));
+    expect(modelsUsed.has('accounts/fireworks/routers/kimi-k2p5-turbo')).toBe(false);
+  });
+
+  it('explicit override model still wins over forceInherit', () => {
+    process.env.CLAUDE_MODEL = 'accounts/fireworks/routers/kimi-k2p5-turbo';
+    mockedLoadConfig.mockReturnValue({
+      ...DEFAULT_CONFIG,
+      routing: { ...DEFAULT_CONFIG.routing, forceInherit: true },
+    } as ReturnType<typeof loadConfig>);
+
+    const defs = getAgentDefinitions({
+      overrides: { executor: { model: 'claude-haiku-4-5-20251001' } },
+    });
+
+    expect(defs.executor?.model).toBe('claude-haiku-4-5-20251001');
   });
 });

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -250,13 +250,20 @@ export function getAgentDefinitions(options?: {
   };
 
   const resolvedConfig = options?.config ?? loadConfig();
+
+  // When forceInherit is enabled, child agents inherit the parent session's model
+  // instead of falling back to their hardcoded defaults (fixes #1989)
+  const inheritModel = resolvedConfig.routing?.forceInherit
+    ? (process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL)
+    : undefined;
+
   const result: Record<string, { description: string; prompt: string; tools?: string[]; disallowedTools?: string[]; model?: string; defaultModel?: string }> = {};
 
   for (const [name, agentConfig] of Object.entries(agents)) {
     const override = options?.overrides?.[name];
     const configuredModel = getConfiguredAgentModel(name, resolvedConfig);
     const disallowedTools = agentConfig.disallowedTools ?? parseDisallowedTools(name);
-    const resolvedModel = override?.model ?? configuredModel ?? agentConfig.model;
+    const resolvedModel = override?.model ?? inheritModel ?? configuredModel ?? agentConfig.model;
     const resolvedDefaultModel = override?.defaultModel ?? agentConfig.defaultModel;
 
     result[name] = {


### PR DESCRIPTION
## Summary

Fixes #1989

When `OMC_ROUTING_FORCE_INHERIT` is enabled, child agents spawned via `subagent_type` were silently using their hardcoded default models instead of the parent session model. The delegation enforcer correctly blocked explicit `model=` parameters, but `getAgentDefinitions` still fell through to `agentConfig.model` as the final fallback.

**Root cause** (`src/agents/definitions.ts:259`):
```typescript
// Before
const resolvedModel = override?.model ?? configuredModel ?? agentConfig.model;

// After
const resolvedModel = override?.model ?? inheritModel ?? configuredModel ?? agentConfig.model;
```

Where `inheritModel` is `process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL` when `forceInherit` is true, `undefined` otherwise.

## Test plan

- [x] All agents use `CLAUDE_MODEL` when `forceInherit=true`
- [x] Falls back to `ANTHROPIC_MODEL` when `CLAUDE_MODEL` unset
- [x] Hardcoded defaults used when `forceInherit=false`
- [x] Explicit `override.model` still wins over `forceInherit`
- [x] All 19 tests pass (15 existing + 4 new)