### PR TITLE
fix(hud): correctly mark background agents as completed in transcript parser

### DIFF
--- a/src/__tests__/hud/transcript-agent-lifecycle.test.ts
+++ b/src/__tests__/hud/transcript-agent-lifecycle.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Regression tests for HUD transcript agent lifecycle tracking.
+ *
+ * Covers bugs that caused agents to be stuck as "running" in the HUD
+ * long after they had finished:
+ *
+ *   1. Foreground agent results containing the literal string
+ *      "Async agent launched" (e.g. investigation reports that quote
+ *      prior launch messages) were misclassified as background launches
+ *      by the naive `.includes()` check, and never flipped to completed.
+ *
+ *   2. Background agent completions arrive as `<task-notification>`
+ *      user-role messages where `message.content` is either a plain
+ *      string or a list containing a `tool_result` block with the
+ *      notification text. The parser originally only handled
+ *      array-shaped content and used the wrong tag spelling
+ *      (`<task_id>` instead of the real `<task-id>`).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { parseTranscript } from "../../hud/transcript.js";
+
+const tempDirs: string[] = [];
+
+function createTempTranscript(lines: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "omc-hud-agent-lifecycle-"));
+  tempDirs.push(dir);
+  const p = join(dir, "transcript.jsonl");
+  writeFileSync(p, `${lines.map((l) => JSON.stringify(l)).join("\n")}\n`, "utf8");
+  return p;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const d = tempDirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("HUD transcript — agent lifecycle", () => {
+  describe("foreground agent completion", () => {
+    it("marks a foreground Task agent as completed when its tool_result arrives", async () => {
+      const transcriptPath = createTempTranscript([
+        {
+          timestamp: "2026-04-07T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_fg_001",
+                name: "Task",
+                input: { subagent_type: "Explore", description: "Find X" },
+              },
+            ],
+          },
+        },
+        {
+          timestamp: "2026-04-07T00:01:30.000Z",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_fg_001",
+                content: [{ type: "text", text: "Here are the results of exploring X..." }],
+              },
+            ],
+          },
+        },
+      ]);
+
+      // Disable stale-agent GC so the test is deterministic regardless of
+      // the wall-clock delta between the fixture timestamps and test run time.
+      const result = await parseTranscript(transcriptPath, { staleTaskThresholdMinutes: 10 ** 9 });
+      const fg = result.agents.find((a) => a.id === "toolu_fg_001");
+      expect(fg).toBeDefined();
+      expect(fg?.status).toBe("completed");
+    });
+
+    it("does NOT misclassify a foreground agent result as a background launch when the result text incidentally contains the phrase 'Async agent launched'", async () => {
+      // This is the regression case. An Explore agent investigation report
+      // quoted earlier background-launch notifications in its output. The
+      // naive `.includes("Async agent launched")` check on the tool_result
+      // content flagged the whole result as a background launch, keeping
+      // the agent stuck as "running" until the 30-minute stale GC fired.
+      const transcriptPath = createTempTranscript([
+        {
+          timestamp: "2026-04-07T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_fg_quote",
+                name: "Task",
+                input: { subagent_type: "Explore", description: "Investigate stuck agents" },
+              },
+            ],
+          },
+        },
+        {
+          timestamp: "2026-04-07T00:02:00.000Z",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_fg_quote",
+                content: [
+                  {
+                    type: "text",
+                    text:
+                      "Investigation report:\n\nThe existing parser checks for 'Async agent launched' " +
+                      "in the content of every tool_result. This is a false positive because the phrase " +
+                      "appears here in the investigation output, quoting a prior launch notification.",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ]);
+
+      // Disable stale-agent GC so the test is deterministic regardless of
+      // the wall-clock delta between the fixture timestamps and test run time.
+      const result = await parseTranscript(transcriptPath, { staleTaskThresholdMinutes: 10 ** 9 });
+      const agent = result.agents.find((a) => a.id === "toolu_fg_quote");
+      expect(agent).toBeDefined();
+      expect(agent?.status).toBe("completed");
+    });
+
+    it("correctly classifies a genuine 'Async agent launched' message as a background launch (agent stays running)", async () => {
+      const transcriptPath = createTempTranscript([
+        {
+          timestamp: "2026-04-07T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_bg_001",
+                name: "Task",
+                input: { subagent_type: "Explore", description: "Long-running scan" },
+              },
+            ],
+          },
+        },
+        {
+          timestamp: "2026-04-07T00:00:02.000Z",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_bg_001",
+                content: [
+                  {
+                    type: "text",
+                    text:
+                      "Async agent launched successfully.\n" +
+                      "agentId: abc123deadbeef (internal ID - do not mention to user.)\n" +
+                      "The agent is working in the background.",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ]);
+
+      // Disable stale-agent GC so the test is deterministic regardless of
+      // the wall-clock delta between the fixture timestamps and test run time.
+      const result = await parseTranscript(transcriptPath, { staleTaskThresholdMinutes: 10 ** 9 });
+      const agent = result.agents.find((a) => a.id === "toolu_bg_001");
+      expect(agent).toBeDefined();
+      expect(agent?.status).toBe("running");
+    });
+  });
+
+  describe("background agent completion via task-notification", () => {
+    it("marks a background agent as completed when a string-shaped task-notification arrives", async () => {
+      const transcriptPath = createTempTranscript([
+        {
+          timestamp: "2026-04-07T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_bg_str",
+                name: "Task",
+                input: { subagent_type: "general-purpose", description: "Check PR status" },
+              },
+            ],
+          },
+        },
+        {
+          timestamp: "2026-04-07T00:00:02.000Z",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_bg_str",
+                content: [
+                  { type: "text", text: "Async agent launched successfully.\nagentId: bgjob001\n" },
+                ],
+              },
+            ],
+          },
+        },
+        // Task-notification arrives later as a user-role message with
+        // STRING-shaped content (real Claude Code shape).
+        {
+          timestamp: "2026-04-07T00:10:00.000Z",
+          message: {
+            role: "user",
+            content:
+              "<task-notification>\n" +
+              "<task-id>bgjob001</task-id>\n" +
+              "<tool-use-id>toolu_bg_str</tool-use-id>\n" +
+              "<status>completed</status>\n" +
+              "<summary>Background agent finished.</summary>\n" +
+              "</task-notification>",
+          },
+        },
+      ]);
+
+      // Disable stale-agent GC so the test is deterministic regardless of
+      // the wall-clock delta between the fixture timestamps and test run time.
+      const result = await parseTranscript(transcriptPath, { staleTaskThresholdMinutes: 10 ** 9 });
+      const agent = result.agents.find((a) => a.id === "toolu_bg_str");
+      expect(agent).toBeDefined();
+      expect(agent?.status).toBe("completed");
+    });
+
+    it("marks a background agent as completed when the task-notification is nested inside a tool_result block", async () => {
+      const transcriptPath = createTempTranscript([
+        {
+          timestamp: "2026-04-07T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_bg_nested",
+                name: "Task",
+                input: { subagent_type: "Explore", description: "Deep scan" },
+              },
+            ],
+          },
+        },
+        {
+          timestamp: "2026-04-07T00:00:02.000Z",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_bg_nested",
+                content: [
+                  { type: "text", text: "Async agent launched successfully.\nagentId: nestedjob\n" },
+                ],
+              },
+            ],
+          },
+        },
+        // Task-notification inside a tool_result.content string (also a real shape).
+        {
+          timestamp: "2026-04-07T00:05:00.000Z",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_wrapper_xyz",
+                content:
+                  "<task-notification>\n" +
+                  "<task-id>nestedjob</task-id>\n" +
+                  "<tool-use-id>toolu_bg_nested</tool-use-id>\n" +
+                  "<status>completed</status>\n" +
+                  "</task-notification>",
+              },
+            ],
+          },
+        },
+      ]);
+
+      // Disable stale-agent GC so the test is deterministic regardless of
+      // the wall-clock delta between the fixture timestamps and test run time.
+      const result = await parseTranscript(transcriptPath, { staleTaskThresholdMinutes: 10 ** 9 });
+      const agent = result.agents.find((a) => a.id === "toolu_bg_nested");
+      expect(agent).toBeDefined();
+      expect(agent?.status).toBe("completed");
+    });
+
+    it("accepts the legacy underscore-cased <task_id> tag as a fallback for older format transcripts", async () => {
+      const transcriptPath = createTempTranscript([
+        {
+          timestamp: "2026-04-07T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_legacy",
+                name: "Task",
+                input: { subagent_type: "Explore", description: "Legacy format" },
+              },
+            ],
+          },
+        },
+        {
+          timestamp: "2026-04-07T00:00:02.000Z",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_legacy",
+                content: [
+                  { type: "text", text: "Async agent launched successfully.\nagentId: legacy1\n" },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          timestamp: "2026-04-07T00:05:00.000Z",
+          message: {
+            role: "user",
+            content:
+              "<task_id>legacy1</task_id><tool_use_id>toolu_legacy</tool_use_id><status>completed</status>",
+          },
+        },
+      ]);
+
+      // Disable stale-agent GC so the test is deterministic regardless of
+      // the wall-clock delta between the fixture timestamps and test run time.
+      const result = await parseTranscript(transcriptPath, { staleTaskThresholdMinutes: 10 ** 9 });
+      const agent = result.agents.find((a) => a.id === "toolu_legacy");
+      expect(agent).toBeDefined();
+      expect(agent?.status).toBe("completed");
+    });
+  });
+});

