### PR TITLE
fix(hooks): use PreToolUse deny API in preflight context guard

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -792,8 +792,12 @@ async function main() {
 
       if (contextPercent >= PREFLIGHT_CONTEXT_THRESHOLD) {
         console.log(JSON.stringify({
-          decision: 'block',
-          reason: buildPreflightRecoveryAdvice(contextPercent),
+          continue: true,
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason: buildPreflightRecoveryAdvice(contextPercent),
+          }
         }));
         return;
       }


### PR DESCRIPTION
## Summary

- The preflight context guard (line 793) uses `{ decision: 'block', reason: ... }`, which is the **Stop hook** API format
- This code runs inside a **PreToolUse** hook, which expects `{ continue: true, hookSpecificOutput: { permissionDecision: 'deny', ... } }`
- The three other deny paths in the same file (lines 695, 716, 748) all use the correct PreToolUse format
- Using the wrong API means Claude Code silently ignores the guard, allowing agent-heavy tools (Task, TaskCreate, TaskUpdate) to execute when context is above the preflight threshold

## Fix

Align the preflight context guard output with the PreToolUse deny API, matching the existing pattern at lines 692-700.

## Test plan

- [x] Verified the three reference deny paths (lines 695, 716, 748) all use `permissionDecision: 'deny'`
- [x] Confirmed `buildPreflightRecoveryAdvice` returns a string compatible with `permissionDecisionReason`
- [x] No other `decision: 'block'` patterns remain in the file