### PR TITLE
docs: fix agent count in README (32 → 19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 
 ### Intelligent Orchestration
 
-- **32 specialized agents** for architecture, research, design, testing, data science
+- **19 specialized agents** (with tier variants) for architecture, research, design, testing, data science
 - **Smart model routing** - Haiku for simple tasks, Opus for complex reasoning
 - **Automatic delegation** - Right agent for the job, every time
 


### PR DESCRIPTION
## Summary

Fix incorrect agent count in README.md: **32 → 19**.

## Evidence

`getAgentDefinitions()` in `src/agents/definitions.ts` registers exactly **19 agents**:

| Lane | Agents | Count |
|------|--------|-------|
| Build/Analysis | explore, analyst, planner, architect, debugger, executor, verifier, tracer | 8 |
| Review | security-reviewer, code-reviewer | 2 |
| Domain | test-engineer, designer, writer, qa-tester, scientist, git-master, document-specialist, code-simplifier | 8 |
| Coordination | critic | 1 |
| **Total** | | **19** |

The previous "32" figure likely included tier variants (`architect-low`, `executor-high`, etc.) and deprecated aliases (`build-fixer`, `deep-executor`, etc.), which are not separate agents — they route to the same 19 base agents with different model tiers.

## Change

```diff
-- **32 specialized agents** for architecture, research, design, testing, data science
+- **19 specialized agents** (with tier variants) for architecture, research, design, testing, data science
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)