### PR TITLE
fix: respect CLAUDE_CONFIG_DIR environment variable in setup scripts

### DIFF
--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -92,9 +92,10 @@ if [ "$MODE" = "local" ]; then
   TARGET_PATH=".claude/CLAUDE.md"
   SKILL_TARGET_PATH=".claude/skills/omc-reference/SKILL.md"
 elif [ "$MODE" = "global" ]; then
-  mkdir -p "$HOME/.claude/skills/omc-reference"
-  TARGET_PATH="$HOME/.claude/CLAUDE.md"
-  SKILL_TARGET_PATH="$HOME/.claude/skills/omc-reference/SKILL.md"
+  CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  mkdir -p "$CONFIG_DIR/skills/omc-reference"
+  TARGET_PATH="$CONFIG_DIR/CLAUDE.md"
+  SKILL_TARGET_PATH="$CONFIG_DIR/skills/omc-reference/SKILL.md"
 else
   echo "ERROR: Invalid mode '$MODE'. Use 'local' or 'global'." >&2
   exit 1
@@ -274,23 +275,24 @@ fi
 
 # Legacy hooks cleanup (global mode only)
 if [ "$MODE" = "global" ]; then
-  rm -f ~/.claude/hooks/keyword-detector.sh
-  rm -f ~/.claude/hooks/stop-continuation.sh
-  rm -f ~/.claude/hooks/persistent-mode.sh
-  rm -f ~/.claude/hooks/session-start.sh
+  CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  rm -f "$CONFIG_DIR/hooks/keyword-detector.sh"
+  rm -f "$CONFIG_DIR/hooks/stop-continuation.sh"
+  rm -f "$CONFIG_DIR/hooks/persistent-mode.sh"
+  rm -f "$CONFIG_DIR/hooks/session-start.sh"
   echo "Legacy hooks cleaned"
 
   # Check for manual hook entries in settings.json
-  SETTINGS_FILE="$HOME/.claude/settings.json"
+  SETTINGS_FILE="$CONFIG_DIR/settings.json"
   if [ -f "$SETTINGS_FILE" ]; then
     if jq -e '.hooks' "$SETTINGS_FILE" > /dev/null 2>&1; then
       echo ""
       echo "NOTE: Found legacy hooks in settings.json. These should be removed since"
       echo "the plugin now provides hooks automatically. Remove the \"hooks\" section"
-      echo "from ~/.claude/settings.json to prevent duplicate hook execution."
+      echo "from $CONFIG_DIR/settings.json to prevent duplicate hook execution."
     fi
   fi
 fi
 
 # Verify plugin installation
-grep -q "oh-my-claudecode" ~/.claude/settings.json && echo "Plugin verified" || echo "Plugin NOT found - run: claude /install-plugin oh-my-claudecode"
+grep -q "oh-my-claudecode" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json" && echo "Plugin verified" || echo "Plugin NOT found - run: claude /install-plugin oh-my-claudecode"

--- a/scripts/setup-progress.sh
+++ b/scripts/setup-progress.sh
@@ -9,7 +9,8 @@
 set -euo pipefail
 
 STATE_FILE=".omc/state/setup-state.json"
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CONFIG_FILE="$CONFIG_DIR/.omc-config.json"
 
 # Cross-platform ISO date to epoch conversion
 iso_to_epoch() {

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -395,4 +395,76 @@ describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {
     expect(installed).toContain('<!-- OMC:VERSION:4.9.0 -->');
     expect(installed).not.toContain('<!-- OMC:VERSION:4.8.2 -->');
   });
