### PR TITLE
fix(security): harden python sandbox module blocklist

### DIFF
--- a/bridge/gyoshu_bridge.py
+++ b/bridge/gyoshu_bridge.py
@@ -397,6 +397,12 @@ SANDBOX_BLOCKED_MODULES = frozenset(
         "webbrowser",
         "http.server",
         "xmlrpc.server",
+        # Bypass prevention
+        "importlib",    # Prevents importlib.import_module('os') bypass
+        "sys",          # Prevents sys.modules direct access bypass
+        "io",           # Prevents file I/O bypass (complements open() block)
+        "pathlib",      # Prevents filesystem access via Path objects
+        "signal",       # Prevents signal handler manipulation
     }
 )
 

--- a/src/tools/python-repl/__tests__/python-sandbox.test.ts
+++ b/src/tools/python-repl/__tests__/python-sandbox.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { isPythonSandboxEnabled, clearSecurityConfigCache } from '../../../lib/security-config.js';
 
 describe('python-repl sandbox env propagation', () => {
@@ -23,5 +27,78 @@ describe('python-repl sandbox env propagation', () => {
     process.env.OMC_SECURITY = 'strict';
     clearSecurityConfigCache();
     expect(isPythonSandboxEnabled()).toBe(true);
+  });
+});
+
+// Helper: test sandbox import blocking by extracting only the relevant constants
+// from gyoshu_bridge.py using AST parsing, avoiding full module initialization.
+function executePythonInSandbox(code: string): string {
+  const bridgePath = new URL('../../../../bridge/gyoshu_bridge.py', import.meta.url).pathname;
+  const tmpScript = join(tmpdir(), `omc-sandbox-test-${Date.now()}.py`);
+  const escapedBridgePath = JSON.stringify(bridgePath);
+  const escapedCode = JSON.stringify(code);
+  const lines = [
+    'import ast, builtins',
+    `_src = open(${escapedBridgePath}).read()`,
+    '_tree = ast.parse(_src)',
+    '_globals = {"__builtins__": builtins, "frozenset": frozenset}',
+    'for _node in _tree.body:',
+    '    if isinstance(_node, ast.Assign):',
+    '        _targets = [t.id for t in _node.targets if isinstance(t, ast.Name)]',
+    '        for _n in _targets:',
+    '            if _n in ("SANDBOX_BLOCKED_MODULES", "SANDBOX_BLOCKED_BUILTINS", "_original_import"):',
+    '                exec(compile(ast.Module(body=[_node], type_ignores=[]), "<bridge>", "exec"), _globals)',
+    '    elif isinstance(_node, ast.FunctionDef):',
+    '        if _node.name in ("_sandbox_import", "get_sandbox_namespace"):',
+    '            exec(compile(ast.Module(body=[_node], type_ignores=[]), "<bridge>", "exec"), _globals)',
+    '_sandbox_import = _globals["_sandbox_import"]',
+    '_blocked = _globals["SANDBOX_BLOCKED_BUILTINS"]',
+    'import builtins as _b',
+    '_safe = {k: v for k, v in vars(_b).items() if k not in _blocked}',
+    '_safe["__import__"] = _sandbox_import',
+    'ns = {"__builtins__": _safe}',
+    'try:',
+    `    exec(compile(${escapedCode}, "<sandbox>", "exec"), ns)`,
+    '    print("ok")',
+    'except ImportError as e:',
+    '    print(str(e))',
+    'except Exception as e:',
+    '    print(f"error: {e}")',
+  ];
+  writeFileSync(tmpScript, lines.join('\n'), 'utf-8');
+  try {
+    return execSync(`python3 ${tmpScript}`, { timeout: 10000 }).toString().trim();
+  } catch (e: unknown) {
+    const err = e as { stdout?: Buffer; stderr?: Buffer };
+    return (err.stdout?.toString() ?? '') + (err.stderr?.toString() ?? '');
+  } finally {
+    try { unlinkSync(tmpScript); } catch { /* ignore */ }
+  }
+}
+
+describe('python-repl sandbox blocked modules (bypass prevention)', () => {
+  it('should block importlib (bypass prevention)', () => {
+    const result = executePythonInSandbox('import importlib');
+    expect(result).toContain('blocked in sandbox mode');
+  });
+
+  it('should block sys module access', () => {
+    const result = executePythonInSandbox('import sys');
+    expect(result).toContain('blocked in sandbox mode');
+  });
+
+  it('should block io module', () => {
+    const result = executePythonInSandbox('import io');
+    expect(result).toContain('blocked in sandbox mode');
+  });
+
+  it('should block pathlib module', () => {
+    const result = executePythonInSandbox('import pathlib');
+    expect(result).toContain('blocked in sandbox mode');
+  });
+
+  it('should block signal module', () => {
+    const result = executePythonInSandbox('import signal');
+    expect(result).toContain('blocked in sandbox mode');
   });
 });


### PR DESCRIPTION
## Summary

- Add `importlib`, `sys`, `io`, `pathlib`, `signal` to `SANDBOX_BLOCKED_MODULES` in `bridge/gyoshu_bridge.py`
- Prevents common sandbox bypass via `importlib.import_module('os')` and `sys.modules` direct access
- Add 5 new tests verifying each blocked module raises `ImportError` with 'blocked in sandbox mode'

## Details

The existing sandbox blocked modules list lacked several modules commonly used to bypass Python sandboxes:
- `importlib` — allows `importlib.import_module('os')` to bypass the import hook
- `sys` — allows `sys.modules['os']` direct access bypass
- `io` — allows file I/O bypass complementing the `open()` block
- `pathlib` — allows filesystem access via `Path` objects
- `signal` — allows signal handler manipulation

The `_sandbox_import` hook uses `top_level = name.split(".")[0]`, so submodules like `importlib.util` are automatically blocked too.

## Test plan

- [x] `npx vitest run src/tools/python-repl/__tests__/python-sandbox.test.ts` — all 7 tests pass
- [x] Tests use AST-based extraction of sandbox logic to avoid bridge server initialization dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)