### PR TITLE
Fix empty hook injections after agent completion

### DIFF
--- a/src/hooks/__tests__/bridge.test.ts
+++ b/src/hooks/__tests__/bridge.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { processHook, resetSkipHooksCache, type HookInput, type HookType } from '../bridge.js';
+import {
+  processHook,
+  resetSkipHooksCache,
+  sanitizeHookOutputForSerialization,
+  type HookInput,
+  type HookType,
+} from '../bridge.js';
 
 describe('processHook - Environment Kill-Switches', () => {
   const originalEnv = process.env;
@@ -363,6 +369,56 @@ describe('processHook - Environment Kill-Switches', () => {
       expect(result.continue).toBe(true);
       expect(result.message).toContain('MANDATORY VERIFICATION - SUBAGENTS LIE');
       expect(result.message).toContain('done');
+    });
+  });
+
+  describe('sanitizeHookOutputForSerialization', () => {
+    it('drops empty top-level message fields', () => {
+      expect(
+        sanitizeHookOutputForSerialization({
+          continue: true,
+          message: '   ',
+        }),
+      ).toEqual({ continue: true });
+    });
+
+    it('drops empty hook additionalContext and systemMessage fields', () => {
+      expect(
+        sanitizeHookOutputForSerialization({
+          continue: true,
+          systemMessage: '\n\t',
+          hookSpecificOutput: {
+            hookEventName: 'PostToolUse',
+            additionalContext: '   ',
+          },
+        }),
+      ).toEqual({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+        },
+      });
+    });
+
+    it('preserves non-text hook metadata while stripping empty injected text', () => {
+      expect(
+        sanitizeHookOutputForSerialization({
+          continue: true,
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            additionalContext: '',
+            permissionDecision: 'deny',
+            permissionDecisionReason: 'Need confirmation',
+          },
+        }),
+      ).toEqual({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'Need confirmation',
+        },
+      });
     });
   });
 });

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -615,6 +615,58 @@ export interface HookOutput {
   modifiedInput?: unknown;
 }
 
+type SerializableHookOutput = HookOutput & {
+  suppressOutput?: boolean;
+  systemMessage?: string;
+  hookSpecificOutput?: Record<string, unknown>;
+};
+
+function hasInjectableText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Strip empty hook text fields before serializing to Claude Code.
+ *
+ * Some hook handlers use empty strings as internal sentinels. Passing those
+ * through to the shell hook protocol can create empty system-message/context
+ * injections on the next turn, which is especially risky after Task/Agent
+ * completion when Claude is deciding whether to continue.
+ */
+export function sanitizeHookOutputForSerialization(
+  output: SerializableHookOutput,
+): SerializableHookOutput {
+  const sanitized: SerializableHookOutput = { ...output };
+
+  if (!hasInjectableText(sanitized.message)) {
+    delete sanitized.message;
+  }
+
+  if (!hasInjectableText(sanitized.systemMessage)) {
+    delete sanitized.systemMessage;
+  }
+
+  const hookSpecificOutput = sanitized.hookSpecificOutput;
+  if (hookSpecificOutput && typeof hookSpecificOutput === "object") {
+    const nextHookSpecificOutput = { ...hookSpecificOutput };
+
+    if (!hasInjectableText(nextHookSpecificOutput.additionalContext)) {
+      delete nextHookSpecificOutput.additionalContext;
+    }
+
+    sanitized.hookSpecificOutput =
+      Object.keys(nextHookSpecificOutput).length > 0
+        ? nextHookSpecificOutput
+        : undefined;
+
+    if (!sanitized.hookSpecificOutput) {
+      delete sanitized.hookSpecificOutput;
+    }
+  }
+
+  return sanitized;
+}
+
 function isDelegationToolName(toolName: string | undefined): boolean {
   const normalizedToolName = (toolName || "").toLowerCase();
   return normalizedToolName === "task" || normalizedToolName === "agent";
@@ -2346,7 +2398,7 @@ export async function main(): Promise<void> {
   const output = await processHook(hookType, input);
 
   // Write output to stdout
-  console.log(JSON.stringify(output));
+  console.log(JSON.stringify(sanitizeHookOutputForSerialization(output)));
 }
 
 // Run if called directly (works in both ESM and bundled CJS)


### PR DESCRIPTION
## Summary
- sanitize empty hook text payloads at the bridge serialization boundary before printing hook JSON
- drop whitespace-only `message`, `systemMessage`, and `hookSpecificOutput.additionalContext` fields so Agent/Task completion cannot emit blank injected context
- add focused regression coverage for the sanitization behavior

## Verification
- npm run test:run -- src/hooks/__tests__/bridge.test.ts
- npx tsc --noEmit --pretty false
- npx eslint src/hooks/bridge.ts src/hooks/__tests__/bridge.test.ts

## Notes
- kept scope intentionally tight at the shell-hook output boundary instead of changing individual hook producers
- live end-to-end Claude Code reproduction was not available in this worktree; coverage is code-path + targeted regression based