### PR TITLE
fix(windows): resolve bash from PATH for explore wrapper

### DIFF
--- a/src/team/__tests__/shell-affinity.test.ts
+++ b/src/team/__tests__/shell-affinity.test.ts
@@ -13,10 +13,15 @@ vi.mock('fs', async (importOriginal) => {
 import { existsSync } from 'fs';
 const mockExistsSync = existsSync as ReturnType<typeof vi.fn>;
 
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
   mockExistsSync.mockReset();
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+  }
 });
 
 describe('resolveShellFromCandidates', () => {
@@ -29,6 +34,21 @@ describe('resolveShellFromCandidates', () => {
   it('returns null when no candidates exist', () => {
     mockExistsSync.mockReturnValue(false);
     expect(resolveShellFromCandidates(['/bin/zsh', '/usr/bin/zsh'], '/home/user/.zshrc')).toBeNull();
+  });
+
+  it('resolves bash.exe from PATH on Windows when fixed Unix candidates do not exist', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    vi.stubEnv('PATH', 'C:\\Windows\\System32;D:\\SoftWare\\Git\\bin');
+    mockExistsSync.mockImplementation((p: string) => p.replace(/\\/g, '/').replace(/\/+/g, '/') === 'D:/SoftWare/Git/bin/bash.exe');
+
+    const result = resolveShellFromCandidates(['/bin/bash', '/usr/bin/bash'], 'C:/Users/test/.bashrc');
+    expect(result?.rcFile).toBe('C:/Users/test/.bashrc');
+    expect(result?.shell.replace(/\\/g, '/')).toBe('D:/SoftWare/Git/bin/bash.exe');
+
+    if (originalDescriptor) {
+      Object.defineProperty(process, 'platform', originalDescriptor);
+    }
   });
 });
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -131,10 +131,41 @@ export interface WorkerLaunchSpec {
 const ZSH_CANDIDATES = ['/bin/zsh', '/usr/bin/zsh', '/usr/local/bin/zsh', '/opt/homebrew/bin/zsh'];
 const BASH_CANDIDATES = ['/bin/bash', '/usr/bin/bash'];
 
-/** Try a list of shell paths; return first that exists with its rcFile, or null */
+function pathEntries(envPath: string | undefined): string[] {
+  return (envPath ?? '')
+    .split(process.platform === 'win32' ? ';' : ':')
+    .map(entry => entry.trim())
+    .filter(Boolean);
+}
+
+function pathCandidateNames(candidatePath: string): string[] {
+  const base = basename(candidatePath.replace(/\\/g, '/'));
+  const bare = base.replace(/\.(exe|cmd|bat)$/i, '');
+
+  if (process.platform === 'win32') {
+    return Array.from(new Set([`${bare}.exe`, `${bare}.cmd`, `${bare}.bat`, bare]));
+  }
+
+  return Array.from(new Set([base, bare]));
+}
+
+function resolveShellFromPath(candidatePath: string): string | null {
+  for (const dir of pathEntries(process.env.PATH)) {
+    for (const name of pathCandidateNames(candidatePath)) {
+      const full = join(dir, name);
+      if (existsSync(full)) return full;
+    }
+  }
+  return null;
+}
+
+/** Try a list of shell paths; return first existing path or PATH-discovered binary with its rcFile, or null */
 export function resolveShellFromCandidates(paths: string[], rcFile: string): WorkerLaunchSpec | null {
   for (const p of paths) {
     if (existsSync(p)) return { shell: p, rcFile };
+
+    const resolvedFromPath = resolveShellFromPath(p);
+    if (resolvedFromPath) return { shell: resolvedFromPath, rcFile };
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- allow worker/explore bash resolution to fall back to PATH-discovered `bash.exe`/`bash.cmd`/`bash.bat` on Windows
- keep existing Unix absolute candidate behavior intact
- add a regression test covering Git Bash discovered from `PATH` on Windows

## Testing
- npm test -- --run src/team/__tests__/shell-affinity.test.ts
- npx eslint src/team/tmux-session.ts src/team/__tests__/shell-affinity.test.ts