### PR TITLE
Fix setup for custom CLAUDE_CONFIG_DIR profiles

### DIFF
--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -87,14 +87,15 @@ EOF
 }
 
 # Determine target path
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 if [ "$MODE" = "local" ]; then
   mkdir -p .claude/skills/omc-reference
   TARGET_PATH=".claude/CLAUDE.md"
   SKILL_TARGET_PATH=".claude/skills/omc-reference/SKILL.md"
 elif [ "$MODE" = "global" ]; then
-  mkdir -p "$HOME/.claude/skills/omc-reference"
-  TARGET_PATH="$HOME/.claude/CLAUDE.md"
-  SKILL_TARGET_PATH="$HOME/.claude/skills/omc-reference/SKILL.md"
+  mkdir -p "$CONFIG_DIR/skills/omc-reference"
+  TARGET_PATH="$CONFIG_DIR/CLAUDE.md"
+  SKILL_TARGET_PATH="$CONFIG_DIR/skills/omc-reference/SKILL.md"
 else
   echo "ERROR: Invalid mode '$MODE'. Use 'local' or 'global'." >&2
   exit 1
@@ -274,23 +275,27 @@ fi
 
 # Legacy hooks cleanup (global mode only)
 if [ "$MODE" = "global" ]; then
-  rm -f ~/.claude/hooks/keyword-detector.sh
-  rm -f ~/.claude/hooks/stop-continuation.sh
-  rm -f ~/.claude/hooks/persistent-mode.sh
-  rm -f ~/.claude/hooks/session-start.sh
+  rm -f "$CONFIG_DIR/hooks/keyword-detector.sh"
+  rm -f "$CONFIG_DIR/hooks/stop-continuation.sh"
+  rm -f "$CONFIG_DIR/hooks/persistent-mode.sh"
+  rm -f "$CONFIG_DIR/hooks/session-start.sh"
   echo "Legacy hooks cleaned"
 
   # Check for manual hook entries in settings.json
-  SETTINGS_FILE="$HOME/.claude/settings.json"
+  SETTINGS_FILE="$CONFIG_DIR/settings.json"
   if [ -f "$SETTINGS_FILE" ]; then
     if jq -e '.hooks' "$SETTINGS_FILE" > /dev/null 2>&1; then
       echo ""
       echo "NOTE: Found legacy hooks in settings.json. These should be removed since"
       echo "the plugin now provides hooks automatically. Remove the \"hooks\" section"
-      echo "from ~/.claude/settings.json to prevent duplicate hook execution."
+      echo "from $SETTINGS_FILE to prevent duplicate hook execution."
     fi
   fi
 fi
 
 # Verify plugin installation
-grep -q "oh-my-claudecode" ~/.claude/settings.json && echo "Plugin verified" || echo "Plugin NOT found - run: claude /install-plugin oh-my-claudecode"
+if [ -f "$CONFIG_DIR/settings.json" ] && grep -q "oh-my-claudecode" "$CONFIG_DIR/settings.json"; then
+  echo "Plugin verified"
+else
+  echo "Plugin NOT found - run: claude /install-plugin oh-my-claudecode"
+fi

