### PR TITLE
fix: respect CLAUDE_CONFIG_DIR across remaining code paths

### DIFF
--- a/scripts/cleanup-orphans.mjs
+++ b/scripts/cleanup-orphans.mjs
@@ -24,7 +24,7 @@
 import { existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
 
 const args = process.argv.slice(2);
 const teamNameIdx = args.indexOf('--team-name');
@@ -124,7 +124,7 @@ function getWindowsProcessListOutput() {
  * Check if a team's config still exists (i.e., team is still active).
  */
 function teamConfigExists(name) {
-  const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+  const configDir = getClaudeConfigDir();
   const configPath = join(configDir, 'teams', name, 'config.json');
   return existsSync(configPath);
 }

--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -21,8 +21,9 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
-import { tmpdir, homedir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
 const THRESHOLD = parseInt(process.env.OMC_CONTEXT_GUARD_THRESHOLD || '75', 10);
@@ -114,7 +115,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
       const lastSep = transcriptPath.lastIndexOf('/');
       const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
       if (sessionFile) {
-        const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+        const configDir = getClaudeConfigDir();
         const projectsDir = join(configDir, 'projects');
         if (existsSync(projectsDir)) {
           const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
@@ -173,7 +174,7 @@ function estimateContextPercent(transcriptPath) {
  * Prevents infinite block loops by capping at MAX_BLOCKS.
  */
 function getGuardFilePath(sessionId) {
-  const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+  const configDir = getClaudeConfigDir();
   const guardDir = join(configDir, 'projects', '.omc-guards');
   mkdirSync(guardDir, { recursive: true, mode: 0o700 });
   return join(guardDir, `context-guard-${sessionId}.json`);

--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -16,10 +16,22 @@
 
 NODE_BIN=""
 
+case "$0" in
+  */*)
+    SCRIPT_DIR="${0%/*}"
+    ;;
+  *)
+    SCRIPT_DIR='.'
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
+. "$SCRIPT_DIR/lib/config-dir.sh"
+
 # ---------------------------------------------------------------------------
 # 1. Read stored node path from OMC config
 # ---------------------------------------------------------------------------
-CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CLAUDE_DIR="$(resolve_claude_config_dir)"
 CONFIG_FILE="$CLAUDE_DIR/.omc-config.json"
 if [ -f "$CONFIG_FILE" ]; then
   # POSIX-safe extraction without requiring jq

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -27,6 +27,7 @@ import { writeFileSync, readFileSync, mkdirSync, existsSync, unlinkSync } from '
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
 // Resolve OMC package root: CLAUDE_PLUGIN_ROOT (plugin system) or derive from this script's location
@@ -309,13 +310,14 @@ function linkRalphTeam(directory, sessionId) {
 
 /**
  * Check if the team feature is enabled in Claude Code settings.
- * Reads ~/.claude/settings.json and checks for CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env var.
+ * Reads settings.json from [$CLAUDE_CONFIG_DIR|~/.claude] and checks for
+ * CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env var.
  * @returns {boolean} true if team feature is enabled
  */
 function isTeamEnabled() {
   try {
     // Check settings.json first (authoritative, user-controlled)
-    const cfgDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+    const cfgDir = getClaudeConfigDir();
     const settingsPath = join(cfgDir, 'settings.json');
     if (existsSync(settingsPath)) {
       const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));

--- a/scripts/lib/config-dir.cjs
+++ b/scripts/lib/config-dir.cjs
@@ -1,0 +1,31 @@
+const { homedir } = require('node:os');
+const { join, normalize, parse, sep } = require('node:path');
+
+function stripTrailingSep(p) {
+  if (!p.endsWith(sep)) {
+    return p;
+  }
+
+  return p === parse(p).root ? p : p.slice(0, -1);
+}
+
+function getClaudeConfigDir() {
+  const home = homedir();
+  const configured = process.env.CLAUDE_CONFIG_DIR?.trim();
+
+  if (!configured) {
+    return stripTrailingSep(normalize(join(home, '.claude')));
+  }
+
+  if (configured === '~') {
+    return stripTrailingSep(normalize(home));
+  }
+
+  if (configured.startsWith('~/') || configured.startsWith('~\\')) {
+    return stripTrailingSep(normalize(join(home, configured.slice(2))));
+  }
+
+  return stripTrailingSep(normalize(configured));
+}
+
+module.exports = { getClaudeConfigDir };

--- a/scripts/lib/config-dir.mjs
+++ b/scripts/lib/config-dir.mjs
@@ -1,0 +1,29 @@
+import { homedir } from 'node:os';
+import { join, normalize, parse, sep } from 'node:path';
+
+function stripTrailingSep(p) {
+  if (!p.endsWith(sep)) {
+    return p;
+  }
+
+  return p === parse(p).root ? p : p.slice(0, -1);
+}
+
+export function getClaudeConfigDir() {
+  const home = homedir();
+  const configured = process.env.CLAUDE_CONFIG_DIR?.trim();
+
+  if (!configured) {
+    return stripTrailingSep(normalize(join(home, '.claude')));
+  }
+
+  if (configured === '~') {
+    return stripTrailingSep(normalize(home));
+  }
+
+  if (configured.startsWith('~/') || configured.startsWith('~\\')) {
+    return stripTrailingSep(normalize(join(home, configured.slice(2))));
+  }
+
+  return stripTrailingSep(normalize(configured));
+}

--- a/scripts/lib/config-dir.sh
+++ b/scripts/lib/config-dir.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+resolve_claude_config_dir() {
+  configured="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  configured="${configured%/}"
+  case "$configured" in
+    \~)
+      printf '%s\n' "$HOME"
+      ;;
+    \~/*)
+      configured="${configured#\~/}"
+      printf '%s/%s\n' "$HOME" "$configured"
+      ;;
+    *)
+      printf '%s\n' "$configured"
+      ;;
+  esac
+}

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -22,7 +22,7 @@ const {
   statSync,
 } = require("fs");
 const { join, dirname, resolve, normalize } = require("path");
-const { homedir } = require("os");
+const { getClaudeConfigDir } = require("./lib/config-dir.cjs");
 
 async function readStdin(timeoutMs = 2000) {
   return new Promise((resolve) => {
@@ -413,7 +413,7 @@ function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) return 0;
 
-  const cfgDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  const cfgDir = getClaudeConfigDir();
   const taskDir = join(cfgDir, "tasks", sessionId);
   if (!existsSync(taskDir)) return 0;
 
@@ -447,8 +447,7 @@ function countIncompleteTodos(sessionId, projectDir) {
     /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)
   ) {
     const sessionTodoPath = join(
-      homedir(),
-      ".claude",
+      getClaudeConfigDir(),
       "todos",
       `${sessionId}.json`,
     );

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -24,6 +24,7 @@ import {
 import { join, dirname, resolve, normalize } from "path";
 import { homedir } from "os";
 import { fileURLToPath, pathToFileURL } from "url";
+import { getClaudeConfigDir } from "./lib/config-dir.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -398,7 +399,7 @@ function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) return 0;
 
-  const cfgDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  const cfgDir = getClaudeConfigDir();
   const taskDir = join(cfgDir, "tasks", sessionId);
   if (!existsSync(taskDir)) return 0;
 
@@ -432,8 +433,7 @@ function countIncompleteTodos(sessionId, projectDir) {
     /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)
   ) {
     const sessionTodoPath = join(
-      homedir(),
-      ".claude",
+      getClaudeConfigDir(),
       "todos",
       `${sessionId}.json`,
     );

--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -5,19 +5,24 @@
  * Configures HUD statusline when plugin is installed.
  */
 
-import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, chmodSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, chmodSync, copyFileSync } from 'node:fs';
 import { execFileSync, execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const CLAUDE_DIR = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+const CLAUDE_DIR = getClaudeConfigDir();
 const HUD_DIR = join(CLAUDE_DIR, 'hud');
+const HUD_LIB_DIR = join(HUD_DIR, 'lib');
 const SETTINGS_FILE = join(CLAUDE_DIR, 'settings.json');
+// Use the absolute node binary path so nvm/fnm users don't get
+// "node not found" errors in non-interactive shells (issue #892).
+const nodeBin = process.execPath || 'node';
 
 console.log('[OMC] Running post-install setup...');
 
@@ -25,6 +30,11 @@ console.log('[OMC] Running post-install setup...');
 if (!existsSync(HUD_DIR)) {
   mkdirSync(HUD_DIR, { recursive: true });
 }
+
+if (!existsSync(HUD_LIB_DIR)) {
+  mkdirSync(HUD_LIB_DIR, { recursive: true });
+}
+copyFileSync(join(__dirname, 'lib', 'config-dir.mjs'), join(HUD_LIB_DIR, 'config-dir.mjs'));
 
 // 2. Create HUD wrapper script
 const hudScriptPath = join(HUD_DIR, 'omc-hud.mjs').replace(/\\/g, '/');
@@ -39,7 +49,11 @@ import { existsSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs")).href);
 
 // Semantic version comparison: returns negative if a < b, positive if a > b, 0 if equal
 function semverCompare(a, b) {
@@ -133,7 +147,7 @@ async function main() {
 
   // 1. Try plugin cache first (marketplace: omc, plugin: oh-my-claudecode)
   // Respect CLAUDE_CONFIG_DIR so installs under a custom config dir are found
-  const configDir = process.env.CLAUDE_CONFIG_DIR || join(home, ".claude");
+  const configDir = getClaudeConfigDir();
   const pluginCacheBase = join(configDir, "plugins", "cache", "omc", "oh-my-claudecode");
   if (existsSync(pluginCacheBase)) {
     try {
@@ -224,9 +238,6 @@ try {
     settings = JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8'));
   }
 
-  // Use the absolute node binary path so nvm/fnm users don't get
-  // "node not found" errors in non-interactive shells (issue #892).
-  const nodeBin = process.execPath || 'node';
   settings.statusLine = {
     type: 'command',
     command: `"${nodeBin}" "${hudScriptPath.replace(/\\/g, "/")}"`

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, ren
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
 const AGENT_OUTPUT_ANALYSIS_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_ANALYSIS_LIMIT || '12000', 10);
@@ -45,7 +46,7 @@ const debugLog = (...args) => {
 };
 
 // State file for session tracking
-const cfgDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+const cfgDir = getClaudeConfigDir();
 const STATE_FILE = join(cfgDir, '.session-stats.json');
 
 // Ensure state directory exists

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -9,8 +9,8 @@
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, renameSync, statSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { execSync } from 'child_process';
-import { homedir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
 // Inlined from src/config/models.ts — avoids a dist/ import so the hook works
@@ -139,7 +139,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
       const lastSep = transcriptPath.lastIndexOf('/');
       const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
       if (sessionFile) {
-        const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+        const configDir = getClaudeConfigDir();
         const projectsDir = join(configDir, 'projects');
         if (existsSync(projectsDir)) {
           const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
@@ -247,7 +247,8 @@ function getTodoStatus(directory) {
     }
   }
 
-  // NOTE: We intentionally do NOT scan the global ~/.claude/todos/ directory.
+  // NOTE: We intentionally do NOT scan the global
+  // [$CLAUDE_CONFIG_DIR|~/.claude]/todos/ directory.
   // That directory accumulates todo files from ALL past sessions across all
   // projects, causing phantom task counts in fresh sessions (see issue #354).
 
@@ -362,7 +363,7 @@ function generateAgentSpawnMessage(toolInput, directory, todoStatus, sessionId) 
       `Task(team_name="${teamName}", name="worker-N", subagent_type="${agentType}"). ` +
       `Do NOT use Task without team_name during an active team session. ` +
       `If TeamCreate is not available in your tools, tell the user to verify ` +
-      `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 is set in ~/.claude/settings.json and restart Claude Code.`;
+      'CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 is set in [$CLAUDE_CONFIG_DIR|~/.claude]/settings.json. Restart Claude Code.';
   }
 
   if (QUIET_LEVEL >= 2) return '';
@@ -455,7 +456,7 @@ function getSkillProtectionLevel(skillName, rawSkillName) {
 // Load OMC config to check forceInherit setting (issues #1135, #1201)
 function loadOmcConfig() {
   const configPaths = [
-    join(homedir(), '.claude', '.omc-config.json'),
+    join(getClaudeConfigDir(), '.omc-config.json'),
     join(process.cwd(), '.omc', 'config.json'),
   ];
   for (const configPath of configPaths) {

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -8,14 +8,14 @@
 
 import { existsSync, readFileSync, readdirSync, rmSync, mkdirSync, writeFileSync, symlinkSync, lstatSync, readlinkSync, unlinkSync, renameSync } from 'fs';
 import { join, dirname } from 'path';
-import { homedir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /** Claude config directory (respects CLAUDE_CONFIG_DIR env var) */
-const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+const configDir = getClaudeConfigDir();
 
 // Import timeout-protected stdin reader (prevents hangs on Linux/Windows, see issue #240, #524)
 let readStdin;
@@ -482,8 +482,10 @@ Treat this as prior-session context only. Prioritize the user's newest request, 
 `);
     }
 
-    // Check for incomplete todos (project-local only, not global ~/.claude/todos/)
-    // NOTE: We intentionally do NOT scan the global ~/.claude/todos/ directory.
+    // Check for incomplete todos (project-local only, not global
+    // [$CLAUDE_CONFIG_DIR|~/.claude]/todos/)
+    // NOTE: We intentionally do NOT scan the global
+    // [$CLAUDE_CONFIG_DIR|~/.claude]/todos/ directory.
     // That directory accumulates todo files from ALL past sessions across all
     // projects, causing phantom task counts in fresh sessions (see issue #354).
     const localTodoPaths = [

--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -13,13 +13,15 @@ INSTALL_STYLE="${2:-overwrite}"
 DOWNLOAD_URL="https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+. "$SCRIPT_DIR/lib/config-dir.sh"
 
 # Resolve active plugin root from installed_plugins.json.
 # Handles stale CLAUDE_PLUGIN_ROOT when a session was started before a plugin
 # update (e.g. 4.8.2 session invoking setup after updating to 4.9.0).
 # Same pattern as run.cjs resolveTarget() fallback.
 resolve_active_plugin_root() {
-  local config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+  local config_dir
+  config_dir="$(resolve_claude_config_dir)"
   local installed_plugins="${config_dir}/plugins/installed_plugins.json"
 
   if [ -f "$installed_plugins" ] && command -v jq >/dev/null 2>&1; then
@@ -89,7 +91,7 @@ EOF
 }
 
 # Determine target path
-CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CONFIG_DIR="$(resolve_claude_config_dir)"
 if [ "$MODE" = "local" ]; then
   mkdir -p .claude/skills/omc-reference
   TARGET_PATH=".claude/CLAUDE.md"

--- a/scripts/setup-progress.sh
+++ b/scripts/setup-progress.sh
@@ -8,8 +8,11 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib/config-dir.sh"
+
 STATE_FILE=".omc/state/setup-state.json"
-CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CONFIG_DIR="$(resolve_claude_config_dir)"
 CONFIG_FILE="$CONFIG_DIR/.omc-config.json"
 
 # Cross-platform ISO date to epoch conversion

--- a/scripts/skill-injector.mjs
+++ b/scripts/skill-injector.mjs
@@ -13,6 +13,7 @@
 import { existsSync, readdirSync, readFileSync, realpathSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { readStdin } from './lib/stdin.mjs';
 import { createRequire } from 'module';
 
@@ -26,7 +27,7 @@ try {
 }
 
 // Constants (used by fallback)
-const cfgDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+const cfgDir = getClaudeConfigDir();
 const USER_SKILLS_DIR = join(cfgDir, 'skills', 'omc-learned');
 const GLOBAL_SKILLS_DIR = join(homedir(), '.omc', 'skills');
 const PROJECT_SKILLS_SUBDIR = join('.omc', 'skills');

--- a/scripts/test-pr25.sh
+++ b/scripts/test-pr25.sh
@@ -18,6 +18,10 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/lib/config-dir.sh"
+CLAUDE_DIR="$(resolve_claude_config_dir)"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -188,23 +192,23 @@ if node dist/cli/index.js postinstall &> /tmp/pr25-postinstall.log; then
     log_pass "Installer postinstall succeeded"
 
     # Verify file exists
-    if [ -f "$HOME/.claude/agents/qa-tester.md" ]; then
-        log_pass "qa-tester.md installed to ~/.claude/agents/"
+    if [ -f "$CLAUDE_DIR/agents/qa-tester.md" ]; then
+        log_pass "qa-tester.md installed to $CLAUDE_DIR/agents/"
 
         # Verify content
-        if grep -q "tmux" "$HOME/.claude/agents/qa-tester.md"; then
+        if grep -q "tmux" "$CLAUDE_DIR/agents/qa-tester.md"; then
             log_pass "qa-tester.md contains tmux content"
         else
             log_fail "qa-tester.md missing tmux content"
         fi
 
-        if grep -q "Architect" "$HOME/.claude/agents/qa-tester.md"; then
+        if grep -q "Architect" "$CLAUDE_DIR/agents/qa-tester.md"; then
             log_pass "qa-tester.md contains Architect collaboration section"
         else
             log_fail "qa-tester.md missing Architect collaboration section"
         fi
     else
-        log_fail "qa-tester.md NOT installed to ~/.claude/agents/"
+        log_fail "qa-tester.md NOT installed to $CLAUDE_DIR/agents/"
     fi
 else
     log_fail "Installer postinstall failed"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -13,8 +13,11 @@ NC='\033[0m'
 echo -e "${BLUE}Oh-My-ClaudeCode Uninstaller${NC}"
 echo ""
 
-# Claude Code config directory (always ~/.claude)
-CLAUDE_CONFIG_DIR="$HOME/.claude"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib/config-dir.sh"
+
+# Claude Code config directory (defaults to ~/.claude)
+CLAUDE_CONFIG_DIR="$(resolve_claude_config_dir)"
 
 echo "This will remove ALL OMC components from:"
 echo "  $CLAUDE_CONFIG_DIR"

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -197,18 +197,18 @@ Use force mode to clear every session plus legacy artifacts via `state_clear`. D
 
 #### If Team Active (Claude Code native)
 
-Teams are detected by checking for config files in `~/.claude/teams/`:
+Teams are detected by checking for config files in `${CLAUDE_CONFIG_DIR:-~/.claude}/teams/`:
 
 ```bash
 # Check for active teams
-TEAM_CONFIGS=$(find ~/.claude/teams -name config.json -maxdepth 2 2>/dev/null)
+TEAM_CONFIGS=$(find "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/teams -name config.json -maxdepth 2 2>/dev/null)
 ```
 
 **Two-pass cancellation protocol:**
 
 **Pass 1: Graceful Shutdown**
 ```
-For each team found in ~/.claude/teams/:
+For each team found in ${CLAUDE_CONFIG_DIR:-~/.claude}/teams/:
   1. Read config.json to get team_name and members list
   2. For each non-lead member:
      a. Send shutdown_request via SendMessage
@@ -267,7 +267,7 @@ Team "{team_name}" cancelled:
 ```
 
 **Implementation note:** The cancel skill is executed by the LLM, not as a bash script. When you detect an active team:
-1. Read `~/.claude/teams/*/config.json` to find active teams
+1. Read `${CLAUDE_CONFIG_DIR:-~/.claude}/teams/*/config.json` to find active teams
 2. If multiple teams exist, cancel oldest first (by `createdAt`)
 3. For each non-lead member, call `SendMessage(type: "shutdown_request", recipient: member-name, content: "Cancelling")`
 4. Wait briefly for shutdown responses (15s per member timeout)

--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -43,12 +43,12 @@ Set up Telegram notifications so OMC can message you when sessions end, need inp
 
 ### How This Skill Works
 
-This is an interactive, natural-language configuration skill. Walk the user through setup by asking questions with AskUserQuestion. Write the result to `~/.claude/.omc-config.json`.
+This is an interactive, natural-language configuration skill. Walk the user through setup by asking questions with AskUserQuestion. Write the result to `${CLAUDE_CONFIG_DIR:-~/.claude}/.omc-config.json`.
 
 ### Step 1: Detect Existing Configuration
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 
 if [ -f "$CONFIG_FILE" ]; then
   HAS_TELEGRAM=$(jq -r '.notifications.telegram.enabled // false' "$CONFIG_FILE" 2>/dev/null)
@@ -151,7 +151,7 @@ Default selection: session-end + ask-user-question.
 Read the existing config, merge the new Telegram settings, and write back:
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
 if [ -f "$CONFIG_FILE" ]; then
@@ -269,12 +269,12 @@ Set up Discord notifications so OMC can ping you when sessions end, need input, 
 
 ### How This Skill Works
 
-This is an interactive, natural-language configuration skill. Walk the user through setup by asking questions with AskUserQuestion. Write the result to `~/.claude/.omc-config.json`.
+This is an interactive, natural-language configuration skill. Walk the user through setup by asking questions with AskUserQuestion. Write the result to `${CLAUDE_CONFIG_DIR:-~/.claude}/.omc-config.json`.
 
 ### Step 1: Detect Existing Configuration
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 
 if [ -f "$CONFIG_FILE" ]; then
   # Check for existing discord config
@@ -385,7 +385,7 @@ Use AskUserQuestion:
 Read the existing config, merge the new Discord settings, and write back:
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
 if [ -f "$CONFIG_FILE" ]; then
@@ -519,12 +519,12 @@ Set up Slack notifications so OMC can message you when sessions end, need input,
 
 ### How This Skill Works
 
-This is an interactive, natural-language configuration skill. Walk the user through setup by asking questions with AskUserQuestion. Write the result to `~/.claude/.omc-config.json`.
+This is an interactive, natural-language configuration skill. Walk the user through setup by asking questions with AskUserQuestion. Write the result to `${CLAUDE_CONFIG_DIR:-~/.claude}/.omc-config.json`.
 
 ### Step 1: Detect Existing Configuration
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 
 if [ -f "$CONFIG_FILE" ]; then
   HAS_SLACK=$(jq -r '.notifications.slack.enabled // false' "$CONFIG_FILE" 2>/dev/null)
@@ -645,7 +645,7 @@ Use AskUserQuestion:
 Read the existing config, merge the new Slack settings, and write back:
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
 if [ -f "$CONFIG_FILE" ]; then
@@ -792,7 +792,7 @@ If the trigger or argument contains "hook", "template", or "customize messages" 
 
 ### Step 1: Detect Existing Hook Config
 
-Check if `~/.claude/omc_config.hook.json` exists. If it does, show the current configuration. If not, explain what it does.
+Check if `${CLAUDE_CONFIG_DIR:-~/.claude}/omc_config.hook.json` exists. If it does, show the current configuration. If not, explain what it does.
 
 ```
 Hook event templates let you customize the notification messages sent to each platform.
@@ -879,7 +879,7 @@ If per-platform: ask for each enabled platform's template separately.
 
 ### Step 6: Write Configuration
 
-Read or create `~/.claude/omc_config.hook.json` and merge the new settings:
+Read or create `${CLAUDE_CONFIG_DIR:-~/.claude}/omc_config.hook.json` and merge the new settings:
 
 ```json
 {
@@ -953,7 +953,7 @@ If `~/.claude/omc_config.openclaw.json` exists, detect and offer migration:
 
 **Step 1: Detect Legacy Config**
 ```bash
-LEGACY_CONFIG="$HOME/.claude/omc_config.openclaw.json"
+LEGACY_CONFIG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/omc_config.openclaw.json"
 if [ -f "$LEGACY_CONFIG" ]; then
   echo "LEGACY_FOUND=true"
   # Check if already migrated

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -53,7 +53,7 @@ First, create the directory:
 node -e "require('fs').mkdirSync(require('path').join(process.env.CLAUDE_CONFIG_DIR||require('path').join(require('os').homedir(),'.claude'),'hud'),{recursive:true})"
 ```
 
-Then, use the Write tool to create `~/.claude/hud/omc-hud.mjs` with this exact content:
+Then, use the Write tool to create `${CLAUDE_CONFIG_DIR:-~/.claude}/hud/omc-hud.mjs` with this exact content:
 
 ```javascript
 #!/usr/bin/env node
@@ -151,7 +151,7 @@ node -e "if(process.platform==='win32'){console.log('Skipped (Windows)')}else{re
 
 **Step 4:** Update settings.json to use the HUD:
 
-Read `~/.claude/settings.json`, then update/add the `statusLine` field.
+Read `${CLAUDE_CONFIG_DIR:-~/.claude}/settings.json`, then update/add the `statusLine` field.
 
 **IMPORTANT:** Do not use `~` in the command. On Unix, use `$HOME` to keep the path portable across machines. On Windows, use an absolute path because Windows does not expand `~` in shell commands.
 
@@ -167,7 +167,7 @@ Then set the `statusLine` field. On Unix it should stay portable and look like:
 {
   "statusLine": {
     "type": "command",
-    "command": "node $HOME/.claude/hud/omc-hud.mjs"
+    "command": "node ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs"
   }
 }
 ```
@@ -329,7 +329,7 @@ If the HUD is not showing:
 {
   "statusLine": {
     "type": "command",
-    "command": "node $HOME/.claude/hud/omc-hud.mjs"
+    "command": "node ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs"
   }
 }
 ```

--- a/skills/learner/SKILL.md
+++ b/skills/learner/SKILL.md
@@ -109,7 +109,7 @@ This classification ensures expertise can be updated independently without desta
 
 ### Step 4: Save Location
 
-- **User-level**: ~/.claude/skills/omc-learned/ - Rare. Only for truly portable insights.
+- **User-level**: ${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/ - Rare. Only for truly portable insights.
 - **Project-level**: .omc/skills/ - Default. Version-controlled with repo.
 
 ### Skill Body Template

--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -27,10 +27,10 @@ npm view oh-my-claudecode version 2>/dev/null || echo "Latest: (unavailable)"
 
 ### Step 2: Check for Legacy Hooks in settings.json
 
-Read both `~/.claude/settings.json` (profile-level) and `./.claude/settings.json` (project-level) and check if there's a `"hooks"` key with entries like:
-- `bash $HOME/.claude/hooks/keyword-detector.sh`
-- `bash $HOME/.claude/hooks/persistent-mode.sh`
-- `bash $HOME/.claude/hooks/session-start.sh`
+Read both `${CLAUDE_CONFIG_DIR:-~/.claude}/settings.json` (profile-level) and `./.claude/settings.json` (project-level) and check if there's a `"hooks"` key with entries like:
+- `bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/keyword-detector.sh`
+- `bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/persistent-mode.sh`
+- `bash ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/session-start.sh`
 
 **Diagnosis**:
 - If found: CRITICAL - legacy hooks causing duplicates
@@ -38,7 +38,7 @@ Read both `~/.claude/settings.json` (profile-level) and `./.claude/settings.json
 ### Step 3: Check for Legacy Bash Hook Scripts
 
 ```bash
-ls -la ~/.claude/hooks/*.sh 2>/dev/null
+ls -la "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/*.sh 2>/dev/null
 ```
 
 **Diagnosis**:
@@ -48,19 +48,19 @@ ls -la ~/.claude/hooks/*.sh 2>/dev/null
 
 ```bash
 # Check if CLAUDE.md exists
-ls -la ~/.claude/CLAUDE.md 2>/dev/null
+ls -la "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/CLAUDE.md 2>/dev/null
 
 # Check for OMC markers (<!-- OMC:START --> is the canonical marker)
-grep -q "<!-- OMC:START -->" ~/.claude/CLAUDE.md 2>/dev/null && echo "Has OMC config" || echo "Missing OMC config in CLAUDE.md"
+grep -q "<!-- OMC:START -->" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" 2>/dev/null && echo "Has OMC config" || echo "Missing OMC config in CLAUDE.md"
 
 # Check companion files for file-split pattern (e.g. CLAUDE-omc.md)
-find "$HOME/.claude" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null
+find "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null
 while IFS= read -r f; do
   grep -q "<!-- OMC:START -->" "$f" 2>/dev/null && echo "Has OMC config in companion: $f"
-done < <(find "$HOME/.claude" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null)
+done < <(find "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null)
 
 # Check if CLAUDE.md references a companion file
-grep -o "CLAUDE-[^ )]*\.md" ~/.claude/CLAUDE.md 2>/dev/null
+grep -o "CLAUDE-[^ )]*\.md" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" 2>/dev/null
 ```
 
 **Diagnosis**:
@@ -86,13 +86,13 @@ Check for legacy agents, commands, and skills installed via curl (before plugin 
 
 ```bash
 # Check for legacy agents directory
-ls -la ~/.claude/agents/ 2>/dev/null
+ls -la "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/agents/ 2>/dev/null
 
 # Check for legacy commands directory
-ls -la ~/.claude/commands/ 2>/dev/null
+ls -la "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/commands/ 2>/dev/null
 
 # Check for legacy skills directory
-ls -la ~/.claude/skills/ 2>/dev/null
+ls -la "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/skills/ 2>/dev/null
 ```
 
 **Diagnosis**:
@@ -152,14 +152,14 @@ If issues found, ask user: "Would you like me to fix these issues automatically?
 If yes, apply fixes:
 
 ### Fix: Legacy Hooks in settings.json
-Remove the `"hooks"` section from `~/.claude/settings.json` (keep other settings intact)
+Remove the `"hooks"` section from `${CLAUDE_CONFIG_DIR:-~/.claude}/settings.json` (keep other settings intact)
 
 ### Fix: Legacy Bash Scripts
 ```bash
-rm -f ~/.claude/hooks/keyword-detector.sh
-rm -f ~/.claude/hooks/persistent-mode.sh
-rm -f ~/.claude/hooks/session-start.sh
-rm -f ~/.claude/hooks/stop-continuation.sh
+rm -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/keyword-detector.sh
+rm -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/persistent-mode.sh
+rm -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/session-start.sh
+rm -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/hooks/stop-continuation.sh
 ```
 
 ### Fix: Outdated Plugin
@@ -175,7 +175,7 @@ node -e "const p=require('path'),f=require('fs'),h=require('os').homedir(),d=pro
 ```
 
 ### Fix: Missing/Outdated CLAUDE.md
-Fetch latest from GitHub and write to `~/.claude/CLAUDE.md`:
+Fetch latest from GitHub and write to `${CLAUDE_CONFIG_DIR:-~/.claude}/CLAUDE.md`:
 ```
 WebFetch(url: "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md", prompt: "Return the complete raw markdown content exactly as-is")
 ```
@@ -186,14 +186,14 @@ Remove legacy agents, commands, and skills directories (now provided by plugin):
 
 ```bash
 # Backup first (optional - ask user)
-# mv ~/.claude/agents ~/.claude/agents.bak
-# mv ~/.claude/commands ~/.claude/commands.bak
-# mv ~/.claude/skills ~/.claude/skills.bak
+# mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/agents "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/agents.bak
+# mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/commands "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/commands.bak
+# mv "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/skills "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/skills.bak
 
 # Or remove directly
-rm -rf ~/.claude/agents
-rm -rf ~/.claude/commands
-rm -rf ~/.claude/skills
+rm -rf "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/agents
+rm -rf "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/commands
+rm -rf "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/skills
 ```
 
 **Note**: Only remove if these contain oh-my-claudecode-related files. If user has custom agents/commands/skills, warn them and ask before removing.

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -88,7 +88,7 @@ For more info: https://github.com/Yeachan-Heo/oh-my-claudecode
 
 ```bash
 # Check if setup was already completed
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 
 if [ -f "$CONFIG_FILE" ]; then
   SETUP_COMPLETED=$(jq -r '.setupCompleted // empty' "$CONFIG_FILE" 2>/dev/null)

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -80,7 +80,7 @@ Use the AskUserQuestion tool to prompt the user:
 Store the preference in `~/.claude/.omc-config.json`:
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
 if [ -f "$CONFIG_FILE" ]; then
@@ -189,7 +189,7 @@ If beads or beads-rust is detected, use AskUserQuestion:
 Store the preference:
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
 if [ -f "$CONFIG_FILE" ]; then

--- a/skills/omc-setup/phases/03-integrations.md
+++ b/skills/omc-setup/phases/03-integrations.md
@@ -5,7 +5,7 @@
 ## Step 3.1: Verify Plugin Installation
 
 ```bash
-grep -q "oh-my-claudecode" ~/.claude/settings.json && echo "Plugin verified" || echo "Plugin NOT found - run: claude /install-plugin oh-my-claudecode"
+grep -q "oh-my-claudecode" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json" && echo "Plugin verified" || echo "Plugin NOT found - run: claude /install-plugin oh-my-claudecode"
 ```
 
 ## Step 3.2: Offer MCP Server Configuration
@@ -44,7 +44,7 @@ Use AskUserQuestion:
 First, read the current settings.json:
 
 ```bash
-SETTINGS_FILE="$HOME/.claude/settings.json"
+SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 
 if [ -f "$SETTINGS_FILE" ]; then
   echo "Current settings.json found"
@@ -54,12 +54,12 @@ else
 fi
 ```
 
-Then use the Read tool to read `~/.claude/settings.json` (if it exists). Use the Edit tool to merge the teams configuration while preserving ALL existing settings.
+Then use the Read tool to read `${CLAUDE_CONFIG_DIR:-~/.claude}/settings.json` (if it exists). Use the Edit tool to merge the teams configuration while preserving ALL existing settings.
 
 Use jq to safely merge without overwriting existing settings:
 
 ```bash
-SETTINGS_FILE="$HOME/.claude/settings.json"
+SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 
 if [ -f "$SETTINGS_FILE" ]; then
   TEMP_FILE=$(mktemp)
@@ -94,7 +94,7 @@ Use AskUserQuestion:
 If user chooses anything other than "Auto", add `teammateMode` to settings.json:
 
 ```bash
-SETTINGS_FILE="$HOME/.claude/settings.json"
+SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 
 # TEAMMATE_MODE is "in-process" or "tmux" based on user choice
 # Skip this if user chose "Auto" (that's the default)
@@ -123,7 +123,7 @@ Use AskUserQuestion with multiple questions:
 Store the team configuration in `~/.claude/.omc-config.json`:
 
 ```bash
-CONFIG_FILE="$HOME/.claude/.omc-config.json"
+CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
 if [ -f "$CONFIG_FILE" ]; then
@@ -151,7 +151,7 @@ echo "  Model: teammates inherit your session model"
 After all modifications, verify settings.json is valid JSON and contains the expected keys:
 
 ```bash
-SETTINGS_FILE="$HOME/.claude/settings.json"
+SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 
 if jq empty "$SETTINGS_FILE" 2>/dev/null; then
   echo "settings.json: valid JSON"

--- a/skills/omc-setup/phases/04-welcome.md
+++ b/skills/omc-setup/phases/04-welcome.md
@@ -5,7 +5,7 @@
 Check if user has existing 2.x configuration:
 
 ```bash
-ls ~/.claude/commands/ralph-loop.md 2>/dev/null || ls ~/.claude/commands/ultrawork.md 2>/dev/null
+ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/commands/ralph-loop.md 2>/dev/null || ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/commands/ultrawork.md 2>/dev/null
 ```
 
 If found, this is an upgrade from 2.x. Set `IS_UPGRADE=true`.
@@ -178,8 +178,8 @@ Get the current OMC version and mark setup complete:
 OMC_VERSION=""
 if [ -f ".claude/CLAUDE.md" ]; then
   OMC_VERSION=$(grep -m1 'OMC:VERSION:' .claude/CLAUDE.md 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
-elif [ -f "$HOME/.claude/CLAUDE.md" ]; then
-  OMC_VERSION=$(grep -m1 'OMC:VERSION:' "$HOME/.claude/CLAUDE.md" 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
+elif [ -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" ]; then
+  OMC_VERSION=$(grep -m1 'OMC:VERSION:' "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
 fi
 if [ -z "$OMC_VERSION" ]; then
   OMC_VERSION=$(omc --version 2>/dev/null | head -1 || true)

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -17,7 +17,7 @@ Show all available skills organized by scope.
 
 **Behavior:**
 1. Scan bundled built-in skills in the plugin `skills/` directory (read-only)
-2. Scan user skills at `~/.claude/skills/omc-learned/`
+2. Scan user skills at `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/`
 3. Scan project skills at `.omc/skills/`
 4. Parse YAML frontmatter for metadata
 5. Display in organized table format:
@@ -61,7 +61,7 @@ Interactive wizard for creating a new skill.
 4. **Ask for argument hint** (optional)
    - Example: "<file> [options]"
 5. **Ask for scope:**
-   - `user` → `~/.claude/skills/omc-learned/<name>/SKILL.md`
+   - `user` → `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/<name>/SKILL.md`
    - `project` → `.omc/skills/<name>/SKILL.md`
 6. **Create skill file** with template:
 
@@ -127,13 +127,13 @@ Remove a skill by name.
 
 **Behavior:**
 1. **Search for skill** in both scopes:
-   - `~/.claude/skills/omc-learned/<name>/SKILL.md`
+   - `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/<name>/SKILL.md`
    - `.omc/skills/<name>/SKILL.md`
 2. **If found:**
    - Display skill info (name, description, scope)
    - **Ask for confirmation:** "Delete '<name>' skill from <scope>? (yes/no)"
 3. **If confirmed:**
-   - Delete entire skill directory (e.g., `~/.claude/skills/omc-learned/<name>/`)
+   - Delete entire skill directory (e.g., `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/<name>/`)
    - Report: "✓ Removed skill '<name>' from <scope>"
 4. **If not found:**
    - Report: "✗ Skill '<name>' not found in user or project scope"
@@ -300,7 +300,7 @@ Sync skills between user and project scopes.
 
 **Behavior:**
 1. **Scan both scopes:**
-   - User skills: `~/.claude/skills/omc-learned/`
+   - User skills: `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/`
    - Project skills: `.omc/skills/`
 2. **Compare and categorize:**
    - User-only skills (not in project)
@@ -370,7 +370,7 @@ First, check if skill directories exist and create them if needed:
 
 ```bash
 # Check and create user-level skills directory
-USER_SKILLS_DIR="$HOME/.claude/skills/omc-learned"
+USER_SKILLS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/omc-learned"
 if [ -d "$USER_SKILLS_DIR" ]; then
   echo "User skills directory exists: $USER_SKILLS_DIR"
 else
@@ -395,14 +395,14 @@ Scan both directories and show a comprehensive inventory:
 ```bash
 # Scan user-level skills
 echo "=== USER-LEVEL SKILLS (~/.claude/skills/omc-learned/) ==="
-if [ -d "$HOME/.claude/skills/omc-learned" ]; then
-  USER_COUNT=$(find "$HOME/.claude/skills/omc-learned" -name "*.md" 2>/dev/null | wc -l)
+if [ -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/omc-learned" ]; then
+  USER_COUNT=$(find "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/omc-learned" -name "*.md" 2>/dev/null | wc -l)
   echo "Total skills: $USER_COUNT"
 
   if [ $USER_COUNT -gt 0 ]; then
     echo ""
     echo "Skills found:"
-    find "$HOME/.claude/skills/omc-learned" -name "*.md" -type f -exec sh -c '
+    find "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/omc-learned" -name "*.md" -type f -exec sh -c '
       FILE="$1"
       NAME=$(grep -m1 "^name:" "$FILE" 2>/dev/null | sed "s/name: //")
       DESC=$(grep -m1 "^description:" "$FILE" 2>/dev/null | sed "s/description: //")

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -800,7 +800,7 @@ See Cancellation section below for details.
 
 If the lead crashes mid-run, the team skill should detect existing state and resume:
 
-1. Check `~/.claude/teams/` for teams matching the task slug
+1. Check `${CLAUDE_CONFIG_DIR:-~/.claude}/teams/` for teams matching the task slug
 2. If found, read `config.json` to discover active members
 3. Resume monitor mode instead of creating a duplicate team
 4. Call `TaskList` to determine current progress

--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -30,9 +30,8 @@ vi.mock('fs', async () => {
 
 import { execSync, execFileSync } from 'child_process';
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { homedir } from 'os';
 import { join } from 'path';
-import { install, isProjectScopedPlugin, checkNodeVersion } from '../installer/index.js';
+import { install, isProjectScopedPlugin, checkNodeVersion, CLAUDE_CONFIG_DIR } from '../installer/index.js';
 import * as hooksModule from '../installer/hooks.js';
 import {
   reconcileUpdateRuntime,
@@ -234,7 +233,7 @@ describe('auto-update reconciliation', () => {
 
   it('syncs the plugin cache directory when cache root exists', () => {
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const cacheRoot = join(homedir(), '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const cacheRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
     const versionedCacheRoot = `${cacheRoot}/4.9.0`;
 
     mockedExecSync.mockImplementation((command: string) => {
@@ -293,7 +292,7 @@ describe('auto-update reconciliation', () => {
   });
 
   it('skips plugin cache sync gracefully when cache dir does not exist', () => {
-    const cacheRoot = join(homedir(), '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const cacheRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
       if (normalized === cacheRoot) {
@@ -311,7 +310,7 @@ describe('auto-update reconciliation', () => {
 
   it('handles plugin cache sync errors non-fatally', () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const cacheRoot = join(homedir(), '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const cacheRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
     const versionedCacheRoot = `${cacheRoot}/4.9.0`;
 
     mockedExecSync.mockImplementation((command: string) => {
@@ -434,8 +433,8 @@ describe('auto-update reconciliation', () => {
   });
 
   it('allows standalone update when CLAUDE_PLUGIN_ROOT is inherited without an active Claude session', async () => {
-    const pluginRoot = join(homedir(), '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.1.5');
-    const cacheRoot = join(homedir(), '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const pluginRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.1.5');
+    const cacheRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
     process.env.OMC_UPDATE_RECONCILE = '1';
     process.env.CLAUDE_PLUGIN_ROOT = pluginRoot;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
@@ -884,7 +883,7 @@ describe('auto-update reconciliation', () => {
       },
     };
 
-    const settingsPath = join(homedir(), '.claude', 'settings.json');
+    const settingsPath = join(CLAUDE_CONFIG_DIR, 'settings.json');
     const baseHooks = hooksModule.getHooksSettingsConfig();
     const freshHooks = {
       ...baseHooks,
@@ -931,7 +930,7 @@ describe('auto-update reconciliation', () => {
     vi.spyOn(hooksModule, 'getHooksSettingsConfig').mockReturnValue(freshHooks);
 
     const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
-    process.env.CLAUDE_PLUGIN_ROOT = join(homedir(), '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.1.5');
+    process.env.CLAUDE_PLUGIN_ROOT = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.1.5');
 
     const result = install({
       force: true,

--- a/src/__tests__/cli-config-stop-callback.test.ts
+++ b/src/__tests__/cli-config-stop-callback.test.ts
@@ -191,4 +191,34 @@ describe('omc config-stop-callback tag options', () => {
     expect(show.stdout).toContain('"webhookUrl"');
     expect(show.stdout).toContain('"tagList"');
   });
+
+  it('uses CLAUDE_CONFIG_DIR for the default file callback path', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'omc-cli-stop-callback-home-'));
+    const claudeConfigDir = join(homeDir, '.claude-isolated-workspace');
+    const configPath = join(claudeConfigDir, '.omc-config.json');
+    mkdirSync(claudeConfigDir, { recursive: true });
+
+    writeFileSync(configPath, JSON.stringify({
+      silentAutoUpdate: false,
+      stopHookCallbacks: {},
+    }, null, 2));
+
+    const result = spawnSync(process.execPath, ['--import', 'tsx', CLI_ENTRY, 'config-stop-callback', 'file', '--enable'], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        CLAUDE_CONFIG_DIR: claudeConfigDir,
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+
+    const config = readConfig(configPath);
+    expect(config.stopHookCallbacks?.file).toEqual({
+      enabled: true,
+      path: join(claudeConfigDir, 'session-logs/{session_id}.md'),
+      format: 'markdown',
+    });
+  });
 });

--- a/src/__tests__/config-dir.test.ts
+++ b/src/__tests__/config-dir.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { basename, join, normalize } from 'path';
+import { getClaudeConfigDir } from '../utils/config-dir.js'
+import { isValidTranscriptPath } from '../lib/worktree-paths.js';
+import { findRuleFiles } from '../hooks/rules-injector/finder.js';
+
+const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+describe('getClaudeConfigDir', () => {
+  afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
+  });
+
+  it('falls back to ~/.claude when CLAUDE_CONFIG_DIR is unset', () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    expect(getClaudeConfigDir()).toBe(normalize(join(homedir(), '.claude')));
+  });
+
+  it('falls back to ~/.claude when CLAUDE_CONFIG_DIR is empty', () => {
+    process.env.CLAUDE_CONFIG_DIR = '   ';
+    expect(getClaudeConfigDir()).toBe(normalize(join(homedir(), '.claude')));
+  });
+
+  it('returns an absolute custom path unchanged aside from normalization', () => {
+    process.env.CLAUDE_CONFIG_DIR = join(tmpdir(), 'custom-claude-config', '..', 'custom-claude-config');
+    expect(getClaudeConfigDir()).toBe(normalize(join(tmpdir(), 'custom-claude-config', '..', 'custom-claude-config')));
+  });
+
+  it('expands a bare tilde to the home directory', () => {
+    process.env.CLAUDE_CONFIG_DIR = '~';
+    expect(getClaudeConfigDir()).toBe(normalize(homedir()));
+  });
+
+  it('expands a ~-prefixed config path', () => {
+    process.env.CLAUDE_CONFIG_DIR = '~/.claude-alt';
+    expect(getClaudeConfigDir()).toBe(normalize(join(homedir(), '.claude-alt')));
+  });
+
+  it('strips a trailing separator from custom paths', () => {
+    process.env.CLAUDE_CONFIG_DIR = join(tmpdir(), 'custom-claude-config') + '/';
+    expect(getClaudeConfigDir()).toBe(normalize(join(tmpdir(), 'custom-claude-config')));
+    expect(getClaudeConfigDir().endsWith('/')).toBe(false);
+  });
+
+  it('preserves a Windows drive root when trimming separators', async () => {
+    process.env.CLAUDE_CONFIG_DIR = 'C:\\';
+
+    vi.resetModules();
+    vi.doMock('node:os', () => ({
+      homedir: () => 'C:\\Users\\tester',
+    }));
+    vi.doMock('node:path', async () => import('node:path/win32'));
+
+    try {
+      const { getClaudeConfigDir: getWindowsConfigDir } = await import('../utils/config-dir.js');
+      expect(getWindowsConfigDir()).toBe('C:\\');
+    } finally {
+      vi.doUnmock('node:os');
+      vi.doUnmock('node:path');
+      vi.resetModules();
+    }
+  });
+
+  it('keeps the script helper aligned with the TypeScript helper', async () => {
+    process.env.CLAUDE_CONFIG_DIR = '~/.claude-alt';
+    const output = execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        "import { getClaudeConfigDir } from './scripts/lib/config-dir.mjs'; process.stdout.write(getClaudeConfigDir());",
+      ],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+        encoding: 'utf-8',
+      },
+    );
+    expect(output).toBe(normalize(join(homedir(), '.claude-alt')));
+  });
+
+  it('find-node.sh resolves a ~-prefixed CLAUDE_CONFIG_DIR before reading .omc-config.json', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'omc-find-node-home-'));
+    const configDir = join(homeDir, '.claude-alt');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, '.omc-config.json'), JSON.stringify({ nodeBinary: process.execPath }));
+
+    const output = execFileSync(
+      '/bin/sh',
+      [join(process.cwd(), 'scripts', 'find-node.sh'), '-e', "process.stdout.write('ok')"],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          PATH: '/bin:/usr/bin',
+          CLAUDE_CONFIG_DIR: '~/.claude-alt',
+        },
+        encoding: 'utf-8',
+      },
+    );
+
+    expect(output).toBe('ok');
+  });
+
+  it('shared shell helper expands a ~-prefixed CLAUDE_CONFIG_DIR', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'omc-uninstall-home-'));
+    const output = execFileSync('bash', ['-lc', `. "${join(process.cwd(), 'scripts', 'lib', 'config-dir.sh')}"; resolve_claude_config_dir`], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        CLAUDE_CONFIG_DIR: '~/.claude-alt',
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(output.trim()).toBe(join(homeDir, '.claude-alt'));
+  });
+
+  it('keeps the CJS helper aligned with the TypeScript helper', () => {
+    process.env.CLAUDE_CONFIG_DIR = '~/.claude-alt';
+    const cjsPath = join(process.cwd(), 'scripts', 'lib', 'config-dir.cjs');
+    const output = execFileSync(
+      process.execPath,
+      ['-e', `const { getClaudeConfigDir } = require(${JSON.stringify(cjsPath)}); process.stdout.write(getClaudeConfigDir());`],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+        encoding: 'utf-8',
+      },
+    );
+    expect(output).toBe(normalize(join(homedir(), '.claude-alt')));
+  });
+});
+
+describe('CLAUDE_CONFIG_DIR downstream integration', () => {
+  let origConfigDir: string | undefined;
+  let tempDir: string;
+  let tildeConfigDir: string;
+
+  beforeEach(() => {
+    origConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    tempDir = join(tmpdir(), `omc-test-configdir-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    tildeConfigDir = join(homedir(), `.omc-test-configdir-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (origConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = origConfigDir;
+    }
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+    try {
+      rmSync(tildeConfigDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('accepts transcript paths under custom CLAUDE_CONFIG_DIR', () => {
+    process.env.CLAUDE_CONFIG_DIR = '/opt/custom-claude-config';
+    const transcriptPath = '/opt/custom-claude-config/projects/-foo/bar/session.jsonl';
+    expect(isValidTranscriptPath(transcriptPath)).toBe(true);
+  });
+
+  it('accepts transcript paths when CLAUDE_CONFIG_DIR uses a ~-prefixed path', () => {
+    process.env.CLAUDE_CONFIG_DIR = `~/${basename(tildeConfigDir)}`;
+    const transcriptPath = join(tildeConfigDir, 'projects', '-foo', 'bar', 'session.jsonl');
+    expect(isValidTranscriptPath(transcriptPath)).toBe(true);
+  });
+
+  it('discovers user rules from custom CLAUDE_CONFIG_DIR/rules', () => {
+    const customRulesDir = join(tempDir, 'rules');
+    mkdirSync(customRulesDir, { recursive: true });
+    writeFileSync(join(customRulesDir, 'my-rule.md'), '# My Rule\nRule content');
+
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+
+    const candidates = findRuleFiles(null, '/some/file.ts');
+    const globalRules = candidates.filter(c => c.isGlobal);
+
+    expect(globalRules.length).toBeGreaterThanOrEqual(1);
+    expect(globalRules.some(c => c.path.includes('my-rule.md'))).toBe(true);
+  });
+
+  it('uses the active config dir rather than default ~/.claude/rules for user rules', () => {
+    const customRulesDir = join(tempDir, 'rules');
+    mkdirSync(customRulesDir, { recursive: true });
+    writeFileSync(join(customRulesDir, 'custom-rule.md'), '# Custom Rule');
+
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+
+    const candidates = findRuleFiles(null, '/some/file.ts');
+    const globalRules = candidates.filter(c => c.isGlobal);
+
+    expect(globalRules.some(c => c.path.includes('custom-rule.md'))).toBe(true);
+  });
+
+  it('discovers user rules when CLAUDE_CONFIG_DIR uses a ~-prefixed path', () => {
+    const customRulesDir = join(tildeConfigDir, 'rules');
+    mkdirSync(customRulesDir, { recursive: true });
+    writeFileSync(join(customRulesDir, 'tilde-rule.md'), '# Tilde Rule');
+
+    process.env.CLAUDE_CONFIG_DIR = `~/${basename(tildeConfigDir)}`;
+
+    const candidates = findRuleFiles(null, '/some/file.ts');
+    const globalRules = candidates.filter(c => c.isGlobal);
+
+    expect(globalRules.some(c => c.path.includes('tilde-rule.md'))).toBe(true);
+  });
+});

--- a/src/__tests__/delegation-enforcement-levels.test.ts
+++ b/src/__tests__/delegation-enforcement-levels.test.ts
@@ -6,7 +6,8 @@
  * processPreToolUse integration in bridge.ts
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
 import {
   processOrchestratorPreTool,
   isAllowedPath,
@@ -55,11 +56,23 @@ const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
 
 describe('delegation-enforcement-levels', () => {
+  const savedConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
   beforeEach(() => {
     vi.clearAllMocks();
     clearEnforcementCache();
+    // Ensure tests use the mocked homedir, not a custom CLAUDE_CONFIG_DIR
+    delete process.env.CLAUDE_CONFIG_DIR;
     // Default: no config files exist
     mockExistsSync.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    if (savedConfigDir !== undefined) {
+      process.env.CLAUDE_CONFIG_DIR = savedConfigDir;
+    } else {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    }
   });
 
   // ─── 1. suggestAgentForFile (tested indirectly via warning messages) ───
@@ -583,6 +596,36 @@ describe('delegation-enforcement-levels', () => {
 
     it('returns true for .claude/ paths', () => {
       expect(isAllowedPath('.claude/settings.json')).toBe(true);
+    });
+
+    it('returns true for absolute paths under CLAUDE_CONFIG_DIR', () => {
+      const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+      process.env.CLAUDE_CONFIG_DIR = '/custom/claude-config';
+      try {
+        expect(isAllowedPath('/custom/claude-config/settings.json')).toBe(true);
+        expect(isAllowedPath('/custom/claude-config/agents/test.md')).toBe(true);
+      } finally {
+        if (originalConfigDir === undefined) {
+          delete process.env.CLAUDE_CONFIG_DIR;
+        } else {
+          process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+        }
+      }
+    });
+
+    it('returns true for absolute paths under a ~-prefixed CLAUDE_CONFIG_DIR', () => {
+      const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+      process.env.CLAUDE_CONFIG_DIR = '~/.claude-alt';
+      try {
+        expect(isAllowedPath(join('/mock/home', '.claude-alt', 'settings.json'))).toBe(true);
+        expect(isAllowedPath(join('/mock/home', '.claude-alt', 'agents', 'test.md'))).toBe(true);
+      } finally {
+        if (originalConfigDir === undefined) {
+          delete process.env.CLAUDE_CONFIG_DIR;
+        } else {
+          process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+        }
+      }
     });
 
     it('returns true for CLAUDE.md', () => {

--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -10,6 +10,12 @@ import { existsSync, mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+// vi.hoisted runs before vi.mock hoisting — safe to reference in mock factories
+const { TEST_DIRS } = vi.hoisted(() => {
+  const TEST_DIRS = { claudeDir: '', projectDir: '', projectClaudeDir: '' };
+  return { TEST_DIRS };
+});
+
 let TEST_CLAUDE_DIR = '';
 let TEST_PROJECT_DIR = '';
 let TEST_PROJECT_CLAUDE_DIR = '';
@@ -18,16 +24,13 @@ function resetTestDirs(): void {
   TEST_CLAUDE_DIR = mkdtempSync(join(tmpdir(), 'omc-doctor-conflicts-claude-'));
   TEST_PROJECT_DIR = mkdtempSync(join(tmpdir(), 'omc-doctor-conflicts-project-'));
   TEST_PROJECT_CLAUDE_DIR = join(TEST_PROJECT_DIR, '.claude');
+  TEST_DIRS.claudeDir = TEST_CLAUDE_DIR;
 }
 
 // Mock getClaudeConfigDir before importing the module under test
-vi.mock('../utils/paths.js', async () => {
-  const actual = await vi.importActual<typeof import('../utils/paths.js')>('../utils/paths.js');
-  return {
-    ...actual,
-    getClaudeConfigDir: () => TEST_CLAUDE_DIR,
-  };
-});
+vi.mock('../utils/config-dir.js', () => ({
+  getClaudeConfigDir: () => TEST_DIRS.claudeDir,
+}));
 
 // Mock builtin skills to return a known list for testing
 vi.mock('../features/builtin-skills/skills.js', () => ({

--- a/src/__tests__/hud-api-key-source.test.ts
+++ b/src/__tests__/hud-api-key-source.test.ts
@@ -14,8 +14,8 @@ vi.mock('fs', () => ({
   readFileSync: vi.fn(),
 }));
 
-// Mock paths utility
-vi.mock('../utils/paths.js', () => ({
+// Mock config-dir utility
+vi.mock('../utils/config-dir.js', () => ({
   getClaudeConfigDir: vi.fn(() => '/home/user/.claude'),
 }));
 

--- a/src/__tests__/hud-marketplace-resolution.test.ts
+++ b/src/__tests__/hud-marketplace-resolution.test.ts
@@ -38,6 +38,7 @@ describe('HUD marketplace resolution', () => {
 
     const hudScriptPath = join(configDir, 'hud', 'omc-hud.mjs');
     expect(existsSync(hudScriptPath)).toBe(true);
+    expect(existsSync(join(configDir, 'hud', 'lib', 'config-dir.mjs'))).toBe(true);
 
     const settings = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8')) as {
       statusLine?: { command?: string };
@@ -46,7 +47,8 @@ describe('HUD marketplace resolution', () => {
     expect(existsSync(join(configDir, '.omc-config.json'))).toBe(true);
 
     const content = readFileSync(hudScriptPath, 'utf-8');
-    expect(content).toContain('import { pathToFileURL } from "node:url"');
+    expect(content).toContain('import { fileURLToPath, pathToFileURL } from "node:url"');
+    expect(content).toContain('const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs")).href);');
     expect(content).toContain('await import(pathToFileURL(pluginPath).href);');
     expect(content).toContain('await import(pathToFileURL(devPath).href);');
     expect(content).toContain('await import(pathToFileURL(marketplaceHudPath).href);');

--- a/src/__tests__/hud-windows.test.ts
+++ b/src/__tests__/hud-windows.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { getPluginCacheBase, getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
+import { getPluginCacheBase } from '../utils/paths.js';
 
 /**
  * HUD Windows Compatibility Tests
@@ -47,7 +48,7 @@ describe('HUD Windows Compatibility', () => {
       const content = readFileSync(installerPath, 'utf-8');
 
       // Should have pathToFileURL import in the generated script
-      expect(content).toContain('import { pathToFileURL } from "node:url"');
+      expect(content).toContain('pathToFileURL } from "node:url"');
     });
 
     it('installer HUD script should use pathToFileURL for dev path import', () => {
@@ -173,7 +174,7 @@ describe('HUD Windows Compatibility', () => {
       const content = readFileSync(setupPath, 'utf-8');
 
       // Should import pathToFileURL
-      expect(content).toContain('import { pathToFileURL } from "node:url"');
+      expect(content).toContain('pathToFileURL } from "node:url"');
       // Should use pathToFileURL for the dynamic import
       expect(content).toContain('pathToFileURL(pluginPath).href');
     });
@@ -182,8 +183,8 @@ describe('HUD Windows Compatibility', () => {
       const setupPath = join(packageRoot, 'scripts', 'plugin-setup.mjs');
       const content = readFileSync(setupPath, 'utf-8');
 
-      // Should use CLAUDE_CONFIG_DIR env var for cross-platform compat (#897)
-      expect(content).toContain('process.env.CLAUDE_CONFIG_DIR');
+      // Should use getClaudeConfigDir() which reads CLAUDE_CONFIG_DIR internally (#897)
+      expect(content).toContain('getClaudeConfigDir()');
       // Should use join() with configDir for path construction
       expect(content).toContain('join(configDir,');
     });
@@ -199,7 +200,7 @@ describe('HUD Windows Compatibility', () => {
       // Should use path.join for constructing paths
       expect(content).toContain("p.join(d,'plugins','cache','omc','oh-my-claudecode')");
       expect(content).not.toContain('ls ~/.claude/CLAUDE-*.md');
-      expect(content).toContain("find \"$HOME/.claude\" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null");
+      expect(content).toContain("find \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\" -maxdepth 1 -type f -name 'CLAUDE-*.md' -print 2>/dev/null");
     });
 
     it('hud skill should use cross-platform Node.js commands for plugin detection', () => {

--- a/src/__tests__/hud/cli-diagnostic.test.ts
+++ b/src/__tests__/hud/cli-diagnostic.test.ts
@@ -92,7 +92,7 @@ describe('HUD CLI diagnostic (no stdin, no watch mode)', () => {
       resolveTranscriptPath: vi.fn((tp?: string) => tp),
       getOmcRoot: vi.fn(() => '/tmp/.omc'),
     }));
-    vi.doMock('../../utils/paths.js', () => ({
+    vi.doMock('../../utils/config-dir.js', () => ({
       getClaudeConfigDir: vi.fn(() => overrides.configDir ?? tempConfigDir),
     }));
 

--- a/src/__tests__/hud/usage-api-lock.test.ts
+++ b/src/__tests__/hud/usage-api-lock.test.ts
@@ -74,7 +74,7 @@ describe('getUsage lock failure fallback', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
-    vi.unmock('../../utils/paths.js');
+    vi.unmock('../../utils/config-dir.js');
     vi.unmock('../../utils/ssrf-guard.js');
     vi.unmock('fs');
     vi.unmock('child_process');
@@ -104,7 +104,7 @@ describe('getUsage lock failure fallback', () => {
       return originalKill.call(process, pid, signal);
     }) as typeof process.kill;
 
-    vi.doMock('../../utils/paths.js', () => ({
+    vi.doMock('../../utils/config-dir.js', () => ({
       getClaudeConfigDir: () => CLAUDE_CONFIG_DIR,
     }));
     vi.doMock('../../utils/ssrf-guard.js', () => ({
@@ -151,7 +151,7 @@ describe('getUsage lock failure fallback', () => {
       return originalKill.call(process, pid, signal);
     }) as typeof process.kill;
 
-    vi.doMock('../../utils/paths.js', () => ({
+    vi.doMock('../../utils/config-dir.js', () => ({
       getClaudeConfigDir: () => CLAUDE_CONFIG_DIR,
     }));
     vi.doMock('../../utils/ssrf-guard.js', () => ({
@@ -193,7 +193,7 @@ describe('getUsage lock behavior', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
-    vi.unmock('../../utils/paths.js');
+    vi.unmock('../../utils/config-dir.js');
     vi.unmock('../../utils/ssrf-guard.js');
     vi.unmock('fs');
     vi.unmock('child_process');
@@ -213,7 +213,7 @@ describe('getUsage lock behavior', () => {
     const { files, fsModule } = createFsMock({ [CACHE_PATH]: expiredCache });
     let requestSawLock = false;
 
-    vi.doMock('../../utils/paths.js', () => ({
+    vi.doMock('../../utils/config-dir.js', () => ({
       getClaudeConfigDir: () => CLAUDE_CONFIG_DIR,
     }));
     vi.doMock('../../utils/ssrf-guard.js', () => ({

--- a/src/__tests__/hud/usage-api-stale.test.ts
+++ b/src/__tests__/hud/usage-api-stale.test.ts
@@ -70,7 +70,7 @@ function createFsMock(initialFiles: Record<string, string>) {
 }
 
 function setupMocks(fsModule: ReturnType<typeof createFsMock>['fsModule'], httpStatus: number, httpBody: string) {
-  vi.doMock('../../utils/paths.js', () => ({
+  vi.doMock('../../utils/config-dir.js', () => ({
     getClaudeConfigDir: () => CLAUDE_CONFIG_DIR,
   }));
   vi.doMock('../../utils/ssrf-guard.js', () => ({
@@ -117,7 +117,7 @@ describe('usage API stale data handling', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
-    vi.unmock('../../utils/paths.js');
+    vi.unmock('../../utils/config-dir.js');
     vi.unmock('../../utils/ssrf-guard.js');
     vi.unmock('fs');
     vi.unmock('child_process');

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -2,6 +2,7 @@
  * Tests for z.ai host validation, response parsing, and getUsage routing.
  */
 
+import { createHash } from 'crypto';
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as childProcess from 'child_process';
@@ -201,6 +202,8 @@ describe('getUsage routing', () => {
   const originalEnv = { ...process.env };
   const originalPlatform = process.platform;
   let httpsModule: { default: { request: ReturnType<typeof vi.fn> } };
+  const expectedServiceName = (configDir: string) =>
+    `Claude Code-credentials-${createHash('sha256').update(configDir).digest('hex').slice(0, 8)}`;
 
   beforeAll(() => {
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
@@ -233,6 +236,118 @@ describe('getUsage routing', () => {
     expect(result.error).toBe('no_credentials');
     // No network call should be made without credentials
     expect(httpsModule.default.request).not.toHaveBeenCalled();
+  });
+
+  it('uses the raw ~-prefixed CLAUDE_CONFIG_DIR value for Keychain service lookup', async () => {
+    process.env.CLAUDE_CONFIG_DIR = '~/.claude-personal';
+
+    const oneHourFromNow = Date.now() + 60 * 60 * 1000;
+    const execFileMock = vi.mocked(childProcess.execFileSync);
+    const username = os.userInfo().username;
+    const expectedService = expectedServiceName(process.env.CLAUDE_CONFIG_DIR);
+
+    execFileMock.mockImplementation((_file, args) => {
+      const argsArr = args as string[];
+      expect(argsArr).toContain('find-generic-password');
+      expect(argsArr).toContain('-s');
+      expect(argsArr).toContain(expectedService);
+
+      if (argsArr.includes('-a') && argsArr.includes(username)) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'raw-token',
+            refreshToken: 'raw-refresh',
+            expiresAt: oneHourFromNow,
+          },
+        });
+      }
+
+      throw new Error(`unexpected keychain lookup: ${JSON.stringify(argsArr)}`);
+    });
+
+    httpsModule.default.request.mockImplementationOnce((_options, callback) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void; on: typeof EventEmitter.prototype.on };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          five_hour: { utilization: 15 },
+          seven_day: { utilization: 35 },
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result).toEqual({
+      rateLimits: {
+        fiveHourPercent: 15,
+        weeklyPercent: 35,
+        fiveHourResetsAt: null,
+        weeklyResetsAt: null,
+      },
+    });
+    expect(execFileMock).toHaveBeenCalledOnce();
+  });
+
+  it('uses a different Keychain service when CLAUDE_CONFIG_DIR is already expanded', async () => {
+    process.env.CLAUDE_CONFIG_DIR = '/Users/test/.claude-personal';
+
+    const oneHourFromNow = Date.now() + 60 * 60 * 1000;
+    const execFileMock = vi.mocked(childProcess.execFileSync);
+    const username = os.userInfo().username;
+    const expectedService = expectedServiceName(process.env.CLAUDE_CONFIG_DIR);
+
+    execFileMock.mockImplementation((_file, args) => {
+      const argsArr = args as string[];
+      expect(argsArr).toContain('find-generic-password');
+      expect(argsArr).toContain('-s');
+      expect(argsArr).toContain(expectedService);
+
+      if (argsArr.includes('-a') && argsArr.includes(username)) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'expanded-token',
+            refreshToken: 'expanded-refresh',
+            expiresAt: oneHourFromNow,
+          },
+        });
+      }
+
+      throw new Error(`unexpected keychain lookup: ${JSON.stringify(argsArr)}`);
+    });
+
+    httpsModule.default.request.mockImplementationOnce((_options, callback) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void; on: typeof EventEmitter.prototype.on };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          five_hour: { utilization: 11 },
+          seven_day: { utilization: 22 },
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result).toEqual({
+      rateLimits: {
+        fiveHourPercent: 11,
+        weeklyPercent: 22,
+        fiveHourResetsAt: null,
+        weeklyResetsAt: null,
+      },
+    });
+    expect(execFileMock).toHaveBeenCalledOnce();
   });
 
   it('prefers the username-scoped keychain entry when the legacy service-only entry is expired', async () => {

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -14,7 +14,6 @@ import {
 import { getRuntimePackageVersion } from '../lib/version.js';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
-import { homedir } from 'os';
 import { readdirSync, readFileSync, existsSync, mkdtempSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 
@@ -376,13 +375,10 @@ describe('Installer Constants', () => {
 
   describe('File Paths', () => {
     it('should define valid directory paths', () => {
-      const expectedBase = join(homedir(), '.claude');
-
-      expect(CLAUDE_CONFIG_DIR).toBe(expectedBase);
-      expect(AGENTS_DIR).toBe(join(expectedBase, 'agents'));
-      expect(COMMANDS_DIR).toBe(join(expectedBase, 'commands'));
-      expect(SKILLS_DIR).toBe(join(expectedBase, 'skills'));
-      expect(HOOKS_DIR).toBe(join(expectedBase, 'hooks'));
+      expect(AGENTS_DIR).toBe(join(CLAUDE_CONFIG_DIR, 'agents'));
+      expect(COMMANDS_DIR).toBe(join(CLAUDE_CONFIG_DIR, 'commands'));
+      expect(SKILLS_DIR).toBe(join(CLAUDE_CONFIG_DIR, 'skills'));
+      expect(HOOKS_DIR).toBe(join(CLAUDE_CONFIG_DIR, 'hooks'));
     });
 
     it('should use absolute paths', () => {
@@ -539,7 +535,7 @@ describe('Installer Constants', () => {
 
     it('should return false for global plugin installation', () => {
       // Global plugins are under ~/.claude/plugins/
-      process.env.CLAUDE_PLUGIN_ROOT = join(homedir(), '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode', '3.9.0');
+      process.env.CLAUDE_PLUGIN_ROOT = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '3.9.0');
       expect(isProjectScopedPlugin()).toBe(false);
     });
 
@@ -562,7 +558,7 @@ describe('Installer Constants', () => {
     });
 
     it('should handle trailing slashes in paths', () => {
-      process.env.CLAUDE_PLUGIN_ROOT = join(homedir(), '.claude', 'plugins', 'cache', 'omc') + '/';
+      process.env.CLAUDE_PLUGIN_ROOT = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc') + '/';
       expect(isProjectScopedPlugin()).toBe(false);
     });
   });

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -15,7 +15,7 @@ vi.mock('fs', async () => {
 });
 
 vi.mock('../utils/config-dir.js', () => ({
-  getConfigDir: vi.fn(() => '/mock/.claude'),
+  getClaudeConfigDir: vi.fn(() => '/mock/.claude'),
 }));
 
 import { existsSync, readFileSync, readdirSync, statSync, rmSync } from 'fs';

--- a/src/__tests__/session-history-search.test.ts
+++ b/src/__tests__/session-history-search.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import { basename, join } from 'path';
 import {
   parseSinceSpec,
   searchSessionHistory,
@@ -18,14 +18,17 @@ function writeTranscript(filePath: string, entries: Array<Record<string, unknown
 
 describe('session history search', () => {
   const repoRoot = process.cwd();
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
   let tempRoot: string;
   let claudeDir: string;
   let otherProject: string;
+  let tildeClaudeDir: string;
 
   beforeEach(() => {
     tempRoot = mkdtempSync(join(tmpdir(), 'omc-session-search-'));
     claudeDir = join(tempRoot, 'claude');
     otherProject = join(tempRoot, 'other-project');
+    tildeClaudeDir = join(homedir(), `.omc-session-search-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     process.env.CLAUDE_CONFIG_DIR = claudeDir;
     process.env.OMC_STATE_DIR = join(tempRoot, 'omc-state');
 
@@ -71,9 +74,14 @@ describe('session history search', () => {
   });
 
   afterEach(() => {
-    delete process.env.CLAUDE_CONFIG_DIR;
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
     delete process.env.OMC_STATE_DIR;
     rmSync(tempRoot, { recursive: true, force: true });
+    rmSync(tildeClaudeDir, { recursive: true, force: true });
   });
 
   it('searches the current project by default and returns structured snippets', async () => {
@@ -122,6 +130,29 @@ describe('session history search', () => {
     expect(report.totalMatches).toBe(3);
     expect(report.results).toHaveLength(1);
     expect(report.results[0].sessionId).toBe('session-current');
+  });
+
+  it('uses a ~-prefixed CLAUDE_CONFIG_DIR for transcript discovery', async () => {
+    process.env.CLAUDE_CONFIG_DIR = `~/${basename(tildeClaudeDir)}`;
+
+    const tildeProjectDir = join(tildeClaudeDir, 'projects', encodeProjectPath(repoRoot));
+    writeTranscript(join(tildeProjectDir, 'session-tilde.jsonl'), [
+      {
+        sessionId: 'session-tilde',
+        cwd: repoRoot,
+        type: 'assistant',
+        timestamp: '2026-03-10T10:00:00.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'tilde config dir search hit' }] },
+      },
+    ]);
+
+    const report = await searchSessionHistory({
+      query: 'tilde config dir search hit',
+      workingDirectory: repoRoot,
+    });
+
+    expect(report.totalMatches).toBe(1);
+    expect(report.results[0].sessionId).toBe('session-tilde');
   });
 
   it('parses relative and absolute since values', () => {

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 
 const REPO_ROOT = join(__dirname, '..', '..');
 const SETUP_SCRIPT = join(REPO_ROOT, 'scripts', 'setup-claude-md.sh');
+const CONFIG_DIR_HELPER = join(REPO_ROOT, 'scripts', 'lib', 'config-dir.sh');
 
 const tempRoots: string[] = [];
 
@@ -26,13 +27,14 @@ function createPluginFixture(claudeMdContent: string) {
   const projectRoot = join(root, 'project');
   const homeRoot = join(root, 'home');
 
-  mkdirSync(join(pluginRoot, 'scripts'), { recursive: true });
+  mkdirSync(join(pluginRoot, 'scripts', 'lib'), { recursive: true });
   mkdirSync(join(pluginRoot, 'docs'), { recursive: true });
   mkdirSync(join(pluginRoot, 'skills', 'omc-reference'), { recursive: true });
   mkdirSync(projectRoot, { recursive: true });
   mkdirSync(homeRoot, { recursive: true });
 
   copyFileSync(SETUP_SCRIPT, join(pluginRoot, 'scripts', 'setup-claude-md.sh'));
+  copyFileSync(CONFIG_DIR_HELPER, join(pluginRoot, 'scripts', 'lib', 'config-dir.sh'));
   writeFileSync(join(pluginRoot, 'docs', 'CLAUDE.md'), claudeMdContent);
   writeFileSync(join(pluginRoot, 'skills', 'omc-reference', 'SKILL.md'), `---
 name: omc-reference
@@ -396,6 +398,8 @@ describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {
     mkdirSync(join(oldVersion, 'scripts'), { recursive: true });
     mkdirSync(join(oldVersion, 'docs'), { recursive: true });
     copyFileSync(SETUP_SCRIPT, join(oldVersion, 'scripts', 'setup-claude-md.sh'));
+    mkdirSync(join(oldVersion, 'scripts', 'lib'), { recursive: true });
+    copyFileSync(CONFIG_DIR_HELPER, join(oldVersion, 'scripts', 'lib', 'config-dir.sh'));
     writeFileSync(
       join(oldVersion, 'docs', 'CLAUDE.md'),
       `<!-- OMC:START -->\n<!-- OMC:VERSION:4.8.2 -->\n\n# Old Version\n<!-- OMC:END -->\n`,
@@ -467,6 +471,8 @@ describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {
     mkdirSync(join(oldVersion, 'scripts'), { recursive: true });
     mkdirSync(join(oldVersion, 'docs'), { recursive: true });
     copyFileSync(SETUP_SCRIPT, join(oldVersion, 'scripts', 'setup-claude-md.sh'));
+    mkdirSync(join(oldVersion, 'scripts', 'lib'), { recursive: true });
+    copyFileSync(CONFIG_DIR_HELPER, join(oldVersion, 'scripts', 'lib', 'config-dir.sh'));
     writeFileSync(
       join(oldVersion, 'docs', 'CLAUDE.md'),
       `<!-- OMC:START -->\n<!-- OMC:VERSION:4.8.2 -->\n\n# Old Version\n<!-- OMC:END -->\n`,
@@ -536,6 +542,8 @@ describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {
     mkdirSync(join(oldVersion, 'scripts'), { recursive: true });
     mkdirSync(join(oldVersion, 'docs'), { recursive: true });
     copyFileSync(SETUP_SCRIPT, join(oldVersion, 'scripts', 'setup-claude-md.sh'));
+    mkdirSync(join(oldVersion, 'scripts', 'lib'), { recursive: true });
+    copyFileSync(CONFIG_DIR_HELPER, join(oldVersion, 'scripts', 'lib', 'config-dir.sh'));
     writeFileSync(
       join(oldVersion, 'docs', 'CLAUDE.md'),
       `<!-- OMC:START -->\n<!-- OMC:VERSION:4.8.2 -->\n\n# Old\n<!-- OMC:END -->\n`,

--- a/src/__tests__/shared-memory.test.ts
+++ b/src/__tests__/shared-memory.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { basename, join } from 'path';
+import { homedir, tmpdir } from 'os';
 
 // Mock getOmcRoot to use our test directory
 const mockGetOmcRoot = vi.fn<(worktreeRoot?: string) => string>();
@@ -25,19 +25,31 @@ import {
 } from '../lib/shared-memory.js';
 
 describe('Shared Memory', () => {
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
   let testDir: string;
   let omcDir: string;
+  let tildeConfigDir: string;
 
   beforeEach(() => {
     testDir = join(tmpdir(), `shared-memory-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     omcDir = join(testDir, '.omc');
+    tildeConfigDir = join(homedir(), `.omc-test-shared-memory-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(omcDir, { recursive: true });
     mockGetOmcRoot.mockReturnValue(omcDir);
+    delete process.env.CLAUDE_CONFIG_DIR;
   });
 
   afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
     if (existsSync(testDir)) {
       rmSync(testDir, { recursive: true, force: true });
+    }
+    if (existsSync(tildeConfigDir)) {
+      rmSync(tildeConfigDir, { recursive: true, force: true });
     }
     vi.restoreAllMocks();
   });
@@ -368,6 +380,37 @@ describe('Shared Memory', () => {
   describe('isSharedMemoryEnabled', () => {
     it('should return true by default (no config file)', () => {
       expect(isSharedMemoryEnabled()).toBe(true);
+    });
+
+    it('should read config from the active CLAUDE_CONFIG_DIR', () => {
+      const claudeConfigDir = join(testDir, 'claude-config');
+      mkdirSync(claudeConfigDir, { recursive: true });
+      writeFileSync(join(claudeConfigDir, '.omc-config.json'), JSON.stringify({
+        agents: {
+          sharedMemory: {
+            enabled: false,
+          },
+        },
+      }));
+
+      process.env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+
+      expect(isSharedMemoryEnabled()).toBe(false);
+    });
+
+    it('should expand ~-prefixed CLAUDE_CONFIG_DIR values', () => {
+      mkdirSync(tildeConfigDir, { recursive: true });
+      writeFileSync(join(tildeConfigDir, '.omc-config.json'), JSON.stringify({
+        agents: {
+          sharedMemory: {
+            enabled: false,
+          },
+        },
+      }));
+
+      process.env.CLAUDE_CONFIG_DIR = `~/${basename(tildeConfigDir)}`;
+
+      expect(isSharedMemoryEnabled()).toBe(false);
     });
   });
 

--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import { isOmcHook } from '../../installer/index.js';
 import { colors } from '../utils/formatting.js';
 import { listBuiltinSkillNames } from '../../features/builtin-skills/skills.js';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,7 +13,9 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { join } from 'path';
 import { writeFileSync, existsSync } from 'fs';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import {
   loadConfig,
   getConfigPaths,
@@ -244,7 +246,7 @@ Profile types (use with --profile):
   webhook      Generic webhook (POST with JSON body)
 
 Examples:
-  $ omc config-stop-callback file --enable --path ~/.claude/logs/{date}.md
+  $ omc config-stop-callback file --enable --path ${join(getClaudeConfigDir(), 'logs/{date}.md')}
   $ omc config-stop-callback telegram --enable --token <token> --chat <id>
   $ omc config-stop-callback discord --enable --webhook <url>
   $ omc config-stop-callback file --disable
@@ -462,7 +464,7 @@ Examples:
         const current = config.stopHookCallbacks.file;
         config.stopHookCallbacks.file = {
           enabled: enabled ?? current?.enabled ?? false,
-          path: options.path ?? current?.path ?? '~/.claude/session-logs/{session_id}.md',
+          path: options.path ?? current?.path ?? join(getClaudeConfigDir(), 'session-logs/{session_id}.md'),
           format: (options.format as 'markdown' | 'json') ?? current?.format ?? 'markdown',
         };
         break;
@@ -841,19 +843,20 @@ Examples:
   });
 
 /**
- * Install command - Install agents and commands to ~/.claude/
+ * Install command - Install agents and commands (default: ~/.claude/)
  */
 program
   .command('install')
-  .description('Install OMC agents and commands to Claude Code config (~/.claude/)')
+  .description('Install OMC agents and commands to Claude Code config directory (default: ~/.claude/)')
   .option('-f, --force', 'Overwrite existing files')
   .option('-q, --quiet', 'Suppress output except for errors')
   .option('--skip-claude-check', 'Skip checking if Claude Code is installed')
   .addHelpText('after', `
 Examples:
-  $ omc install                  Install to ~/.claude/
+  $ omc install                  Install to config directory (default: ~/.claude/)
   $ omc install --force          Reinstall, overwriting existing files
-  $ omc install --quiet          Silent install for scripts`)
+  $ omc install --quiet          Silent install for scripts
+  $ CLAUDE_CONFIG_DIR=$HOME/.claude-isolated-workspace omc install  Isolated config directory`)
   .action(async (options) => {
     if (!options.quiet) {
       console.log(chalk.blue('╔═══════════════════════════════════════════════════════════╗'));
@@ -891,7 +894,7 @@ Examples:
         console.log(chalk.green('║         Installation Complete!                            ║'));
         console.log(chalk.green('╚═══════════════════════════════════════════════════════════╝'));
         console.log('');
-        console.log(chalk.gray(`Installed to: ~/.claude/`));
+        console.log(chalk.gray(`Installed to: ${getClaudeConfigDir()}`));
         console.log('');
         console.log(chalk.yellow('Usage:'));
         console.log('  claude                        # Start Claude Code normally');

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 
 export interface CommandInfo {
   name: string;

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -22,7 +22,7 @@ import {
   getInstalledOmcPluginRoots,
   getRuntimePackageRoot,
 } from '../installer/index.js';
-import { getConfigDir } from '../utils/config-dir.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { purgeStalePluginCacheVersions } from '../utils/paths.js';
 import type { NotificationConfig } from '../notifications/types.js';
 import { isAutoUpdateDisabled } from '../lib/security-config.js';
@@ -40,7 +40,7 @@ export const GITHUB_RAW_URL = `https://raw.githubusercontent.com/${REPO_OWNER}/$
  * and cache rebuilds reinstall old versions. (See #506)
  */
 function syncMarketplaceClone(verbose: boolean = false): { ok: boolean; message: string } {
-  const marketplacePath = join(getConfigDir(), 'plugins', 'marketplaces', 'omc');
+  const marketplacePath = join(getClaudeConfigDir(), 'plugins', 'marketplaces', 'omc');
   if (!existsSync(marketplacePath)) {
     return { ok: true, message: 'Marketplace clone not found; skipping' };
   }
@@ -211,7 +211,7 @@ export function shouldBlockStandaloneUpdateInCurrentSession(): boolean {
 }
 
 export function syncPluginCache(verbose: boolean = false): { synced: boolean; skipped: boolean; errors: string[] } {
-  const pluginCacheRoot = join(getConfigDir(), 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+  const pluginCacheRoot = join(getClaudeConfigDir(), 'plugins', 'cache', 'omc', 'oh-my-claudecode');
   if (!existsSync(pluginCacheRoot)) {
     return { synced: false, skipped: true, errors: [] };
   }
@@ -265,7 +265,7 @@ export function syncPluginCache(verbose: boolean = false): { synced: boolean; sk
 }
 
 /** Installation paths (respects CLAUDE_CONFIG_DIR env var) */
-export const CLAUDE_CONFIG_DIR = getConfigDir();
+export const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
 export const VERSION_FILE = join(CLAUDE_CONFIG_DIR, '.omc-version.json');
 export const CONFIG_FILE = join(CLAUDE_CONFIG_DIR, '.omc-config.json');
 

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -10,7 +10,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import { ConcurrencyManager } from './concurrency.js';
 import type {
   BackgroundTask,

--- a/src/features/session-history-search/index.ts
+++ b/src/features/session-history-search/index.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 import { createReadStream, existsSync, readdirSync, statSync } from 'fs';
-import { homedir } from 'os';
 import { dirname, join, normalize, resolve } from 'path';
 import { createInterface } from 'readline';
 import {
@@ -9,6 +8,7 @@ import {
   validateWorkingDirectory,
   getOmcRoot,
 } from '../../lib/worktree-paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import type {
   SessionHistoryMatch,
   SessionHistorySearchOptions,
@@ -31,10 +31,6 @@ interface SearchableEntry {
   role?: string;
   entryType?: string;
   texts: string[];
-}
-
-function getClaudeConfigDir(): string {
-  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
 }
 
 function compactWhitespace(text: string): string {

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -8,7 +8,7 @@
 
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join, basename } from 'path';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import type {
   ParsedSlashCommand,
   CommandInfo,
@@ -353,7 +353,7 @@ export function executeSlashCommand(parsed: ParsedSlashCommand): ExecuteResult {
   if (!command) {
     return {
       success: false,
-      error: `Command "/${parsed.command}" not found. Available commands are in $CLAUDE_CONFIG_DIR/commands/ (or ~/.claude/commands/ by default) or .claude/commands/`,
+      error: `Command "/${parsed.command}" not found. Available commands are in ${CLAUDE_CONFIG_DIR}/commands/ or .claude/commands/`,
     };
   }
 

--- a/src/hooks/autopilot/enforcement.ts
+++ b/src/hooks/autopilot/enforcement.ts
@@ -9,7 +9,7 @@
 
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { getClaudeConfigDir } from "../../utils/paths.js";
+import { getClaudeConfigDir } from "../../utils/config-dir.js";
 import {
   resolveAutopilotPlanPath,
   resolveOpenQuestionsPlanPath,

--- a/src/hooks/factcheck/__tests__/factcheck.test.ts
+++ b/src/hooks/factcheck/__tests__/factcheck.test.ts
@@ -7,8 +7,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { tmpdir, homedir } from 'os';
+import { tmpdir } from 'os';
 import { runChecks } from '../index.js';
+import { getClaudeConfigDir } from '../../../utils/config-dir.js';
 import type { FactcheckPolicy } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -20,7 +21,7 @@ function defaultPolicy(): FactcheckPolicy {
     enabled: true,
     mode: 'quick',
     strict_project_patterns: [],
-    forbidden_path_prefixes: [join(homedir(), '.claude/plugins/cache/omc/')],
+    forbidden_path_prefixes: [join(getClaudeConfigDir(), 'plugins/cache/omc/')],
     forbidden_path_substrings: ['/.omc/', '.omc-config.json'],
     readonly_command_prefixes: [
       'ls ', 'cat ', 'find ', 'grep ', 'head ', 'tail ', 'stat ', 'echo ', 'wc ',
@@ -111,7 +112,7 @@ describe('Factcheck Guard (issue #1155)', () => {
     const policy = defaultPolicy();
     const claims = baseClaims();
     (claims as Record<string, unknown>).files_created = [
-      join(homedir(), '.claude/plugins/cache/omc/touched.txt'),
+      join(getClaudeConfigDir(), 'plugins/cache/omc/touched.txt'),
     ];
 
     const result = runChecks(claims, 'declared', policy, '/tmp/original');
@@ -150,7 +151,7 @@ describe('Factcheck Guard (issue #1155)', () => {
   it('forbidden command in mutating context is FAIL', () => {
     const policy = defaultPolicy();
     const claims = baseClaims();
-    const forbiddenPath = join(homedir(), '.claude/plugins/cache/omc/');
+    const forbiddenPath = join(getClaudeConfigDir(), 'plugins/cache/omc/');
     (claims as Record<string, unknown>).commands_executed = [
       `rm -rf ${forbiddenPath}data`,
     ];
@@ -166,7 +167,7 @@ describe('Factcheck Guard (issue #1155)', () => {
   it('readonly command in forbidden path is allowed', () => {
     const policy = defaultPolicy();
     const claims = baseClaims();
-    const forbiddenPath = join(homedir(), '.claude/plugins/cache/omc/');
+    const forbiddenPath = join(getClaudeConfigDir(), 'plugins/cache/omc/');
     (claims as Record<string, unknown>).commands_executed = [
       `ls ${forbiddenPath}`,
       `cat ${forbiddenPath}file.txt`,

--- a/src/hooks/factcheck/config.ts
+++ b/src/hooks/factcheck/config.ts
@@ -7,6 +7,7 @@
 
 import { homedir } from 'os';
 import { loadConfig } from '../../config/loader.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import type { GuardsConfig, FactcheckPolicy, SentinelPolicy } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -17,7 +18,7 @@ const DEFAULT_FACTCHECK_POLICY: FactcheckPolicy = {
   enabled: false,
   mode: 'quick',
   strict_project_patterns: [],
-  forbidden_path_prefixes: ['${HOME}/.claude/plugins/cache/omc/'],
+  forbidden_path_prefixes: ['${CLAUDE_CONFIG_DIR}/plugins/cache/omc/'],
   forbidden_path_substrings: ['/.omc/', '.omc-config.json'],
   readonly_command_prefixes: [
     'ls ', 'cat ', 'find ', 'grep ', 'head ', 'tail ', 'stat ', 'echo ', 'wc ',
@@ -48,14 +49,15 @@ export const DEFAULT_GUARDS_CONFIG: GuardsConfig = {
 // ---------------------------------------------------------------------------
 
 /**
- * Expand ${HOME} and ${WORKSPACE} tokens in a string.
+ * Expand ${HOME}, ${WORKSPACE}, and ${CLAUDE_CONFIG_DIR} tokens in a string.
  */
 export function expandTokens(value: string, workspace?: string): string {
   const home = homedir();
   const ws = workspace ?? process.env.OMC_WORKSPACE ?? process.cwd();
   return value
     .replace(/\$\{HOME\}/g, home)
-    .replace(/\$\{WORKSPACE\}/g, ws);
+    .replace(/\$\{WORKSPACE\}/g, ws)
+    .replace(/\$\{CLAUDE_CONFIG_DIR\}/g, getClaudeConfigDir());
 }
 
 /**
@@ -113,7 +115,7 @@ function deepMergeGuards(
  * Load guards config from the OMC config system.
  *
  * Reads the `guards` key from the merged OMC config, deep-merges over
- * defaults, and expands ${HOME}/${WORKSPACE} tokens.
+ * defaults, and expands ${HOME}/${WORKSPACE}/${CLAUDE_CONFIG_DIR} tokens.
  */
 export function loadGuardsConfig(workspace?: string): GuardsConfig {
   try {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -159,7 +159,6 @@ export {
   PROJECT_MARKERS,
   PROJECT_RULE_SUBDIRS,
   PROJECT_RULE_FILES,
-  USER_RULE_DIR,
   RULE_EXTENSIONS,
   TRACKED_TOOLS,
   type RuleMetadata,
@@ -821,4 +820,3 @@ export {
   type CodeSimplifierConfig,
   type CodeSimplifierHookResult,
 } from './code-simplifier/index.js';
-

--- a/src/hooks/learner/auto-invoke.ts
+++ b/src/hooks/learner/auto-invoke.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import { atomicWriteJson } from '../../lib/atomic-write.js';
 
 export interface InvocationConfig {

--- a/src/hooks/learner/config.ts
+++ b/src/hooks/learner/config.ts
@@ -6,7 +6,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import { DEBUG_ENABLED } from './constants.js';
 
 export interface LearnerConfig {

--- a/src/hooks/learner/constants.ts
+++ b/src/hooks/learner/constants.ts
@@ -4,7 +4,7 @@
 
 import { join } from 'path';
 import { homedir } from 'os';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import { OmcPaths } from '../../lib/worktree-paths.js';
 
 /** User-level skills directory (read by skill-injector.mjs hook) */

--- a/src/hooks/omc-orchestrator/constants.ts
+++ b/src/hooks/omc-orchestrator/constants.ts
@@ -16,7 +16,7 @@ export const ALLOWED_PATH_PREFIX = '.omc/';
 export const ALLOWED_PATH_PATTERNS = [
   /^\.omc\//,                    // .omc/**
   /^\.claude\//,                 // .claude/** (local)
-  /^~?\/\.claude\//,             // ~/.claude/** (global)
+  /^~?\/\.claude\//,             // legacy ~/.claude/** references
   /\/\.claude\//,                // any /.claude/ path
   /CLAUDE\.md$/,                 // **/CLAUDE.md
   /AGENTS\.md$/,                 // **/AGENTS.md
@@ -104,7 +104,7 @@ As an ORCHESTRATOR, you MUST:
 
 **ALLOWED direct file operations:**
 - Files inside \`.omc/\` (plans, notepads, drafts)
-- Files inside \`~/.claude/\` (global config)
+- Files inside \`[$CLAUDE_CONFIG_DIR|~/.claude]/\`
 - \`CLAUDE.md\` and \`AGENTS.md\` files
 - Reading files for verification
 - Running diagnostics/tests

--- a/src/hooks/omc-orchestrator/index.ts
+++ b/src/hooks/omc-orchestrator/index.ts
@@ -10,8 +10,9 @@
 
 import * as path from 'path';
 import { execSync } from 'child_process';
-import { getOmcRoot } from '../../lib/worktree-paths.js';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getOmcRoot, getWorktreeRoot } from '../../lib/worktree-paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { toForwardSlash } from '../../utils/paths.js';
 import { existsSync, readFileSync } from 'fs';
 import {
   HOOK_NAME,
@@ -33,8 +34,6 @@ import {
   setPriorityContext,
 } from '../notepad/index.js';
 import { logAuditEntry } from './audit.js';
-import { getWorktreeRoot } from '../../lib/worktree-paths.js';
-import { toForwardSlash } from '../../utils/paths.js';
 
 // Re-export constants
 export * from './constants.js';
@@ -54,8 +53,8 @@ export function clearEnforcementCache(): void {
 }
 
 /**
- * Read enforcement level from config
- * Checks: .omc/config.json → ~/.claude/.omc-config.json → default (warn)
+ * Read enforcement level from config.
+ * Checks: .omc/config.json → [$CLAUDE_CONFIG_DIR|~/.claude]/.omc-config.json → default (warn)
  */
 function getEnforcementLevel(directory: string): EnforcementLevel {
   const now = Date.now();
@@ -137,6 +136,11 @@ export function isAllowedPath(filePath: string, directory?: string): boolean {
   if (ALLOWED_PATH_PATTERNS.some(pattern => pattern.test(normalized))) return true;
   // Absolute path: strip worktree root, then re-check
   if (path.isAbsolute(filePath)) {
+    const relToConfigDir = path.relative(getClaudeConfigDir(), filePath);
+    if (!relToConfigDir || (!relToConfigDir.startsWith('..') && !path.isAbsolute(relToConfigDir))) {
+      return true;
+    }
+
     const root = directory ? getWorktreeRoot(directory) : getWorktreeRoot();
     if (root) {
       const rel = toForwardSlash(path.relative(root, filePath));

--- a/src/hooks/permission-handler/index.ts
+++ b/src/hooks/permission-handler/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { getOmcRoot } from '../../lib/worktree-paths.js';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 export interface PermissionRequestInput {
   session_id: string;

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -14,7 +14,8 @@ import { existsSync, readFileSync, unlinkSync, statSync, openSync, readSync, clo
 import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
 import { join } from 'path';
 import { getHardMaxIterations } from '../../lib/security-config.js';
-import { getClaudeConfigDir, getGlobalOmcConfigCandidates } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { getGlobalOmcConfigCandidates } from '../../utils/paths.js';
 import {
   readUltraworkState,
   writeUltraworkState,

--- a/src/hooks/rules-injector/constants.ts
+++ b/src/hooks/rules-injector/constants.ts
@@ -38,9 +38,6 @@ export const PROJECT_RULE_FILES: string[] = [
 /** Pattern for GitHub instructions files */
 export const GITHUB_INSTRUCTIONS_PATTERN = /\.instructions\.md$/;
 
-/** User-level rule directory */
-export const USER_RULE_DIR = '.claude/rules';
-
 /** Valid rule file extensions */
 export const RULE_EXTENSIONS = ['.md', '.mdc'];
 

--- a/src/hooks/rules-injector/finder.ts
+++ b/src/hooks/rules-injector/finder.ts
@@ -1,7 +1,7 @@
 /**
  * Rules Finder
  *
- * Finds rule files in project directories and user home.
+ * Finds rule files in project directories and [$CLAUDE_CONFIG_DIR|~/.claude].
  *
  * Ported from oh-my-opencode's rules-injector hook.
  */
@@ -19,8 +19,8 @@ import {
   PROJECT_RULE_FILES,
   PROJECT_RULE_SUBDIRS,
   RULE_EXTENSIONS,
-  USER_RULE_DIR,
 } from './constants.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import type { RuleFileCandidate } from './types.js';
 
 /**
@@ -153,11 +153,10 @@ export function calculateDistance(
 /**
  * Find all rule files for a given context.
  * Searches from currentFile upward to projectRoot for rule directories,
- * then user-level directory (~/.claude/rules).
+ * then [$CLAUDE_CONFIG_DIR|~/.claude]/rules.
  */
 export function findRuleFiles(
   projectRoot: string | null,
-  homeDir: string,
   currentFile: string
 ): RuleFileCandidate[] {
   const candidates: RuleFileCandidate[] = [];
@@ -223,8 +222,8 @@ export function findRuleFiles(
     }
   }
 
-  // Search user-level rule directory (~/.claude/rules)
-  const userRuleDir = join(homeDir, USER_RULE_DIR);
+  // Search user-level rule directory
+  const userRuleDir = join(getClaudeConfigDir(), 'rules');
   const userFiles: string[] = [];
   findRuleFilesRecursive(userRuleDir, userFiles);
 

--- a/src/hooks/rules-injector/index.ts
+++ b/src/hooks/rules-injector/index.ts
@@ -3,13 +3,12 @@
  *
  * Automatically injects relevant rule files when Claude accesses files.
  * Supports project-level (.claude/rules, .github/instructions) and
- * user-level (~/.claude/rules) rule files.
+ * user-level rules under [$CLAUDE_CONFIG_DIR|~/.claude].
  *
  * Ported from oh-my-opencode's rules-injector hook.
  */
 
 import { readFileSync } from 'fs';
-import { homedir } from 'os';
 import { isAbsolute, relative, resolve } from 'path';
 import { findProjectRoot, findRuleFiles } from './finder.js';
 import {
@@ -77,9 +76,8 @@ export function createRulesInjectorHook(workingDirectory: string) {
 
     const projectRoot = findProjectRoot(resolved);
     const cache = getSessionCache(sessionId);
-    const home = homedir();
 
-    const ruleFileCandidates = findRuleFiles(projectRoot, home, resolved);
+    const ruleFileCandidates = findRuleFiles(projectRoot, resolved);
     const toInject: RuleToInject[] = [];
 
     for (const candidate of ruleFileCandidates) {
@@ -166,9 +164,8 @@ export function createRulesInjectorHook(workingDirectory: string) {
       if (!resolved) return [];
 
       const projectRoot = findProjectRoot(resolved);
-      const home = homedir();
 
-      const ruleFileCandidates = findRuleFiles(projectRoot, home, resolved);
+      const ruleFileCandidates = findRuleFiles(projectRoot, resolved);
       const rules: RuleToInject[] = [];
 
       for (const candidate of ruleFileCandidates) {

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -28,7 +28,7 @@ function debugLog(message: string, ...args: unknown[]): void {
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { getOmcRoot } from '../../lib/worktree-paths.js';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 /**
  * Validates that a session ID is safe to use in file paths.

--- a/src/hud/custom-rate-provider.ts
+++ b/src/hud/custom-rate-provider.ts
@@ -22,7 +22,7 @@
 import { spawn } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import type {
   RateLimitsProviderConfig,
   CustomBucket,

--- a/src/hud/elements/api-key-source.ts
+++ b/src/hud/elements/api-key-source.ts
@@ -12,7 +12,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { dim, cyan } from '../colors.js';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 export type ApiKeySource = 'project' | 'global' | 'env';
 

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -52,7 +52,7 @@ import { homedir } from "os";
 import { spawn } from "child_process";
 import { fileURLToPath } from "url";
 import { getOmcRoot } from "../lib/worktree-paths.js";
-import { getClaudeConfigDir } from "../utils/paths.js";
+import { getClaudeConfigDir } from "../utils/config-dir.js";
 
 /**
  * Extract session ID (UUID) from a transcript path.

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, readFileSync, mkdirSync } from "fs";
 import { join } from "path";
-import { getClaudeConfigDir } from "../utils/paths.js";
+import { getClaudeConfigDir } from "../utils/config-dir.js";
 import { validateWorkingDirectory, getOmcRoot } from "../lib/worktree-paths.js";
 import {
   atomicWriteFileSync,

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -13,7 +13,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync } from 'fs';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { join, dirname } from 'path';
 import { execFileSync } from 'child_process';
 import { createHash } from 'crypto';
@@ -297,7 +297,11 @@ function createRateLimitedCacheEntry(
 
 /**
  * Get the Keychain service name for the current config directory.
- * Claude Code uses "Claude Code-credentials-{sha256(configDir)[:8]}" for non-default dirs.
+ * Claude Code uses "Claude Code-credentials-{sha256(configDir)[:8]}" for
+ * non-default dirs, where configDir is derived from the exact
+ * CLAUDE_CONFIG_DIR value rather than the expanded filesystem path. Preserve
+ * that behavior so ~-prefixed profiles keep matching Claude Code's own
+ * Keychain entries.
  */
 function getKeychainServiceName(): string {
   const configDir = process.env.CLAUDE_CONFIG_DIR;

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -72,6 +72,15 @@ describe('install() standalone hook reconciliation', () => {
     expect((writtenSettings as { statusLine?: { command?: string } }).statusLine?.command).toContain(
       `${join(testClaudeDir, 'hud', 'omc-hud.mjs').replace(/\\/g, '/')}`,
     );
+    expect(readFileSync(join(testClaudeDir, 'hud', 'omc-hud.mjs'), 'utf-8')).toContain(
+      'const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs")).href);',
+    );
+    expect(readFileSync(join(testClaudeDir, 'hud', 'lib', 'config-dir.mjs'), 'utf-8')).toContain(
+      'export function getClaudeConfigDir()',
+    );
+    expect(readFileSync(join(testClaudeDir, 'hooks', 'lib', 'config-dir.mjs'), 'utf-8')).toContain(
+      'export function getClaudeConfigDir()',
+    );
     expect(readFileSync(join(testClaudeDir, 'hooks', 'keyword-detector.mjs'), 'utf-8')).toContain('Ralph keywords');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'pre-tool-use.mjs'), 'utf-8')).toContain('PreToolUse');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'code-simplifier.mjs'), 'utf-8')).toContain('Code Simplifier');

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -13,7 +13,7 @@ import { join, dirname } from "path";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { homedir } from "os";
-import { getConfigDir } from '../utils/config-dir.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 
 // =============================================================================
 // TEMPLATE LOADER (loads hook scripts from templates/hooks/)
@@ -69,11 +69,6 @@ export function isWindows(): boolean {
   return process.platform === "win32";
 }
 
-
-/** Get the Claude config directory path (cross-platform) */
-export function getClaudeConfigDir(): string {
-  return getConfigDir();
-}
 
 /** Get the hooks directory path */
 export function getHooksDir(): string {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -19,12 +19,12 @@ import {
   getHooksSettingsConfig,
 } from './hooks.js';
 import { getRuntimePackageVersion } from '../lib/version.js';
-import { getConfigDir } from '../utils/config-dir.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { resolveNodeBinary } from '../utils/resolve-node.js';
 import { syncUnifiedMcpRegistryTargets } from './mcp-registry.js';
 
 /** Claude Code configuration directory */
-export const CLAUDE_CONFIG_DIR = getConfigDir();
+export const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
 export const AGENTS_DIR = join(CLAUDE_CONFIG_DIR, 'agents');
 export const COMMANDS_DIR = join(CLAUDE_CONFIG_DIR, 'commands');
 export const SKILLS_DIR = join(CLAUDE_CONFIG_DIR, 'skills');
@@ -402,9 +402,14 @@ const STANDALONE_HOOK_TEMPLATE_FILES = [
 function ensureStandaloneHookScripts(log: (msg: string) => void): void {
   const packageDir = getPackageDir();
   const templatesDir = join(packageDir, 'templates', 'hooks');
+  const templatesLibDir = join(templatesDir, 'lib');
+  const hooksLibDir = join(HOOKS_DIR, 'lib');
 
   if (!existsSync(HOOKS_DIR)) {
     mkdirSync(HOOKS_DIR, { recursive: true });
+  }
+  if (!existsSync(hooksLibDir)) {
+    mkdirSync(hooksLibDir, { recursive: true });
   }
 
   for (const filename of STANDALONE_HOOK_TEMPLATE_FILES) {
@@ -416,11 +421,33 @@ function ensureStandaloneHookScripts(log: (msg: string) => void): void {
     }
   }
 
+  for (const filename of readdirSync(templatesLibDir)) {
+    if (filename === 'config-dir.mjs') continue; // sourced from scripts/lib/ below
+    const sourcePath = join(templatesLibDir, filename);
+    const targetPath = join(hooksLibDir, filename);
+    copyFileSync(sourcePath, targetPath);
+    if (!isWindows()) {
+      chmodSync(targetPath, 0o755);
+    }
+  }
+
+  // config-dir.mjs: canonical source is scripts/lib/, not templates (avoids duplication)
+  const configDirHelperMjs = join(packageDir, 'scripts', 'lib', 'config-dir.mjs');
+  const configDirHelperMjsDest = join(hooksLibDir, 'config-dir.mjs');
+  copyFileSync(configDirHelperMjs, configDirHelperMjsDest);
+  if (!isWindows()) {
+    chmodSync(configDirHelperMjsDest, 0o755);
+  }
+
   if (!isWindows()) {
     const findNodeSrc = join(packageDir, 'scripts', 'find-node.sh');
     const findNodeDest = join(HOOKS_DIR, 'find-node.sh');
+    const configDirHelperSrc = join(packageDir, 'scripts', 'lib', 'config-dir.sh');
+    const configDirHelperDest = join(hooksLibDir, 'config-dir.sh');
     copyFileSync(findNodeSrc, findNodeDest);
+    copyFileSync(configDirHelperSrc, configDirHelperDest);
     chmodSync(findNodeDest, 0o755);
+    chmodSync(configDirHelperDest, 0o755);
   }
 
   log('  Installed standalone hook scripts');
@@ -1032,7 +1059,11 @@ export function install(options: InstallOptions = {}): InstallResult {
         'import { createRequire } from "node:module";',
         'import { homedir } from "node:os";',
         'import { dirname, join, resolve } from "node:path";',
-        'import { pathToFileURL } from "node:url";',
+        'import { fileURLToPath, pathToFileURL } from "node:url";',
+        '',
+        'const __filename = fileURLToPath(import.meta.url);',
+        'const __dirname = dirname(__filename);',
+        'const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs")).href);',
         '',
         'function uniquePaths(paths) {',
         '  return [...new Set(paths.filter(Boolean).map((candidate) => resolve(candidate)))];',
@@ -1127,7 +1158,7 @@ export function install(options: InstallOptions = {}): InstallResult {
         '  ',
         '  // 2. Plugin cache (for production installs)',
         '  // Respect CLAUDE_CONFIG_DIR so installs under a custom config dir are found',
-        '  const configDir = process.env.CLAUDE_CONFIG_DIR || join(home, ".claude");',
+        '  const configDir = getClaudeConfigDir();',
         '  const pluginCacheBase = join(configDir, "plugins", "cache", "omc", "oh-my-claudecode");',
         '  if (existsSync(pluginCacheBase)) {',
         '    try {',
@@ -1276,6 +1307,17 @@ export function install(options: InstallOptions = {}): InstallResult {
       if (hudScriptPath) {
         const nodeBin = resolveNodeBinary();
         const absoluteCommand = '"' + nodeBin + '" "' + hudScriptPath.replace(/\\/g, '/') + '"';
+        try {
+          const configDirHelperMjsSrc = join(__dirname, '..', '..', 'scripts', 'lib', 'config-dir.mjs');
+          const hudLibDir = join(HUD_DIR, 'lib');
+          const configDirHelperMjsDest = join(hudLibDir, 'config-dir.mjs');
+          if (!existsSync(hudLibDir)) {
+            mkdirSync(hudLibDir, { recursive: true });
+          }
+          copyFileSync(configDirHelperMjsSrc, configDirHelperMjsDest);
+        } catch {
+          // Keep HUD installation best-effort if helper copy fails unexpectedly.
+        }
 
         // On Unix, use find-node.sh for portable $HOME paths (multi-machine sync)
         // and robust node discovery (nvm/fnm in non-interactive shells).
@@ -1286,8 +1328,16 @@ export function install(options: InstallOptions = {}): InstallResult {
           try {
             const findNodeSrc = join(__dirname, '..', '..', 'scripts', 'find-node.sh');
             const findNodeDest = join(HUD_DIR, 'find-node.sh');
+            const configDirHelperSrc = join(__dirname, '..', '..', 'scripts', 'lib', 'config-dir.sh');
+            const hudLibDir = join(HUD_DIR, 'lib');
+            const configDirHelperDest = join(hudLibDir, 'config-dir.sh');
+            if (!existsSync(hudLibDir)) {
+              mkdirSync(hudLibDir, { recursive: true });
+            }
             copyFileSync(findNodeSrc, findNodeDest);
+            copyFileSync(configDirHelperSrc, configDirHelperDest);
             chmodSync(findNodeDest, 0o755);
+            chmodSync(configDirHelperDest, 0o755);
             statusLineCommand = buildStatusLineCommand(nodeBin, hudScriptPath.replace(/\\/g, '/'), findNodeDest);
           } catch {
             // Fallback to bare node if find-node.sh copy fails

--- a/src/installer/mcp-registry.ts
+++ b/src/installer/mcp-registry.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
 
-import { getConfigDir } from '../utils/config-dir.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import {
   getGlobalOmcConfigPath,
   getGlobalOmcConfigCandidates,
@@ -71,7 +71,7 @@ export function getClaudeMcpConfigPath(): string {
     return process.env.CLAUDE_MCP_CONFIG_PATH.trim();
   }
 
-  return join(dirname(getConfigDir()), '.claude.json');
+  return join(dirname(getClaudeConfigDir()), '.claude.json');
 }
 
 export function getCodexConfigPath(): string {

--- a/src/lib/shared-memory.ts
+++ b/src/lib/shared-memory.ts
@@ -22,6 +22,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, readdir
 import { join } from 'path';
 import { getOmcRoot } from './worktree-paths.js';
 import { withFileLockSync } from './file-lock.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,17 +55,14 @@ const CONFIG_FILE_NAME = '.omc-config.json';
 /**
  * Check if shared memory is enabled via config.
  *
- * Reads `agents.sharedMemory.enabled` from ~/.claude/.omc-config.json.
+ * Reads `agents.sharedMemory.enabled` from
+ * `[$CLAUDE_CONFIG_DIR|~/.claude]/.omc-config.json`.
  * Defaults to true when the config key is absent (opt-out rather than opt-in
  * once the feature ships, but tools check this gate).
  */
 export function isSharedMemoryEnabled(): boolean {
   try {
-    const configPath = join(
-      process.env.HOME || process.env.USERPROFILE || '',
-      '.claude',
-      CONFIG_FILE_NAME,
-    );
+    const configPath = join(getClaudeConfigDir(), CONFIG_FILE_NAME);
     if (!existsSync(configPath)) return true; // default enabled
     const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
     const enabled = raw?.agents?.sharedMemory?.enabled;

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -14,6 +14,7 @@ import { execSync } from 'child_process';
 import { existsSync, mkdirSync, realpathSync, readdirSync } from 'fs';
 import { homedir } from 'os';
 import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 
 /** Standard .omc subdirectories */
 export const OmcPaths = {
@@ -422,15 +423,18 @@ export function isValidTranscriptPath(transcriptPath: string): boolean {
   const normalized = normalize(expandedPath);
   const home = homedir();
 
-  // Allowed: ~/.claude/..., ~/.omc/..., /tmp/...
+  // Allowed: [$CLAUDE_CONFIG_DIR|~/.claude], ~/.omc/..., /tmp/...
   const allowedPrefixes = [
-    join(home, '.claude'),
+    getClaudeConfigDir(),
     join(home, '.omc'),
     '/tmp',
     '/var/folders', // macOS temp
   ];
 
-  return allowedPrefixes.some(prefix => normalized.startsWith(prefix));
+  return allowedPrefixes.some((prefix) => {
+    const rel = relative(prefix, normalized);
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+  });
 }
 
 
@@ -589,8 +593,7 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
     const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
     if (sessionFile) {
       // The projects directory is under the Claude config dir
-      const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
-      const projectsDir = join(configDir, 'projects');
+      const projectsDir = join(getClaudeConfigDir(), 'projects');
 
       if (existsSync(projectsDir)) {
         // Encode the main project root the same way Claude Code does:
@@ -627,8 +630,7 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
       const lastSep = transcriptPath.lastIndexOf('/');
       const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
       if (sessionFile) {
-        const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
-        const projectsDir = join(configDir, 'projects');
+        const projectsDir = join(getClaudeConfigDir(), 'projects');
         if (existsSync(projectsDir)) {
           const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
           const resolvedPath = join(projectsDir, encodedMain, sessionFile);

--- a/src/notifications/__tests__/config-merge.test.ts
+++ b/src/notifications/__tests__/config-merge.test.ts
@@ -16,7 +16,7 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 // Mock getClaudeConfigDir to return a predictable path
-vi.mock("../../utils/paths.js", () => ({
+vi.mock("../../utils/config-dir.js", () => ({
   getClaudeConfigDir: () => "/mock-claude-config",
 }));
 

--- a/src/notifications/__tests__/profiles.test.ts
+++ b/src/notifications/__tests__/profiles.test.ts
@@ -18,7 +18,7 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 // Mock getClaudeConfigDir to return a predictable path
-vi.mock("../../utils/paths.js", () => ({
+vi.mock("../../utils/config-dir.js", () => ({
   getClaudeConfigDir: () => "/mock-claude-config",
 }));
 

--- a/src/notifications/config.ts
+++ b/src/notifications/config.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
-import { getClaudeConfigDir } from "../utils/paths.js";
+import { getClaudeConfigDir } from "../utils/config-dir.js";
 import type {
   NotificationConfig,
   NotificationEvent,

--- a/src/notifications/hook-config.ts
+++ b/src/notifications/hook-config.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
-import { getClaudeConfigDir } from "../utils/paths.js";
+import { getClaudeConfigDir } from "../utils/config-dir.js";
 import type { HookNotificationConfig } from "./hook-config-types.js";
 import type {
   NotificationConfig,

--- a/src/openclaw/__tests__/config.test.ts
+++ b/src/openclaw/__tests__/config.test.ts
@@ -6,7 +6,7 @@ vi.mock("fs", () => ({
   readFileSync: vi.fn(),
 }));
 
-vi.mock("../../utils/paths.js", () => ({
+vi.mock("../../utils/config-dir.js", () => ({
   getClaudeConfigDir: vi.fn(() => "/home/user/.claude"),
 }));
 

--- a/src/openclaw/config.ts
+++ b/src/openclaw/config.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
-import { getClaudeConfigDir } from "../utils/paths.js";
+import { getClaudeConfigDir } from "../utils/config-dir.js";
 import type { OpenClawConfig, OpenClawHookEvent, OpenClawGatewayConfig, OpenClawCommandGatewayConfig } from "./types.js";
 
 const CONFIG_FILE = process.env.OMC_OPENCLAW_CONFIG

--- a/src/skills/__tests__/mingw-escape.test.ts
+++ b/src/skills/__tests__/mingw-escape.test.ts
@@ -128,7 +128,7 @@ describe('MINGW64 escape safety: no "!" in node -e inline scripts (issue #729)',
 
     it('hud SKILL.md keeps Unix statusLine guidance portable while preserving Windows-safe paths', () => {
       const content = readFileSync(join(REPO_ROOT, 'skills', 'hud', 'SKILL.md'), 'utf-8');
-      expect(content).toContain('"command": "node $HOME/.claude/hud/omc-hud.mjs"');
+      expect(content).toContain('"command": "node ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs"');
       expect(content).toContain('"command": "node C:/Users/username/.claude/hud/omc-hud.mjs"');
       expect(content).not.toContain('"command": "node /home/username/.claude/hud/omc-hud.mjs"');
       expect(content).not.toContain('The command must use an absolute path, not `~`');

--- a/src/team/__tests__/bridge-integration.test.ts
+++ b/src/team/__tests__/bridge-integration.test.ts
@@ -8,11 +8,13 @@ import { checkShutdownSignal, writeShutdownSignal, appendOutbox } from '../inbox
 import { writeHeartbeat, readHeartbeat } from '../heartbeat.js';
 import { sanitizeName } from '../tmux-session.js';
 import { logAuditEvent, readAuditLog } from '../audit-log.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 const TEST_TEAM = 'test-bridge-int';
 // Task files now live in the canonical .omc/state/team path (relative to WORK_DIR)
-const TEAMS_DIR = join(homedir(), '.claude', 'teams', TEST_TEAM);
-const WORK_DIR = join(tmpdir(), '__test_bridge_work__');
+const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', TEST_TEAM);
+// Resolve symlinks (macOS /var -> /private/var) so validateResolvedPath matches
+const WORK_DIR = join(realpathSync(tmpdir()), '__test_bridge_work__');
 // Canonical tasks dir for this team
 const TASKS_DIR = join(WORK_DIR, '.omc', 'state', 'team', TEST_TEAM, 'tasks');
 
@@ -323,7 +325,7 @@ describe('validateBridgeWorkingDirectory logic', () => {
   });
 
   it('accepts a valid directory under home', () => {
-    const testDir = join(homedir(), '.claude', '__bridge_validate_test__');
+    const testDir = join(getClaudeConfigDir(), '__bridge_validate_test__');
     mkdirSync(testDir, { recursive: true });
     try {
       expect(() => validateBridgeWorkingDirectory(testDir)).not.toThrow();

--- a/src/team/__tests__/edge-cases.test.ts
+++ b/src/team/__tests__/edge-cases.test.ts
@@ -16,10 +16,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   mkdirSync, writeFileSync, rmSync, existsSync,
-  readFileSync, appendFileSync
+  readFileSync, appendFileSync, realpathSync
 } from 'fs';
 import { join } from 'path';
-import { homedir, tmpdir } from 'os';
+import { tmpdir } from 'os';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 // --- task-file-ops imports ---
 import {
@@ -64,14 +65,12 @@ const EDGE_TEAM_IO = 'test-edge-io';
 let TASK_TEST_CWD: string;
 let TASKS_DIR: string;
 
-// inbox-outbox tests still use the legacy ~/.claude/teams path (inbox-outbox.ts
-// was not changed in this refactor and still uses getClaudeConfigDir internally)
-const TEAMS_IO_DIR = join(homedir(), '.claude', 'teams', EDGE_TEAM_IO);
+const TEAMS_IO_DIR = join(getClaudeConfigDir(), 'teams', EDGE_TEAM_IO);
 
 const HB_DIR = join(tmpdir(), 'test-edge-hb');
 const REG_DIR = join(tmpdir(), 'test-edge-reg');
 const REG_TEAM = 'test-edge-reg-team';
-const CONFIG_DIR = join(homedir(), '.claude', 'teams', REG_TEAM);
+const CONFIG_DIR = join(getClaudeConfigDir(), 'teams', REG_TEAM);
 
 function writeTaskHelper(task: TaskFile): void {
   mkdirSync(TASKS_DIR, { recursive: true });
@@ -98,7 +97,7 @@ function makeHeartbeat(overrides?: Partial<HeartbeatData>): HeartbeatData {
 
 describe('task-file-ops edge cases', () => {
   beforeEach(() => {
-    TASK_TEST_CWD = join(tmpdir(), `omc-edge-tasks-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    TASK_TEST_CWD = join(realpathSync(tmpdir()), `omc-edge-tasks-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     TASKS_DIR = join(TASK_TEST_CWD, '.omc', 'state', 'team', EDGE_TEAM_TASKS, 'tasks');
     mkdirSync(TASKS_DIR, { recursive: true });
   });

--- a/src/team/__tests__/inbox-outbox.test.ts
+++ b/src/team/__tests__/inbox-outbox.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import {
   appendOutbox, rotateOutboxIfNeeded, readNewInboxMessages,
   readAllInboxMessages, clearInbox, writeShutdownSignal,
@@ -11,10 +10,11 @@ import {
 } from '../inbox-outbox.js';
 import { sanitizeName } from '../tmux-session.js';
 import { validateResolvedPath } from '../fs-utils.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import type { OutboxMessage, InboxMessage } from '../types.js';
 
 const TEST_TEAM = 'test-team-io';
-const TEAMS_DIR = join(homedir(), '.claude', 'teams', TEST_TEAM);
+const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', TEST_TEAM);
 
 beforeEach(() => {
   mkdirSync(join(TEAMS_DIR, 'inbox'), { recursive: true });

--- a/src/team/__tests__/message-router.test.ts
+++ b/src/team/__tests__/message-router.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { tmpdir, homedir } from 'os';
+import { tmpdir } from 'os';
 import { routeMessage, broadcastToTeam } from '../message-router.js';
 import { registerMcpWorker } from '../team-registration.js';
 import { writeHeartbeat } from '../heartbeat.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 describe('message-router', () => {
   let testDir: string;
@@ -18,7 +19,7 @@ describe('message-router', () => {
     rmSync(testDir, { recursive: true, force: true });
     // Clean up inbox files that may have been created
     try {
-      const inboxDir = join(homedir(), '.claude', 'teams', teamName, 'inbox');
+      const inboxDir = join(getClaudeConfigDir(), 'teams', teamName, 'inbox');
       rmSync(inboxDir, { recursive: true, force: true });
     } catch { /* ignore */ }
   });
@@ -47,7 +48,7 @@ describe('message-router', () => {
       expect(result.details).toContain('inbox');
 
       // Verify inbox file was written
-      const inboxPath = join(homedir(), '.claude', 'teams', teamName, 'inbox', 'codex-1.jsonl');
+      const inboxPath = join(getClaudeConfigDir(), 'teams', teamName, 'inbox', 'codex-1.jsonl');
       expect(existsSync(inboxPath)).toBe(true);
       const content = readFileSync(inboxPath, 'utf-8').trim();
       const msg = JSON.parse(content);
@@ -73,8 +74,8 @@ describe('message-router', () => {
       expect(result.nativeRecipients).toEqual([]);
 
       // Verify both inbox files were written
-      const inbox1 = join(homedir(), '.claude', 'teams', teamName, 'inbox', 'worker1.jsonl');
-      const inbox2 = join(homedir(), '.claude', 'teams', teamName, 'inbox', 'worker2.jsonl');
+      const inbox1 = join(getClaudeConfigDir(), 'teams', teamName, 'inbox', 'worker1.jsonl');
+      const inbox2 = join(getClaudeConfigDir(), 'teams', teamName, 'inbox', 'worker2.jsonl');
       expect(existsSync(inbox1)).toBe(true);
       expect(existsSync(inbox2)).toBe(true);
     });

--- a/src/team/__tests__/outbox-reader.test.ts
+++ b/src/team/__tests__/outbox-reader.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import {
   readNewOutboxMessages,
   readAllTeamOutboxMessages,
   resetOutboxCursor,
 } from '../outbox-reader.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import type { OutboxMessage } from '../types.js';
 
 const TEST_TEAM = 'test-team-outbox-reader';
-const TEAMS_DIR = join(homedir(), '.claude', 'teams', TEST_TEAM);
+const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', TEST_TEAM);
 
 beforeEach(() => {
   mkdirSync(join(TEAMS_DIR, 'outbox'), { recursive: true });

--- a/src/team/__tests__/team-registration.test.ts
+++ b/src/team/__tests__/team-registration.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
-import { tmpdir, homedir } from 'os';
+import { tmpdir } from 'os';
 import {
   readProbeResult, writeProbeResult, getRegistrationStrategy,
   registerMcpWorker, unregisterMcpWorker, isMcpWorker, listMcpWorkers
 } from '../team-registration.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import type { ConfigProbeResult } from '../types.js';
 
 const TEST_DIR = join(tmpdir(), '__test_team_reg__');
 const TEST_TEAM = 'test-team-reg-team';
-const CONFIG_DIR = join(homedir(), '.claude', 'teams', TEST_TEAM);
+const CONFIG_DIR = join(getClaudeConfigDir(), 'teams', TEST_TEAM);
 
 beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });

--- a/src/team/__tests__/team-status.test.ts
+++ b/src/team/__tests__/team-status.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync } from 'fs';
+import { mkdirSync, rmSync, realpathSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { getTeamStatus } from '../team-status.js';
 import { atomicWriteJson } from '../fs-utils.js';
 import { appendOutbox } from '../inbox-outbox.js';
 import { recordTaskUsage } from '../usage-tracker.js';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import type { HeartbeatData, TaskFile, OutboxMessage, McpWorkerMember } from '../types.js';
 
 const TEST_TEAM = 'test-team-status';
@@ -15,7 +15,7 @@ let WORK_DIR: string;
 let TASKS_DIR: string;
 
 beforeEach(() => {
-  WORK_DIR = join(tmpdir(), `omc-team-status-test-${Date.now()}`);
+  WORK_DIR = join(realpathSync(tmpdir()), `omc-team-status-test-${Date.now()}`);
   TASKS_DIR = join(WORK_DIR, '.omc', 'state', 'team', TEST_TEAM, 'tasks');
   mkdirSync(TASKS_DIR, { recursive: true });
   mkdirSync(join(WORK_DIR, '.omc', 'state', 'team-bridge', TEST_TEAM), { recursive: true });

--- a/src/team/bridge-entry.ts
+++ b/src/team/bridge-entry.ts
@@ -17,7 +17,7 @@ import { runBridge } from './mcp-team-bridge.js';
 import { deleteHeartbeat } from './heartbeat.js';
 import { unregisterMcpWorker } from './team-registration.js';
 import { getWorktreeRoot } from '../lib/worktree-paths.js';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { sanitizeName } from './tmux-session.js';
 
 /**

--- a/src/team/inbox-outbox.ts
+++ b/src/team/inbox-outbox.ts
@@ -13,7 +13,7 @@ import {
   readSync, closeSync
 } from 'fs';
 import { join, dirname } from 'path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import type { InboxMessage, OutboxMessage, ShutdownSignal, DrainSignal, InboxCursor } from './types.js';
 import { sanitizeName } from './tmux-session.js';
 import { appendFileWithMode, writeFileWithMode, atomicWriteJson, ensureDirWithMode, validateResolvedPath } from './fs-utils.js';

--- a/src/team/message-router.ts
+++ b/src/team/message-router.ts
@@ -9,7 +9,7 @@
  */
 
 import { join } from 'node:path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { appendFileWithMode, ensureDirWithMode, validateResolvedPath } from './fs-utils.js';
 import { getTeamMembers } from './unified-team.js';
 import { sanitizeName } from './tmux-session.js';

--- a/src/team/outbox-reader.ts
+++ b/src/team/outbox-reader.ts
@@ -12,7 +12,7 @@ import {
   statSync, existsSync, readdirSync
 } from 'fs';
 import { join } from 'path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { validateResolvedPath, writeFileWithMode, atomicWriteJson, ensureDirWithMode } from './fs-utils.js';
 import { sanitizeName } from './tmux-session.js';
 import type { OutboxMessage } from './types.js';

--- a/src/team/task-file-ops.ts
+++ b/src/team/task-file-ops.ts
@@ -18,7 +18,7 @@
 
 import { readFileSync, readdirSync, existsSync, openSync, closeSync, unlinkSync, writeSync, statSync, constants as fsConstants } from 'fs';
 import { join } from 'path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import type { TaskFile, TaskFileUpdate, TaskFailureSidecar } from './types.js';
 import { sanitizeName } from './tmux-session.js';
 import { atomicWriteJson, validateResolvedPath, ensureDirWithMode } from './fs-utils.js';

--- a/src/team/team-registration.ts
+++ b/src/team/team-registration.ts
@@ -9,7 +9,7 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import type { McpWorkerMember, ConfigProbeResult } from './types.js';
 import { sanitizeName } from './tmux-session.js';
 import { atomicWriteJson, validateResolvedPath } from './fs-utils.js';

--- a/src/team/team-status.ts
+++ b/src/team/team-status.ts
@@ -9,7 +9,7 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { listMcpWorkers } from './team-registration.js';
 import { readHeartbeat, isWorkerAlive } from './heartbeat.js';
 import { listTaskIds, readTask } from './task-file-ops.js';

--- a/src/team/unified-team.ts
+++ b/src/team/unified-team.ts
@@ -9,7 +9,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getClaudeConfigDir } from '../utils/paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import type { WorkerBackend, WorkerCapability } from './types.js';
 import { listMcpWorkers } from './team-registration.js';
 import { readHeartbeat, isWorkerAlive } from './heartbeat.js';

--- a/src/tools/shared-memory-tools.ts
+++ b/src/tools/shared-memory-tools.ts
@@ -14,6 +14,7 @@
 
 import { z } from 'zod';
 import { validateWorkingDirectory } from '../lib/worktree-paths.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js'
 import {
   isSharedMemoryEnabled,
   writeEntry,
@@ -29,7 +30,7 @@ import type { ToolDefinition } from './types.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const DISABLED_MSG = 'Shared memory is disabled. Set agents.sharedMemory.enabled = true in ~/.claude/.omc-config.json to enable.';
+const DISABLED_MSG = `Shared memory is disabled. Set agents.sharedMemory.enabled = true in ${getClaudeConfigDir()}/.omc-config.json to enable.`;
 
 function disabledResponse() {
   return {

--- a/src/tools/skills-tools.ts
+++ b/src/tools/skills-tools.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import { resolve, normalize, sep } from 'path';
 import { homedir } from 'os';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { loadAllSkills } from '../hooks/learner/loader.js';
 import { MAX_SKILL_CONTENT_LENGTH } from '../hooks/learner/constants.js';
 import type { LearnedSkill } from '../hooks/learner/types.js';
@@ -121,7 +122,7 @@ export const loadLocalTool = {
 // Tool 2: load_omc_skills_global
 export const loadGlobalTool = {
   name: 'load_omc_skills_global',
-  description: 'Load and list skills from global user directories (~/.omc/skills/ and ~/.claude/skills/omc-learned/). Returns skill metadata for all discovered user-scoped skills.',
+  description: 'Load and list skills from global user directories (~/.omc/skills/ and [$CLAUDE_CONFIG_DIR|~/.claude]/skills/omc-learned/). Returns skill metadata for all discovered user-scoped skills.',
   schema: loadGlobalSchema,
   handler: async (_args: Record<string, never>) => {
     const allSkills = loadAllSkills(null);
@@ -158,7 +159,7 @@ export const listSkillsTool = {
     }
 
     if (skills.length === 0) {
-      output = '## No Skills Found\n\nNo skill files were discovered in any searched directories.\n\nSearched:\n- Project: .omc/skills/\n- Global: ~/.omc/skills/\n- Legacy: ~/.claude/skills/omc-learned/';
+      output = `## No Skills Found\n\nNo skill files were discovered in any searched directories.\n\nSearched:\n- Project: .omc/skills/\n- Global: ~/.omc/skills/\n- Claude config: ${getClaudeConfigDir()}/skills/omc-learned/`;
     }
 
     return {

--- a/src/utils/config-dir.ts
+++ b/src/utils/config-dir.ts
@@ -1,6 +1,53 @@
-import { homedir } from "node:os";
-import { join } from "node:path";
+/**
+ * Claude Code Configuration Directory Resolution
+ *
+ * Resolves the active Claude Code configuration directory, honouring
+ * CLAUDE_CONFIG_DIR (absolute path, or ~-prefixed) with fallback to
+ * ~/.claude.  Trailing separators are stripped; filesystem roots are
+ * preserved.
+ *
+ * Multi-surface mirrors (keep in sync):
+ *   scripts/lib/config-dir.mjs   — ESM hook/HUD runtime
+ *   scripts/lib/config-dir.cjs   — CJS bridge runtime
+ *   scripts/lib/config-dir.sh    — POSIX shell runtime
+ */
 
-export function getConfigDir(): string {
-  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+import { join, normalize, parse, sep } from 'path';
+import { homedir } from 'os';
+
+/**
+ * Strip a single trailing path separator (preserve filesystem root).
+ * @internal Shared with scripts/lib/config-dir.{mjs,cjs,sh} — keep in sync.
+ */
+function stripTrailingSep(p: string): string {
+  if (!p.endsWith(sep)) {
+    return p;
+  }
+  return p === parse(p).root ? p : p.slice(0, -1);
+}
+
+/**
+ * Resolve the Claude Code configuration directory.
+ *
+ * Honours CLAUDE_CONFIG_DIR (absolute path, or ~-prefixed) with fallback
+ * to ~/.claude.  Trailing separators are stripped; filesystem roots are
+ * preserved.
+ */
+export function getClaudeConfigDir(): string {
+  const home = homedir();
+  const configured = process.env.CLAUDE_CONFIG_DIR?.trim();
+
+  if (!configured) {
+    return stripTrailingSep(normalize(join(home, '.claude')));
+  }
+
+  if (configured === '~') {
+    return stripTrailingSep(normalize(home));
+  }
+
+  if (configured.startsWith('~/') || configured.startsWith('~\\')) {
+    return stripTrailingSep(normalize(join(home, configured.slice(2))));
+  }
+
+  return stripTrailingSep(normalize(configured));
 }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -9,7 +9,7 @@
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, rmSync } from 'fs';
 import { homedir } from 'os';
-import { getConfigDir as getClaudeBaseConfigDir } from './config-dir.js';
+import { getClaudeConfigDir } from './config-dir.js';
 
 /**
  * Convert a path to use forward slashes (for JSON/config files)
@@ -18,14 +18,6 @@ import { getConfigDir as getClaudeBaseConfigDir } from './config-dir.js';
  */
 export function toForwardSlash(path: string): string {
   return path.replace(/\\/g, '/');
-}
-
-/**
- * Get Claude config directory path.
- * Respects the CLAUDE_CONFIG_DIR environment variable when set.
- */
-export function getClaudeConfigDir(): string {
-  return getClaudeBaseConfigDir();
 }
 
 /**

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -34,6 +34,7 @@ const __dirname = dirname(__filename);
 // Dynamic import for the shared stdin module (use pathToFileURL for Windows compatibility, #524)
 const { readStdin } = await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href);
 const { atomicWriteFileSync } = await import(pathToFileURL(join(__dirname, 'lib', 'atomic-write.mjs')).href);
+const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, 'lib', 'config-dir.mjs')).href);
 
 const ULTRATHINK_MESSAGE = `<think-mode>
 
@@ -370,13 +371,14 @@ function createHookOutput(additionalContext) {
 
 /**
  * Check if the team feature is enabled in Claude Code settings.
- * Reads ~/.claude/settings.json and checks for CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env var.
+ * Reads settings.json from [$CLAUDE_CONFIG_DIR|~/.claude] and checks for
+ * CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env var.
  * @returns {boolean} true if team feature is enabled
  */
 function isTeamEnabled() {
   try {
     // Check settings.json first (authoritative, user-controlled)
-    const cfgDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+    const cfgDir = getClaudeConfigDir();
     const settingsPath = join(cfgDir, 'settings.json');
     if (existsSync(settingsPath)) {
       const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));

--- a/templates/hooks/lib/config-dir.mjs
+++ b/templates/hooks/lib/config-dir.mjs
@@ -1,0 +1,29 @@
+import { homedir } from 'node:os';
+import { join, normalize, parse, sep } from 'node:path';
+
+function stripTrailingSep(p) {
+  if (!p.endsWith(sep)) {
+    return p;
+  }
+
+  return p === parse(p).root ? p : p.slice(0, -1);
+}
+
+export function getClaudeConfigDir() {
+  const home = homedir();
+  const configured = process.env.CLAUDE_CONFIG_DIR?.trim();
+
+  if (!configured) {
+    return stripTrailingSep(normalize(join(home, '.claude')));
+  }
+
+  if (configured === '~') {
+    return stripTrailingSep(normalize(home));
+  }
+
+  if (configured.startsWith('~/') || configured.startsWith('~\\')) {
+    return stripTrailingSep(normalize(join(home, configured.slice(2))));
+  }
+
+  return stripTrailingSep(normalize(configured));
+}

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath, pathToFileURL } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, 'lib', 'config-dir.mjs')).href);
 
 // Dynamic import for the shared stdin module
 const { readStdin } = await import(
@@ -413,7 +414,7 @@ function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) return 0;
 
-  const taskDir = join(homedir(), ".claude", "tasks", sessionId);
+  const taskDir = join(getClaudeConfigDir(), "tasks", sessionId);
   if (!existsSync(taskDir)) return 0;
 
   let count = 0;
@@ -446,8 +447,7 @@ function countIncompleteTodos(sessionId, projectDir) {
     /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)
   ) {
     const sessionTodoPath = join(
-      homedir(),
-      ".claude",
+      getClaudeConfigDir(),
       "todos",
       `${sessionId}.json`,
     );

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, 'lib', 'config-dir.mjs')).href);
 
 // Import timeout-protected stdin reader (prevents hangs on Linux/Windows, see issue #240, #524)
 let readStdin;
@@ -294,7 +295,7 @@ async function main() {
     const updateInfo = currentVersion ? await checkForUpdates(currentVersion) : null;
     if (updateInfo) {
       // Read config to check autoUpgradePrompt preference
-      const configPath = join(homedir(), '.claude', '.omc-config.json');
+      const configPath = join(getClaudeConfigDir(), '.omc-config.json');
       const omcConfig = readJsonFile(configPath) || {};
       const autoUpgradePrompt = omcConfig.autoUpgradePrompt !== false; // default: true
 
@@ -308,7 +309,7 @@ oh-my-claudecode v${updateInfo.latestVersion} is available (current: v${updateIn
 ACTION: Use AskUserQuestion to ask the user if they want to upgrade now. Offer these options:
 - "Upgrade now" (Recommended): Run \`npm install -g oh-my-claude-sisyphus@latest\` via Bash, then run \`omc install --force --skip-claude-check --refresh-hooks\` to reconcile hooks and CLAUDE.md
 - "Skip this time": Continue the session without upgrading
-- "Don't ask again": Tell the user to set "autoUpgradePrompt": false in ~/.claude/.omc-config.json to disable future prompts
+- "Don't ask again": Tell the user to set "autoUpgradePrompt": false in [$CLAUDE_CONFIG_DIR|~/.claude]/.omc-config.json to disable future prompts
 
 Keep the prompt brief. If the user accepts, execute the upgrade commands and report the result.
 
@@ -358,8 +359,10 @@ Continue working in ultrawork mode until all tasks are complete.
 `);
     }
 
-    // Check for incomplete todos (project-local only, not global ~/.claude/todos/)
-    // NOTE: We intentionally do NOT scan the global ~/.claude/todos/ directory.
+    // Check for incomplete todos (project-local only, not global
+    // [$CLAUDE_CONFIG_DIR|~/.claude]/todos/)
+    // NOTE: We intentionally do NOT scan the global
+    // [$CLAUDE_CONFIG_DIR|~/.claude]/todos/ directory.
     // That directory accumulates todo files from ALL past sessions across all
     // projects, causing phantom task counts in fresh sessions (see issue #354).
     const localTodoPaths = [


### PR DESCRIPTION
### Summary

PR #2086 partially addressed issue #2084 by fixing installer/setup profile handling. Several runtime code paths identified in that issue scope still hardcoded `~/.claude` instead of using the active Claude Code config directory.

This continues the work started in PR #563 (initial `getConfigDir()` utility), PR #898 (HUD plugin cache), and PR #1125 (Keychain service name), and addresses all remaining runtime code paths identified in the issue #2155.

#### Shared helper

- **config-dir helper**: implement full `getClaudeConfigDir()` in `config-dir.ts` with `~` expansion and trailing-slash normalisation, replacing the trivial `getConfigDir()` wrapper; remove the re-export from `paths.ts` ([`src/utils/config-dir.ts`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/utils/config-dir.ts#L4-L5))

#### TypeScript runtime

- **transcript validation**: allow paths under the active config directory ([`worktree-paths.ts#L425`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/lib/worktree-paths.ts#L425-L433))
- **transcript fallback resolution**: build `projects/` lookups from the active config directory ([`worktree-paths.ts#L592`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/lib/worktree-paths.ts#L592-L593), [`#L630`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/lib/worktree-paths.ts#L630-L631))
- **rules discovery**: use `getClaudeConfigDir()` instead of hardcoded path; remove the dead `homeDir` parameter from `findRuleFiles` and the stale `USER_RULE_DIR` export ([`finder.ts#L226`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/hooks/rules-injector/finder.ts#L226-L229))
- **CLI**: use `getClaudeConfigDir()` for runtime paths and help text (default: `~/.claude/`)
  - [`index.ts#L247`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/cli/index.ts#L247) — stop-callback example
  - [`#L465`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/cli/index.ts#L465) — default stop-callback file path
  - [`#L844-L856`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/cli/index.ts#L844-L856) — install description and help text
  - [`#L894`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/cli/index.ts#L894) — post-install output
- **orchestrator**: allow absolute paths under the active config directory while preserving project-root and relative-path checks ([`index.ts#L129`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/hooks/omc-orchestrator/index.ts#L129-L148))
- **skills tools**: reference the active config directory in runtime output and help text ([`skills-tools.ts#L122`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/tools/skills-tools.ts#L122-L124), [`#L160`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/tools/skills-tools.ts#L160-L161))
- **shared memory**: read `.omc-config.json` from the active config directory ([`shared-memory.ts#L63`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/lib/shared-memory.ts#L63-L67))
- **session history search**: resolve transcript roots from the active config directory ([`index.ts#L36`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/features/session-history-search/index.ts#L36-L38))
- **auto-slash-command executor**: replace hardcoded `~/.claude` in error message output ([`executor.ts#L356`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/hooks/auto-slash-command/executor.ts#L356))
- **factcheck guard**: add `${CLAUDE_CONFIG_DIR}` token to `forbidden_path_prefixes` defaults and token expander, replacing the hardcoded `${HOME}/.claude` prefix ([`config.ts#L20`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/hooks/factcheck/config.ts#L20),[`#L53`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/hooks/factcheck/config.ts#L53-L58))
- **HUD usage API**: document and test that Keychain service names continue to hash the exact `CLAUDE_CONFIG_DIR` string, preserving distinct service-name mapping for `~`-prefixed vs expanded inputs (PR #1125 behaviour)([`usage-api.ts`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/hud/usage-api.ts))
- **installer**: copy config-dir helpers alongside standalone hooks and the HUD `find-node.sh` helper ([`index.ts`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/installer/index.ts))

#### Runtime scripts

- **Node ESM scripts**: use a shared `lib/config-dir.mjs` helper instead of repeating `~/.claude` fallbacks ([`scripts/`](https://github.com/Yeachan-Heo/oh-my-claudecode/tree/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts))
- **Node CJS helper**: add `scripts/lib/config-dir.cjs` so `persistent-mode.cjs` reuses the same logic
- **standalone hook templates**: add `templates/hooks/lib/config-dir.mjs` (mirrors `scripts/lib/config-dir.mjs`) so template scripts resolve the config directory consistently
- **HUD wrapper**: import the shared `lib/config-dir` helper instead of embedding duplicate resolution logic ([`plugin-setup.mjs`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/plugin-setup.mjs#L18))
- **persistent-mode**: resolve native tasks/todos from the active config directory
  - [`persistent-mode.cjs#L450`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/persistent-mode.cjs#L450-L452)
  - [`persistent-mode.mjs#L434`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/persistent-mode.mjs#L434-L437)
- **plugin setup** (incidental): move `nodeBin` to module scope so both the settings.json and hooks.json patching blocks can access it — pre-existing `const` scoping bug where hooks.json patching always failed silently with a `ReferenceError`([`plugin-setup.mjs#L229`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/plugin-setup.mjs#L229))

#### Shell scripts

- use a shared `config-dir.sh` helper with `~` expansion and trailing-slash normalisation
  - [`scripts/find-node.sh#L22`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/find-node.sh#L22-L23)
  - [`scripts/setup-claude-md.sh#L20`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/setup-claude-md.sh#L20)
  - [`scripts/setup-progress.sh#L12`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/setup-progress.sh#L12)
- **uninstall**: preserve existing `CLAUDE_CONFIG_DIR` env var ([`uninstall.sh#L16`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/uninstall.sh#L16-L17))
- **test script**: source `lib/config-dir.sh` for post-install path verification ([`test-pr25.sh#L191`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/scripts/test-pr25.sh#L191-L208))

#### Skill files

- replace `$HOME/.claude` with `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` in executable shell code blocks, and hardcoded `~/.claude` in LLM-actionable directives (Read/Write tool targets, step instructions) with `${CLAUDE_CONFIG_DIR:-~/.claude}` so both shell execution and LLM tool-call construction honour the active config directory:
  - [`skills/omc-doctor/SKILL.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/omc-doctor/SKILL.md#L30)
  - [`skills/skill/SKILL.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/skill/SKILL.md#L20)
  - [`skills/configure-notifications/SKILL.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/configure-notifications/SKILL.md#L46)
  - [`skills/cancel/SKILL.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/cancel/SKILL.md#L200)
  - [`skills/hud/SKILL.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/hud/SKILL.md#L56)
  - [`skills/omc-setup/SKILL.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/omc-setup/SKILL.md#L90)
  - [`skills/omc-setup/phases/02-configure.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/omc-setup/phases/02-configure.md#L83)
  - [`skills/omc-setup/phases/03-integrations.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/omc-setup/phases/03-integrations.md#L8)
  - [`skills/omc-setup/phases/04-welcome.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/omc-setup/phases/04-welcome.md#L8)
  - [`skills/team/SKILL.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/team/SKILL.md#L803)
  - [`skills/learner/SKILL.md`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/skills/learner/SKILL.md#L112)

  **Note on LLM-actionable prose:** directives like `Read ${CLAUDE_CONFIG_DIR:-~/.claude}/settings.json` use shell-style fallback syntax which an LLM will not literally expand. This is a known limitation — strictly better than the previous hardcoded `~/.claude` (which always missed custom directories), but not equivalent to true runtime resolution. A proper fix would require a skill-template preprocessing step that substitutes the active config directory before the LLM sees the prompt; that is out of scope for this change and tracked as a future improvement.

#### Tests

- align mock paths from `paths.js` to `config-dir.js` to match the new import source
- fix `vi.mock` hoisting in `doctor-conflicts.test.ts`
- resolve macOS `/var` symlink mismatch in `bridge-integration.test.ts`, `edge-cases.test.ts`, and `team-status.test.ts`
- update string-pattern assertions in `hud-windows.test.ts` and `mingw-escape.test.ts`
- use `getClaudeConfigDir()` or the exported `CLAUDE_CONFIG_DIR` constant in auto-update, installer, delegation enforcement, factcheck, and team integration tests so the suite passes under custom config directories

The helper is implemented in [`src/utils/config-dir.ts`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/42b92f6f2940ce638562ea35bb65e1050f211c57/src/utils/config-dir.ts) (canonical TypeScript source) and mirrored across three runtime surfaces:

- `scripts/lib/config-dir.mjs` (ESM hooks/HUD)
- `scripts/lib/config-dir.cjs` (CJS for `persistent-mode.cjs`)
- `scripts/lib/config-dir.sh` (POSIX shell)

Each mirror exists because the runtime surfaces cannot share a single module: standalone hook scripts run as plain ESM outside the compiled TypeScript bundle, `persistent-mode.cjs` requires CJS `require()`, and shell scripts have no Node runtime at all. The logic is intentionally small (~20 lines per surface) so keeping them in sync manually is straightforward; code generation was considered but would add build-pipeline complexity disproportionate to four short files. Each mirror carries a "keep in sync" header comment pointing to its siblings.

`templates/hooks/lib/config-dir.mjs` is a byte-identical copy of `scripts/lib/config-dir.mjs`. It exists so that template-based standalone installs (which copy the `templates/hooks/` tree without running the full installer) have a working helper in place. The installer's `ensureStandaloneHookScripts` also copies the canonical `scripts/lib/config-dir.mjs` into the hooks `lib/` directory at install time, so both paths converge on the same file. This follows the existing pattern of `stdin.mjs` and `atomic-write.mjs` in `templates/hooks/lib/`.

**Compatibility note:** the `findRuleFiles(projectRoot, homeDir, currentFile)` signature and the `USER_RULE_DIR` export have been removed from the rules-injector surface. There are no known downstream consumers, but maintainers should treat that as a small exported-surface break when choosing release semantics.
If backwards compatibility is a concern, the old signature could be kept as a deprecated overload that ignores `homeDir` and forwards to the new two-argument form.

### Testing

```sh
npm run lint -- \
  src/__tests__/auto-update.test.ts \
  src/__tests__/cli-config-stop-callback.test.ts \
  src/__tests__/config-dir.test.ts \
  src/__tests__/delegation-enforcement-levels.test.ts \
  src/__tests__/doctor-conflicts.test.ts \
  src/__tests__/hud-api-key-source.test.ts \
  src/__tests__/hud-marketplace-resolution.test.ts \
  src/__tests__/hud-windows.test.ts \
  src/__tests__/hud/cli-diagnostic.test.ts \
  src/__tests__/hud/usage-api-lock.test.ts \
  src/__tests__/hud/usage-api-stale.test.ts \
  src/__tests__/hud/usage-api.test.ts \
  src/__tests__/installer.test.ts \
  src/__tests__/purge-stale-cache.test.ts \
  src/__tests__/session-history-search.test.ts \
  src/__tests__/setup-claude-md-script.test.ts \
  src/__tests__/shared-memory.test.ts \
  src/cli/index.ts \
  src/features/session-history-search/index.ts \
  src/hooks/auto-slash-command/executor.ts \
  src/hooks/factcheck/config.ts \
  src/hooks/factcheck/__tests__/factcheck.test.ts \
  src/hooks/index.ts \
  src/hooks/omc-orchestrator/constants.ts \
  src/hooks/omc-orchestrator/index.ts \
  src/hooks/rules-injector/constants.ts \
  src/hooks/rules-injector/finder.ts \
  src/hooks/rules-injector/index.ts \
  src/hud/usage-api.ts \
  src/installer/__tests__/standalone-hook-reconcile.test.ts \
  src/installer/index.ts \
  src/lib/shared-memory.ts \
  src/lib/worktree-paths.ts \
  src/notifications/__tests__/config-merge.test.ts \
  src/notifications/__tests__/profiles.test.ts \
  src/openclaw/__tests__/config.test.ts \
  src/skills/__tests__/mingw-escape.test.ts \
  src/team/__tests__/bridge-integration.test.ts \
  src/team/__tests__/edge-cases.test.ts \
  src/team/__tests__/inbox-outbox.test.ts \
  src/team/__tests__/message-router.test.ts \
  src/team/__tests__/outbox-reader.test.ts \
  src/team/__tests__/team-registration.test.ts \
  src/team/__tests__/team-status.test.ts \
  src/tools/shared-memory-tools.ts \
  src/tools/skills-tools.ts \
  src/utils/paths.ts

npm test -- --run \
  src/__tests__/auto-update.test.ts \
  src/__tests__/cli-config-stop-callback.test.ts \
  src/__tests__/config-dir.test.ts \
  src/__tests__/delegation-enforcement-levels.test.ts \
  src/__tests__/doctor-conflicts.test.ts \
  src/__tests__/hud-api-key-source.test.ts \
  src/__tests__/hud-marketplace-resolution.test.ts \
  src/__tests__/hud-windows.test.ts \
  src/__tests__/hud/cli-diagnostic.test.ts \
  src/__tests__/hud/usage-api-lock.test.ts \
  src/__tests__/hud/usage-api-stale.test.ts \
  src/__tests__/hud/usage-api.test.ts \
  src/__tests__/installer-hooks-merge.test.ts \
  src/__tests__/installer.test.ts \
  src/__tests__/keyword-detector-script.test.ts \
  src/__tests__/pipeline-orchestrator.test.ts \
  src/__tests__/plugin-setup-deps.test.ts \
  src/__tests__/plugin-setup-devpaths.test.ts \
  src/__tests__/post-tool-verifier.test.mjs \
  src/__tests__/pre-tool-enforcer.test.ts \
  src/__tests__/purge-stale-cache.test.ts \
  src/__tests__/session-history-search.test.ts \
  src/__tests__/session-start-cache-cleanup.test.ts \
  src/__tests__/session-start-script-context.test.ts \
  src/__tests__/session-start-timeout-cleanup.test.ts \
  src/__tests__/setup-claude-md-script.test.ts \
  src/__tests__/setup-progress-script.test.ts \
  src/__tests__/shared-memory-concurrency.test.ts \
  src/__tests__/shared-memory.test.ts \
  src/__tests__/skills.test.ts \
  src/__tests__/tools/skills-tools.test.ts \
  src/hooks/factcheck/__tests__/factcheck.test.ts \
  src/installer/__tests__/hook-templates.test.ts \
  src/installer/__tests__/safe-installer.test.ts \
  src/installer/__tests__/session-start-template.test.ts \
  src/installer/__tests__/standalone-hook-reconcile.test.ts \
  src/notifications/__tests__/config-merge.test.ts \
  src/notifications/__tests__/profiles.test.ts \
  src/openclaw/__tests__/config.test.ts \
  src/skills/__tests__/mingw-escape.test.ts \
  src/team/__tests__/bridge-integration.test.ts \
  src/team/__tests__/edge-cases.test.ts \
  src/team/__tests__/inbox-outbox.test.ts \
  src/team/__tests__/message-router.test.ts \
  src/team/__tests__/outbox-reader.test.ts \
  src/team/__tests__/team-registration.test.ts \
  src/team/__tests__/team-status.test.ts

bash -n scripts/find-node.sh scripts/lib/config-dir.sh \
  scripts/setup-claude-md.sh scripts/setup-progress.sh \
  scripts/test-pr25.sh scripts/uninstall.sh

npm exec tsc -- --noEmit
```

Focused regression coverage in:

- `src/__tests__/auto-update.test.ts` — plugin cache sync paths under custom config directory
- `src/__tests__/cli-config-stop-callback.test.ts` — CLI default file-callback path
- `src/__tests__/config-dir.test.ts` — shared helper expansion (TS, MJS, shell), trailing-slash stripping, downstream integration (transcript validation, rules discovery)
- `src/__tests__/delegation-enforcement-levels.test.ts` — orchestrator absolute-path allowance, CLAUDE_CONFIG_DIR env isolation
- `src/__tests__/doctor-conflicts.test.ts` — hook ownership classification under custom config directory; vi.hoisted() fix for mock factory
- `src/__tests__/hud-api-key-source.test.ts` — mock path alignment (paths.js → config-dir.js)
- `src/__tests__/hud-marketplace-resolution.test.ts` — HUD wrapper helper copy
- `src/__tests__/hud-windows.test.ts` — string pattern assertions updated for getClaudeConfigDir() and CLAUDE_CONFIG_DIR shell expansions
- `src/__tests__/hud/cli-diagnostic.test.ts` — mock path alignment (paths.js → config-dir.js)
- `src/__tests__/hud/usage-api-lock.test.ts` — mock path alignment (paths.js → config-dir.js)
- `src/__tests__/hud/usage-api-stale.test.ts` — mock path alignment (paths.js → config-dir.js)
- `src/__tests__/hud/usage-api.test.ts` — Keychain service-name hashing unchanged (PR #1125 behaviour preserved)
- `src/__tests__/installer.test.ts` — file path assertions, isProjectScopedPlugin under custom config directory
- `src/__tests__/purge-stale-cache.test.ts` — mock function name alignment (getConfigDir → getClaudeConfigDir)
- `src/__tests__/session-history-search.test.ts` — transcript root resolution
- `src/__tests__/setup-claude-md-script.test.ts` — shell flow with `~`-prefixed `CLAUDE_CONFIG_DIR`
- `src/__tests__/shared-memory.test.ts` — shared-memory reads from active config directory
- `src/hooks/factcheck/__tests__/factcheck.test.ts` — forbidden path prefix uses `getClaudeConfigDir()`, `${CLAUDE_CONFIG_DIR}` token expansion
- `src/installer/__tests__/standalone-hook-reconcile.test.ts` — standalone hooks lib `config-dir.mjs` installed alongside hooks
- `src/notifications/__tests__/config-merge.test.ts` — mock path alignment (paths.js → config-dir.js)
- `src/notifications/__tests__/profiles.test.ts` — mock path alignment (paths.js → config-dir.js)
- `src/openclaw/__tests__/config.test.ts` — mock path alignment (paths.js → config-dir.js)
- `src/skills/__tests__/mingw-escape.test.ts` — SKILL.md shell snippet assertion updated for CLAUDE_CONFIG_DIR expansion
- `src/team/__tests__/bridge-integration.test.ts` — bridge lifecycle under custom config directory; macOS /var symlink fix
- `src/team/__tests__/edge-cases.test.ts` — inbox-outbox and registration edge cases under custom config directory; macOS /var symlink fix (realpathSync)
- `src/team/__tests__/inbox-outbox.test.ts` — team inbox/outbox filesystem operations under custom config directory
- `src/team/__tests__/message-router.test.ts` — inbox routing to MCP workers under custom config directory
- `src/team/__tests__/outbox-reader.test.ts` — outbox cursor and message reads under custom config directory
- `src/team/__tests__/team-registration.test.ts` — worker registration under custom config directory
- `src/team/__tests__/team-status.test.ts` — mock path alignment (paths.js → config-dir.js); macOS /var symlink fix (realpathSync)

Closes #2155.