### PR TITLE
Fix deepsearch keyword dispatch for mode-message hooks

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -45,6 +45,17 @@ Use your extended thinking capabilities to provide the most thorough and well-re
 ---
 `;
 
+const SEARCH_MESSAGE = `<search-mode>
+MAXIMIZE SEARCH EFFORT. Launch multiple background agents IN PARALLEL:
+- explore agents (codebase patterns, file structures)
+- document-specialist agents (remote repos, official docs, GitHub examples)
+Plus direct tools: Grep, Glob
+NEVER stop at first result - be exhaustive.
+</search-mode>
+
+---
+`;
+
 const ANALYZE_MESSAGE = `<analyze-mode>
 ANALYSIS MODE. Gather context before diving deep:
 - Search relevant code paths first
@@ -78,6 +89,15 @@ Perform a focused security review of the relevant changes or target area. Check 
 
 ---
 `;
+
+const MODE_MESSAGE_KEYWORDS = new Map([
+  ['ultrathink', ULTRATHINK_MESSAGE],
+  ['deepsearch', SEARCH_MESSAGE],
+  ['analyze', ANALYZE_MESSAGE],
+  ['tdd', TDD_MESSAGE],
+  ['code-review', CODE_REVIEW_MESSAGE],
+  ['security-review', SECURITY_REVIEW_MESSAGE],
+]);
 
 // Extract prompt from various JSON structures
 function extractPrompt(input) {
@@ -611,13 +631,7 @@ async function main() {
     }
 
     const additionalContextParts = [];
-    for (const [keywordName, message] of [
-      ['ultrathink', ULTRATHINK_MESSAGE],
-      ['analyze', ANALYZE_MESSAGE],
-      ['tdd', TDD_MESSAGE],
-      ['code-review', CODE_REVIEW_MESSAGE],
-      ['security-review', SECURITY_REVIEW_MESSAGE],
-    ]) {
+    for (const [keywordName, message] of MODE_MESSAGE_KEYWORDS) {
       const index = resolved.findIndex(m => m.name === keywordName);
       if (index !== -1) {
         resolved.splice(index, 1);

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+const SCRIPT_PATH = join(process.cwd(), 'scripts', 'keyword-detector.mjs');
+const NODE = process.execPath;
+
+function runKeywordDetector(prompt: string) {
+  const raw = execFileSync(NODE, [SCRIPT_PATH], {
+    input: JSON.stringify({
+      hook_event_name: 'UserPromptSubmit',
+      cwd: process.cwd(),
+      session_id: 'session-2053',
+      prompt,
+    }),
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      OMC_SKIP_HOOKS: '',
+    },
+    timeout: 15000,
+  }).trim();
+
+  return JSON.parse(raw) as {
+    continue: boolean;
+    suppressOutput?: boolean;
+    hookSpecificOutput?: {
+      hookEventName?: string;
+      additionalContext?: string;
+    };
+  };
+}
+
+describe('keyword-detector.mjs mode-message dispatch', () => {
+  it('injects search mode for deepsearch without emitting a magic skill invocation', () => {
+    const output = runKeywordDetector('deepsearch the codebase for keyword dispatch');
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(output.hookSpecificOutput?.hookEventName).toBe('UserPromptSubmit');
+    expect(context).toContain('<search-mode>');
+    expect(context).toContain('MAXIMIZE SEARCH EFFORT');
+    expect(context).not.toContain('[MAGIC KEYWORD: DEEPSEARCH]');
+    expect(context).not.toContain('Skill: oh-my-claudecode:deepsearch');
+  });
+
+  it.each([
+    ['ultrathink', '<think-mode>'],
+    ['deep-analyze this subsystem', '<analyze-mode>'],
+    ['tdd fix the failing test', '<tdd-mode>'],
+    ['code review this diff', '<code-review-mode>'],
+    ['security review this auth flow', '<security-review-mode>'],
+  ])('keeps mode keyword %s on the context-injection path', (prompt, marker) => {
+    const output = runKeywordDetector(prompt);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain(marker);
+    expect(context).not.toContain('[MAGIC KEYWORD:');
+  });
+
+  it('still emits magic keyword invocation for true skills like ralplan', () => {
+    const output = runKeywordDetector('ralplan fix issue #2053');
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain('[MAGIC KEYWORD: RALPLAN]');
+    expect(context).toContain('Skill: oh-my-claudecode:ralplan');
+  });
+});


### PR DESCRIPTION
## Summary
- keep deepsearch on the mode-message context injection path instead of emitting a missing-skill invocation
- add the missing runtime `SEARCH_MESSAGE` and centralize the mode-message keyword map in the keyword detector hook
- add a direct regression test for script-level hook output and preserve real skill dispatch for keywords like `ralplan`

## Problem
The UserPromptSubmit hook was emitting `[MAGIC KEYWORD: DEEPSEARCH]` even though `deepsearch` is handled by bridge-side mode-message injection, not by a real skill. That produced an Unknown skill error.

## Testing
- `npm test -- --run src/__tests__/keyword-detector-script.test.ts src/hooks/keyword-detector/__tests__/index.test.ts`
- `npm run build`
- `npm test -- --run`
