### PR TITLE
Fix deep-interview ambiguityThreshold runtime loading

### DIFF
--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { createBuiltinSkills, getBuiltinSkill, listBuiltinSkillNames, clearSkillsCache } from '../features/builtin-skills/skills.js';
 
 describe('Builtin Skills', () => {
   const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   const originalPath = process.env.PATH;
   const originalUserType = process.env.USER_TYPE;
+  const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const originalCwd = process.cwd();
+  let tempDirs: string[] = [];
 
   // Clear cache before each test to ensure fresh loads
   beforeEach(() => {
@@ -23,6 +29,13 @@ describe('Builtin Skills', () => {
     } else {
       process.env.USER_TYPE = originalUserType;
     }
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    }
+    process.chdir(originalCwd);
+    tempDirs = [];
     clearSkillsCache();
   });
 
@@ -42,6 +55,16 @@ describe('Builtin Skills', () => {
     } else {
       process.env.USER_TYPE = originalUserType;
     }
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    }
+    process.chdir(originalCwd);
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
     clearSkillsCache();
   });
 
@@ -257,6 +280,37 @@ describe('Builtin Skills', () => {
       expect(skill?.argumentHint).toContain('--autoresearch');
       expect(skill?.template).toContain('zero-learning-curve setup lane for `omc autoresearch`');
       expect(skill?.template).toContain('autoresearch --mission "<mission>" --eval "<evaluator>"');
+    });
+
+    it('loads deep-interview ambiguityThreshold from settings before state init and updates the announcement copy', () => {
+      const profileDir = mkdtempSync(join(tmpdir(), 'omc-skill-profile-'));
+      const projectDir = mkdtempSync(join(tmpdir(), 'omc-skill-project-'));
+      tempDirs.push(profileDir, projectDir);
+
+      process.env.CLAUDE_CONFIG_DIR = profileDir;
+      writeFileSync(
+        join(profileDir, 'settings.json'),
+        JSON.stringify({ omc: { deepInterview: { ambiguityThreshold: 0.15 } } }),
+      );
+
+      mkdirSync(join(projectDir, '.claude'), { recursive: true });
+      writeFileSync(
+        join(projectDir, '.claude', 'settings.json'),
+        JSON.stringify({ omc: { deepInterview: { ambiguityThreshold: 0.12 } } }),
+      );
+
+      process.chdir(projectDir);
+      clearSkillsCache();
+
+      const skill = getBuiltinSkill('deep-interview');
+      expect(skill).toBeDefined();
+      expect(skill?.template).toContain('Load runtime settings');
+      expect(skill?.template).toContain('ambiguityThreshold = 0.12');
+      expect(skill?.template).toContain('"threshold": 0.12,');
+      expect(skill?.template).toContain('drops below 12%.');
+      expect(skill?.template?.indexOf('Load runtime settings')).toBeLessThan(
+        skill?.template?.indexOf('Initialize state') ?? Number.POSITIVE_INFINITY,
+      );
     });
 
     it('rewrites built-in skill command examples to plugin-safe bridge invocations when omc is unavailable', () => {

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -19,6 +19,7 @@ import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../u
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from './runtime-guidance.js';
 import { isSkininthegamebrosUser } from '../../utils/skininthegamebros-user.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 function getPackageDir(): string {
   if (typeof __dirname !== 'undefined' && __dirname) {
@@ -75,11 +76,75 @@ const SKININTHEGAMEBROS_ONLY_SKILLS = new Set([
   'skillify',
 ]);
 
+const DEFAULT_DEEP_INTERVIEW_AMBIGUITY_THRESHOLD = 0.2;
+
 function toSafeSkillName(name: string): string {
   const normalized = name.trim();
   return CC_NATIVE_COMMANDS.has(normalized.toLowerCase())
     ? `omc-${normalized}`
     : normalized;
+}
+
+function readJsonObject(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readDeepInterviewThresholdFromSettings(path: string): number | null {
+  const settings = readJsonObject(path);
+  const omc = settings?.omc;
+  if (!omc || typeof omc !== 'object' || Array.isArray(omc)) {
+    return null;
+  }
+
+  const deepInterview = (omc as Record<string, unknown>).deepInterview;
+  if (!deepInterview || typeof deepInterview !== 'object' || Array.isArray(deepInterview)) {
+    return null;
+  }
+
+  const threshold = (deepInterview as Record<string, unknown>).ambiguityThreshold;
+  return typeof threshold === 'number' && Number.isFinite(threshold) && threshold >= 0 && threshold <= 1
+    ? threshold
+    : null;
+}
+
+function getDeepInterviewAmbiguityThreshold(): number {
+  const profileThreshold = readDeepInterviewThresholdFromSettings(join(getClaudeConfigDir(), 'settings.json'));
+  const projectThreshold = readDeepInterviewThresholdFromSettings(join(process.cwd(), '.claude', 'settings.json'));
+  return projectThreshold ?? profileThreshold ?? DEFAULT_DEEP_INTERVIEW_AMBIGUITY_THRESHOLD;
+}
+
+function formatThresholdPercent(threshold: number): string {
+  return `${(threshold * 100).toFixed(2).replace(/\.?0+$/, '')}%`;
+}
+
+function applyDeepInterviewRuntimeSettings(template: string): string {
+  const threshold = getDeepInterviewAmbiguityThreshold();
+  const percent = formatThresholdPercent(threshold);
+
+  return template
+    .replace(
+      '4. **Initialize state** via `state_write(mode="deep-interview")`:',
+      [
+        `3.5. **Load runtime settings** from \`~/.claude/settings.json\` and \`./.claude/settings.json\` before state init (project overrides profile). For this run, use \`ambiguityThreshold = ${threshold}\`.`,
+        '4. **Initialize state** via `state_write(mode="deep-interview")`:',
+      ].join('\n'),
+    )
+    .replace('"threshold": 0.2,', `"threshold": ${threshold},`)
+    .replace(
+      'We\'ll proceed to execution once ambiguity drops below 20%.',
+      `We'll proceed to execution once ambiguity drops below ${percent}.`,
+    );
 }
 
 /**
@@ -92,7 +157,9 @@ function loadSkillFromFile(skillPath: string, skillName: string): BuiltinSkill[]
     const resolvedName = metadata.name || skillName;
     const safePrimaryName = toSafeSkillName(resolvedName);
     const pipeline = parseSkillPipelineMetadata(metadata);
-    const renderedBody = rewriteOmcCliInvocations(body.trim());
+    const renderedBody = safePrimaryName === 'deep-interview'
+      ? applyDeepInterviewRuntimeSettings(rewriteOmcCliInvocations(body.trim()))
+      : rewriteOmcCliInvocations(body.trim());
     const template = [
       renderedBody,
       renderSkillRuntimeGuidance(safePrimaryName),


### PR DESCRIPTION
## Summary
- load `omc.deepInterview.ambiguityThreshold` from Claude settings when materializing the built-in deep-interview skill
- inject the resolved threshold before the state-init instructions and use it in the startup announcement instead of hardcoded 20%
- add a focused regression test for project-over-profile settings precedence and dynamic threshold rendering

## Testing
- `npx vitest run src/__tests__/skills.test.ts -t "loads deep-interview ambiguityThreshold"`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/features/builtin-skills/skills.ts src/__tests__/skills.test.ts`

Closes #2192
