### PR TITLE
fix(skills/ralplan): point to /oh-my-claudecode:plan instead of :omc-plan

### DIFF
--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -7,7 +7,7 @@ level: 4
 
 # Ralplan (Consensus Planning Alias)
 
-Ralplan is a shorthand alias for `/oh-my-claudecode:omc-plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work).
+Ralplan is a shorthand alias for `/oh-my-claudecode:plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work).
 
 ## Usage
 
@@ -33,7 +33,7 @@ Ralplan is a shorthand alias for `/oh-my-claudecode:omc-plan --consensus`. It tr
 This skill invokes the Plan skill in consensus mode:
 
 ```
-/oh-my-claudecode:omc-plan --consensus <arguments>
+/oh-my-claudecode:plan --consensus <arguments>
 ```
 
 The consensus workflow:


### PR DESCRIPTION
## Problem

`skills/ralplan/SKILL.md` instructs callers to invoke the plan skill via `/oh-my-claudecode:omc-plan`, but no skill folder by that name exists — the folder is `skills/plan/`. Every ralplan invocation that tries to expand into the plan skill fails with:

```
Skill("oh-my-claudecode:omc-plan", args="--consensus ...")
→ Error: Unknown skill: oh-my-claudecode:omc-plan
```

This breaks the entire ralplan consensus-planning entrypoint — step 1 of the workflow can never run.

## Root cause

Claude Code's Skill tool and slash command resolver register skills by **folder name** under `skills/`, not by the frontmatter `name:` field. The plan skill's frontmatter declares `name: omc-plan`, but the folder is `plan/`, so the resolvable slug is `oh-my-claudecode:plan`.

The plugin's internal bridge router already accommodates this — both names are accepted for internal routing decisions:

```ts
// src/hooks/bridge.ts:287
if (skillName !== "omc-plan" && skillName !== "plan") {
  return false;
}
```

```js
// scripts/pre-tool-enforcer.mjs:427
'omc-plan': 'medium', plan: 'medium',
```

So the codebase was already mid-migration toward the `plan` name — only the user-facing ralplan documentation was left pointing at the old slug.

## Fix

Two single-line changes in `skills/ralplan/SKILL.md`:

```diff
- Ralplan is a shorthand alias for `/oh-my-claudecode:omc-plan --consensus`.
+ Ralplan is a shorthand alias for `/oh-my-claudecode:plan --consensus`.
```

```diff
  This skill invokes the Plan skill in consensus mode:

  ```
- /oh-my-claudecode:omc-plan --consensus <arguments>
+ /oh-my-claudecode:plan --consensus <arguments>
  ```
```

## Verification

1. Empirical: `Skill("oh-my-claudecode:omc-plan")` → `Unknown skill`. `Skill("oh-my-claudecode:plan")` resolves.
2. Folder check: `ls skills/` shows `plan/`, not `omc-plan/`.
3. Bridge check: `src/hooks/bridge.ts:287` accepts both strings, so internal routing is unaffected.

## Out of scope

The frontmatter `name: omc-plan` in `skills/plan/SKILL.md` is left untouched because the bridge already handles both strings and there are 36 files referencing the `omc-plan` identifier across `src/`, `dist/`, tests, and docs. A full rename is a separate, larger refactor and would benefit from coordination with the maintainer.

## Related broken doc references found during audit

Two unrelated broken `/oh-my-claudecode:<X>` references surfaced while auditing for the same bug class but require maintainer judgment and so are filed as separate issues:

- #2226 — `skills/configure-notifications/SKILL.md:938` `/oh-my-claudecode:configure-openclaw` (no such skill)
- #2227 — `skills/learner/SKILL.md:140` `/oh-my-claudecode:note` (no such skill)

## Test plan

- [ ] Confirm `skills/ralplan/SKILL.md` no longer contains the string `omc-plan`
- [ ] Confirm both edited references now point to the resolvable slug `/oh-my-claudecode:plan`
- [ ] Confirm `skills/plan/` folder still exists (resolver target unchanged)
- [ ] No code or test files modified — pure docs change in a single SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
