### PR TITLE
fix(hooks): prevent fd leak in estimateContextPercent

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -548,14 +548,16 @@ const CRITICAL_CONTEXT_STOP_PERCENT = 95;
 function estimateContextPercent(transcriptPath) {
   if (!transcriptPath || !existsSync(transcriptPath)) return 0;
 
+  let fd = -1;
   try {
     const size = statSync(transcriptPath).size;
     const readSize = 4096;
     const offset = Math.max(0, size - readSize);
     const buf = Buffer.alloc(Math.min(readSize, size));
-    const fd = openSync(transcriptPath, "r");
+    fd = openSync(transcriptPath, "r");
     readSync(fd, buf, 0, buf.length, offset);
     closeSync(fd);
+    fd = -1;
     const content = buf.toString("utf-8");
 
     const windowMatch = content.match(/"context_window"\s{0,5}:\s{0,5}(\d+)/g);
@@ -568,6 +570,8 @@ function estimateContextPercent(transcriptPath) {
     return Math.round((lastInput / lastWindow) * 100);
   } catch {
     return 0;
+  } finally {
+    if (fd !== -1) try { closeSync(fd); } catch { /* best-effort */ }
   }
 }
 


### PR DESCRIPTION
## Summary

- `estimateContextPercent` in `persistent-mode.cjs` declares `const fd = openSync(...)` inside the try block
- If `readSync` throws, the catch block cannot close the descriptor because `fd` is out of scope
- The `.mjs` version of the same function (line 516) correctly uses `let fd = -1` before the try block with a finally clause
- `pre-tool-enforcer.mjs` (line 161) and `context-guard-stop.mjs` (line 139) also use the correct pattern

## Fix

Align the `.cjs` version with the established pattern:
1. Declare `let fd = -1` before the try block
2. Set `fd = -1` after successful `closeSync` (prevent double-close)
3. Add `finally` block for best-effort cleanup on error

## Test plan

- [x] Verified `.mjs` version (line 516), `pre-tool-enforcer.mjs` (line 161), and `context-guard-stop.mjs` (line 139) all use `let fd = -1` with finally
- [x] Confirmed the catch block in `.cjs` had no fd cleanup (just `return 0`)
- [x] Fix preserves all existing logic, only changes fd lifecycle management