### PR TITLE
fix(state-tools): add skill-active to STATE_TOOL_MODES so cancel can clear it

### DIFF
--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -303,6 +303,18 @@ Autopilot handles its own cleanup including linked ralph and ultraqa.
 
 Clear directly: `state_clear(mode="ultraqa", session_id)`
 
+#### Clear Skill Active State (always, as final step)
+
+After all mode-specific cleanup, always clear `skill-active` state to unblock the stop hook:
+
+```
+state_clear(mode="skill-active", session_id)
+```
+
+This removes `skill-active-state.json` for the current session. If `skill-active` is not in the active modes list, the call is still safe — it is a no-op when no state file exists.
+
+This step is required because `skill-active-state.json` is written when the cancel skill itself is invoked (protection level `none` so it is not written, but skills like `sciomc`, `learner`, and `release` that triggered the cancel may have left stale state). Without this step the stop hook keeps firing reinforcements until the 15-minute TTL expires.
+
 #### No Active Modes
 
 Report: "No active OMC modes detected. Use --force to clear all state files anyway."

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -43,9 +43,10 @@ const STATE_TOOL_MODES: [string, ...string[]] = [
   ...EXECUTION_MODES,
   'ralplan',
   'omc-teams',
-  'deep-interview'
+  'deep-interview',
+  'skill-active'
 ];
-const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'deep-interview'] as const;
+const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'deep-interview', 'skill-active'] as const;
 type StateToolMode = typeof STATE_TOOL_MODES[number];
 const CANCEL_SIGNAL_TTL_MS = 30_000;
 


### PR DESCRIPTION
## Summary

Fixes #2118 — `cancel` skill does not clear `skill-active-state.json`.

When a `medium`/`heavy`-protected skill (e.g. `sciomc`, `learner`, `release`) was active and the user invoked `/oh-my-claudecode:cancel`, the stop hook kept firing reinforcements until the 15-minute TTL or 5-reinforcement limit, because `state_clear(mode='skill-active')` was **rejected by Zod** — `'skill-active'` was not listed in `STATE_TOOL_MODES`.

### Root Cause

`STATE_TOOL_MODES` in `src/tools/state-tools.ts` did not include `'skill-active'`:

```typescript
const STATE_TOOL_MODES: [string, ...string[]] = [
  ...EXECUTION_MODES,
  'ralplan',
  'omc-teams',
  'deep-interview'
  // ← no 'skill-active'
];
```

The `z.enum(STATE_TOOL_MODES)` validator in `state_clear`, `state_read`, `state_write`, and `state_get_status` rejected any call with `mode='skill-active'`, leaving the state file in place indefinitely.

### Changes

1. **`src/tools/state-tools.ts`**: Add `'skill-active'` to `STATE_TOOL_MODES` and `EXTRA_STATE_ONLY_MODES`, making it a first-class mode consistent with how `'ralplan'`, `'omc-teams'`, and `'deep-interview'` are managed. Because `'skill-active'` is not in `MODE_CONFIGS` (it doesn't use the mode-registry), it falls through to the session-path branch in `state_clear`, which calls `resolveSessionStatePath('skill-active', sessionId, root)` → removes `skill-active-state.json`.

2. **`skills/cancel/SKILL.md`**: Add an explicit **final cleanup step** that always calls `state_clear(mode="skill-active", session_id)` after all other mode-specific cleanup. This is idempotent — when no state file exists, it is a no-op.

### Test Plan

- [ ] Invoke a `medium`-protected skill (e.g. `sciomc`, `learner`, `release`)
- [ ] Before it completes, invoke `/oh-my-claudecode:cancel`
- [ ] Verify: stop hook does NOT continue to fire `[SKILL ACTIVE: ...]` reinforcements after cancel
- [ ] Verify: `state_clear(mode="skill-active", session_id)` returns success (not a Zod validation error)
- [ ] Verify: `skill-active-state.json` is removed from `.omc/state/sessions/{sessionId}/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)