### PR TITLE
Fix hook template tests for injected skill content

### DIFF
--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -64,6 +64,6 @@ describe('keyword-detector.mjs mode-message dispatch', () => {
     const context = output.hookSpecificOutput?.additionalContext ?? '';
 
     expect(context).toContain('[MAGIC KEYWORD: RALPLAN]');
-    expect(context).toContain('Skill: oh-my-claudecode:ralplan');
+    expect(context).toContain('name: ralplan');
   });
 });

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -51,8 +51,8 @@ describe('keyword-detector packaged artifacts', () => {
     for (const [prompt, expected] of [
       ['tdd implement password validation', '[TDD MODE ACTIVATED]'],
       ['deep-analyze the test failure', 'ANALYSIS MODE'],
-      ['deep interview me about requirements', 'oh-my-claudecode:deep-interview'],
-      ['deslop this module with duplicate dead code', 'oh-my-claudecode:ai-slop-cleaner'],
+      ['deep interview me about requirements', '[MAGIC KEYWORD: DEEP-INTERVIEW]'],
+      ['deslop this module with duplicate dead code', '[MAGIC KEYWORD: AI-SLOP-CLEANER]'],
     ] as const) {
       const templateResult = JSON.stringify(runKeywordHook(templatePath, prompt));
       const pluginResult = JSON.stringify(runKeywordHook(pluginPath, prompt));
@@ -73,8 +73,8 @@ describe('keyword-detector packaged artifacts', () => {
     const templateNegative = runKeywordHook(templatePath, negativePrompt);
     const pluginNegative = runKeywordHook(pluginPath, negativePrompt);
 
-    expect(templatePositive).toContain('oh-my-claudecode:ai-slop-cleaner');
-    expect(pluginPositive).toContain('oh-my-claudecode:ai-slop-cleaner');
+    expect(templatePositive).toContain('[MAGIC KEYWORD: AI-SLOP-CLEANER]');
+    expect(pluginPositive).toContain('[MAGIC KEYWORD: AI-SLOP-CLEANER]');
     expect(templateNegative).toEqual({ continue: true, suppressOutput: true });
     expect(pluginNegative).toEqual({ continue: true, suppressOutput: true });
   });


### PR DESCRIPTION
## Summary
- update hook template compatibility assertions to check magic keyword markers instead of legacy skill invocation strings
- update the keyword-detector script test to assert raw skill frontmatter for ralplan
- keep keyword-detector behavior unchanged and align tests with current SKILL.md injection output

## Verification
- npm test
- npm run lint
- npx tsc --noEmit