### PR TITLE
fix(state-tools): write cancel signal in state_clear when no session_id provided

### DIFF
--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -563,6 +563,29 @@ export const stateClearTool: ToolDefinition<{
       }
 
       // No session_id: clear from all locations (legacy + all sessions)
+      // Write cancel signals FIRST (before deleting files) so the stop hook's
+      // isSessionCancelInProgress check sees the signal during the deletion window.
+      // Mirrors the session_id path at line ~403. (patch: fix missing cancel signal)
+      {
+        const now = Date.now();
+        const cancelSignalPayload = {
+          active: true,
+          requested_at: new Date(now).toISOString(),
+          expires_at: new Date(now + CANCEL_SIGNAL_TTL_MS).toISOString(),
+          mode,
+          source: 'state_clear' as const,
+        };
+        // Write to legacy path (checked by stop hook fallback)
+        const legacySignalPath = join(root, 'state', 'cancel-signal-state.json');
+        try { atomicWriteJsonSync(legacySignalPath, cancelSignalPayload); } catch { /* best-effort */ }
+        // Write to each session path (checked by stop hook primary check)
+        for (const sid of listSessionIds(root)) {
+          try {
+            const sessionSignalPath = resolveSessionStatePath('cancel-signal', sid, root);
+            atomicWriteJsonSync(sessionSignalPath, cancelSignalPayload);
+          } catch { /* best-effort */ }
+        }
+      }
       let clearedCount = 0;
       const errors: string[] = [];
       if (mode === 'team') {


### PR DESCRIPTION
## Bug

When `state_clear` is called **without** a `session_id` (the "clear all locations" path at line ~565), the cancel signal was never written before files were deleted. The stop hook's `isSessionCancelInProgress` check therefore saw no signal during the deletion window and treated the mode as still active, triggering unwanted stop-hook side-effects during ralph/ultrawork/autopilot mode exit.

The **with-session_id** path (~line 403) already wrote cancel signals correctly. The no-session_id path was missing the equivalent logic.

## Fix

Mirror the session_id-path cancel-signal logic into the no-session_id branch of `state_clear`:

1. Build the cancel signal payload (same shape as the existing path).
2. Write it to the **legacy path** (`state/cancel-signal-state.json`) — checked by the stop hook as a fallback.
3. Write it to **every active session path** (`resolveSessionStatePath('cancel-signal', sid, root)`) — checked by the stop hook as the primary path.

All writes are best-effort (`try/catch` silently swallowed) so a signal-write failure never blocks cleanup.

## Affected modes

ralph, ultrawork, autopilot — any mode that calls `state_clear` without a specific `session_id`.

## Changes

- `src/tools/state-tools.ts`: insert cancel-signal block before `let clearedCount` in the no-session_id branch (~line 565).