+
+  it('respects CLAUDE_CONFIG_DIR for global mode installation (issue #2084)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-config-dir-test-'));
+    tempRoots.push(root);
+
+    const homeRoot = join(root, 'home');
+    const customConfigDir = join(root, 'custom-claude-config');
+    const cacheBase = join(customConfigDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const pluginVersion = join(cacheBase, '4.9.3');
+
+    // Create plugin with CLAUDE.md
+    mkdirSync(join(pluginVersion, 'scripts'), { recursive: true });
+    mkdirSync(join(pluginVersion, 'docs'), { recursive: true });
+    mkdirSync(join(pluginVersion, 'skills', 'omc-reference'), { recursive: true });
+    copyFileSync(SETUP_SCRIPT, join(pluginVersion, 'scripts', 'setup-claude-md.sh'));
+    writeFileSync(
+      join(pluginVersion, 'docs', 'CLAUDE.md'),
+      `<!-- OMC:START -->\n<!-- OMC:VERSION:4.9.3 -->\n\n# Custom Config Test\n<!-- OMC:END -->\n`,
+    );
+    writeFileSync(
+      join(pluginVersion, 'skills', 'omc-reference', 'SKILL.md'),
+      `---\nname: omc-reference\ndescription: Test fixture\n---\n\n# Test Reference`,
+    );
+
+    // Create installed_plugins.json pointing to the plugin
+    mkdirSync(join(customConfigDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(customConfigDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        'oh-my-claudecode@omc': [
+          {
+            installPath: pluginVersion,
+            version: '4.9.3',
+          },
+        ],
+      }),
+    );
+
+    // Create settings.json for plugin verification
+    writeFileSync(
+      join(customConfigDir, 'settings.json'),
+      JSON.stringify({ plugins: ['oh-my-claudecode'] }),
+    );
+
+    const result = spawnSync(
+      'bash',
+      [join(pluginVersion, 'scripts', 'setup-claude-md.sh'), 'global'],
+      {
+        cwd: root,
+        env: {
+          ...process.env,
+          HOME: homeRoot,
+          CLAUDE_CONFIG_DIR: customConfigDir,
+        },
+        encoding: 'utf-8',
+      },
+    );
+
+    expect(result.status).toBe(0);
+
+    // CLAUDE.md should be installed to the custom config dir, not ~/.claude
+    const installedPath = join(customConfigDir, 'CLAUDE.md');
+    expect(existsSync(installedPath)).toBe(true);
+    expect(readFileSync(installedPath, 'utf-8')).toContain('# Custom Config Test');
+
+    // Skill should also be installed to custom config dir
+    const skillPath = join(customConfigDir, 'skills', 'omc-reference', 'SKILL.md');
+    expect(existsSync(skillPath)).toBe(true);
+
+    // Verify it was NOT installed to the default ~/.claude location
+    expect(existsSync(join(homeRoot, '.claude', 'CLAUDE.md'))).toBe(false);
+  });
 });

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1054,10 +1054,10 @@ export function install(options: InstallOptions = {}): InstallResult {
             const findNodeDest = join(HUD_DIR, 'find-node.sh');
             copyFileSync(findNodeSrc, findNodeDest);
             chmodSync(findNodeDest, 0o755);
-            statusLineCommand = 'sh $HOME/.claude/hud/find-node.sh $HOME/.claude/hud/omc-hud.mjs';
+            statusLineCommand = 'sh "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/find-node.sh" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs"';
           } catch {
             // Fallback to bare node if find-node.sh copy fails
-            statusLineCommand = 'node $HOME/.claude/hud/omc-hud.mjs';
+            statusLineCommand = 'node "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs"';
           }
         }
         // Auto-migrate legacy string format (pre-v4.5) to object format


### PR DESCRIPTION
## Summary

Fixes #2084 - Setup now respects `CLAUDE_CONFIG_DIR` environment variable when set to a non-default path.

## Changes

- **scripts/setup-claude-md.sh**: Global mode now uses `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` for all paths (CLAUDE.md, skills, hooks cleanup, settings.json)
- **scripts/setup-progress.sh**: Config file path now respects `CLAUDE_CONFIG_DIR`
- **src/installer/index.ts**: statusLineCommand now uses shell parameter expansion to resolve the correct HUD path at runtime
- **src/__tests__/setup-claude-md-script.test.ts**: Added test to verify CLAUDE_CONFIG_DIR support

## Testing

- All existing tests pass
- Added new test specifically for CLAUDE_CONFIG_DIR in global mode
- Verified build passes with no new lint errors

Closes #2084