### PR TITLE
fix(security): SSRF, shell injection, and unsafe API proxy (v2 - addresses review feedback)

### DIFF
--- a/benchmark/.env.example
+++ b/benchmark/.env.example
@@ -4,8 +4,9 @@
 # Required: Anthropic authentication token for Claude Code
 ANTHROPIC_AUTH_TOKEN=your_token_here
 
-# Optional: Custom Anthropic API base URL
-ANTHROPIC_BASE_URL=https://api.layofflabs.com
+# Optional: Custom Anthropic API base URL (defaults to https://api.anthropic.com)
+# WARNING: Only set this to a trusted endpoint. Third-party proxies may intercept credentials.
+# ANTHROPIC_BASE_URL=https://api.anthropic.com
 
 # Run mode: 'vanilla' for standard Claude Code, 'omc' for oh-my-claudecode enhanced
 RUN_MODE=vanilla

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -519,6 +519,20 @@ export async function runAutoresearchEvaluator(
   latestEvaluatorFile?: string,
 ): Promise<AutoresearchEvaluationRecord> {
   const ran_at = nowIso();
+  // Reject commands containing shell metacharacters that enable chaining/injection
+  // (semicolons, pipes, backticks, $() substitution, etc.)
+  // Quoted arguments and simple commands are still allowed via shell: true.
+  const DANGEROUS_SHELL_CHARS = /[;&|`$()<>\n\r\0\\{}]/;
+  if (DANGEROUS_SHELL_CHARS.test(contract.sandbox.evaluator.command)) {
+    return {
+      command: contract.sandbox.evaluator.command,
+      ran_at,
+      status: 'error' as const,
+      exit_code: null,
+      stdout: '',
+      stderr: 'Evaluator command rejected: contains dangerous shell metacharacters',
+    };
+  }
   const result = spawnSync(contract.sandbox.evaluator.command, {
     cwd: worktreePath,
     encoding: 'utf-8',

--- a/src/hud/custom-rate-provider.ts
+++ b/src/hud/custom-rate-provider.ts
@@ -83,11 +83,20 @@ function isCacheValid(cache: CustomProviderCache): boolean {
  */
 function spawnWithTimeout(cmd: string | string[], timeoutMs: number): Promise<string> {
   return new Promise((resolve, reject) => {
-    const [executable, ...args] = Array.isArray(cmd)
-      ? cmd
-      : (['sh', '-c', cmd] as string[]);
-
-    const child = spawn(executable, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    // For array commands, use directly (safe). For string commands, reject dangerous
+    // shell metacharacters then use sh -c to preserve quoted arguments.
+    const DANGEROUS_SHELL_CHARS = /[;&|`$()<>\n\r\0\\{}]/;
+    let child;
+    if (Array.isArray(cmd)) {
+      const [executable, ...args] = cmd;
+      child = spawn(executable, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    } else {
+      if (DANGEROUS_SHELL_CHARS.test(cmd)) {
+        reject(new Error('Command rejected: contains dangerous shell metacharacters'));
+        return;
+      }
+      child = spawn('sh', ['-c', cmd], { stdio: ['ignore', 'pipe', 'pipe'] });
+    }
 
     let stdout = '';
     child.stdout.on('data', (chunk: Buffer) => {

--- a/src/notifications/dispatcher.ts
+++ b/src/notifications/dispatcher.ts
@@ -7,6 +7,7 @@
  */
 
 import { request as httpsRequest } from "https";
+import { validateUrlForSSRF } from "../utils/ssrf-guard.js";
 import type {
   DiscordNotificationConfig,
   DiscordBotNotificationConfig,
@@ -122,12 +123,28 @@ function validateSlackUrl(webhookUrl: string): boolean {
 }
 
 /**
- * Validate generic webhook URL. Must be HTTPS.
+ * Validate generic webhook URL. Must be HTTPS and pass SSRF checks.
  */
 function validateWebhookUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "https:";
+    if (parsed.protocol !== "https:") return false;
+  } catch {
+    return false;
+  }
+  return validateUrlForSSRF(url).allowed;
+}
+
+/**
+ * Check if a custom webhook URL is safe. Passes SSRF guard but also
+ * allows localhost/127.0.0.1/::1 for local development receivers.
+ */
+function isWebhookUrlSafe(url: string): boolean {
+  const ssrf = validateUrlForSSRF(url);
+  if (ssrf.allowed) return true;
+  try {
+    const h = new URL(url).hostname;
+    return h === "localhost" || h === "127.0.0.1" || h === "::1";
   } catch {
     return false;
   }
@@ -746,18 +763,24 @@ export async function sendCustomWebhook(
   try {
     // Interpolate template variables
     const url = interpolateTemplate(config.url, payload);
+
+    // SSRF guard: block internal IPs except localhost (for local dev webhooks)
+    if (!isWebhookUrlSafe(url)) {
+      return { platform: "webhook", success: false, error: "URL blocked by SSRF guard" };
+    }
+
     const body = interpolateTemplate(config.bodyTemplate, payload);
-    
+
     // Prepare headers
     const headers: Record<string, string> = {};
     for (const [key, value] of Object.entries(config.headers)) {
       headers[key] = interpolateTemplate(value, payload);
     }
-    
+
     // Use native fetch (Node.js 18+)
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), config.timeout);
-    
+
     try {
       const response = await fetch(url, {
         method: config.method,

--- a/src/openclaw/dispatcher.ts
+++ b/src/openclaw/dispatcher.ts
@@ -13,24 +13,34 @@ import type {
   OpenClawPayload,
   OpenClawResult,
 } from "./types.js";
+import { validateUrlForSSRF } from "../utils/ssrf-guard.js";
 
 /** Default per-request timeout */
 const DEFAULT_TIMEOUT_MS = 10_000;
 
 /**
- * Validate gateway URL. Must be HTTPS, except localhost/127.0.0.1
- * which allows HTTP for local development.
+ * Validate gateway URL using SSRF guard for HTTPS URLs.
+ * HTTP is only allowed to localhost/127.0.0.1/::1 for local development.
+ * All other private/internal addresses are blocked via SSRF validation.
  */
 function validateGatewayUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    if (parsed.protocol === "https:") return true;
-    if (
-      parsed.protocol === "http:" &&
-      (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1")
-    ) {
-      return true;
+
+    // Allow HTTP only to localhost
+    if (parsed.protocol === "http:") {
+      return (
+        parsed.hostname === "localhost" ||
+        parsed.hostname === "127.0.0.1" ||
+        parsed.hostname === "::1"
+      );
     }
+
+    // HTTPS URLs must pass full SSRF validation (blocks private IPs, metadata, etc.)
+    if (parsed.protocol === "https:") {
+      return validateUrlForSSRF(url).allowed;
+    }
+
     return false;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Security scan identified 6 vulnerabilities (3 critical, 2 high, 1 medium). This PR fixes all of them with minimal, non-breaking changes. **v2** addresses all feedback from [#2031](https://github.com/Yeachan-Heo/oh-my-claudecode/pull/2031):

- Localhost is now allowed in custom webhook SSRF gate (local dev workflows preserved)
- Evaluator commands keep `shell: true` for proper quoted-argument handling, with metacharacter validation instead of naive whitespace splitting
- Rate provider string commands keep `sh -c` for quoted-argument handling, with metacharacter validation

**Zero test regressions** — 379/403 files pass (23 pre-existing failures unchanged), 7101/7191 individual tests pass.

## Fixes

| # | Severity | File | Issue | Fix |
|---|----------|------|-------|-----|
| 1 | **Critical** | `src/notifications/dispatcher.ts` | `sendCustomWebhook()` fetches URLs without SSRF check | Added `isWebhookUrlSafe()` — SSRF guard + localhost allowlist |
| 2 | **Critical** | `src/autoresearch/runtime.ts:522` | `spawnSync(command, { shell: true })` — no input validation | Reject dangerous shell metacharacters (`;&\|` etc.) before execution; keeps `shell: true` for quoted args |
| 3 | **Critical** | `src/hud/custom-rate-provider.ts:88` | `sh -c` without validation | Same metacharacter rejection; keeps `sh -c` for quoted args |
| 4 | **High** | `benchmark/.env.example:8` | `ANTHROPIC_BASE_URL` points to unknown third-party proxy | Commented out with security warning |
| 5 | **High** | `src/notifications/dispatcher.ts:127` | `validateWebhookUrl()` only checks protocol | Added SSRF guard (blocks private IPs, metadata endpoints) |
| 6 | **Medium** | `src/openclaw/dispatcher.ts:24` | HTTPS URLs not validated against SSRF | Applied `validateUrlForSSRF()` for HTTPS; localhost HTTP preserved |

## Changes from v1 (#2031)

- **P1 fixed**: Custom webhook SSRF gate now allows localhost/127.0.0.1/::1
- **P1 fixed**: Evaluator command uses `shell: true` (preserves quoted args) with metacharacter blocklist instead of naive `.split()`
- **P2 fixed**: Rate provider keeps `sh -c` with metacharacter validation

## Scanning methodology

- **Bandit** (Python SAST) — AST-based analysis
- **Gitleaks** (secret detection) — git history + file scanning
- **Claude security-scanner skill** (118-rule SAST) — OWASP Top 10 / CWE mapped

## Test plan

- [x] `npm run build` — passes
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors (13 pre-existing warnings)
- [x] `npm run test -- --run` — 379 passed, 23 failed (pre-existing), 1 skipped
- [x] Targeted tests on dispatcher + openclaw + webhook-timeout — all 122 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)