### PR TITLE
fix: correct release note generation for merged PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,13 @@ jobs:
             echo "npm install -g oh-my-claude-sisyphus@${VERSION}" >> release-notes.md
             echo '```' >> release-notes.md
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           body_path: release-notes.md
-          generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
         env:

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -3,7 +3,8 @@
  * Release Automation Script
  *
  * Automates version bumping, changelog generation, and release notes creation.
- * Uses conventional commits to categorize changes automatically.
+ * Uses merged PR metadata when available so changelog content, PR counts,
+ * and contributors all reflect the same release dataset.
  *
  * Usage:
  *   npm run release -- patch              # Bump patch version
@@ -18,10 +19,25 @@ import { join, resolve } from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import {
+  type ReleasePullRequest,
+  type ReleaseNoteEntry,
+  extractPullRequestNumbers,
+  isReleasePullRequest,
+  deriveContributorLogins,
+  buildReleaseNoteEntriesFromPullRequests,
+  categorizeReleaseNoteEntries,
+  generateChangelog,
+  generateReleaseBody,
+} from '../src/lib/release-generation.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, '..');
+const DEFAULT_REPO_SLUG = 'Yeachan-Heo/oh-my-claudecode';
+const REPO_SLUG = process.env.GITHUB_REPOSITORY || DEFAULT_REPO_SLUG;
+const REPO_URL = `https://github.com/${REPO_SLUG}`;
+const GITHUB_API_URL = process.env.GITHUB_API_URL || 'https://api.github.com';
 
 // ── Colors ──────────────────────────────────────────────────────────────────
 
@@ -51,9 +67,16 @@ interface ParsedCommit {
   raw: string;
 }
 
