### PR TITLE
fix: guard against non-string tool_response in project-memory learner

### DIFF
--- a/scripts/project-memory-posttool.mjs
+++ b/scripts/project-memory-posttool.mjs
@@ -53,11 +53,17 @@ async function main() {
     const projectRoot = findProjectRoot(directory);
 
     if (projectRoot) {
+      // tool_response may be string or object — normalize to string
+      const rawOutput = data.tool_response || data.toolOutput || '';
+      const toolOutput = typeof rawOutput === 'string'
+        ? rawOutput
+        : (typeof rawOutput?.stdout === 'string' ? rawOutput.stdout : JSON.stringify(rawOutput));
+
       // Learn from tool output
       await learnFromToolOutput(
         data.tool_name || data.toolName || '',
         data.tool_input || data.toolInput || {},
-        data.tool_response || data.toolOutput || '',
+        toolOutput,
         projectRoot
       );
     }

--- a/src/hooks/project-memory/learner.ts
+++ b/src/hooks/project-memory/learner.ts
@@ -168,6 +168,7 @@ function isTestCommand(command: string): boolean {
  * Returns custom notes to add to project memory
  */
 function extractEnvironmentHints(output: string): CustomNote[] {
+  if (typeof output !== 'string') return [];
   const hints: CustomNote[] = [];
   const timestamp = Date.now();
 


### PR DESCRIPTION
## Summary

`project-memory-posttool.mjs` throws `TypeError: output.match is not a function` when Claude Code sends `tool_response` as an **object** instead of a string (observed with Bash tool calls). The error is caught internally and the hook returns `{continue: true}` with exit code 0, but `console.error` writes to stderr, causing Claude Code to display `PostToolUse:<tool> hook error` on every affected tool call.

**Note:** `post-tool-verifier.mjs` already handles this correctly with the `typeof rawResponse === 'string'` pattern — this PR brings `project-memory-posttool.mjs` in line.

## Root Cause

1. `project-memory-posttool.mjs:60` passes `data.tool_response || data.toolOutput || ''` directly — the `|| ''` fallback doesn't trigger for truthy objects
2. `learnFromToolOutput()` forwards this to `extractEnvironmentHints(toolOutput)` for Bash commands
3. `extractEnvironmentHints` (learner.ts:175) calls `output.match(...)` — crashes when `output` is an object

## Debug Evidence

Captured via a diagnostic PostToolUse wrapper hook:

```
memory stderr: Error learning from tool output: TypeError: output.match is not a function
    at extractEnvironmentHints (learner.js:144)
```

## Changes

- **`project-memory-posttool.mjs`**: normalize `tool_response` to string at the boundary, following the established `post-tool-verifier.mjs` pattern. Extracts `stdout` field from object responses when available for more accurate regex matching, with `JSON.stringify` fallback.
- **`learner.ts`**: add runtime type guard in `extractEnvironmentHints` as defense-in-depth

## Test plan

- [x] Verify `PostToolUse hook error` no longer appears after Bash/Read/Edit tool calls
- [ ] Verify project-memory learning still works for string tool responses
- [ ] Verify object tool responses (with `stdout` field) are properly extracted and processed
- [ ] Verify object tool responses (without `stdout` field) fall back to `JSON.stringify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)