### PR TITLE
fix: preserve existing global CLAUDE.md during setup

### DIFF
--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -3,7 +3,7 @@
 # Usage: setup-claude-md.sh <local|global>
 #
 # Handles: version extraction, backup, download, marker stripping, merge, version reporting.
-# For global mode, also cleans up legacy hooks.
+# For global mode, preserves existing base CLAUDE.md via a companion import when possible.
 
 set -euo pipefail
 
@@ -141,6 +141,7 @@ if [ -z "$OLD_VERSION" ]; then
 fi
 
 # Backup existing
+BACKUP_DATE=""
 if [ -f "$TARGET_PATH" ]; then
   BACKUP_DATE=$(date +%Y-%m-%d_%H%M%S)
   BACKUP_PATH="${TARGET_PATH}.backup.${BACKUP_DATE}"
@@ -151,6 +152,45 @@ fi
 # Load canonical OMC content to temp file
 TEMP_OMC=$(mktemp /tmp/omc-claude-XXXXXX.md)
 trap 'rm -f "$TEMP_OMC"' EXIT
+
+OMC_IMPORT_START='<!-- OMC:IMPORT:START -->'
+OMC_IMPORT_END='<!-- OMC:IMPORT:END -->'
+COMPANION_FILENAME='CLAUDE-omc.md'
+
+write_wrapped_omc_file() {
+  local destination="$1"
+  mkdir -p "$(dirname "$destination")"
+  {
+    echo '<!-- OMC:START -->'
+    cat "$TEMP_OMC"
+    echo '<!-- OMC:END -->'
+  } > "$destination"
+}
+
+ensure_managed_companion_import() {
+  local target_path="$1"
+  local companion_name="$2"
+  local import_block
+  import_block=$(cat <<EOF
+$OMC_IMPORT_START
+@${companion_name}
+$OMC_IMPORT_END
+EOF
+)
+
+  if grep -Fq "$OMC_IMPORT_START" "$target_path"; then
+    perl -0pe 's/^<!-- OMC:IMPORT:START -->\R[\s\S]*?^<!-- OMC:IMPORT:END -->(?:\R)?//msg' "$target_path" > "${target_path}.importless"
+    mv "${target_path}.importless" "$target_path"
+  fi
+
+  if [ -s "$target_path" ]; then
+    printf '\n\n%s\n' "$import_block" >> "$target_path"
+  else
+    printf '%s\n' "$import_block" > "$target_path"
+  fi
+}
+
+VALIDATION_PATH="$TARGET_PATH"
 
 SOURCE_LABEL=""
 if [ -f "$CANONICAL_CLAUDE_MD" ]; then
@@ -186,11 +226,7 @@ fi
 
 if [ ! -f "$TARGET_PATH" ]; then
   # Fresh install: wrap in markers
-  {
-    echo '<!-- OMC:START -->'
-    cat "$TEMP_OMC"
-    echo '<!-- OMC:END -->'
-  } > "$TARGET_PATH"
+  write_wrapped_omc_file "$TARGET_PATH"
   rm -f "$TEMP_OMC"
   echo "Installed CLAUDE.md (fresh)"
 else
@@ -229,6 +265,16 @@ else
     mv "${TARGET_PATH}.tmp" "$TARGET_PATH"
     rm -f "${TARGET_PATH}.preserved"
     echo "Updated OMC section (user customizations preserved)"
+  elif [ "$MODE" = "global" ]; then
+    COMPANION_TARGET_PATH="$CONFIG_DIR/$COMPANION_FILENAME"
+    if [ -f "$COMPANION_TARGET_PATH" ] && [ -n "$BACKUP_DATE" ]; then
+      cp "$COMPANION_TARGET_PATH" "${COMPANION_TARGET_PATH}.backup.${BACKUP_DATE}"
+      echo "Backed up existing companion CLAUDE.md to ${COMPANION_TARGET_PATH}.backup.${BACKUP_DATE}"
+    fi
+    write_wrapped_omc_file "$COMPANION_TARGET_PATH"
+    ensure_managed_companion_import "$TARGET_PATH" "$COMPANION_FILENAME"
+    VALIDATION_PATH="$COMPANION_TARGET_PATH"
+    echo "Installed OMC companion file and preserved existing CLAUDE.md"
   else
     # No markers: wrap new content in markers, append old content as user section
     OLD_CONTENT=$(cat "$TARGET_PATH")
@@ -246,8 +292,8 @@ else
   rm -f "$TEMP_OMC"
 fi
 
-if ! grep -q '<!-- OMC:START -->' "$TARGET_PATH" || ! grep -q '<!-- OMC:END -->' "$TARGET_PATH"; then
-  echo "ERROR: Installed CLAUDE.md is missing required OMC markers: $TARGET_PATH" >&2
+if ! grep -q '<!-- OMC:START -->' "$VALIDATION_PATH" || ! grep -q '<!-- OMC:END -->' "$VALIDATION_PATH"; then
+  echo "ERROR: Installed CLAUDE.md is missing required OMC markers: $VALIDATION_PATH" >&2
   exit 1
 fi
 
@@ -258,7 +304,7 @@ if [ "$MODE" = "local" ]; then
 fi
 
 # Extract new version and report
