### PR TITLE
fix(hud): show worktree name instead of volatile main repo HEAD

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -37490,7 +37490,7 @@ function getWorktreeInfo(cwd2) {
     stdio: ["pipe", "pipe", "pipe"],
     shell: process.platform === "win32" ? "cmd.exe" : void 0
   };
-  let result = { isWorktree: false, baseBranch: null };
+  let result = { isWorktree: false, worktreeName: null };
   try {
     const gitDir = (0, import_node_child_process6.execSync)("git rev-parse --git-dir", execOpts).trim();
     const gitCommonDir = (0, import_node_child_process6.execSync)("git rev-parse --git-common-dir", execOpts).trim();
@@ -37505,13 +37505,7 @@ function getWorktreeInfo(cwd2) {
     } catch {
     }
     if (resolvedGitDir !== resolvedCommonDir) {
-      result = { isWorktree: true, baseBranch: null };
-      try {
-        const headContent = (0, import_node_fs7.readFileSync)((0, import_node_path12.join)(resolvedCommonDir, "HEAD"), "utf-8").trim();
-        const match = headContent.match(/^ref: refs\/heads\/(.+)$/);
-        result.baseBranch = match ? match[1] : null;
-      } catch {
-      }
+      result = { isWorktree: true, worktreeName: require("node:path").basename(resolvedGitDir) };
     }
   } catch {
   }
@@ -37527,8 +37521,8 @@ function renderGitBranch(cwd2) {
   const branch = getGitBranch(cwd2);
   if (!branch) return null;
   const wtInfo = getWorktreeInfo(cwd2);
-  if (wtInfo.isWorktree && wtInfo.baseBranch) {
-    return `${dim("branch:")}${cyan(branch)} ${dim("(wt:")}${cyan(wtInfo.baseBranch)}${dim(")")}`;
+  if (wtInfo.isWorktree && wtInfo.worktreeName) {
+    return `${dim("branch:")}${cyan(branch)} ${dim("(wt:")}${cyan(wtInfo.worktreeName)}${dim(")")}`;
   }
   return `${dim("branch:")}${cyan(branch)}`;
 }

--- a/dist/hud/elements/git.d.ts
+++ b/dist/hud/elements/git.d.ts
@@ -5,7 +5,7 @@
  */
 export interface WorktreeDetection {
     isWorktree: boolean;
-    baseBranch: string | null;
+    worktreeName: string | null;
 }
 /**
  * Clear all git caches. Call in tests beforeEach to ensure a clean slate.
@@ -31,7 +31,7 @@ export declare function getGitBranch(cwd?: string): string | null;
 /**
  * Detect if the current directory is inside a git linked worktree.
  * Compares --git-dir with --git-common-dir; they differ in linked worktrees.
- * When in a worktree, reads the main repo's HEAD to determine the base branch.
+ * When in a worktree, extracts the worktree name from the git-dir path.
  *
  * @param cwd - Working directory
  * @returns Worktree detection result (cached for CACHE_TTL_MS)
@@ -46,8 +46,8 @@ export declare function getWorktreeInfo(cwd?: string): WorktreeDetection;
 export declare function renderGitRepo(cwd?: string): string | null;
 /**
  * Render git branch element.
- * When inside a linked worktree, appends the main repo's branch as suffix:
- *   branch:feature-x (wt:main)
+ * When inside a linked worktree, appends the worktree name as suffix:
+ *   branch:feature-x (wt:my-wt)
  *
  * @param cwd - Working directory
  * @returns Formatted branch name or null

--- a/dist/hud/elements/git.js
+++ b/dist/hud/elements/git.js
@@ -4,8 +4,8 @@
  * Renders git repository name and branch information.
  */
 import { execSync } from 'node:child_process';
-import { readFileSync, realpathSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
 import { dim, cyan } from '../colors.js';
 const CACHE_TTL_MS = 30_000;
 const repoCache = new Map();
@@ -109,7 +109,7 @@ export function getWorktreeInfo(cwd) {
         stdio: ['pipe', 'pipe', 'pipe'],
         shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
     };
-    let result = { isWorktree: false, baseBranch: null };
+    let result = { isWorktree: false, worktreeName: null };
     try {
         const gitDir = execSync('git rev-parse --git-dir', execOpts).trim();
         const gitCommonDir = execSync('git rev-parse --git-common-dir', execOpts).trim();
@@ -125,15 +125,8 @@ export function getWorktreeInfo(cwd) {
         }
         catch { /* use resolved */ }
         if (resolvedGitDir !== resolvedCommonDir) {
-            result = { isWorktree: true, baseBranch: null };
-            try {
-                const headContent = readFileSync(join(resolvedCommonDir, 'HEAD'), 'utf-8').trim();
-                const match = headContent.match(/^ref: refs\/heads\/(.+)$/);
-                result.baseBranch = match ? match[1] : null;
-            }
-            catch {
-                // Can't read HEAD — mark as worktree without base branch
-            }
+            // Extract worktree name from gitDir path (e.g. /repo/.git/worktrees/my-wt → my-wt)
+            result = { isWorktree: true, worktreeName: basename(resolvedGitDir) };
         }
     }
     catch {
@@ -167,8 +160,8 @@ export function renderGitBranch(cwd) {
     if (!branch)
         return null;
     const wtInfo = getWorktreeInfo(cwd);
-    if (wtInfo.isWorktree && wtInfo.baseBranch) {
-        return `${dim('branch:')}${cyan(branch)} ${dim('(wt:')}${cyan(wtInfo.baseBranch)}${dim(')')}`;
+    if (wtInfo.isWorktree && wtInfo.worktreeName) {
+        return `${dim('branch:')}${cyan(branch)} ${dim('(wt:')}${cyan(wtInfo.worktreeName)}${dim(')')}`;
     }
     return `${dim('branch:')}${cyan(branch)}`;
 }

--- a/src/__tests__/hud/git.test.ts
+++ b/src/__tests__/hud/git.test.ts
@@ -6,16 +6,8 @@ vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
 }));
 
-// Mock node:fs for worktree HEAD reading
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
-  return { ...actual, readFileSync: vi.fn() };
-});
-
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
 const mockExecSync = vi.mocked(execSync);
