### PR TITLE
fix(security): disable remote MCP servers when security policy requires

### DIFF
--- a/src/__tests__/remote-mcp-disable.test.ts
+++ b/src/__tests__/remote-mcp-disable.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/security-config.js', () => ({
+  isRemoteMcpDisabled: vi.fn(),
+}));
+
+import { isRemoteMcpDisabled } from '../lib/security-config.js';
+import { getDefaultMcpServers } from '../mcp/servers.js';
+
+describe('Remote MCP disable via security config', () => {
+  beforeEach(() => {
+    vi.mocked(isRemoteMcpDisabled).mockReset();
+  });
+
+  it('should include Exa and Context7 by default (non-strict)', () => {
+    vi.mocked(isRemoteMcpDisabled).mockReturnValue(false);
+    const servers = getDefaultMcpServers();
+    expect(servers.exa).toBeDefined();
+    expect(servers.context7).toBeDefined();
+  });
+
+  it('should exclude Exa and Context7 in strict mode', () => {
+    vi.mocked(isRemoteMcpDisabled).mockReturnValue(true);
+    const servers = getDefaultMcpServers();
+    expect(servers.exa).toBeUndefined();
+    expect(servers.context7).toBeUndefined();
+  });
+
+  it('should still allow explicit enableExa=false to disable', () => {
+    vi.mocked(isRemoteMcpDisabled).mockReturnValue(false);
+    const servers = getDefaultMcpServers({ enableExa: false });
+    expect(servers.exa).toBeUndefined();
+    expect(servers.context7).toBeDefined();
+  });
+});

--- a/src/mcp/servers.ts
+++ b/src/mcp/servers.ts
@@ -9,6 +9,8 @@
  * - Memory: Persistent knowledge graph
  */
 
+import { isRemoteMcpDisabled } from '../lib/security-config.js';
+
 export interface McpServerConfig {
   command: string;
   args: string[];
@@ -89,12 +91,13 @@ export function getDefaultMcpServers(options?: {
   enableMemory?: boolean;
 }): McpServersConfig {
   const servers: McpServersConfig = {};
+  const remoteMcpDisabled = isRemoteMcpDisabled();
 
-  if (options?.enableExa !== false) {
+  if (!remoteMcpDisabled && options?.enableExa !== false) {
     servers.exa = createExaServer(options?.exaApiKey);
   }
 
-  if (options?.enableContext7 !== false) {
+  if (!remoteMcpDisabled && options?.enableContext7 !== false) {
     servers.context7 = createContext7Server();
   }
 


### PR DESCRIPTION
## Summary

Wire `isRemoteMcpDisabled()` from `security-config.ts` into `servers.ts` so that remote MCP servers (Exa, Context7) are not started when the security policy disables them.

When `OMC_SECURITY=strict` or `disableRemoteMcp: true` in config, no queries are sent to external Exa/Context7 servers.

> **CI Note**: Previous PR #2013 was all-green (7/7) but closed before review. Same branch, rebased on latest #2016 fix. Depends on #2016.

## Depends on
- #2016 (security-config strict override protection)

## Changes

- `src/mcp/servers.ts`: Import `isRemoteMcpDisabled()`, skip Exa/Context7 when disabled
- `src/__tests__/remote-mcp-disable.test.ts`: 3 tests (strict disables, default enables, explicit disable)

## Verified

- #2013 CI: 7/7 all green
- Local: `vitest run remote-mcp-disable.test.ts` — 3/3 pass

## Test plan
- [x] `OMC_SECURITY=strict` → Exa and Context7 not created
- [x] Default (non-strict) → Exa and Context7 created normally
- [x] Explicit `enableExa: false` still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)