### PR TITLE
fix: follow up #2143 with explicit overwrite choice + omc launch profile

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -85,7 +85,7 @@ Applies OMC to all Claude Code sessions:
 - Settings are saved to `~/.claude/CLAUDE.md`
 - Applied across all projects
 
-> ⚠️ **Warning:** Global setup overwrites the existing `~/.claude/CLAUDE.md` file. If you already have configuration there, use project-scoped setup (`--local`) instead.
+> ⚠️ **Warning:** Global setup now asks explicitly before changing your base `~/.claude/CLAUDE.md`. The default choice is still overwrite. If you choose preserve mode instead, plain `claude` stays on your base config and `omc` force-loads the OMC companion config.
 
 ### Verifying the installation
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -74,7 +74,8 @@ Configure omc for all Claude Code sessions:
 
 - Creates `~/.claude/CLAUDE.md` globally
 - Configuration applies to all projects
-- **Warning**: Completely overwrites existing `~/.claude/CLAUDE.md`
+- **Default**: explicitly overwrites existing `~/.claude/CLAUDE.md`
+- **Optional preserve mode**: keeps the base file, writes OMC to `~/.claude/CLAUDE-omc.md`, and lets `omc` force-load that companion config at launch while plain `claude` stays unchanged
 
 ### What Configuration Enables
 

--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # setup-claude-md.sh - Unified CLAUDE.md download/merge script
-# Usage: setup-claude-md.sh <local|global>
+# Usage: setup-claude-md.sh <local|global> [overwrite|preserve]
 #
 # Handles: version extraction, backup, download, marker stripping, merge, version reporting.
-# For global mode, preserves existing base CLAUDE.md via a companion import when possible.
+# For global mode, defaults to overwrite; preserve mode keeps the user's base
+# CLAUDE.md and writes OMC content to a companion file for `omc` launch.
 
 set -euo pipefail
 
-MODE="${1:?Usage: setup-claude-md.sh <local|global>}"
+MODE="${1:?Usage: setup-claude-md.sh <local|global> [overwrite|preserve]}"
+INSTALL_STYLE="${2:-overwrite}"
 DOWNLOAD_URL="https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -101,6 +103,11 @@ else
   exit 1
 fi
 
+if [ "$INSTALL_STYLE" != "overwrite" ] && [ "$INSTALL_STYLE" != "preserve" ]; then
+  echo "ERROR: Invalid install style '$INSTALL_STYLE'. Use 'overwrite' or 'preserve'." >&2
+  exit 1
+fi
+
 
 install_omc_reference_skill() {
   local source_label=""
@@ -190,6 +197,16 @@ EOF
   fi
 }
 
+ensure_not_symlink_path() {
+  local target_path="$1"
+  local label="$2"
+
+  if [ -L "$target_path" ]; then
+    echo "ERROR: Refusing to write $label because the destination is a symlink: $target_path" >&2
+    exit 1
+  fi
+}
+
 VALIDATION_PATH="$TARGET_PATH"
 
 SOURCE_LABEL=""
@@ -265,8 +282,10 @@ else
     mv "${TARGET_PATH}.tmp" "$TARGET_PATH"
     rm -f "${TARGET_PATH}.preserved"
     echo "Updated OMC section (user customizations preserved)"
-  elif [ "$MODE" = "global" ]; then
+  elif [ "$MODE" = "global" ] && [ "$INSTALL_STYLE" = "preserve" ]; then
     COMPANION_TARGET_PATH="$CONFIG_DIR/$COMPANION_FILENAME"
+    ensure_not_symlink_path "$COMPANION_TARGET_PATH" "OMC companion CLAUDE.md"
+    ensure_not_symlink_path "$TARGET_PATH" "base CLAUDE.md import block"
     if [ -f "$COMPANION_TARGET_PATH" ] && [ -n "$BACKUP_DATE" ]; then
       cp "$COMPANION_TARGET_PATH" "${COMPANION_TARGET_PATH}.backup.${BACKUP_DATE}"
       echo "Backed up existing companion CLAUDE.md to ${COMPANION_TARGET_PATH}.backup.${BACKUP_DATE}"

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -62,7 +62,8 @@ MODES:
   Global Configuration (--global)
     - Downloads fresh CLAUDE.md to ~/.claude/
     - Backs up existing CLAUDE.md to ~/.claude/CLAUDE.md.backup.YYYY-MM-DD
-    - Preserves an existing user-authored base CLAUDE.md via a companion `CLAUDE-omc.md` import when possible
+    - Default: explicitly overwrites ~/.claude/CLAUDE.md so plain `claude` also uses OMC
+    - Optional preserve mode keeps the user's base `CLAUDE.md` and installs OMC into `CLAUDE-omc.md` for `omc` launches
     - Applies to all Claude Code sessions
     - Cleans up legacy hooks
     - Use this to update global config after OMC upgrades

