### PR TITLE
fix: clear skill-active state during cancel

### DIFF
--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -51,7 +51,7 @@ escape from the stop hook loop**. This is NOT a full replacement for the cancel 
 it only removes state files to unblock the session. Linked modes (e.g. ralph→ultrawork,
 autopilot→ralph/ultraqa) must be cleared separately by running the fallback once per mode.
 
-Replace `MODE` with the specific mode (e.g. `ralplan`, `ralph`, `ultrawork`, `ultraqa`).
+Replace `MODE` with the specific mode (e.g. `ralplan`, `ralph`, `ultrawork`, `ultraqa`, `skill-active`).
 
 **WARNING:** Do NOT use this fallback for `autopilot` or `omc-teams`. Autopilot requires
 `state_write(active=false)` to preserve resume data. omc-teams requires tmux session
@@ -85,6 +85,7 @@ MODE="ralplan"  # <-- replace with the target mode
 if [ -n "$SESSION_ID" ] && [ -d "$OMC_STATE/sessions/$SESSION_ID" ]; then
   rm -f "$OMC_STATE/sessions/$SESSION_ID/${MODE}-state.json"
   rm -f "$OMC_STATE/sessions/$SESSION_ID/${MODE}-stop-breaker.json"
+  rm -f "$OMC_STATE/sessions/$SESSION_ID/skill-active-state.json"
   # Write cancel signal so stop hook detects cancellation in progress
   NOW_ISO="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   EXPIRES_ISO="$(date -u -d "+30 seconds" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || python3 - <<'PY'\nfrom datetime import datetime, timedelta, timezone\nprint((datetime.now(timezone.utc) + timedelta(seconds=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))\nPY\n)"
@@ -95,6 +96,7 @@ fi
 # Clear legacy state only if no session ID (avoid clearing another session's state)
 if [ -z "$SESSION_ID" ]; then
   rm -f "$OMC_STATE/${MODE}-state.json"
+  rm -f "$OMC_STATE/skill-active-state.json"
 fi
 ```
 
@@ -105,6 +107,7 @@ fi
 - When a session id is provided or already known, that session-scoped path is authoritative. Legacy files in `.omc/state/*.json` are consulted only as a compatibility fallback if the session id is missing or empty.
 - Swarm is a shared SQLite/marker mode (`.omc/state/swarm.db` / `.omc/state/swarm-active.marker`) and is not session-scoped.
 - The default cleanup flow calls `state_clear` with the session id to remove only the matching session files; modes stay bound to their originating session.
+- `skill-active-state.json` is part of that state-tool cleanup surface, so cancel clears active skill protection state alongside execution-mode state.
 
 Active modes are still cancelled in dependency order:
 1. Autopilot (includes linked ralph/ultraqa/ cleanup)
@@ -158,6 +161,7 @@ Legacy compatibility list (removed only under `--force`/`--all`):
 - `.omc/state/omc-teams-state.json`
 - `.omc/state/plan-consensus.json`
 - `.omc/state/ralplan-state.json`
+- `.omc/state/skill-active-state.json`
 - `.omc/state/boulder.json`
 - `.omc/state/hud-state.json`
 - `.omc/state/subagent-tracking.json`

--- a/src/tools/__tests__/cancel-integration.test.ts
+++ b/src/tools/__tests__/cancel-integration.test.ts
@@ -186,6 +186,30 @@ describe('cancel-integration', () => {
       expect(result.content[0].text).toContain('Locations cleared: 4');
       expect(result.content[0].text).toContain('WARNING: No session_id provided');
     });
+
+    it('should clear skill-active state across legacy and session paths', async () => {
+      const sessionId = 'skill-active-force-session';
+      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+
+      writeFileSync(
+        join(sessionDir, 'skill-active-state.json'),
+        JSON.stringify({ active: true, skill_name: 'plan', session_id: sessionId }),
+      );
+      writeFileSync(
+        join(TEST_DIR, '.omc', 'state', 'skill-active-state.json'),
+        JSON.stringify({ active: true, skill_name: 'plan' }),
+      );
+
+      const result = await stateClearTool.handler({
+        mode: 'skill-active',
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(existsSync(join(sessionDir, 'skill-active-state.json'))).toBe(false);
+      expect(existsSync(join(TEST_DIR, '.omc', 'state', 'skill-active-state.json'))).toBe(false);
+      expect(result.content[0].text).toContain('Locations cleared: 2');
+    });
   });
 
   describe('3. Cancel signal', () => {

--- a/src/tools/__tests__/state-tools.test.ts
+++ b/src/tools/__tests__/state-tools.test.ts
@@ -137,6 +137,25 @@ describe('state-tools', () => {
       expect(existsSync(join(sessionDir, 'ralplan-state.json'))).toBe(false);
     });
 
+    it('should clear skill-active state with explicit session_id', async () => {
+      const sessionId = 'test-session-skill-active';
+      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, 'skill-active-state.json'),
+        JSON.stringify({ active: true, skill_name: 'plan', session_id: sessionId }),
+      );
+
+      const result = await stateClearTool.handler({
+        mode: 'skill-active',
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain('cleared');
+      expect(existsSync(join(sessionDir, 'skill-active-state.json'))).toBe(false);
+    });
+
     it('should also remove non-session legacy state files during session clear', async () => {
       const sessionId = 'legacy-cleanup-session';
       const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
@@ -344,6 +363,24 @@ describe('state-tools', () => {
       expect(result.content[0].text).toContain('deep-interview');
     });
 
+    it('should include skill-active when skill-active state is active', async () => {
+      const sessionId = 'skill-active-session';
+      await stateWriteTool.handler({
+        mode: 'skill-active',
+        active: true,
+        state: { skill_name: 'plan' },
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      const result = await stateListActiveTool.handler({
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain('skill-active');
+    });
+
     it('should include team in status output when team state is active', async () => {
       await stateWriteTool.handler({
         mode: 'team',
@@ -371,6 +408,27 @@ describe('state-tools', () => {
 
       expect(result.content[0].text).toContain('Status: ralph');
       expect(result.content[0].text).toContain('Active:');
+    });
+
+    it('should return status for skill-active mode in a session', async () => {
+      const sessionId = 'skill-active-status-session';
+      await stateWriteTool.handler({
+        mode: 'skill-active',
+        active: true,
+        state: { skill_name: 'plan' },
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      const result = await stateGetStatusTool.handler({
+        mode: 'skill-active',
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain('Status: skill-active');
+      expect(result.content[0].text).toContain('skill-active-state.json');
+      expect(result.content[0].text).toContain('**Active:** Yes');
     });
 
     it('should return all mode statuses when no mode specified', async () => {

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -41,12 +41,13 @@ const EXECUTION_MODES: [string, ...string[]] = [
 // Extended type for state tools - includes state-bearing modes outside mode-registry
 const STATE_TOOL_MODES: [string, ...string[]] = [
   ...EXECUTION_MODES,
+  'skill-active',
   'ralplan',
   'omc-teams',
   'deep-interview',
   'self-improve'
 ];
-const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'deep-interview', 'self-improve'] as const;
+const EXTRA_STATE_ONLY_MODES = ['skill-active', 'ralplan', 'omc-teams', 'deep-interview', 'self-improve'] as const;
 type StateToolMode = typeof STATE_TOOL_MODES[number];
 const CANCEL_SIGNAL_TTL_MS = 30_000;
 


### PR DESCRIPTION
## Summary
- teach the shared state tools to treat  as a supported state-only mode
- let , , and  cover 
- document the cancel fallback/state contract and add regression tests for session and broad cleanup

## Root cause
 relies on the shared state tools, but those tools did not include the session-scoped  state name. That meant cancel could not discover or clear , so stop-hook reinforcement could continue after cancel.

## Testing
- 
> oh-my-claude-sisyphus@4.9.3 test
> vitest --run src/tools/__tests__/state-tools.test.ts src/tools/__tests__/cancel-integration.test.ts


 RUN  v4.0.18 /home/bellman/Workspace/oh-my-claudecode-issue-2118-cancel-skill-active-state

 ✓ src/tools/__tests__/cancel-integration.test.ts (13 tests) 51ms
 ✓ src/tools/__tests__/state-tools.test.ts (33 tests) 120ms

 Test Files  2 passed (2)
      Tests  46 passed (46)
   Start at  21:43:46
   Duration  399ms (transform 296ms, setup 0ms, import 376ms, tests 172ms, environment 0ms)
- 
> oh-my-claude-sisyphus@4.9.3 test
> vitest --run src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts src/__tests__/smoke-slack-and-state.test.ts


 RUN  v4.0.18 /home/bellman/Workspace/oh-my-claudecode-issue-2118-cancel-skill-active-state

 ✓ src/__tests__/smoke-slack-and-state.test.ts (23 tests) 131ms
 ✓ src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts (9 tests) 151ms

 Test Files  2 passed (2)
      Tests  32 passed (32)
   Start at  21:43:48
   Duration  763ms (transform 591ms, setup 0ms, import 746ms, tests 282ms, environment 0ms)
- 
- 

Closes #2118