### PR TITLE
Fix stale Skill state cleanup in PostToolUse hooks

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -15,6 +15,7 @@ import { readStdin } from './lib/stdin.mjs';
 const AGENT_OUTPUT_ANALYSIS_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_ANALYSIS_LIMIT || '12000', 10);
 const AGENT_OUTPUT_SUMMARY_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_SUMMARY_LIMIT || '360', 10);
 const QUIET_LEVEL = getQuietLevel();
+const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 
 function getQuietLevel() {
   const parsed = Number.parseInt(process.env.OMC_QUIET || '0', 10);
@@ -214,6 +215,53 @@ function detectBackgroundOperation(output) {
   ];
 
   return bgPatterns.some(pattern => pattern.test(output));
+}
+
+function getInvokedSkillName(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const rawSkill =
+    toolInput.skill ||
+    toolInput.skill_name ||
+    toolInput.skillName ||
+    toolInput.command ||
+    null;
+  if (typeof rawSkill !== 'string' || !rawSkill.trim()) return null;
+  const normalized = rawSkill.trim();
+  return normalized.includes(':')
+    ? normalized.split(':').at(-1).toLowerCase()
+    : normalized.toLowerCase();
+}
+
+function getSkillActiveStatePaths(directory, sessionId) {
+  const stateDir = join(directory, '.omc', 'state');
+  const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  return [
+    safeSessionId ? join(stateDir, 'sessions', safeSessionId, 'skill-active-state.json') : null,
+    join(stateDir, 'skill-active-state.json'),
+  ].filter(Boolean);
+}
+
+function readSkillActiveState(directory, sessionId) {
+  for (const statePath of getSkillActiveStatePaths(directory, sessionId)) {
+    try {
+      if (!existsSync(statePath)) continue;
+      const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+      if (state && typeof state === 'object') return state;
+    } catch {
+      // Ignore malformed or unreadable state; cleanup remains best-effort
+    }
+  }
+  return null;
+}
+
+function clearSkillActiveState(directory, sessionId) {
+  for (const statePath of getSkillActiveStatePaths(directory, sessionId)) {
+    try {
+      unlinkSync(statePath);
+    } catch {
+      // Best-effort cleanup; never fail the hook
+    }
+  }
 }
 
 export function summarizeAgentResult(output, maxChars = AGENT_OUTPUT_SUMMARY_LIMIT) {
@@ -466,6 +514,17 @@ async function main() {
       toolName === 'TaskUpdate'
     ) {
       processRememberTags(clippedToolOutput, directory);
+    }
+
+    if (toolName === 'Skill' || toolName === 'skill') {
+      const toolInput = data.tool_input || data.toolInput || {};
+      const currentState = readSkillActiveState(directory, sessionId);
+      const completingSkill = (getInvokedSkillName(toolInput) ?? '')
+        .toLowerCase()
+        .replace(/^oh-my-claudecode:/, '');
+      if (!currentState || !currentState.active || currentState.skill_name === completingSkill) {
+        clearSkillActiveState(directory, sessionId);
+      }
     }
 
     // Generate contextual message

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -6,15 +6,20 @@
 import { describe, it, expect } from 'vitest';
 import { execSync } from 'child_process';
 import { join } from 'path';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import process from 'process';
 import { detectBashFailure, detectWriteFailure, isNonZeroExitWithOutput, summarizeAgentResult } from '../../scripts/post-tool-verifier.mjs';
 
 const SCRIPT_PATH = join(process.cwd(), 'scripts', 'post-tool-verifier.mjs');
+const TEMPLATE_HOOK_PATH = join(process.cwd(), 'templates', 'hooks', 'post-tool-use.mjs');
 
 function runPostToolVerifier(input, env = {}) {
-  const stdout = execSync(`node "${SCRIPT_PATH}"`, {
+  return runHookScript(SCRIPT_PATH, input, env);
+}
+
+function runHookScript(scriptPath, input, env = {}) {
+  const stdout = execSync(`node "${scriptPath}"`, {
     input: JSON.stringify(input),
     encoding: 'utf-8',
     timeout: 5000,
@@ -30,6 +35,39 @@ function withTempDir(fn) {
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
+}
+
+function skillStatePath(tempDir, sessionId) {
+  return join(tempDir, '.omc', 'state', 'sessions', sessionId, 'skill-active-state.json');
+}
+
+function legacySkillStatePath(tempDir) {
+  return join(tempDir, '.omc', 'state', 'skill-active-state.json');
+}
+
+function writeSkillStateFixtures(tempDir, sessionId, skillName = 'plan') {
+  mkdirSync(join(tempDir, '.omc', 'state', 'sessions', sessionId), { recursive: true });
+  writeFileSync(
+    skillStatePath(tempDir, sessionId),
+    JSON.stringify({
+      active: true,
+      skill_name: skillName,
+      session_id: sessionId,
+      started_at: '2026-04-01T00:00:00.000Z',
+      last_checked_at: '2026-04-01T00:00:00.000Z',
+      reinforcement_count: 0,
+      max_reinforcements: 5,
+      stale_ttl_ms: 900000,
+    }),
+  );
+  mkdirSync(join(tempDir, '.omc', 'state'), { recursive: true });
+  writeFileSync(
+    legacySkillStatePath(tempDir),
+    JSON.stringify({
+      active: true,
+      skill_name: skillName,
+    }),
+  );
 }
 
 describe('detectBashFailure', () => {
@@ -400,5 +438,64 @@ describe('OMC_QUIET hook message suppression (issue #1646)', () => {
     });
 
     expect(taskSummary).toEqual({ continue: true, suppressOutput: true });
+  });
+});
+
+describe('Skill active state cleanup on PostToolUse (issue #2103)', () => {
+  it('clears session and legacy skill-active-state files for Skill completion in post-tool-verifier', () => {
+    withTempDir((tempDir) => {
+      const sessionId = 'skill-clear-script';
+      writeSkillStateFixtures(tempDir, sessionId, 'plan');
+
+      const out = runPostToolVerifier({
+        tool_name: 'Skill',
+        tool_input: { skill: 'oh-my-claudecode:plan' },
+        tool_response: { ok: true },
+        session_id: sessionId,
+        cwd: tempDir,
+      });
+
+      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(false);
+      expect(existsSync(legacySkillStatePath(tempDir))).toBe(false);
+    });
+  });
+
+  it('does not clear parent-owned skill-active-state for nested child Skill completion in post-tool-verifier', () => {
+    withTempDir((tempDir) => {
+      const sessionId = 'skill-nested-script';
+      writeSkillStateFixtures(tempDir, sessionId, 'omc-setup');
+
+      const out = runPostToolVerifier({
+        tool_name: 'Skill',
+        tool_input: { skill: 'oh-my-claudecode:mcp-setup' },
+        tool_response: { ok: true },
+        session_id: sessionId,
+        cwd: tempDir,
+      });
+
+      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(true);
+      expect(existsSync(legacySkillStatePath(tempDir))).toBe(true);
+    });
+  });
+
+  it('clears session and legacy skill-active-state files for the template post-tool hook path', () => {
+    withTempDir((tempDir) => {
+      const sessionId = 'skill-clear-template';
+      writeSkillStateFixtures(tempDir, sessionId, 'plan');
+
+      const out = runHookScript(TEMPLATE_HOOK_PATH, {
+        tool_name: 'Skill',
+        tool_input: { skill: 'oh-my-claudecode:plan' },
+        tool_response: { ok: true },
+        session_id: sessionId,
+        cwd: tempDir,
+      });
+
+      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(false);
+      expect(existsSync(legacySkillStatePath(tempDir))).toBe(false);
+    });
   });
 });

--- a/templates/hooks/post-tool-use.mjs
+++ b/templates/hooks/post-tool-use.mjs
@@ -3,7 +3,7 @@
 // Processes <remember> tags from Task agent output
 // Saves to .omc/notepad.md for compaction-resilient memory
 
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -57,6 +57,34 @@ function getInvokedSkillName(toolInput) {
 }
 
 const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+
+function getSkillActiveStatePaths(directory, sessionId) {
+  const stateDir = join(directory, '.omc', 'state');
+  const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  return [
+    safeSessionId ? join(stateDir, 'sessions', safeSessionId, 'skill-active-state.json') : null,
+    join(stateDir, 'skill-active-state.json'),
+  ].filter(Boolean);
+}
+
+function readSkillActiveState(directory, sessionId) {
+  for (const statePath of getSkillActiveStatePaths(directory, sessionId)) {
+    try {
+      if (!existsSync(statePath)) continue;
+      const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+      if (state && typeof state === 'object') return state;
+    } catch {}
+  }
+  return null;
+}
+
+function clearSkillActiveState(directory, sessionId) {
+  for (const statePath of getSkillActiveStatePaths(directory, sessionId)) {
+    try {
+      unlinkSync(statePath);
+    } catch {}
+  }
+}
 
 function activateState(directory, stateName, state, sessionId) {
   const stateDir = join(directory, '.omc', 'state');
@@ -153,6 +181,11 @@ async function main() {
     // Handle Skill("...:ralph") invocations so ralph handoffs activate persistent states.
     if (String(toolName).toLowerCase() === 'skill') {
       const skillName = getInvokedSkillName(toolInput);
+      const currentState = readSkillActiveState(directory, sessionId);
+      const completingSkill = (skillName || '').replace(/^oh-my-claudecode:/, '');
+      if (!currentState || !currentState.active || currentState.skill_name === completingSkill) {
+        clearSkillActiveState(directory, sessionId);
+      }
       if (skillName === 'ralph') {
         const now = new Date().toISOString();
         const promptText = data.prompt || data.message || 'Ralph loop activated via Skill tool';


### PR DESCRIPTION
## Summary
- clear `skill-active-state.json` on Skill PostToolUse in the script hook path
- mirror the same ownership-aware cleanup in the packaged template hook path
- add regressions for direct script cleanup, nested child-skill safety, and template parity

## Verification
- `npx vitest run src/__tests__/post-tool-verifier.test.mjs`
- `npm run build:cli && npm run build:bridge && node scripts/build-mcp-server.mjs`
- `npm test`
- `npm run lint`
- `npx tsc --noEmit`

Closes #2103