### PR TITLE
fix(team): change sendToWorker fallback from fail-open to fail-closed

### DIFF
--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -855,12 +855,12 @@ export async function sendToWorker(
       return false;
     }
 
-    // Fail-open: one last nudge, then continue regardless.
+    // Fail-closed: one last nudge, but report failure so callers can retry.
     await sendKey('C-m');
     await sleep(120);
     await sendKey('C-m');
 
-    return true;
+    return false;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- `sendToWorker` returns `true` after all retry rounds exhaust without confirming the message left the pane buffer
- All callers (`notifyPaneWithRetry`, `idle-nudge`, `api-interop`) treat `true` as delivery success, so no retry is attempted
- The worker silently misses its task assignment and the dispatch system marks it as notified

## Fix

Change the final `return true` to `return false` at line 863. The callers already handle `false` correctly (retry or record failure), as confirmed by existing tests (`idle-nudge.test.ts:313-315`, `runtime-v2.dispatch.test.ts:240`).

## Failure scenario

1. `sendToWorker` sends message text via `tmux send-keys -l`
2. 6 submit rounds + adaptive retry + 4 more rounds all fail to clear the text from the pane
3. Function returns `true` -- caller believes delivery succeeded
4. Worker never receives the task, leader never retries

## Test plan

- [x] All 63 existing team tests pass (tmux-session, tmux-comm, idle-nudge, runtime-v2.dispatch)
- [x] `idle-nudge.test.ts:313` already tests the `sendToWorker → false` path and verifies pane is not counted as nudged
- [x] `runtime-v2.dispatch.test.ts:240` already tests the `sendToWorker → false` path and verifies retry behavior