### PR TITLE
fix(hooks): heal stdin.mjs symlink on every init

### DIFF
--- a/dist/hooks/setup/index.js
+++ b/dist/hooks/setup/index.js
@@ -6,8 +6,9 @@
  * - init: Create directory structure, validate configs, set environment
  * - maintenance: Prune old state files, cleanup orphaned state, vacuum SQLite
  */
-import { existsSync, mkdirSync, readdirSync, statSync, unlinkSync, readFileSync, writeFileSync, appendFileSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, statSync, unlinkSync, readFileSync, writeFileSync, appendFileSync, symlinkSync } from 'fs';
 import { join } from 'path';
+import os from 'os';
 import { registerBeadsContext } from '../beads-context/index.js';
 // ============================================================================
 // Constants
@@ -132,6 +133,31 @@ export function patchHooksJsonForWindows(pluginRoot) {
     }
 }
 /**
+ * Ensure ~/.claude/hooks/lib/stdin.mjs symlink points to the current plugin version.
+ *
+ * This fixes a silent breakage that occurs when OMC upgrades to a new version:
+ * the symlink stays pointing at the old version's cache dir, so hooks that
+ * import stdin.mjs fail with ERR_MODULE_NOT_FOUND.  Rebuilding the symlink on
+ * every init keeps it in sync automatically.
+ */
+export function ensureStdinSymlink(pluginRoot) {
+    const libDstDir = join(os.homedir(), '.claude/hooks/lib');
+    const libSrc = join(pluginRoot, 'templates/hooks/lib');
+    const stdinSrc = join(libSrc, 'stdin.mjs');
+    const stdinDst = join(libDstDir, 'stdin.mjs');
+    if (!existsSync(libDstDir)) {
+        mkdirSync(libDstDir, { recursive: true });
+    }
+    // Always recreate so upgrade always heals the symlink
+    try { unlinkSync(stdinDst); } catch { /* ignore if didn't exist */ }
+    try {
+        symlinkSync(stdinSrc, stdinDst);
+    } catch (err) {
+        // Non-fatal: older setups may have copied the file instead
+    }
+}
+
+/**
  * Process setup init trigger
  */
 export async function processSetupInit(input) {
@@ -145,11 +171,15 @@ export async function processSetupInit(input) {
     // The sh->find-node.sh->node chain triggers Claude Code UI bug #17088 on
     // MSYS2/Git Bash, mislabeling every successful hook as an error (issue #899).
     // find-node.sh is only needed on Unix for nvm/fnm PATH discovery.
+    const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
     if (process.platform === 'win32') {
-        const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
         if (pluginRoot) {
             patchHooksJsonForWindows(pluginRoot);
         }
+    }
+    // Always heal the stdin.mjs symlink so upgrades don't break hooks
+    if (pluginRoot) {
+        ensureStdinSymlink(pluginRoot);
     }
     try {
         // Create directory structure


### PR DESCRIPTION
## Summary

After OMC upgrades, `~/.claude/hooks/lib/stdin.mjs` keeps pointing at the old plugin version's cache directory, causing `ERR_MODULE_NOT_FOUND` in `persistent-mode` and other hooks.

## Fix

Added `ensureStdinSymlink()` that runs on every `processSetupInit`:

1. Creates `~/.claude/hooks/lib/` if missing
2. Unlinks any existing (possibly stale) symlink
3. Creates a fresh symlink pointing to the **current** `CLAUDE_PLUGIN_ROOT/templates/hooks/lib/stdin.mjs`

This makes every `omc:setup` (including upgrades) self-healing — no more silent breakage after version bumps.

## Test plan

- [ ] `omc:setup --global` runs without error on fresh install
- [ ] After upgrading OMC via `omc:setup --global`, `ls -la ~/.claude/hooks/lib/stdin.mjs` points to the new version
- [ ] `node -e "import('~/.claude/hooks/lib/stdin.mjs')"` loads successfully after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)