### PR TITLE
fix(hooks): align post-tool file_path extraction with pre-tool handler

### DIFF
--- a/src/hooks/omc-orchestrator/index.ts
+++ b/src/hooks/omc-orchestrator/index.ts
@@ -446,7 +446,7 @@ export function processOrchestratorPostTool(
 
   // Handle write/edit tools
   if (isWriteEditTool(toolName)) {
-    const filePath = (toolInput?.filePath ?? toolInput?.path ?? toolInput?.file) as string | undefined;
+    const filePath = (toolInput?.file_path ?? toolInput?.filePath ?? toolInput?.path ?? toolInput?.file ?? toolInput?.notebook_path) as string | undefined;
 
     if (filePath && !isAllowedPath(filePath, workDir)) {
       return {


### PR DESCRIPTION
## Summary

- `processOrchestratorPostTool` (line 449) extracts `filePath` using `toolInput?.filePath` (camelCase), but Claude Code sends `file_path` (snake_case) for Write/Edit tools and `notebook_path` for NotebookEdit
- The pre-tool handler at line 387 already handles both forms correctly
- This mismatch causes `DIRECT_WORK_REMINDER` to never fire after write/edit completions

## Fix

Align the post-tool extraction chain with the pre-tool handler:

```diff
- const filePath = (toolInput?.filePath ?? toolInput?.path ?? toolInput?.file) as string | undefined;
+ const filePath = (toolInput?.file_path ?? toolInput?.filePath ?? toolInput?.path ?? toolInput?.file ?? toolInput?.notebook_path) as string | undefined;
```

## Failure scenario

1. Claude writes to a file outside the allowed path via `Edit` tool (sends `file_path` in snake_case)
2. Pre-tool handler correctly warns about delegation (line 387 matches `file_path`)
3. Post-tool handler fails to match the same path (line 449 only checks `filePath` camelCase)
4. `DIRECT_WORK_REMINDER` never fires -- delegation enforcement is one-sided

## Test plan

- [x] All 1845 existing hook tests pass (1 pre-existing failure in idle notification cooldown, unrelated)
- [x] Verified the pre-tool handler's extraction chain at line 387 as the reference implementation
- [x] Confirmed `toolInput` is passed raw (not normalized) via `bridge.ts:1903-1906`