### PR TITLE
fix(hud): gracefully handle getUsage() failures instead of crashing

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -301,8 +301,21 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     }
 
     // Fetch rate limits from OAuth API (if available)
+    // Use .catch() to degrade gracefully when getUsage() throws (e.g., file lock
+    // contention from concurrent HUD processes). The HUD continues rendering
+    // without rate limit data instead of crashing with "HUD error - check stderr".
     const rateLimitsResult =
-      config.elements.rateLimits !== false ? await getUsage() : null;
+      config.elements.rateLimits !== false
+        ? await getUsage().catch((error: unknown) => {
+            if (process.env.OMC_DEBUG) {
+              console.error(
+                "[HUD] Rate limits fetch failed:",
+                error instanceof Error ? error.message : error,
+              );
+            }
+            return null;
+          })
+        : null;
 
     // Fetch custom rate limit buckets (if configured)
     const customBuckets =


### PR DESCRIPTION
## Problem

When multiple HUD statusline processes run concurrently (Claude Code invokes the statusline command frequently), the file lock in `getUsage()` can fail to be acquired within the 12-second timeout. `withFileLock` throws `"Failed to acquire file lock: .usage-cache.json.lock"`, which propagates up uncaught and crashes the entire HUD with:

```
[OMC] HUD error - check stderr
```

This is especially common in **non-git directories** where worktree resolution adds slight overhead, increasing the window for lock contention.

## Root Cause

In `src/hud/index.ts`, the `getUsage()` call has no error handling:

```typescript
const rateLimitsResult =
  config.elements.rateLimits !== false ? await getUsage() : null;
```

When `getUsage()` → `withFileLock()` throws, the error falls through to the outer `main()` catch block, which outputs the generic `[OMC] HUD error - check stderr` message — crashing the entire HUD for a non-critical feature.

## Fix

Add `.catch()` to the `getUsage()` promise so that lock contention (or any other transient failure) degrades gracefully — the HUD renders without rate limit data instead of showing an error message:

```typescript
const rateLimitsResult =
  config.elements.rateLimits !== false
    ? await getUsage().catch((error: unknown) => {
        if (process.env.OMC_DEBUG) {
          console.error(
            "[HUD] Rate limits fetch failed:",
            error instanceof Error ? error.message : error,
          );
        }
        return null;
      })
    : null;
```

## Reproducer

1. Open Claude Code in a non-git directory
2. Observe the statusline — `[OMC] HUD error - check stderr` appears intermittently
3. Run manually with `OMC_DEBUG=1` and capture stderr: `Failed to acquire file lock: .../.usage-cache.json.lock`

## Impact

- **Minimal diff**: 1 file changed, +14 −1 lines
- **No behavioral change on success**: when `getUsage()` succeeds, behavior is identical
- **Graceful degradation**: on failure, HUD renders normally without rate limit bars
- **Debug-friendly**: errors are still logged to stderr when `OMC_DEBUG=1`