### PR TITLE
fix: expire stale awaiting_confirmation flags for persistent modes

### DIFF
--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -200,8 +200,29 @@ function getSafeReinforcementCount(value) {
     : 0;
 }
 
+const AWAITING_CONFIRMATION_TTL_MS = 2 * 60 * 1000;
+
 function isAwaitingConfirmation(state) {
-  return state?.awaiting_confirmation === true;
+  if (!state || state.awaiting_confirmation !== true) {
+    return false;
+  }
+
+  const setAt =
+    state.awaiting_confirmation_set_at ||
+    state.last_checked_at ||
+    state.started_at ||
+    null;
+
+  if (!setAt) {
+    return false;
+  }
+
+  const setAtMs = new Date(setAt).getTime();
+  if (!Number.isFinite(setAtMs)) {
+    return false;
+  }
+
+  return Date.now() - setAtMs < AWAITING_CONFIRMATION_TTL_MS;
 }
 
 /**

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -183,17 +183,21 @@ describe('processHook - Routing Matrix', () => {
         const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
         const ralphState = JSON.parse(readFileSync(join(sessionDir, 'ralph-state.json'), 'utf-8')) as {
           awaiting_confirmation?: boolean;
+          awaiting_confirmation_set_at?: string;
           active?: boolean;
         };
         const ultraworkState = JSON.parse(readFileSync(join(sessionDir, 'ultrawork-state.json'), 'utf-8')) as {
           awaiting_confirmation?: boolean;
+          awaiting_confirmation_set_at?: string;
           active?: boolean;
         };
 
         expect(ralphState.active).toBe(true);
         expect(ralphState.awaiting_confirmation).toBe(true);
+        expect(typeof ralphState.awaiting_confirmation_set_at).toBe('string');
         expect(ultraworkState.active).toBe(true);
         expect(ultraworkState.awaiting_confirmation).toBe(true);
+        expect(typeof ultraworkState.awaiting_confirmation_set_at).toBe('string');
 
         const stopResult = await processHook('persistent-mode', {
           sessionId,
@@ -286,13 +290,17 @@ describe('processHook - Routing Matrix', () => {
 
         const ralphState = JSON.parse(readFileSync(join(sessionDir, 'ralph-state.json'), 'utf-8')) as {
           awaiting_confirmation?: boolean;
+          awaiting_confirmation_set_at?: string;
         };
         const ultraworkState = JSON.parse(readFileSync(join(sessionDir, 'ultrawork-state.json'), 'utf-8')) as {
           awaiting_confirmation?: boolean;
+          awaiting_confirmation_set_at?: string;
         };
 
         expect(ralphState.awaiting_confirmation).toBeUndefined();
+        expect(ralphState.awaiting_confirmation_set_at).toBeUndefined();
         expect(ultraworkState.awaiting_confirmation).toBeUndefined();
+        expect(ultraworkState.awaiting_confirmation_set_at).toBeUndefined();
       } finally {
         rmSync(tempDir, { recursive: true, force: true });
       }

--- a/src/hooks/autopilot/enforcement.ts
+++ b/src/hooks/autopilot/enforcement.ts
@@ -149,12 +149,34 @@ export function detectAnySignal(sessionId: string): AutopilotSignal | null {
 // ENFORCEMENT
 // ============================================================================
 
+const AWAITING_CONFIRMATION_TTL_MS = 2 * 60 * 1000;
+
 function isAwaitingConfirmation(state: unknown): boolean {
-  return Boolean(
-    state &&
-    typeof state === 'object' &&
-    (state as Record<string, unknown>).awaiting_confirmation === true
-  );
+  if (!state || typeof state !== 'object') {
+    return false;
+  }
+
+  const stateRecord = state as Record<string, unknown>;
+  if (stateRecord.awaiting_confirmation !== true) {
+    return false;
+  }
+
+  const setAt =
+    (typeof stateRecord.awaiting_confirmation_set_at === 'string' && stateRecord.awaiting_confirmation_set_at) ||
+    (typeof stateRecord.last_checked_at === 'string' && stateRecord.last_checked_at) ||
+    (typeof stateRecord.started_at === 'string' && stateRecord.started_at) ||
+    null;
+
+  if (!setAt) {
+    return false;
+  }
+
+  const setAtMs = new Date(setAt).getTime();
+  if (!Number.isFinite(setAtMs)) {
+    return false;
+  }
+
+  return Date.now() - setAtMs < AWAITING_CONFIRMATION_TTL_MS;
 }
 
 /**

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -213,8 +213,10 @@ function updateModeAwaitingConfirmation(
 
       if (awaitingConfirmation) {
         state.awaiting_confirmation = true;
+        state.awaiting_confirmation_set_at = new Date().toISOString();
       } else if (state.awaiting_confirmation === true) {
         delete state.awaiting_confirmation;
+        delete state.awaiting_confirmation_set_at;
       } else {
         continue;
       }

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -363,12 +363,34 @@ function isCriticalContextStop(stopContext?: StopContext): boolean {
   return estimateTranscriptContextPercent(transcriptPath) >= CRITICAL_CONTEXT_STOP_PERCENT;
 }
 
+const AWAITING_CONFIRMATION_TTL_MS = 2 * 60 * 1000;
+
 function isAwaitingConfirmation(state: unknown): boolean {
-  return Boolean(
-    state &&
-    typeof state === 'object' &&
-    (state as Record<string, unknown>).awaiting_confirmation === true
-  );
+  if (!state || typeof state !== 'object') {
+    return false;
+  }
+
+  const stateRecord = state as Record<string, unknown>;
+  if (stateRecord.awaiting_confirmation !== true) {
+    return false;
+  }
+
+  const setAt =
+    (typeof stateRecord.awaiting_confirmation_set_at === 'string' && stateRecord.awaiting_confirmation_set_at) ||
+    (typeof stateRecord.last_checked_at === 'string' && stateRecord.last_checked_at) ||
+    (typeof stateRecord.started_at === 'string' && stateRecord.started_at) ||
+    null;
+
+  if (!setAt) {
+    return false;
+  }
+
+  const setAtMs = new Date(setAt).getTime();
+  if (!Number.isFinite(setAtMs)) {
+    return false;
+  }
+
+  return Date.now() - setAtMs < AWAITING_CONFIRMATION_TTL_MS;
 }
 
 /**

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -146,6 +146,30 @@ describe("Stop Hook Blocking Contract", () => {
       expect(result.mode).toBe("none");
     });
 
+
+    it("stale awaiting_confirmation does not suppress ultrawork enforcement", async () => {
+      const sessionId = "ultrawork-stale-awaiting-confirmation";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ultrawork-state.json"),
+        JSON.stringify({
+          active: true,
+          awaiting_confirmation: true,
+          awaiting_confirmation_set_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+          started_at: new Date().toISOString(),
+          original_prompt: "Test task",
+          session_id: sessionId,
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString(),
+        })
+      );
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(true);
+      expect(result.mode).toBe("ultrawork");
+    });
+
     it("blocks stop for active ultrawork (shouldBlock: true -> continue: false)", async () => {
       const sessionId = "test-session-block";
       activateUltrawork("Fix the bug", sessionId, tempDir);
@@ -501,6 +525,40 @@ describe("Stop Hook Blocking Contract", () => {
       });
       expect(output.continue).toBe(true);
       expect(output.decision).toBeUndefined();
+    });
+
+
+    it("returns decision: block when autopilot awaiting_confirmation is stale", () => {
+      const sessionId = "autopilot-stale-awaiting-confirmation-mjs";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "autopilot-state.json"),
+        JSON.stringify({
+          active: true,
+          phase: "execution",
+          iteration: 1,
+          max_iterations: 10,
+          awaiting_confirmation: true,
+          awaiting_confirmation_set_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+          originalIdea: "test",
+          expansion: { analyst_complete: false, architect_complete: false, spec_path: null, requirements_summary: "", tech_stack: [] },
+          planning: { plan_path: null, architect_iterations: 0, approved: false },
+          execution: { ralph_iterations: 0, ultrawork_active: false, tasks_completed: 0, tasks_total: 0, files_created: [], files_modified: [] },
+          qa: { ultraqa_cycles: 0, build_status: "pending", lint_status: "pending", test_status: "pending" },
+          validation: { architects_spawned: 0, verdicts: [], all_approved: false, validation_rounds: 0 },
+          started_at: new Date().toISOString(),
+          completed_at: null,
+          phase_durations: {},
+          total_agents_spawned: 0,
+          wisdom_entries: 0,
+          session_id: sessionId,
+          project_path: tempDir,
+        })
+      );
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.decision).toBe("block");
     });
 
     it("returns continue: true for user abort", () => {

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -193,8 +193,29 @@ function getSafeReinforcementCount(value) {
     : 0;
 }
 
+const AWAITING_CONFIRMATION_TTL_MS = 2 * 60 * 1000;
+
 function isAwaitingConfirmation(state) {
-  return state?.awaiting_confirmation === true;
+  if (!state || state.awaiting_confirmation !== true) {
+    return false;
+  }
+
+  const setAt =
+    state.awaiting_confirmation_set_at ||
+    state.last_checked_at ||
+    state.started_at ||
+    null;
+
+  if (!setAt) {
+    return false;
+  }
+
+  const setAtMs = new Date(setAt).getTime();
+  if (!Number.isFinite(setAtMs)) {
+    return false;
+  }
+
+  return Date.now() - setAtMs < AWAITING_CONFIRMATION_TTL_MS;
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix stale `awaiting_confirmation` gating that could permanently disable reinforcement for ralph/ultrawork/autopilot when a skill invocation never arrives
- store `awaiting_confirmation_set_at` when the bridge marks modes awaiting confirmation
- add a 2-minute TTL for awaiting-confirmation checks in TypeScript enforcement and in the runtime hook script/template
- keep current behavior for immediate, valid skill-confirmation windows

## Verification
- `npm test -- src/hooks/__tests__/bridge-routing.test.ts src/hooks/persistent-mode/stop-hook-blocking.test.ts`

Closes #2061
