### PR TITLE
feat(skill): add self-improve autonomous code improvement skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp
 <skills>
 Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
 
-Workflow: `autopilot`, `ralph`, `ultrawork`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`
+Workflow: `autopilot`, `ralph`, `ultrawork`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`, `self-improve`
 Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
 Utilities: `ask-codex`, `ask-gemini`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `configure-notifications`, `learn-about-omc` (`trace` is the evidence-driven tracing lane)
 </skills>

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -115,6 +115,7 @@ Active modes are still cancelled in dependency order:
 8. Team (Claude Code native)
 9. OMC Teams (tmux CLI workers)
 10. Plan Consensus (standalone)
+11. Self-Improve (standalone — clear state, clean orphaned worktrees, preserve iteration_state for resume, set status: "user_stopped" in .omc/self-improve/state/agent-settings.json)
 
 ## Force Clear All
 

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: self-improve
+description: Autonomous evolutionary code improvement engine with tournament selection
+level: 4
+---
+
+# Self-Improvement Orchestrator
+
+You are the **loop controller** for the self-improvement system. You manage the full lifecycle: setup, research, planning, execution, tournament selection, history recording, visualization, and stop-condition evaluation. You delegate to specialized OMC agents and coordinate their inputs and outputs.
+
+---
+
+## Autonomous Execution Policy
+
+**NEVER stop or pause to ask the user during the improvement loop.** Once the gate check passes and the loop begins, you run fully autonomously until a stop condition is met.
+
+- **Do not ask for confirmation** between iterations or between steps within an iteration.
+- **Do not summarize and wait** — execute the next step immediately.
+- **On agent failure**: retry once, then skip that agent and continue with remaining agents. Log the failure in iteration history.
+- **On all plans rejected**: log it, continue to the next iteration automatically.
+- **On all executors failing**: log it, continue to the next iteration automatically.
+- **On benchmark errors**: log the error, mark the executor as failed, continue with other executors.
+- **The only things that stop the loop** are the stop conditions in Step 11.
+
+---
+
+## State Tracking
+
+All state lives under `.omc/self-improve/`:
+
+```
+.omc/self-improve/
+├── config/                    # User configuration
+│   ├── settings.json          # agents, benchmark, thresholds, sealed_files
+│   ├── goal.md                # Improvement objective + target metric
+│   ├── harness.md             # Guardrail rules (H001/H002/H003)
+│   └── idea.md                # User experiment ideas
+├── state/                     # Runtime state
+│   ├── agent-settings.json    # iterations, best_score, status, counters
+│   ├── iteration_state.json   # Within-iteration progress (resumability)
+│   ├── research_briefs/       # Research output per round
+│   ├── iteration_history/     # Full history per round
+│   ├── merge_reports/         # Tournament results
+│   └── plan_archive/          # Archived plans (permanent)
+├── plans/                     # Active plans (current round)
+└── tracking/                  # Visualization data
+    ├── raw_data.json          # All candidate scores
+    ├── baseline.json          # Initial benchmark score
+    ├── events.json            # Config changes
+    └── progress.png           # Generated chart
+```
+
+OMC mode lifecycle: `.omc/state/sessions/{sessionId}/self-improve-state.json`
+
+---
+
+## Agent Mapping
+
+All augmentations delivered via Task description context at spawn time. No modifications to existing agent .md files.
+
+| Step | Role | OMC Agent | Model |
+|------|------|-----------|-------|
+| Research | Codebase analysis + hypothesis generation | general-purpose Agent | opus |
+| Planning | Hypothesis → structured plan | oh-my-claudecode:planner | opus |
+| Architecture Review | 6-point plan review | oh-my-claudecode:architect | opus |
+| Critic Review | Harness rule enforcement | oh-my-claudecode:critic | opus |
+| Execution | Implement plan + run benchmark | oh-my-claudecode:executor | opus |
+| Git Operations | Atomic merge/tag/PR | oh-my-claudecode:git-master | sonnet |
+| Goal Setup | Interactive interview | (directly in this skill) | N/A |
+| Benchmark Setup | Create + validate benchmark | custom agent | opus |
+
+**Research prompt**: Read `si-researcher.md` from this skill directory and pass its content as the agent prompt.
+
+**Benchmark builder**: Read `si-benchmark-builder.md` from this skill directory and pass its content as the agent prompt.
+
+**Goal clarifier**: Read `si-goal-clarifier.md` from this skill directory and execute the interview directly (interactive, needs user).
+
+---
+
+## Inputs
+
+Read these files at startup and at the beginning of each iteration:
+
+| File | Purpose |
+|---|---|
+| `.omc/self-improve/config/settings.json` | User config: `number_of_agents`, `benchmark_command`, `benchmark_format`, `benchmark_direction`, `max_iterations`, `plateau_threshold`, `plateau_window`, `target_value`, `primary_metric`, `sealed_files`, `regression_threshold`, `circuit_breaker_threshold`, `target_branch`, `current_repo_url`, `fork_url`, `upstream_url` |
+| `.omc/self-improve/state/agent-settings.json` | Runtime: `iterations`, `best_score`, `plateau_consecutive_count`, `circuit_breaker_count`, `status`, `goal_slug` (derived: lowercase underscore from goal objective, persisted for cross-session consistency) |
+| `.omc/self-improve/state/iteration_state.json` | Per-iteration progress for resumability |
+| `.omc/self-improve/config/goal.md` | Improvement objective, target metric, scope |
+| `.omc/self-improve/config/harness.md` | Guardrail rules (H001, H002, H003) |
+
+---
+
+## Setup Phase
+
+1. Check if target repo path exists. If not configured, ask user for the path to the repository to improve.
+2. Create `.omc/self-improve/` directory structure by copying from `templates/` in this skill directory.
+3. Read `.omc/self-improve/state/agent-settings.json`. Check `si_setting_goal`, `si_setting_benchmark`, `si_setting_harness`.
+4. If goal not set → read `si-goal-clarifier.md` from this skill directory and run the 4-dimension Socratic interview directly in this context (Objective, Metric, Target, Scope). Write result to `.omc/self-improve/config/goal.md`.
+5. If benchmark not set → read `si-benchmark-builder.md` from this skill directory, spawn a custom Agent(model=opus) with its content as prompt. The agent surveys the repo, creates or wraps a benchmark, validates 3x, and records baseline.
+6. If harness not set → confirm default harness rules (H001/H002/H003) with user or customize.
+7. **Gate**: All of `si_setting_goal`, `si_setting_benchmark`, `si_setting_harness` must be true.
+8. **Create improvement branch** (if it does not exist):
+   ```
+   git -C {repo_path} checkout -b improve/{goal_slug} {target_branch}
+   git -C {repo_path} checkout {target_branch}
+   ```
+   Where `{goal_slug}` is derived from the goal objective (lowercase, underscored). If the branch already exists, skip creation.
+9. **Mode exclusivity**: Call `state_list_active`. If autopilot, ralph, or ultrawork is active, refuse to start.
+10. Write initial state: `state_write(mode='self-improve', active=true, iteration=0, started_at=<now>)`
+
+---
+
+## Git Strategy
+
+All git operations happen inside the target repo, NOT in the OMC project root.
+
+- **Improvement branch**: `improve/{goal_slug}` — accumulates winning changes only.
+- **Experiment branches**: `experiment/round_{n}_executor_{id}` — short-lived, per executor.
+- **Archive tags**: `archive/round_{n}_executor_{id}` — losing branches tagged before deletion.
+- **Worktree setup** (SKILL.md creates before each executor):
+  ```
+  git -C {repo_path} worktree add worktrees/round_{n}_executor_{id} -b experiment/round_{n}_executor_{id} improve/{goal_slug}
+  ```
+- **Winner merges** via `oh-my-claudecode:git-master`:
+  ```
+  Merge experiment/round_{n}_executor_{winner_id} into improve/{goal_slug} with --no-ff
+  Message: "Iteration {n}: {hypothesis} (score: {before} → {after})"
+  ```
+- **Push after merge**: `git -C {repo_path} push origin improve/{goal_slug}` (backup, non-blocking)
+- **Losers archived**: Tag + delete via git-master.
+
+---
+
+## Improvement Loop
+
+**Gate**: All settings must be true. Once the gate passes, execute continuously without stopping.
+
+Update `state_write(mode='self-improve', active=true, status="running")`.
+
+### Step 1 — Refresh State
+
+`state_write(mode='self-improve', active=true, iteration=N)` to reset 30min TTL.
+
+### Step 2 — Check Stop Request
+
+`state_read(mode='self-improve')` — if state is cleared or status is `user_stopped`, exit gracefully.
+
+### Step 3 — Check User Ideas
+
+Read `.omc/self-improve/config/idea.md`. If non-empty, snapshot contents for planners. Clear after planners consume.
+
+### Step 4 — Research
+
+Spawn 1 general-purpose Agent(model=opus) with the content of `si-researcher.md` as prompt.
+
+Pass in the prompt:
+- Current iteration number
+- Path to target repo
+- Path to `.omc/self-improve/config/goal.md`
+- Path to `.omc/self-improve/state/iteration_history/` (all prior records)
+- Path to `.omc/self-improve/state/research_briefs/` (prior briefs)
+- Content of `data_contracts.md` Section 3 (Research Brief schema)
+
+Expected output: research brief JSON → `.omc/self-improve/state/research_briefs/round_{n}.json`
+
+If researcher fails, proceed with history only.
+
+### Step 5 — Plan
+
+Spawn N `oh-my-claudecode:planner`(model=opus) agents in parallel (N = `number_of_agents` from settings).
+
+Pass in each planner's prompt:
+- Planner identity (planner_a, planner_b, planner_c...)
+- Research brief path
+- Iteration history path
+- Harness rules from `.omc/self-improve/config/harness.md`
+- Data contract schema for Plan Document
+- **Override instructions**: Output JSON (not markdown), skip interview mode, generate exactly ONE testable hypothesis per plan, include approach_family tag and history_reference.
+- User ideas (if any, planner_a gets priority)
+
+Expected output: Plan Document JSON → `.omc/self-improve/plans/round_{n}/plan_planner_{id}.json`
+
+### Step 6 — Review
+
+For each plan, **sequentially** (architect before critic):
+
+**6a. Architecture Review**: Spawn `oh-my-claudecode:architect` with the plan + 6-point checklist:
+1. Testability — is the hypothesis testable?
+2. Novelty — different from prior attempts?
+3. Scope — right-sized?
+4. Target files — exist, not sealed?
+5. Implementation clarity — executor can implement without guessing?
+6. Expected outcome — realistic given evidence?
+
+Architect verdict is **advisory only**.
+
+**6b. Critic Review**: Spawn `oh-my-claudecode:critic` with the plan + harness rules:
+- H001: Exactly one hypothesis (reject if zero or multiple)
+- H002: No approach_family repetition streak >= 3
+- H003: Intra-round diversity (no two plans same family in same round)
+- Schema validation against data_contracts.md
+- History awareness check
+
+Critic sets `critic_approved: true` or `false`. Plans with `false` are excluded from execution.
+
+If ALL plans rejected, log and skip to Step 9.
+
+### Step 7 — Execute
+
+For each approved plan, spawn `oh-my-claudecode:executor`(model=opus) in parallel.
+
+**Before spawning**, create worktree:
+```
+git -C {repo_path} worktree add worktrees/round_{n}_executor_{id} -b experiment/round_{n}_executor_{id} improve/{goal_slug}
+```
+
+Pass in each executor's prompt:
+- The approved plan JSON
+- Worktree directory path
+- Benchmark command from settings
+- Sealed files list from settings
+- Path to `scripts/validate.sh` in this skill directory
+- Data contract schema for Benchmark Result
+- **Override instructions**: Implement the plan faithfully, run validate.sh before benchmarking, run the benchmark command, produce Benchmark Result JSON as output.
+
+Expected output: Benchmark Result JSON (written by executor or returned as output).
+
+### Step 8 — Tournament Selection
+
+SKILL.md does this directly (not delegated):
+
+1. **Collect** all executor results
+2. **Filter** to `status: "success"` only. If zero candidates, skip to Step 9 (Record & Visualize).
+3. **Rank** by `benchmark_score` (respecting `benchmark_direction`)
+4. **Ranked-candidate loop** — for each candidate in rank order (best first):
+   a. **No-regression check**: candidate score must be >= current `best_score`
+   b. **Merge** via `oh-my-claudecode:git-master`: `git merge experiment/round_{n}_executor_{id} --no-ff -m "Iteration {n}: {hypothesis} (score: {before} → {after})"`
+   c. **Re-benchmark** on merged state to confirm improvement
+   d. If re-benchmark **confirms** improvement: **accept winner**, break loop
+   e. If re-benchmark shows **regression**: **revert merge** via `git -C {repo_path} reset --hard HEAD~1`, continue to next candidate
+   f. If merge **conflicts**: `git -C {repo_path} merge --abort`, continue to next candidate
+5. If a winner was accepted: **Push** improvement branch: `git push origin improve/{goal_slug}` (non-blocking)
+6. **Archive** all non-winner branches via git-master: tag + delete
+7. If no candidate survived the loop: no merge this round. Improvement branch stays at prior state.
+8. **Write Merge Report** JSON to `.omc/self-improve/state/merge_reports/round_{n}.json` (schema: data_contracts.md Section 9).
+
+### Step 9 — Record & Visualize
+
+1. Write iteration history to `.omc/self-improve/state/iteration_history/round_{n}.json`
+2. Update `.omc/self-improve/state/agent-settings.json`:
+   - Increment `iterations` by 1
+   - If winner AND improvement exceeds `plateau_threshold` (`abs(new_score - best_score) >= plateau_threshold`): update `best_score`, reset `plateau_consecutive_count = 0`, reset `circuit_breaker_count = 0`
+   - If winner AND improvement below threshold (`abs(new_score - best_score) < plateau_threshold`): update `best_score` if better, increment `plateau_consecutive_count += 1`, reset `circuit_breaker_count = 0`
+   - If no winner (all rejected, all failed, or all regressed): increment `circuit_breaker_count += 1` (do NOT increment `plateau_consecutive_count` — plateau tracks stagnating wins, not failures)
+3. Append to `.omc/self-improve/tracking/raw_data.json` (one entry per candidate)
+4. Run `python3 {skill_dir}/scripts/plot_progress.py` for visualization
+5. Archive plans: copy current round plans to `state/plan_archive/round_{n}/`
+
+### Step 10 — Cleanup
+
+Remove worktrees:
+```
+git -C {repo_path} worktree remove worktrees/round_{n}_executor_{id} --force
+git -C {repo_path} worktree prune
+```
+
+Update `iteration_state.json` status to `completed`.
+
+### Step 11 — Stop Condition Check
+
+Evaluate ALL conditions. If ANY is true, exit:
+
+| Condition | Check |
+|---|---|
+| User stop | `status == "user_stopped"` in agent-settings or state cleared |
+| Target reached | `best_score` meets/exceeds `target_value` (respecting direction) |
+| Plateau | `plateau_consecutive_count >= plateau_window` |
+| Max iterations | `iterations >= max_iterations` |
+| Circuit breaker | `circuit_breaker_count >= circuit_breaker_threshold` |
+
+If NO stop condition: immediately go back to Step 1.
+
+---
+
+## Resumability
+
+On session restart, read `.omc/self-improve/state/iteration_state.json`:
+
+- `status: "in_progress"` → resume from `current_step`, skip completed sub-steps
+- `status: "completed"` → start next iteration
+- `status: "failed"` → complete recording step if needed, start next iteration
+- File missing → start from iteration 1
+
+---
+
+## Completion
+
+When the loop exits:
+
+1. Update agent-settings.json with final status
+2. If `target_reached`: spawn git-master to create PR from `improve/{goal_slug}` to upstream
+3. Run plot_progress.py one final time
+4. Print summary report:
+   ```
+   === Self-Improvement Loop Complete ===
+   Status: {status}
+   Iterations: {iterations}
+   Best Score: {best_score} (baseline: {baseline})
+   Improvement: {delta} ({delta_pct}%)
+   ```
+5. Run `/oh-my-claudecode:cancel` for clean state cleanup
+
+---
+
+## Error Handling
+
+| Situation | Action |
+|---|---|
+| Agent fails to produce output | Retry once. If still no output, log and continue. |
+| Researcher produces empty brief | Proceed — planners work from history alone. |
+| All plans rejected by critic | Skip execution. Log. Continue to next iteration. |
+| All executors fail | Skip tournament. Record failures. Continue. |
+| Merge conflict | Reject candidate, try next. |
+| Re-benchmark regression | Reject candidate, revert merge, try next. |
+| Push failure | Log warning. Continue — push is backup. |
+| Worktree already exists | Remove and recreate. |
+| Settings corrupted | Report and stop. |
+
+---
+
+## Approach Family Taxonomy
+
+Every plan must be tagged with exactly one:
+
+| Tag | Description |
+|-----|-------------|
+| `architecture` | Model/component structure changes |
+| `training_config` | Optimizer, LR, scheduler, batch size |
+| `data` | Data loading, augmentation, preprocessing |
+| `infrastructure` | Mixed precision, distributed training, compiled kernels |
+| `optimization` | Algorithmic/numerical optimizations |
+| `testing` | Evaluation methodology changes |
+| `documentation` | Documentation-only changes |
+| `other` | Does not fit above — explain in evidence |

