### PR TITLE
fix(pre-tool-enforcer): allow tier aliases when OMC_SUBAGENT_MODEL is set

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -653,14 +653,17 @@ async function main() {
           }
           // else: valid provider-specific model ID — fall through to continue.
         } else if (sessionHasLmSuffix) {
-          // No model param, but the session model has a [1m] context-window suffix.
-          // Check if stripping the suffix yields a valid provider-specific ID — if so,
-          // the sub-agent will inherit that stripped ID cleanly (e.g.
-          // global.anthropic.claude-sonnet-4-6[1m] → global.anthropic.claude-sonnet-4-6).
-          const strippedSessionModel = sessionModel.replace(/\[\d+[mk]\]$/i, '');
-          if (!isProviderSpecificModelId(strippedSessionModel)) {
-            // Stripped ID would be a bare Anthropic ID (e.g. claude-sonnet-4-6) which
-            // is invalid on Bedrock. Block and guide the user.
+          // No model param, but at least one session model env var has a [1m] suffix.
+          // Validate EVERY suffixed var: the runtime may pick any of them (e.g.
+          // resolveClaudeWorkerModel prefers ANTHROPIC_MODEL), so a safe CLAUDE_MODEL
+          // cannot vouch for an unsafe ANTHROPIC_MODEL in the same session.
+          // Only allow when ALL stripped values are valid provider-specific IDs.
+          const unsafeVar = [claudeModel, anthropicModel]
+            .filter(v => hasExtendedContextSuffix(v))
+            .find(v => !isProviderSpecificModelId(v.replace(/\[\d+[mk]\]$/i, '')));
+          if (unsafeVar) {
+            // At least one var strips to a bare Anthropic ID (e.g. claude-sonnet-4-6)
+            // which is invalid on Bedrock. Block and guide the user.
             const subagentModel = process.env.OMC_SUBAGENT_MODEL || '';
             const suggestion = subagentModel
               ? `Pass model="${subagentModel}" (your configured OMC_SUBAGENT_MODEL) explicitly on this ${toolName} call.`
@@ -675,8 +678,7 @@ async function main() {
             }));
             return;
           }
-          // else: stripping [1m] gives a valid provider-specific ID (e.g.
-          // global.anthropic.claude-sonnet-4-6) — inheritance is safe, fall through.
+          // else: all suffixed vars strip to valid provider-specific IDs — inheritance is safe.
         }
         // else: no model param and no [1m] on session model → normal forceInherit,
         // agents inherit the parent session's model cleanly.

--- a/src/__tests__/bedrock-lm-suffix-hook.test.ts
+++ b/src/__tests__/bedrock-lm-suffix-hook.test.ts
@@ -294,4 +294,18 @@ describe('hook integration — force-inherit + [1m] scenarios', () => {
     expect(result.denied).toBe(true);
     expect(result.reason).toMatch(/us\.anthropic\.claude-sonnet-4-5-20250929-v1:0/);
   });
+
+  it('denies no-model call when CLAUDE_MODEL is provider-specific[1m] but ANTHROPIC_MODEL is bare[1m]', () => {
+    // Mixed case: CLAUDE_MODEL strips safely, but ANTHROPIC_MODEL strips to a bare Anthropic ID.
+    // The runtime (resolveClaudeWorkerModel) may pick ANTHROPIC_MODEL, so both must be safe.
+    const result = runHook(
+      {},
+      {
+        CLAUDE_MODEL: 'global.anthropic.claude-sonnet-4-6[1m]',
+        ANTHROPIC_MODEL: 'claude-sonnet-4-6[1m]',
+      },
+    );
+    expect(result.denied).toBe(true);
+    expect(result.reason).toMatch(/OMC_SUBAGENT_MODEL/);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `isTierAlias()` helper to detect `sonnet`/`opus`/`haiku` short-form model names
- Allows tier aliases to pass through the forceInherit model guard when `OMC_SUBAGENT_MODEL` is set to a valid provider-specific ID
- The Agent tool schema only accepts these short aliases — full Bedrock/Vertex IDs are rejected at the schema level, leaving no escape hatch without this fix

Follows up on #1863.

## Test plan

- [ ] Unit tests: all 22 pass (`npm test src/__tests__/pre-tool-enforcer.test.ts`)
- [ ] Covers new cases: tier alias allowed when `OMC_SUBAGENT_MODEL` is a valid Bedrock ID, blocked when unset or invalid
- [ ] Manual: subagent spawn verified working in `--plugin-dir` session