### PR TITLE
feat(agents): add safety protocols to orchestrator AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,12 @@ Sizing guidance:
 Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work.
 </verification>
 
+<evidence_only_protocol>
+Never claim completion without running a verification command first.
+BANNED words in completion claims: should, probably, seems, likely, appears to.
+Every completion claim must cite: command run, output received, and how output proves the claim.
+</evidence_only_protocol>
+
 <execution_protocols>
 Broad Request Detection:
   A request is broad when it uses vague verbs without targets, names no specific file or function, touches 3+ areas, or is a single sentence without a clear deliverable. When detected: explore first, optionally consult architect, then plan.
@@ -325,6 +331,12 @@ Continuation:
 Ralph planning gate:
   If ralph is active, verify PRD + test spec artifacts exist before any implementation work/tool execution. If missing, stay in planning and create them first (ralplan-first).
 </execution_protocols>
+
+<context_pressure_protocol>
+When context usage exceeds 80%, trigger autocompact. When exceeds 90%, halt new complex work.
+Ralph/ultrawork exemption: compact and save state instead of halting.
+Read-only agents (explore, analyst) are exempt from pressure limits.
+</context_pressure_protocol>
 
 <cancellation>
 Use the `cancel` skill to end execution modes. This clears state files and stops active loops.
@@ -405,3 +417,16 @@ Run `omc setup` to install all components. Run `omc doctor` to verify installati
 - Configuration changes must be backward-compatible or include migration notes.
 - MCP tool definitions must validate inputs and handle timeouts gracefully.
 - Agent orchestration changes: verify state machine transitions are complete and recoverable.
+
+<forbidden_files>
+Never read, write, or commit these file patterns:
+- `.env`, `.env.*` (secrets)
+- `*.pem`, `*.key`, `*.p12` (certificates)
+- `credentials.json`, `serviceaccount.json` (service accounts)
+- `*.sqlite`, `*.db` (local databases)
+- `.npmrc`, `.pypirc`, `.netrc` (package manager credentials)
+- `id_rsa`, `id_ed25519` (SSH private keys)
+- `*.pfx`, `*.jks`, `*.keystore` (certificate stores)
+- `.git-credentials` (Git credential store)
+Exception: `security-reviewer` agent may read (not write) these for audit purposes.
+</forbidden_files>


### PR DESCRIPTION
## Summary

- Adds 3 safety-oriented sections to `AGENTS.md` that protect multi-agent workflows at the orchestrator level
- **evidence_only_protocol**: bans vague completion claims (should/probably/seems/likely), requires verification command output citing command run, output received, and how it proves the claim
- **context_pressure_protocol**: defines behavior at 80% context (autocompact) and 90% (halt new complex work), with ralph/ultrawork exemption (compact + save state instead of halting) and read-only agent exemption
- **forbidden_files**: comprehensive blocklist for sensitive file patterns (.env, certificates, credentials, SSH keys, package manager creds, certificate stores, git credentials) with security-reviewer read-only exemption

Total: ~25 lines added. All sections use existing XML tag conventions.

## Rationale

These are orchestrator-level safety rails that apply to ALL agent delegations:
1. Without evidence_only_protocol, the orchestrator can accept "it should work" from subagents and report completion to the user
2. Without context_pressure_protocol, long sessions (ralph, autopilot, team) either panic-cut corners or exhaust context with lost state
3. Without forbidden_files, multi-agent workflows amplify the blast radius of a single agent reading `.env` or writing credentials

## Test plan

- [ ] Verify `evidence_only_protocol` sits logically after `<verification>` section
- [ ] Verify `context_pressure_protocol` sits logically after `<execution_protocols>`
- [ ] Verify `forbidden_files` sits after review guidelines at end of file
- [ ] Verify security-reviewer exemption is preserved
- [ ] Verify no existing section conflicts with new content