-const mockReadFileSync = vi.mocked(readFileSync);
 
 describe('git elements', () => {
   beforeEach(() => {
@@ -123,7 +115,6 @@ describe('git elements', () => {
 
   describe('getWorktreeInfo', () => {
     it('returns isWorktree false for normal repo', () => {
-      // In a normal repo, --git-dir and --git-common-dir resolve to the same path
       mockExecSync.mockImplementation((cmd: string) => {
         if (cmd === 'git rev-parse --git-dir') return '.git\n';
         if (cmd === 'git rev-parse --git-common-dir') return '.git\n';
@@ -131,48 +122,31 @@ describe('git elements', () => {
       });
       const result = getWorktreeInfo('/some/repo');
       expect(result.isWorktree).toBe(false);
-      expect(result.baseBranch).toBeNull();
+      expect(result.worktreeName).toBeNull();
     });
 
-    it('detects linked worktree when git-dir differs from git-common-dir', () => {
+    it('detects linked worktree and extracts worktree name from git-dir', () => {
       mockExecSync.mockImplementation((cmd: string) => {
         if (cmd === 'git rev-parse --git-dir') return '/main-repo/.git/worktrees/my-wt\n';
         if (cmd === 'git rev-parse --git-common-dir') return '/main-repo/.git\n';
         return '';
       });
-      mockReadFileSync.mockReturnValue('ref: refs/heads/main\n');
 
       const result = getWorktreeInfo('/some/worktree');
       expect(result.isWorktree).toBe(true);
-      expect(result.baseBranch).toBe('main');
+      expect(result.worktreeName).toBe('my-wt');
     });
 
-    it('returns null baseBranch when HEAD is detached', () => {
+    it('extracts worktree name with nested path segments', () => {
       mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git rev-parse --git-dir') return '/main-repo/.git/worktrees/my-wt\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '/main-repo/.git\n';
+        if (cmd === 'git rev-parse --git-dir') return '/repo/.git/worktrees/feature-NAVERCAFE-12345\n';
+        if (cmd === 'git rev-parse --git-common-dir') return '/repo/.git\n';
         return '';
-      });
-      mockReadFileSync.mockReturnValue('abc123def456\n');
-
-      const result = getWorktreeInfo('/some/worktree');
-      expect(result.isWorktree).toBe(true);
-      expect(result.baseBranch).toBeNull();
-    });
-
-    it('returns isWorktree true with null baseBranch when HEAD read fails', () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git rev-parse --git-dir') return '/main-repo/.git/worktrees/my-wt\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '/main-repo/.git\n';
-        return '';
-      });
-      mockReadFileSync.mockImplementation(() => {
-        throw new Error('EACCES: permission denied');
       });
 
       const result = getWorktreeInfo('/some/worktree');
       expect(result.isWorktree).toBe(true);
-      expect(result.baseBranch).toBeNull();
+      expect(result.worktreeName).toBe('feature-NAVERCAFE-12345');
     });
 
     it('returns not a worktree when git commands fail', () => {
@@ -181,7 +155,7 @@ describe('git elements', () => {
       });
       const result = getWorktreeInfo();
       expect(result.isWorktree).toBe(false);
-      expect(result.baseBranch).toBeNull();
+      expect(result.worktreeName).toBeNull();
     });
 
     it('caches result for same cwd', () => {
@@ -194,7 +168,6 @@ describe('git elements', () => {
       getWorktreeInfo('/cached/path');
       getWorktreeInfo('/cached/path');
 
-      // Should only call git commands once per unique command (2 calls total, not 4)
       const gitDirCalls = mockExecSync.mock.calls.filter(c => c[0] === 'git rev-parse --git-dir');
       expect(gitDirCalls).toHaveLength(1);
     });
@@ -221,20 +194,19 @@ describe('git elements', () => {
       expect(result).toContain('\x1b['); // contains ANSI escape codes
     });
 
-    it('shows worktree suffix when in a linked worktree', () => {
+    it('shows worktree suffix with worktree name when in a linked worktree', () => {
       mockExecSync.mockImplementation((cmd: string) => {
         if (cmd === 'git branch --show-current') return 'feature-x\n';
-        if (cmd === 'git rev-parse --git-dir') return '/main/.git/worktrees/wt\n';
+        if (cmd === 'git rev-parse --git-dir') return '/main/.git/worktrees/my-wt\n';
         if (cmd === 'git rev-parse --git-common-dir') return '/main/.git\n';
         return '';
       });
-      mockReadFileSync.mockReturnValue('ref: refs/heads/main\n');
 
       const result = renderGitBranch('/some/worktree');
       expect(result).toContain('branch:');
       expect(result).toContain('feature-x');
       expect(result).toContain('wt:');
-      expect(result).toContain('main');
+      expect(result).toContain('my-wt');
     });
 
     it('does not show worktree suffix in normal repo', () => {
@@ -248,22 +220,6 @@ describe('git elements', () => {
       const result = renderGitBranch('/some/repo');
       expect(result).toContain('branch:');
       expect(result).toContain('main');
-      expect(result).not.toContain('wt:');
-    });
-
-    it('does not show worktree suffix when baseBranch is null (detached HEAD in main)', () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git branch --show-current') return 'feature-y\n';
-        if (cmd === 'git rev-parse --git-dir') return '/main/.git/worktrees/wt\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '/main/.git\n';
-        return '';
-      });
-      // Detached HEAD — no ref: prefix
-      mockReadFileSync.mockReturnValue('abc123def456789\n');
-
-      const result = renderGitBranch('/some/worktree');
-      expect(result).toContain('branch:');
-      expect(result).toContain('feature-y');
       expect(result).not.toContain('wt:');
     });
   });

--- a/src/hud/elements/git.ts
+++ b/src/hud/elements/git.ts
@@ -5,8 +5,8 @@
  */
 
 import { execSync } from 'node:child_process';
-import { readFileSync, realpathSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
 import { dim, cyan } from '../colors.js';
 
 const CACHE_TTL_MS = 30_000;
@@ -18,7 +18,7 @@ interface CacheEntry<T> {
 
 export interface WorktreeDetection {
   isWorktree: boolean;
-  baseBranch: string | null;
+  worktreeName: string | null;
 }
 
 const repoCache = new Map<string, CacheEntry<string | null>>();
@@ -111,7 +111,7 @@ export function getGitBranch(cwd?: string): string | null {
 /**
  * Detect if the current directory is inside a git linked worktree.
  * Compares --git-dir with --git-common-dir; they differ in linked worktrees.
- * When in a worktree, reads the main repo's HEAD to determine the base branch.
+ * When in a worktree, extracts the worktree name from the git-dir path.
  *
  * @param cwd - Working directory
  * @returns Worktree detection result (cached for CACHE_TTL_MS)
@@ -131,7 +131,7 @@ export function getWorktreeInfo(cwd?: string): WorktreeDetection {
     shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
   };
 
-  let result: WorktreeDetection = { isWorktree: false, baseBranch: null };
+  let result: WorktreeDetection = { isWorktree: false, worktreeName: null };
   try {
     const gitDir = (execSync('git rev-parse --git-dir', execOpts) as string).trim();
     const gitCommonDir = (execSync('git rev-parse --git-common-dir', execOpts) as string).trim();
@@ -143,14 +143,8 @@ export function getWorktreeInfo(cwd?: string): WorktreeDetection {
     try { resolvedCommonDir = realpathSync(resolvedCommonDir); } catch { /* use resolved */ }
 
     if (resolvedGitDir !== resolvedCommonDir) {
-      result = { isWorktree: true, baseBranch: null };
-      try {
-        const headContent = readFileSync(join(resolvedCommonDir, 'HEAD'), 'utf-8').trim();
-        const match = headContent.match(/^ref: refs\/heads\/(.+)$/);
-        result.baseBranch = match ? match[1] : null;
-      } catch {
-        // Can't read HEAD — mark as worktree without base branch
-      }
+      // Extract worktree name from gitDir path (e.g. /repo/.git/worktrees/my-wt → my-wt)
+      result = { isWorktree: true, worktreeName: basename(resolvedGitDir) };
     }
   } catch {
     // Not in a git repo or command failed
@@ -174,8 +168,8 @@ export function renderGitRepo(cwd?: string): string | null {
 
 /**
  * Render git branch element.
- * When inside a linked worktree, appends the main repo's branch as suffix:
- *   branch:feature-x (wt:main)
+ * When inside a linked worktree, appends the worktree name as suffix:
+ *   branch:feature-x (wt:my-wt)
  *
  * @param cwd - Working directory
  * @returns Formatted branch name or null
@@ -185,8 +179,8 @@ export function renderGitBranch(cwd?: string): string | null {
   if (!branch) return null;
 
   const wtInfo = getWorktreeInfo(cwd);
-  if (wtInfo.isWorktree && wtInfo.baseBranch) {
-    return `${dim('branch:')}${cyan(branch)} ${dim('(wt:')}${cyan(wtInfo.baseBranch)}${dim(')')}`;
+  if (wtInfo.isWorktree && wtInfo.worktreeName) {
+    return `${dim('branch:')}${cyan(branch)} ${dim('(wt:')}${cyan(wtInfo.worktreeName)}${dim(')')}`;
   }
 
   return `${dim('branch:')}${cyan(branch)}`;


### PR DESCRIPTION
## Summary

- HUD `wt:` suffix was reading `commonDir/HEAD` (main repo's current branch), which is volatile and identical across all worktrees
- Now extracts the actual worktree name from `git-dir` path via `basename()`, providing a stable, unique identifier
- Removed unused `readFileSync`/`join` imports and HEAD-reading logic (~60 lines net reduction)

## Test plan

- [x] `vitest run src/__tests__/hud/git.test.ts` — 25 tests passing
- [x] `tsc --noEmit` — no type errors
- [x] Manual verification in a live worktree environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)