### PR TITLE
feat: add Kiro CLI as a worker provider

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -8,6 +8,7 @@ const PROVIDER_BINARIES = {
   claude: 'claude',
   codex: 'codex',
   gemini: 'gemini',
+  kiro: 'kiro-cli',
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
@@ -16,6 +17,7 @@ const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
  * - claude: `claude -p <prompt>`
  * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
  * - gemini: `gemini -p <prompt> --yolo`
+ * - kiro: `kiro-cli chat --trust-all-tools --no-interactive <prompt>`
  */
 function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
   if (provider === 'codex') {
@@ -24,18 +26,21 @@ function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}
   if (provider === 'gemini') {
     return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
   }
+  if (provider === 'kiro') {
+    return ['chat', '--trust-all-tools', '--no-interactive', pipePromptViaStdin ? '-' : prompt];
+  }
   return ['-p', prompt];
 }
 
 function shouldPipePromptViaStdin(provider) {
-  return SHOULD_USE_WINDOWS_SHELL && (provider === 'codex' || provider === 'gemini');
+  return SHOULD_USE_WINDOWS_SHELL && (provider === 'codex' || provider === 'gemini' || provider === 'kiro');
 }
 
 const ASK_ORIGINAL_TASK_ENV = 'OMC_ASK_ORIGINAL_TASK';
 const ASK_ORIGINAL_TASK_ENV_ALIAS = 'OMX_ASK_ORIGINAL_TASK';
 
 function usage() {
-  console.error('Usage: omc ask <claude|codex|gemini> "<prompt>"');
+  console.error('Usage: omc ask <claude|codex|gemini|kiro> "<prompt>"');
   console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -49,6 +49,7 @@ export const CLAUDE_FAMILY_HIGH_VARIANTS: Record<ClaudeModelFamily, string> = {
 export const BUILTIN_EXTERNAL_MODEL_DEFAULTS = {
   codexModel: 'gpt-5.3-codex',
   geminiModel: 'gemini-3.1-pro-preview',
+  kiroModel: 'auto',
 } as const;
 
 /**
@@ -147,10 +148,10 @@ export function getClaudeHighVariantFromModel(modelId: string): string | null {
 }
 
 /** Get built-in default model for an external provider */
-export function getBuiltinExternalDefaultModel(provider: 'codex' | 'gemini'): string {
-  return provider === 'codex'
-    ? BUILTIN_EXTERNAL_MODEL_DEFAULTS.codexModel
-    : BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel;
+export function getBuiltinExternalDefaultModel(provider: 'codex' | 'gemini' | 'kiro'): string {
+  if (provider === 'codex') return BUILTIN_EXTERNAL_MODEL_DEFAULTS.codexModel;
+  if (provider === 'kiro') return BUILTIN_EXTERNAL_MODEL_DEFAULTS.kiroModel;
+  return BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel;
 }
 
 /**

--- a/src/team/bridge-entry.ts
+++ b/src/team/bridge-entry.ts
@@ -129,8 +129,8 @@ function main(): void {
   config.workerName = sanitizeName(config.workerName);
 
   // Validate provider
-  if (config.provider !== 'codex' && config.provider !== 'gemini') {
-    console.error(`Invalid provider: ${config.provider}. Must be 'codex' or 'gemini'.`);
+  if (config.provider !== 'codex' && config.provider !== 'gemini' && config.provider !== 'kiro') {
+    console.error(`Invalid provider: ${config.provider}. Must be 'codex', 'gemini', or 'kiro'.`);
     process.exit(1);
   }
 

--- a/src/team/capabilities.ts
+++ b/src/team/capabilities.ts
@@ -18,6 +18,8 @@ const DEFAULT_CAPABILITIES: Record<WorkerBackend, WorkerCapability[]> = {
   'tmux-claude': ['code-edit', 'testing', 'general'],
   'tmux-codex': ['code-review', 'security-review', 'architecture', 'refactoring'],
   'tmux-gemini': ['ui-design', 'documentation', 'research', 'code-edit'],
+  'mcp-kiro': ['code-edit', 'testing', 'architecture', 'general'],
+  'tmux-kiro': ['code-edit', 'testing', 'architecture', 'general'],
 };
 
 /**

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -165,9 +165,9 @@ function validateModelName(model: string | undefined): void {
 
 /** Validate provider is one of allowed values */
 function validateProvider(provider: string): void {
-  if (provider !== "codex" && provider !== "gemini") {
+  if (provider !== "codex" && provider !== "gemini" && provider !== "kiro") {
     throw new Error(
-      `Invalid provider: ${provider}. Must be 'codex' or 'gemini'`,
+      `Invalid provider: ${provider}. Must be 'codex', 'gemini', or 'kiro'`,
     );
   }
 }
@@ -381,7 +381,7 @@ export function recordTaskCompletionUsage(args: {
   taskId: string;
   promptFile: string;
   outputFile: string;
-  provider: "codex" | "gemini";
+  provider: "codex" | "gemini" | "kiro";
   startedAt: number;
   startedAtIso: string;
 }): void {
@@ -461,7 +461,7 @@ function parseCodexOutput(output: string): string {
  * This allows the bridge to kill the child on shutdown while still awaiting the result.
  */
 function spawnCliProcess(
-  provider: "codex" | "gemini",
+  provider: "codex" | "gemini" | "kiro",
   prompt: string,
   model: string | undefined,
   cwd: string,
@@ -484,6 +484,10 @@ function spawnCliProcess(
       "--dangerously-bypass-approvals-and-sandbox",
       "--skip-git-repo-check",
     ];
+  } else if (provider === "kiro") {
+    cmd = "kiro-cli";
+    args = ["chat", "--trust-all-tools", "--no-interactive"];
+    if (model) args.push("--model", model);
   } else {
     cmd = "gemini";
     args = ["--approval-mode", "yolo"];
@@ -522,7 +526,7 @@ function spawnCliProcess(
         clearTimeout(timeoutHandle);
         if (code === 0) {
           const response =
-            provider === "codex" ? parseCodexOutput(stdout) : stdout.trim();
+            provider === "codex" ? parseCodexOutput(stdout) : stdout.trim(); // gemini and kiro output plain text
           resolve(response);
         } else {
           const detail = stderr || stdout.trim() || "No output";

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -4,7 +4,7 @@ import { validateTeamName } from './team-name.js';
 import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
 
-export type CliAgentType = 'claude' | 'codex' | 'gemini';
+export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'kiro';
 
 export interface CliAgentContract {
   agentType: CliAgentType;
@@ -217,6 +217,21 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
       return rawOutput.trim();
     },
   },
+  kiro: {
+    agentType: 'kiro',
+    binary: 'kiro-cli',
+    installInstructions: 'Install Kiro CLI: https://kiro.dev/downloads',
+    supportsPromptMode: true,
+    // Kiro CLI uses positional prompt: kiro-cli chat [OPTIONS] [INPUT]
+    buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
+      const args = ['chat', '--trust-all-tools', '--no-interactive'];
+      if (model) args.push('--model', model);
+      return [...args, ...extraFlags];
+    },
+    parseOutput(rawOutput: string): string {
+      return rawOutput.trim();
+    },
+  },
 };
 
 export function getContract(agentType: CliAgentType): CliAgentContract {
@@ -331,6 +346,8 @@ const WORKER_MODEL_ENV_ALLOWLIST = [
   'OMC_CODEX_DEFAULT_MODEL',
   'OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL',
   'OMC_GEMINI_DEFAULT_MODEL',
+  'OMC_EXTERNAL_MODELS_DEFAULT_KIRO_MODEL',
+  'OMC_KIRO_DEFAULT_MODEL',
 ] as const;
 
 export function getWorkerEnv(

--- a/src/team/team-registration.ts
+++ b/src/team/team-registration.ts
@@ -77,7 +77,7 @@ export function getRegistrationStrategy(workingDirectory: string): 'config' | 's
 export function registerMcpWorker(
   teamName: string,
   workerName: string,
-  provider: 'codex' | 'gemini' | 'claude',
+  provider: 'codex' | 'gemini' | 'claude' | 'kiro',
   model: string,
   tmuxTarget: string,
   cwd: string,

--- a/src/team/team-status.ts
+++ b/src/team/team-status.ts
@@ -59,7 +59,7 @@ function peekRecentOutboxMessages(
 
 export interface WorkerStatus {
   workerName: string;
-  provider: 'claude' | 'codex' | 'gemini';
+  provider: 'claude' | 'codex' | 'gemini' | 'kiro';
   heartbeat: HeartbeatData | null;
   isAlive: boolean;
   currentTask: TaskFile | null;
@@ -133,7 +133,7 @@ export function getTeamStatus(
     };
 
     const currentTask = workerTasks.find(t => t.status === 'in_progress') || null;
-    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini';
+    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini' | 'kiro';
 
     return {
       workerName: w.name,

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -14,7 +14,7 @@ import type { TeamLeaderNextAction } from './leader-nudge-guidance.js';
 export interface BridgeConfig {
   teamName: string;
   workerName: string;
-  provider: 'codex' | 'gemini';
+  provider: 'codex' | 'gemini' | 'kiro';
   model?: string;
   workingDirectory: string;
   pollIntervalMs: number;       // default: 3000
@@ -102,7 +102,7 @@ export interface McpWorkerMember {
 export interface HeartbeatData {
   workerName: string;
   teamName: string;
-  provider: 'codex' | 'gemini' | 'claude';
+  provider: 'codex' | 'gemini' | 'claude' | 'kiro';
   pid: number;
   lastPollAt: string;       // ISO timestamp of last poll cycle
   currentTaskId?: string;   // task being executed, if any
@@ -125,7 +125,7 @@ export interface ConfigProbeResult {
 /** Sidecar mapping task IDs to execution modes */
 export interface TaskModeMap {
   teamName: string;
-  taskModes: Record<string, 'mcp_codex' | 'mcp_gemini' | 'claude_worker'>;
+  taskModes: Record<string, 'mcp_codex' | 'mcp_gemini' | 'mcp_kiro' | 'claude_worker'>;
 }
 
 /** Failure sidecar for a task */
@@ -137,7 +137,7 @@ export interface TaskFailureSidecar {
 }
 
 /** Worker backend type */
-export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini';
+export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'mcp-kiro' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini' | 'tmux-kiro';
 
 /** Worker capability tag */
 export type WorkerCapability =

--- a/src/team/usage-tracker.ts
+++ b/src/team/usage-tracker.ts
@@ -17,7 +17,7 @@ import { appendFileWithMode, ensureDirWithMode, validateResolvedPath } from './f
 export interface TaskUsageRecord {
   taskId: string;
   workerName: string;
-  provider: 'codex' | 'gemini';
+  provider: 'codex' | 'gemini' | 'kiro';
   model: string;
   startedAt: string;
   completedAt: string;
@@ -28,7 +28,7 @@ export interface TaskUsageRecord {
 
 export interface WorkerUsageSummary {
   workerName: string;
-  provider: 'codex' | 'gemini';
+  provider: 'codex' | 'gemini' | 'kiro';
   model: string;
   taskCount: number;
   totalWallClockMs: number;

--- a/src/team/worker-restart.ts
+++ b/src/team/worker-restart.ts
@@ -144,7 +144,7 @@ export function synthesizeBridgeConfig(
     workerName: worker.name,
     teamName,
     workingDirectory: worker.cwd,
-    provider: worker.agentType.replace('mcp-', '') as 'codex' | 'gemini',
+    provider: worker.agentType.replace('mcp-', '') as 'codex' | 'gemini' | 'kiro',
     model: worker.model,
     pollIntervalMs: 3000,
     taskTimeoutMs: 600000,


### PR DESCRIPTION
## Summary

- Add [Kiro CLI](https://kiro.dev) (`kiro-cli`) as a fourth worker type alongside claude, codex, and gemini
- Kiro CLI provides agentic coding capabilities with multi-model routing (Claude, DeepSeek, Qwen, etc.)
- Headless mode: `kiro-cli chat --trust-all-tools --no-interactive <prompt>`
- Default model: `auto` (Kiro's smart model routing)

## Changes

**Core contract** (`model-contract.ts`):
- Add `kiro` to `CliAgentType` union
- Add kiro contract: binary `kiro-cli`, launch args `chat --trust-all-tools --no-interactive`
- Add `OMC_KIRO_DEFAULT_MODEL` and `OMC_EXTERNAL_MODELS_DEFAULT_KIRO_MODEL` env vars

**Bridge** (`mcp-team-bridge.ts`, `bridge-entry.ts`):
- Add kiro to `validateProvider()` and `spawnCliProcess()`
- Kiro outputs plain text (same parsing as gemini)

**Types** (`types.ts`, `team-status.ts`, `usage-tracker.ts`, `team-registration.ts`, `worker-restart.ts`):
- Extend all provider type unions to include `'kiro'`
- Add `mcp-kiro` / `tmux-kiro` to `WorkerBackend`

**Config** (`models.ts`):
- Add `kiroModel: 'auto'` to `BUILTIN_EXTERNAL_MODEL_DEFAULTS`
- Update `getBuiltinExternalDefaultModel()` to handle kiro

**Capabilities** (`capabilities.ts`):
- Add `mcp-kiro` and `tmux-kiro` with default capabilities: code-edit, testing, architecture, general

**Advisor script** (`run-provider-advisor.js`):
- Add kiro to `PROVIDER_BINARIES`, `buildProviderArgs`, usage string

## Test plan

- [x] `npm run build` passes
- [x] `getContract('kiro')` returns correct contract
- [x] `isCliAvailable('kiro')` returns true when kiro-cli installed
- [ ] End-to-end: `omc ask kiro "What is 2+2?"` returns correct answer via artifact
- [ ] `omc team 1:kiro "<task>"` spawns kiro worker in tmux
- [ ] Skills docs update (ask, omc-teams, omc-reference) — can follow up in separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)