### PR TITLE
feat(skills): inject Codex availability for ralplan/plan/ralph, enhance Codex critic

### DIFF
--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -95,7 +95,11 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
    - Standard changes: STANDARD tier (architect-medium / Sonnet)
    - >20 files or security/architectural changes: THOROUGH tier (architect / Opus)
    - If `--critic=critic`, use the Claude `critic` agent for the approval pass
-   - If `--critic=codex`, run `omc ask codex --agent-prompt critic "..."` for the approval pass
+   - If `--critic=codex`, run `omc ask codex --agent-prompt critic "..."` for the approval pass. The Codex critic prompt MUST include:
+     1. The full list of acceptance criteria from prd.json for verification
+     2. A directive to evaluate whether the implementation is **OPTIMAL** — not just correct, but whether there exists a meaningfully better approach (simpler, faster, more maintainable) that the implementation missed
+     3. A directive to review **all code related to the changes** (callers, callees, shared types, adjacent modules), not only the files directly modified
+     4. The list of files changed during the ralph session for context
    - Ralph floor: always at least STANDARD, even for small changes
    - The selected reviewer verifies against the SPECIFIC acceptance criteria from prd.json, not vague "is it done?"
 
@@ -118,7 +122,7 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 <Tool_Usage>
 - Use `Task(subagent_type="oh-my-claudecode:architect", ...)` for architect verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
 - Use `Task(subagent_type="oh-my-claudecode:critic", ...)` when `--critic=critic`
-- Use `omc ask codex --agent-prompt critic "..."` when `--critic=codex`
+- Use `omc ask codex --agent-prompt critic "..."` when `--critic=codex`. Construct the prompt to include: (a) prd.json acceptance criteria, (b) files changed + related files, (c) explicit optimality question: "Is there a meaningfully simpler, faster, or more maintainable approach that achieves the same acceptance criteria?"
 - Skip architect consultation for simple feature additions, well-tested changes, or time-critical verification
 - Proceed with architect agent verification alone -- never block on unavailable tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations

--- a/src/features/builtin-skills/runtime-guidance.ts
+++ b/src/features/builtin-skills/runtime-guidance.ts
@@ -20,6 +20,17 @@ function normalizeSkillName(skillName: string): string {
   return skillName.trim().toLowerCase();
 }
 
+function renderPlanRuntimeGuidance(availability: SkillRuntimeAvailability): string {
+  if (!availability.codex) {
+    return '';
+  }
+
+  return [
+    '## Provider Runtime Availability',
+    'Codex CLI is installed and available. When `--architect codex` or `--critic codex` flags are present, use `omc ask codex --agent-prompt <role> "<prompt>"` for those passes. Do NOT report Codex as unavailable.',
+  ].join('\n');
+}
+
 function renderDeepInterviewRuntimeGuidance(availability: SkillRuntimeAvailability): string {
   if (!availability.codex) {
     return '';
@@ -44,6 +55,11 @@ export function renderSkillRuntimeGuidance(
   switch (normalizeSkillName(skillName)) {
     case 'deep-interview':
       return renderDeepInterviewRuntimeGuidance(availability ?? detectSkillRuntimeAvailability());
+    case 'ralplan':
+    case 'omc-plan':
+    case 'plan':
+    case 'ralph':
+      return renderPlanRuntimeGuidance(availability ?? detectSkillRuntimeAvailability());
     default:
       return '';
   }


### PR DESCRIPTION
## Problem

When using `--architect codex` or `--critic codex` flags with `/ralplan` or `ralph --critic=codex`, the Claude agent reports "Codex is unavailable" and silently falls back to the default Claude-only reviewer — even when Codex CLI is installed, authenticated, and working correctly (`codex --version` succeeds, `omc ask codex` produces valid output).

**Root cause**: `runtime-guidance.ts` → `renderSkillRuntimeGuidance()` only injects Codex CLI availability signals for the `deep-interview` skill. The `ralplan`, `omc-plan`, `plan`, and `ralph` skills all hit the `default:` case which returns `''`. Without any availability signal in the skill prompt, the Claude agent has no way to know Codex is installed and defaults to "unavailable."

Additionally, when the Codex critic path *does* activate (e.g., via workaround), the `ralph` skill only asks Codex to verify acceptance criteria — the same shallow pass the Claude architect already does. As Codex can run GPT-5.4 at max reasoning effort, this underutilizes the external critic.

## Expected Result

1. When Codex CLI is installed, `/ralplan --critic codex` and `ralph --critic=codex` should detect it and route the critic pass through `omc ask codex` without requiring manual workarounds.
2. The Codex critic prompt should maximize the value of the external review by evaluating **optimality** (not just correctness) and reviewing **all related code** (not just changed files).

## Solution

### Change 1: `src/features/builtin-skills/runtime-guidance.ts`

Added `renderPlanRuntimeGuidance()` — mirrors the existing `renderDeepInterviewRuntimeGuidance()` pattern. Checks `availability.codex` and injects a clear directive into the skill prompt: "Codex CLI is installed and available. Do NOT report Codex as unavailable."

Added `case 'ralplan'`, `case 'omc-plan'`, `case 'plan'`, `case 'ralph'` to the `renderSkillRuntimeGuidance()` switch, routing them to the new render function.

This bridges the gap: the `isCliAvailable('codex')` detection already works correctly at the TypeScript level — the missing piece was propagating that signal into the skill prompt text that the Claude agent actually reads.

### Change 2: `skills/ralph/SKILL.md`

Enhanced the `--critic=codex` instructions in Step 7 (Reviewer verification) and Tool_Usage. The Codex critic prompt now MUST include:

1. Full acceptance criteria from prd.json
2. An **optimality directive** — evaluate whether a meaningfully simpler, faster, or more maintainable approach exists
3. A **related-code review directive** — review callers, callees, shared types, and adjacent modules, not only directly modified files
4. The list of files changed during the ralph session

This preserves the existing ralph design (PRD loop, story tracking, verification flow) while extracting maximum value from the GPT-5.4 xhigh-effort Codex pass.

## Test plan

- [ ] Verify `codex --version` succeeds → `renderPlanRuntimeGuidance` returns non-empty guidance
- [ ] Verify `codex --version` fails → function returns `''` (graceful fallback preserved)
- [ ] Run `/ralplan --critic codex "trivial task"` → Codex critic is invoked, not skipped
- [ ] Run `ralph --critic=codex` → Step 7 sends optimality + related-code review prompt to Codex
- [ ] Existing `deep-interview` Codex detection is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)