### PR TITLE
fix(scripts): return sessionPath instead of null when session state not found

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -408,7 +408,7 @@ function readStateFileWithSession(stateDir, filename, sessionId) {
     if (legacyResult.state && legacyResult.state.session_id === sessionId) {
       return legacyResult;
     }
-    return { state: null, path: null, isGlobal: false };
+    return { state: null, path: sessionPath, isGlobal: false };
   }
   // No sessionId: fall back to legacy path (backward compat)
   return readStateFile(stateDir, filename);


### PR DESCRIPTION
## Problem
In `scripts/persistent-mode.cjs`, `readStateFileWithSession` returns `{ state: null, path: null }` when no matching session state is found. The `path: null` return causes `shouldWriteStateBack` to return `false`, silently skipping all state writes for that session.

## Fix
Changed `path: null` to `path: sessionPath`, matching the `.mjs` implementation.

## Evidence
The parallel `.mjs` implementation at `scripts/persistent-mode.mjs:364` correctly returns `{ state: null, path: sessionPath }`, preserving the intended write target.

## Testing
- [x] `node --check scripts/persistent-mode.cjs` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes