### PR TITLE
Add skill argument hints for discoverability

### DIFF
--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autopilot
 description: Full autonomous execution from idea to working code
+argument-hint: "<product idea or task description>"
 level: 4
 ---
 

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cancel
 description: Cancel any active OMC mode (autopilot, ralph, ultrawork, ultraqa, swarm, ultrapilot, pipeline, team)
+argument-hint: "[--force|--all]"
 level: 2
 ---
 

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: hud
 description: Configure HUD display options (layout, presets, display elements)
+argument-hint: "[setup|minimal|focused|full|status]"
 role: config-writer  # DOCUMENTATION ONLY - This skill writes to ~/.claude/ paths
 scope: ~/.claude/**  # DOCUMENTATION ONLY - Allowed write scope
 level: 2

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: omc-plan
 description: Strategic planning with optional interview workflow
+argument-hint: "[--direct|--consensus|--review] [--interactive] [--deliberate] <task description>"
 pipeline: [deep-interview, omc-plan, autopilot]
 next-skill: autopilot
 handoff: .omc/plans/ralplan-*.md

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ralph
 description: Self-referential loop until task completion with configurable verification reviewer
+argument-hint: "[--no-prd] [--no-deslop] [--critic=architect|critic|codex] <task description>"
 level: 4
 ---
 

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ralplan
 description: Consensus planning entrypoint that auto-gates vague ralph/autopilot/team requests before execution
+argument-hint: "[--interactive] [--deliberate] [--architect codex] [--critic codex] <task description>"
 level: 4
 ---
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: team
 description: N coordinated agents on shared task list using Claude Code native teams
+argument-hint: "[N:agent-type] [ralph] <task description>"
 aliases: []
 level: 4
 ---

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: trace
 description: Evidence-driven tracing lane that orchestrates competing tracer hypotheses in Claude built-in team mode
+argument-hint: "<observation to trace>"
 agent: tracer
 level: 2
 ---

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ultraqa
 description: QA cycling workflow - test, verify, fix, repeat until goal met
+argument-hint: "[--tests|--build|--lint|--typecheck|--custom <pattern>] [--interactive]"
 level: 3
 ---
 

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ultrawork
 description: Parallel execution engine for high-throughput task completion
+argument-hint: "<task description with parallel work items>"
 level: 4
 ---
 


### PR DESCRIPTION
## Summary
- add the requested `argument-hint` frontmatter entries to the 10 user-invocable skills from issue #2079
- keep the change metadata-only because the existing frontmatter parser/loaders already consume `argument-hint`
- verify the repo still passes `npm test` and `tsc --noEmit`

## Verification
- `npm test`
- `tsc --noEmit`

## Notes
- parser support already exists in `src/utils/frontmatter.ts`
- skill loading already exposes `argument-hint` in `src/features/builtin-skills/skills.ts` and `src/hooks/auto-slash-command/executor.ts`
