### PR TITLE
test: add regression tests for CJS safety and import cleanup

### DIFF
--- a/src/mcp/__tests__/team-job-convergence.test.ts
+++ b/src/mcp/__tests__/team-job-convergence.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('team-job-convergence imports', () => {
+  const sourcePath = join(__dirname, '..', 'team-job-convergence.ts');
+  const source = readFileSync(sourcePath, 'utf-8');
+
+  it('does not import isProcessAlive (unused)', () => {
+    expect(source).not.toContain("import { isProcessAlive }");
+  });
+
+  it('exports OmcTeamJob interface', () => {
+    expect(source).toContain('export interface OmcTeamJob');
+  });
+
+  it('exports clearScopedTeamState function', () => {
+    expect(source).toContain('export function clearScopedTeamState');
+  });
+
+  it('exports convergeJobWithResultArtifact function', () => {
+    expect(source).toContain('export function convergeJobWithResultArtifact');
+  });
+
+  it('exports isJobTerminal function', () => {
+    expect(source).toContain('export function isJobTerminal');
+  });
+});

--- a/src/mcp/__tests__/team-server.test.ts
+++ b/src/mcp/__tests__/team-server.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('team-server CJS safety', () => {
+  const sourcePath = join(__dirname, '..', 'team-server.ts');
+  const source = readFileSync(sourcePath, 'utf-8');
+
+  it('uses __ownDir instead of bare __dirname for CJS compatibility', () => {
+    expect(source).toContain('__ownDir');
+    expect(source).not.toMatch(/^const __dirname = fileURLToPath/m);
+  });
+
+  it('checks typeof __dirname before using import.meta.url', () => {
+    const ownDirBlock = source.match(/const __ownDir[\s\S]*?\)\(\)/);
+    expect(ownDirBlock).toBeTruthy();
+    const block = ownDirBlock![0];
+    const dirnameCheckIdx = block.indexOf("typeof __dirname");
+    const importMetaIdx = block.indexOf("import.meta.url");
+    expect(dirnameCheckIdx).toBeLessThan(importMetaIdx);
+  });
+
+  it('has process.cwd() as last-resort fallback', () => {
+    const ownDirBlock = source.match(/const __ownDir[\s\S]*?\)\(\)/);
+    expect(ownDirBlock![0]).toContain('process.cwd()');
+  });
+
+  it('uses __ownDir for runtimeCliPath join', () => {
+    expect(source).toContain("join(__ownDir, 'runtime-cli.cjs')");
+  });
+
+  it('wraps import.meta.url in try/catch for CJS safety', () => {
+    const ownDirBlock = source.match(/const __ownDir[\s\S]*?\)\(\)/);
+    expect(ownDirBlock![0]).toContain('try {');
+    expect(ownDirBlock![0]).toContain('catch');
+  });
+});


### PR DESCRIPTION
## Summary

Add 10 regression tests to guard fixes from #1994:

- `src/mcp/__tests__/team-server.test.ts` — 5 tests verifying `__ownDir` CJS-safe pattern (typeof check before import.meta.url, try/catch, process.cwd fallback)
- `src/mcp/__tests__/team-job-convergence.test.ts` — 5 tests verifying unused `isProcessAlive` import stays removed and public API surface is stable

## Changes (2 files, 65 lines — tests only)

| File | Change |
|------|--------|
| `src/mcp/__tests__/team-server.test.ts` | NEW: 5 regression tests for CJS fix |
| `src/mcp/__tests__/team-job-convergence.test.ts` | NEW: 5 regression tests for import cleanup |

No source code changes. No version bump. Tests only.

## Verification

```
TypeScript: 0 errors
ESLint:     0 warnings, 0 errors
Tests:      405 files (+2), 7213 tests (+10) ALL PASS
```

## Test plan

- [x] `npx vitest run` — 405 files, 7213 tests pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint src` — 0 warnings
- [x] No conflicts with upstream/dev (branch created from upstream/dev HEAD)