--- a/scripts/setup-progress.sh
+++ b/scripts/setup-progress.sh
@@ -9,7 +9,8 @@
 set -euo pipefail
 
 STATE_FILE=".omc/state/setup-state.json"
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CONFIG_FILE="$CONFIG_DIR/.omc-config.json"
 
 # Cross-platform ISO date to epoch conversion
 iso_to_epoch() {

--- a/src/__tests__/hud-marketplace-resolution.test.ts
+++ b/src/__tests__/hud-marketplace-resolution.test.ts
@@ -39,6 +39,12 @@ describe('HUD marketplace resolution', () => {
     const hudScriptPath = join(configDir, 'hud', 'omc-hud.mjs');
     expect(existsSync(hudScriptPath)).toBe(true);
 
+    const settings = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8')) as {
+      statusLine?: { command?: string };
+    };
+    expect(settings.statusLine?.command).toContain(`${join(configDir, 'hud', 'omc-hud.mjs').replace(/\\/g, '/')}`);
+    expect(existsSync(join(configDir, '.omc-config.json'))).toBe(true);
+
     const content = readFileSync(hudScriptPath, 'utf-8');
     expect(content).toContain('import { pathToFileURL } from "node:url"');
     expect(content).toContain('await import(pathToFileURL(pluginPath).href);');

--- a/src/__tests__/installer-hooks-merge.test.ts
+++ b/src/__tests__/installer-hooks-merge.test.ts
@@ -122,6 +122,10 @@ describe('isOmcHook()', () => {
     expect(isOmcHook('node "%USERPROFILE%\\.claude\\hooks\\keyword-detector.mjs"')).toBe(true);
   });
 
+  it('recognises custom-profile hook paths by known filename', () => {
+    expect(isOmcHook('node "/tmp/custom-claude/hooks/keyword-detector.mjs"')).toBe(true);
+  });
+
   it('recognises oh-my-claudecode in command path', () => {
     expect(isOmcHook('/path/to/oh-my-claudecode/hook.mjs')).toBe(true);
   });

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -197,6 +197,37 @@ Use the real docs file.
     const excludeContents = readFileSync(join(fixture.projectRoot, '.git', 'info', 'exclude'), 'utf-8');
     expect(excludeContents.match(/# BEGIN OMC local artifacts/g)).toHaveLength(1);
   });
+
+  it('uses CLAUDE_CONFIG_DIR for global setup targets and plugin verification', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(join(configDir, 'hooks'), { recursive: true });
+    writeFileSync(join(configDir, 'hooks', 'keyword-detector.sh'), 'legacy');
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ plugins: ['oh-my-claudecode'] }));
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'global'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(join(configDir, 'CLAUDE.md'))).toBe(true);
+    expect(existsSync(join(configDir, 'skills', 'omc-reference', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(configDir, 'hooks', 'keyword-detector.sh'))).toBe(false);
+    expect(`${result.stdout}\n${result.stderr}`).toContain('Plugin verified');
+  });
 });
 
 describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {

--- a/src/__tests__/setup-progress-script.test.ts
+++ b/src/__tests__/setup-progress-script.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const SCRIPT_PATH = join(REPO_ROOT, 'scripts', 'setup-progress.sh');
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('setup-progress.sh', () => {
+  it('writes setup completion metadata to CLAUDE_CONFIG_DIR', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-setup-progress-'));
+    tempRoots.push(root);
+
+    const projectRoot = join(root, 'project');
+    const homeRoot = join(root, 'home');
+    const configDir = join(root, 'custom-claude');
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(homeRoot, { recursive: true });
+
+    const result = spawnSync('bash', [SCRIPT_PATH, 'complete', 'v9.9.9'], {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        HOME: homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+
+    const configPath = join(configDir, '.omc-config.json');
+    expect(existsSync(configPath)).toBe(true);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+      setupCompleted?: string;
+      setupVersion?: string;
+    };
+
+    expect(config.setupVersion).toBe('v9.9.9');
+    expect(config.setupCompleted).toBeTruthy();
+  });
+});

--- a/src/installer/__tests__/safe-installer.test.ts
+++ b/src/installer/__tests__/safe-installer.test.ts
@@ -74,6 +74,10 @@ describe('isOmcHook detection', () => {
     expect(isOmcHook('node "$HOME/.claude/hooks/persistent-mode.mjs"')).toBe(true);
   });
 
+  it('detects custom-profile OMC hook commands by hook filename', () => {
+    expect(isOmcHook('node "/tmp/custom-claude/hooks/keyword-detector.mjs"')).toBe(true);
+  });
+
   it('detects Windows-style OMC hook commands (issue #606)', () => {
     expect(isOmcHook('node "%USERPROFILE%\\.claude\\hooks\\keyword-detector.mjs"')).toBe(true);
     expect(isOmcHook('node "%USERPROFILE%\\.claude\\hooks\\pre-tool-use.mjs"')).toBe(true);

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -64,10 +64,13 @@ describe('install() standalone hook reconciliation', () => {
     expect(result.success).toBe(true);
     expect(result.hooksConfigured).toBe(true);
     expect(writtenSettings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toBe(
-      'node "$HOME/.claude/hooks/keyword-detector.mjs"',
+      `node "${join(testClaudeDir, 'hooks', 'keyword-detector.mjs').replace(/\\/g, '/')}"`,
     );
     expect(writtenSettings.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toBe(
-      'node "$HOME/.claude/hooks/session-start.mjs"',
+      `node "${join(testClaudeDir, 'hooks', 'session-start.mjs').replace(/\\/g, '/')}"`,
+    );
+    expect((writtenSettings as { statusLine?: { command?: string } }).statusLine?.command).toContain(
+      `${join(testClaudeDir, 'hud', 'omc-hud.mjs').replace(/\\/g, '/')}`,
     );
     expect(readFileSync(join(testClaudeDir, 'hooks', 'keyword-detector.mjs'), 'utf-8')).toContain('Ralph keywords');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'pre-tool-use.mjs'), 'utf-8')).toContain('PreToolUse');
@@ -105,6 +108,8 @@ describe('install() standalone hook reconciliation', () => {
 
     expect(result.success).toBe(true);
     expect(commands).toContain('node $HOME/.claude/hooks/other-plugin.mjs');
-    expect(commands).toContain('node "$HOME/.claude/hooks/keyword-detector.mjs"');
+    expect(commands).toContain(
+      `node "${join(testClaudeDir, 'hooks', 'keyword-detector.mjs').replace(/\\/g, '/')}"`,
+    );
   });
 });

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -12,6 +12,7 @@
 import { join, dirname } from "path";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
+import { homedir } from "os";
 import { getConfigDir } from '../utils/config-dir.js';
 
 // =============================================================================
@@ -85,6 +86,34 @@ export function getHooksDir(): string {
  */
 export function getHomeEnvVar(): string {
   return isWindows() ? "%USERPROFILE%" : "$HOME";
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+function isDefaultClaudeConfigDir(): boolean {
+  return normalizePath(getClaudeConfigDir()) === normalizePath(join(homedir(), '.claude'));
+}
+
+function quoteCommandPath(path: string): string {
+  return `"${path.replace(/"/g, '\\"')}"`;
+}
+
+function buildHookCommand(filename: string): string {
+  if (isWindows()) {
+    if (isDefaultClaudeConfigDir()) {
+      return `node "%USERPROFILE%\\\\.claude\\\\hooks\\\\${filename}"`;
+    }
+
+    return `node ${quoteCommandPath(join(getClaudeConfigDir(), 'hooks', filename))}`;
+  }
+
+  if (isDefaultClaudeConfigDir()) {
+    return `node "$HOME/.claude/hooks/${filename}"`;
+  }
+
+  return `node ${quoteCommandPath(join(getClaudeConfigDir(), 'hooks', filename).replace(/\\/g, '/'))}`;
 }
 
 /**
@@ -381,11 +410,7 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
         hooks: [
           {
             type: "command" as const,
-            // Note: On Windows, %USERPROFILE% is expanded by cmd.exe
-            // On Unix with node hooks, $HOME is expanded by the shell
-            command: isWindows()
-              ? 'node "%USERPROFILE%\\.claude\\hooks\\keyword-detector.mjs"'
-              : 'node "$HOME/.claude/hooks/keyword-detector.mjs"',
+            command: buildHookCommand('keyword-detector.mjs'),
           },
         ],
       },
@@ -395,9 +420,7 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
         hooks: [
           {
             type: "command" as const,
-            command: isWindows()
-              ? 'node "%USERPROFILE%\\.claude\\hooks\\session-start.mjs"'
-              : 'node "$HOME/.claude/hooks/session-start.mjs"',
+            command: buildHookCommand('session-start.mjs'),
           },
         ],
       },
@@ -407,9 +430,7 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
         hooks: [
           {
             type: "command" as const,
-            command: isWindows()
-              ? 'node "%USERPROFILE%\\.claude\\hooks\\pre-tool-use.mjs"'
-              : 'node "$HOME/.claude/hooks/pre-tool-use.mjs"',
+            command: buildHookCommand('pre-tool-use.mjs'),
           },
         ],
       },
@@ -419,9 +440,7 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
         hooks: [
           {
             type: "command" as const,
-            command: isWindows()
-              ? 'node "%USERPROFILE%\\.claude\\hooks\\post-tool-use.mjs"'
-              : 'node "$HOME/.claude/hooks/post-tool-use.mjs"',
+            command: buildHookCommand('post-tool-use.mjs'),
           },
         ],
       },
@@ -431,9 +450,7 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
         hooks: [
           {
             type: "command" as const,
-            command: isWindows()
-              ? 'node "%USERPROFILE%\\.claude\\hooks\\post-tool-use-failure.mjs"'
-              : 'node "$HOME/.claude/hooks/post-tool-use-failure.mjs"',
+            command: buildHookCommand('post-tool-use-failure.mjs'),
           },
         ],
       },
@@ -443,9 +460,7 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
         hooks: [
           {
             type: "command" as const,
-            command: isWindows()
-              ? 'node "%USERPROFILE%\\.claude\\hooks\\persistent-mode.mjs"'
-              : 'node "$HOME/.claude/hooks/persistent-mode.mjs"',
+            command: buildHookCommand('persistent-mode.mjs'),
           },
         ],
       },
@@ -453,9 +468,7 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
         hooks: [
           {
             type: "command" as const,
-            command: isWindows()
-              ? 'node "%USERPROFILE%\\.claude\\hooks\\code-simplifier.mjs"'
-              : 'node "$HOME/.claude/hooks/code-simplifier.mjs"',
+            command: buildHookCommand('code-simplifier.mjs'),
           },
         ],
       },
@@ -473,4 +486,3 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
 export function getHooksSettingsConfig(): typeof HOOKS_SETTINGS_CONFIG_NODE {
   return HOOKS_SETTINGS_CONFIG_NODE;
 }
-

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -146,6 +146,39 @@ function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+function isDefaultClaudeConfigDirPath(configDir: string): boolean {
+  return normalizePath(configDir) === normalizePath(join(homedir(), '.claude'));
+}
+
+function quoteShellArg(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+function buildStatusLineCommand(nodeBin: string, hudScriptPath: string, findNodePath?: string): string {
+  if (isWindows()) {
+    return `${quoteShellArg(nodeBin)} ${quoteShellArg(hudScriptPath)}`;
+  }
+
+  if (isDefaultClaudeConfigDirPath(CLAUDE_CONFIG_DIR)) {
+    if (findNodePath) {
+      return 'sh $HOME/.claude/hud/find-node.sh $HOME/.claude/hud/omc-hud.mjs';
+    }
+
+    return 'node $HOME/.claude/hud/omc-hud.mjs';
+  }
+
+  const normalizedHudScriptPath = hudScriptPath.replace(/\\/g, '/');
+  if (findNodePath) {
+    return `sh ${quoteShellArg(findNodePath.replace(/\\/g, '/'))} ${quoteShellArg(normalizedHudScriptPath)}`;
+  }
+
+  return `node ${quoteShellArg(normalizedHudScriptPath)}`;
+}
+
 function createLineAnchoredMarkerRegex(marker: string, flags: string = 'gm'): RegExp {
   return new RegExp(`^${escapeRegex(marker)}$`, flags);
 }
@@ -273,8 +306,9 @@ export function isOmcHook(command: string): boolean {
   }
   // Check for known OMC hook filenames in .claude/hooks/ path.
   // Handles both Unix (.claude/hooks/) and Windows (.claude\hooks\) paths.
-  const hookPathMatch = lowerCommand.match(/\.claude[/\\]hooks[/\\]([a-z0-9-]+\.mjs)/);
-  if (hookPathMatch && OMC_HOOK_FILENAMES.has(hookPathMatch[1])) {
+  const containsHooksDir = /hooks[/\\]/.test(lowerCommand);
+  const hookFilenameMatch = lowerCommand.match(/([a-z0-9-]+\.mjs)(?:$|["'\s])/);
+  if (containsHooksDir && hookFilenameMatch && OMC_HOOK_FILENAMES.has(hookFilenameMatch[1])) {
     return true;
   }
   return false;
@@ -1185,11 +1219,13 @@ export function install(options: InstallOptions = {}): InstallResult {
             const findNodeDest = join(HUD_DIR, 'find-node.sh');
             copyFileSync(findNodeSrc, findNodeDest);
             chmodSync(findNodeDest, 0o755);
-            statusLineCommand = 'sh $HOME/.claude/hud/find-node.sh $HOME/.claude/hud/omc-hud.mjs';
+            statusLineCommand = buildStatusLineCommand(nodeBin, hudScriptPath.replace(/\\/g, '/'), findNodeDest);
           } catch {
             // Fallback to bare node if find-node.sh copy fails
-            statusLineCommand = 'node $HOME/.claude/hud/omc-hud.mjs';
+            statusLineCommand = buildStatusLineCommand(nodeBin, hudScriptPath.replace(/\\/g, '/'));
           }
+        } else {
+          statusLineCommand = buildStatusLineCommand(nodeBin, hudScriptPath);
         }
         // Auto-migrate legacy string format (pre-v4.5) to object format
         const needsMigration = typeof existingSettings.statusLine === 'string'


### PR DESCRIPTION
## Summary
- respect `CLAUDE_CONFIG_DIR` in global setup targets, legacy cleanup, plugin verification, and setup progress persistence
- emit hook and HUD statusLine commands that stay portable for the default profile but resolve to the custom profile when `CLAUDE_CONFIG_DIR` is non-default
- add regression coverage for custom-profile setup, hook detection, and installer-generated hook/statusLine output

## Testing
- `npx vitest run src/__tests__/installer.test.ts src/__tests__/hud-marketplace-resolution.test.ts src/__tests__/setup-claude-md-script.test.ts src/__tests__/setup-progress-script.test.ts src/installer/__tests__/safe-installer.test.ts src/installer/__tests__/standalone-hook-reconcile.test.ts src/__tests__/installer-hooks-merge.test.ts`
- `npm run build`
- `npx eslint src/installer/index.ts src/installer/hooks.ts src/__tests__/setup-claude-md-script.test.ts src/__tests__/setup-progress-script.test.ts src/__tests__/hud-marketplace-resolution.test.ts src/__tests__/installer-hooks-merge.test.ts src/installer/__tests__/standalone-hook-reconcile.test.ts src/installer/__tests__/safe-installer.test.ts`

Closes #2084.
