### PR TITLE
fix(keyword-detector): inject SKILL.md content directly, remove Skill tool dependency

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -24,9 +24,27 @@
  */
 
 import { writeFileSync, readFileSync, mkdirSync, existsSync, unlinkSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
 import { readStdin } from './lib/stdin.mjs';
+
+// Resolve OMC package root: CLAUDE_PLUGIN_ROOT (plugin system) or derive from this script's location
+const _omcRoot = process.env.CLAUDE_PLUGIN_ROOT ||
+  join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Load skill content directly from SKILL.md on disk.
+ * Works for both npm installs and plugin marketplace installs.
+ * Returns null if the skill file is not found.
+ */
+function loadSkillContent(skillName) {
+  const skillPath = join(_omcRoot, 'skills', skillName, 'SKILL.md');
+  if (existsSync(skillPath)) {
+    try { return readFileSync(skillPath, 'utf8'); } catch { /* fall through */ }
+  }
+  return null;
+}
 
 const ULTRATHINK_MESSAGE = `<think-mode>
 
@@ -318,10 +336,16 @@ function isTeamEnabled() {
 }
 
 /**
- * Create a skill invocation message that tells Claude to use the Skill tool
+ * Create a skill invocation message.
+ * Prefers direct SKILL.md content injection (works for npm and plugin installs).
+ * Falls back to Skill tool invocation (requires plugin marketplace install).
  */
 function createSkillInvocation(skillName, originalPrompt, args = '') {
   const argsSection = args ? `\nArguments: ${args}` : '';
+  const skillContent = loadSkillContent(skillName);
+  if (skillContent) {
+    return `[MAGIC KEYWORD: ${skillName.toUpperCase()}]\n\n${skillContent}\n\n---\nUser request:\n${originalPrompt}${argsSection}`;
+  }
   return `[MAGIC KEYWORD: ${skillName.toUpperCase()}]
 
 You MUST invoke the skill using the Skill tool:
@@ -345,20 +369,24 @@ function createMultiSkillInvocation(skills, originalPrompt) {
 
   const skillBlocks = skills.map((s, i) => {
     const argsSection = s.args ? `\nArguments: ${s.args}` : '';
-    return `### Skill ${i + 1}: ${s.name.toUpperCase()}
-Skill: oh-my-claudecode:${s.name}${argsSection}`;
+    const content = loadSkillContent(s.name);
+    if (content) {
+      return `### Skill ${i + 1}: ${s.name.toUpperCase()}\n\n${content}${argsSection}`;
+    }
+    return `### Skill ${i + 1}: ${s.name.toUpperCase()}\nSkill: oh-my-claudecode:${s.name}${argsSection}`;
   }).join('\n\n');
 
+  const hasDirectContent = skills.some(s => loadSkillContent(s.name));
   return `[MAGIC KEYWORDS DETECTED: ${skills.map(s => s.name.toUpperCase()).join(', ')}]
 
-You MUST invoke ALL of the following skills using the Skill tool, in order:
+${hasDirectContent ? 'Execute ALL of the following skills in order:' : 'You MUST invoke ALL of the following skills using the Skill tool, in order:'}
 
 ${skillBlocks}
 
 User request:
 ${originalPrompt}
 
-IMPORTANT: Invoke ALL skills listed above. Start with the first skill IMMEDIATELY. After it completes, invoke the next skill in order. Do not skip any skill.`;
+IMPORTANT: Complete ALL skills listed above in order. Start with the first skill IMMEDIATELY.`;
 }
 
 /**


### PR DESCRIPTION
## Problem

When installed via `npm install -g oh-my-claude-sisyphus`, magic keywords like `autopilot:` are detected by the hook but then fail silently:

```
● Skill(oh-my-claudecode:autopilot)
  └ Error: Unknown skill: oh-my-claudecode:autopilot
```

Plugin-scoped skills (`oh-my-claudecode:*`) are only registered with Claude Code's Skill tool when installed through the plugin marketplace. The npm install path has no mechanism to register them.

## Fix

In `createSkillInvocation` and `createMultiSkillInvocation`, try loading `SKILL.md` content directly from disk before falling back to the Skill tool invocation.

**Resolution order:**
1. `$CLAUDE_PLUGIN_ROOT/skills/<name>/SKILL.md` — plugin system (existing behavior preserved)
2. `<package-root>/skills/<name>/SKILL.md` — npm install (derived from `import.meta.url`)
3. Fallback: Skill tool invocation — backward compat for cases where skill files aren't found

This makes both install paths work without any changes to Claude Code's plugin registry.

## Testing

```bash
echo '{"prompt":"autopilot: write hello world","cwd":"/tmp","session_id":"test"}' \
  | node scripts/keyword-detector.mjs | python3 -c "
import json,sys
d=json.load(sys.stdin)
ctx=d['hookSpecificOutput']['additionalContext']
print('Direct inject:', 'Skill: oh-my-claudecode' not in ctx)
print('Has content:', 'autopilot' in ctx.lower())
"
# Direct inject: True
# Has content: True
```

Note: HUD package name fix is covered separately in #2066.