### PR TITLE
Add skin in the game builtin workflows and prompt guidance

### DIFF
--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: debug
+description: Diagnose the current OMC session or repo state using logs, traces, state, and focused reproduction
+---
+
+# Debug
+
+Use this skill when the user wants help diagnosing a current OMC/Claude-Code session problem, workflow breakage, or confusing runtime behavior.
+
+## Goal
+Find the real failure signal quickly and explain the next corrective step.
+
+## Workflow
+1. Read the user’s issue description carefully.
+2. Inspect the most relevant local evidence first:
+   - trace tools
+   - state tools
+   - notepad / project memory when relevant
+   - failing tests or commands
+3. Reproduce the issue narrowly if possible.
+4. Distinguish symptoms from root cause.
+5. Recommend the smallest next fix or verification step.
+
+## Rules
+- Prefer real evidence over guesses.
+- Use the trace/state surfaces when the issue involves orchestration, hooks, or agent flow.
+- If the issue is actually a product/runtime bug rather than app code, say so plainly.
+- Do not prescribe broad rewrites before isolating the failure.
+
+## Output
+- Observed failure
+- Root-cause hypothesis
+- Evidence for that hypothesis
+- Smallest next action
+

--- a/skills/remember/SKILL.md
+++ b/skills/remember/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: remember
+description: Review reusable project knowledge and decide what belongs in project memory, notepad, or durable docs
+---
+
+# Remember
+
+Use this skill when the user wants to preserve or organize useful knowledge discovered during a session.
+
+## Goal
+Promote durable, reusable knowledge into the right memory surface instead of leaving it buried in chat history.
+
+## Memory surfaces
+- **Project memory** — durable team/project knowledge
+- **Notepad priority** — short high-signal context for the next turns
+- **Notepad working** — temporary active-session notes
+- **Docs / AGENTS / CLAUDE files** — durable instructions and conventions when they truly belong there
+
+## Workflow
+1. Gather the relevant session findings.
+2. Classify each item:
+   - durable project fact
+   - temporary working note
+   - operator preference or instruction
+   - duplicate / stale / conflicting information
+3. Propose the best destination for each item.
+4. Write or update only the appropriate memory surface.
+5. Call out duplicates or conflicts that should be cleaned up.
+
+## Rules
+- Do not dump everything into one store.
+- Prefer project memory for durable team knowledge.
+- Prefer notepad for short-lived working context.
+- Keep entries concise and actionable.
+- If something is uncertain, mark it as uncertain rather than storing it as fact.
+
+## Output
+- What was stored
+- Where it was stored
+- Any duplicates/conflicts found
+

