### PR TITLE
feat(hud): make call-count icon rendering configurable

### DIFF
--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -278,6 +278,7 @@ You can manually edit the config file. Each option can be set individually - any
     "sessionHealth": true,
     "useBars": true,
     "showCallCounts": true,
+    "callCountsFormat": "auto",
     "safeMode": true,
     "maxOutputLines": 4
   },
@@ -294,6 +295,13 @@ You can manually edit the config file. Each option can be set individually - any
   }
 }
 ```
+
+### callCountsFormat
+
+Controls the call-count badge icon style:
+- `"auto"` (default): emoji on macOS/Linux, ASCII on Windows/WSL
+- `"emoji"`: force `🔧 🤖 ⚡`
+- `"ascii"`: force `T: A: S:`
 
 ### safeMode
 

--- a/src/__tests__/hud/call-counts.test.ts
+++ b/src/__tests__/hud/call-counts.test.ts
@@ -57,6 +57,16 @@ describe('renderCallCounts', () => {
   });
 
   describe('output format', () => {
+    it('supports explicit ASCII rendering overrides', () => {
+      const result = renderCallCounts(5, 2, 1, 'ascii');
+      expect(result).toBe('T:5 A:2 S:1');
+    });
+
+    it('supports explicit emoji rendering overrides', () => {
+      const result = renderCallCounts(5, 2, 1, 'emoji');
+      expect(result).toBe('🔧5 🤖2 ⚡1');
+    });
+
     it('separates parts with a space', () => {
       const result = renderCallCounts(5, 2, 1);
       expect(result).toBe('🔧5 🤖2 ⚡1');
@@ -72,6 +82,10 @@ describe('renderCallCounts', () => {
 });
 
 describe('showCallCounts config option', () => {
+  it('DEFAULT_HUD_CONFIG uses auto call-count icon selection', () => {
+    expect(DEFAULT_HUD_CONFIG.elements.callCountsFormat).toBe('auto');
+  });
+
   it('DEFAULT_HUD_CONFIG has showCallCounts enabled', () => {
     expect(DEFAULT_HUD_CONFIG.elements.showCallCounts).toBe(true);
   });

--- a/src/__tests__/hud/state.test.ts
+++ b/src/__tests__/hud/state.test.ts
@@ -62,6 +62,28 @@ describe("readHudConfig", () => {
       expect(config.elements.gitBranch).toBe(true);
     });
 
+    it("reads callCountsFormat from settings.json", () => {
+      mockExistsSync.mockImplementation((path) => {
+        const s = String(path);
+        return /[\/]Users[\/]testuser[\/]\.claude[\/]settings\.json$/.test(
+          s,
+        );
+      });
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          omcHud: {
+            elements: {
+              callCountsFormat: "emoji",
+            },
+          },
+        }),
+      );
+
+      const config = readHudConfig();
+
+      expect(config.elements.callCountsFormat).toBe("emoji");
+    });
+
     it("falls back to legacy hud-config.json when settings.json has no omcHud", () => {
       mockExistsSync.mockImplementation((path) => {
         const s = String(path);

--- a/src/__tests__/hud/windows-platform.test.ts
+++ b/src/__tests__/hud/windows-platform.test.ts
@@ -138,7 +138,7 @@ describe('Windows HUD Platform Fixes (#739)', () => {
       expect(result).toContain('\u26A1');    // zap
     });
 
-    it('should use ASCII icons on Windows', async () => {
+    it('should use ASCII icons on Windows by default', async () => {
       Object.defineProperty(process, 'platform', { value: 'win32' });
       vi.resetModules();
 
@@ -148,6 +148,24 @@ describe('Windows HUD Platform Fixes (#739)', () => {
       expect(result).not.toContain('\u{1F527}');
       expect(result).not.toContain('\u{1F916}');
       expect(result).not.toContain('\u26A1');
+    });
+
+    it('should allow emoji icons on Windows when explicitly configured', async () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      vi.resetModules();
+
+      const mod = await import('../../hud/elements/call-counts.js');
+      const result = mod.renderCallCounts(42, 7, 3, 'emoji');
+      expect(result).toBe('🔧42 🤖7 ⚡3');
+    });
+
+    it('should allow ASCII icons on Unix when explicitly configured', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      vi.resetModules();
+
+      const mod = await import('../../hud/elements/call-counts.js');
+      const result = mod.renderCallCounts(42, 7, 3, 'ascii');
+      expect(result).toBe('T:42 A:7 S:3');
     });
 
     it('should return null for zero counts on Windows', async () => {

--- a/src/hud/elements/call-counts.ts
+++ b/src/hud/elements/call-counts.ts
@@ -4,18 +4,30 @@
  * Renders real-time counts of tool calls, agent invocations, and skill usages
  * on the right side of the HUD status line. (Issue #710)
  *
- * Format: 🔧42 🤖7 ⚡3  (Unix)
- * Format: T:42 A:7 S:3   (Windows - ASCII fallback to avoid rendering issues)
+ * Format: 🔧42 🤖7 ⚡3  (emoji)
+ * Format: T:42 A:7 S:3   (ASCII fallback / explicit override)
  */
 
 // Windows terminals (cmd.exe, PowerShell, Windows Terminal) may not render
 // multi-byte emoji correctly, causing HUD layout corruption.
 // WSL terminals may also lack emoji support.
 import { isWSL } from '../../platform/index.js';
-const useAscii = process.platform === 'win32' || isWSL();
-const TOOL_ICON = useAscii ? 'T:' : '\u{1F527}';
-const AGENT_ICON = useAscii ? 'A:' : '\u{1F916}';
-const SKILL_ICON = useAscii ? 'S:' : '\u26A1';
+import type { CallCountsFormat } from '../types.js';
+
+function shouldUseAscii(format: CallCountsFormat = 'auto'): boolean {
+  if (format === 'ascii') return true;
+  if (format === 'emoji') return false;
+  return process.platform === 'win32' || isWSL();
+}
+
+function getIcons(format: CallCountsFormat = 'auto') {
+  const useAscii = shouldUseAscii(format);
+  return {
+    tool: useAscii ? 'T:' : '\u{1F527}',
+    agent: useAscii ? 'A:' : '\u{1F916}',
+    skill: useAscii ? 'S:' : '\u26A1',
+  };
+}
 
 /**
  * Render call counts badge.
@@ -31,17 +43,19 @@ export function renderCallCounts(
   toolCalls: number,
   agentInvocations: number,
   skillUsages: number,
+  format: CallCountsFormat = 'auto',
 ): string | null {
   const parts: string[] = [];
+  const icons = getIcons(format);
 
   if (toolCalls > 0) {
-    parts.push(`${TOOL_ICON}${toolCalls}`);
+    parts.push(`${icons.tool}${toolCalls}`);
   }
   if (agentInvocations > 0) {
-    parts.push(`${AGENT_ICON}${agentInvocations}`);
+    parts.push(`${icons.agent}${agentInvocations}`);
   }
   if (skillUsages > 0) {
-    parts.push(`${SKILL_ICON}${skillUsages}`);
+    parts.push(`${icons.skill}${skillUsages}`);
   }
 
   return parts.length > 0 ? parts.join(' ') : null;

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -395,6 +395,7 @@ export async function render(
       context.toolCallCount,
       context.agentCallCount,
       context.skillCallCount,
+      enabledElements.callCountsFormat ?? 'auto',
     );
     if (counts) rendered.set("callCounts", counts);
   }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -415,6 +415,8 @@ export type CwdFormat = 'relative' | 'absolute' | 'folder';
  */
 export type ModelFormat = 'short' | 'versioned' | 'full';
 
+export type CallCountsFormat = 'auto' | 'emoji' | 'ascii';
+
 export interface HudElementConfig {
   cwd: boolean;              // Show working directory
   cwdFormat: CwdFormat;      // Path display format
@@ -450,6 +452,7 @@ export interface HudElementConfig {
   showTokens?: boolean;           // Show last-request token usage when enabled (tok:i1.2k/o340)
   useBars: boolean;           // Show visual progress bars instead of/alongside percentages
   showCallCounts?: boolean;   // Show tool/agent/skill call counts on the right of the status line (default: true)
+  callCountsFormat?: CallCountsFormat; // Controls call count icon rendering: auto (platform default), emoji, or ascii
   showLastTool?: boolean;      // Show name of last tool called (tool:Read)
   sessionSummary: boolean;    // Show AI-generated session summary (<20 chars) - generated every 10 turns via claude -p
   maxOutputLines: number;     // Max total output lines to prevent input field shrinkage
@@ -569,6 +572,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     showTokens: false,
     useBars: false,  // Disabled by default for backwards compatibility
     showCallCounts: true,  // Show tool/agent/skill call counts by default (Issue #710)
+    callCountsFormat: 'auto',  // Preserve platform-based emoji/ASCII defaults unless explicitly overridden
     showLastTool: false,
     sessionSummary: false, // Disabled by default - opt-in AI-generated session summary
     maxOutputLines: 4,


### PR DESCRIPTION
## Summary
- add `omcHud.elements.callCountsFormat` with `auto | emoji | ascii`
- preserve current default behavior with `auto` (emoji on macOS/Linux, ASCII on Windows/WSL)
- allow explicit emoji opt-in on Windows terminals and explicit ASCII opt-out elsewhere
- document the setting in the HUD skill guide

## Config behavior
```json
{
  "omcHud": {
    "elements": {
      "showCallCounts": true,
      "callCountsFormat": "auto"
    }
  }
}
```

- `auto` keeps today's behavior
- `emoji` forces `🔧 🤖 ⚡`
- `ascii` forces `T: A: S:`

This keeps the change tightly scoped to the call-count badge instead of introducing a broader HUD-wide emoji flag.

## Verification
- `npx vitest run src/__tests__/hud/call-counts.test.ts src/__tests__/hud/state.test.ts src/__tests__/hud/windows-platform.test.ts`
- `npx vitest run src/__tests__/hud/render.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/hud/elements/call-counts.ts src/hud/render.ts src/hud/types.ts src/__tests__/hud/call-counts.test.ts src/__tests__/hud/windows-platform.test.ts src/__tests__/hud/state.test.ts`

Closes #2150.
