### PR TITLE
fix(scripts): add missing homedir import in persistent-mode.cjs

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -22,6 +22,7 @@ const {
   statSync,
 } = require("fs");
 const { join, dirname, resolve, normalize } = require("path");
+const { homedir } = require("os");
 const { getClaudeConfigDir } = require("./lib/config-dir.cjs");
 
 async function readStdin(timeoutMs = 2000) {


### PR DESCRIPTION
## Problem
`homedir()` is called in `getIdleCooldownSeconds()` (line 75) to build the config path `~/.omc/config.json`, but was never imported from Node's `os` module. This causes a `ReferenceError: homedir is not defined` at runtime whenever the idle notification cooldown logic is evaluated.

## Fix
Added `const { homedir } = require('os');` to the require block at the top of the file.

## Evidence
The parallel `.mjs` variant (`scripts/persistent-mode.mjs:25`) already imports it correctly: `import { homedir } from "os";`

## Testing
- [x] `node --check scripts/persistent-mode.cjs` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes