### PR TITLE
feat(hud): add hostname element for multi-host SSH workflows

### DIFF
--- a/src/hud/__tests__/hostname.test.ts
+++ b/src/hud/__tests__/hostname.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock node:os.hostname so tests are deterministic across environments.
+const hostnameMock = vi.fn<() => string>();
+vi.mock('node:os', () => ({
+  hostname: () => hostnameMock(),
+}));
+
+import { renderHostname } from '../elements/hostname.js';
+
+describe('renderHostname', () => {
+  beforeEach(() => {
+    hostnameMock.mockReset();
+  });
+
+  it('returns null when the OS reports an empty hostname', () => {
+    hostnameMock.mockReturnValue('');
+    expect(renderHostname()).toBeNull();
+  });
+
+  it('returns null when splitting an FQDN yields an empty short name', () => {
+    // Defensive: hostname starting with a dot would split to '' first.
+    hostnameMock.mockReturnValue('.local');
+    expect(renderHostname()).toBeNull();
+  });
+
+  it('returns a host:<name> label for a simple hostname', () => {
+    hostnameMock.mockReturnValue('laptop');
+    const result = renderHostname();
+    expect(result).not.toBeNull();
+    expect(result).toContain('host:laptop');
+  });
+
+  it('strips the FQDN suffix and keeps only the short hostname', () => {
+    hostnameMock.mockReturnValue('gpu-box.lan.example.com');
+    const result = renderHostname();
+    expect(result).toContain('host:gpu-box');
+    expect(result).not.toContain('lan.example.com');
+  });
+
+  it('applies cyan styling', () => {
+    hostnameMock.mockReturnValue('laptop');
+    const result = renderHostname();
+    // cyan() wraps text in ANSI escape codes — just verify an escape
+    // sequence is present rather than hard-coding the specific color code.
+    expect(result).toMatch(/\x1b\[[0-9;]+m/);
+  });
+});

--- a/src/hud/elements/hostname.ts
+++ b/src/hud/elements/hostname.ts
@@ -1,0 +1,25 @@
+/**
+ * OMC HUD - Hostname Element
+ *
+ * Renders the current machine's short hostname. Useful when running
+ * `omc` via SSH across multiple machines — the hostname in the HUD
+ * prevents accidentally running destructive commands on the wrong
+ * host when terminal tab titles are hidden behind tmux/screen splits.
+ */
+
+import { hostname } from 'node:os';
+import { cyan } from '../colors.js';
+
+/**
+ * Render the short hostname (FQDN stripped).
+ *
+ * @returns Cyan-colored "host:<name>" label, or null if the OS returns
+ *          an empty hostname (e.g. misconfigured containers).
+ */
+export function renderHostname(): string | null {
+  const full = hostname();
+  if (!full) return null;
+  const short = full.split('.')[0];
+  if (!short) return null;
+  return cyan(`host:${short}`);
+}

--- a/src/hud/elements/index.ts
+++ b/src/hud/elements/index.ts
@@ -24,3 +24,4 @@ export { detectApiKeySource, renderApiKeySource, type ApiKeySource } from './api
 export { renderMissionBoard } from './mission-board.js';
 export { renderSessionSummary, type SessionSummaryState } from './session-summary.js';
 export { renderLastTool } from './last-tool.js';
+export { renderHostname } from './hostname.js';

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -31,6 +31,7 @@ import { renderTokenUsage } from "./elements/token-usage.js";
 import { renderPromptTime } from "./elements/prompt-time.js";
 import { renderAutopilot } from "./elements/autopilot.js";
 import { renderCwd } from "./elements/cwd.js";
+import { renderHostname } from "./elements/hostname.js";
 import { renderGitRepo, renderGitBranch } from "./elements/git.js";
 import { renderModel } from "./elements/model.js";
 import { renderApiKeySource } from "./elements/api-key-source.js";
@@ -212,6 +213,11 @@ export async function render(
   const renderedDetail = new Map<string, string[]>();
 
   // -- line1-group elements (default: git info line) --
+
+  if (enabledElements.hostname) {
+    const hostnameElement = renderHostname();
+    if (hostnameElement) rendered.set("hostname", hostnameElement);
+  }
 
   if (enabledElements.cwd) {
     const cwdElement = renderCwd(

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -443,6 +443,7 @@ export interface HudElementConfig {
   thinking: boolean;          // Show extended thinking indicator
   thinkingFormat: ThinkingFormat;  // Thinking indicator format
   apiKeySource: boolean;       // Show API key source (project/global/env)
+  hostname: boolean;           // Show machine hostname (useful for multi-host SSH workflows)
   profile: boolean;            // Show active profile name (from CLAUDE_CONFIG_DIR)
   missionBoard?: boolean;      // Show opt-in mission board above existing HUD detail lines
   promptTime: boolean;        // Show last prompt submission time (HH:MM:SS)
@@ -503,7 +504,7 @@ export interface LayoutConfig {
  * Used as fallback when no layout is configured.
  */
 export const DEFAULT_ELEMENT_ORDER: Required<LayoutConfig> = {
-  line1: ['cwd', 'gitRepo', 'gitBranch', 'model', 'apiKeySource', 'profile'],
+  line1: ['hostname', 'cwd', 'gitRepo', 'gitBranch', 'model', 'apiKeySource', 'profile'],
   main: [
     'omcLabel', 'rateLimits', 'customBuckets', 'permission', 'thinking',
     'promptTime', 'session', 'tokens', 'ralph', 'autopilot', 'prd',
@@ -563,6 +564,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     thinking: true,
     thinkingFormat: 'text',   // Text format for backward compatibility
     apiKeySource: false, // Disabled by default
+    hostname: false,
     profile: true,  // Show profile name when CLAUDE_CONFIG_DIR is set
     missionBoard: false,  // Opt-in mission board for whole-run progress tracking
     promptTime: true,  // Show last prompt time by default
@@ -621,6 +623,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: false,
     thinkingFormat: 'text',
     apiKeySource: false,
+    hostname: false,
     profile: true,
     missionBoard: false,
     promptTime: false,
@@ -661,6 +664,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     thinkingFormat: 'text',
     apiKeySource: false,
+    hostname: false,
     profile: true,
     missionBoard: false,
     promptTime: true,
@@ -701,6 +705,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     thinkingFormat: 'text',
     apiKeySource: true,
+    hostname: false,
     profile: true,
     missionBoard: false,
     promptTime: true,
@@ -741,6 +746,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     thinkingFormat: 'text',
     apiKeySource: false,
+    hostname: false,
     profile: true,
     missionBoard: false,
     promptTime: true,
@@ -781,6 +787,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinking: true,
     thinkingFormat: 'text',
     apiKeySource: true,
+    hostname: false,
     profile: true,
     missionBoard: false,
     promptTime: true,


### PR DESCRIPTION
> Reopens #2231 with a strictly source-only diff per maintainer feedback. The previous PR included regenerated `dist/` and `bridge/` artifacts that made the diff look much broader than the actual change. This branch now contains **5 source files only** — no generated/runtime churn.

## Summary

Adds a new `hostname` HUD element that renders the current machine's short hostname. Useful when running `omc` via SSH across multiple machines — the hostname in the HUD prevents accidentally running destructive commands on the wrong host when terminal tab titles are hidden behind tmux/screen splits.

Addresses part (a) of #2222.

## Why

When running `omc` across a dev laptop, home desktop, remote GPU box, and CI jumphost, the only visual difference between sessions is the terminal tab title — which is easy to lose in tmux/screen/iTerm splits. A one-word hostname in the HUD makes it impossible to accidentally run a destructive command on the wrong host.

## UX

```
host:gpu-box  ~/workspace/proj  repo:proj  branch:main  [OMC#4.10.2] ...
host:laptop   ~/src/proj        repo:proj  branch:fix   [OMC#4.10.2] ...
```

- Renders `host:<short-name>` in cyan on `line1`, before `cwd` / `gitRepo` / `gitBranch` — hostname is the most stable identifier, so it goes to the far left.
- FQDN suffix is stripped (`gpu-box.lan.example.com` → `gpu-box`).
- Returns `null` on empty hostname (misconfigured containers) so the HUD never shows a bare `host:` label.

## Implementation

New file `src/hud/elements/hostname.ts`:

\`\`\`ts
import { hostname } from 'node:os';
import { cyan } from '../colors.js';

export function renderHostname(): string | null {
  const full = hostname();
  if (!full) return null;
  const short = full.split('.')[0];
  if (!short) return null;
  return cyan(\`host:\${short}\`);
}
\`\`\`

Wiring:
- Exported from `src/hud/elements/index.ts`
- `hostname: boolean` added to `HudElementConfig` in `src/hud/types.ts`
- Default `false` in `DEFAULT_HUD_CONFIG` and all 5 presets (backward compatible, strictly opt-in)
- Added to `DEFAULT_ELEMENT_ORDER.line1` as the first element
- Rendered from `src/hud/render.ts` in the line1 element group

## Diff scope

**5 files, 88 insertions, 1 deletion** — source only:

```
src/hud/__tests__/hostname.test.ts  (new)
src/hud/elements/hostname.ts        (new)
src/hud/elements/index.ts           (+1)
src/hud/render.ts                   (+5 / -1)
src/hud/types.ts                    (+8)
```

No `dist/` or `bridge/` changes — those are regenerated by CI from the source.

## Settings

Enable via `~/.claude/settings.json`:

\`\`\`json
{
  "omcHud": {
    "elements": { "hostname": true }
  }
}
\`\`\`

## Tests

`src/hud/__tests__/hostname.test.ts` — 5 tests covering:

- Empty hostname → null
- FQDN split producing empty short name → null
- Simple hostname → `host:<name>` label
- FQDN → short name only (`gpu-box.lan.example.com` → `host:gpu-box`)
- ANSI color codes applied

All 5 pass locally.

## Test plan

- [x] Unit tests for `renderHostname` (5 tests)
- [x] Source-only diff (5 files)
- [x] Manual verification on macOS + Linux SSH session

## Scope

Single-feature PR. Does not touch cwd format or gitStatus (parts (b) and (c) of #2222 — separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)