### PR TITLE
docs: add Getting Started, Hooks, and Tools guides

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,0 +1,361 @@
+# Getting Started
+
+> Quick start guide: from installation to your first OMC session.
+
+If you're new to Oh My ClaudeCode (OMC), follow the steps below in order.
+
+1. [Installation](#installation) - Install the OMC plugin and run initial setup
+2. [First Session](#first-session) - Run your first task with autopilot
+3. [Configuration](#configuration) - Customize settings and agent models per project
+
+### What this guide covers
+
+- How to install the OMC plugin
+- Running your first autopilot session and understanding the flow
+- Configuring per-user and per-project settings
+
+### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/claude-code) must be installed
+- Claude Max/Pro subscription or an Anthropic API key is required
+
+---
+
+## Installation
+
+OMC is installed exclusively as a Claude Code Plugin. Direct installation via npm or bun is not supported.
+
+### Step 1: Add the marketplace source
+
+Run the following command inside Claude Code:
+
+```bash
+/plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+```
+
+### Step 2: Install the plugin
+
+After adding the marketplace, install the plugin:
+
+```bash
+/plugin install oh-my-claudecode
+```
+
+### Step 3: Run initial setup
+
+After installation, enter one of the following in Claude Code:
+
+```bash
+# Option 1: natural language
+setup omc
+
+# Option 2: skill command
+/oh-my-claudecode:omc-setup
+```
+
+### Prerequisites summary
+
+| Item | Requirement |
+|------|-------------|
+| Claude Code | Must be installed |
+| Authentication | Claude Max/Pro subscription or `ANTHROPIC_API_KEY` environment variable |
+
+### Choosing a setup scope
+
+#### Project-scoped setup (recommended)
+
+Applies OMC only to the current project:
+
+```bash
+/oh-my-claudecode:omc-setup --local
+```
+
+- Settings are saved to `./.claude/CLAUDE.md`
+- No effect on other projects
+- Existing global `CLAUDE.md` is preserved
+
+#### Global setup
+
+Applies OMC to all Claude Code sessions:
+
+```bash
+/oh-my-claudecode:omc-setup
+```
+
+- Settings are saved to `~/.claude/CLAUDE.md`
+- Applied across all projects
+
+> ⚠️ **Warning:** Global setup overwrites the existing `~/.claude/CLAUDE.md` file. If you already have configuration there, use project-scoped setup (`--local`) instead.
+
+### Verifying the installation
+
+To confirm everything is working, run the diagnostics tool:
+
+```bash
+/oh-my-claudecode:omc-doctor
+```
+
+This checks the following:
+
+- Dependency installation status
+- Configuration file errors
+- Hook installation status
+- Agent availability
+- Skill registration status
+
+### Platform support
+
+| Platform | Installation | Hook type |
+|----------|--------------|-----------|
+| macOS | Claude Code Plugin | Bash (.sh) |
+| Linux | Claude Code Plugin | Bash (.sh) |
+| Windows | WSL2 recommended | Node.js (.mjs) |
+
+> ℹ️ **Note:** Native Windows support is experimental. OMC requires tmux, which is not available on native Windows. Use WSL2 instead.
+
+### Updates
+
+OMC automatically checks for updates every 24 hours. To update manually, re-run the plugin install command.
+
+> ⚠️ **Warning:** After a plugin update, run `/oh-my-claudecode:omc-setup` again to apply the latest configuration.
+
+### Uninstalling
+
+```bash
+/plugin uninstall oh-my-claudecode@oh-my-claudecode
+```
+
+---
+
+## First Session
+
+Once OMC is installed, run your first task immediately. Open Claude Code and type:
+
+```bash
+autopilot build me a hello world app
+```
+
+That single line is enough for OMC to run the full development pipeline automatically.
+
+### What happens
+
+When OMC detects the `autopilot` magic keyword, it starts a 5-stage pipeline:
+
+### Stage 1: Expansion
+
+The `analyst` and `architect` agents analyze the idea, clarify requirements, and produce a technical specification.
+
+### Stage 2: Planning
+
+The `planner` agent creates an execution plan. The `critic` agent reviews the plan and identifies gaps.
+
+### Stage 3: Execution
+
+The `executor` agent writes the code. Multiple agents work in parallel when needed.
+
+### Stage 4: QA
+
+Verifies that the build succeeds and tests pass. Automatically fixes failures and re-verifies.
+
+### Stage 5: Validation
+
+Specialist agents perform a final review of functionality, security, and code quality. Work is complete once all pass.
+
+### HUD status display
+
+While work is in progress, you can monitor the current state in the Claude Code status bar (HUD):
+
+```
+[OMC] autopilot:execution | agents:3 | todos:2/5 | ctx:45%
+```
+
+| Field | Meaning |
+|-------|---------|
+| `autopilot:execution` | Current stage within the autopilot pipeline |
+| `agents:3` | Number of currently active agents |
+| `todos:2/5` | Completed tasks / total tasks |
+| `ctx:45%` | Context window usage percentage |
+
+To configure the HUD display, run:
+
+```bash
+/oh-my-claudecode:hud setup
+```
+
+### Starting smaller
+
+If autopilot feels too large, start with a single-task command:
+
+```bash
+# Code analysis
+analyze why this test is failing
+
+# File search
+deepsearch for files that handle authentication
+
+# Simple implementation
+ultrawork add a health check endpoint
+```
+
+These keywords invoke a single appropriate agent directly, without running the full pipeline.
+
+### Next steps
+
+- [Configuration](#configuration) - Adjust agent models and features for your project
+- [Concepts](/docs/concepts) - Understand the relationship between agents, skills, and hooks
+
+---
+
+## Configuration
+
+OMC supports two levels of configuration files.
+
+| Scope | File path | Purpose |
+|-------|-----------|---------|
+| User (global) | `~/.config/claude-omc/config.jsonc` | Applied to all projects |
+| Project | `.claude/omc.jsonc` | Applied to current project only |
+
+> ⚠️ **Warning:** The configuration file format is JSONC (JSON with comments support). It is not a TypeScript config file (`omc.config.ts`).
+
+### Configuration priority
+
+When settings exist from multiple sources, they are merged in the following order (lower entries take precedence):
+
+```
+Defaults → User config (~/.config/claude-omc/config.jsonc)
+         → Project config (.claude/omc.jsonc)
+         → Environment variables
+```
+
+### Basic configuration structure
+
+```jsonc
+{
+  // Per-agent model assignments
+  "agents": {
+    "explore": { "model": "haiku" },
+    "executor": { "model": "sonnet" },
+    "architect": { "model": "opus" }
+  },
+
+  // Feature toggles
+  "features": {
+    "parallelExecution": true,
+    "lspTools": true,
+    "astTools": true
+  },
+
+  // Magic keyword customization
+  "magicKeywords": {
+    "ultrawork": ["ultrawork", "ulw", "uw"],
+    "search": ["search", "find", "locate"],
+    "analyze": ["analyze", "investigate", "examine"],
+    "ultrathink": ["ultrathink", "think", "reason"]
+  }
+}
+```
+
+### Overriding agent models
+
+You can change the AI model used by each agent:
+
+```jsonc
+{
+  "agents": {
+    // Upgrade explore agent to a stronger model
+    "explore": { "model": "sonnet" },
+
+    // Upgrade executor to opus for complex projects
+    "executor": { "model": "opus" },
+
+    // Cost saving: use haiku for documentation writing
+    "writer": { "model": "haiku" }
+  }
+}
+```
+
+#### Default model mapping
+
+| Agent | Default model | Role |
+|-------|--------------|------|
+| `explore` | haiku | Codebase discovery |
+| `writer` | haiku | Documentation writing |
+| `executor` | sonnet | Code implementation |
+| `debugger` | sonnet | Debugging |
+| `designer` | sonnet | UI/UX design |
+| `verifier` | sonnet | Verification |
+| `tracer` | sonnet | Evidence-driven causal tracing |
+| `security-reviewer` | sonnet | Security vulnerabilities and trust boundaries |
+| `test-engineer` | sonnet | Test strategy and coverage |
+| `qa-tester` | sonnet | Interactive CLI/service runtime validation |
+| `scientist` | sonnet | Data and statistical analysis |
+| `git-master` | sonnet | Git operations and history management |
+| `document-specialist` | sonnet | External documentation and API reference lookup |
+| `architect` | opus | System design |
+| `planner` | opus | Strategic planning |
+| `critic` | opus | Plan review |
+| `analyst` | opus | Requirements analysis |
+| `code-reviewer` | opus | Comprehensive code review |
+| `code-simplifier` | opus | Code clarity and simplification |
+
+### Customizing magic keywords
+
+You can change keywords in four categories via the `magicKeywords` section of `config.jsonc`:
+
+```jsonc
+{
+  "magicKeywords": {
+    // Triggers parallel execution mode
+    "ultrawork": ["ultrawork", "ulw", "parallel"],
+
+    // Triggers codebase search mode
+    "search": ["search", "find", "locate", "grep"],
+
+    // Triggers analysis mode
+    "analyze": ["analyze", "debug", "investigate"],
+
+    // Triggers deep reasoning mode
+    "ultrathink": ["ultrathink", "think", "reason"]
+  }
+}
+```
+
+> ℹ️ **Note:** The `magicKeywords` section in `config.jsonc` only allows customizing four categories: `ultrawork`, `search`, `analyze`, and `ultrathink`. Keywords such as `autopilot`, `ralph`, and `ccg` are hardcoded in the keyword-detector hook and cannot be changed via config files.
+
+### Model routing configuration
+
+OMC automatically selects a model tier based on task complexity:
+
+```jsonc
+{
+  "routing": {
+    "enabled": true,
+    "defaultTier": "MEDIUM",
+    // Force all agents to inherit the parent model
+    // (auto-activated when using CC Switch, Bedrock, or Vertex AI)
+    "forceInherit": false
+  }
+}
+```
+
+| Tier | Model | Use case |
+|------|-------|----------|
+| LOW | haiku | Quick lookups, simple tasks |
+| MEDIUM | sonnet | Standard implementation, general tasks |
+| HIGH | opus | Architecture, deep analysis |
+
+### CLAUDE.md configuration
+
+OMC's default behavior is also configured via `CLAUDE.md` files. Running `/oh-my-claudecode:omc-setup` generates this file automatically.
+
+| Scope | File | Description |
+|-------|------|-------------|
+| Global | `~/.claude/CLAUDE.md` | Shared settings across all projects |
+| Project | `.claude/CLAUDE.md` | Per-project context and overrides |
+
+### When to re-run setup
+
+- After initial installation
+- After an OMC update (to apply the latest configuration)
+- When switching to a different machine
+- When starting a new project (use the `--local` option)

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,0 +1,462 @@
+# Hooks System
+
+> OMC's 20 hooks intercept Claude Code lifecycle events to enable magic keywords, context injection, and quality enforcement.
+
+## What Are Hooks?
+
+Hooks are scripts that execute automatically in response to Claude Code lifecycle events. oh-my-claudecode extends Claude Code's default behavior with 20 hooks.
+
+When a user submits a prompt, a tool runs, or a session starts/ends, hooks fire automatically to inject additional context, activate modes, and manage state.
+
+## How Hooks Work
+
+Hooks are defined in a `hooks.json` file. Each hook follows this structure:
+
+```json
+{
+  "EventName": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node scripts/hook-script.mjs",
+          "timeout": 5
+        }
+      ]
+    }
+  ]
+}
+```
+
+- **EventName**: The lifecycle event the hook responds to
+- **matcher**: Condition for running the hook (`*` matches all cases)
+- **command**: The Node.js script to execute
+- **timeout**: Maximum execution time in seconds
+
+Hook output is injected into Claude via `<system-reminder>` tags. Additional context is passed through `hookSpecificOutput.additionalContext`.
+
+## Hook Categories
+
+OMC hooks fall into four categories:
+
+### Core Hooks
+
+Handle orchestration, keyword detection, and mode persistence.
+
+| Hook | Description |
+|------|-------------|
+| keyword-detector | Detects magic keywords and activates corresponding skills |
+| persistent-mode | Enforces continuation when an execution mode (ralph, autopilot, ultrawork, etc.) is active — injects reinforcement messages on Stop to prevent premature halting |
+
+### Context Management Hooks
+
+Manage memory, project state, and compaction.
+
+| Hook | Description |
+|------|-------------|
+| notepad | Compaction-resistant memory system |
+| project-memory | Manages project-level memory |
+| pre-compact | Processes state before compaction |
+
+### Quality / Verification Hooks
+
+Handle code quality, permissions, and subagent tracking.
+
+| Hook | Description |
+|------|-------------|
+| permission-handler | Handles permission requests and validation |
+| subagent-tracker | Tracks subagent spawn and completion |
+| code-simplifier | Auto-simplifies recently modified files on Stop (opt-in) |
+
+## Disabling Hooks
+
+### Disable All Hooks
+
+```bash
+export DISABLE_OMC=1
+```
+
+### Disable Specific Hooks
+
+```bash
+export OMC_SKIP_HOOKS="keyword-detector,notepad"
+```
+
+Separate hook names with commas to skip only those hooks.
+
+---
+
+## Lifecycle Events
+
+Claude Code emits events throughout a session. OMC attaches hooks to these events to extend behavior. There are 11 lifecycle events.
+
+### UserPromptSubmit
+
+Fires when the user submits a prompt.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `keyword-detector.mjs` | Detects magic keywords and invokes the corresponding skill | 5s |
+| `skill-injector.mjs` | Injects skill prompts | 3s |
+
+Runs on all user input (`matcher: "*"`). When the keyword detector finds keywords like "ultrawork", "ralph", or "autopilot", it injects the corresponding skill invocation instruction via `additionalContext`.
+
+### SessionStart
+
+Fires when a new session begins.
+
+| Script | Matcher | Role | Timeout |
+|--------|---------|------|---------|
+| `session-start.mjs` | `*` | Session initialization, state restoration | 5s |
+| `project-memory-session.mjs` | `*` | Loads project memory | 5s |
+| `setup-init.mjs` | `init` | Initial setup wizard | 30s |
+| `setup-maintenance.mjs` | `maintenance` | Maintenance tasks | 60s |
+
+The `init` and `maintenance` matchers only run in special cases. For normal session starts, only the two `*` matcher scripts execute.
+
+### PreToolUse
+
+Fires immediately before Claude uses a tool.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `pre-tool-enforcer.mjs` | Validates rules before tool use | 3s |
+
+Runs on all tool calls (`matcher: "*"`). Enforces agent permission restrictions (e.g., blocking Write/Edit for read-only agents).
+
+### PermissionRequest
+
+Fires when a permission request arises during Bash tool execution.
+
+| Script | Matcher | Role | Timeout |
+|--------|---------|------|---------|
+| `permission-handler.mjs` | `Bash` | Handles Bash command permissions | 5s |
+
+Only processes permission requests for the Bash tool.
+
+### PostToolUse
+
+Fires after a tool use completes.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `post-tool-verifier.mjs` | Verifies tool results and injects additional context | 3s |
+| `project-memory-posttool.mjs` | Updates project memory | 3s |
+
+Injects additional guidance based on Read, Write, Edit, and Bash results. For example, after reading a file it may hint "consider using parallel reads."
+
+### PostToolUseFailure
+
+Fires when a tool use fails.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `post-tool-use-failure.mjs` | Provides recovery guidance for failed tool use | 3s |
+
+### SubagentStart
+
+Fires when a subagent is spawned.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `subagent-tracker.mjs start` | Tracks subagent start, injects prompts | 3s |
+
+Records the subagent name, start time, and session information.
+
+### SubagentStop
+
+Fires when a subagent completes.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `subagent-tracker.mjs stop` | Tracks subagent completion | 5s |
+| `verify-deliverables.mjs` | Verifies subagent deliverables | 5s |
+
+### PreCompact
+
+Fires immediately before context compaction.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `pre-compact.mjs` | Preserves state before compaction | 10s |
+| `project-memory-precompact.mjs` | Preserves project memory | 5s |
+
+Saves important state and memory before compaction runs because the context window is full.
+
+### Stop
+
+Fires when Claude finishes a response.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `context-guard-stop.mjs` | Monitors context usage | 5s |
+| `persistent-mode.cjs` | Maintains active mode state (ralph, ultrawork, etc.) | 10s |
+| `code-simplifier.mjs` | Auto-simplifies modified files (opt-in) | 5s |
+
+`persistent-mode` injects a reinforcement message like "The boulder never stops" when an active execution mode is running, prompting continued work.
+
+### SessionEnd
+
+Fires when a session ends.
+
+| Script | Role | Timeout |
+|--------|------|---------|
+| `session-end.mjs` | Saves session summary, sends callback notifications | 30s |
+
+Saves agent activity, token usage, and other session data to `.omc/sessions/`. If configured, sends completion notifications via Discord, Telegram, or Slack.
+
+---
+
+## Core Hooks
+
+### Core Hook Details
+
+#### keyword-detector
+
+Detects magic keywords in user prompts and invokes the corresponding skill.
+
+- **Event**: UserPromptSubmit
+- **Behavior**: Sanitizes the prompt (removes code blocks, URLs, file paths) then matches keyword patterns
+- **Conflict resolution**: cancel has highest priority, then ralph > autopilot > ultrawork
+- **Safety**: Disabled inside team workers to prevent infinite spawning
+
+See the [Magic Keywords](#magic-keywords) section for the full keyword list.
+
+#### persistent-mode
+
+Enforces continuation when an execution mode is active. This is the hook that keeps skills like autopilot, ralph, and ultrawork running.
+
+- **Event**: Stop
+- **Behavior**: Checks `.omc/state/` for active mode state files. If any mode (ralph, autopilot, ultrawork, ultraqa, team, pipeline) is active, injects a reinforcement message to prevent Claude from stopping.
+- **Reinforcement message**: "The boulder never stops" — prompts Claude to continue working
+- **Staleness check**: States older than 2 hours are treated as inactive to prevent stale state from blocking new sessions
+- **Notification**: Sends Discord/Telegram/Slack notification on first stop (if configured)
+- **Cancel**: Use `/oh-my-claudecode:cancel` to deactivate modes
+
+> **Note**: autopilot, ralph, ultrawork, and ultraqa are **skills** (invoked via keyword-detector), not hooks. The persistent-mode hook is what enforces their continuation by blocking the Stop event.
+
+### Mode State Management
+
+Execution mode hooks manage state files in the `.omc/state/` directory.
+
+```json
+{
+  "active": true,
+  "started_at": "2025-01-15T10:30:00Z",
+  "prompt": "ultrawork implement auth",
+  "session_id": "abc123",
+  "project_path": "/path/to/project",
+  "iteration": 0,
+  "max_iterations": 10,
+  "linked_ultrawork": false,
+  "last_checked_at": "2025-01-15T10:30:00Z"
+}
+```
+
+When a session ID is present, state is stored in session scope under `.omc/state/sessions/{sessionId}/`.
+
+#### Canceling a Mode
+
+```
+cancelomc
+```
+
+or
+
+```
+/oh-my-claudecode:cancel
+```
+
+`cancel` removes state files for all active modes: ralph, autopilot, ultrawork, and any others.
+
+---
+
+## Context Management Hooks
+
+Claude Code's context window is finite. During long sessions, compaction occurs and previous conversation content is summarized. OMC's context management hooks prepare for compaction, preserve important information, and maintain project-level memory.
+
+### notepad
+
+A compaction-resistant memory system.
+
+- **Storage path**: `.omc/notepad.md`
+- **MCP tools**: `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`
+- **Behavior**: Information written to the notepad persists after compaction
+
+The notepad supports three priority levels:
+
+| Priority | Tool | Description |
+|----------|------|-------------|
+| Priority | `notepad_write_priority` | Information that must never be lost |
+| Working | `notepad_write_working` | Current work-in-progress status |
+| Manual | `notepad_write_manual` | Manually recorded notes |
+
+Use `notepad_prune` to clean up old entries and `notepad_stats` to check status.
+
+### project-memory
+
+Manages permanent project-level memory.
+
+- **Storage path**: `.omc/project-memory.json`
+- **MCP tools**: `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
+- **Related hooks**:
+  - `project-memory-session.mjs` (SessionStart): Loads project memory when session starts
+  - `project-memory-posttool.mjs` (PostToolUse): Updates memory after tool use
+  - `project-memory-precompact.mjs` (PreCompact): Preserves memory before compaction
+
+Two types of data are stored in project-memory:
+
+- **Notes**: Learned facts about the project (architecture patterns, bug history, etc.)
+- **Directives**: Instructions to follow when working on the project
+
+### pre-compact
+
+Preserves important state immediately before compaction.
+
+- **Event**: PreCompact
+- **Behavior**: Summarizes and preserves the current work state, in-progress TODOs, and critical context
+- **Purpose**: Retains essential information so work can resume after compaction
+
+### Context Preservation Strategy
+
+OMC's context management hooks cooperate with the following strategy:
+
+```
+Session Start
+  → Load project-memory
+    → [Work in progress]
+    → Write important info to notepad
+    → Update project-memory
+      → [Compaction fires]
+      → pre-compact preserves state
+      → project-memory preserved
+        → [After compaction]
+        → Restored via notepad / project-memory
+```
+
+---
+
+## Magic Keywords
+
+Magic keywords automatically activate OMC skills or execution modes when specific words or patterns are detected in the user's natural language prompt. No slash command is needed — include a keyword in your prompt and the feature activates automatically.
+
+### How keyword-detector Works
+
+`keyword-detector.mjs` runs on the UserPromptSubmit event.
+
+1. Receives the user prompt and sanitizes it
+2. Removes code blocks, XML tags, URLs, and file paths to prevent false positives
+3. Matches keyword patterns against the sanitized text
+4. Resolves conflicts, then injects the skill invocation instruction
+
+**Safety measures:**
+
+- **Sanitization**: Keywords inside code blocks, within URLs, or in file paths are ignored
+- **Team worker protection**: Disabled when the `OMC_TEAM_WORKER` environment variable is set (prevents infinite spawning)
+- **Disable**: Set `DISABLE_OMC=1` or `OMC_SKIP_HOOKS=keyword-detector`
+
+### Execution Mode Keywords
+
+These keywords invoke a skill and create a state file.
+
+| Keyword | Skill | Description |
+|---------|-------|-------------|
+| `cancelomc`, `stopomc` | cancel | Cancels all active modes |
+| `ralph`, `don't stop`, `must complete`, `until done` | ralph | Persistent execution until verification completes |
+| `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `auto-pilot`, `full auto`, `fullsend`, `e2e this` | autopilot | Fully autonomous execution |
+| `ultrawork`, `ulw`, `uw` | ultrawork | Maximum parallel execution |
+| `ccg`, `claude-codex-gemini` | ccg | Claude-Codex-Gemini tri-model orchestration |
+| `ralplan` | ralplan | Consensus-based iterative planning |
+| `deep interview`, `ouroboros` | deep-interview | Socratic deep interview |
+
+### AI Slop Cleanup Keywords
+
+Supports two pattern types:
+
+**Explicit patterns** (activate on their own):
+
+- `ai-slop`, `anti-slop`, `deslop`, `de-slop`
+
+**Combination patterns** (activate when an action keyword is combined with a smell keyword):
+
+| Action Keywords | Smell Keywords |
+|----------------|----------------|
+| `cleanup`, `refactor`, `simplify`, `dedupe`, `prune` | `slop`, `duplicate`, `dead code`, `unused code`, `over-abstraction`, `wrapper layers`, `needless abstractions`, `ai-generated`, `tech debt` |
+
+Example: "cleanup the duplicate code" → activates the ai-slop-cleaner skill.
+
+### Agent Shortcut Keywords
+
+Activate agents with natural language instead of slash commands.
+
+| Keyword | Effect | Behavior |
+|---------|--------|----------|
+| `tdd`, `test first`, `red green` | TDD mode | Enforces test-first writing |
+| `code review`, `review code` | Code review mode | Runs comprehensive code review |
+| `security review`, `review security` | Security review mode | Runs security-focused review |
+
+These keywords inject an inline mode message rather than invoking a skill.
+
+### Reasoning Enhancement Keywords
+
+| Keyword | Effect |
+|---------|--------|
+| `ultrathink`, `think hard`, `think deeply` | Activates extended reasoning mode |
+| `deepsearch`, `search the codebase`, `find in codebase` | Activates codebase-focused search mode |
+| `deep-analyze`, `deepanalyze` | Activates deep analysis mode |
+
+### Priority and Conflict Resolution
+
+When multiple keywords are detected simultaneously, they resolve by the following priority:
+
+```
+cancel  (highest priority, exclusive)
+  → ralph
+    → autopilot
+      → ultrawork
+        → ccg
+          → ralplan
+            → deep-interview
+              → ai-slop-cleaner
+                → tdd
+                  → code-review
+                    → security-review
+                      → ultrathink
+                        → deepsearch
+                          → analyze
+```
+
+`cancel` is exclusive — it ignores all other matches and only runs the cancel action. All other keywords can be matched together and are processed in priority order.
+
+### Usage Examples
+
+```bash
+# In Claude Code:
+
+# Autonomous execution
+autopilot: implement user authentication with OAuth
+
+# Parallel execution
+ultrawork write all tests for this module
+
+# Persistent execution
+ralph refactor this authentication module
+
+# TDD
+implement password validation with tdd
+
+# Code review
+code review the recent changes
+
+# Cancel
+stopomc
+```
+
+### Note on the `team` Keyword
+
+`team` is not auto-detected. It must be invoked explicitly via the `/team` slash command to prevent infinite spawning.
+
+```
+/oh-my-claudecode:team 3:executor "build a fullstack todo app"
+```

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,781 @@
+# MCP Tools
+
+> OMC provides MCP tools for state management, code intelligence, and data analysis.
+
+Unlike skills that users invoke directly, tools are used internally by agents during task execution.
+
+## Tool Categories
+
+- [State](#state) — Manage execution mode state
+- [Notepad](#notepad) — Persistent notes that survive context compaction
+- [Project Memory](#project-memory) — Long-term per-project memory across sessions
+- [LSP](#lsp) — Language Server Protocol code intelligence (12 tools)
+- [AST Grep](#ast-grep) — Structural AST-based code search and replacement
+- [Python REPL](#python-repl) — Persistent Python execution environment
+- [Session Search](#session-search) — Search previous session history
+- [Trace](#trace) — Agent flow trace analysis
+- [Shared Memory](#shared-memory) — Cross-agent shared memory for team coordination
+- [Skills](#skills) — Internal skill management tools
+- [Deepinit Manifest](#deepinit-manifest) — Incremental AGENTS.md regeneration manifest
+
+---
+
+## State
+
+State tools manage the state of OMC execution modes (autopilot, ralph, ultrawork, etc.). Each mode records its current progress, active status, and configuration in state files.
+
+### Storage Path
+
+```
+.omc/state/
+├── sessions/{sessionId}/     # Session-scoped state
+│   ├── autopilot-state.json
+│   ├── ralph-state.json
+│   └── ultrawork-state.json
+├── autopilot-state.json      # Legacy fallback
+├── ralph-state.json
+└── ultrawork-state.json
+```
+
+When a session ID is provided, the session-scoped path is used; otherwise the legacy path is used as a fallback.
+
+### Tools
+
+#### `state_read`
+
+Reads the state for a given mode.
+
+```
+state_read(mode="ralph")
+state_read(mode="ralph", session_id="abc123")
+```
+
+Returns an empty response if no state file exists.
+
+#### `state_write`
+
+Saves the state for a given mode.
+
+```
+state_write(mode="ralph", state={
+  active: true,
+  current_phase: "execution",
+  iteration: 3,
+  max_iterations: 10
+})
+```
+
+#### `state_clear`
+
+Deletes the state file for a given mode.
+
+```
+state_clear(mode="ralph")
+state_clear(mode="ralph", session_id="abc123")
+```
+
+When called without a session ID, clears the legacy file.
+
+#### `state_list_active`
+
+Lists all currently active sessions.
+
+```
+state_list_active()
+```
+
+Returns all session IDs and their corresponding modes under `.omc/state/sessions/`.
+
+#### `state_get_status`
+
+Returns a status summary for a specific session.
+
+```
+state_get_status(session_id="abc123")
+```
+
+Includes the active mode name and whether dependent modes exist.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OMC_STATE_DIR` | (unset) | Centralized state directory. When set, state persists even if the worktree is deleted. |
+
+When `OMC_STATE_DIR` is set, state is stored at `$OMC_STATE_DIR/{project-id}/`.
+
+```bash
+export OMC_STATE_DIR="$HOME/.claude/omc"
+```
+
+### Usage Patterns
+
+**Activate a mode:**
+
+```
+state_write(mode="autopilot", state={
+  active: true,
+  current_phase: "expansion",
+  started_at: "2024-01-15T09:00:00Z"
+})
+```
+
+**Deactivate a mode:**
+
+```
+state_clear(mode="autopilot")
+```
+
+**Check active modes:**
+
+```
+state_list_active()
+→ [{session_id: "abc123", mode: "ralph", active: true}]
+```
+
+---
+
+## Notepad
+
+Notepad is a persistent note system that survives context window compaction. In long sessions, when important information from early in the conversation is pushed out of context, notes saved to Notepad are restored after compaction.
+
+### Storage Path
+
+```
+.omc/notepad.md
+```
+
+### Tools
+
+#### `notepad_read`
+
+Reads the full contents of the notepad.
+
+```
+notepad_read()
+```
+
+#### `notepad_write_priority`
+
+Saves a note at the highest priority. Restored first during compaction.
+
+```
+notepad_write_priority(content="This project uses TypeScript strict mode")
+```
+
+Use for architecture decisions, critical constraints, and information that must never be forgotten.
+
+#### `notepad_write_working`
+
+Saves the current working context. General-purpose notes.
+
+```
+notepad_write_working(content="Currently refactoring auth module, 3/5 files done")
+```
+
+Use for progress tracking, next steps, and information discovered during work.
+
+#### `notepad_write_manual`
+
+Manually saves a note at a specific location.
+
+```
+notepad_write_manual(content="Bug: sessionId undefined at session.ts:45")
+```
+
+#### `notepad_prune`
+
+Cleans up old or unnecessary notes.
+
+```
+notepad_prune()
+```
+
+#### `notepad_stats`
+
+Returns statistics about the notepad (entry count, size, etc.).
+
+```
+notepad_stats()
+```
+
+### Usage Patterns
+
+**Record an important decision:**
+
+```
+notepad_write_priority(content="DB migration: PostgreSQL → MySQL is forbidden. Existing query compatibility issue.")
+```
+
+**Track work progress:**
+
+```
+notepad_write_working(content="TODO: 1. Fix auth module ✓  2. Add tests  3. Update docs")
+```
+
+**Restore context when resuming a session:**
+
+```
+notepad_read()
+→ "Currently refactoring auth. src/auth/login.ts done. Next: src/auth/session.ts"
+```
+
+### Compaction Behavior
+
+When Claude Code compacts context:
+
+1. Notepad contents are included in the compaction result
+2. Priority notes are restored first
+3. Working notes are restored next
+4. Pruned notes are excluded
+
+Core context is preserved even in very long sessions.
+
+---
+
+## Project Memory
+
+Project Memory manages long-term per-project memory. It persists project structure, rules, learned knowledge, and directives across sessions, enabling agents to quickly understand project context.
+
+### Storage Path
+
+```
+.omc/project-memory.json
+```
+
+### Tools
+
+#### `project_memory_read`
+
+Reads the full contents of project memory.
+
+```
+project_memory_read()
+```
+
+Returns all stored notes and directives for the project.
+
+#### `project_memory_write`
+
+Overwrites project memory entirely.
+
+```
+project_memory_write(content={
+  notes: ["Uses TypeScript strict mode", "Tests use vitest"],
+  directives: ["JSDoc required on all functions"]
+})
+```
+
+> **Warning:** This completely replaces existing content. For partial updates, use `project_memory_add_note` or `project_memory_add_directive` instead.
+
+#### `project_memory_add_note`
+
+Adds a note about the project.
+
+```
+project_memory_add_note(note="src/utils/ should contain pure functions only")
+```
+
+Use for project structure, patterns, and learned knowledge.
+
+#### `project_memory_add_directive`
+
+Adds a directive that agents must follow.
+
+```
+project_memory_add_directive(directive="Use structured logging instead of console.log")
+```
+
+Use for coding rules, prohibitions, and requirements.
+
+### Notes vs Directives
+
+| | Notes | Directives |
+|---|---|---|
+| Nature | Information, observations, learned knowledge | Rules, constraints, requirements |
+| Example | "This project uses a monorepo structure" | "No PRs without tests" |
+| Agent behavior | Used as reference for decisions | Must be strictly followed |
+
+### Notepad vs Project Memory
+
+| | Notepad | Project Memory |
+|---|---|---|
+| Scope | Current session | Entire project (persists across sessions) |
+| Purpose | In-progress notes | Project rules, structure, learned knowledge |
+| File | `.omc/notepad.md` | `.omc/project-memory.json` |
+| Compaction | Restored during compaction | Always available |
+
+### Usage Patterns
+
+**Register project rules:**
+
+```
+project_memory_add_directive("This repo uses conventional commits")
+project_memory_add_directive("Files under src/generated/ must not be edited manually")
+```
+
+**Record codebase structure:**
+
+```
+project_memory_add_note("API layer: src/api/ → src/services/ → src/repositories/")
+project_memory_add_note("Auth: JWT + passport.js, implemented in src/auth/")
+```
+
+**Record learned knowledge:**
+
+```
+project_memory_add_note("tsconfig paths settings need to be kept in sync with jest.config")
+```
+
+---
+
+## LSP
+
+LSP tools provide Language Server Protocol-based code intelligence: type information, go-to-definition, find references, error diagnostics, symbol search, and renaming.
+
+A language server must be installed (e.g., `typescript-language-server`, `pylsp`, `rust-analyzer`, `gopls`). Use `lsp_servers()` to check installation status.
+
+### Tools
+
+#### `lsp_hover`
+
+Returns type information and documentation at the specified position.
+
+```
+lsp_hover(file="src/auth.ts", line=42, character=10)
+```
+
+#### `lsp_goto_definition`
+
+Navigates to the definition of a symbol.
+
+```
+lsp_goto_definition(file="src/auth.ts", line=42, character=10)
+```
+
+#### `lsp_find_references`
+
+Finds all usage locations of a symbol.
+
+```
+lsp_find_references(file="src/auth.ts", line=42, character=10)
+```
+
+#### `lsp_document_symbols`
+
+Returns the structural outline of a file (functions, classes, interfaces, etc.).
+
+```
+lsp_document_symbols(file="src/auth.ts")
+```
+
+#### `lsp_workspace_symbols`
+
+Searches for symbols across the entire workspace.
+
+```
+lsp_workspace_symbols(query="UserConfig")
+```
+
+#### `lsp_diagnostics`
+
+Returns errors, warnings, and hints for a file.
+
+```
+lsp_diagnostics(file="src/auth.ts")
+```
+
+Useful for immediately checking type errors after a code change.
+
+#### `lsp_diagnostics_directory`
+
+Returns diagnostics for an entire directory or project.
+
+```
+lsp_diagnostics_directory(path="src/")
+```
+
+Use after complex multi-file changes to check project-wide type errors.
+
+#### `lsp_prepare_rename`
+
+Checks whether a rename operation at the given position is valid.
+
+```
+lsp_prepare_rename(file="src/auth.ts", line=42, character=10)
+```
+
+#### `lsp_rename`
+
+Renames a symbol across the entire project.
+
+```
+lsp_rename(file="src/auth.ts", line=42, character=10, newName="AuthService")
+```
+
+#### `lsp_code_actions`
+
+Returns available refactoring actions for a range.
+
+```
+lsp_code_actions(file="src/auth.ts", startLine=40, endLine=50)
+```
+
+#### `lsp_code_action_resolve`
+
+Returns detailed information for a specific code action.
+
+```
+lsp_code_action_resolve(action=<action_object>)
+```
+
+#### `lsp_servers`
+
+Returns the list of available language servers and their installation status.
+
+```
+lsp_servers()
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OMC_LSP_TIMEOUT_MS` | `15000` | LSP request timeout in ms. Increase for large repos or slow servers. |
+
+### Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| LSP tools not working | Install the language server: `npm install -g typescript-language-server` |
+| Timeout errors | Increase `OMC_LSP_TIMEOUT_MS` |
+| Check server status | Run `lsp_servers()` to verify installation |
+
+---
+
+## AST Grep
+
+AST Grep tools use [@ast-grep/napi](https://ast-grep.github.io/) to search and replace structural code patterns. Because it operates on AST (Abstract Syntax Tree) rather than regex, it matches code structure precisely.
+
+### Tools
+
+#### `ast_grep_search`
+
+Searches code using AST patterns.
+
+```
+ast_grep_search(
+  pattern="console.log($$$ARGS)",
+  lang="typescript"
+)
+```
+
+**Meta variables:**
+
+| Meta Variable | Description | Example |
+|---|---|---|
+| `$VAR` | Matches a single AST node | `$VAR.map($FUNC)` |
+| `$$$` | Matches multiple AST nodes | `console.log($$$ARGS)` |
+
+**Examples:**
+
+```
+# Find all console.log calls
+ast_grep_search(pattern="console.log($$$)", lang="typescript")
+
+# Find specific fetch call patterns
+ast_grep_search(pattern="fetch($URL, { method: 'POST', $$$REST })", lang="typescript")
+
+# Find React useState usage
+ast_grep_search(pattern="const [$STATE, $SETTER] = useState($INIT)", lang="tsx")
+
+# Find try-catch blocks
+ast_grep_search(pattern="try { $$$ } catch($ERR) { $$$ }", lang="typescript")
+```
+
+#### `ast_grep_replace`
+
+Replaces code using structural AST patterns.
+
+```
+ast_grep_replace(
+  pattern="console.log($$$ARGS)",
+  replacement="logger.info($$$ARGS)",
+  lang="typescript",
+  dryRun=true
+)
+```
+
+> **Always run with `dryRun=true` first to review changes before applying.**
+
+**Examples:**
+
+```
+# Replace console.log with logger.info
+ast_grep_replace(
+  pattern="console.log($$$ARGS)",
+  replacement="logger.info($$$ARGS)",
+  lang="typescript",
+  dryRun=true
+)
+
+# Convert synchronous functions to async
+ast_grep_replace(
+  pattern="function $NAME($$$PARAMS) { $$$BODY }",
+  replacement="async function $NAME($$$PARAMS) { $$$BODY }",
+  lang="typescript",
+  dryRun=true
+)
+```
+
+### AST Grep vs Regex
+
+| | Regex (Grep) | AST Grep |
+|---|---|---|
+| Matches against | Text patterns | Code structure |
+| Whitespace/newlines | Sensitive | Irrelevant |
+| Comments | Matched | Skipped |
+| Refactoring safety | Risky | Structure-preserving |
+| Use case | Text search | Code transformation |
+
+### Supported Languages
+
+TypeScript, JavaScript, TSX, JSX, Python, Go, Rust, Java, C, C++, C#, Ruby, Swift, Kotlin, and most major programming languages.
+
+---
+
+## Python REPL
+
+Python REPL is a Python execution environment where state persists across calls within a session. Used for data analysis, statistical computation, visualization, and prototyping.
+
+### Tool
+
+#### `python_repl`
+
+Executes Python code and returns the result.
+
+```
+python_repl(code="import json; data = json.loads('{\"key\": \"value\"}'); print(data)")
+```
+
+### Features
+
+**Persistent state:** Variables, functions, and imports defined in one call remain available in subsequent calls.
+
+```python
+# First call
+python_repl(code="import pandas as pd; df = pd.read_csv('data.csv')")
+
+# Second call (df is still available)
+python_repl(code="print(df.describe())")
+```
+
+**Data analysis:**
+
+```python
+python_repl(code="""
+import json
+with open('.omc/research/session-1/state.json') as f:
+    state = json.load(f)
+print(f"Stages: {len(state['stages'])}")
+print(f"Status: {state['status']}")
+""")
+```
+
+**Computation and transformation:**
+
+```python
+python_repl(code="""
+# Token cost estimation
+input_tokens = 150000
+output_tokens = 50000
+cost = (input_tokens * 0.003 + output_tokens * 0.015) / 1000
+print(f"Estimated cost: ${cost:.4f}")
+""")
+```
+
+**File processing:**
+
+```python
+python_repl(code="""
+import os
+
+# Project file statistics
+extensions = {}
+for root, dirs, files in os.walk('src'):
+    for f in files:
+        ext = os.path.splitext(f)[1]
+        extensions[ext] = extensions.get(ext, 0) + 1
+
+for ext, count in sorted(extensions.items(), key=lambda x: -x[1]):
+    print(f"{ext}: {count} files")
+""")
+```
+
+### Use Cases
+
+| Use Case | Description |
+|----------|-------------|
+| Data analysis | Analyze CSV/JSON files, compute statistics |
+| Prototyping | Validate algorithms, test logic |
+| File processing | File transformation, batch processing |
+| Visualization | Generate charts with matplotlib or plotly |
+| Computation | Math calculations, cost estimation |
+
+### Integration with scientist Agent
+
+The `scientist` agent uses `python_repl` for data analysis tasks.
+
+---
+
+## Session Search
+
+Search previous local session history and transcript artifacts.
+
+### Tool
+
+#### `session_search`
+
+Searches session history and returns matching excerpts.
+
+```
+session_search(query="authentication refactor")
+```
+
+Returns session IDs, timestamps, source paths, and matching excerpts as structured JSON.
+
+---
+
+## Trace
+
+Analyze agent flow trace data for debugging and performance analysis.
+
+### Tools
+
+#### `trace_timeline`
+
+Displays hooks, keywords, skills, agents, and tools in chronological order.
+
+```
+trace_timeline()
+```
+
+#### `trace_summary`
+
+Aggregates hook statistics, keyword frequency, skill activations, mode transitions, and tool bottlenecks.
+
+```
+trace_summary()
+```
+
+---
+
+## Shared Memory
+
+Cross-agent shared memory for team coordination. Enables agents to share data across team boundaries during coordinated workflows.
+
+### Tools
+
+#### `shared_memory_write`
+
+Writes a value to shared memory.
+
+```
+shared_memory_write(key="auth-spec", value="JWT with refresh tokens")
+```
+
+#### `shared_memory_read`
+
+Reads a value from shared memory.
+
+```
+shared_memory_read(key="auth-spec")
+```
+
+#### `shared_memory_list`
+
+Lists all keys in shared memory.
+
+```
+shared_memory_list()
+```
+
+#### `shared_memory_delete`
+
+Deletes a key from shared memory.
+
+```
+shared_memory_delete(key="auth-spec")
+```
+
+#### `shared_memory_cleanup`
+
+Removes all entries from shared memory.
+
+```
+shared_memory_cleanup()
+```
+
+---
+
+## Skills
+
+Internal skill management tools used by the runtime to load and list available skills.
+
+### Tools
+
+#### `load_omc_skills_local`
+
+Loads skills from the local project directory (`.omc/skills/`).
+
+```
+load_omc_skills_local()
+```
+
+#### `load_omc_skills_global`
+
+Loads skills from the global user directory (`~/.claude/skills/`).
+
+```
+load_omc_skills_global()
+```
+
+#### `list_omc_skills`
+
+Lists all available OMC skills (built-in + local + global).
+
+```
+list_omc_skills()
+```
+
+---
+
+## Deepinit Manifest
+
+Manages the manifest for incremental AGENTS.md regeneration. Compares directory file lists to detect structural changes, enabling the `deepinit` skill to only regenerate documentation for directories that have changed.
+
+### Tool
+
+#### `deepinit_manifest`
+
+Manages the deepinit manifest with three actions.
+
+**diff** — Find directories with structural changes since last generation:
+
+```
+deepinit_manifest(action="diff")
+```
+
+**save** — Persist the current directory structure as the new baseline:
+
+```
+deepinit_manifest(action="save")
+```
+
+**check** — Validate the existing manifest:
+
+```
+deepinit_manifest(action="check")
+```
+
+Used internally by the `deepinit` skill (`/oh-my-claudecode:deepinit`) to enable incremental AGENTS.md regeneration instead of full re-scans.


### PR DESCRIPTION
## Summary

Three new documentation files, all verified against OMC 4.8.2 source.

## New Files

### GETTING-STARTED.md
- Plugin marketplace installation (3-step)
- First autopilot session walkthrough (5-stage pipeline)
- `config.jsonc` structure with all 19 agent model defaults
- Magic keyword customization (4 configurable categories)
- Model routing tiers (LOW/MEDIUM/HIGH)

### HOOKS.md
- 20 hook scripts across 11 lifecycle events (all timeouts verified against `hooks.json`)
- Clear hooks vs skills distinction: autopilot/ralph/ultrawork are **skills**, `persistent-mode.cjs` is the **hook** that enforces their continuation
- keyword-detector: sanitization, conflict resolution, team worker safety
- Context management: notepad + project-memory + pre-compact cooperation strategy
- Magic keyword reference: 14 keyword groups with priority chain

### TOOLS.md
- 42 MCP tools across 11 categories:
  - State (5), Notepad (6), Project Memory (4), LSP (12), AST Grep (2), Python REPL (1), Session Search (1), Trace (2), Shared Memory (5), Skills (3), Deepinit Manifest (1)
- Usage patterns with examples for each tool
- Environment variables (`OMC_STATE_DIR`, `OMC_LSP_TIMEOUT_MS`)

## Verification

Every claim cross-referenced against OMC 4.8.2 source:
- `hooks/hooks.json` — 11 events, 20 scripts, all timeouts match
- `scripts/keyword-detector.mjs` — 14 keyword groups, priority order
- `scripts/persistent-mode.cjs` — staleness threshold, reinforcement message
- `src/tools/*.ts` — 41 tool definitions + python_repl = 42 total
- `src/agents/definitions.ts` — 19 agent model defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)