### PR TITLE
ci: fail when dist artifacts drift after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Verify generated artifacts are up to date
-        run: npm run check:generated-artifacts
+      - name: Verify dist artifacts are up to date
+        run: npm run check:dist-sync
 
       - name: Check dist size
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Verify generated artifacts are up to date
-        run: npm run check:generated-artifacts
+      - name: Verify dist artifacts are up to date
+        run: npm run check:dist-sync
 
       - name: Run tests
         run: npm test -- --run

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "build": "tsc && node scripts/build-skill-bridge.mjs && node scripts/build-mcp-server.mjs && node scripts/build-bridge-entry.mjs && npm run compose-docs && npm run build:runtime-cli && npm run build:team-server && npm run build:cli",
-    "check:generated-artifacts": "git diff --exit-code -- dist bridge docs/CLAUDE.md",
+    "check:dist-sync": "git diff --exit-code -- dist",
     "build:bridge": "node scripts/build-skill-bridge.mjs",
     "build:bridge-entry": "node scripts/build-bridge-entry.mjs",
     "build:cli": "node scripts/build-cli.mjs",


### PR DESCRIPTION
## Summary
- confirm the issue #2124 reproduction exactly on the `v4.10.0` tag
- note that the actual rebuild hotfix is already present on `main` at `8868fd42` / tag `v4.10.1`
- add a `dist` sync guardrail to CI and tag-release workflows
- extend CI to `release/**` branches so future patch-release PRs also exercise the guardrail

## Verified reproduction
```bash
git show refs/tags/v4.10.0:src/hud/state.ts | grep -c "layout"   # 1
git show refs/tags/v4.10.0:dist/hud/state.js | grep -c "layout"   # 0
git show refs/tags/v4.10.0:dist/hud/render.js | grep -c "layout"  # 0
```

## Hotfix status
The rebuild-based release fix is already on `main`:
- `8868fd42` `fix(release): rebuild dist for 4.10.1`

This PR is the safe follow-up guardrail so the same src/dist mismatch fails fast next time.

## Guardrail
- `npm run check:dist-sync`
- CI build now fails if `npm run build` dirties committed `dist/`
- CI also runs on `release/**` branches so release-line PRs get the same protection
- tag-release workflow runs the same `dist` sync check before publish

## Verification
- `npm test -- --run src/__tests__/hud/render.test.ts src/__tests__/hud/state.test.ts src/__tests__/plugin-setup-deps.test.ts`
- `npm run build`
- `npm run check:dist-sync`

Fixes #2124.
