### PR TITLE
Fix child-agent model inheritance when forceInherit is enabled

### DIFF
--- a/src/__tests__/agent-registry.test.ts
+++ b/src/__tests__/agent-registry.test.ts
@@ -8,6 +8,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const MODEL_ENV_KEYS = [
+  'CLAUDE_MODEL',
+  'ANTHROPIC_MODEL',
   'CLAUDE_CODE_BEDROCK_OPUS_MODEL',
   'CLAUDE_CODE_BEDROCK_SONNET_MODEL',
   'CLAUDE_CODE_BEDROCK_HAIKU_MODEL',
@@ -88,6 +90,67 @@ describe('Agent Registry Validation', () => {
     expect(agents.executor?.model).toBe('us.anthropic.claude-sonnet-4-6-v1:0');
     expect(agents.explore?.model).toBe('us.anthropic.claude-haiku-4-5-v1:0');
     expect(agents.tracer?.model).toBe('us.anthropic.claude-sonnet-4-6-v1:0');
+  });
+
+
+  test('inherits parent session model when forceInherit is enabled and no configured model exists', async () => {
+    process.env.CLAUDE_MODEL = 'claude-3-7-session-parent';
+
+    const { DEFAULT_CONFIG } = await import('../config/loader.js');
+    const agents = getAgentDefinitions({
+      config: {
+        ...DEFAULT_CONFIG,
+        agents: {},
+        routing: {
+          ...DEFAULT_CONFIG.routing,
+          forceInherit: true,
+        },
+      },
+    });
+
+    expect(agents.executor?.model).toBe('claude-3-7-session-parent');
+  });
+
+  test('explicit override model still wins when forceInherit is enabled', async () => {
+    process.env.CLAUDE_MODEL = 'claude-3-7-session-parent';
+
+    const { DEFAULT_CONFIG } = await import('../config/loader.js');
+    const agents = getAgentDefinitions({
+      config: {
+        ...DEFAULT_CONFIG,
+        agents: {},
+        routing: {
+          ...DEFAULT_CONFIG.routing,
+          forceInherit: true,
+        },
+      },
+      overrides: {
+        executor: {
+          model: 'opus',
+        },
+      },
+    });
+
+    expect(agents.executor?.model).toBe('opus');
+  });
+
+  test('keeps agent fallback model when forceInherit is disabled and no configured model exists', async () => {
+    process.env.CLAUDE_MODEL = 'claude-3-7-session-parent';
+
+    const { DEFAULT_CONFIG } = await import('../config/loader.js');
+    const agents = getAgentDefinitions({
+      config: {
+        ...DEFAULT_CONFIG,
+        agents: {},
+        routing: {
+          ...DEFAULT_CONFIG.routing,
+          forceInherit: false,
+        },
+      },
+    });
+
+    expect(agents.executor?.model).toBe('sonnet');
+    expect(agents.executor?.model).not.toBe('claude-3-7-session-parent');
   });
 
   test('no hardcoded prompts in base agent .ts files', () => {

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -250,13 +250,16 @@ export function getAgentDefinitions(options?: {
   };
 
   const resolvedConfig = options?.config ?? loadConfig();
+  const inheritModel = resolvedConfig.routing?.forceInherit
+    ? process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL
+    : undefined;
   const result: Record<string, { description: string; prompt: string; tools?: string[]; disallowedTools?: string[]; model?: string; defaultModel?: string }> = {};
 
   for (const [name, agentConfig] of Object.entries(agents)) {
     const override = options?.overrides?.[name];
     const configuredModel = getConfiguredAgentModel(name, resolvedConfig);
     const disallowedTools = agentConfig.disallowedTools ?? parseDisallowedTools(name);
-    const resolvedModel = override?.model ?? configuredModel ?? agentConfig.model;
+    const resolvedModel = override?.model ?? inheritModel ?? configuredModel ?? agentConfig.model;
     const resolvedDefaultModel = override?.defaultModel ?? agentConfig.defaultModel;
 
     result[name] = {


### PR DESCRIPTION
## Summary
- make `getAgentDefinitions()` prefer the parent session model from `CLAUDE_MODEL`/`ANTHROPIC_MODEL` when `routing.forceInherit` is enabled
- preserve explicit override precedence and existing configured/default behavior when force-inherit is disabled
- add regression tests for inherit, override-precedence, and disabled-force-inherit cases

## Testing
- npm run test:run -- src/__tests__/agent-registry.test.ts
- npx eslint src/agents/definitions.ts src/__tests__/agent-registry.test.ts
- npx tsc --noEmit
