### PR TITLE
fix(hud): respect explicit safeMode: false on Windows

### DIFF
--- a/src/__tests__/hud-windows.test.ts
+++ b/src/__tests__/hud-windows.test.ts
@@ -125,6 +125,29 @@ describe('HUD Windows Compatibility', () => {
     });
   });
 
+  describe('safeMode override (#346)', () => {
+    it('safeMode logic: explicit false overrides platform detection', () => {
+      // Simulate the logic from src/hud/index.ts
+      const resolveSafeMode = (safeMode: boolean, isWin32: boolean) =>
+        safeMode !== false && (safeMode || isWin32);
+
+      // explicit false: disabled even on Windows
+      expect(resolveSafeMode(false, true)).toBe(false);
+      expect(resolveSafeMode(false, false)).toBe(false);
+      // explicit true: always enabled
+      expect(resolveSafeMode(true, false)).toBe(true);
+      expect(resolveSafeMode(true, true)).toBe(true);
+      // default true on Windows: enabled
+      expect(resolveSafeMode(true, true)).toBe(true);
+    });
+
+    it('hud index.ts should use explicit-false override for safeMode', () => {
+      const indexPath = join(packageRoot, 'src', 'hud', 'index.ts');
+      const content = readFileSync(indexPath, 'utf-8');
+      expect(content).toContain('config.elements.safeMode !== false');
+    });
+  });
+
   describe('Cross-Platform Plugin Cache Path (#670)', () => {
     it('getPluginCacheBase should return path with correct segments', () => {
       const cachePath = getPluginCacheBase();

--- a/src/__tests__/hud/windows-platform.test.ts
+++ b/src/__tests__/hud/windows-platform.test.ts
@@ -36,7 +36,7 @@ function getShellOption(platform: string): string | undefined {
 }
 
 function getSafeMode(configSafeMode: boolean, platform: string): boolean {
-  return configSafeMode || isWin32(platform);
+  return configSafeMode !== false && (configSafeMode || isWin32(platform));
 }
 
 describe('Windows HUD Platform Fixes (#739)', () => {
@@ -204,15 +204,15 @@ describe('Windows HUD Platform Fixes (#739)', () => {
         'utf-8',
       );
       expect(content).toContain("process.platform === 'win32'");
-      expect(content).toMatch(/config\.elements\.safeMode \|\| process\.platform === 'win32'/);
+      expect(content).toContain('config.elements.safeMode !== false');
     });
 
     it('safe mode logic: config=false on Mac -> disabled', () => {
       expect(getSafeMode(false, 'darwin')).toBe(false);
     });
 
-    it('safe mode logic: config=false on Windows -> auto-enabled', () => {
-      expect(getSafeMode(false, 'win32')).toBe(true);
+    it('safe mode logic: config=false on Windows -> disabled (explicit override)', () => {
+      expect(getSafeMode(false, 'win32')).toBe(false);
     });
 
     it('safe mode logic: config=true on Mac -> enabled', () => {

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -464,13 +464,15 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
 
     // Apply safe mode sanitization if enabled (Issue #346)
     // This strips ANSI codes and uses ASCII-only output to prevent
-    // terminal rendering corruption during concurrent updates
-    // On Windows, always use safe mode to prevent terminal rendering issues
-    // with non-breaking spaces and ANSI escape sequences
-    // Keep explicit win32 check visible for regression tests: process.platform === 'win32'
-    // config.elements.safeMode || process.platform === 'win32'
+    // terminal rendering corruption during concurrent updates.
+    // On Windows, default to safe mode unless the user explicitly sets safeMode: false
+    // (e.g. Windows Terminal and modern terminals support ANSI natively).
+    // The win32 fallback is retained for configs that omit safeMode entirely
+    // (before default merge, e.g. minimal config files or future schema changes).
+    // explicit false overrides platform detection: process.platform === 'win32'
     const useSafeMode =
-      config.elements.safeMode || process.platform === "win32";
+      config.elements.safeMode !== false &&
+      (config.elements.safeMode || process.platform === "win32");
 
     if (useSafeMode) {
       output = sanitizeOutput(output);

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -453,7 +453,8 @@ export interface HudElementConfig {
   showLastTool?: boolean;      // Show name of last tool called (tool:Read)
   sessionSummary: boolean;    // Show AI-generated session summary (<20 chars) - generated every 10 turns via claude -p
   maxOutputLines: number;     // Max total output lines to prevent input field shrinkage
-  safeMode: boolean;          // Strip ANSI codes and use ASCII-only output to prevent terminal rendering corruption (Issue #346)
+  safeMode: boolean;          // Strip ANSI codes and use ASCII-only output to prevent terminal rendering corruption (Issue #346).
+                              // Default true. Set to false to explicitly disable even on Windows (e.g. Windows Terminal with ANSI support).
 }
 
 export interface HudThresholds {


### PR DESCRIPTION
## Problem

On Windows, `safeMode` was always forced `true` regardless of user config:

```ts
config.elements.safeMode || process.platform === 'win32'
// false || true = true → setting safeMode: false in hud-config.json had no effect
```

Users on Windows Terminal (which supports ANSI natively) couldn't get colored HUD output even when explicitly opting out.

## Fix

Explicit `false` now overrides platform detection:

```ts
config.elements.safeMode !== false &&
  (config.elements.safeMode || process.platform === 'win32')
```

The `win32` fallback is intentionally retained for configs that omit `safeMode` entirely (before default merge, e.g. minimal config files or future schema changes).

## Behavior

| config | Windows | non-Windows |
|--------|---------|-------------|
| `true` | safe ✅ | safe ✅ |
| `false` | ANSI ✅ | ANSI ✅ |
| (default / omitted) | safe ✅ | safe ✅ |

Backward compatible — existing configs with `safeMode: true` are unaffected.

## Changes

- `src/hud/index.ts`: fix safeMode logic
- `src/hud/types.ts`: update comment to document `false` override behavior
- `src/__tests__/hud-windows.test.ts`: add safeMode override tests
- `src/__tests__/hud/windows-platform.test.ts`: update stale assertions to match new behavior