### PR TITLE
fix(autopilot): pass sessionId to generateContinuationPrompt on failed transition

### DIFF
--- a/src/hooks/autopilot/enforcement.ts
+++ b/src/hooks/autopilot/enforcement.ts
@@ -273,7 +273,7 @@ export async function checkAutopilot(
         const result = transitionRalphToUltraQA(workingDir, sessionId);
         if (!result.success) {
           // Transition failed, continue in current phase
-          return generateContinuationPrompt(state, workingDir);
+          return generateContinuationPrompt(state, workingDir, sessionId);
         }
       } else if (state.phase === "qa" && nextPhase === "validation") {
         const result = transitionUltraQAToValidation(workingDir, sessionId);


### PR DESCRIPTION
## Problem
In `src/hooks/autopilot/enforcement.ts` line 276, `generateContinuationPrompt(state, workingDir)` is missing the `sessionId` 3rd argument. This occurs in the execution-to-QA transition failure path. Without `sessionId`, session-scoped state lookups fall back to legacy paths, potentially generating continuation prompts for the wrong session.

## Fix
Added `sessionId` as the 3rd argument: `generateContinuationPrompt(state, workingDir, sessionId)`

## Evidence
All other call sites in the same function pass `sessionId`:
- Line 281: `generateContinuationPrompt(state, workingDir, sessionId)`
- Line 297: `generateContinuationPrompt(state, workingDir, sessionId)`
- Line 303: `generateContinuationPrompt(state, workingDir, sessionId)`

## Testing
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test -- --run` passes
- [x] `npm run build` passes