--- a/skills/self-improve/data_contracts.md
+++ b/skills/self-improve/data_contracts.md
@@ -1,0 +1,274 @@
+# Data Contracts: Inter-Agent Communication Schemas
+
+Canonical JSON schemas for all messages exchanged between agents in the self-improvement loop.
+
+## 1. Plan Document
+
+**Producer:** planner | **Consumer:** critic, executor
+
+```json
+{
+  "plan_id": "round_{N}_{planner_id}",
+  "planner_id": "planner_a|planner_b|planner_c",
+  "round": 1,
+  "hypothesis": "Doing X should improve Y because Z",
+  "approach_family": "<taxonomy value>",
+  "critic_approved": false,
+  "target_files": ["path/to/file1"],
+  "steps": [
+    { "step": 1, "file": "path/to/file", "change": "exact description" }
+  ],
+  "expected_outcome": {
+    "metric": "<metric from goal>",
+    "estimated_impact": "<quantified estimate>",
+    "rationale": "<why>",
+    "sub_score_expectations": {}
+  },
+  "history_reference": {
+    "builds_on": "<prior success or 'none'>",
+    "avoids": "<prior failure or 'none'>"
+  },
+  "critic_review": {
+    "h001_hypothesis_count": "pass|fail",
+    "h002_family_streak": "pass|fail",
+    "h003_intra_round_diversity": "pass|fail",
+    "schema_valid": "pass|fail",
+    "history_aware": "pass|fail",
+    "verdict": "approved|rejected",
+    "rejection_reason": null
+  },
+  "architect_review": {
+    "verdict": "approve|reject",
+    "feedback": "",
+    "structural_concerns": []
+  }
+}
+```
+
+## 2. Benchmark Result
+
+**Producer:** executor | **Consumer:** tournament (SKILL.md)
+
+```json
+{
+  "executor_id": "executor_{id}",
+  "plan_id": "round_{n}_planner_{x}",
+  "benchmark_score": 85.2,
+  "benchmark_raw": "full stdout verbatim",
+  "status": "success|regression|error|timeout",
+  "sub_scores": { "dim_a": 85.2, "dim_b": 42.3 },
+  "failure_analysis": null,
+  "timestamp": "ISO 8601 UTC"
+}
+```
+
+**Status definitions:**
+- `success` — score improved or held even
+- `regression` — score dropped below baseline
+- `error` — benchmark could not run
+- `timeout` — exceeded time limit
+
+## 3. Research Brief
+
+**Producer:** researcher | **Consumer:** planners
+
+```json
+{
+  "iteration": 1,
+  "researcher_id": "researcher",
+  "repo_analysis_summary": "...",
+  "ideas": [
+    {
+      "title": "Short action name",
+      "source": "Specific origin",
+      "evidence": "Concrete evidence",
+      "approach_family": "<taxonomy value>",
+      "confidence": "high|medium|low",
+      "estimated_impact": "3-5%"
+    }
+  ]
+}
+```
+
+## 4. Iteration History Record
+
+**Producer:** orchestrator | **Consumer:** planners, researcher
+
+```json
+{
+  "iteration": 1,
+  "baseline_score": 80.0,
+  "winner": {
+    "plan_id": "round_1_planner_a",
+    "score": 85.2,
+    "approach_family": "training_config",
+    "hypothesis": "...",
+    "sub_scores": {}
+  },
+  "losers": [
+    {
+      "plan_id": "round_1_planner_b",
+      "score": 78.5,
+      "approach_family": "architecture",
+      "hypothesis": "...",
+      "sub_scores": {},
+      "failure_analysis": {
+        "what": "Score dropped",
+        "why": "Root cause",
+        "category": "regression",
+        "lesson": "Actionable lesson"
+      }
+    }
+  ],
+  "research_brief_id": "round_1"
+}
+```
+
+## 5. Visualization Data
+
+**File:** `.omc/self-improve/tracking/raw_data.json` — top-level JSON array, append-only.
+
+```json
+[
+  {
+    "iteration": 1,
+    "plan_id": "round_1_planner_a",
+    "benchmark_score": 85.2,
+    "is_winner": true,
+    "approach_family": "training_config",
+    "sub_scores": {}
+  }
+]
+```
+
+## 6. Approach Family Taxonomy
+
+| Tag | Description |
+|-----|-------------|
+| `architecture` | Model/component structure changes |
+| `training_config` | Optimizer, LR, scheduler, batch size, epochs |
+| `data` | Data loading, augmentation, preprocessing |
+| `infrastructure` | Mixed precision, distributed training, checkpointing |
+| `optimization` | Algorithmic/numerical optimizations |
+| `testing` | Evaluation methodology changes |
+| `documentation` | Documentation-only changes |
+| `other` | Does not fit above — explain in evidence |
+
+Custom families from harness.md are also valid.
+
+## 7. Failure Analysis Object
+
+```json
+{
+  "what": "Factual description with scores/errors",
+  "why": "Root cause mechanism",
+  "category": "oom|timeout|regression|logic_error|scope_error|infrastructure|benchmark_parse_error|sealed_file_violation",
+  "lesson": "Actionable lesson for future planners"
+}
+```
+
+## 8. Iteration State
+
+**File:** `.omc/self-improve/state/iteration_state.json` — tracks within-iteration progress.
+
+```json
+{
+  "iteration": 1,
+  "status": "in_progress|completed|failed|interrupted",
+  "current_step": "research|planning|critic_review|execution|tournament|recording|stop_check",
+  "started_at": "ISO 8601",
+  "updated_at": "ISO 8601",
+  "research": { "status": "pending|in_progress|completed|failed", "output_path": null, "completed_at": null },
+  "planning": {
+    "status": "pending|in_progress|completed",
+    "plans": {
+      "planner_a": { "status": "completed", "output_path": "...", "critic_approved": true }
+    },
+    "approved_count": 2,
+    "completed_at": null
+  },
+  "execution": {
+    "status": "pending|in_progress|completed",
+    "executors": {
+      "executor_1": { "status": "running", "plan_id": "...", "output_path": null, "benchmark_score": null }
+    },
+    "completed_at": null
+  },
+  "tournament": { "status": "pending", "winner": null, "winner_score": null, "completed_at": null },
+  "recording": { "status": "pending", "history_path": null, "visualization_updated": false, "cleanup_done": false },
+  "user_ideas_consumed": []
+}
+```
+
+## 9. Merge Report
+
+**Producer:** tournament (SKILL.md) | **Consumer:** orchestrator
+
+```json
+{
+  "iteration": 3,
+  "goal_slug": "reduce_latency",
+  "winner": {
+    "executor_id": "executor_2",
+    "branch": "experiment/round_3_executor_2",
+    "hypothesis": "Cache intermediate results",
+    "score_before": 142.3,
+    "score_after": 118.7,
+    "sub_scores": {}
+  },
+  "archived": ["archive/round_3_executor_1"],
+  "regressions_detected": false,
+  "re_benchmark_score": 118.7,
+  "status": "merged|no_improvement|no_winner|all_rejected",
+  "reason": null
+}
+```
+
+**Status definitions:**
+- `merged` — a candidate was merged and re-benchmark confirmed improvement
+- `no_improvement` — candidates existed and were tested, but all failed re-benchmark (no merge occurred)
+- `no_winner` — all executors failed or produced non-success status (no candidates to evaluate)
+- `all_rejected` — all plans were rejected by the critic (execution was skipped)
+
+`reason` is required (string) when status is not `merged`, null when `merged`.
+```
+
+## 10. Plan Archive
+
+**Location:** `.omc/self-improve/state/plan_archive/round_{n}/`
+
+Exact copies of all plan JSON files, including critic and architect reviews. Permanent retention.
+
+## 11. Event Log
+
+**File:** `.omc/self-improve/tracking/events.json` — append-only array.
+
+```json
+[
+  {
+    "timestamp": "ISO 8601",
+    "event_type": "config_change|phase_transition",
+    "iteration": 5,
+    "details": {
+      "field": "number_of_agents",
+      "old_value": 2,
+      "new_value": 3,
+      "source": "user"
+    }
+  }
+]
+```
+
+## 12. Goal Phase
+
+Defined in goal.md under `## Phases`. Tracked in agent-settings.json as `current_phase`.
+
+```markdown
+## Phases
+| Phase | Focus | Sub-Score Targets | Status |
+|-------|-------|-------------------|--------|
+| phase_1 | Primary dimension | dim_a >= 90.0 | active |
+| phase_2 | Secondary dimension | dim_b <= 50.0 | pending |
+```
+
+Phase transitions are tracked as events but do not affect tournament selection.

