### PR TITLE
fix(pre-tool-enforcer): allow tier aliases when OMC_SUBAGENT_MODEL is set

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -634,8 +634,8 @@ async function main() {
           // IDs are rejected by the tool schema, leaving no valid escape hatch otherwise.
           // The routing layer maps tier aliases through OMC_SUBAGENT_MODEL at call time.
           const subagentModelForAlias = process.env.OMC_SUBAGENT_MODEL || '';
-          if (isTierAlias(toolModel) && subagentModelForAlias) {
-            // fall through to continue — tier alias is safe when OMC_SUBAGENT_MODEL routes it
+          if (isTierAlias(toolModel) && isSubagentSafeModelId(subagentModelForAlias)) {
+            // fall through to continue — tier alias is safe when OMC_SUBAGENT_MODEL is a valid provider-specific ID
           } else if (!isSubagentSafeModelId(toolModel)) {
             const subagentModel = process.env.OMC_SUBAGENT_MODEL || '';
             const guidance = subagentModel

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -458,6 +458,42 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(hookOutput.permissionDecisionReason as string).toContain('MODEL ROUTING');
   });
 
+  it('blocks tier alias when OMC_SUBAGENT_MODEL is itself a bare Anthropic model ID', () => {
+    const output = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Agent',
+        toolInput: { subagent_type: 'oh-my-claudecode:executor', model: 'sonnet' },
+        cwd: tempDir,
+        session_id: 'session-tier-alias-bare',
+      },
+      {
+        OMC_ROUTING_FORCE_INHERIT: 'true',
+        OMC_SUBAGENT_MODEL: 'claude-sonnet-4-6',
+      },
+    );
+
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(hookOutput.permissionDecisionReason as string).toContain('MODEL ROUTING');
+  });
+
+  it('blocks tier alias when OMC_SUBAGENT_MODEL has a [1m] extended-context suffix', () => {
+    const output = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Agent',
+        toolInput: { subagent_type: 'oh-my-claudecode:executor', model: 'opus' },
+        cwd: tempDir,
+        session_id: 'session-tier-alias-lm',
+      },
+      {
+        OMC_ROUTING_FORCE_INHERIT: 'true',
+        OMC_SUBAGENT_MODEL: 'global.anthropic.claude-sonnet-4-6[1m]',
+      },
+    );
+
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(hookOutput.permissionDecisionReason as string).toContain('MODEL ROUTING');
+  });
+
   it('still blocks bare Anthropic model ID even when OMC_SUBAGENT_MODEL is set', () => {
     const output = runPreToolEnforcerWithEnv(
       {


### PR DESCRIPTION
## Problem

In Bedrock/Vertex/proxy environments with `forceInherit` enabled, spawning
sub-agents with `model="sonnet"` (or `opus`/`haiku`) was impossible — a
catch-22 with no valid escape hatch:

- The hook blocked tier aliases as invalid Bedrock model IDs
- The `Agent` tool schema only accepts tier aliases, not full Bedrock model IDs

The error message told users to pass `OMC_SUBAGENT_MODEL` directly, but the
tool schema made that impossible.

## Approach

When `OMC_SUBAGENT_MODEL` is configured, tier aliases are allowed through the
`forceInherit` gate. The Claude Code routing layer already maps them through
`OMC_SUBAGENT_MODEL` at call time, so the hook's block was redundant and
harmful in this case.

- Tier aliases with no `OMC_SUBAGENT_MODEL`: still blocked (no routing target)
- Bare Anthropic model IDs (`claude-sonnet-4-6`): still blocked as before
- Full Bedrock/Vertex IDs: still allowed as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)