--- a/skills/omc-setup/phases/01-install-claude-md.md
+++ b/skills/omc-setup/phases/01-install-claude-md.md
@@ -15,15 +15,25 @@ Otherwise (initial setup wizard), use AskUserQuestion to prompt:
 
 Set `CONFIG_TARGET` to `local` or `global` based on user's choice.
 
+If `CONFIG_TARGET=global` and `~/.claude/CLAUDE.md` already exists without OMC markers, ask a second explicit question before running setup:
+
+**Question:** "Global setup will change your base Claude config. Which behavior do you want?"
+
+**Options (default first):**
+1. **Overwrite base CLAUDE.md (Recommended)** - plain `claude` and `omc` both use OMC globally.
+2. **Keep base CLAUDE.md; use OMC only through `omc`** - preserve the user's base file, install OMC into `CLAUDE-omc.md`, and let `omc` force-load that companion config at launch.
+
+Set `GLOBAL_INSTALL_STYLE=overwrite` or `preserve` based on the user's choice. If you did not ask this question, default `GLOBAL_INSTALL_STYLE=overwrite`.
+
 ## Download and Install CLAUDE.md
 
 **MANDATORY**: Always run this command. Do NOT skip. Do NOT use the Write tool. Let the setup script choose the safest canonical source (bundled `docs/CLAUDE.md` first, GitHub fallback only if needed).
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-claude-md.sh" <CONFIG_TARGET>
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-claude-md.sh" <CONFIG_TARGET> [GLOBAL_INSTALL_STYLE]
 ```
 
-Replace `<CONFIG_TARGET>` with `local` or `global`.
+Replace `<CONFIG_TARGET>` with `local` or `global`. For local installs, omit the optional style argument. For global installs, pass `overwrite` or `preserve` when you know the user's choice; otherwise let the script default to `overwrite`.
 
 The script must install the canonical `docs/CLAUDE.md` content and preserve the required
 `<!-- OMC:START -->` / `<!-- OMC:END -->` markers. Do **not** hand-write, summarize, or
@@ -40,7 +50,7 @@ https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.
 
 **Note**: The downloaded CLAUDE.md includes Context Persistence instructions with `<remember>` tags for surviving conversation compaction.
 
-**Note**: If an existing global `CLAUDE.md` is user-authored (no OMC markers), setup preserves it and installs OMC into a companion `CLAUDE-omc.md` with a small managed import block for easier revert/vanilla fallback.
+**Note**: Preserve mode installs OMC into a companion `CLAUDE-omc.md` with a small managed import block, and `omc` launch force-loads that companion config without changing plain `claude`.
 
 ## Report Success
 
@@ -61,8 +71,8 @@ Note: This configuration is project-specific and won't affect other projects or 
 If `CONFIG_TARGET` is `global`:
 ```
 OMC Global Configuration Complete
-- CLAUDE.md: Updated or preserved safely at ~/.claude/CLAUDE.md
-- Companion: May install ~/.claude/CLAUDE-omc.md when preserving an existing base config
+- CLAUDE.md: Updated at ~/.claude/CLAUDE.md, or preserved with explicit preserve mode
+- Companion: May install ~/.claude/CLAUDE-omc.md when preserve mode is chosen
 - Backup: Previous CLAUDE.md backed up (if existed)
 - Scope: GLOBAL - applies to all Claude Code sessions
 - Hooks: Provided by plugin (no manual installation needed)

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -229,7 +230,7 @@ Use the real docs file.
     expect(`${result.stdout}\n${result.stderr}`).toContain('Plugin verified');
   });
 
