### PR TITLE
fix: make sync-version.sh cross-platform (macOS BSD sed)

### DIFF
--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -13,26 +13,35 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VERSION="${1:-$(node -p "require('$ROOT/package.json').version")}"
 
+# Cross-platform sed -i wrapper (macOS BSD sed requires -i '', GNU sed does not)
+sedi() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 echo "🔄 Syncing version $VERSION to satellite files..."
 
 # 1. .claude-plugin/plugin.json
 PLUGIN="$ROOT/.claude-plugin/plugin.json"
 if [ -f "$PLUGIN" ]; then
-  sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$PLUGIN"
+  sedi "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$PLUGIN"
   echo "  ✓ plugin.json → $VERSION"
 fi
 
 # 2. .claude-plugin/marketplace.json (has 2 version fields)
 MARKET="$ROOT/.claude-plugin/marketplace.json"
 if [ -f "$MARKET" ]; then
-  sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" "$MARKET"
+  sedi "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" "$MARKET"
   echo "  ✓ marketplace.json → $VERSION"
 fi
 
 # 3. docs/CLAUDE.md version marker
 CLAUDE_MD="$ROOT/docs/CLAUDE.md"
 if [ -f "$CLAUDE_MD" ]; then
-  sed -i "s/<!-- OMC:VERSION:[^ ]* -->/<!-- OMC:VERSION:$VERSION -->/" "$CLAUDE_MD"
+  sedi "s/<!-- OMC:VERSION:[^ ]* -->/<!-- OMC:VERSION:$VERSION -->/" "$CLAUDE_MD"
   echo "  ✓ docs/CLAUDE.md → $VERSION"
 fi
 


### PR DESCRIPTION
## Summary

- Add `sedi()` wrapper function to `scripts/sync-version.sh` that detects macOS via `$OSTYPE` and passes the required empty extension argument (`-i ''`) for BSD sed
- Replaces all three bare `sed -i` calls with the cross-platform wrapper

Fixes #2019

## Root Cause

`sed -i` behaves differently on macOS (BSD) vs Linux (GNU):
- **GNU sed**: `sed -i 'expr' file` works
- **BSD sed**: `sed -i '' 'expr' file` requires empty extension argument

Without it, BSD sed interprets the sed expression as a backup suffix, silently failing the in-place edit. This caused `docs/CLAUDE.md` in the npm 4.9.3 package to retain the 4.9.2 version marker.

## Test plan

- [x] Tested `sync-version.sh 4.9.3` on macOS — all three files updated correctly
- [ ] Verify on Linux (GNU sed) that the wrapper still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)