### PR TITLE
fix: resolve security vulnerabilities, lint warnings, and CJS runtime bug

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-src/__tests__/benchmark-scoring.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2282,9 +2282,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2808,9 +2808,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3208,9 +3208,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3994,9 +3994,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4018,9 +4018,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/__tests__/jobid-collision-safety.test.ts
+++ b/src/__tests__/jobid-collision-safety.test.ts
@@ -7,11 +7,9 @@
  * BUG 4: generateJobId not collision-safe
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
-import { execFileSync } from 'child_process';
 
 // ---------------------------------------------------------------------------
 describe('generateJobId collision safety', () => {

--- a/src/__tests__/shared-state-locking.test.ts
+++ b/src/__tests__/shared-state-locking.test.ts
@@ -8,10 +8,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { execFileSync } from 'child_process';
 
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------

--- a/src/mcp/team-job-convergence.ts
+++ b/src/mcp/team-job-convergence.ts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { cleanupTeamWorktrees } from '../team/git-worktree.js';
 import { validateTeamName } from '../team/team-name.js';
-import { isProcessAlive } from '../platform/index.js';
 
 export interface OmcTeamJob {
   status: 'running' | 'completed' | 'failed' | 'timeout';

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -13,7 +13,12 @@ import { z } from 'zod';
 import { spawn } from 'child_process';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __ownDir: string = (() => {
+  // CJS bundle: __dirname is reliable and takes precedence
+  if (typeof __dirname !== 'undefined' && __dirname) return __dirname;
+  // ESM: derive from import.meta.url
+  try { return fileURLToPath(new URL('.', import.meta.url)); } catch { return process.cwd(); }
+})();
 import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { killWorkerPanes, killTeamSession } from '../team/tmux-session.js';
@@ -239,7 +244,7 @@ async function handleStart(args: unknown): Promise<{ content: Array<{ type: 'tex
   const input = startSchema.parse(args);
   validateTeamName(input.teamName);
   const jobId = `omc-${Date.now().toString(36)}`;
-  const runtimeCliPath = join(__dirname, 'runtime-cli.cjs');
+  const runtimeCliPath = join(__ownDir, 'runtime-cli.cjs');
 
   const job: OmcTeamJob = { status: 'running', startedAt: Date.now(), teamName: input.teamName, cwd: input.cwd };
   omcTeamJobs.set(jobId, job);


### PR DESCRIPTION
## Summary

- **Security**: `npm audit fix` patches 4 CVEs (1 moderate, 3 high) in brace-expansion, flatted, path-to-regexp, picomatch
- **Lint**: Remove 13 unused imports across 3 files; delete deprecated `.eslintignore` (patterns already in `eslint.config.js`)
- **Bug fix**: Fix CJS runtime crash in `team-server.ts` — `import.meta.url` is empty in CJS bundles, causing `TypeError: Invalid URL` on module load. Replaced with CJS-first `__dirname` resolution following codebase convention (`agents/utils.ts` pattern)

## Changes (6 files, 62 lines)

| File | Change |
|------|--------|
| `package-lock.json` | Security patches for 4 vulnerable packages |
| `.eslintignore` | Deleted (redundant with `eslint.config.js` ignores) |
| `src/__tests__/jobid-collision-safety.test.ts` | Remove 9 unused imports |
| `src/__tests__/shared-state-locking.test.ts` | Remove 3 unused imports |
| `src/mcp/team-job-convergence.ts` | Remove 1 unused import |
| `src/mcp/team-server.ts` | Fix CJS `__dirname` resolution (runtime bug) |

## Verification

All validators green after changes:

```
TypeScript: 0 errors
ESLint:     0 warnings, 0 errors
npm audit:  0 vulnerabilities
Build:      success (import.meta warning eliminated)
Tests:      403 files, 7185 tests ALL PASS
```

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint src` returns 0 warnings, 0 errors
- [x] `npm audit` returns 0 vulnerabilities
- [x] `npm run build` succeeds with no warnings
- [x] `npx vitest run` — 403 files, 7185 tests pass
- [x] Code review: APPROVED
- [x] Security review: SAFE