-interface ChangelogSection {
+interface GitHubPullRequestResponse {
   title: string;
-  entries: string[];
+  user?: { login?: string | null } | null;
+  head?: { ref?: string | null } | null;
+}
+
+interface GitHubCompareResponse {
+  commits?: Array<{
+    author?: { login?: string | null } | null;
+  }>;
 }
 
 // ── Version helpers ─────────────────────────────────────────────────────────
@@ -85,243 +108,123 @@ function bumpVersion(current: string, bump: string): string {
 
 // ── Git helpers ─────────────────────────────────────────────────────────────
 
-function getCommitsSinceTag(tag: string): string[] {
+function getGitLog(tag: string, format: string, flags: string[] = []): string[] {
   const range = tag ? `${tag}..HEAD` : 'HEAD';
-  const raw = execSync(
-    `git log ${range} --format="%H|%s" --no-merges`,
-    { cwd: ROOT, encoding: 'utf-8' }
-  ).trim();
+  const cmd = ['git', 'log', range, `--format=${JSON.stringify(format)}`, ...flags].join(' ');
+  const raw = execSync(cmd, { cwd: ROOT, encoding: 'utf-8' }).trim();
   return raw ? raw.split('\n') : [];
 }
 
-function getMergeCommitsSinceTag(tag: string): string[] {
-  const range = tag ? `${tag}..HEAD` : 'HEAD';
-  const raw = execSync(
-    `git log ${range} --format="%s" --merges`,
-    { cwd: ROOT, encoding: 'utf-8' }
-  ).trim();
-  return raw ? raw.split('\n') : [];
+function getCommitLinesSinceTag(tag: string): string[] {
+  return getGitLog(tag, '%H|%s');
 }
 
-function getContributors(tag: string): string[] {
-  const merges = getMergeCommitsSinceTag(tag);
-  const contributors = new Set<string>();
-
-  for (const msg of merges) {
-    const match = msg.match(/from\s+([^/]+)\//);
-    if (match && match[1]) {
-      const user = match[1].trim();
-      if (user && !user.startsWith('#')) {
-        contributors.add(user);
-      }
-    }
-  }
-
-  return [...contributors].sort();
+function getNonMergeCommitLinesSinceTag(tag: string): string[] {
+  return getGitLog(tag, '%H|%s', ['--no-merges']);
 }
 
-function getPRCount(tag: string): number {
-  const merges = getMergeCommitsSinceTag(tag);
-  return merges.filter(m => m.startsWith('Merge pull request')).length;
+function getHeadSha(): string {
+  return execSync('git rev-parse HEAD', { cwd: ROOT, encoding: 'utf-8' }).trim();
 }
 
-// ── Commit parsing ──────────────────────────────────────────────────────────
-
-const CONVENTIONAL_RE = /^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?:\s*(?<desc>.+)$/;
+// ── Commit / PR parsing ─────────────────────────────────────────────────────
 
 function parseCommit(line: string): ParsedCommit | null {
   const [hash, ...rest] = line.split('|');
   const raw = rest.join('|');
 
   if (!raw) return null;
-
-  // Skip merge commits, chore(release) version bumps
   if (raw.startsWith('Merge ')) return null;
   if (raw.match(/^chore\(release\)/i)) return null;
 
-  const match = raw.match(CONVENTIONAL_RE);
-  if (!match?.groups) return null;
+  const conventionalMatch = raw.match(/^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?:\s*(?<desc>.+)$/);
+  if (!conventionalMatch?.groups) return null;
 
   const prMatch = raw.match(/\(#(\d+)\)/);
 
   return {
     hash: hash.trim(),
-    type: match.groups.type,
-    scope: match.groups.scope || '',
-    description: match.groups.desc.replace(/\s*\(#\d+\)$/, '').trim(),
+    type: conventionalMatch.groups.type,
+    scope: conventionalMatch.groups.scope || '',
+    description: conventionalMatch.groups.desc.replace(/\s*\(#\d+\)$/, '').trim(),
     prNumber: prMatch ? prMatch[1] : null,
     raw,
   };
 }
 
-// ── Categorization ──────────────────────────────────────────────────────────
-
-function categorize(commits: ParsedCommit[]): Map<string, ParsedCommit[]> {
-  const categories = new Map<string, ParsedCommit[]>();
-
-  for (const commit of commits) {
-    let category: string;
-
-    if (commit.type === 'feat') {
-      category = 'features';
-    } else if (commit.type === 'fix' && /^(security|deps)$/.test(commit.scope)) {
-      category = 'security';
-    } else if (commit.type === 'fix') {
-      category = 'fixes';
-    } else if (commit.type === 'refactor') {
-      category = 'refactoring';
-    } else if (commit.type === 'docs') {
-      category = 'docs';
-    } else if (commit.type === 'chore' && commit.scope === 'deps') {
-      category = 'security';
-    } else if (commit.type === 'perf') {
-      category = 'features';
-    } else {
-      // skip test, chore, ci, build, style
-      continue;
-    }
-
-    if (!categories.has(category)) categories.set(category, []);
-    categories.get(category)!.push(commit);
-  }
-
-  return categories;
+function toReleaseNoteEntryFromCommit(commit: ParsedCommit): ReleaseNoteEntry {
+  return {
+    type: commit.type,
+    scope: commit.scope,
+    description: commit.description,
+    prNumber: commit.prNumber,
+  };
 }
 
-// ── Changelog generation ────────────────────────────────────────────────────
 
-function formatEntry(commit: ParsedCommit): string {
-  const scope = commit.scope ? `(${commit.scope})` : '';
-  const pr = commit.prNumber ? ` (#${commit.prNumber})` : '';
-  return `- **${commit.type}${scope}: ${commit.description}**${pr}`;
+// ── GitHub metadata helpers ─────────────────────────────────────────────────
+
+function getGitHubApiHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'oh-my-claudecode-release-script',
+  };
+
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  return headers;
 }
 
-function generateTitle(categories: Map<string, ParsedCommit[]>): string {
-  const parts: string[] = [];
-
-  if (categories.has('features')) {
-    // Pick the most notable feature keywords
-    const feats = categories.get('features')!;
-    const keywords = feats
-      .slice(0, 3)
-      .map(f => {
-        // Extract key noun from description
-        const words = f.description.split(/\s+/);
-        return words.slice(0, 3).join(' ');
-      });
-    parts.push(...keywords);
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const response = await fetch(url, { headers: getGitHubApiHeaders() });
+    if (!response.ok) return null;
+    return await response.json() as T;
+  } catch {
+    return null;
   }
-  if (categories.has('security')) parts.push('Security Hardening');
-  if (categories.has('fixes') && !parts.length) parts.push('Bug Fixes');
-
-  if (parts.length === 0) return 'Maintenance Release';
-  if (parts.length <= 3) return parts.join(', ');
-  return parts.slice(0, 3).join(', ');
 }
 
-function generateSummary(categories: Map<string, ParsedCommit[]>, prCount: number): string {
-  const parts: string[] = [];
-  if (categories.has('features')) parts.push(`**${categories.get('features')!.length} new features**`);
-  if (categories.has('security')) parts.push(`**security hardening**`);
-  if (categories.has('fixes')) parts.push(`**${categories.get('fixes')!.length} bug fixes**`);
-
-  if (parts.length === 0) return 'Maintenance release with internal improvements.';
-  return `Release with ${parts.join(', ')} across ${prCount}+ merged PRs.`;
+function getRepoApiPath(): string {
+  return REPO_SLUG
+    .split('/')
+    .map(part => encodeURIComponent(part))
+    .join('/');
 }
 
-function generateChangelog(
-  version: string,
-  categories: Map<string, ParsedCommit[]>,
-  prCount: number,
-): string {
-  const title = generateTitle(categories);
-  const summary = generateSummary(categories, prCount);
+async function fetchPullRequestMetadata(prNumbers: string[]): Promise<ReleasePullRequest[]> {
+  const repoPath = getRepoApiPath();
+  const records = await Promise.all(prNumbers.map(async number => {
+    const data = await fetchJson<GitHubPullRequestResponse>(
+      `${GITHUB_API_URL}/repos/${repoPath}/pulls/${encodeURIComponent(number)}`
+    );
 
-  const sections: ChangelogSection[] = [];
+    if (!data) return null;
 
-  // Highlights: top features + security
-  const highlights: string[] = [];
-  if (categories.has('features')) {
-    for (const f of categories.get('features')!.slice(0, 5)) {
-      highlights.push(formatEntry(f));
-    }
-  }
-  if (categories.has('security')) {
-    for (const s of categories.get('security')!.slice(0, 3)) {
-      highlights.push(formatEntry(s));
-    }
-  }
-  if (highlights.length) sections.push({ title: 'Highlights', entries: highlights });
+    return {
+      number,
+      title: data.title,
+      author: data.user?.login ?? null,
+      headRefName: data.head?.ref ?? null,
+    } satisfies ReleasePullRequest;
+  }));
 
-  // New Features
-  if (categories.has('features')) {
-    sections.push({ title: 'New Features', entries: categories.get('features')!.map(formatEntry) });
-  }
-
-  // Security & Hardening
-  if (categories.has('security')) {
-    sections.push({ title: 'Security & Hardening', entries: categories.get('security')!.map(formatEntry) });
-  }
-
-  // Bug Fixes
-  if (categories.has('fixes')) {
-    sections.push({ title: 'Bug Fixes', entries: categories.get('fixes')!.map(formatEntry) });
-  }
-
-  // Refactoring
-  if (categories.has('refactoring')) {
-    sections.push({ title: 'Refactoring', entries: categories.get('refactoring')!.map(formatEntry) });
-  }
-
-  // Documentation
-  if (categories.has('docs')) {
-    sections.push({ title: 'Documentation', entries: categories.get('docs')!.map(formatEntry) });
-  }
-
-  // Stats
-  const featCount = categories.get('features')?.length ?? 0;
-  const fixCount = categories.get('fixes')?.length ?? 0;
-  const secCount = categories.get('security')?.length ?? 0;
-  const statsLine = `- **${prCount}+ PRs merged** | **${featCount} new features** | **${fixCount} bug fixes** | **${secCount} security/hardening improvements**`;
-
-  // Assemble
-  let md = `# oh-my-claudecode v${version}: ${title}\n\n`;
-  md += `## Release Notes\n\n${summary}\n`;
-
-  for (const section of sections) {
-    md += `\n### ${section.title}\n\n`;
-    md += section.entries.join('\n') + '\n';
-  }
-
-  md += `\n### Stats\n\n${statsLine}\n`;
-
-  return md;
+  return records.filter((record): record is ReleasePullRequest => record !== null);
 }
 
-function generateReleaseBody(
-  version: string,
-  changelog: string,
-  contributors: string[],
-  prevTag: string,
-): string {
-  let body = changelog;
+async function fetchCompareCommitAuthors(prevTag: string): Promise<string[]> {
+  if (!prevTag) return [];
 
-  body += `\n### Install / Update\n\n`;
-  body += '```bash\n';
-  body += `npm install -g oh-my-claude-sisyphus@${version}\n`;
-  body += '```\n\n';
-  body += 'Or reinstall the plugin:\n```bash\nclaude /install-plugin oh-my-claudecode\n```\n';
+  const repoPath = getRepoApiPath();
+  const headRef = process.env.GITHUB_SHA || getHeadSha();
+  const data = await fetchJson<GitHubCompareResponse>(
+    `${GITHUB_API_URL}/repos/${repoPath}/compare/${encodeURIComponent(prevTag)}...${encodeURIComponent(headRef)}`
+  );
 
-  if (prevTag) {
-    body += `\n**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/${prevTag}...v${version}\n`;
-  }
-
-  if (contributors.length > 0) {
-    body += `\n## Contributors\n\nThank you to all contributors who made this release possible!\n\n`;
-    body += contributors.map(u => `@${u}`).join(' ') + '\n';
-  }
-
-  return body;
+  return (data?.commits ?? [])
+    .map(commit => commit.author?.login ?? null)
+    .filter((author): author is string => Boolean(author));
 }
 
 // ── Version file bumping ────────────────────────────────────────────────────
@@ -329,7 +232,6 @@ function generateReleaseBody(
 function bumpVersionFiles(newVersion: string, dryRun: boolean): string[] {
   const changes: string[] = [];
 
-  // 1. package.json
   const pkgPath = join(ROOT, 'package.json');
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
   if (pkg.version !== newVersion) {
@@ -338,7 +240,6 @@ function bumpVersionFiles(newVersion: string, dryRun: boolean): string[] {
     changes.push(`package.json: ${pkg.version} → ${newVersion}`);
   }
 
-  // 2. .claude-plugin/plugin.json
   const pluginPath = join(ROOT, '.claude-plugin/plugin.json');
   if (existsSync(pluginPath)) {
     const content = readFileSync(pluginPath, 'utf-8');
@@ -349,7 +250,6 @@ function bumpVersionFiles(newVersion: string, dryRun: boolean): string[] {
     }
   }
 
-  // 3. .claude-plugin/marketplace.json (has 2 version fields)
   const marketPath = join(ROOT, '.claude-plugin/marketplace.json');
   if (existsSync(marketPath)) {
     const content = readFileSync(marketPath, 'utf-8');
@@ -360,7 +260,6 @@ function bumpVersionFiles(newVersion: string, dryRun: boolean): string[] {
     }
   }
 
-  // 4. docs/CLAUDE.md version marker
   const claudeMdPath = join(ROOT, 'docs/CLAUDE.md');
   if (existsSync(claudeMdPath)) {
     const content = readFileSync(claudeMdPath, 'utf-8');
@@ -371,7 +270,6 @@ function bumpVersionFiles(newVersion: string, dryRun: boolean): string[] {
     }
   }
 
-  // 5. package-lock.json (via npm)
   if (!dryRun) {
     try {
       execSync('npm install --package-lock-only --ignore-scripts 2>/dev/null', { cwd: ROOT });
@@ -386,9 +284,28 @@ function bumpVersionFiles(newVersion: string, dryRun: boolean): string[] {
   return changes;
 }
 
+function buildFallbackPullRequests(prNumbers: string[], subjects: string[]): ReleasePullRequest[] {
+  return prNumbers.map(number => {
+    const subject = subjects.find(entry => entry.includes(`(#${number})`));
+    const mergeSubject = subjects.find(entry => entry.startsWith(`Merge pull request #${number} `));
+    const headRefMatch = mergeSubject?.match(/from\s+[^/]+\/(.+)$/);
+
+    return {
+      number,
+      title: subject ? subject.replace(/\s*\(#\d+\)$/, '').trim() : `PR #${number}`,
+      author: null,
+      headRefName: headRefMatch?.[1] ?? null,
+    } satisfies ReleasePullRequest;
+  });
+}
+
+function isMainModule(): boolean {
+  return process.argv[1] ? resolve(process.argv[1]) === __filename : false;
+}
+
 // ── Main ────────────────────────────────────────────────────────────────────
 
-function main(): void {
+async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
   const help = args.includes('--help') || args.includes('-h');
@@ -409,7 +326,7 @@ ${clr('Examples:', c.cyan)}
 
 ${clr('What it does:', c.cyan)}
   1. Bumps version in all 5 files (package.json, plugin.json, marketplace.json, docs/CLAUDE.md, lockfile)
-  2. Generates CHANGELOG.md from conventional commits
+  2. Generates CHANGELOG.md from the merged PR set when metadata is available
   3. Generates .github/release-body.md with contributor @mentions
   4. Runs sync-metadata to update doc badges
 
@@ -435,31 +352,45 @@ ${clr('After running:', c.cyan)}
   console.log(`  Previous tag:    ${clr(prevTag || '(none)', c.dim)}`);
   if (dryRun) console.log(clr('\n  DRY RUN — no files will be modified\n', c.yellow));
 
-  // 1. Parse commits
-  const rawCommits = getCommitsSinceTag(prevTag);
-  const parsed = rawCommits.map(parseCommit).filter((c): c is ParsedCommit => c !== null);
-  const categories = categorize(parsed);
-  const prCount = getPRCount(prevTag);
-  const contributors = getContributors(prevTag);
+  const allCommitLines = getCommitLinesSinceTag(prevTag);
+  const allSubjects = allCommitLines.map(line => line.split('|').slice(1).join('|'));
+  const fallbackCommits = getNonMergeCommitLinesSinceTag(prevTag)
+    .map(parseCommit)
+    .filter((commit): commit is ParsedCommit => commit !== null);
 
-  console.log(clr('\n📊 Commit Analysis', c.cyan));
-  console.log(`  Total commits: ${rawCommits.length}`);
-  console.log(`  Parsed conventional: ${parsed.length}`);
-  console.log(`  PRs merged: ${prCount}`);
+  const extractedPrNumbers = extractPullRequestNumbers(allSubjects);
+  const fetchedPullRequests = await fetchPullRequestMetadata(extractedPrNumbers);
+  const pullRequests = fetchedPullRequests.length > 0
+    ? fetchedPullRequests
+    : buildFallbackPullRequests(extractedPrNumbers, allSubjects);
+  const userFacingPullRequests = pullRequests.filter(pr => !isReleasePullRequest(pr));
+  const compareCommitAuthors = fetchedPullRequests.length > 0 ? await fetchCompareCommitAuthors(prevTag) : [];
+  const contributors = deriveContributorLogins(userFacingPullRequests, compareCommitAuthors);
+
+  const usingPullRequests = fetchedPullRequests.length > 0;
+  const releaseEntries = usingPullRequests
+    ? buildReleaseNoteEntriesFromPullRequests(userFacingPullRequests)
+    : fallbackCommits.map(toReleaseNoteEntryFromCommit);
+  const categories = categorizeReleaseNoteEntries(releaseEntries);
+  const prCount = userFacingPullRequests.length > 0 ? userFacingPullRequests.length : extractedPrNumbers.length;
+
+  console.log(clr('\n📊 Release Analysis', c.cyan));
+  console.log(`  Total commits: ${allCommitLines.length}`);
+  console.log(`  Extracted PRs: ${extractedPrNumbers.length}`);
+  console.log(`  User-facing PRs: ${prCount}`);
+  console.log(`  Metadata source: ${usingPullRequests ? 'GitHub PR metadata' : 'git fallback'}`);
   console.log(`  Contributors: ${contributors.join(', ') || '(none)'}`);
 
-  for (const [cat, commits] of categories) {
-    console.log(`  ${cat}: ${commits.length}`);
+  for (const [cat, entries] of categories) {
+    console.log(`  ${cat}: ${entries.length}`);
   }
 
-  // 2. Bump version files
   console.log(clr('\n📦 Version Bump', c.cyan));
   const versionChanges = bumpVersionFiles(newVersion, dryRun);
   for (const change of versionChanges) {
     console.log(`  ${clr('✓', c.green)} ${change}`);
   }
 
-  // 3. Generate CHANGELOG
   console.log(clr('\n📝 Changelog', c.cyan));
   const changelog = generateChangelog(newVersion, categories, prCount);
   if (!dryRun) {
@@ -472,9 +403,8 @@ ${clr('After running:', c.cyan)}
     console.log(clr('--- End Preview ---\n', c.dim));
   }
 
-  // 4. Generate release body
   console.log(clr('\n📋 Release Body', c.cyan));
-  const releaseBody = generateReleaseBody(newVersion, changelog, contributors, prevTag);
+  const releaseBody = generateReleaseBody(newVersion, changelog, contributors, prevTag, REPO_URL);
   const releaseBodyPath = join(ROOT, '.github/release-body.md');
   if (!dryRun) {
     writeFileSync(releaseBodyPath, releaseBody, 'utf-8');
@@ -483,7 +413,6 @@ ${clr('After running:', c.cyan)}
     console.log(`  ${clr('→', c.yellow)} Would write .github/release-body.md`);
   }
 
-  // 5. Run sync-metadata
   console.log(clr('\n🔄 Sync Metadata', c.cyan));
   if (!dryRun) {
     try {
@@ -495,17 +424,22 @@ ${clr('After running:', c.cyan)}
     console.log(`  ${clr('→', c.yellow)} Would run sync-metadata`);
   }
 
-  // 6. Next steps
   console.log(clr('\n✅ Done!', c.green));
   if (!dryRun) {
     console.log(clr('\nNext steps:', c.bold));
     console.log(`  1. ${clr(`git add -A && git commit -m "chore(release): bump version to v${newVersion}"`, c.cyan)}`);
-    console.log(`  2. ${clr(`git push origin dev`, c.cyan)}`);
-    console.log(`  3. Wait for CI green`);
-    console.log(`  4. ${clr(`git checkout main && git merge dev && git push origin main`, c.cyan)}`);
+    console.log(`  2. ${clr('git push origin dev', c.cyan)}`);
+    console.log('  3. Wait for CI green');
+    console.log(`  4. ${clr('git checkout main && git merge dev && git push origin main', c.cyan)}`);
     console.log(`  5. ${clr(`git tag -a v${newVersion} -m "v${newVersion}" && git push origin v${newVersion}`, c.cyan)}`);
-    console.log(`  6. release.yml handles npm publish + GitHub release automatically`);
+    console.log('  6. release.yml handles npm publish + GitHub release automatically');
   }
 }
 
-main();
+if (isMainModule()) {
+  void main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(clr(`\n✖ ${message}`, c.red));
+    process.exit(1);
+  });
+}

--- a/src/__tests__/release-generation.test.ts
+++ b/src/__tests__/release-generation.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  extractPullRequestNumbers,
+  isReleasePullRequest,
+  deriveContributorLogins,
+  buildReleaseNoteEntriesFromPullRequests,
+  categorizeReleaseNoteEntries,
+  generateChangelog,
+  generateReleaseBody,
+} from '../lib/release-generation.js';
+
+describe('release generation', () => {
+  it('extracts a deduped PR set from squash and merge subjects', () => {
+    const prNumbers = extractPullRequestNumbers([
+      'feat(hud): add configurable call count icon format (#2151)',
+      'fix(hud): replace misleading CLI error with installation diagnostic (#2129)',
+      'Merge pull request #2146 from Yeachan-Heo/issue-2143-omc-launch-followup',
+      'Merge pull request #2162 from Yeachan-Heo/release/4.10.2',
+      'feat(hud): add configurable call count icon format (#2151)',
+    ]);
+
+    expect(prNumbers).toEqual(['2151', '2129', '2146', '2162']);
+  });
+
+  it('identifies release PRs by release branch or release title', () => {
+    expect(isReleasePullRequest({
+      title: 'release: 4.10.2',
+      headRefName: 'release/4.10.2',
+    })).toBe(true);
+
+    expect(isReleasePullRequest({
+      title: 'chore(release): bump version to v4.10.2',
+      headRefName: null,
+    })).toBe(true);
+
+    expect(isReleasePullRequest({
+      title: 'fix(hud): replace misleading CLI error with installation diagnostic',
+      headRefName: 'fix/hud-cli-diagnostic',
+    })).toBe(false);
+  });
+
+  it('derives sorted deduped contributor handles from PR and compare metadata', () => {
+    const contributors = deriveContributorLogins(
+      [
+        { author: 'Yeachan-Heo' },
+        { author: 'blue-int' },
+        { author: 'EthanJStark' },
+        { author: 'blue-int' },
+      ],
+      ['tjsingleton', 'DdangJin', 'Yeachan-Heo', 'EthanJStark', null],
+    );
+
+    expect(contributors).toEqual([
+      'blue-int',
+      'DdangJin',
+      'EthanJStark',
+      'tjsingleton',
+      'Yeachan-Heo',
+    ]);
+  });
+
+  it('keeps non-conventional PRs in other changes and renders exact PR counts', () => {
+    const pullRequests = [
+      { number: '2107', title: 'fix(pre-tool-enforcer): deny subagent_type calls whose agent definition has a bare Anthropic model ID on Bedrock', author: 'EthanJStark', headRefName: 'fix/agent-def-model-routing-bedrock' },
+      { number: '2108', title: 'chore: enforce dev base branch and gitignore build artifacts', author: 'EthanJStark', headRefName: 'fix/contributor-guardrails' },
+      { number: '2122', title: 'fix(state-tools): add skill-active to STATE_TOOL_MODES so cancel can clear it', author: 'tjsingleton', headRefName: 'fix/cancel-clear-skill-active-state' },
+      { number: '2127', title: 'fix(hud): show worktree name instead of volatile main repo HEAD', author: 'blue-int', headRefName: 'fix/hud-worktree-name' },
+      { number: '2129', title: 'fix(hud): replace misleading CLI error with installation diagnostic', author: 'DdangJin', headRefName: 'fix/hud-cli-diagnostic' },
+      { number: '2137', title: 'Fix team tmux pane geometry collapse and bundled agent path resolution', author: 'Yeachan-Heo', headRefName: 'fix-issue-2135-pane-geometry' },
+      { number: '2144', title: 'fix: preserve existing global CLAUDE.md during setup', author: 'Yeachan-Heo', headRefName: 'issue-2143-safe-setup-config' },
+      { number: '2146', title: 'fix: follow up #2143 with explicit overwrite choice + omc launch profile', author: 'Yeachan-Heo', headRefName: 'issue-2143-omc-launch-followup' },
+      { number: '2149', title: 'fix: resolve global HUD npm package lookup outside Node projects', author: 'Yeachan-Heo', headRefName: 'fix/issue-2148-hud-global-npm' },
+      { number: '2151', title: 'feat(hud): make call-count icon rendering configurable', author: 'Yeachan-Heo', headRefName: 'issue-2150-hud-call-count-icons' },
+    ];
+
+    const categories = categorizeReleaseNoteEntries(
+      buildReleaseNoteEntriesFromPullRequests(pullRequests),
+    );
+    const changelog = generateChangelog('4.10.2', categories, pullRequests.length);
+
+    expect(changelog).toContain('across **10 merged PRs**.');
+    expect(changelog).toContain('### Other Changes');
+    expect(changelog).toContain('Fix team tmux pane geometry collapse and bundled agent path resolution');
+    expect(changelog).not.toContain('1+ PRs merged');
+  });
+
+  it('assembles a single custom release body with compare link and contributors', () => {
+    const body = generateReleaseBody(
+      '4.10.2',
+      '# oh-my-claudecode v4.10.2: Bug Fixes',
+      ['blue-int', 'DdangJin', 'Yeachan-Heo'],
+      'v4.10.1',
+    );
+
+    expect(body).toContain('npm install -g oh-my-claude-sisyphus@4.10.2');
+    expect(body).toContain('https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.10.1...v4.10.2');
+    expect(body).toContain('@blue-int @DdangJin @Yeachan-Heo');
+    expect(body.match(/## Contributors/g)).toHaveLength(1);
+  });
+
+  it('configures the workflow to use one custom release body source with github auth', () => {
+    const workflow = readFileSync(
+      resolve(process.cwd(), '.github/workflows/release.yml'),
+      'utf-8',
+    );
+
+    expect(workflow).toContain('body_path: release-notes.md');
+    expect(workflow).toContain('GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}');
+    expect(workflow).not.toContain('generate_release_notes: true');
+  });
+});

--- a/src/lib/release-generation.ts
+++ b/src/lib/release-generation.ts
@@ -1,0 +1,249 @@
+const DEFAULT_REPO_URL = 'https://github.com/Yeachan-Heo/oh-my-claudecode';
+
+export interface ReleasePullRequest {
+  number: string;
+  title: string;
+  author: string | null;
+  headRefName: string | null;
+}
+
+export interface ReleaseNoteEntry {
+  type: string;
+  scope: string;
+  description: string;
+  prNumber: string | null;
+}
+
+interface ChangelogSection {
+  title: string;
+  entries: string[];
+}
+
+const CONVENTIONAL_RE = /^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?:\s*(?<desc>.+)$/;
+
+function parseConventionalSubject(raw: string): { type: string; scope: string; description: string } | null {
+  const match = raw.match(CONVENTIONAL_RE);
+  if (!match?.groups) return null;
+
+  return {
+    type: match.groups.type,
+    scope: match.groups.scope || '',
+    description: match.groups.desc.replace(/\s*\(#\d+\)$/, '').trim(),
+  };
+}
+
+export function extractPullRequestNumbers(subjects: string[]): string[] {
+  const numbers = new Set<string>();
+
+  for (const subject of subjects) {
+    for (const match of subject.matchAll(/#(\d+)/g)) {
+      numbers.add(match[1]);
+    }
+  }
+
+  return [...numbers];
+}
+
+export function isReleasePullRequest(pr: Pick<ReleasePullRequest, 'title' | 'headRefName'>): boolean {
+  const title = pr.title.trim();
+  const headRefName = pr.headRefName?.trim() || '';
+
+  return (
+    /^release\s*:/i.test(title) ||
+    /^chore\(release\)/i.test(title) ||
+    /^release\//i.test(headRefName)
+  );
+}
+
+export function deriveContributorLogins(
+  pullRequests: Array<Pick<ReleasePullRequest, 'author'>>,
+  compareCommitAuthors: Array<string | null | undefined>,
+): string[] {
+  const contributors = new Set<string>();
+
+  for (const author of compareCommitAuthors) {
+    if (author) contributors.add(author);
+  }
+
+  for (const pr of pullRequests) {
+    if (pr.author) contributors.add(pr.author);
+  }
+
+  return [...contributors].sort((a, b) => a.localeCompare(b));
+}
+
+function toReleaseNoteEntryFromPullRequest(pr: ReleasePullRequest): ReleaseNoteEntry {
+  const parsed = parseConventionalSubject(pr.title);
+  if (!parsed) {
+    return {
+      type: 'other',
+      scope: '',
+      description: pr.title,
+      prNumber: pr.number,
+    };
+  }
+
+  return {
+    type: parsed.type,
+    scope: parsed.scope,
+    description: parsed.description,
+    prNumber: pr.number,
+  };
+}
+
+export function buildReleaseNoteEntriesFromPullRequests(pullRequests: ReleasePullRequest[]): ReleaseNoteEntry[] {
+  return pullRequests.map(toReleaseNoteEntryFromPullRequest);
+}
+
+export function categorizeReleaseNoteEntries(entries: ReleaseNoteEntry[]): Map<string, ReleaseNoteEntry[]> {
+  const categories = new Map<string, ReleaseNoteEntry[]>();
+
+  for (const entry of entries) {
+    let category: string;
+
+    if (entry.type === 'feat' || entry.type === 'perf') {
+      category = 'features';
+    } else if ((entry.type === 'fix' && /^(security|deps)$/.test(entry.scope)) || (entry.type === 'chore' && entry.scope === 'deps')) {
+      category = 'security';
+    } else if (entry.type === 'fix') {
+      category = 'fixes';
+    } else if (entry.type === 'refactor') {
+      category = 'refactoring';
+    } else if (entry.type === 'docs') {
+      category = 'docs';
+    } else if (entry.type === 'other' || entry.type === 'chore' || entry.type === 'ci' || entry.type === 'build') {
+      category = 'other';
+    } else {
+      continue;
+    }
+
+    if (!categories.has(category)) categories.set(category, []);
+    categories.get(category)!.push(entry);
+  }
+
+  return categories;
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function formatEntry(entry: ReleaseNoteEntry): string {
+  const pr = entry.prNumber ? ` (#${entry.prNumber})` : '';
+
+  if (entry.type === 'other') {
+    return `- **${entry.description}**${pr}`;
+  }
+
+  const scope = entry.scope ? `(${entry.scope})` : '';
+  return `- **${entry.type}${scope}: ${entry.description}**${pr}`;
+}
+
+function generateTitle(categories: Map<string, ReleaseNoteEntry[]>): string {
+  const parts: string[] = [];
+
+  if (categories.has('features')) {
+    const keywords = categories.get('features')!
+      .slice(0, 3)
+      .map(entry => entry.description.split(/\s+/).slice(0, 3).join(' '));
+    parts.push(...keywords);
+  }
+  if (categories.has('security')) parts.push('Security Hardening');
+  if (categories.has('fixes') && parts.length === 0) parts.push('Bug Fixes');
+
+  if (parts.length === 0) return 'Maintenance Release';
+  if (parts.length <= 3) return parts.join(', ');
+  return parts.slice(0, 3).join(', ');
+}
+
+function generateSummary(categories: Map<string, ReleaseNoteEntry[]>, prCount: number): string {
+  const parts: string[] = [];
+  const featureCount = categories.get('features')?.length ?? 0;
+  const securityCount = categories.get('security')?.length ?? 0;
+  const fixCount = categories.get('fixes')?.length ?? 0;
+  const otherCount = categories.get('other')?.length ?? 0;
+
+  if (featureCount > 0) parts.push(`**${pluralize(featureCount, 'new feature')}**`);
+  if (securityCount > 0) parts.push(`**${pluralize(securityCount, 'security improvement')}**`);
+  if (fixCount > 0) parts.push(`**${pluralize(fixCount, 'bug fix', 'bug fixes')}**`);
+  if (otherCount > 0) parts.push(`**${pluralize(otherCount, 'other change')}**`);
+
+  if (parts.length === 0) return 'Maintenance release with internal improvements.';
+  return `Release with ${parts.join(', ')} across **${pluralize(prCount, 'merged PR')}**.`;
+}
+
+export function generateChangelog(
+  version: string,
+  categories: Map<string, ReleaseNoteEntry[]>,
+  prCount: number,
+): string {
+  const title = generateTitle(categories);
+  const summary = generateSummary(categories, prCount);
+  const sections: ChangelogSection[] = [];
+
+  const highlights: string[] = [];
+  const highlightSources = [
+    ...(categories.get('features') ?? []).slice(0, 5),
+    ...(categories.get('security') ?? []).slice(0, 3),
+  ];
+
+  if (highlightSources.length === 0) {
+    highlightSources.push(...(categories.get('fixes') ?? []).slice(0, 3));
+  }
+
+  for (const entry of highlightSources) {
+    highlights.push(formatEntry(entry));
+  }
+
+  if (highlights.length) sections.push({ title: 'Highlights', entries: highlights });
+  if (categories.has('features')) sections.push({ title: 'New Features', entries: categories.get('features')!.map(formatEntry) });
+  if (categories.has('security')) sections.push({ title: 'Security & Hardening', entries: categories.get('security')!.map(formatEntry) });
+  if (categories.has('fixes')) sections.push({ title: 'Bug Fixes', entries: categories.get('fixes')!.map(formatEntry) });
+  if (categories.has('refactoring')) sections.push({ title: 'Refactoring', entries: categories.get('refactoring')!.map(formatEntry) });
+  if (categories.has('docs')) sections.push({ title: 'Documentation', entries: categories.get('docs')!.map(formatEntry) });
+  if (categories.has('other')) sections.push({ title: 'Other Changes', entries: categories.get('other')!.map(formatEntry) });
+
+  const featCount = categories.get('features')?.length ?? 0;
+  const fixCount = categories.get('fixes')?.length ?? 0;
+  const secCount = categories.get('security')?.length ?? 0;
+  const otherCount = categories.get('other')?.length ?? 0;
+  const statsLine = `- **${pluralize(prCount, 'PR merged', 'PRs merged')}** | **${pluralize(featCount, 'new feature')}** | **${pluralize(fixCount, 'bug fix', 'bug fixes')}** | **${pluralize(secCount, 'security/hardening improvement')}** | **${pluralize(otherCount, 'other change')}**`;
+
+  let md = `# oh-my-claudecode v${version}: ${title}\n\n`;
+  md += `## Release Notes\n\n${summary}\n`;
+
+  for (const section of sections) {
+    md += `\n### ${section.title}\n\n`;
+    md += section.entries.join('\n') + '\n';
+  }
+
+  md += `\n### Stats\n\n${statsLine}\n`;
+  return md;
+}
+
+export function generateReleaseBody(
+  version: string,
+  changelog: string,
+  contributors: string[],
+  prevTag: string,
+  repoUrl: string = DEFAULT_REPO_URL,
+): string {
+  let body = changelog;
+
+  body += `\n### Install / Update\n\n`;
+  body += '```bash\n';
+  body += `npm install -g oh-my-claude-sisyphus@${version}\n`;
+  body += '```\n\n';
+  body += 'Or reinstall the plugin:\n```bash\nclaude /install-plugin oh-my-claudecode\n```\n';
+
+  if (prevTag) {
+    body += `\n**Full Changelog**: ${repoUrl}/compare/${prevTag}...v${version}\n`;
+  }
+
+  if (contributors.length > 0) {
+    body += `\n## Contributors\n\nThank you to all contributors who made this release possible!\n\n`;
+    body += contributors.map(login => `@${login}`).join(' ') + '\n';
+  }
+
+  return body;
+}


### PR DESCRIPTION
## Summary
- build release notes from a deduped real PR set instead of mixing raw commits with merge-subject heuristics
- derive contributor mentions from GitHub PR/compare metadata, with a narrow git fallback when metadata is unavailable
- stop layering `generate_release_notes` on top of the custom `body_path` release body

## Verification
- `npm test -- --run src/__tests__/release-generation.test.ts`
- `npx eslint scripts/release.ts src/lib/release-generation.ts src/__tests__/release-generation.test.ts`
- `npx tsc --noEmit`
- `npx tsx scripts/release.ts 4.10.2 --dry-run`
- replayed v4.10.2 compare/PR metadata through `src/lib/release-generation.ts` to confirm 10 user-facing PRs and contributors `blue-int`, `DdangJin`, `EthanJStark`, `tjsingleton`, `Yeachan-Heo`

## Notes
- scope stays tightly on release generation correctness
- not yet exercised against a live tag-triggered GitHub Actions release
