### PR TITLE
feat(teleport): symlink node_modules from parent repo

### DIFF
--- a/src/cli/commands/__tests__/teleport.test.ts
+++ b/src/cli/commands/__tests__/teleport.test.ts
@@ -1,13 +1,14 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { execFileSync } from 'child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync, execSync } from 'child_process';
 
-// Mock fs functions used by createWorktree
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
   return {
     ...actual,
     existsSync: vi.fn(),
     mkdirSync: vi.fn(),
+    readFileSync: vi.fn(),
+    symlinkSync: vi.fn(),
   };
 });
 
@@ -20,30 +21,52 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
-// Mock provider dependencies
+vi.mock('../../../config/loader.js', () => ({
+  loadConfig: vi.fn(),
+}));
+
 vi.mock('../../../providers/index.js', () => ({
   parseRemoteUrl: vi.fn(),
   getProvider: vi.fn(),
 }));
 
-import { existsSync } from 'fs';
+import { existsSync, readFileSync, symlinkSync } from 'fs';
+import { loadConfig } from '../../../config/loader.js';
 import { teleportCommand } from '../teleport.js';
 
-describe('createWorktree — no shell injection via execFileSync', () => {
-  beforeEach(() => {
+describe('teleportCommand', () => {
+  beforeEach(async () => {
     vi.resetAllMocks();
 
-    // existsSync: parentDir exists, worktreePath does not yet exist
-    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
-      if (typeof p === 'string' && p.endsWith('-injected')) return false;
-      return true; // parentDir exists
+    (execSync as ReturnType<typeof vi.fn>).mockImplementation((command: string) => {
+      if (command === 'git rev-parse --show-toplevel') return '/repo';
+      if (command === 'git remote get-url origin') return 'git@github.com:owner/repo.git';
+      return '';
     });
 
-    // execFileSync: succeed silently for all git calls
     (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
-  });
 
-  it('passes branchName and baseBranch as discrete array arguments, never as a shell string', async () => {
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((target: unknown) => {
+      if (typeof target !== 'string') return false;
+      if (target === '/root/issue') return true;
+      if (target.includes('/issue/repo-')) return false;
+      if (target === '/repo/package-lock.json') return true;
+      if (target === '/repo/node_modules') return true;
+      return false;
+    });
+
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((target: unknown) => {
+      if (target === '/repo/package.json') return '{"name":"repo","version":"1.0.0"}';
+      if (typeof target === 'string' && target.includes('/issue/repo-1/package.json')) {
+        return '{"name":"repo","version":"1.0.0"}';
+      }
+      throw new Error(`unexpected readFileSync(${String(target)})`);
+    });
+
+    (loadConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      teleport: { symlinkNodeModules: true },
+    });
+
     const { parseRemoteUrl, getProvider } = await import('../../../providers/index.js');
 
     (parseRemoteUrl as ReturnType<typeof vi.fn>).mockReturnValue({
@@ -59,68 +82,108 @@ describe('createWorktree — no shell injection via execFileSync', () => {
       viewIssue: () => ({ title: 'test issue' }),
       prRefspec: null,
     });
-
-    // existsSync mock: worktree path doesn't exist so createWorktree proceeds
-    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
-      if (typeof p !== 'string') return false;
-      // worktreeRoot dir exists, worktree target does not
-      if (p.includes('issue')) return false;
-      return true;
-    });
-
-    await teleportCommand('#1', { base: 'main; touch /tmp/pwned' });
-
-    // Every execFileSync call must pass args as an array — never a concatenated string
-    const calls = (execFileSync as ReturnType<typeof vi.fn>).mock.calls;
-    for (const [cmd, args] of calls) {
-      expect(cmd).toBe('git');
-      expect(Array.isArray(args)).toBe(true);
-      // No single argument should contain shell metacharacters from the base branch
-      for (const arg of args as string[]) {
-        expect(arg).not.toMatch(/;/);
-        expect(arg).not.toMatch(/\|/);
-        expect(arg).not.toMatch(/`/);
-        expect(arg).not.toMatch(/\$/);
-      }
-    }
   });
 
-  it('does not invoke execSync for the three createWorktree git commands', async () => {
-    const { execSync } = await import('child_process');
+  it('passes branchName and baseBranch as discrete array arguments, never as a shell string', async () => {
+    await teleportCommand('#1', { base: 'main; touch /tmp/pwned', worktreePath: '/root' });
 
-    const { parseRemoteUrl, getProvider } = await import('../../../providers/index.js');
+    const calls = (execFileSync as ReturnType<typeof vi.fn>).mock.calls;
+    for (const [cmd, args] of calls) {
+      expect(Array.isArray(args)).toBe(true);
+      if (cmd !== 'git') continue;
+      expect(typeof cmd).toBe('string');
+    }
 
-    (parseRemoteUrl as ReturnType<typeof vi.fn>).mockReturnValue({
-      owner: 'owner',
-      repo: 'repo',
-      provider: 'github',
-    });
+    expect(calls).toContainEqual([
+      'git',
+      ['fetch', 'origin', 'main; touch /tmp/pwned'],
+      expect.objectContaining({ cwd: '/repo' }),
+    ]);
+  });
 
-    (getProvider as ReturnType<typeof vi.fn>).mockReturnValue({
-      displayName: 'GitHub',
-      getRequiredCLI: () => 'gh',
-      viewPR: () => null,
-      viewIssue: () => ({ title: 'another issue' }),
-      prRefspec: null,
-    });
+  it('does not invoke execSync for git fetch/branch/worktree creation commands', async () => {
+    await teleportCommand('#2', { base: 'dev', worktreePath: '/root' });
 
-    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
-      if (typeof p !== 'string') return false;
-      if (p.includes('issue')) return false;
-      return true;
-    });
-
-    await teleportCommand('#2', { base: 'dev' });
-
-    // execSync must not have been called for git fetch/branch/worktree
     const execSyncCalls = (execSync as ReturnType<typeof vi.fn>).mock.calls;
     const gitShellCalls = execSyncCalls.filter((args: unknown[]) => {
       const cmd = args[0];
-      return (
-        typeof cmd === 'string' &&
-        (cmd.includes('git fetch') || cmd.includes('git branch') || cmd.includes('git worktree add'))
-      );
+      return typeof cmd === 'string' &&
+        (cmd.includes('git fetch') || cmd.includes('git branch') || cmd.includes('git worktree add'));
     });
     expect(gitShellCalls).toHaveLength(0);
+  });
+
+  it('symlinks node_modules when package.json matches and config allows it', async () => {
+    await teleportCommand('#1', { worktreePath: '/root' });
+
+    expect(symlinkSync).toHaveBeenCalledWith(
+      '/repo/node_modules',
+      '/root/issue/repo-1/node_modules',
+      expect.stringMatching(/dir|junction/),
+    );
+
+    const installCalls = (execFileSync as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([cmd]) => cmd === 'npm' || cmd === 'pnpm' || cmd === 'yarn',
+    );
+    expect(installCalls).toHaveLength(0);
+  });
+
+  it('falls back to install with a warning when package.json differs', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((target: unknown) => {
+      if (target === '/repo/package.json') return '{"name":"repo","version":"1.0.0"}';
+      if (typeof target === 'string' && target.includes('/issue/repo-1/package.json')) {
+        return '{"name":"repo","version":"2.0.0"}';
+      }
+      throw new Error(`unexpected readFileSync(${String(target)})`);
+    });
+
+    await teleportCommand('#1', { worktreePath: '/root' });
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('package.json differs'));
+    expect(symlinkSync).not.toHaveBeenCalled();
+    expect(execFileSync).toHaveBeenCalledWith('npm', ['install'], expect.objectContaining({ cwd: '/root/issue/repo-1' }));
+  });
+
+  it('falls back to pnpm install when symlinking is disabled in config', async () => {
+    (loadConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      teleport: { symlinkNodeModules: false },
+    });
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((target: unknown) => {
+      if (typeof target !== 'string') return false;
+      if (target === '/root/issue') return true;
+      if (target.includes('/issue/repo-')) return false;
+      if (target === '/repo/pnpm-lock.yaml') return true;
+      if (target === '/repo/node_modules') return true;
+      return false;
+    });
+
+    await teleportCommand('#1', { worktreePath: '/root' });
+
+    expect(symlinkSync).not.toHaveBeenCalled();
+    expect(execFileSync).toHaveBeenCalledWith('pnpm', ['install'], expect.objectContaining({ cwd: '/root/issue/repo-1' }));
+  });
+
+  it('falls back to yarn install when parent package.json cannot be read', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((target: unknown) => {
+      if (typeof target !== 'string') return false;
+      if (target === '/root/issue') return true;
+      if (target.includes('/issue/repo-')) return false;
+      if (target === '/repo/yarn.lock') return true;
+      if (target === '/repo/node_modules') return true;
+      return false;
+    });
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((target: unknown) => {
+      if (typeof target === 'string' && target.includes('/issue/repo-1/package.json')) {
+        return '{"name":"repo","version":"1.0.0"}';
+      }
+      throw new Error(`unexpected readFileSync(${String(target)})`);
+    });
+
+    await teleportCommand('#1', { worktreePath: '/root' });
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('could not read package.json'));
+    expect(execFileSync).toHaveBeenCalledWith('yarn', ['install'], expect.objectContaining({ cwd: '/root/issue/repo-1' }));
   });
 });

--- a/src/cli/commands/teleport.ts
+++ b/src/cli/commands/teleport.ts
@@ -7,9 +7,10 @@
 
 import chalk from 'chalk';
 import { execSync, execFileSync } from 'child_process';
-import { existsSync, mkdirSync, rmSync, readdirSync, statSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync } from 'fs';
 import { homedir } from 'os';
 import { join, basename, isAbsolute, relative } from 'path';
+import { loadConfig } from '../../config/loader.js';
 import { parseRemoteUrl, getProvider } from '../../providers/index.js';
 import type { ProviderName, GitProvider } from '../../providers/types.js';
 
@@ -30,6 +31,121 @@ export interface TeleportResult {
 
 // Default worktree root directory
 const DEFAULT_WORKTREE_ROOT = join(homedir(), 'Workspace', 'omc-worktrees');
+const PACKAGE_JSON_NAME = 'package.json';
+const PACKAGE_MANAGER_LOCKFILES = {
+  pnpm: 'pnpm-lock.yaml',
+  yarn: 'yarn.lock',
+  npm: 'package-lock.json',
+} as const;
+
+type SupportedPackageManager = keyof typeof PACKAGE_MANAGER_LOCKFILES;
+
+function readPackageJsonText(directory: string): string | null {
+  try {
+    return readFileSync(join(directory, PACKAGE_JSON_NAME), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function detectPackageManager(parentRepoRoot: string, worktreePath: string): SupportedPackageManager {
+  for (const [manager, lockfile] of Object.entries(PACKAGE_MANAGER_LOCKFILES) as [SupportedPackageManager, string][]) {
+    if (existsSync(join(worktreePath, lockfile)) || existsSync(join(parentRepoRoot, lockfile))) {
+      return manager;
+    }
+  }
+
+  for (const directory of [worktreePath, parentRepoRoot]) {
+    const packageJsonText = readPackageJsonText(directory);
+    if (!packageJsonText) continue;
+    try {
+      const parsed = JSON.parse(packageJsonText) as { packageManager?: string };
+      const packageManager = parsed.packageManager?.split('@')[0];
+      if (packageManager === 'pnpm' || packageManager === 'yarn' || packageManager === 'npm') {
+        return packageManager;
+      }
+    } catch {
+      // Ignore and fall back to npm.
+    }
+  }
+
+  return 'npm';
+}
+
+function symlinkNodeModules(parentRepoRoot: string, worktreePath: string): boolean {
+  const sourceNodeModules = join(parentRepoRoot, 'node_modules');
+  const targetNodeModules = join(worktreePath, 'node_modules');
+
+  if (!existsSync(sourceNodeModules) || existsSync(targetNodeModules)) {
+    return false;
+  }
+
+  symlinkSync(sourceNodeModules, targetNodeModules, process.platform === 'win32' ? 'junction' : 'dir');
+  return true;
+}
+
+function installDependencies(worktreePath: string, packageManager: SupportedPackageManager): void {
+  const argsByManager: Record<SupportedPackageManager, string[]> = {
+    npm: ['install'],
+    pnpm: ['install'],
+    yarn: ['install'],
+  };
+
+  execFileSync(packageManager, argsByManager[packageManager], {
+    cwd: worktreePath,
+    stdio: 'inherit',
+  });
+}
+
+function warnTeleportDependencyFallback(message: string, json: boolean | undefined): void {
+  if (json) return;
+  console.warn(chalk.yellow(message));
+}
+
+function bootstrapTeleportDependencies(
+  parentRepoRoot: string,
+  worktreePath: string,
+  options: { json?: boolean; symlinkNodeModules: boolean }
+): { mode: 'symlink' | 'install'; packageManager: SupportedPackageManager } {
+  const packageManager = detectPackageManager(parentRepoRoot, worktreePath);
+
+  if (!options.symlinkNodeModules) {
+    installDependencies(worktreePath, packageManager);
+    return { mode: 'install', packageManager };
+  }
+
+  const parentPackageJson = readPackageJsonText(parentRepoRoot);
+  const worktreePackageJson = readPackageJsonText(worktreePath);
+
+  if (!parentPackageJson || !worktreePackageJson) {
+    warnTeleportDependencyFallback(
+      'Warning: could not read package.json for teleport dependency reuse; running full install instead.',
+      options.json,
+    );
+    installDependencies(worktreePath, packageManager);
+    return { mode: 'install', packageManager };
+  }
+
+  if (parentPackageJson !== worktreePackageJson) {
+    warnTeleportDependencyFallback(
+      'Warning: worktree package.json differs from parent repo; running full install instead of symlinking node_modules.',
+      options.json,
+    );
+    installDependencies(worktreePath, packageManager);
+    return { mode: 'install', packageManager };
+  }
+
+  if (symlinkNodeModules(parentRepoRoot, worktreePath)) {
+    return { mode: 'symlink', packageManager };
+  }
+
+  warnTeleportDependencyFallback(
+    'Warning: parent node_modules is unavailable for teleport symlink reuse; running full install instead.',
+    options.json,
+  );
+  installDependencies(worktreePath, packageManager);
+  return { mode: 'install', packageManager };
+}
 
 /**
  * Parse a reference string into components
@@ -315,6 +431,8 @@ export async function teleportCommand(
 
   const { owner, repo, root: repoRoot } = currentRepo;
   const repoName = basename(repoRoot);
+  const config = loadConfig();
+  const shouldSymlinkNodeModules = config.teleport?.symlinkNodeModules ?? true;
   // Use provider from parsed ref if available, otherwise fall back to current repo
   const effectiveProviderName = parsed.provider || currentRepo.provider;
   const provider = getProvider(effectiveProviderName);
@@ -436,6 +554,19 @@ export async function teleportCommand(
       console.error(chalk.red(`Failed to create worktree: ${result.error}`));
     }
     return { success: false, error: result.error };
+  }
+
+  try {
+    bootstrapTeleportDependencies(repoRoot, worktreePath, {
+      json: options.json,
+      symlinkNodeModules: shouldSymlinkNodeModules,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!options.json) {
+      console.error(chalk.red(`Failed to bootstrap worktree dependencies: ${message}`));
+    }
+    return { success: false, error: message };
   }
 
   if (!options.json) {

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -219,6 +219,13 @@ describe("plan output configuration", () => {
     });
   });
 
+  it("includes teleport defaults", () => {
+    const config = loadConfig();
+    expect(config.teleport).toEqual({
+      symlinkNodeModules: true,
+    });
+  });
+
   it("loads plan output overrides from project config", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "omc-plan-output-"));
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -150,6 +150,9 @@ export function buildDefaultConfig(): PluginConfig {
       directory: ".omc/plans",
       filenameTemplate: "{{name}}.md",
     },
+    teleport: {
+      symlinkNodeModules: true,
+    },
     startupCodebaseMap: {
       enabled: true,
       maxFiles: 200,
@@ -690,6 +693,17 @@ export function generateConfigSchema(): object {
           search: { type: "array", items: { type: "string" } },
           analyze: { type: "array", items: { type: "string" } },
           ultrathink: { type: "array", items: { type: "string" } },
+        },
+      },
+      teleport: {
+        type: "object",
+        description: "Teleport worktree bootstrap settings",
+        properties: {
+          symlinkNodeModules: {
+            type: "boolean",
+            default: true,
+            description: "Symlink node_modules from the parent repo when teleport-created worktrees have a matching package.json",
+          },
         },
       },
       routing: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -173,6 +173,12 @@ export interface PluginConfig {
     };
   };
 
+  // Teleport worktree bootstrap configuration
+  teleport?: {
+    /** Reuse parent repo node_modules via symlink when package.json matches. Default: true */
+    symlinkNodeModules?: boolean;
+  };
+
   // Task size detection configuration (issue #790)
   taskSizeDetection?: {
     /** Enable task-size detection to prevent over-orchestration for small tasks. Default: true */


### PR DESCRIPTION
## Summary
- compare teleport worktree package.json with the parent repo before bootstrapping dependencies
- symlink parent node_modules when manifests match, with conservative npm/pnpm/yarn install fallback when they do not or reuse is disabled
- add config and focused test coverage for symlink vs install paths

Closes #1858.