### PR TITLE
fix: copy hooks/lib/ directory during omc setup

### DIFF
--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -407,6 +407,18 @@ function ensureStandaloneHookScripts(log: (msg: string) => void): void {
     mkdirSync(HOOKS_DIR, { recursive: true });
   }
 
+  // Copy shared lib modules (stdin.mjs, atomic-write.mjs) required by hook scripts
+  const libSourceDir = join(templatesDir, 'lib');
+  const libTargetDir = join(HOOKS_DIR, 'lib');
+  if (existsSync(libSourceDir)) {
+    if (!existsSync(libTargetDir)) {
+      mkdirSync(libTargetDir, { recursive: true });
+    }
+    for (const libFile of readdirSync(libSourceDir)) {
+      copyFileSync(join(libSourceDir, libFile), join(libTargetDir, libFile));
+    }
+  }
+
   for (const filename of STANDALONE_HOOK_TEMPLATE_FILES) {
     const sourcePath = join(templatesDir, filename);
     const targetPath = join(HOOKS_DIR, filename);


### PR DESCRIPTION
## Summary
- `ensureStandaloneHookScripts()` in `src/installer/index.ts` copies individual `.mjs` hook files but **skips the `templates/hooks/lib/` directory**
- This causes `persistent-mode.mjs` to fail with `ERR_MODULE_NOT_FOUND: Cannot find module '~/.claude/hooks/lib/stdin.mjs'` because it imports `lib/stdin.mjs` without a try/catch fallback (unlike other hooks)
- Added `lib/` directory copy logic before individual hook file copies

## Reproduction
1. Fresh install: `npm i -g oh-my-claude-sisyphus@4.10.1`
2. Run `omc setup`
3. Check `~/.claude/hooks/lib/` → directory does not exist
4. Any hook triggering `persistent-mode.mjs` throws `ERR_MODULE_NOT_FOUND`

## Fix
Copy all files from `templates/hooks/lib/` → `~/.claude/hooks/lib/` during setup (before individual hook scripts).

## Test plan
- [x] Existing `standalone-hook-reconcile.test.ts` passes (2/2)
- [x] TypeScript type check passes
- [ ] Manual: run `omc setup` → verify `~/.claude/hooks/lib/stdin.mjs` and `atomic-write.mjs` exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)