### PR TITLE
fix(state-tools): write cancel signal in state_clear when no session_id provided

### DIFF
--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -598,6 +598,29 @@ export const stateClearTool: ToolDefinition<{
       }
 
       // No session_id: clear from all locations (legacy + all sessions)
+      // Write cancel signals FIRST (before deleting files) so the stop hook's
+      // isSessionCancelInProgress check sees the signal during the deletion window.
+      // Mirrors the session_id path at line ~403. (patch: fix missing cancel signal)
+      {
+        const now = Date.now();
+        const cancelSignalPayload = {
+          active: true,
+          requested_at: new Date(now).toISOString(),
+          expires_at: new Date(now + CANCEL_SIGNAL_TTL_MS).toISOString(),
+          mode,
+          source: 'state_clear' as const,
+        };
+        // Write to legacy path (checked by stop hook fallback)
+        const legacySignalPath = join(root, 'state', 'cancel-signal-state.json');
+        try { atomicWriteJsonSync(legacySignalPath, cancelSignalPayload); } catch { /* best-effort */ }
+        // Write to each session path (checked by stop hook primary check)
+        for (const sid of listSessionIds(root)) {
+          try {
+            const sessionSignalPath = resolveSessionStatePath('cancel-signal', sid, root);
+            atomicWriteJsonSync(sessionSignalPath, cancelSignalPayload);
+          } catch { /* best-effort */ }
+        }
+      }
       let clearedCount = 0;
       const errors: string[] = [];
       if (mode === 'team') {


### PR DESCRIPTION
## Problem

When `state_clear` is called **without** a `session_id` (the "clear all locations" path), the cancel signal was never written before files were deleted. This meant the stop hook's `isSessionCancelInProgress` check would not see a signal during the deletion window, causing ralph/ultrawork/autopilot mode exit to trigger stop-hook side-effects as though the mode was still active.

The `session_id` path (around line ~403) already wrote cancel signals correctly. This patch mirrors that logic into the no-session_id branch.

## Fix

- Write cancel signals to both the legacy path and every active session path **before** any deletion proceeds in the no-session_id code path.
- All writes are best-effort (errors silently swallowed) to avoid blocking cleanup on signal-write failures.
- Mirrors the existing pattern already used in the session_id branch of the same function.

## Notes

- Rebased onto `dev` per contribution guidelines (previous PR #2092 incorrectly targeted `main`).
- No behaviour change in the `session_id` path.