### PR TITLE
fix(scripts): replace sed -i with perl for macOS compatibility

### DIFF
--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -18,21 +18,21 @@ echo "🔄 Syncing version $VERSION to satellite files..."
 # 1. .claude-plugin/plugin.json
 PLUGIN="$ROOT/.claude-plugin/plugin.json"
 if [ -f "$PLUGIN" ]; then
-  sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$PLUGIN"
+  perl -i -pe "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$PLUGIN"
   echo "  ✓ plugin.json → $VERSION"
 fi
 
 # 2. .claude-plugin/marketplace.json (has 2 version fields)
 MARKET="$ROOT/.claude-plugin/marketplace.json"
 if [ -f "$MARKET" ]; then
-  sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" "$MARKET"
+  perl -i -pe "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" "$MARKET"
   echo "  ✓ marketplace.json → $VERSION"
 fi
 
 # 3. docs/CLAUDE.md version marker
 CLAUDE_MD="$ROOT/docs/CLAUDE.md"
 if [ -f "$CLAUDE_MD" ]; then
-  sed -i "s/<!-- OMC:VERSION:[^ ]* -->/<!-- OMC:VERSION:$VERSION -->/" "$CLAUDE_MD"
+  perl -i -pe "s/<!-- OMC:VERSION:[^ ]* -->/<!-- OMC:VERSION:$VERSION -->/" "$CLAUDE_MD"
   echo "  ✓ docs/CLAUDE.md → $VERSION"
 fi
 


### PR DESCRIPTION
## Summary

- `sync-version.sh` uses `sed -i "s/..."` which is GNU sed syntax
- On macOS, BSD `sed -i` requires a backup extension argument (e.g., `sed -i '' "s/..."`)
- Without it, BSD sed treats the substitution pattern as the backup extension, causing silent failure or corrupted files
- The rest of the codebase (`setup-claude-md.sh`) already uses `perl` for cross-platform text manipulation

## Fix

Replace all 3 `sed -i` calls with `perl -i -pe`, which behaves identically on both GNU/Linux and macOS. The regex patterns are unchanged.

## Test plan

- [x] Verified `perl -i -pe` produces identical output on macOS
- [x] Confirmed regex patterns are preserved exactly
- [x] No `sed -i` calls remain in the file