### PR TITLE
feat(hud): display session ID in statusline

### DIFF
--- a/src/__tests__/hud/mission-board.test.ts
+++ b/src/__tests__/hud/mission-board.test.ts
@@ -108,6 +108,7 @@ describe('mission board renderer', () => {
       apiKeySource: null,
       profileName: null,
     sessionSummary: null,
+    sessionId: null,
     };
 
     const config: HudConfig = {

--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -48,6 +48,7 @@ function makeContext(overrides: Partial<HudRenderContext> = {}): HudRenderContex
     apiKeySource: null,
     profileName: null,
     sessionSummary: null,
+    sessionId: null,
     ...overrides,
   };
 }

--- a/src/__tests__/hud/render.test.ts
+++ b/src/__tests__/hud/render.test.ts
@@ -199,6 +199,7 @@ describe('gitInfoPosition configuration', () => {
     apiKeySource: null,
     profileName: null,
     sessionSummary: null,
+    sessionId: null,
   });
 
   const createMockConfig = (gitInfoPosition: 'above' | 'below'): HudConfig => ({
@@ -383,6 +384,7 @@ describe('maxWidth wrapMode behavior', () => {
     apiKeySource: null,
     profileName: null,
     sessionSummary: null,
+    sessionId: null,
   });
 
   const createWrapConfig = (
@@ -500,6 +502,7 @@ describe('token usage rendering', () => {
     apiKeySource: null,
     profileName: null,
     sessionSummary: null,
+    sessionId: null,
   });
 
   const createTokenConfig = (showTokens?: boolean): HudConfig => ({
@@ -571,6 +574,7 @@ describe('layout element ordering', () => {
     apiKeySource: null,
     profileName: null,
     sessionSummary: null,
+    sessionId: null,
   });
 
   const createLayoutConfig = (layout?: HudConfig['layout']): HudConfig => ({
@@ -746,6 +750,7 @@ describe('optional HUD line defaults', () => {
       apiKeySource: null,
       profileName: null,
       sessionSummary: null,
+    sessionId: null,
     };
 
     const config: HudConfig = {

--- a/src/__tests__/hud/version-display.test.ts
+++ b/src/__tests__/hud/version-display.test.ts
@@ -30,6 +30,7 @@ function createMinimalContext(overrides: Partial<HudRenderContext> = {}): HudRen
     apiKeySource: null,
     profileName: null,
     sessionSummary: null,
+    sessionId: null,
     ...overrides,
   };
 }

--- a/src/hud/elements/session.ts
+++ b/src/hud/elements/session.ts
@@ -17,12 +17,13 @@ const RED = '\x1b[31m';
  *
  * Format: session:45m or session:45m (healthy)
  */
-export function renderSession(session: SessionHealth | null): string | null {
+export function renderSession(session: SessionHealth | null, sessionId?: string | null): string | null {
   if (!session) return null;
 
   const color = session.health === 'critical' ? RED
     : session.health === 'warning' ? YELLOW
     : GREEN;
 
-  return `session:${color}${session.durationMinutes}m${RESET}`;
+  const idSuffix = sessionId ? `[${sessionId}]` : '';
+  return `session:${color}${session.durationMinutes}m${RESET}${idSuffix}`;
 }

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -455,6 +455,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
         : null,
       sessionSummary,
       lastToolName: transcriptData.lastToolName,
+      sessionId: currentSessionId || null,
     };
 
     // Debug: log data if OMC_DEBUG is set

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -309,7 +309,7 @@ export async function render(
   if (enabledElements.sessionHealth && context.sessionHealth) {
     const showDuration = enabledElements.showSessionDuration ?? true;
     if (showDuration) {
-      const session = renderSession(context.sessionHealth);
+      const session = renderSession(context.sessionHealth, context.sessionId);
       if (session) rendered.set("session", session);
     }
   }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -370,6 +370,9 @@ export interface HudRenderContext {
 
   /** Name of the last tool called in this session */
   lastToolName?: string | null;
+
+  /** Current session ID (UUID extracted from transcript path) */
+  sessionId: string | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Surface the session UUID (already extracted from the transcript path) in the HUD session element.

Output: `session:19m[b23fe3e9-1939-40db-b1e2-76ac54cd1ef6]`

## Source-only changes (8 files, +16 −3)

- `src/hud/types.ts` — add `sessionId: string | null` to `HudRenderContext`
- `src/hud/index.ts` — pass `currentSessionId` into the render context
- `src/hud/elements/session.ts` — accept optional `sessionId`, append as suffix
- `src/hud/render.ts` — forward `context.sessionId` to `renderSession()`
- `src/__tests__/hud/*.test.ts` — add `sessionId: null` to fixtures

No dist/, bridge/, or generated files included.

🤖 Generated with [Claude Code](https://claude.ai/code)