### PR TITLE
fix(team): auto-dismiss bypass-permissions dialog for Claude workers

### DIFF
--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -166,9 +166,10 @@ describe('model-contract', () => {
   });
 
   describe('buildLaunchArgs', () => {
-    it('claude includes --dangerously-skip-permissions', () => {
+    it('claude includes --permission-mode bypassPermissions', () => {
       const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp' });
-      expect(args).toContain('--dangerously-skip-permissions');
+      expect(args).toContain('--permission-mode');
+      expect(args).toContain('bypassPermissions');
     });
     it('codex includes --dangerously-bypass-approvals-and-sandbox', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp' });

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -157,7 +157,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     binary: 'claude',
     installInstructions: 'Install Claude CLI: https://claude.ai/download',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
-      const args = ['--dangerously-skip-permissions'];
+      const args = ['--permission-mode', 'bypassPermissions'];
       if (model) {
         // Provider-specific model IDs (Bedrock, Vertex) must be passed as-is.
         // Normalizing them to aliases like "sonnet" causes Claude Code to expand

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -638,6 +638,19 @@ function paneHasTrustPrompt(captured: string): boolean {
   return hasQuestion && hasChoices;
 }
 
+/**
+ * Detect the bypass-permissions confirmation dialog.
+ * This dialog shows "No, exit" / "Yes, I accept" and blocks worker startup.
+ * Auto-dismiss by pressing Down + Enter to select "Yes, I accept".
+ */
+function paneHasBypassPermissionsPrompt(captured: string): boolean {
+  const lines = captured.split('\n').map(l => l.replace(/\r/g, '').trim()).filter(l => l.length > 0);
+  const tail = lines.slice(-15);
+  const hasWarning = tail.some(l => /Bypass Permissions mode/i.test(l));
+  const hasNoExit = tail.some(l => /No,\s*exit/i.test(l));
+  return hasWarning && hasNoExit;
+}
+
 function paneIsBootstrapping(captured: string): boolean {
   const lines = captured
     .split('\n')
@@ -697,6 +710,18 @@ export async function waitForPaneReady(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const captured = await capturePaneAsync(paneId, promisifiedExecFile as never);
+
+    // Auto-accept bypass-permissions dialog if it appears during startup
+    if (paneHasBypassPermissionsPrompt(captured)) {
+      try {
+        await promisifiedExecFile('tmux', ['send-keys', '-t', paneId, 'Down']);
+        await sleep(100);
+        await promisifiedExecFile('tmux', ['send-keys', '-t', paneId, 'Enter']);
+        await sleep(500);
+      } catch { /* best effort */ }
+      continue;
+    }
+
     if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
       return true;
     }
@@ -783,6 +808,14 @@ export async function sendToWorker(
       await sleep(120);
       await sendKey('C-m');
       await sleep(200);
+    }
+
+    // Check for bypass-permissions dialog and auto-accept (press Down then Enter)
+    if (paneHasBypassPermissionsPrompt(initialCapture)) {
+      await sendKey('Down');
+      await sleep(100);
+      await sendKey('C-m');
+      await sleep(500);
     }
 
     // Send text in literal mode with -- separator


### PR DESCRIPTION
## Problem

`omc team` with Claude workers fails silently — workers exit before starting because Claude Code's bypass-permissions TUI dialog auto-selects "No, exit" in small tmux panes.

Fixes #2184.

## Root cause

Claude Code shows an interactive confirmation dialog for `--dangerously-skip-permissions` (and `--permission-mode bypassPermissions`). The dialog renders a select component with "No, exit" as the default selection. In omc team's tmux panes, this dialog either:
- Auto-confirms "No, exit" (small panes can't display the "Yes" option)
- Gets dismissed by omc's send-keys attempting to send the task text

## Fix (3 changes)

### 1. `src/team/model-contract.ts`
Replace `--dangerously-skip-permissions` with `--permission-mode bypassPermissions` — the modern Claude Code flag.

### 2. `src/team/tmux-session.ts` — `paneHasBypassPermissionsPrompt()`
New detection function (mirrors existing `paneHasTrustPrompt` pattern) that checks for the bypass-permissions dialog by looking for "Bypass Permissions mode" + "No, exit" in the pane content.

### 3. `src/team/tmux-session.ts` — Auto-dismiss in two places
- In the message-send flow (before text injection): detect dialog → press Down+Enter to select "Yes, I accept"
- In `waitForPaneReady` poll loop: catch the dialog during startup → same auto-dismiss

This mirrors the existing pattern where `paneHasTrustPrompt` detects and auto-dismisses the workspace trust dialog.

## Testing

Tested with omc 4.10.2 + Claude Code 2.1.92 on Ubuntu WSL2:
- Without fix: both workers exit, task text hits raw bash
- With fix: both workers start and complete work (155 tests passing on our test project)

## Note on `skipDangerousModePermissionPrompt`

Users can also set `skipDangerousModePermissionPrompt: true` in `~/.claude/settings.json` to suppress the dialog entirely. But this auto-dismiss approach is more robust — it works without requiring user configuration.