--- a/src/hud/transcript.ts
+++ b/src/hud/transcript.ts
@@ -29,7 +29,11 @@ import type {
 } from "./types.js";
 
 // Performance constants
-const MAX_TAIL_BYTES = 512 * 1024; // 500KB - enough for recent activity
+// 4MB tail window: enough to catch the full tool_use → tool_result → task-notification
+// chain for agent-heavy sessions (typically ~30-50KB per agent call, so 4MB covers
+// ~80-130 agents). The previous 512KB window lost completion signals for older
+// agents in long sessions, leaving them stuck as "running" in the HUD.
+const MAX_TAIL_BYTES = 4 * 1024 * 1024;
 const MAX_AGENT_MAP_SIZE = 100; // Cap agent tracking
 const _MIN_RUNNING_AGENTS_THRESHOLD = 10; // Early termination threshold
 
@@ -356,22 +360,35 @@ function extractBackgroundAgentId(
 }
 
 /**
- * Parse TaskOutput result for completion status
+ * Parse TaskOutput result for completion status.
+ *
+ * Claude Code emits completion as a `<task-notification>` block with
+ * hyphen-cased tags (`<task-id>`, `<tool-use-id>`, `<status>`). Accept
+ * both hyphen and underscore variants for defence in depth.
  */
 function parseTaskOutputResult(
   content: string | Array<{ type?: string; text?: string }>,
-): { taskId: string; status: string } | null {
+): { taskId: string; toolUseId: string | null; status: string } | null {
   const text =
     typeof content === "string"
       ? content
       : content.find((c) => c.type === "text")?.text || "";
 
-  // Extract task_id and status from XML-like format
-  const taskIdMatch = text.match(/<task_id>([^<]+)<\/task_id>/);
+  // Hyphen variant (real Claude Code format) first, underscore fallback second.
+  const taskIdMatch =
+    text.match(/<task-id>([^<]+)<\/task-id>/) ||
+    text.match(/<task_id>([^<]+)<\/task_id>/);
   const statusMatch = text.match(/<status>([^<]+)<\/status>/);
+  const toolUseIdMatch =
+    text.match(/<tool-use-id>([^<]+)<\/tool-use-id>/) ||
+    text.match(/<tool_use_id>([^<]+)<\/tool_use_id>/);
 
   if (taskIdMatch && statusMatch) {
-    return { taskId: taskIdMatch[1], status: statusMatch[1] };
+    return {
+      taskId: taskIdMatch[1],
+      toolUseId: toolUseIdMatch ? toolUseIdMatch[1] : null,
+      status: statusMatch[1],
+    };
   }
   return null;
 }
