### PR TITLE
fix(keyword-detector): ignore HTML comments during keyword detection

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -149,6 +149,8 @@ function isAntiSlopCleanupRequest(text) {
 
 function sanitizeForKeywordDetection(text) {
   return text
+    // 0. Strip HTML/markdown comments before XML stripping to avoid keyword leaks
+    .replace(/<!--[\s\S]*?-->/g, '')
     // 1. Strip XML-style tag blocks: <tag-name ...>...</tag-name> (multi-line, greedy on tag name)
     .replace(/<(\w[\w-]*)[\s>][\s\S]*?<\/\1>/g, '')
     // 2. Strip self-closing XML tags: <tag-name />, <tag-name attr="val" />

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -4,6 +4,18 @@ import { join } from 'node:path';
 
 const SCRIPT_PATH = join(process.cwd(), 'scripts', 'keyword-detector.mjs');
 const NODE = process.execPath;
+const HTML_COMMENT_REPRO = `Please review this draft document for tone and clarity:
+
+<!-- ralph: rewrite intro section with more urgency -->
+<!-- autopilot note: Why Artificially Inflating GitHub Star Counts Is Harmful:
+popularity without merit misleads developers, distorts discovery, unfairly rewards dishonest projects, and erodes trust in GitHub stars as a community signal. -->
+
+Final draft:
+
+Why Artificially Inflating GitHub Star Counts Is Harmful
+=========================================================
+
+This article argues that fake popularity signals damage trust in open source.`;
 
 function runKeywordDetector(prompt: string) {
   const raw = execFileSync(NODE, [SCRIPT_PATH], {
@@ -65,5 +77,15 @@ describe('keyword-detector.mjs mode-message dispatch', () => {
 
     expect(context).toContain('[MAGIC KEYWORD: RALPLAN]');
     expect(context).toContain('name: ralplan');
+  });
+
+  it('does not trigger on keywords inside HTML comments', () => {
+    const output = runKeywordDetector(HTML_COMMENT_REPRO);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD:');
+    expect(context).not.toContain('<ralph-mode>');
+    expect(context).not.toContain('<autopilot-mode>');
   });
 });

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -20,6 +20,18 @@ vi.mock('../../../features/auto-update.js', () => ({
 
 import { isTeamEnabled } from '../../../features/auto-update.js';
 const mockedIsTeamEnabled = vi.mocked(isTeamEnabled);
+const HTML_COMMENT_REPRO = `Please review this draft document for tone and clarity:
+
+<!-- ralph: rewrite intro section with more urgency -->
+<!-- autopilot note: Why Artificially Inflating GitHub Star Counts Is Harmful:
+popularity without merit misleads developers, distorts discovery, unfairly rewards dishonest projects, and erodes trust in GitHub stars as a community signal. -->
+
+Final draft:
+
+Why Artificially Inflating GitHub Star Counts Is Harmful
+=========================================================
+
+This article argues that fake popularity signals damage trust in open source.`;
 
 describe('keyword-detector', () => {
   describe('removeCodeBlocks', () => {
@@ -86,6 +98,13 @@ World`);
     it('should strip self-closing XML tags', () => {
       const result = sanitizeForKeywordDetection('text <br /> more');
       expect(result).not.toContain('<br');
+    });
+
+    it('should strip HTML comments containing keywords', () => {
+      const result = sanitizeForKeywordDetection(HTML_COMMENT_REPRO);
+      expect(result).not.toContain('ralph');
+      expect(result).not.toContain('autopilot');
+      expect(result).toContain('Why Artificially Inflating GitHub Star Counts Is Harmful');
     });
 
     it('should strip URLs', () => {
@@ -156,6 +175,11 @@ World`);
       // "file.txt" alone (no path separator) should be kept
       const result = sanitizeForKeywordDetection('rename codex.config');
       expect(result).toContain('codex');
+    });
+
+    it('should not detect keywords when they only appear inside HTML comments', () => {
+      expect(detectKeywordsWithType(HTML_COMMENT_REPRO)).toEqual([]);
+      expect(hasKeyword(HTML_COMMENT_REPRO)).toBe(false);
     });
   });
 

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -101,8 +101,10 @@ export const NON_LATIN_SCRIPT_PATTERN =
  * Strips XML tags, URLs, file paths, and code blocks.
  */
 export function sanitizeForKeywordDetection(text: string): string {
+  // Remove HTML/markdown comments before XML stripping
+  let result = text.replace(/<!--[\s\S]*?-->/g, '');
   // Remove XML tag blocks (opening + content + closing; tag names must match)
-  let result = text.replace(/<(\w[\w-]*)[\s>][\s\S]*?<\/\1>/g, '');
+  result = result.replace(/<(\w[\w-]*)[\s>][\s\S]*?<\/\1>/g, '');
   // Remove self-closing XML tags
   result = result.replace(/<\w[\w-]*(?:\s[^>]*)?\s*\/>/g, '');
   // Remove URLs


### PR DESCRIPTION
 ## Summary

  - strip HTML/markdown comments before keyword scanning
  - apply the fix in both implementations:
    - `scripts/keyword-detector.mjs`
    - `src/hooks/keyword-detector/index.ts`
  - add focused regressions proving comment-contained `ralph` / `autopilot` text does not activate modes

  ## Root cause

  `sanitizeForKeywordDetection()` stripped code blocks, inline code, XML tags, URLs, and file paths, but it did not strip `<!-- ... -->`
  comments.

  That allowed keywords inside commented review text to survive sanitization and trigger mode activation even though the visible prompt
  was a normal review request.

  ## Testing

  - `npm test -- --run src/__tests__/keyword-detector-script.test.ts src/hooks/keyword-detector/__tests__/index.test.ts`
  - `npx tsc --noEmit`
  - `npm run lint`

  ## Notes

  - kept the fix scoped to comment stripping only; visible prompt text behavior is unchanged
  - regression coverage uses the reported review-style repro, including:
    - `Why Artificially Inflating GitHub Star Counts Is Harmful`
    - `popularity without merit misleads developers, distorts discovery, unfairly rewards dishonest projects, and erodes trust in GitHub
  stars as a community signal.`
  - full `npm test -- --run` still has unrelated pre-existing failures outside the keyword-detector suites in the current repo state

  Closes #2236.