### PR TITLE
fix(installer): update CLAUDE.md even when running in plugin context

### DIFF
--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -814,7 +814,20 @@ export function install(options: InstallOptions = {}): InstallResult {
         }
       }
 
-      // Install CLAUDE.md with merge support
+      // Note: hook scripts are no longer installed to ~/.claude/hooks/.
+      // All hooks are delivered via the plugin's hooks/hooks.json + scripts/.
+      // Legacy hook entries are cleaned up from settings.json below.
+      result.hooksConfigured = true; // Will be set properly after consolidated settings.json write
+    } else {
+      log('Skipping agent/command/hook files (managed by plugin system)');
+    }
+
+    // Install CLAUDE.md with merge support.
+    // This runs regardless of plugin context so that `omc update` (which re-execs
+    // as `update-reconcile` with CLAUDE_PLUGIN_ROOT still set) always keeps the
+    // version marker and OMC instructions in ~/.claude/CLAUDE.md up to date.
+    // Skipped only for project-scoped plugins to avoid mutating global config.
+    if (!projectScoped) {
       const claudeMdPath = join(CLAUDE_CONFIG_DIR, 'CLAUDE.md');
       const homeMdPath = join(homedir(), 'CLAUDE.md');
 
@@ -847,13 +860,6 @@ export function install(options: InstallOptions = {}): InstallResult {
       } else {
         log('CLAUDE.md exists in home directory, skipping');
       }
-
-      // Note: hook scripts are no longer installed to ~/.claude/hooks/.
-      // All hooks are delivered via the plugin's hooks/hooks.json + scripts/.
-      // Legacy hook entries are cleaned up from settings.json below.
-      result.hooksConfigured = true; // Will be set properly after consolidated settings.json write
-    } else {
-      log('Skipping agent/command/hook files (managed by plugin system)');
     }
 
     // Install HUD statusline (skip for project-scoped plugins, skipHud option, or hudEnabled config)


### PR DESCRIPTION
## Problem

When `omc update` is run inside a Claude Code session (e.g. via `! omc update`), the `CLAUDE_PLUGIN_ROOT` environment variable is set by the plugin system. The update process re-execs `omc update-reconcile` using `...process.env`, so the child process inherits `CLAUDE_PLUGIN_ROOT`.

This causes `isRunningAsPlugin()` to return `true` inside the reconcile process, which makes the entire CLAUDE.md update block (gated on `if (!runningAsPlugin)`) get **skipped**. As a result, the `<!-- OMC:VERSION:x.y.z -->` marker in `~/.claude/CLAUDE.md` is never updated after `omc update`, so the status line continues to show the old version.

<img width="277" height="126" alt="스크린샷 2026-03-30 오전 9 52 26" src="https://github.com/user-attachments/assets/37178196-28cc-4845-ade7-557b1a6744b7" />

<img width="572" height="55" alt="스크린샷 2026-03-30 오전 9 52 19" src="https://github.com/user-attachments/assets/17000989-dc6c-4bac-a944-124da593b548" />


## Root Cause

In `src/installer/index.ts`, the CLAUDE.md update block was nested inside `if (!runningAsPlugin)`. Since `runningAsPlugin` is determined solely by whether `CLAUDE_PLUGIN_ROOT` is set in the environment, and this env var is inherited by the `update-reconcile` subprocess, the update is silently skipped.

## Fix

Move the CLAUDE.md update block **outside** the `!runningAsPlugin` guard, replacing it with a `!projectScoped` guard. Project-scoped plugins should still not touch global config, but a global plugin context (the common case) must always keep `~/.claude/CLAUDE.md` in sync with the installed version.

## Testing

- All 51 existing installer tests pass (`installer.test.ts`, `installer-version-guard.test.ts`, `setup-claude-md-script.test.ts`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)