### PR TITLE
fix(hooks): catch EEXIST on Windows concurrent mkdir race (#2138)

### DIFF
--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -175,7 +175,12 @@ function estimateContextPercent(transcriptPath) {
 function getGuardFilePath(sessionId) {
   const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
   const guardDir = join(configDir, 'projects', '.omc-guards');
-  mkdirSync(guardDir, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(guardDir, { recursive: true, mode: 0o700 });
+  } catch (err) {
+    // On Windows, concurrent hooks can throw EEXIST even with recursive:true
+    if (err?.code !== 'EEXIST') throw err;
+  }
   return join(guardDir, `context-guard-${sessionId}.json`);
 }
 

--- a/scripts/session-summary.mjs
+++ b/scripts/session-summary.mjs
@@ -126,7 +126,12 @@ function readSummaryState(stateDir, sessionId) {
  * Write summary state to disk (scoped by sessionId).
  */
 function writeSummaryState(stateDir, sessionId, state) {
-  mkdirSync(stateDir, { recursive: true });
+  try {
+    mkdirSync(stateDir, { recursive: true });
+  } catch (err) {
+    // On Windows, concurrent hooks can throw EEXIST even with recursive:true
+    if (err?.code !== 'EEXIST') throw err;
+  }
   const statePath = join(stateDir, `session-summary-${sessionId}.json`);
   writeFileSync(statePath, JSON.stringify(state, null, 2));
 }

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -235,7 +235,13 @@ export function ensureOmcDir(relativePath: string, worktreeRoot?: string): strin
   const fullPath = resolveOmcPath(relativePath, worktreeRoot);
 
   if (!existsSync(fullPath)) {
-    mkdirSync(fullPath, { recursive: true });
+    try {
+      mkdirSync(fullPath, { recursive: true });
+    } catch (err) {
+      // On Windows, concurrent hooks can race past the existsSync check and
+      // throw EEXIST. Safe to ignore — see atomic-write.ts:ensureDirSync.
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    }
   }
 
   return fullPath;
@@ -311,7 +317,13 @@ export function ensureAllOmcDirs(worktreeRoot?: string): void {
   for (const subdir of subdirs) {
     const fullPath = subdir ? join(omcRoot, subdir) : omcRoot;
     if (!existsSync(fullPath)) {
-      mkdirSync(fullPath, { recursive: true });
+      try {
+        mkdirSync(fullPath, { recursive: true });
+      } catch (err) {
+        // On Windows, concurrent hooks can race past the existsSync check and
+        // throw EEXIST. Safe to ignore — see atomic-write.ts:ensureDirSync.
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      }
     }
   }
 }
@@ -497,7 +509,13 @@ export function ensureSessionStateDir(sessionId: string, worktreeRoot?: string):
   const sessionDir = getSessionStateDir(sessionId, worktreeRoot);
 
   if (!existsSync(sessionDir)) {
-    mkdirSync(sessionDir, { recursive: true });
+    try {
+      mkdirSync(sessionDir, { recursive: true });
+    } catch (err) {
+      // On Windows, concurrent hooks can race past the existsSync check and
+      // throw EEXIST. Safe to ignore — see atomic-write.ts:ensureDirSync.
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    }
   }
 
   return sessionDir;


### PR DESCRIPTION
## Summary

- Fixes #2138: Hooks fail with EEXIST on every invocation on Windows
- Root cause: `existsSync()` → `mkdirSync({ recursive: true })` TOCTOU race in 5 callsites. On Windows, concurrent hook processes race past the existence check and `mkdirSync` throws EEXIST even with `recursive: true`
- Adds EEXIST catch to 3 functions in `src/lib/worktree-paths.ts` (`ensureOmcDir`, `ensureAllOmcDirs`, `ensureSessionStateDir`) and 2 unguarded `.mjs` hook scripts (`context-guard-stop.mjs`, `session-summary.mjs`)

## Root Cause Analysis

**The fault is in OMC, not Claude Code's plugin framework.**

Claude Code fires multiple hooks per event concurrently (e.g. PostToolUse runs `post-tool-verifier.mjs` + `project-memory-posttool.mjs` in parallel). Both hooks call into shared TS code that invokes `ensureOmcDir()`, which has a TOCTOU race:

```typescript
// BEFORE (vulnerable):
if (!existsSync(fullPath)) {
  mkdirSync(fullPath, { recursive: true }); // throws EEXIST on Windows race
}

// AFTER (safe):
if (!existsSync(fullPath)) {
  try {
    mkdirSync(fullPath, { recursive: true });
  } catch (err) {
    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
  }
}
```

The `existsSync` pre-check **reintroduces** the very race that `recursive: true` was designed to avoid. The safe pattern already existed in `atomic-write.ts:ensureDirSync` — this PR applies it to all remaining vulnerable sites.

## Files Changed

| File | Change |
|------|--------|
| `src/lib/worktree-paths.ts` | EEXIST catch in `ensureOmcDir`, `ensureAllOmcDirs`, `ensureSessionStateDir` |
| `scripts/context-guard-stop.mjs` | Wrap bare `mkdirSync` in EEXIST-safe try-catch |
| `scripts/session-summary.mjs` | Wrap bare `mkdirSync` in EEXIST-safe try-catch |

## Test plan

- [x] All 55 worktree-paths tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual verification on Windows with concurrent hook invocations
- [ ] No behavior change on POSIX (EEXIST catch is a no-op on Linux/macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)