### PR TITLE
fix(ask): always pipe codex prompts via stdin to avoid arg parsing errors

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -28,7 +28,11 @@ function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}
 }
 
 function shouldPipePromptViaStdin(provider) {
-  return SHOULD_USE_WINDOWS_SHELL && (provider === 'codex' || provider === 'gemini');
+  // Always pipe for codex — complex prompts (e.g. agent prompts with YAML
+  // frontmatter starting with "---") are misinterpreted as CLI flags when
+  // passed as positional arguments.
+  if (provider === 'codex') return true;
+  return SHOULD_USE_WINDOWS_SHELL && provider === 'gemini';
 }
 
 const ASK_ORIGINAL_TASK_ENV = 'OMC_ASK_ORIGINAL_TASK';

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -133,7 +133,7 @@ function writeFakeProviderBinary(dir: string, provider: 'claude' | 'gemini'): st
   return binDir;
 }
 
-function writeSpawnSyncCapturePrelude(dir: string): string {
+function writeSpawnSyncCapturePrelude(dir: string, { platform = 'win32' }: { platform?: string } = {}): string {
   const preludePath = join(dir, 'spawn-sync-capture-prelude.mjs');
   writeFileSync(
     preludePath,
@@ -142,7 +142,7 @@ function writeSpawnSyncCapturePrelude(dir: string): string {
       "import { writeFileSync } from 'node:fs';",
       "import { syncBuiltinESMExports } from 'node:module';",
       '',
-      "Object.defineProperty(process, 'platform', { value: 'win32' });",
+      `Object.defineProperty(process, 'platform', { value: '${platform}' });`,
       'const capturePath = process.env.SPAWN_CAPTURE_PATH;',
       "const mode = process.env.SPAWN_CAPTURE_MODE || 'success';",
       'const calls = [];',
@@ -546,6 +546,44 @@ describe('run-provider-advisor script contract', () => {
         command: 'codex',
         args: ['exec', '--dangerously-bypass-approvals-and-sandbox', '-'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: 'windows cmd support 你好' },
+      });
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('pipes codex prompts over stdin on non-Windows to avoid YAML frontmatter arg parsing errors', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-unix-stdin-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd, { platform: 'darwin' });
+      const yamlPrompt = '---\nname: critic\n---\n\nReview this code';
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['codex', '--prompt', yamlPrompt],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+        options: { shell: boolean; encoding: string | null; stdio: string | null; input: string | null };
+      }>;
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]).toMatchObject({
+        command: 'codex',
+        args: ['--version'],
+        options: { shell: false, encoding: 'utf8', stdio: 'ignore', input: null },
+      });
+      expect(calls[1]).toMatchObject({
+        command: 'codex',
+        args: ['exec', '--dangerously-bypass-approvals-and-sandbox', '-'],
+        options: { shell: false, encoding: 'utf8', stdio: null, input: yamlPrompt },
       });
     } finally {
       rmSync(wd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- `omc ask codex critic` (and any agent-prompt role) fails with exit code 2 when the resolved agent prompt contains YAML frontmatter starting with `---`
- The Codex CLI arg parser misinterprets the leading `---` as an invalid flag instead of prompt content
- Fix: always pipe prompts via stdin for codex (the path already existed for Windows; this makes it the default on all platforms)

## Reproduction
1. Run `omc ask codex critic "review this code"`
2. The critic agent prompt gets prepended (with `---` YAML frontmatter)
3. `codex exec --dangerously-bypass-approvals-and-sandbox "---\nname: critic\n..."` fails with `error: unexpected argument`

## Change
`shouldPipePromptViaStdin()` in `scripts/run-provider-advisor.js` now returns `true` unconditionally for codex, bypassing the positional-argument path that triggers the parsing error.

## Test plan
- [ ] `omc ask codex critic "review latest commit"` completes without arg parsing error
- [ ] `omc ask codex "simple prompt"` still works (stdin pipe is transparent)
- [ ] Windows behavior unchanged (was already using stdin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)