### PR TITLE
Fix /team role shorthand for executor workers

### DIFF
--- a/src/cli/commands/__tests__/team-role-shorthand.test.ts
+++ b/src/cli/commands/__tests__/team-role-shorthand.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtimeV2Mocks = vi.hoisted(() => ({
+  isRuntimeV2Enabled: vi.fn(() => true),
+  startTeamV2: vi.fn(),
+  monitorTeamV2: vi.fn(),
+  findActiveTeamsV2: vi.fn(async () => []),
+}));
+
+const agentUtilsMocks = vi.hoisted(() => ({
+  loadAgentPrompt: vi.fn((role: string) => `prompt:${role}`),
+}));
+
+vi.mock('../../../team/runtime-v2.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../team/runtime-v2.js')>();
+  return {
+    ...actual,
+    isRuntimeV2Enabled: runtimeV2Mocks.isRuntimeV2Enabled,
+    startTeamV2: runtimeV2Mocks.startTeamV2,
+    monitorTeamV2: runtimeV2Mocks.monitorTeamV2,
+    findActiveTeamsV2: runtimeV2Mocks.findActiveTeamsV2,
+  };
+});
+
+vi.mock('../../../agents/utils.js', () => ({
+  loadAgentPrompt: agentUtilsMocks.loadAgentPrompt,
+}));
+
+describe('teamCommand role-only shorthand', () => {
+  const originalCwd = process.cwd();
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    runtimeV2Mocks.isRuntimeV2Enabled.mockReturnValue(true);
+    runtimeV2Mocks.findActiveTeamsV2.mockResolvedValue([]);
+    runtimeV2Mocks.startTeamV2.mockResolvedValue({
+      teamName: 'fix-the-bug',
+      sessionName: 'team-session',
+      config: { worker_count: 2 },
+    });
+    runtimeV2Mocks.monitorTeamV2.mockResolvedValue({
+      tasks: { total: 2, pending: 0, in_progress: 2, completed: 0, failed: 0 },
+    });
+    agentUtilsMocks.loadAgentPrompt.mockImplementation((role: string) => `prompt:${role}`);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    logSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('routes `N:executor` through claude agent types plus executor worker roles', async () => {
+    const { teamCommand } = await import('../team.js');
+
+    await teamCommand(['2:executor', 'fix the bug']);
+
+    expect(agentUtilsMocks.loadAgentPrompt).toHaveBeenCalledWith('executor');
+    expect(runtimeV2Mocks.startTeamV2).toHaveBeenCalledWith(expect.objectContaining({
+      workerCount: 2,
+      agentTypes: ['claude', 'claude'],
+      workerRoles: ['executor', 'executor'],
+      roleName: 'executor',
+      rolePrompt: 'prompt:executor',
+      tasks: [
+        { subject: 'Worker 1: fix the bug', description: 'fix the bug', owner: 'worker-1' },
+        { subject: 'Worker 2: fix the bug', description: 'fix the bug', owner: 'worker-2' },
+      ],
+    }));
+  });
+});

