### PR TITLE
fix(hud): resolve autopilot phase undefined display

### DIFF
--- a/src/__tests__/hud/omc-state.test.ts
+++ b/src/__tests__/hud/omc-state.test.ts
@@ -116,6 +116,30 @@ describe('hud omc state session scoping', () => {
     expect(readAutopilotStateForHud(worktree, 'session-a')).toBeNull();
   });
 
+
+  it('reads current_phase when phase is missing for autopilot HUD state', () => {
+    const worktree = createWorktree();
+    const omcRoot = join(worktree, '.omc');
+
+    writeJson(join(omcRoot, 'state', 'autopilot-state.json'), {
+      active: true,
+      current_phase: 'execution',
+      iteration: 3,
+      max_iterations: 10,
+      execution: { tasks_completed: 2, tasks_total: 4, files_created: ['a.ts'] },
+    });
+
+    expect(readAutopilotStateForHud(worktree)).toMatchObject({
+      active: true,
+      phase: 'execution',
+      iteration: 3,
+      maxIterations: 10,
+      tasksCompleted: 2,
+      tasksTotal: 4,
+      filesCreated: 1,
+    });
+  });
+
   it('applies session scoping to combined mode helpers', () => {
     const worktree = createWorktree();
     const omcRoot = join(worktree, '.omc');

--- a/src/hud/omc-state.ts
+++ b/src/hud/omc-state.ts
@@ -262,7 +262,8 @@ export function readPrdStateForHud(directory: string): PrdStateForHud | null {
 
 interface AutopilotStateFile {
   active: boolean;
-  phase: string;
+  phase?: string;
+  current_phase?: string;
   iteration: number;
   max_iterations: number;
   execution?: {
@@ -296,9 +297,14 @@ export function readAutopilotStateForHud(directory: string, sessionId?: string):
       return null;
     }
 
+    const phase = state.phase ?? state.current_phase;
+    if (!phase) {
+      return null;
+    }
+
     return {
       active: state.active,
-      phase: state.phase,
+      phase,
       iteration: state.iteration,
       maxIterations: state.max_iterations,
       tasksCompleted: state.execution?.tasks_completed,


### PR DESCRIPTION
## Summary
- read `phase` or `current_phase` from autopilot HUD state files
- return no HUD autopilot state when neither field exists
- add a regression test covering `current_phase`-only state

Closes #2038.