-  it('preserves an existing global CLAUDE.md by installing OMC into a companion file', () => {
+  it('overwrites an existing global CLAUDE.md by default when preserve mode is not requested', () => {
     const fixture = createPluginFixture(`<!-- OMC:START -->
 <!-- OMC:VERSION:9.9.9 -->
 
@@ -244,6 +245,40 @@ Use the real docs file.
     writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ plugins: ['oh-my-claudecode'] }));
 
     const result = spawnSync('bash', [fixture.scriptPath, 'global'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+
+    const baseClaude = readFileSync(join(configDir, 'CLAUDE.md'), 'utf-8');
+    expect(baseClaude).toContain('<!-- OMC:START -->');
+    expect(baseClaude).toContain('<!-- OMC:END -->');
+    expect(baseClaude).toContain('<!-- User customizations (migrated from previous CLAUDE.md) -->');
+    expect(baseClaude).toContain('# User CLAUDE');
+    expect(existsSync(join(configDir, 'CLAUDE-omc.md'))).toBe(false);
+  });
+
+  it('preserves an existing global CLAUDE.md when preserve mode is explicitly requested', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '# User CLAUDE\nKeep my base config.\n');
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ plugins: ['oh-my-claudecode'] }));
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'global', 'preserve'], {
       cwd: fixture.projectRoot,
       env: {
         ...process.env,
@@ -271,7 +306,7 @@ Use the real docs file.
     expect(companionClaude).toContain('# Canonical CLAUDE');
   });
 
-  it('updates the companion file idempotently without duplicating the managed import block', () => {
+  it('updates the preserved companion file idempotently without duplicating the managed import block', () => {
     const fixture = createPluginFixture(`<!-- OMC:START -->
 <!-- OMC:VERSION:9.9.9 -->
 
@@ -291,14 +326,14 @@ Use the real docs file.
       CLAUDE_CONFIG_DIR: configDir,
     };
 
-    const first = spawnSync('bash', [fixture.scriptPath, 'global'], {
+    const first = spawnSync('bash', [fixture.scriptPath, 'global', 'preserve'], {
       cwd: fixture.projectRoot,
       env,
       encoding: 'utf-8',
     });
     expect(first.status).toBe(0);
 
-    const second = spawnSync('bash', [fixture.scriptPath, 'global'], {
+    const second = spawnSync('bash', [fixture.scriptPath, 'global', 'preserve'], {
       cwd: fixture.projectRoot,
       env,
       encoding: 'utf-8',
@@ -309,6 +344,39 @@ Use the real docs file.
     expect(baseClaude.match(/<!-- OMC:IMPORT:START -->/g)).toHaveLength(1);
     expect(baseClaude.match(/@CLAUDE-omc\.md/g)).toHaveLength(1);
     expect(readFileSync(join(configDir, 'CLAUDE-omc.md'), 'utf-8')).toContain('<!-- OMC:VERSION:9.9.9 -->');
+  });
+
+  it('refuses preserve mode when the companion path is a symlink', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '# User CLAUDE\nKeep my base config.\n');
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ plugins: ['oh-my-claudecode'] }));
+
+    const realTarget = join(fixture.homeRoot, 'outside-target.md');
+    writeFileSync(realTarget, 'outside target');
+    symlinkSync(realTarget, join(configDir, 'CLAUDE-omc.md'));
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'global', 'preserve'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain('Refusing to write OMC companion CLAUDE.md');
+    expect(readFileSync(realTarget, 'utf-8')).toBe('outside target');
   });
 });
 

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -8,6 +8,9 @@
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
@@ -26,7 +29,7 @@ vi.mock('../tmux-utils.js', () => ({
   isClaudeAvailable: vi.fn(() => true),
 }));
 
-import { runClaude, launchCommand, extractNotifyFlag, extractOpenClawFlag, extractTelegramFlag, extractDiscordFlag, extractSlackFlag, extractWebhookFlag, normalizeClaudeLaunchArgs, isPrintMode } from '../launch.js';
+import { runClaude, launchCommand, extractNotifyFlag, extractOpenClawFlag, extractTelegramFlag, extractDiscordFlag, extractSlackFlag, extractWebhookFlag, normalizeClaudeLaunchArgs, isPrintMode, prepareOmcLaunchConfigDir } from '../launch.js';
 import {
   resolveLaunchPolicy,
   buildTmuxShellCommand,
@@ -806,6 +809,58 @@ describe('launchCommand — env var propagation', () => {
     expect(claudeArgs).not.toContain('--webhook');
     expect(claudeArgs).not.toContain('--openclaw');
     expect(claudeArgs).toContain('--print');
+  });
+});
+
+describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () => {
+  const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  let tempRoot: string | null = null;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    tempRoot = mkdtempSync(join(tmpdir(), 'omc-launch-profile-'));
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
+    (resolveLaunchPolicy as ReturnType<typeof vi.fn>).mockReturnValue('direct');
+  });
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    }
+  });
+
+  it('uses a runtime launch profile when a preserved CLAUDE-omc.md companion exists', async () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(join(configDir, 'skills'), { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '# User base config\n');
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC companion\n<!-- OMC:END -->\n');
+    writeFileSync(join(configDir, 'settings.json'), '{"hooks":{}}');
+
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+
+    await launchCommand(['--print']);
+
+    const runtimeDir = join(configDir, '.omc-launch');
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(runtimeDir);
+    expect(existsSync(join(runtimeDir, 'CLAUDE.md'))).toBe(true);
+    expect(readFileSync(join(runtimeDir, 'CLAUDE.md'), 'utf-8')).toContain('# OMC companion');
+    expect(readFileSync(join(configDir, 'CLAUDE.md'), 'utf-8')).toBe('# User base config\n');
+    expect(existsSync(join(runtimeDir, 'settings.json'))).toBe(true);
+  });
+
+  it('leaves CLAUDE_CONFIG_DIR unchanged when no preserved companion exists', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '<!-- OMC:START -->\n# OMC base\n<!-- OMC:END -->\n');
+
+    expect(prepareOmcLaunchConfigDir(configDir)).toBe(configDir);
+    expect(existsSync(join(configDir, '.omc-launch'))).toBe(false);
   });
 });
 

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -5,6 +5,19 @@
 
 import { execFileSync } from 'child_process';
 import {
+  cpSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { homedir } from 'os';
+import { basename, join } from 'path';
+import {
   resolveLaunchPolicy,
   buildTmuxSessionName,
   buildTmuxShellCommand,
@@ -22,6 +35,79 @@ const TELEGRAM_FLAG = '--telegram';
 const DISCORD_FLAG = '--discord';
 const SLACK_FLAG = '--slack';
 const WEBHOOK_FLAG = '--webhook';
+const OMC_RUNTIME_DIRNAME = '.omc-launch';
+
+function hasOmcMarkers(path: string): boolean {
+  if (!existsSync(path)) return false;
+  const content = readFileSync(path, 'utf-8');
+  return content.includes('<!-- OMC:START -->') && content.includes('<!-- OMC:END -->');
+}
+
+function ensureMirroredPath(sourcePath: string, targetPath: string): void {
+  if (!existsSync(sourcePath)) return;
+
+  try {
+    const sourceStat = lstatSync(sourcePath);
+    const targetExists = existsSync(targetPath);
+    if (targetExists) {
+      const targetStat = lstatSync(targetPath);
+      if (targetStat.isSymbolicLink()) {
+        return;
+      }
+      rmSync(targetPath, { recursive: true, force: true });
+    }
+
+    if (sourceStat.isDirectory()) {
+      symlinkSync(sourcePath, targetPath, process.platform === 'win32' ? 'junction' : 'dir');
+      return;
+    }
+
+    symlinkSync(sourcePath, targetPath, 'file');
+  } catch {
+    const sourceStat = lstatSync(sourcePath);
+    if (sourceStat.isDirectory()) {
+      cpSync(sourcePath, targetPath, { recursive: true });
+      return;
+    }
+    copyFileSync(sourcePath, targetPath);
+  }
+}
+
+export function prepareOmcLaunchConfigDir(baseConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude')): string {
+  const companionPath = join(baseConfigDir, 'CLAUDE-omc.md');
+  if (!hasOmcMarkers(companionPath)) {
+    return baseConfigDir;
+  }
+
+  const runtimeConfigDir = join(baseConfigDir, OMC_RUNTIME_DIRNAME);
+  rmSync(runtimeConfigDir, { recursive: true, force: true });
+  mkdirSync(runtimeConfigDir, { recursive: true });
+  copyFileSync(companionPath, join(runtimeConfigDir, 'CLAUDE.md'));
+
+  for (const entry of [
+    'agents',
+    'commands',
+    'hooks',
+    'hud',
+    'plugins',
+    'projects',
+    'skills',
+    '.omc-config.json',
+    '.omc-version.json',
+    '.omc-silent-update.json',
+    'settings.json',
+    'settings.local.json',
+  ]) {
+    ensureMirroredPath(join(baseConfigDir, entry), join(runtimeConfigDir, basename(entry)));
+  }
+
+  writeFileSync(
+    join(runtimeConfigDir, '.omc-launch-profile.json'),
+    JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2),
+  );
+
+  return runtimeConfigDir;
+}
 
 /**
  * Extract the OMC-specific --notify flag from launch args.
@@ -440,6 +526,8 @@ export async function launchCommand(args: string[]): Promise<void> {
     console.error('  npm install -g @anthropic-ai/claude-code');
     process.exit(1);
   }
+
+  process.env.CLAUDE_CONFIG_DIR = prepareOmcLaunchConfigDir();
 
   const normalizedArgs = normalizeClaudeLaunchArgs(argsAfterWebhook);
   const sessionId = `omc-${Date.now()}-${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;


### PR DESCRIPTION
## Summary
- make global setup default back to explicit overwrite while keeping an explicit preserve mode
- make `omc` force-load the OMC companion config when users preserve their base `CLAUDE.md`
- harden preserve mode against symlink-follow writes and align setup docs/prompts/tests with the approved product direction

## Testing
- npm test -- --run src/__tests__/setup-claude-md-script.test.ts
- npm test -- --run src/cli/__tests__/launch.test.ts
- npx tsc --noEmit
- npx eslint src/cli/launch.ts src/cli/__tests__/launch.test.ts src/__tests__/setup-claude-md-script.test.ts

Follow-up to #2143 and supersedes the closed direction in #2144.