### PR TITLE
fix(hooks): add deepsearch to mode-message filter in keyword-detector

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -79,6 +79,17 @@ Perform a focused security review of the relevant changes or target area. Check 
 ---
 `;
 
+const SEARCH_MESSAGE = `<search-mode>
+MAXIMIZE SEARCH EFFORT. Launch multiple background agents IN PARALLEL:
+- explore agents (codebase patterns, file structures)
+- document-specialist agents (remote repos, official docs, GitHub examples)
+Plus direct tools: Grep, Glob
+NEVER stop at first result - be exhaustive.
+</search-mode>
+
+---
+`;
+
 // Extract prompt from various JSON structures
 function extractPrompt(input) {
   try {
@@ -613,6 +624,7 @@ async function main() {
     const additionalContextParts = [];
     for (const [keywordName, message] of [
       ['ultrathink', ULTRATHINK_MESSAGE],
+      ['deepsearch', SEARCH_MESSAGE],
       ['analyze', ANALYZE_MESSAGE],
       ['tdd', TDD_MESSAGE],
       ['code-review', CODE_REVIEW_MESSAGE],


### PR DESCRIPTION
## Summary

The `deepsearch` keyword was missing from the mode-message filter list in `scripts/keyword-detector.mjs`, causing it to be dispatched as a skill invocation (`Skill("oh-my-claudecode:deepsearch")`) which fails with `Error: Unknown skill: oh-my-claudecode:deepsearch`.

## Root Cause

`templates/hooks/keyword-detector.mjs` already has the fix (line 546: `['deepsearch', SEARCH_MESSAGE]`), but `scripts/keyword-detector.mjs` was not synchronized. This is the same class of bug as #691.

## Changes

- Added `SEARCH_MESSAGE` constant to `scripts/keyword-detector.mjs`
- Added `['deepsearch', SEARCH_MESSAGE]` to the mode-message filter array

## Test

Before fix:
```
❯ deepsearch for pattern X
⏺ Skill(oh-my-claudecode:deepsearch)
  ⎿ Error: Unknown skill: oh-my-claudecode:deepsearch
```

After fix: `deepsearch` keyword injects `SEARCH_MESSAGE` context instead of attempting skill invocation.

Fixes #2053