--- a/src/cli/commands/__tests__/team.test.ts
+++ b/src/cli/commands/__tests__/team.test.ts
@@ -239,6 +239,18 @@ describe('teamCommand api operations', () => {
 });
 
 describe('parseTeamArgs comma-separated multi-type specs', () => {
+  it('treats role-only shorthand as claude workers plus a shared role', () => {
+    const parsed = parseTeamArgs(['2:executor', 'fix the bug']);
+    expect(parsed.workerCount).toBe(2);
+    expect(parsed.agentTypes).toEqual(['claude', 'claude']);
+    expect(parsed.workerSpecs).toEqual([
+      { agentType: 'claude', role: 'executor' },
+      { agentType: 'claude', role: 'executor' },
+    ]);
+    expect(parsed.role).toBe('executor');
+    expect(parsed.task).toBe('fix the bug');
+  });
+
   it('parses 1:codex,1:gemini into heterogeneous agentTypes', () => {
     const parsed = parseTeamArgs(['1:codex,1:gemini', 'do the task']);
     expect(parsed.workerCount).toBe(2);
@@ -270,6 +282,17 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
       { agentType: 'gemini', role: 'executor' },
     ]);
     expect(parsed.role).toBe('executor');
+  });
+
+  it('supports mixed explicit cli types and role-only shorthand in comma specs', () => {
+    const parsed = parseTeamArgs(['1:executor,1:codex:architect', 'run tasks']);
+    expect(parsed.workerCount).toBe(2);
+    expect(parsed.agentTypes).toEqual(['claude', 'codex']);
+    expect(parsed.workerSpecs).toEqual([
+      { agentType: 'claude', role: 'executor' },
+      { agentType: 'codex', role: 'architect' },
+    ]);
+    expect(parsed.role).toBeUndefined();
   });
 
   it('still parses single-type spec 3:codex into uniform agentTypes', () => {

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -19,6 +19,7 @@ import type { CliAgentType } from '../../team/model-contract.js';
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
+const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini']);
 
 const TEAM_HELP = `
 Usage: omc team [N:agent-type[:role]] [--new-window] "<task description>"
@@ -239,6 +240,12 @@ export interface ParsedTeamArgs {
   newWindow: boolean;
 }
 
+interface NormalizedWorkerSpecSegment {
+  count: number;
+  agentType: string;
+  role?: string;
+}
+
 function getTeamWorkerIdentityFromEnv(env: NodeJS.ProcessEnv = process.env): string | null {
   const omc = typeof env.OMC_TEAM_WORKER === 'string' ? env.OMC_TEAM_WORKER.trim() : '';
   if (omc) return omc;
@@ -284,6 +291,29 @@ export async function assertTeamSpawnAllowed(cwd: string, env: NodeJS.ProcessEnv
 /** Regex for a single worker spec segment: N[:type[:role]] */
 const SINGLE_SPEC_RE = /^(\d+)(?::([a-z][a-z0-9-]*)(?::([a-z][a-z0-9-]*))?)?$/i;
 
+function normalizeWorkerSpecSegment(match: RegExpMatchArray): NormalizedWorkerSpecSegment {
+  const count = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(count) || count < MIN_WORKER_COUNT || count > MAX_WORKER_COUNT) {
+    throw new Error(`Invalid worker count "${match[1]}". Expected ${MIN_WORKER_COUNT}-${MAX_WORKER_COUNT}.`);
+  }
+
+  const token = match[2]?.toLowerCase();
+  const explicitRole = match[3]?.toLowerCase();
+  if (!token) {
+    return { count, agentType: 'claude' };
+  }
+
+  if (explicitRole) {
+    return { count, agentType: token, role: explicitRole };
+  }
+
+  if (VALID_TEAM_CLI_AGENT_TYPES.has(token)) {
+    return { count, agentType: token };
+  }
+
+  return { count, agentType: 'claude', role: token };
+}
+
 /** @internal Exported for testing */
 export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   const args = [...tokens];
@@ -313,17 +343,13 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
 
   if (first.includes(',')) {
     const segments = first.split(',');
-    const parsedSegments: Array<{ count: number; type: string; role?: string }> = [];
+    const parsedSegments: NormalizedWorkerSpecSegment[] = [];
     let allValid = true;
 
     for (const seg of segments) {
       const m = seg.match(SINGLE_SPEC_RE);
       if (!m) { allValid = false; break; }
-      const count = Number.parseInt(m[1], 10);
-      if (!Number.isFinite(count) || count < MIN_WORKER_COUNT || count > MAX_WORKER_COUNT) {
-        throw new Error(`Invalid worker count "${m[1]}". Expected ${MIN_WORKER_COUNT}-${MAX_WORKER_COUNT}.`);
-      }
-      parsedSegments.push({ count, type: m[2] || 'claude', role: m[3] });
+      parsedSegments.push(normalizeWorkerSpecSegment(m));
     }
 
     if (allValid && parsedSegments.length > 0) {
@@ -331,8 +357,8 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
       for (const seg of parsedSegments) {
         workerCount += seg.count;
         for (let i = 0; i < seg.count; i++) {
-          agentTypes.push(seg.type);
-          workerSpecs.push({ agentType: seg.type, ...(seg.role ? { role: seg.role } : {}) });
+          agentTypes.push(seg.agentType);
+          workerSpecs.push({ agentType: seg.agentType, ...(seg.role ? { role: seg.role } : {}) });
         }
       }
       if (workerCount > MAX_WORKER_COUNT) {
@@ -351,15 +377,14 @@ export function parseTeamArgs(tokens: string[]): ParsedTeamArgs {
   if (!specMatched) {
     const match = first.match(SINGLE_SPEC_RE);
     if (match) {
-      const count = Number.parseInt(match[1], 10);
-      if (!Number.isFinite(count) || count < MIN_WORKER_COUNT || count > MAX_WORKER_COUNT) {
-        throw new Error(`Invalid worker count "${match[1]}". Expected ${MIN_WORKER_COUNT}-${MAX_WORKER_COUNT}.`);
-      }
-      workerCount = count;
-      const type = match[2] || 'claude';
-      if (match[3]) role = match[3];
-      agentTypes = Array.from({ length: workerCount }, () => type);
-      workerSpecs = Array.from({ length: workerCount }, () => ({ agentType: type, ...(role ? { role } : {}) }));
+      const normalized = normalizeWorkerSpecSegment(match);
+      workerCount = normalized.count;
+      role = normalized.role;
+      agentTypes = Array.from({ length: workerCount }, () => normalized.agentType);
+      workerSpecs = Array.from({ length: workerCount }, () => ({
+        agentType: normalized.agentType,
+        ...(role ? { role } : {}),
+      }));
       filteredArgs.shift();
     }
   }


### PR DESCRIPTION
## Summary
- normalize role-only `/team N:executor` shorthand at the CLI parse boundary so it uses supported CLI backends plus executor worker roles
- add parser and command-path regression coverage for role-only shorthand and mixed shorthand/explicit backend specs
- preserve the existing runtime-v2 prompt-delivery path unchanged because it already works once valid agent types reach it

## Root cause
`src/cli/commands/team.ts` parsed `N:executor` as an agent type instead of a worker role, forwarding `agentTypes=["executor", ...]` into a runtime that only supports `claude|codex|gemini`. That prevented the expected worker startup/prompt-delivery path from receiving a valid backend configuration.

## Verification
- `npx vitest --run src/cli/commands/__tests__/team.test.ts src/cli/commands/__tests__/team-role-shorthand.test.ts`
- `npx vitest --run src/team/__tests__/runtime-v2.dispatch.test.ts src/team/__tests__/runtime-prompt-mode.test.ts`
- `npx eslint src/cli/commands/team.ts src/cli/commands/__tests__/team.test.ts src/cli/commands/__tests__/team-role-shorthand.test.ts`
- `npx tsc --noEmit`
- `npm run build`

Closes #2120
