### PR TITLE
fix(team): stop double-sending startup inbox on team init

### DIFF
--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -258,7 +258,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(requests[0]?.last_reason).toBe('worker_notify_failed');
   });
 
-  it('requires Claude startup evidence beyond the initial notify and retries once before failing', async () => {
+  it('requires Claude startup evidence without resending the startup inbox', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-claude-evidence-missing-'));
     const { startTeamV2 } = await import('../runtime-v2.js');
 
@@ -272,14 +272,14 @@ describe('runtime v2 startup inbox dispatch', () => {
 
     expect(runtime.config.workers[0]?.pane_id).toBe('%2');
     expect(runtime.config.workers[0]?.assigned_tasks).toEqual([]);
-    expect(mocks.sendToWorker).toHaveBeenCalledTimes(2);
+    expect(mocks.sendToWorker).toHaveBeenCalledTimes(1);
 
     const requests = await listDispatchRequests('dispatch-team', cwd, { kind: 'inbox' });
     expect(requests).toHaveLength(1);
     expect(requests[0]?.status).toBe('notified');
   });
 
-  it('does not treat ACK-only mailbox replies as Claude startup evidence', async () => {
+  it('does not treat ACK-only mailbox replies as Claude startup evidence or resend the startup inbox', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-claude-evidence-ack-'));
 
     mocks.sendToWorker.mockImplementation(async () => {
@@ -309,7 +309,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     });
 
     expect(runtime.config.workers[0]?.assigned_tasks).toEqual([]);
-    expect(mocks.sendToWorker).toHaveBeenCalledTimes(2);
+    expect(mocks.sendToWorker).toHaveBeenCalledTimes(1);
   });
 
   it('accepts Claude startup once the worker claims the task', async () => {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -530,29 +530,14 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
       opts.workerName,
       opts.taskId,
       opts.cwd,
+      6,
     );
     if (!settled) {
-      const renotified = await notifyStartupInbox(opts.sessionName, paneId, inboxTriggerMessage);
-      if (!renotified.ok) {
-        return {
-          paneId,
-          startupAssigned: false,
-          startupFailureReason: `${renotified.reason}:startup_evidence_missing`,
-        };
-      }
-      const settledAfterRetry = await waitForWorkerStartupEvidence(
-        opts.teamName,
-        opts.workerName,
-        opts.taskId,
-        opts.cwd,
-      );
-      if (!settledAfterRetry) {
-        return {
-          paneId,
-          startupAssigned: false,
-          startupFailureReason: 'claude_startup_evidence_missing',
-        };
-      }
+      return {
+        paneId,
+        startupAssigned: false,
+        startupFailureReason: 'claude_startup_evidence_missing',
+      };
     }
   }
 


### PR DESCRIPTION
## Summary
- restore the single-send startup inbox contract for Claude team workers
- keep the startup evidence gate, but wait longer instead of sending a second startup trigger
- lock the regression with focused runtime-v2 dispatch tests

## Root cause
`spawnV2Worker()` already sends the startup inbox once through `queueInboxInstruction()`, but the Claude-only startup evidence fallback called `notifyStartupInbox()` directly when claim/status evidence did not appear quickly. That second direct notify bypassed queued dispatch accounting and sent the same startup inbox twice.

## Verification
- `npx vitest --run src/team/__tests__/runtime-v2.dispatch.test.ts`
- `npx vitest --run src/team/__tests__/runtime-prompt-mode.test.ts -t 'non-prompt worker waits for pane readiness before sending inbox instruction'`
- `npx vitest --run src/team/__tests__/runtime-v2.dispatch.test.ts src/team/__tests__/runtime-prompt-mode.test.ts -t 'non-prompt worker waits for pane readiness before sending inbox instruction|requires Claude startup evidence without resending the startup inbox|does not treat ACK-only mailbox replies as Claude startup evidence or resend the startup inbox|writes durable inbox dispatch evidence when startup worker notification succeeds'`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

## Notes
I could not corroborate the owner's `0.11.13` version marker in this repo's tags/history. The duplicate-send behavior appears to have been introduced by commit `b1e7e36b5d5ffc4a8dfd92e3296fc6798f3ea622` (`fix(team): port startup hardening from omx`, 2026-03-10 UTC).
