### PR TITLE
fix(security): block tmux send-keys in worker bash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ See `scripts/openclaw-gateway-demo.mjs` for a reference gateway that relays Open
 - **[Migration Guide](docs/MIGRATION.md)** - Upgrade from v2.x
 - **[Architecture](docs/ARCHITECTURE.md)** - How it works under the hood
 - **[Performance Monitoring](docs/PERFORMANCE-MONITORING.md)** - Agent tracking, debugging, and optimization
+- **[Security Guide](SECURITY.md)** - Enterprise deployment and hardening
 
 ---
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -92,7 +92,7 @@ import { wrapUntrustedFileContent } from "../agents/prompt-helpers.js";
 const PKILL_F_FLAG_PATTERN = /\bpkill\b.*\s-f\b/;
 const PKILL_FULL_FLAG_PATTERN = /\bpkill\b.*--full\b/;
 const WORKER_BLOCKED_TMUX_PATTERN =
-  /\btmux\s+(split-window|new-session|new-window|join-pane)\b/i;
+  /\btmux\s+(split-window|new-session|new-window|join-pane|send-keys)\b/i;
 const WORKER_BLOCKED_TEAM_CLI_PATTERN = /\bom[cx]\s+team\b(?!\s+api\b)/i;
 const WORKER_BLOCKED_SKILL_PATTERN = /\$(team|ultrawork|autopilot|ralph)\b/i;
 


### PR DESCRIPTION
## Summary
- Add `send-keys` to `WORKER_BLOCKED_TMUX_PATTERN` in bridge.ts to prevent workers from injecting commands into other tmux panes
- Add SECURITY.md link to README Documentation section

## Context
Internal security review (SERVICESECURITY-499) identified that `tmux send-keys` was missing from the worker bash command blocklist. A team worker could use `tmux send-keys -t <pane> 'command' Enter` to inject commands into leader or sibling worker panes.

OMC's own internal `send-keys` usage (ralphthon, team-leader-nudge, rate-limit-wait) calls `execFileSync` directly and is unaffected by the Bash tool blocklist.

## Test plan
- [x] `bridge.test.ts` — 19/19 passed
- [x] Verified OMC internal `send-keys` calls use `execFileSync`, not Bash tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)