### PR TITLE
Rollback jonckr runtime PRs #2175-#2179

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -548,16 +548,14 @@ const CRITICAL_CONTEXT_STOP_PERCENT = 95;
 function estimateContextPercent(transcriptPath) {
   if (!transcriptPath || !existsSync(transcriptPath)) return 0;
 
-  let fd = -1;
   try {
     const size = statSync(transcriptPath).size;
     const readSize = 4096;
     const offset = Math.max(0, size - readSize);
     const buf = Buffer.alloc(Math.min(readSize, size));
-    fd = openSync(transcriptPath, "r");
+    const fd = openSync(transcriptPath, "r");
     readSync(fd, buf, 0, buf.length, offset);
     closeSync(fd);
-    fd = -1;
     const content = buf.toString("utf-8");
 
     const windowMatch = content.match(/"context_window"\s{0,5}:\s{0,5}(\d+)/g);
@@ -570,8 +568,6 @@ function estimateContextPercent(transcriptPath) {
     return Math.round((lastInput / lastWindow) * 100);
   } catch {
     return 0;
-  } finally {
-    if (fd !== -1) try { closeSync(fd); } catch { /* best-effort */ }
   }
 }
 

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -792,12 +792,8 @@ async function main() {
 
       if (contextPercent >= PREFLIGHT_CONTEXT_THRESHOLD) {
         console.log(JSON.stringify({
-          continue: true,
-          hookSpecificOutput: {
-            hookEventName: 'PreToolUse',
-            permissionDecision: 'deny',
-            permissionDecisionReason: buildPreflightRecoveryAdvice(contextPercent),
-          }
+          decision: 'block',
+          reason: buildPreflightRecoveryAdvice(contextPercent),
         }));
         return;
       }

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -18,21 +18,21 @@ echo "🔄 Syncing version $VERSION to satellite files..."
 # 1. .claude-plugin/plugin.json
 PLUGIN="$ROOT/.claude-plugin/plugin.json"
 if [ -f "$PLUGIN" ]; then
-  perl -i -pe "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$PLUGIN"
+  sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$PLUGIN"
   echo "  ✓ plugin.json → $VERSION"
 fi
 
 # 2. .claude-plugin/marketplace.json (has 2 version fields)
 MARKET="$ROOT/.claude-plugin/marketplace.json"
 if [ -f "$MARKET" ]; then
-  perl -i -pe "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" "$MARKET"
+  sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" "$MARKET"
   echo "  ✓ marketplace.json → $VERSION"
 fi
 
 # 3. docs/CLAUDE.md version marker
 CLAUDE_MD="$ROOT/docs/CLAUDE.md"
 if [ -f "$CLAUDE_MD" ]; then
-  perl -i -pe "s/<!-- OMC:VERSION:[^ ]* -->/<!-- OMC:VERSION:$VERSION -->/" "$CLAUDE_MD"
+  sed -i "s/<!-- OMC:VERSION:[^ ]* -->/<!-- OMC:VERSION:$VERSION -->/" "$CLAUDE_MD"
   echo "  ✓ docs/CLAUDE.md → $VERSION"
 fi
 

--- a/src/hooks/omc-orchestrator/index.ts
+++ b/src/hooks/omc-orchestrator/index.ts
@@ -450,7 +450,7 @@ export function processOrchestratorPostTool(
 
   // Handle write/edit tools
   if (isWriteEditTool(toolName)) {
-    const filePath = (toolInput?.file_path ?? toolInput?.filePath ?? toolInput?.path ?? toolInput?.file ?? toolInput?.notebook_path) as string | undefined;
+    const filePath = (toolInput?.filePath ?? toolInput?.path ?? toolInput?.file) as string | undefined;
 
     if (filePath && !isAllowedPath(filePath, workDir)) {
       return {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -855,12 +855,12 @@ export async function sendToWorker(
       return false;
     }
 
-    // Fail-closed: one last nudge, but report failure so callers can retry.
+    // Fail-open: one last nudge, then continue regardless.
     await sendKey('C-m');
     await sleep(120);
     await sendKey('C-m');
 
-    return false;
+    return true;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- revert jonckr merged PRs #2175, #2176, #2177, #2178, and #2179 with mainline parent 1 semantics
- restore the pre-jonckr runtime / hook / team behavior in the five touched files only
- keep the rollback narrowly scoped for auditability

## Why
This is an owner-directed rollback of high-risk external runtime/hook/team changes after CI/base-red fallout.

## Validation
- `npx vitest run src/team/__tests__/tmux-session.test.ts`
- `npx vitest run src/__tests__/pre-tool-enforcer.test.ts src/__tests__/bedrock-lm-suffix-hook.test.ts`
- `npx vitest run src/hooks/persistent-mode/stop-hook-blocking.test.ts`
- `node` version consistency check for `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm pack` + local-prefix smoke install (`omc --version`, `omc --help`)

## Notes / remaining risk
- Full `npm test -- --run` is still red on `src/__tests__/hooks-command-escaping.test.ts` due an unrelated Windows-style plugin-root path failure outside the reverted files.
- This rollback intentionally restores the older pre-tool deny payload, removes the extra transcript fd-cleanup, and reverts `scripts/sync-version.sh` to `sed -i`; the macOS-specific sync-version risk remains a known blind spot unless re-fixed separately.
