### PR TITLE
fix(setup): hoist nodeBin to module scope so hooks.json is patched

### DIFF
--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -21,6 +21,13 @@ const SETTINGS_FILE = join(CLAUDE_DIR, 'settings.json');
 
 console.log('[OMC] Running post-install setup...');
 
+// Resolve absolute node binary path at module level so both the
+// settings.json block and the hooks.json patching block can reference it.
+// Previously declared inside the settings.json try-block, making it
+// inaccessible to the hooks.json try-block (ReferenceError: nodeBin is
+// not defined) and silently skipping the hooks.json patch. Fixes #2165.
+const nodeBin = process.execPath || 'node';
+
 // 1. Create HUD directory
 if (!existsSync(HUD_DIR)) {
   mkdirSync(HUD_DIR, { recursive: true });
@@ -226,7 +233,6 @@ try {
 
   // Use the absolute node binary path so nvm/fnm users don't get
   // "node not found" errors in non-interactive shells (issue #892).
-  const nodeBin = process.execPath || 'node';
   settings.statusLine = {
     type: 'command',
     command: `"${nodeBin}" "${hudScriptPath.replace(/\\/g, "/")}"`


### PR DESCRIPTION
## Problem

`nodeBin` is declared with `const` inside the **settings.json `try`-block** (~line 229) but referenced in a separate **hooks.json `try`-block** (~line 287). JavaScript `const` is block-scoped, so the reference throws:

```
[OMC] Warning: Could not patch hooks.json: nodeBin is not defined
```

The `catch` silently swallows the error, `hooks.json` is never patched, and every hook command keeps the bare `node` prefix — which fails in non-interactive shells where `node` is not on `PATH` (nvm/fnm users, macOS app launches, etc.).

**Visible symptom:** repeated `PreToolUse:Bash hook error` / `PostToolUse:Bash hook error` messages in the Claude Code UI on every tool call.

## Fix

Declare `nodeBin` once at module level (before the first `try`-block) and remove the duplicate declaration inside the settings block. Both the `statusLine` configuration and the `hooks.json` patching can then reference it safely.

## Reproduction

Run `plugin-setup.mjs` with nvm/fnm active (or any environment where `node` is not at a fixed PATH location) and observe the warning. After this fix, `hooks.json` is patched correctly and the warning is gone.

Fixes #2165