--- a/skills/skillify/SKILL.md
+++ b/skills/skillify/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: skillify
+description: Turn a repeatable workflow from the current session into a reusable OMC skill draft
+---
+
+# Skillify
+
+Use this skill when the current session uncovered a repeatable workflow that should become a reusable OMC skill.
+
+## Goal
+Capture a successful multi-step workflow as a concrete skill draft instead of rediscovering it later.
+
+## Workflow
+1. Identify the repeatable task the session accomplished.
+2. Extract:
+   - inputs
+   - ordered steps
+   - success criteria
+   - constraints / pitfalls
+   - best target location for the skill
+3. Decide whether the workflow belongs as:
+   - a repo built-in skill
+   - a user/project learned skill
+   - documentation only
+4. Draft the SKILL.md content with clear triggers, steps, and success criteria.
+5. Point out anything still too fuzzy to encode safely.
+
+## Rules
+- Only capture workflows that are actually repeatable.
+- Keep the skill practical and scoped.
+- Prefer explicit success criteria over vague prose.
+- If the workflow still has unresolved branching decisions, note them before drafting.
+
+## Output
+- Proposed skill name
+- Target location
+- Draft workflow structure
+- Open questions, if any

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: verify
+description: Verify that a change really works before you claim completion
+---
+
+# Verify
+
+Use this skill when the user wants confidence that a feature, fix, or refactor actually works.
+
+## Goal
+Turn vague “it should work” claims into concrete evidence.
+
+## Workflow
+1. Identify the exact behavior that must be proven.
+2. Prefer existing tests first.
+3. If coverage is missing, run the narrowest direct verification commands available.
+4. If direct automation is not enough, describe the manual validation steps and gather concrete observable evidence.
+5. Report only what was actually verified.
+
+## Verification order
+1. Existing tests
+2. Typecheck / build
+3. Narrow direct command checks
+4. Manual or interactive validation
+
+## Rules
+- Do not say a change is complete without evidence.
+- If a check fails, include the failure clearly.
+- If no realistic verification path exists, say that explicitly instead of bluffing.
+- Prefer concise evidence summaries over noisy logs.
+
+## Output
+- What was verified
+- Which commands/tests were run
+- What passed
+- What failed or remains unverified
+

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -4,6 +4,7 @@ import { createBuiltinSkills, getBuiltinSkill, listBuiltinSkillNames, clearSkill
 describe('Builtin Skills', () => {
   const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   const originalPath = process.env.PATH;
+  const originalUserType = process.env.USER_TYPE;
 
   // Clear cache before each test to ensure fresh loads
   beforeEach(() => {
@@ -16,6 +17,11 @@ describe('Builtin Skills', () => {
       delete process.env.PATH;
     } else {
       process.env.PATH = originalPath;
+    }
+    if (originalUserType === undefined) {
+      delete process.env.USER_TYPE;
+    } else {
+      process.env.USER_TYPE = originalUserType;
     }
     clearSkillsCache();
   });
@@ -30,6 +36,11 @@ describe('Builtin Skills', () => {
       delete process.env.PATH;
     } else {
       process.env.PATH = originalPath;
+    }
+    if (originalUserType === undefined) {
+      delete process.env.USER_TYPE;
+    } else {
+      process.env.USER_TYPE = originalUserType;
     }
     clearSkillsCache();
   });
@@ -391,6 +402,29 @@ describe('Builtin Skills', () => {
 
     it('should not return a skill for "clear" via getBuiltinSkill', () => {
       expect(getBuiltinSkill('clear')).toBeUndefined();
+    });
+  });
+
+  describe('skininthegamebros-only builtin skills', () => {
+    it('keeps skininthegamebros-only skills hidden by default', () => {
+      const names = listBuiltinSkillNames({ includeAliases: true });
+      expect(names).not.toContain('remember');
+      expect(names).not.toContain('verify');
+      expect(names).not.toContain('debug');
+      expect(names).not.toContain('skillify');
+    });
+
+    it('surfaces skininthegamebros-only skills when USER_TYPE=ant', () => {
+      process.env.USER_TYPE = 'ant';
+      clearSkillsCache();
+
+      const names = listBuiltinSkillNames({ includeAliases: true });
+      expect(names).toContain('remember');
+      expect(names).toContain('verify');
+      expect(names).toContain('debug');
+      expect(names).toContain('skillify');
+      expect(names).not.toContain('stuck');
+      expect(names).not.toContain('lorem-ipsum');
     });
   });
 

--- a/src/__tests__/skininthegamebros-guidance.test.ts
+++ b/src/__tests__/skininthegamebros-guidance.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getOmcSystemPrompt } from '../index.js';
+import { getAgentDefinitions } from '../agents/definitions.js';
+import { resolveSystemPrompt } from '../agents/prompt-helpers.js';
+
+describe('skininthegamebros guidance', () => {
+  const originalUserType = process.env.USER_TYPE;
+
+  beforeEach(() => {
+    if (originalUserType === undefined) {
+      delete process.env.USER_TYPE;
+    } else {
+      process.env.USER_TYPE = originalUserType;
+    }
+  });
+
+  afterEach(() => {
+    if (originalUserType === undefined) {
+      delete process.env.USER_TYPE;
+    } else {
+      process.env.USER_TYPE = originalUserType;
+    }
+  });
+
+  it('does not append skininthegamebros guidance by default', () => {
+    const prompt = getOmcSystemPrompt();
+    expect(prompt).not.toContain('Skininthegamebros Execution Guidance');
+  });
+
+  it('appends skininthegamebros guidance to the orchestrator prompt for USER_TYPE=ant', () => {
+    process.env.USER_TYPE = 'ant';
+    const prompt = getOmcSystemPrompt();
+    expect(prompt).toContain('Skininthegamebros Execution Guidance');
+    expect(prompt).toContain('Report outcomes faithfully');
+  });
+
+  it('appends skininthegamebros guidance to agent prompts for USER_TYPE=ant', () => {
+    process.env.USER_TYPE = 'ant';
+    const agents = getAgentDefinitions();
+    expect(agents.architect.prompt).toContain('## Skininthegamebros Guidance');
+    expect(agents.architect.prompt).toContain('Default to writing no comments');
+  });
+
+  it('appends skininthegamebros guidance when resolving agent-role prompts for USER_TYPE=ant', () => {
+    process.env.USER_TYPE = 'ant';
+    const prompt = resolveSystemPrompt(undefined, 'architect');
+    expect(prompt).toContain('## Skininthegamebros Guidance');
+    expect(prompt).toContain('verify the result with tests');
+  });
+});

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -11,6 +11,7 @@
 import type { AgentConfig, PluginConfig } from '../shared/types.js';
 import { loadAgentPrompt, parseDisallowedTools } from './utils.js';
 import { loadConfig } from '../config/loader.js';
+import { appendSkininthegamebrosGuidance } from './skininthegamebros-guidance.js';
 
 // Re-export base agents from individual files (rebranded names)
 export { architectAgent } from './architect.js';
@@ -264,7 +265,10 @@ export function getAgentDefinitions(options?: {
 
     result[name] = {
       description: override?.description ?? agentConfig.description,
-      prompt: override?.prompt ?? agentConfig.prompt,
+      prompt: appendSkininthegamebrosGuidance(
+        override?.prompt ?? agentConfig.prompt,
+        'agent',
+      ),
       tools: override?.tools ?? agentConfig.tools,
       disallowedTools,
       model: resolvedModel,

--- a/src/agents/prompt-helpers.ts
+++ b/src/agents/prompt-helpers.ts
@@ -9,6 +9,7 @@ import { readdirSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { loadAgentPrompt } from './utils.js';
+import { appendSkininthegamebrosGuidance } from './skininthegamebros-guidance.js';
 
 /**
  * Build-time injected agent roles list.
@@ -143,7 +144,7 @@ export function resolveSystemPrompt(
       console.warn(`[prompt-injection] Agent role "${role}" prompt not found, skipping injection`);
       return undefined;
     }
-    return prompt;
+    return appendSkininthegamebrosGuidance(prompt, 'agent');
   }
 
   return undefined;

--- a/src/agents/skininthegamebros-guidance.ts
+++ b/src/agents/skininthegamebros-guidance.ts
@@ -1,0 +1,37 @@
+import { isSkininthegamebrosUser } from '../utils/skininthegamebros-user.js';
+
+type GuidanceSurface = 'system' | 'agent';
+
+const SKININTHEGAMEBROS_GUIDANCE_HEADER: Record<GuidanceSurface, string> = {
+  system: '## Skininthegamebros Execution Guidance',
+  agent: '## Skininthegamebros Guidance',
+};
+
+const SKININTHEGAMEBROS_GUIDANCE_LINES = [
+  '- Default to writing no comments unless the why is genuinely non-obvious.',
+  '- Before reporting completion, verify the result with tests, commands, or observable output whenever possible.',
+  '- If the user is operating on a misconception, or you notice an adjacent bug worth flagging, say so directly.',
+  '- Report outcomes faithfully: do not imply checks passed if you did not run them, and do not hide failing verification.',
+];
+
+export function renderSkininthegamebrosGuidance(surface: GuidanceSurface): string {
+  if (!isSkininthegamebrosUser()) {
+    return '';
+  }
+
+  return [SKININTHEGAMEBROS_GUIDANCE_HEADER[surface], ...SKININTHEGAMEBROS_GUIDANCE_LINES].join(
+    '\n',
+  );
+}
+
+export function appendSkininthegamebrosGuidance(
+  basePrompt: string,
+  surface: GuidanceSurface,
+): string {
+  const guidance = renderSkininthegamebrosGuidance(surface);
+  if (!guidance) {
+    return basePrompt;
+  }
+
+  return `${basePrompt}\n\n${guidance}`;
+}

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -18,6 +18,7 @@ import { rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from './runtime-guidance.js';
+import { isSkininthegamebrosUser } from '../../utils/skininthegamebros-user.js';
 
 function getPackageDir(): string {
   if (typeof __dirname !== 'undefined' && __dirname) {
@@ -65,6 +66,13 @@ const CC_NATIVE_COMMANDS = new Set([
   'clear',
   'compact',
   'memory',
+]);
+
+const SKININTHEGAMEBROS_ONLY_SKILLS = new Set([
+  'remember',
+  'verify',
+  'debug',
+  'skillify',
 ]);
 
 function toSafeSkillName(name: string): string {
@@ -149,6 +157,9 @@ function loadSkillsFromDirectory(): BuiltinSkill[] {
 
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
+      if (SKININTHEGAMEBROS_ONLY_SKILLS.has(entry.name) && !isSkininthegamebrosUser()) {
+        continue;
+      }
 
       const skillPath = join(SKILLS_DIR, entry.name, 'SKILL.md');
       if (existsSync(skillPath)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { getDefaultMcpServers, toSdkMcpFormat } from './mcp/servers.js';
 import { omcToolsServer, getOmcToolNames } from './mcp/omc-tools-server.js';
 import { createMagicKeywordProcessor, detectMagicKeywords } from './features/magic-keywords.js';
 import { continuationSystemPromptAddition } from './features/continuation-enforcement.js';
+import { appendSkininthegamebrosGuidance } from './agents/skininthegamebros-guidance.js';
 import {
   createBackgroundTaskManager,
   shouldRunInBackground as shouldRunInBackgroundFn,
@@ -279,7 +280,7 @@ export function createOmcSession(options?: OmcOptions): OmcSession {
   }
 
   // Build system prompt
-  let systemPrompt = omcSystemPrompt;
+  let systemPrompt = appendSkininthegamebrosGuidance(omcSystemPrompt, 'system');
 
   // Add continuation enforcement
   if (config.features?.continuationEnforcement !== false) {
@@ -390,7 +391,7 @@ export function getOmcSystemPrompt(options?: {
   includeContinuation?: boolean;
   customAddition?: string;
 }): string {
-  let prompt = omcSystemPrompt;
+  let prompt = appendSkininthegamebrosGuidance(omcSystemPrompt, 'system');
 
   if (options?.includeContinuation !== false) {
     prompt += continuationSystemPromptAddition;

--- a/src/utils/skininthegamebros-user.ts
+++ b/src/utils/skininthegamebros-user.ts
@@ -1,0 +1,4 @@
+export function isSkininthegamebrosUser(): boolean {
+  return process.env.USER_TYPE === 'ant';
+}
+


### PR DESCRIPTION
## Summary
- add four builtin skills: `remember`, `verify`, `debug`, and `skillify`
- add skininthegamebros prompt guidance to the orchestrator, agent prompts, and agent-role prompt injection paths
- rename the newly introduced wording to `skininthegamebros` in the live implementation and tests

## Details
This keeps the implementation intentionally narrow:
- no profile/capability config layer
- no remote-isolation port
- `stuck` and `lorem-ipsum` remain deferred

The new builtin skills are shipped from the repo `skills/` tree.

## Verification
- `npx vitest run src/__tests__/skininthegamebros-guidance.test.ts src/__tests__/skills.test.ts`
- `npx tsc --noEmit`
