### PR TITLE
fix(daemon): add NODE_EXTRA_CA_CERTS to daemon env allowlist

### DIFF
--- a/src/features/rate-limit-wait/daemon.ts
+++ b/src/features/rate-limit-wait/daemon.ts
@@ -76,7 +76,7 @@ const DAEMON_ENV_ALLOWLIST = [
   // Shell
   'SHELL',
   // Node.js
-  'NODE_ENV',
+  'NODE_ENV', 'NODE_EXTRA_CA_CERTS',
   // Proxy settings
   'HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy', 'NO_PROXY', 'no_proxy',
   // Windows system

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -69,7 +69,7 @@ const DAEMON_ENV_ALLOWLIST = [
   'TMPDIR', 'TMP', 'TEMP',
   'XDG_RUNTIME_DIR', 'XDG_DATA_HOME', 'XDG_CONFIG_HOME',
   'SHELL',
-  'NODE_ENV',
+  'NODE_ENV', 'NODE_EXTRA_CA_CERTS',
   'HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy', 'NO_PROXY', 'no_proxy',
   'SystemRoot', 'SYSTEMROOT', 'windir', 'COMSPEC',
 ] as const;


### PR DESCRIPTION
Fixes #1998.

Add `NODE_EXTRA_CA_CERTS` to `DAEMON_ENV_ALLOWLIST` in both daemon spawn points:
- `src/features/rate-limit-wait/daemon.ts`
- `src/notifications/reply-listener.ts`

Without this, daemon child processes behind SSL-intercepting proxies (Zscaler, corporate firewalls) fail silently on all HTTPS requests because Node.js can't find the custom CA certificate.

2-line change, consistent with existing proxy var allowlist pattern.