### PR TITLE
feat(ralph): enforce prompt prerequisite sections as blocking gates

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -161,6 +161,17 @@ export function buildDefaultConfig(): PluginConfig {
       largeWordLimit: 200,
       suppressHeavyModesForSmallTasks: true,
     },
+    promptPrerequisites: {
+      enabled: true,
+      sectionNames: {
+        memory: ["MÉMOIRE", "MEMOIRE", "MEMORY"],
+        skills: ["SKILLS"],
+        verifyFirst: ["VERIFY-FIRST", "VERIFY FIRST", "VERIFY_FIRST"],
+        context: ["CONTEXT"],
+      },
+      blockingTools: ["Edit", "MultiEdit", "Write", "Agent", "Task"],
+      executionKeywords: ["ralph", "ultrawork", "autopilot"],
+    },
   };
 }
 

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -125,6 +125,44 @@ describe('processHook - Routing Matrix', () => {
       expect(result.message).toContain('[SECURITY REVIEW MODE ACTIVATED]');
     });
 
+    it('injects prompt prerequisite reminder and state for execution prompts with declared sections', async () => {
+      const tempDir = process.cwd();
+      try {
+        const sessionId = 'keyword-prereq-session';
+
+        const result = await processHook('keyword-detector', {
+          sessionId,
+          prompt: `ralph fix the parser
+
+# MÉMOIRE
+Use notepad_read and project_memory_read first.
+
+# VERIFY-FIRST
+Read src/hooks/bridge.ts before editing.`,
+          directory: tempDir,
+        });
+
+        expect(result.continue).toBe(true);
+        expect(result.message).toContain('[BLOCKING PREREQUISITE GATE]');
+        expect(result.message).toContain('notepad_read');
+        expect(result.message).toContain('src/hooks/bridge.ts');
+
+        const prereqStatePath = join(process.cwd(), '.omc', 'state', 'sessions', sessionId, 'prompt-prerequisites-state.json');
+        expect(existsSync(prereqStatePath)).toBe(true);
+
+        const prereqState = JSON.parse(readFileSync(prereqStatePath, 'utf-8')) as {
+          active?: boolean;
+          required_tool_calls?: string[];
+          required_file_paths?: string[];
+        };
+        expect(prereqState.active).toBe(true);
+        expect(prereqState.required_tool_calls).toEqual(['notepad_read', 'project_memory_read']);
+        expect(prereqState.required_file_paths).toEqual(['src/hooks/bridge.ts']);
+      } finally {
+        rmSync(join(process.cwd(), '.omc', 'state', 'sessions', 'keyword-prereq-session'), { recursive: true, force: true });
+      }
+    });
+
     it('should handle keyword-detector with no keyword prompt', async () => {
       const input: HookInput = {
         sessionId: 'test-session',
@@ -136,6 +174,66 @@ describe('processHook - Routing Matrix', () => {
       expect(result.continue).toBe(true);
       // No keyword detected, so no message
       expect(result.message).toBeUndefined();
+    });
+
+    it('denies Edit until prompt prerequisites are completed, then unblocks after reads', async () => {
+      const tempDir = process.cwd();
+      try {
+        const sessionId = 'prereq-pretool-session';
+
+        await processHook('keyword-detector', {
+          sessionId,
+          prompt: `ultrawork fix it
+
+# MÉMOIRE
+Use notepad_read first.
+
+# CONTEXT
+Read src/hooks/bridge.ts first.`,
+          directory: tempDir,
+        });
+
+        const denied = await processHook('pre-tool-use', {
+          sessionId,
+          toolName: 'Edit',
+          toolInput: { file_path: 'src/hooks/bridge.ts' },
+          directory: tempDir,
+        });
+
+        expect(denied.continue).toBe(true);
+        expect((denied as unknown as Record<string, unknown>).hookSpecificOutput).toBeDefined();
+        const denyHook = (denied as unknown as Record<string, unknown>).hookSpecificOutput as Record<string, unknown>;
+        expect(denyHook.permissionDecision).toBe('deny');
+        expect(String(denyHook.permissionDecisionReason)).toContain('Blocking Edit');
+
+        const readStep = await processHook('pre-tool-use', {
+          sessionId,
+          toolName: 'Read',
+          toolInput: { file_path: 'src/hooks/bridge.ts' },
+          directory: tempDir,
+        });
+        expect(readStep.continue).toBe(true);
+
+        const toolStep = await processHook('pre-tool-use', {
+          sessionId,
+          toolName: 'mcp__omx_notepad__notepad_read',
+          toolInput: {},
+          directory: tempDir,
+        });
+        expect(toolStep.continue).toBe(true);
+        expect(String(toolStep.message ?? '')).toContain('PROMPT PREREQUISITES COMPLETE');
+
+        const allowed = await processHook('pre-tool-use', {
+          sessionId,
+          toolName: 'Edit',
+          toolInput: { file_path: 'src/hooks/bridge.ts' },
+          directory: tempDir,
+        });
+        expect(allowed.continue).toBe(true);
+        expect((allowed as unknown as Record<string, unknown>).hookSpecificOutput).toBeUndefined();
+      } finally {
+        rmSync(join(process.cwd(), '.omc', 'state', 'sessions', 'prereq-pretool-session'), { recursive: true, force: true });
+      }
     });
 
     it('should handle pre-tool-use with Bash tool input', async () => {

--- a/src/hooks/__tests__/prompt-prerequisites.test.ts
+++ b/src/hooks/__tests__/prompt-prerequisites.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPromptPrerequisiteDenyReason,
+  buildPromptPrerequisiteReminder,
+  extractFilePaths,
+  extractRequiredToolCalls,
+  getPromptPrerequisiteConfig,
+  isPromptPrerequisiteBlockingTool,
+  parsePromptPrerequisiteSections,
+  recordPromptPrerequisiteProgress,
+  type PromptPrerequisiteState,
+} from '../prompt-prerequisites/index.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { writeModeState } from '../../lib/mode-state-io.js';
+
+describe('prompt prerequisite parser', () => {
+  it('parses default sections, tool calls, and file paths', () => {
+    const config = getPromptPrerequisiteConfig();
+    const parsed = parsePromptPrerequisiteSections(
+      `ralph fix issue\n\n# MÉMOIRE\nCall supermemory search and notepad_read first.\n\n# VERIFY-FIRST\nOpen src/hooks/bridge.ts and ./docs/plan.md before editing.\n\n# CONTEXT\nAlso use project_memory_read.`,
+      config,
+    );
+
+    expect(parsed.sections.map((section) => section.kind)).toEqual([
+      'memory',
+      'verifyFirst',
+      'context',
+    ]);
+    expect(parsed.requiredToolCalls).toEqual([
+      'notepad_read',
+      'supermemory.search',
+      'project_memory_read',
+    ]);
+    expect(parsed.requiredFilePaths).toEqual([
+      'src/hooks/bridge.ts',
+      './docs/plan.md',
+    ]);
+  });
+
+  it('supports configurable section aliases', () => {
+    const config = getPromptPrerequisiteConfig({
+      promptPrerequisites: {
+        sectionNames: {
+          memory: ['Brain Dump'],
+        },
+      },
+    });
+
+    const parsed = parsePromptPrerequisiteSections(
+      `# Brain Dump\nRun notepad_read before editing.`,
+      config,
+    );
+
+    expect(parsed.sections).toHaveLength(1);
+    expect(parsed.sections[0]?.kind).toBe('memory');
+    expect(parsed.requiredToolCalls).toEqual(['notepad_read']);
+  });
+
+  it('extracts supported tool names and ignores non-path text', () => {
+    expect(extractRequiredToolCalls('Use mcp__supermemory__search, project_memory_read, then notepad_read.')).toEqual([
+      'notepad_read',
+      'project_memory_read',
+      'supermemory.search',
+    ]);
+    expect(extractFilePaths('Read README and https://example.com but also src/index.ts and ../notes/todo.md')).toEqual([
+      'src/index.ts',
+      '../notes/todo.md',
+    ]);
+  });
+
+  it('builds reminder and deny text', () => {
+    const state: PromptPrerequisiteState = {
+      active: true,
+      session_id: 'sess',
+      execution_keywords: ['ralph'],
+      required_tool_calls: ['notepad_read'],
+      required_file_paths: ['src/hooks/bridge.ts'],
+      completed_tool_calls: [],
+      completed_file_paths: [],
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    expect(buildPromptPrerequisiteReminder(state)).toContain('[BLOCKING PREREQUISITE GATE]');
+    expect(buildPromptPrerequisiteDenyReason(state, 'Edit')).toContain('Blocking Edit');
+    expect(isPromptPrerequisiteBlockingTool('Edit', getPromptPrerequisiteConfig())).toBe(true);
+    expect(isPromptPrerequisiteBlockingTool('Read', getPromptPrerequisiteConfig())).toBe(false);
+  });
+});
+
+describe('prompt prerequisite progress tracking', () => {
+  it('tracks prerequisite tool calls and file reads until complete', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'prompt-prereq-'));
+    try {
+      writeModeState('prompt-prerequisites', {
+        active: true,
+        session_id: 'sess',
+        execution_keywords: ['ralph'],
+        required_tool_calls: ['notepad_read', 'project_memory_read'],
+        required_file_paths: ['src/hooks/bridge.ts'],
+        completed_tool_calls: [],
+        completed_file_paths: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, tempDir, 'sess');
+
+      const afterNotepad = recordPromptPrerequisiteProgress(tempDir, 'sess', 'mcp__omx_notepad__notepad_read', {});
+      expect(afterNotepad?.toolSatisfied).toBe('notepad_read');
+      expect(afterNotepad?.isComplete).toBe(false);
+
+      const afterRead = recordPromptPrerequisiteProgress(tempDir, 'sess', 'Read', { file_path: 'src/hooks/bridge.ts' });
+      expect(afterRead?.fileSatisfied).toBe('src/hooks/bridge.ts');
+      expect(afterRead?.isComplete).toBe(false);
+
+      const afterMemory = recordPromptPrerequisiteProgress(tempDir, 'sess', 'project_memory_read', {});
+      expect(afterMemory?.toolSatisfied).toBe('project_memory_read');
+      expect(afterMemory?.isComplete).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -52,6 +52,18 @@ import {
 import { readHudState, writeHudState } from "../hud/state.js";
 import { compactOmcStartupGuidance, loadConfig } from "../config/loader.js";
 import {
+  activatePromptPrerequisiteState,
+  buildPromptPrerequisiteDenyReason,
+  buildPromptPrerequisiteReminder,
+  clearPromptPrerequisiteState,
+  getPromptPrerequisiteConfig,
+  isPromptPrerequisiteBlockingTool,
+  parsePromptPrerequisiteSections,
+  readPromptPrerequisiteState,
+  recordPromptPrerequisiteProgress,
+  shouldEnforcePromptPrerequisites,
+} from "./prompt-prerequisites/index.js";
+import {
   resolveAutopilotPlanPath,
   resolveOpenQuestionsPlanPath,
 } from "../config/plan-output.js";
@@ -71,7 +83,6 @@ import {
 import { getAgentDashboard } from "./subagent-tracker/index.js";
 // Session replay recordFileTouch is used in pre-tool-use hot path
 import { recordFileTouch } from "./subagent-tracker/session-replay.js";
-
 // Type-only imports for lazy-loaded modules (zero runtime cost)
 import type {
   SubagentStartInput,
@@ -687,6 +698,7 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
   // Load config for task-size detection settings
   const config = loadConfig();
   const taskSizeConfig = config.taskSizeDetection ?? {};
+  const promptPrerequisiteConfig = getPromptPrerequisiteConfig(config);
 
   // Get all keywords with optional task-size filtering (issue #790)
   const sizeCheckResult = getAllKeywordsWithSizeCheck(cleanedText, {
@@ -738,6 +750,24 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
           `Use explicit mode keywords (e.g. \`ralph\`) only when you need full orchestration.`,
       );
     }
+  }
+
+  const promptPrerequisiteParse = parsePromptPrerequisiteSections(promptText, promptPrerequisiteConfig);
+  const executionKeywords = fullKeywords.filter((keywordType) =>
+    promptPrerequisiteConfig.executionKeywords.includes(keywordType),
+  );
+  if (shouldEnforcePromptPrerequisites(executionKeywords, promptPrerequisiteParse, promptPrerequisiteConfig)) {
+    const state = activatePromptPrerequisiteState(
+      directory,
+      sessionId,
+      executionKeywords,
+      promptPrerequisiteParse,
+    );
+    if (state) {
+      messages.push(buildPromptPrerequisiteReminder(state));
+    }
+  } else if (executionKeywords.length > 0) {
+    clearPromptPrerequisiteState(directory, sessionId);
   }
 
   const sanitizedText = sanitizeForKeywordDetection(cleanedText);
@@ -1386,6 +1416,7 @@ export const _openclaw = {
 function processPreToolUse(input: HookInput): HookOutput {
   const directory = resolveToWorktreeRoot(input.directory);
   const teamWorkerIdentity = teamWorkerIdentityFromEnv();
+  const promptPrerequisiteConfig = getPromptPrerequisiteConfig(loadConfig());
 
   if (teamWorkerIdentity) {
     if (input.toolName === "Task") {
@@ -1440,6 +1471,34 @@ function processPreToolUse(input: HookInput): HookOutput {
     ? [enforcementResult.message]
     : [];
   let modifiedToolInput: Record<string, unknown> | undefined;
+
+  const promptPrerequisiteProgress = recordPromptPrerequisiteProgress(
+    directory,
+    input.sessionId,
+    input.toolName,
+    input.toolInput,
+  );
+
+  if (promptPrerequisiteProgress?.isComplete) {
+    preToolMessages.push(
+      "[PROMPT PREREQUISITES COMPLETE] Required context tools/files were read. Editing and agent delegation are unblocked.",
+    );
+  }
+
+  const promptPrerequisiteState = readPromptPrerequisiteState(directory, input.sessionId);
+  if (
+    promptPrerequisiteState?.active
+    && isPromptPrerequisiteBlockingTool(input.toolName, promptPrerequisiteConfig)
+  ) {
+    return {
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: buildPromptPrerequisiteDenyReason(promptPrerequisiteState, input.toolName),
+      },
+    } as HookOutput & { hookSpecificOutput: Record<string, unknown> };
+  }
 
   // Force-inherit: deny Task/Agent calls that carry a `model` parameter when
   // forceInherit is enabled (Bedrock, Vertex, CC Switch, etc.).

--- a/src/hooks/prompt-prerequisites/index.ts
+++ b/src/hooks/prompt-prerequisites/index.ts
@@ -1,0 +1,395 @@
+import { clearModeStateFile, readModeState, writeModeState } from "../../lib/mode-state-io.js";
+import type { PluginConfig } from "../../shared/types.js";
+
+export type PromptPrerequisiteSectionKind =
+  | "memory"
+  | "skills"
+  | "verifyFirst"
+  | "context";
+
+export interface PromptPrerequisiteSection {
+  kind: PromptPrerequisiteSectionKind;
+  heading: string;
+  content: string;
+}
+
+export interface PromptPrerequisiteParseResult {
+  sections: PromptPrerequisiteSection[];
+  requiredToolCalls: string[];
+  requiredFilePaths: string[];
+}
+
+export interface PromptPrerequisiteState {
+  active: boolean;
+  session_id?: string;
+  execution_keywords: string[];
+  required_tool_calls: string[];
+  required_file_paths: string[];
+  completed_tool_calls: string[];
+  completed_file_paths: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PromptPrerequisiteConfig {
+  enabled: boolean;
+  sectionNames: Record<PromptPrerequisiteSectionKind, string[]>;
+  blockingTools: string[];
+  executionKeywords: string[];
+}
+
+export interface PromptPrerequisiteProgress {
+  toolSatisfied?: string | null;
+  fileSatisfied?: string | null;
+  remainingToolCalls: string[];
+  remainingFilePaths: string[];
+  isComplete: boolean;
+}
+
+const STATE_MODE = "prompt-prerequisites";
+
+const DEFAULT_SECTION_NAMES: Record<PromptPrerequisiteSectionKind, string[]> = {
+  memory: ["MÉMOIRE", "MEMOIRE", "MEMORY"],
+  skills: ["SKILLS"],
+  verifyFirst: ["VERIFY-FIRST", "VERIFY FIRST", "VERIFY_FIRST"],
+  context: ["CONTEXT"],
+};
+
+const DEFAULT_BLOCKING_TOOLS = ["Edit", "MultiEdit", "Write", "Agent", "Task"];
+const DEFAULT_EXECUTION_KEYWORDS = ["ralph", "ultrawork", "autopilot"];
+
+const HEADING_PATTERN = /^#{1,6}\s+(.+?)\s*$/gm;
+const FILE_PATH_PATTERN =
+  /(?:(?:^|\s|["'`(]))(\.{1,2}\/[^\s"'`)<>\]]+|\/[^\s"'`)<>\]]+|(?:[A-Za-z0-9_.-]+\/){1,}[A-Za-z0-9_.-]+)(?=$|\s|["'`),:;\]])/gm;
+
+function normalizeHeading(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{M}+/gu, "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, " ")
+    .trim();
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function normalizePath(value: string): string {
+  return value.trim().replace(/^[("'`]+|[)"'`]+$/g, "");
+}
+
+function isLikelyPath(value: string): boolean {
+  if (!value) return false;
+  if (/^https?:\/\//i.test(value)) return false;
+  if (value.startsWith("#")) return false;
+  if (value.includes("://")) return false;
+  return value.includes("/") || value.startsWith("./") || value.startsWith("../");
+}
+
+export function getPromptPrerequisiteConfig(
+  config?: PluginConfig,
+): PromptPrerequisiteConfig {
+  const raw = config?.promptPrerequisites;
+
+  return {
+    enabled: raw?.enabled !== false,
+    sectionNames: {
+      memory: dedupe([...(raw?.sectionNames?.memory ?? []), ...DEFAULT_SECTION_NAMES.memory]),
+      skills: dedupe([...(raw?.sectionNames?.skills ?? []), ...DEFAULT_SECTION_NAMES.skills]),
+      verifyFirst: dedupe([
+        ...(raw?.sectionNames?.verifyFirst ?? []),
+        ...DEFAULT_SECTION_NAMES.verifyFirst,
+      ]),
+      context: dedupe([...(raw?.sectionNames?.context ?? []), ...DEFAULT_SECTION_NAMES.context]),
+    },
+    blockingTools: dedupe(raw?.blockingTools?.length ? raw.blockingTools : DEFAULT_BLOCKING_TOOLS),
+    executionKeywords: dedupe(
+      raw?.executionKeywords?.length ? raw.executionKeywords : DEFAULT_EXECUTION_KEYWORDS,
+    ),
+  };
+}
+
+function getSectionKind(
+  heading: string,
+  config: PromptPrerequisiteConfig,
+): PromptPrerequisiteSectionKind | null {
+  const normalized = normalizeHeading(heading);
+  for (const [kind, aliases] of Object.entries(config.sectionNames) as Array<
+    [PromptPrerequisiteSectionKind, string[]]
+  >) {
+    if (aliases.some((alias) => normalizeHeading(alias) === normalized)) {
+      return kind;
+    }
+  }
+  return null;
+}
+
+export function parsePromptPrerequisiteSections(
+  promptText: string,
+  config: PromptPrerequisiteConfig,
+): PromptPrerequisiteParseResult {
+  const sections: PromptPrerequisiteSection[] = [];
+  const matches = [...promptText.matchAll(HEADING_PATTERN)];
+
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index];
+    const heading = match[1]?.trim() ?? "";
+    const kind = getSectionKind(heading, config);
+    if (!kind || match.index === undefined) {
+      continue;
+    }
+
+    const start = match.index + match[0].length;
+    const end = index + 1 < matches.length && matches[index + 1].index !== undefined
+      ? matches[index + 1].index!
+      : promptText.length;
+    const content = promptText.slice(start, end).trim();
+    if (!content) {
+      continue;
+    }
+
+    sections.push({ kind, heading, content });
+  }
+
+  const requiredToolCalls = dedupe(sections.flatMap((section) => extractRequiredToolCalls(section.content)));
+  const requiredFilePaths = dedupe(sections.flatMap((section) => extractFilePaths(section.content)));
+
+  return {
+    sections,
+    requiredToolCalls,
+    requiredFilePaths,
+  };
+}
+
+export function extractRequiredToolCalls(content: string): string[] {
+  const required: string[] = [];
+  if (/\bnotepad_read\b/i.test(content)) {
+    required.push("notepad_read");
+  }
+  if (/\bproject_memory_read\b/i.test(content)) {
+    required.push("project_memory_read");
+  }
+  if (/\bsupermemory(?:\s+|_)?search\b|\bmcp__supermemory__search\b/i.test(content)) {
+    required.push("supermemory.search");
+  }
+  return required;
+}
+
+export function extractFilePaths(content: string): string[] {
+  const paths: string[] = [];
+  for (const match of content.matchAll(FILE_PATH_PATTERN)) {
+    const candidate = normalizePath(match[1] ?? "");
+    if (isLikelyPath(candidate)) {
+      paths.push(candidate);
+    }
+  }
+  return dedupe(paths);
+}
+
+export function shouldEnforcePromptPrerequisites(
+  keywords: string[],
+  parseResult: PromptPrerequisiteParseResult,
+  config: PromptPrerequisiteConfig,
+): boolean {
+  if (!config.enabled) {
+    return false;
+  }
+
+  if (!keywords.some((keyword) => config.executionKeywords.includes(keyword))) {
+    return false;
+  }
+
+  return parseResult.requiredToolCalls.length > 0 || parseResult.requiredFilePaths.length > 0;
+}
+
+export function readPromptPrerequisiteState(
+  directory: string,
+  sessionId?: string,
+): PromptPrerequisiteState | null {
+  return readModeState<PromptPrerequisiteState>(STATE_MODE, directory, sessionId);
+}
+
+export function clearPromptPrerequisiteState(
+  directory: string,
+  sessionId?: string,
+): boolean {
+  return clearModeStateFile(STATE_MODE, directory, sessionId);
+}
+
+export function activatePromptPrerequisiteState(
+  directory: string,
+  sessionId: string | undefined,
+  executionKeywords: string[],
+  parseResult: PromptPrerequisiteParseResult,
+): PromptPrerequisiteState | null {
+  if (parseResult.requiredToolCalls.length === 0 && parseResult.requiredFilePaths.length === 0) {
+    clearPromptPrerequisiteState(directory, sessionId);
+    return null;
+  }
+
+  const now = new Date().toISOString();
+  const state: PromptPrerequisiteState = {
+    active: true,
+    session_id: sessionId,
+    execution_keywords: executionKeywords,
+    required_tool_calls: parseResult.requiredToolCalls,
+    required_file_paths: parseResult.requiredFilePaths,
+    completed_tool_calls: [],
+    completed_file_paths: [],
+    created_at: now,
+    updated_at: now,
+  };
+
+  return writeModeState(STATE_MODE, state as unknown as Record<string, unknown>, directory, sessionId)
+    ? state
+    : null;
+}
+
+export function buildPromptPrerequisiteReminder(
+  state: PromptPrerequisiteState,
+): string {
+  const toolList = state.required_tool_calls.length > 0
+    ? state.required_tool_calls.map((tool) => `- Call \`${tool}\``).join("\n")
+    : "";
+  const fileList = state.required_file_paths.length > 0
+    ? state.required_file_paths.map((path) => `- Read \`${path}\``).join("\n")
+    : "";
+
+  return `<system-reminder>
+[BLOCKING PREREQUISITE GATE]
+This prompt declared prerequisite context. Before any Edit/Write/Agent/Task tool use, you MUST satisfy every prerequisite below.
+
+Required MCP/tool calls:
+${toolList || "- None"}
+
+Required file reads:
+${fileList || "- None"}
+
+Do the prerequisite reads first. Do not edit files. Do not spawn/delegate agents until the list is complete.
+</system-reminder>`;
+}
+
+export function isPromptPrerequisiteBlockingTool(
+  toolName: string | undefined,
+  config: PromptPrerequisiteConfig,
+): boolean {
+  return Boolean(toolName && config.blockingTools.includes(toolName));
+}
+
+function matchesToolRequirement(toolName: string | undefined, requiredTool: string): boolean {
+  if (!toolName) {
+    return false;
+  }
+
+  const normalizedTool = toolName.toLowerCase();
+  switch (requiredTool) {
+    case "notepad_read":
+      return normalizedTool === "notepad_read" || normalizedTool.endsWith("__notepad_read");
+    case "project_memory_read":
+      return normalizedTool === "project_memory_read" || normalizedTool.endsWith("__project_memory_read");
+    case "supermemory.search":
+      return normalizedTool === "supermemory_search"
+        || normalizedTool === "supermemory.search"
+        || /supermemory.*search/i.test(toolName);
+    default:
+      return normalizedTool === requiredTool.toLowerCase();
+  }
+}
+
+function extractReadFilePath(toolName: string | undefined, toolInput: unknown): string | null {
+  if ((toolName || "").toLowerCase() !== "read") {
+    return null;
+  }
+
+  if (!toolInput || typeof toolInput !== "object") {
+    return null;
+  }
+
+  const input = toolInput as Record<string, unknown>;
+  const filePath = input.file_path ?? input.path;
+  return typeof filePath === "string" && filePath.trim().length > 0 ? filePath.trim() : null;
+}
+
+export function recordPromptPrerequisiteProgress(
+  directory: string,
+  sessionId: string | undefined,
+  toolName: string | undefined,
+  toolInput: unknown,
+): PromptPrerequisiteProgress | null {
+  const state = readPromptPrerequisiteState(directory, sessionId);
+  if (!state?.active) {
+    return null;
+  }
+
+  let toolSatisfied: string | null = null;
+  let fileSatisfied: string | null = null;
+
+  for (const requiredTool of state.required_tool_calls) {
+    if (!state.completed_tool_calls.includes(requiredTool) && matchesToolRequirement(toolName, requiredTool)) {
+      state.completed_tool_calls = dedupe([...state.completed_tool_calls, requiredTool]);
+      toolSatisfied = requiredTool;
+    }
+  }
+
+  const readPath = extractReadFilePath(toolName, toolInput);
+  if (readPath) {
+    for (const requiredPath of state.required_file_paths) {
+      if (!state.completed_file_paths.includes(requiredPath) && normalizePath(readPath) === requiredPath) {
+        state.completed_file_paths = dedupe([...state.completed_file_paths, requiredPath]);
+        fileSatisfied = requiredPath;
+      }
+    }
+  }
+
+  const remainingToolCalls = state.required_tool_calls.filter(
+    (requiredTool) => !state.completed_tool_calls.includes(requiredTool),
+  );
+  const remainingFilePaths = state.required_file_paths.filter(
+    (requiredPath) => !state.completed_file_paths.includes(requiredPath),
+  );
+  const isComplete = remainingToolCalls.length === 0 && remainingFilePaths.length === 0;
+
+  if (isComplete) {
+    clearPromptPrerequisiteState(directory, sessionId);
+  } else if (toolSatisfied || fileSatisfied) {
+    state.updated_at = new Date().toISOString();
+    writeModeState(STATE_MODE, state as unknown as Record<string, unknown>, directory, sessionId);
+  }
+
+  return {
+    toolSatisfied,
+    fileSatisfied,
+    remainingToolCalls,
+    remainingFilePaths,
+    isComplete,
+  };
+}
+
+export function getRemainingPromptPrerequisites(
+  state: PromptPrerequisiteState,
+): { remainingToolCalls: string[]; remainingFilePaths: string[] } {
+  return {
+    remainingToolCalls: state.required_tool_calls.filter(
+      (requiredTool) => !state.completed_tool_calls.includes(requiredTool),
+    ),
+    remainingFilePaths: state.required_file_paths.filter(
+      (requiredPath) => !state.completed_file_paths.includes(requiredPath),
+    ),
+  };
+}
+
+export function buildPromptPrerequisiteDenyReason(
+  state: PromptPrerequisiteState,
+  toolName: string | undefined,
+): string {
+  const remaining = getRemainingPromptPrerequisites(state);
+  const toolBits = remaining.remainingToolCalls.length > 0
+    ? `Missing tool calls: ${remaining.remainingToolCalls.join(", ")}.`
+    : "";
+  const fileBits = remaining.remainingFilePaths.length > 0
+    ? `Missing file reads: ${remaining.remainingFilePaths.join(", ")}.`
+    : "";
+
+  return `[PROMPT PREREQUISITES] Blocking ${toolName || "tool"} until prompt prerequisites are completed. ${toolBits} ${fileBits}`.trim();
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -184,6 +184,23 @@ export interface PluginConfig {
     /** Suppress heavy orchestration modes (ralph/autopilot/team/ultrawork) for small tasks. Default: true */
     suppressHeavyModesForSmallTasks?: boolean;
   };
+
+  // Prompt prerequisite gating for execution modes (issue #1859)
+  promptPrerequisites?: {
+    /** Enable parsing + blocking gate injection for prerequisite sections. Default: true */
+    enabled?: boolean;
+    /** Extensible heading aliases grouped by semantic section kind. */
+    sectionNames?: {
+      memory?: string[];
+      skills?: string[];
+      verifyFirst?: string[];
+      context?: string[];
+    };
+    /** Tool names denied until prerequisites are satisfied. */
+    blockingTools?: string[];
+    /** Execution keywords that activate the gate. */
+    executionKeywords?: string[];
+  };
 }
 
 export interface SessionState {


### PR DESCRIPTION
Closes #1859.

## Summary
- parse structured prerequisite sections from execution prompts (# MÉMOIRE, # SKILLS, # VERIFY-FIRST, # CONTEXT)
- persist required MCP reads/file reads in session-scoped state and inject a blocking system reminder
- deny Edit/Write/Task/Agent until prerequisites are satisfied, then automatically unblock
- add configurable section aliases plus focused parser/bridge regression tests

## Verification
- `npm test -- --run src/hooks/__tests__/prompt-prerequisites.test.ts src/hooks/__tests__/bridge-routing.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/hooks/prompt-prerequisites/index.ts src/hooks/__tests__/prompt-prerequisites.test.ts src/hooks/bridge.ts src/hooks/__tests__/bridge-routing.test.ts src/shared/types.ts src/config/loader.ts`