@@ -442,6 +459,38 @@ function processEntry(
   }
 
   const content = entry.message?.content;
+
+  // Claude Code emits background-agent completion as a user-role message with
+  // string-shaped content: `<task-notification>...<tool-use-id>...</tool-use-id>
+  // ...<status>completed</status>...</task-notification>`. The block-based
+  // parser below only handles array-shaped content, so we handle the string
+  // case up front — otherwise background agents (subagents launched with
+  // run_in_background, Explore/Plan/general-purpose, etc.) never transition
+  // from "running" to "completed" in the HUD.
+  if (typeof content === "string") {
+    if (content.includes("<task-notification>") || content.includes("<task_id>") || content.includes("<task-id>")) {
+      const taskOutput = parseTaskOutputResult(content);
+      if (taskOutput && taskOutput.status === "completed") {
+        // Prefer direct tool-use-id lookup (skips the backgroundAgentMap
+        // indirection). Fall back to the legacy agentId → tool_use_id mapping.
+        let toolUseId: string | undefined;
+        if (taskOutput.toolUseId) {
+          toolUseId = taskOutput.toolUseId;
+        } else if (backgroundAgentMap) {
+          toolUseId = backgroundAgentMap.get(taskOutput.taskId);
+        }
+        if (toolUseId) {
+          const agent = agentMap.get(toolUseId);
+          if (agent && agent.status === "running") {
+            agent.status = "completed";
+            agent.endTime = timestamp;
+          }
+        }
+      }
+    }
+    return;
+  }
+
   if (!content || !Array.isArray(content)) return;
 
   for (const block of content) {
@@ -542,15 +591,30 @@ function processEntry(
       if (agent) {
         const blockContent = block.content;
 
-        // Check if this is a background agent launch result
+        // Check if this is a background agent launch result.
+        //
+        // The real "Async agent launched successfully" notification is a
+        // short (~400B), standalone tool_result whose text STARTS with the
+        // exact phrase. A completed foreground agent result can easily
+        // contain the same phrase quoted elsewhere (e.g. an investigation
+        // report that cites a previous launch message), so a naive
+        // `.includes()` check misclassifies legitimate completions as
+        // background launches and leaves them stuck as "running" in the HUD.
+        //
+        // Require the text to START WITH "Async agent launched" (after
+        // trimming leading whitespace) — nothing else qualifies.
+        const ASYNC_LAUNCH_PREFIX = "Async agent launched";
+        const startsWithAsyncLaunch = (text: string | undefined): boolean =>
+          !!text && text.trimStart().startsWith(ASYNC_LAUNCH_PREFIX);
         const isBackgroundLaunch =
           typeof blockContent === "string"
-            ? blockContent.includes("Async agent launched")
+            ? startsWithAsyncLaunch(blockContent)
             : Array.isArray(blockContent) &&
-              blockContent.some(
-                (c: { type?: string; text?: string }) =>
-                  c.type === "text" && c.text?.includes("Async agent launched"),
-              );
+              blockContent.length > 0 &&
+              typeof blockContent[0] === "object" &&
+              blockContent[0] !== null &&
+              (blockContent[0] as { type?: string }).type === "text" &&
+              startsWithAsyncLaunch((blockContent[0] as { text?: string }).text);
 
         if (isBackgroundLaunch) {
           // Extract and store the background agent ID mapping
@@ -569,11 +633,16 @@ function processEntry(
       }
 
       // Check if this is a TaskOutput result showing completion
-      if (backgroundAgentMap && block.content) {
+      if (block.content) {
         const taskOutput = parseTaskOutputResult(block.content);
         if (taskOutput && taskOutput.status === "completed") {
-          // Find the original agent by background agent ID
-          const toolUseId = backgroundAgentMap.get(taskOutput.taskId);
+          // Prefer direct tool-use-id lookup; fall back to the legacy agentId mapping.
+          let toolUseId: string | undefined;
+          if (taskOutput.toolUseId) {
+            toolUseId = taskOutput.toolUseId;
+          } else if (backgroundAgentMap) {
+            toolUseId = backgroundAgentMap.get(taskOutput.taskId);
+          }
           if (toolUseId) {
             const bgAgent = agentMap.get(toolUseId);
             if (bgAgent && bgAgent.status === "running") {
@@ -611,7 +680,11 @@ interface TranscriptEntry {
   sessionId?: string;
   timestamp?: string;
   message?: {
-    content?: ContentBlock[];
+    // Claude Code writes assistant/user messages with either a content-block
+    // array (normal messages) OR a plain string (e.g. background-agent
+    // `<task-notification>` blocks land as user-role messages with
+    // `content: "<task-notification>...</task-notification>"`).
+    content?: ContentBlock[] | string;
     usage?: TranscriptUsage;
   };
 }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -584,7 +584,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     contextCritical: 85,
     ralphWarning: 7,
   },
-  staleTaskThresholdMinutes: 30,
+  staleTaskThresholdMinutes: 10,
   contextLimitWarning: {
     threshold: 80,
     autoCompact: false,


### PR DESCRIPTION
## Summary

Fixes a bug where background agents (Task tool launches with `run_in_background`, Explore/Plan/general-purpose sub-agents, etc.) remain stuck as `running` in the HUD long after they finish. The HUD's `agents:N` count drifts above 0 and never returns to 0; the multi-line agent display shows ghost entries with elapsed times of 25m+.

**Source-only diff: 3 files, +440/-17. No `dist/`, no `bridge/`.**

```
src/__tests__/hud/transcript-agent-lifecycle.test.ts   +350  (new file, 6 regression tests)
src/hud/transcript.ts                                   +88/-17
src/hud/types.ts                                         +2/-1
```

## Reproduction

In any session that spawns at least one background sub-agent (the most common case is `Agent` / `Task` with `run_in_background: true`, but it also affects synchronous Explore/Plan sub-agents that emit `<task-notification>` blocks), the HUD's running-agent count drifts above 0 and never returns to 0. The 30-minute stale-task GC eventually cleans up but only after 30m of misleading display.

I hit this in a real session and verified it against a 5.2 MB transcript: the parser reported 2 running agents when only 1 was actually running.

## Root cause

Four overlapping bugs in `src/hud/transcript.ts`. Each one alone is enough to keep an agent stuck.

### Bug 1 — `isBackgroundLaunch` false positive (the actual user-facing case)

```ts
// Before — matches the literal phrase ANYWHERE in any text block
const isBackgroundLaunch =
  blockContent.some(c => c.type === "text" && c.text?.includes("Async agent launched"));
```

A completed foreground agent's result that incidentally quoted the phrase (e.g. an investigation report citing prior launch notifications) was misclassified as a background launch and kept as `running`.

**Fix:** require the phrase at the START of the FIRST text block:
```ts
const startsWithAsyncLaunch = (text?: string) =>
  !!text && text.trimStart().startsWith("Async agent launched");
```

### Bug 2 — task-notification format mismatch

`parseTaskOutputResult` looked for `<task_id>` (underscore) but Claude Code emits `<task-id>` (hyphen). It also missed `<tool-use-id>`, which would let it skip the `backgroundAgentMap` indirection entirely.

**Fix:** accept both hyphen and underscore variants for `<task-id>`/`<task_id>` and `<tool-use-id>`/`<tool_use_id>`. Prefer direct tool-use-id lookup; fall back to the legacy agentId mapping.

### Bug 3 — string-shaped `message.content` ignored

```ts
const content = entry.message?.content;
if (!content || !Array.isArray(content)) return;   // <-- bails out
```

But Claude Code delivers task-notification completions as user-role messages with plain string content:
```
message.content: "<task-notification><task-id>...</task-id><tool-use-id>...</tool-use-id><status>completed</status></task-notification>"
```

These entries were silently dropped and never reached the completion path.

**Fix:** handle string content explicitly before the array branch. Update the `TranscriptEntry.message.content` type from `ContentBlock[]` to `ContentBlock[] | string`.

### Bug 4 — tail window too small

`MAX_TAIL_BYTES = 512KB` is below the typical agent-call footprint (~30KB each) for any non-trivial Ralph or autopilot session. When the `tool_use` was in the tail window but the matching `tool_result`/`task-notification` was just above it, the parser saw a half-finished agent and never resolved it.

**Fix:** bump `MAX_TAIL_BYTES` to 4MB (covers ~80-130 agent calls per session) and lower `staleTaskThresholdMinutes` from 30 → 10 as defence in depth so any GC fallback fires sooner.

## Tests

New file `src/__tests__/hud/transcript-agent-lifecycle.test.ts` with 6 regression tests, each capturing a distinct failure mode:

1. Foreground agent normal completion (sanity baseline)
2. **Foreground agent result quoting "Async agent launched"** — Bug 1
3. Genuine background launch keeps agent running (sanity)
4. **String-shaped task-notification** — Bug 3
5. **Nested task-notification inside `tool_result.content`** — Bug 2
6. **Legacy underscore `<task_id>` still works** — Bug 2 backward compat

**Test-driven evidence**: against unmodified `upstream/dev`, **4 of 6 tests fail immediately**. After this fix all 6 pass. All 522 tests in the broader HUD suite pass.

## Live verification

Against a real 5.2 MB transcript from a session that exhibited the bug:

```
$ node -e 'parseTranscript(...)'
# Before fix:
Running agents: 2
  - Explore         | Investigate stuck agents in HUD   ← stuck for 25m, completed long ago
  - general-purpose | Check status of PRs               ← genuinely running

# After fix:
Running agents: 1
  - general-purpose | Check status of PRs               ← only the actually-running one
```

## Test plan

- [x] 6 new regression tests (`src/__tests__/hud/transcript-agent-lifecycle.test.ts`)
- [x] All 522 HUD tests pass
- [x] Full test suite: 7604 passing, 7 skipped, 0 failed
- [x] Live transcript verification (5.2 MB session that previously showed stuck agents)
- [x] Source-only diff (3 files)
- [x] No platform-specific branches; same code path on macOS/Linux/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)