--- a/skills/self-improve/scripts/plot_progress.py
+++ b/skills/self-improve/scripts/plot_progress.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Progress visualization for the self-improvement loop.
+Reads raw_data.json and generates progress.png.
+
+Usage:
+    python3 plot_progress.py --data /path/to/raw_data.json --output /path/to/progress.png
+    python3 plot_progress.py --tracking-dir /path/to/.omc/self-improve/tracking/
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_data(data_path: str) -> list:
+    path = Path(data_path)
+    if not path.exists():
+        print(f"Warning: {data_path} not found. No visualization generated.")
+        return []
+    with open(path) as f:
+        return json.load(f)
+
+
+def plot_with_matplotlib(data: list, output_path: str):
+    try:
+        import matplotlib
+        matplotlib.use('Agg')
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("Warning: matplotlib not available. Generating text summary instead.")
+        generate_text_summary(data, output_path)
+        return
+
+    iterations = sorted(set(d['iteration'] for d in data))
+    winners = [d for d in data if d.get('is_winner')]
+    losers = [d for d in data if not d.get('is_winner')]
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    if losers:
+        ax.scatter(
+            [d['iteration'] for d in losers],
+            [d['benchmark_score'] for d in losers],
+            c='lightgray', alpha=0.5, s=30, label='Candidates', zorder=2
+        )
+
+    if winners:
+        ax.plot(
+            [d['iteration'] for d in winners],
+            [d['benchmark_score'] for d in winners],
+            'b-o', linewidth=2, markersize=8, label='Winners', zorder=3
+        )
+
+        families = list(set(d.get('approach_family', 'unknown') for d in winners))
+        colors = plt.cm.Set2(range(len(families)))
+        family_color = dict(zip(families, colors))
+        for d in winners:
+            family = d.get('approach_family', 'unknown')
+            ax.annotate(
+                family[:4],
+                (d['iteration'], d['benchmark_score']),
+                textcoords="offset points", xytext=(0, 10),
+                fontsize=7, ha='center', color=family_color.get(family, 'black')
+            )
+
+    ax.set_xlabel('Iteration')
+    ax.set_ylabel('Benchmark Score')
+    ax.set_title('Self-Improvement Progress')
+    ax.legend(loc='best')
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    print(f"Visualization saved to: {output_path}")
+
+
+def generate_text_summary(data: list, output_path: str):
+    """Fallback when matplotlib is not available."""
+    winners = [d for d in data if d.get('is_winner')]
+    summary_path = Path(output_path).with_suffix('.txt')
+
+    lines = ["Self-Improvement Progress Summary", "=" * 40, ""]
+    for w in winners:
+        lines.append(
+            f"Iteration {w['iteration']}: score={w['benchmark_score']:.4f} "
+            f"family={w.get('approach_family', '?')} plan={w.get('plan_id', '?')}"
+        )
+
+    if winners:
+        scores = [w['benchmark_score'] for w in winners]
+        lines.append("")
+        lines.append(f"Best: {max(scores):.4f}  Worst: {min(scores):.4f}  "
+                      f"Delta: {max(scores) - min(scores):.4f}")
+
+    with open(summary_path, 'w') as f:
+        f.write('\n'.join(lines))
+    print(f"Text summary saved to: {summary_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Self-improvement progress visualization')
+    parser.add_argument('--data', help='Path to raw_data.json')
+    parser.add_argument('--output', help='Path to output image')
+    parser.add_argument('--tracking-dir', help='Path to tracking/ directory (auto-discovers data and output)')
+    args = parser.parse_args()
+
+    if args.tracking_dir:
+        data_path = str(Path(args.tracking_dir) / 'raw_data.json')
+        output_path = str(Path(args.tracking_dir) / 'progress.png')
+    elif args.data and args.output:
+        data_path = args.data
+        output_path = args.output
+    else:
+        print("Usage: plot_progress.py --tracking-dir /path/ OR --data /path/raw_data.json --output /path/progress.png")
+        sys.exit(1)
+
+    data = load_data(data_path)
+    if not data:
+        sys.exit(0)
+
+    plot_with_matplotlib(data, output_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/self-improve/scripts/validate.sh
+++ b/skills/self-improve/scripts/validate.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# validate.sh — Sealed file enforcement + plan schema validation for self-improvement loop.
+# Usage:
+#   ./validate.sh --worktree /path plan.json    # worktree mode + plan validation
+#   ./validate.sh plan.json                     # plan schema validation only
+#   ./validate.sh                               # sealed file check only
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Settings path must be provided or discovered from .omc/self-improve/config/
+SETTINGS=""
+VALID_APPROACH_FAMILIES="architecture training_config data infrastructure optimization testing documentation other"
+
+# Parse arguments
+WORKTREE_PATH=""
+POSITIONAL_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree)
+            WORKTREE_PATH="$2"
+            shift 2
+            ;;
+        --settings)
+            SETTINGS="$2"
+            shift 2
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL_ARGS[@]+"${POSITIONAL_ARGS[@]}"}"
+
+# Auto-discover settings if not provided
+if [[ -z "${SETTINGS}" ]]; then
+    # Walk up from worktree or CWD to find .omc/self-improve/config/settings.json
+    SEARCH_DIR="${WORKTREE_PATH:-$(pwd)}"
+    while [[ "${SEARCH_DIR}" != "/" ]]; do
+        if [[ -f "${SEARCH_DIR}/.omc/self-improve/config/settings.json" ]]; then
+            SETTINGS="${SEARCH_DIR}/.omc/self-improve/config/settings.json"
+            break
+        fi
+        SEARCH_DIR="$(dirname "${SEARCH_DIR}")"
+    done
+fi
+
+GIT_DIR="${WORKTREE_PATH:-$(pwd)}"
+
+err() { echo "ERROR: $*" >&2; }
+ok()  { echo "OK: $*"; }
+
+require_jq() {
+    if ! command -v jq &>/dev/null; then
+        err "jq is not installed. Install with: brew install jq (macOS) or apt-get install jq (Linux)"
+        exit 1
+    fi
+}
+
+check_sealed_files() {
+    require_jq
+
+    if [[ -z "${SETTINGS}" || ! -f "${SETTINGS}" ]]; then
+        ok "No settings file found — skipping sealed file check."
+        return 0
+    fi
+
+    has_sealed=$(jq -r 'if (.sealed_files | type) == "array" and (.sealed_files | length) > 0 then "yes" else "no" end' "${SETTINGS}" 2>/dev/null || echo "no")
+
+    if [[ "${has_sealed}" != "yes" ]]; then
+        ok "No sealed files configured — skipping."
+        return 0
+    fi
+
+    if ! git -C "${GIT_DIR}" rev-parse --git-dir &>/dev/null 2>&1; then
+        ok "Not a git repository — skipping sealed file check."
+        return 0
+    fi
+
+    local modified_files_str=""
+    if [[ -n "${WORKTREE_PATH}" ]]; then
+        local base_commit
+        base_commit=$(git -C "${GIT_DIR}" merge-base HEAD HEAD~1 2>/dev/null || echo "HEAD~1")
+        modified_files_str=$(git -C "${GIT_DIR}" diff --name-only "${base_commit}" 2>/dev/null || true)
+        local uncommitted
+        uncommitted=$(git -C "${GIT_DIR}" diff --name-only 2>/dev/null || true)
+        if [[ -n "${uncommitted}" ]]; then
+            modified_files_str="${modified_files_str}"$'\n'"${uncommitted}"
+        fi
+    else
+        modified_files_str=$(git -C "${GIT_DIR}" diff --name-only HEAD 2>/dev/null || true)
+        local staged
+        staged=$(git -C "${GIT_DIR}" diff --name-only --cached 2>/dev/null || true)
+        if [[ -n "${staged}" ]]; then
+            modified_files_str="${modified_files_str}"$'\n'"${staged}"
+        fi
+    fi
+
+    if [[ -n "${modified_files_str}" ]]; then
+        modified_files_str=$(echo "${modified_files_str}" | sort -u)
+    fi
+
+    if [[ -z "${modified_files_str}" ]]; then
+        ok "No modified files detected."
+        return 0
+    fi
+
+    violations=""
+    while IFS= read -r sealed; do
+        [[ -z "${sealed}" ]] && continue
+        while IFS= read -r modified; do
+            [[ -z "${modified}" ]] && continue
+            if [[ "${sealed}" == */ ]]; then
+                [[ "${modified}" == "${sealed}"* ]] && violations="${violations} ${modified}"
+            else
+                [[ "${modified}" == "${sealed}" ]] && violations="${violations} ${modified}"
+            fi
+        done <<< "${modified_files_str}"
+    done < <(jq -r '.sealed_files[]' "${SETTINGS}" 2>/dev/null)
+
+    if [[ -n "${violations}" ]]; then
+        err "Sealed file(s) were modified:${violations}"
+        exit 1
+    fi
+
+    local modified_count
+    modified_count=$(echo "${modified_files_str}" | wc -l | tr -d ' ')
+    ok "Sealed file check passed (${modified_count} modified, none sealed)."
+}
+
+check_plan_schema() {
+    local plan_file="$1"
+    require_jq
+
+    if [[ ! -f "${plan_file}" ]]; then
+        err "Plan file not found: ${plan_file}"
+        exit 1
+    fi
+
+    local required_fields="plan_id planner_id round hypothesis approach_family critic_approved target_files steps expected_outcome history_reference"
+    local missing=""
+
+    for field in ${required_fields}; do
+        val=$(jq -r --arg f "${field}" '.[$f]' "${plan_file}" 2>/dev/null)
+        if [[ "${val}" == "null" || -z "${val}" ]]; then
+            missing="${missing} ${field}"
+        fi
+    done
+
+    if [[ -n "${missing}" ]]; then
+        err "Plan is missing required fields:${missing}"
+        exit 1
+    fi
+    ok "Plan contains all required fields."
+
+    # Validate approach_family
+    approach=$(jq -r '.approach_family' "${plan_file}")
+    local valid=0
+    for family in ${VALID_APPROACH_FAMILIES}; do
+        if [[ "${approach}" == "${family}" ]]; then
+            valid=1
+            break
+        fi
+    done
+    if [[ ${valid} -eq 0 ]]; then
+        err "approach_family '${approach}' is not valid. Must be one of: ${VALID_APPROACH_FAMILIES}"
+        exit 1
+    fi
+    ok "Approach family '${approach}' is valid."
+
+    # Validate hypothesis is a single string
+    hypothesis_type=$(jq -r '.hypothesis | type' "${plan_file}" 2>/dev/null)
+    if [[ "${hypothesis_type}" != "string" ]]; then
+        err "hypothesis must be a string (got ${hypothesis_type})"
+        exit 1
+    fi
+    ok "One-hypothesis check passed."
+
+    # Validate steps non-empty
+    steps_len=$(jq '.steps | length' "${plan_file}" 2>/dev/null || echo "0")
+    if [[ "${steps_len}" -eq 0 ]]; then
+        err "steps must be a non-empty array"
+        exit 1
+    fi
+    ok "Steps validated (${steps_len} step(s))."
+}
+
+check_result_schema() {
+    local result_file="$1"
+    require_jq
+
+    if [[ ! -f "${result_file}" ]]; then
+        err "Result file not found: ${result_file}"
+        exit 1
+    fi
+
+    local required_fields="executor_id plan_id benchmark_score status timestamp benchmark_raw"
+    local missing=""
+
+    for field in ${required_fields}; do
+        val=$(jq -r --arg f "${field}" '.[$f]' "${result_file}" 2>/dev/null)
+        if [[ "${val}" == "null" || -z "${val}" ]]; then
+            if [[ "${field}" == "benchmark_raw" ]]; then
+                exists=$(jq --arg f "${field}" 'has($f)' "${result_file}" 2>/dev/null || echo "false")
+                if [[ "${exists}" != "true" ]]; then
+                    missing="${missing} ${field}"
+                fi
+            elif [[ "${field}" == "benchmark_score" ]]; then
+                exists=$(jq --arg f "${field}" 'has($f)' "${result_file}" 2>/dev/null || echo "false")
+                if [[ "${exists}" != "true" ]]; then
+                    missing="${missing} ${field}"
+                fi
+            else
+                missing="${missing} ${field}"
+            fi
+        fi
+    done
+
+    if [[ -n "${missing}" ]]; then
+        err "Result is missing required fields:${missing}"
+        exit 1
+    fi
+    ok "Result contains all required fields."
+
+    # Validate status enum
+    local status
+    status=$(jq -r '.status' "${result_file}" 2>/dev/null)
+    case "${status}" in
+        success|regression|error|timeout) ;;
+        *)
+            err "Invalid status '${status}'. Must be one of: success, regression, error, timeout"
+            exit 1
+            ;;
+    esac
+    ok "Status '${status}' is valid."
+
+    # Check failure_analysis on non-success status
+    if [[ "${status}" != "success" ]]; then
+        local fa_type
+        fa_type=$(jq -r '.failure_analysis | type' "${result_file}" 2>/dev/null)
+        if [[ "${fa_type}" != "object" ]]; then
+            err "failure_analysis must be a non-null object when status is '${status}' (got ${fa_type})"
+            exit 1
+        fi
+
+        local fa_fields="what why category lesson"
+        local fa_missing=""
+        for field in ${fa_fields}; do
+            val=$(jq -r --arg f "${field}" '.failure_analysis[$f]' "${result_file}" 2>/dev/null)
+            if [[ "${val}" == "null" || -z "${val}" ]]; then
+                fa_missing="${fa_missing} ${field}"
+            fi
+        done
+
+        if [[ -n "${fa_missing}" ]]; then
+            err "failure_analysis is missing required fields:${fa_missing}"
+            exit 1
+        fi
+        ok "failure_analysis is complete for non-success status."
+
+        # Validate failure category enum
+        local fa_category
+        fa_category=$(jq -r '.failure_analysis.category' "${result_file}" 2>/dev/null)
+        local valid_categories="oom timeout regression logic_error scope_error infrastructure benchmark_parse_error sealed_file_violation"
+        local cat_valid=0
+        for cat in ${valid_categories}; do
+            if [[ "${fa_category}" == "${cat}" ]]; then
+                cat_valid=1
+                break
+            fi
+        done
+
+        if [[ ${cat_valid} -eq 0 ]]; then
+            err "failure_analysis.category '${fa_category}' is not valid. Must be one of: ${valid_categories}"
+            exit 1
+        fi
+        ok "failure_analysis.category '${fa_category}' is valid."
+    fi
+
+    # Validate sub_scores if present
+    local has_sub_scores
+    has_sub_scores=$(jq 'has("sub_scores")' "${result_file}" 2>/dev/null || echo "false")
+    if [[ "${has_sub_scores}" == "true" ]]; then
+        local sub_scores_type
+        sub_scores_type=$(jq -r '.sub_scores | type' "${result_file}" 2>/dev/null)
+        if [[ "${sub_scores_type}" == "object" ]]; then
+            local invalid_values
+            invalid_values=$(jq -r '.sub_scores | to_entries[] | select(.value != null and (.value | type) != "number") | .key' "${result_file}" 2>/dev/null)
+            if [[ -n "${invalid_values}" ]]; then
+                err "sub_scores contains non-numeric values for keys: ${invalid_values}"
+                exit 1
+            fi
+            local sub_scores_count
+            sub_scores_count=$(jq '.sub_scores | length' "${result_file}" 2>/dev/null)
+            ok "sub_scores is a valid object (${sub_scores_count} dimension(s))."
+        elif [[ "${sub_scores_type}" != "null" ]]; then
+            err "sub_scores must be an object or null (got ${sub_scores_type})"
+            exit 1
+        fi
+    fi
+}
+
+main() {
+    echo "=== self-improve validate.sh ==="
+    check_sealed_files
+
+    if [[ ${#POSITIONAL_ARGS[@]} -ge 1 ]]; then
+        check_plan_schema "${POSITIONAL_ARGS[0]}"
+    fi
+
+    if [[ ${#POSITIONAL_ARGS[@]} -ge 2 ]]; then
+        check_result_schema "${POSITIONAL_ARGS[1]}"
+    fi
+
+    echo "=== All checks passed ==="
+}
+
+main

--- a/skills/self-improve/si-benchmark-builder.md
+++ b/skills/self-improve/si-benchmark-builder.md
@@ -1,0 +1,79 @@
+# Self-Improvement Benchmark Builder
+
+## Input Contract
+
+Arguments passed via prompt context:
+- `repo_path`: Absolute path to the target repository
+- `goal_path`: Path to goal.md with defined objective and metric
+- `settings_path`: Path to settings.json
+- `agent_settings_path`: Path to agent-settings.json
+- `tracking_path`: Path to tracking/ directory
+
+## Role
+
+You build a benchmark for the self-improvement loop. The benchmark must produce a measurable score that the loop can optimize against. Prefer adapting existing evaluation over building from scratch.
+
+## Prerequisites
+
+- Target repo exists and is cloned
+- Goal is defined (si_setting_goal is true)
+- goal.md has a defined objective and metric
+
+## Workflow
+
+### Phase 1 — Understand the Goal
+Read goal.md. Extract metric name, direction, target value, scope.
+
+### Phase 2 — Repo Survey
+Explore the target repo for existing evaluation:
+- Test suites (pytest, jest, go test, cargo test)
+- Benchmark scripts (benchmark.*, eval.*, score.*)
+- CI evaluation (.github/workflows/)
+- Performance tests, metrics in code
+
+Classify: Ready to use | Partially usable | Nothing exists
+
+### Phase 3 — Interview (only if needed)
+If approach is unclear, ask up to 3 questions. Hard cap.
+
+### Phase 4 — Design
+Requirements:
+- **JSON output preferred**: Last line of stdout as `{"primary": 85.2, "sub_scores": {"dim_a": 0.92}}`
+- **Deterministic**: Same code → same score (fixed seeds)
+- **Fast**: Under 5 minutes ideally
+- **Self-contained**: No external services
+- **Honest**: Measures actual quality
+
+### Phase 5 — Implement
+Build the benchmark. Place it in the target repo (scripts/benchmark.py or benchmark.py).
+Must exit 0 on success, non-zero on error. Print score as last stdout line.
+
+### Phase 6 — Validate
+Run the benchmark 3 times:
+```
+Run 1: {x}
+Run 2: {y}
+Run 3: {z}
+Variance: {(max-min)/mean * 100}%
+```
+All 3 must complete. Variance must be < 5%.
+
+### Phase 7 — Record and Configure
+Update settings.json:
+- `benchmark_command`: the shell command
+- `benchmark_format`: "json", "number", or "pass_fail"
+- `primary_metric`: key name in JSON output (default: "primary")
+
+**Add benchmark script to `sealed_files`** — prevents the loop from modifying it.
+
+Record baseline to tracking/baseline.json:
+```json
+{ "baseline_score": <mean_score>, "recorded_at": "<ISO 8601>" }
+```
+
+Update agent-settings.json:
+- `si_setting_benchmark` → true
+- `best_score` → mean_score
+
+### Phase 8 — Handoff
+Report: benchmark command, score, variance, and next step.

--- a/skills/self-improve/si-goal-clarifier.md
+++ b/skills/self-improve/si-goal-clarifier.md
@@ -1,0 +1,93 @@
+# Self-Improvement Goal Clarifier
+
+## Input Contract
+
+Arguments passed via context:
+- `repo_path`: Absolute path to the target repository
+- `config_path`: Path to .omc/self-improve/config/
+- `agent_settings_path`: Path to agent-settings.json
+
+## Role
+
+You are an interviewer. Turn a vague improvement idea into a crystal-clear, measurable goal through targeted questioning. One question per round, always targeting the weakest dimension.
+
+## Prerequisites
+
+- Target repo exists and is cloned
+- If goal.md already has a complete goal, ask: "A goal is already defined. Refine or start fresh?"
+
+## Clarity Dimensions
+
+Score each 0-100 after every round:
+
+| Dimension | What it measures |
+|-----------|-----------------|
+| **Objective** | What exactly should improve? Specific enough to act on? |
+| **Metric** | How do we measure it? Well-defined and automatable? |
+| **Target** | What score are we aiming for? Realistic? |
+| **Scope** | Which files/modules in/out of bounds? |
+
+**Ambiguity score** = 100 - average(all dimensions)
+
+## Workflow
+
+### Phase 1 — Repo Scan (silent)
+Explore the target repo: README, main source, tests, configs. Identify what it does, existing metrics, improvement opportunities. Use this to inform questions.
+
+### Phase 2 — Fast-Path Check
+If user provides fully formed goal (objective, metric, target, scope all clear), skip interview. Go to Phase 4.
+
+### Phase 3 — Interview Rounds
+Each round:
+1. Score all 4 dimensions
+2. Display scoreboard:
+   ```
+   === Round {n} ===
+   Objective:  {score}/100
+   Metric:     {score}/100
+   Target:     {score}/100
+   Scope:      {score}/100
+   Ambiguity:  {score}%
+   ```
+3. Ask ONE question targeting the lowest-scoring dimension. Use repo context.
+4. Wait for response. Update scores. Repeat.
+
+**Exit when ambiguity <= 20%** (all dimensions >= 80).
+**Soft cap: 8 rounds**. **Hard cap: 12 rounds**.
+
+### Phase 4 — Write Goal
+Write `.omc/self-improve/config/goal.md`:
+```markdown
+# Improvement Goal
+
+## Objective
+{specific objective}
+
+## Target Metric
+- **Metric name**: {name}
+- **Target value**: {value}
+- **Direction**: higher_is_better | lower_is_better
+
+## Scope
+- **In scope**: {files, modules}
+- **Out of scope**: {exclusions}
+
+## Milestones (optional)
+| Milestone | Target | Strategy Focus |
+|-----------|--------|----------------|
+
+## Experiment Ideas (optional)
+{ideas from interview}
+```
+
+Update settings.json: `benchmark_direction`, `target_value`
+Set `si_setting_goal` → true in agent-settings.json
+
+### Phase 5 — Handoff
+Print summary and suggest next step (benchmark builder if needed).
+
+## Constraints
+- ONE question per round
+- Never assume — ask
+- Use repo evidence in questions
+- Partial updates only when writing settings JSON

--- a/skills/self-improve/si-researcher.md
+++ b/skills/self-improve/si-researcher.md
@@ -1,0 +1,73 @@
+# Self-Improvement Researcher
+
+## Input Contract
+
+Arguments passed via prompt context:
+- `iteration`: Current iteration number (1-indexed)
+- `repo_path`: Absolute path to the target repository
+- `goal_path`: Path to goal.md
+- `history_path`: Path to iteration_history/ directory
+- `briefs_path`: Path to research_briefs/ directory
+
+## Role
+
+You are the **knowledge gatherer** for the self-improvement loop. Your job is to explore the target repository and search externally to produce a structured **research brief** before planners begin work. You run once per iteration, first.
+
+Your output — a research brief JSON — is the foundation all N planners read before generating hypotheses.
+
+## Inputs
+
+Read all of the following before producing output:
+
+- Goal file — improvement objective, target metric, scope constraints, experiment ideas
+- Iteration history — ALL prior records (winners, losers, lessons)
+- Prior research briefs — avoid redundant research
+- Target repository — source files, tests, configs, documentation
+
+## Workflow
+
+1. **Read the goal**: Extract primary metric, target score, scope constraints, user ideas
+2. **Read all iteration history**: Build a map of what has been tried, what worked, what failed
+3. **Check for user ideas**: Treat as highest-priority input
+4. **Deep-dive the target repository**:
+   - README, main source, tests, configs, dependencies
+   - Known bottlenecks (TODO/FIXME comments, profile outputs)
+   - Test coverage gaps, configuration defaults, outdated dependencies
+5. **Determine research strategy** based on iteration state:
+   - First iteration → broad exploration across all approach families
+   - After failures → avoid repeating documented failures
+   - Strategy exhaustion (same family 3+ wins) → shift to unexplored families
+   - Near target (within 5%) → fine-grained, low-risk changes
+6. **Search externally** when needed: papers, benchmarks, similar projects, official docs
+7. **Rank ideas**: high confidence first, then medium, then low. 3-10 ideas.
+8. **Write the research brief** as JSON
+
+## Output
+
+Write to the path specified by the orchestrator. JSON format:
+
+```json
+{
+  "iteration": 1,
+  "researcher_id": "researcher",
+  "repo_analysis_summary": "What the codebase does, current metric state, what has been tried, biggest gap",
+  "ideas": [
+    {
+      "title": "Short action-oriented name",
+      "source": "Specific origin — file names, issue numbers, paper titles",
+      "evidence": "Concrete evidence — line numbers, config values, benchmark numbers",
+      "approach_family": "architecture|training_config|data|infrastructure|optimization|testing|documentation|other",
+      "confidence": "high|medium|low",
+      "estimated_impact": "3-5% or unknown"
+    }
+  ]
+}
+```
+
+## Quality Standards
+
+- Every idea has specific, citable evidence
+- No idea repeats a documented failure without explaining the difference
+- Ideas span at least 2 different approach families
+- Ideas sorted: high confidence first
+- Valid JSON matching the schema

--- a/skills/self-improve/templates/agent-settings.json
+++ b/skills/self-improve/templates/agent-settings.json
@@ -1,0 +1,13 @@
+{
+  "si_setting_goal": false,
+  "si_setting_benchmark": false,
+  "si_setting_harness": false,
+  "iterations": 0,
+  "best_score": null,
+  "current_milestone": null,
+  "current_phase": null,
+  "plateau_consecutive_count": 0,
+  "circuit_breaker_count": 0,
+  "status": "idle",
+  "goal_slug": null
+}

--- a/skills/self-improve/templates/goal.md
+++ b/skills/self-improve/templates/goal.md
@@ -1,0 +1,22 @@
+# Improvement Goal
+
+## Objective
+<!-- Define what exactly should improve -->
+
+## Target Metric
+- **Metric name**:
+- **Target value**:
+- **Direction**: higher_is_better | lower_is_better
+
+## Scope
+- **In scope**:
+- **Out of scope**:
+
+## Milestones (optional)
+| Milestone | Target | Strategy Focus |
+|-----------|--------|----------------|
+| M1 | | Quick wins, low-hanging fruit |
+| M2 | | Moderate improvements |
+
+## Experiment Ideas (optional)
+<!-- Add specific ideas for the improvement loop to try -->

--- a/skills/self-improve/templates/harness.md
+++ b/skills/self-improve/templates/harness.md
@@ -1,0 +1,18 @@
+# Harness Rules
+
+## H001 — One Hypothesis Per Plan
+Each plan must test exactly ONE hypothesis. Plans with zero or multiple hypotheses are rejected by the critic.
+
+## H002 — No Approach Family Streak
+The same `approach_family` must not appear as the winner for 3 or more consecutive iterations. This prevents the system from getting stuck in a local exploration loop.
+
+## H003 — Intra-Round Diversity
+Within a single round, no two plans may share the same `approach_family`. The critic rejects the later plan if a duplicate family is detected.
+
+## Custom Rules
+<!-- Add project-specific rules here -->
+
+## Custom Approach Families
+<!-- Add custom approach families here (one per line, prefixed with - or *) -->
+<!-- Example: -->
+<!-- - `prompt_engineering` -->

--- a/skills/self-improve/templates/idea.md
+++ b/skills/self-improve/templates/idea.md
@@ -1,0 +1,5 @@
+# Experiment Ideas
+
+<!-- Add your experiment ideas here. These will be given highest priority by the planners. -->
+<!-- Format: one idea per section with a title and description. -->
+<!-- Ideas are consumed once per iteration and cleared after planners read them. -->

--- a/skills/self-improve/templates/settings.json
+++ b/skills/self-improve/templates/settings.json
@@ -1,0 +1,20 @@
+{
+  "si_claude_setting": false,
+  "number_of_agents": 3,
+  "number_of_max_critics": 3,
+  "current_repo_url": "",
+  "fork_url": "",
+  "upstream_url": "",
+  "target_branch": "main",
+  "benchmark_command": "",
+  "benchmark_format": "json",
+  "benchmark_direction": "higher_is_better",
+  "max_iterations": 50,
+  "plateau_threshold": 0.01,
+  "plateau_window": 3,
+  "target_value": null,
+  "primary_metric": "primary",
+  "sealed_files": [],
+  "regression_threshold": 0.05,
+  "circuit_breaker_threshold": 3
+}

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -35,10 +35,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (31 canonical + 1 alias)', () => {
+    it('should return correct number of skills (32 canonical + 1 alias)', () => {
       const skills = createBuiltinSkills();
-      // 32 entries: 31 canonical skills + 1 deprecated alias (psm)
-      expect(skills).toHaveLength(32);
+      // 33 entries: 32 canonical skills + 1 deprecated alias (psm)
+      expect(skills).toHaveLength(33);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -112,6 +112,7 @@ describe('Builtin Skills', () => {
         'ralplan',
         'release',
         'sciomc',
+        'self-improve',
         'setup',
         'skill',
         'team',
@@ -329,7 +330,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(31);
+      expect(names).toHaveLength(32);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -363,7 +364,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131, psm still exists
-      expect(names).toHaveLength(32);
+      expect(names).toHaveLength(33);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('trace');
       expect(names).toContain('visual-verdict');

--- a/src/hooks/skill-state/index.ts
+++ b/src/hooks/skill-state/index.ts
@@ -116,6 +116,7 @@ const SKILL_PROTECTION: Record<string, SkillProtectionLevel> = {
 
   // === Heavy protection (long-running, 10 reinforcements) ===
   deepinit: 'heavy',
+  'self-improve': 'heavy',
 };
 
 // ---------------------------------------------------------------------------

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -43,9 +43,10 @@ const STATE_TOOL_MODES: [string, ...string[]] = [
   ...EXECUTION_MODES,
   'ralplan',
   'omc-teams',
-  'deep-interview'
+  'deep-interview',
+  'self-improve'
 ];
-const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'deep-interview'] as const;
+const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'deep-interview', 'self-improve'] as const;
 type StateToolMode = typeof STATE_TOOL_MODES[number];
 const CANCEL_SIGNAL_TTL_MS = 30_000;
 


### PR DESCRIPTION
## Summary

- Add a self-contained `self-improve` skill that autonomously improves any target codebase through tournament-based evolutionary optimization
- Spawns parallel agent pairs (researcher → planner → executor), benchmarks experiments in isolated git worktrees, merges only the best-performing change per iteration
- Leverages 4 existing OMC agents (planner, architect, critic, executor) with 4 custom reference docs for specialized roles (researcher, benchmark-builder, goal-clarifier, tournament logic)
- Skill-only invocation via `/oh-my-claudecode:self-improve` (no keyword trigger — "self improve" is too common in English)

## What's included

**New skill directory** (`skills/self-improve/`):
- `SKILL.md` — Loop controller with 11-step iteration cycle, resumability, cancellation
- `si-researcher.md`, `si-benchmark-builder.md`, `si-goal-clarifier.md` — Custom agent prompts
- `data_contracts.md` — 12 JSON schemas for inter-agent communication
- `scripts/validate.sh` — Sealed file + plan/result schema validation
- `scripts/plot_progress.py` — Progress visualization (matplotlib with text fallback)
- `templates/` — Default configs (settings, agent-state, goal, harness, ideas)

**Integration points** (4 files):
- `src/tools/state-tools.ts` — `'self-improve'` in `STATE_TOOL_MODES` + `EXTRA_STATE_ONLY_MODES`
- `src/hooks/skill-state/index.ts` — `'self-improve': 'heavy'` (10 reinforcements, 30min TTL)
- `skills/cancel/SKILL.md` — Position 11 in cancellation dependency order
- `CLAUDE.md` — Added to workflow skill catalog

**Test update**: `src/__tests__/skills.test.ts` — Updated expected skill counts (32→33 total, 31→32 canonical)

## Inspired by

[lonj7798/self-improvement](https://github.com/lonj7798/self-improvement) — evolutionary code improvement engine with tournament selection, sealed benchmarks, and institutional memory.

## Test plan

- [ ] `npm test` passes (skill count assertions updated)
- [ ] `/oh-my-claudecode:self-improve` loads the skill (auto-discovered from `skills/` directory)
- [ ] `state_read(mode='self-improve')` returns null when inactive
- [ ] `state_write(mode='self-improve', active=true)` creates state file
- [ ] Stop hook reinforces with heavy protection (10x, 30min)
- [ ] `/oh-my-claudecode:cancel` clears self-improve state
- [ ] `scripts/validate.sh` runs without errors
- [ ] Manual: full iteration cycle with a test repo + benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)