-NEW_VERSION=$(grep -m1 'OMC:VERSION:' "$TARGET_PATH" 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
+NEW_VERSION=$(grep -m1 'OMC:VERSION:' "$VALIDATION_PATH" 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
 if [ -z "$NEW_VERSION" ]; then
   NEW_VERSION=$(omc --version 2>/dev/null | head -1 || true)
 fi

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -62,6 +62,7 @@ MODES:
   Global Configuration (--global)
     - Downloads fresh CLAUDE.md to ~/.claude/
     - Backs up existing CLAUDE.md to ~/.claude/CLAUDE.md.backup.YYYY-MM-DD
+    - Preserves an existing user-authored base CLAUDE.md via a companion `CLAUDE-omc.md` import when possible
     - Applies to all Claude Code sessions
     - Cleans up legacy hooks
     - Use this to update global config after OMC upgrades

--- a/skills/omc-setup/phases/01-install-claude-md.md
+++ b/skills/omc-setup/phases/01-install-claude-md.md
@@ -40,7 +40,7 @@ https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.
 
 **Note**: The downloaded CLAUDE.md includes Context Persistence instructions with `<remember>` tags for surviving conversation compaction.
 
-**Note**: If an existing CLAUDE.md is found, it will be backed up before downloading the new version.
+**Note**: If an existing global `CLAUDE.md` is user-authored (no OMC markers), setup preserves it and installs OMC into a companion `CLAUDE-omc.md` with a small managed import block for easier revert/vanilla fallback.
 
 ## Report Success
 
@@ -61,7 +61,8 @@ Note: This configuration is project-specific and won't affect other projects or 
 If `CONFIG_TARGET` is `global`:
 ```
 OMC Global Configuration Complete
-- CLAUDE.md: Updated with latest configuration from GitHub at ~/.claude/CLAUDE.md
+- CLAUDE.md: Updated or preserved safely at ~/.claude/CLAUDE.md
+- Companion: May install ~/.claude/CLAUDE-omc.md when preserving an existing base config
 - Backup: Previous CLAUDE.md backed up (if existed)
 - Scope: GLOBAL - applies to all Claude Code sessions
 - Hooks: Provided by plugin (no manual installation needed)

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -228,6 +228,88 @@ Use the real docs file.
     expect(existsSync(join(configDir, 'hooks', 'keyword-detector.sh'))).toBe(false);
     expect(`${result.stdout}\n${result.stderr}`).toContain('Plugin verified');
   });
+
+  it('preserves an existing global CLAUDE.md by installing OMC into a companion file', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '# User CLAUDE\nKeep my base config.\n');
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ plugins: ['oh-my-claudecode'] }));
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'global'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+
+    const baseClaude = readFileSync(join(configDir, 'CLAUDE.md'), 'utf-8');
+    const companionClaude = readFileSync(join(configDir, 'CLAUDE-omc.md'), 'utf-8');
+
+    expect(baseClaude).toContain('# User CLAUDE');
+    expect(baseClaude).toContain('Keep my base config.');
+    expect(baseClaude).toContain('<!-- OMC:IMPORT:START -->');
+    expect(baseClaude).toContain('@CLAUDE-omc.md');
+    expect(baseClaude).toContain('<!-- OMC:IMPORT:END -->');
+    expect(baseClaude).not.toContain('<!-- OMC:START -->');
+
+    expect(companionClaude).toContain('<!-- OMC:START -->');
+    expect(companionClaude).toContain('<!-- OMC:END -->');
+    expect(companionClaude).toContain('<!-- OMC:VERSION:9.9.9 -->');
+    expect(companionClaude).toContain('# Canonical CLAUDE');
+  });
+
+  it('updates the companion file idempotently without duplicating the managed import block', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '# User CLAUDE\nKeep my base config.\n');
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ plugins: ['oh-my-claudecode'] }));
+
+    const env = {
+      ...process.env,
+      HOME: fixture.homeRoot,
+      CLAUDE_CONFIG_DIR: configDir,
+    };
+
+    const first = spawnSync('bash', [fixture.scriptPath, 'global'], {
+      cwd: fixture.projectRoot,
+      env,
+      encoding: 'utf-8',
+    });
+    expect(first.status).toBe(0);
+
+    const second = spawnSync('bash', [fixture.scriptPath, 'global'], {
+      cwd: fixture.projectRoot,
+      env,
+      encoding: 'utf-8',
+    });
+    expect(second.status).toBe(0);
+
+    const baseClaude = readFileSync(join(configDir, 'CLAUDE.md'), 'utf-8');
+    expect(baseClaude.match(/<!-- OMC:IMPORT:START -->/g)).toHaveLength(1);
+    expect(baseClaude.match(/@CLAUDE-omc\.md/g)).toHaveLength(1);
+    expect(readFileSync(join(configDir, 'CLAUDE-omc.md'), 'utf-8')).toContain('<!-- OMC:VERSION:9.9.9 -->');
+  });
 });
 
 describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {


### PR DESCRIPTION
## Summary
- preserve an existing user-authored global `CLAUDE.md` instead of rewriting it in place
- install OMC content into companion `CLAUDE-omc.md` and add one managed import block
- document the safer setup flow and add regression coverage

## Testing
- npm test -- --run src/__tests__/setup-claude-md-script.test.ts
- npm test -- --run src/__tests__/doctor-conflicts.test.ts
- manual shell repro with custom CLAUDE_CONFIG_DIR

Closes #2143