### PR TITLE
fix(persistent-mode): relax overly-strict ralph/ultrawork session-id check

### DIFF
--- a/src/hooks/persistent-mode/__tests__/ralph-session-mismatch.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ralph-session-mismatch.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression test for the Ralph iteration counter stuck-at-1 bug.
+ *
+ * Symptom: HUD shows `ralph:1/100` permanently for the entire duration of
+ * a long Ralph session, even though the Stop hook fires many times. The
+ * iteration counter never increments past 1.
+ *
+ * Root cause: `checkRalphLoop` and `checkUltrawork` in
+ * `src/hooks/persistent-mode/index.ts` re-applied a strict session-id
+ * check on top of the lenient check already done by `readRalphState` /
+ * `readUltraworkState`. The strict check `state.session_id !== sessionId`
+ * rejected the legitimate case where ONE side is undefined and the other
+ * is a UUID, causing the entire ralph/ultrawork loop to bail out before
+ * `incrementRalphIteration()` could fire.
+ *
+ * Two scenarios that trigger the bug:
+ *   - Ralph state file written with `session_id: undefined`, Stop hook
+ *     fires with a UUID extracted from the transcript path.
+ *   - Ralph state file written with a UUID, Stop hook fires with
+ *     `sessionId: undefined` (transcript path lookup failed).
+ *
+ * Either scenario silently breaks Ralph for the entire session.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { checkPersistentModes } from '../index.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const d = tempDirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+function createGitProject(): string {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ralph-session-mismatch-'));
+  tempDirs.push(tempDir);
+  execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+  return tempDir;
+}
+
+function writeRalphStateFile(
+  tempDir: string,
+  sessionId: string | undefined,
+  storedSessionId: string | undefined,
+  iteration = 1,
+): void {
+  // Write to the legacy unscoped path when sessionId is undefined,
+  // session-scoped path when defined.
+  const stateDir = sessionId
+    ? join(tempDir, '.omc', 'state', 'sessions', sessionId)
+    : join(tempDir, '.omc', 'state');
+  mkdirSync(stateDir, { recursive: true });
+
+  const state: Record<string, unknown> = {
+    active: true,
+    iteration,
+    max_iterations: 100,
+    started_at: new Date().toISOString(),
+    prompt: 'Long-running ralph session',
+    project_path: tempDir,
+  };
+  if (storedSessionId !== undefined) {
+    state.session_id = storedSessionId;
+  }
+
+  writeFileSync(join(stateDir, 'ralph-state.json'), JSON.stringify(state, null, 2));
+}
+
+describe('persistent-mode ralph session-id mismatch (stuck counter regression)', () => {
+  it('increments the counter when state file has no session_id but Stop hook supplies one', async () => {
+    const tempDir = createGitProject();
+    const sessionId = 'fresh-session-uuid-1';
+
+    // Simulate the bug: state file written without a session_id (e.g. ralph
+    // started before the session_id was known, or an older state schema).
+    // Place it at the SESSION-SCOPED path so readRalphState finds it.
+    const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        iteration: 5,
+        max_iterations: 100,
+        started_at: new Date().toISOString(),
+        prompt: 'Test prompt',
+        project_path: tempDir,
+        // No session_id field
+      }),
+    );
+
+    const result = await checkPersistentModes(sessionId, tempDir);
+
+    expect(result.mode).toBe('ralph');
+    expect(result.shouldBlock).toBe(true);
+
+    const updated = JSON.parse(
+      readFileSync(join(stateDir, 'ralph-state.json'), 'utf-8'),
+    ) as { iteration: number };
+    expect(updated.iteration).toBe(6);
+  });
+
+  it('still rejects state files that explicitly belong to a different session', async () => {
+    const tempDir = createGitProject();
+    const sessionA = 'session-a';
+    const sessionB = 'session-b';
+
+    // Write state under session A's directory with session A's id
+    writeRalphStateFile(tempDir, sessionA, sessionA, 5);
+
+    // Now invoke as session B — should not pick up session A's state
+    const result = await checkPersistentModes(sessionB, tempDir);
+    expect(result.mode).not.toBe('ralph');
+
+    // Session A's state should be unchanged
+    const stateFile = join(tempDir, '.omc', 'state', 'sessions', sessionA, 'ralph-state.json');
+    const unchanged = JSON.parse(readFileSync(stateFile, 'utf-8')) as { iteration: number };
+    expect(unchanged.iteration).toBe(5);
+  });
+
+  it('correctly increments when both stored and incoming session_ids match', async () => {
+    // Sanity check: the existing happy path still works after the fix.
+    const tempDir = createGitProject();
+    const sessionId = 'session-happy-path';
+
+    writeRalphStateFile(tempDir, sessionId, sessionId, 3);
+
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.mode).toBe('ralph');
+
+    const stateFile = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
+    const updated = JSON.parse(readFileSync(stateFile, 'utf-8')) as { iteration: number };
+    expect(updated.iteration).toBe(4);
+  });
+});

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -470,8 +470,18 @@ async function checkRalphLoop(
     return null;
   }
 
-  // Strict session isolation: only process state for matching session
-  if (state.session_id !== sessionId) {
+  // Session isolation. `readRalphState()` already enforces the lenient form
+  // ("only reject when BOTH sides have defined session_ids that differ"),
+  // so by the time we get here, the state file is either explicitly bound
+  // to this session or has no session_id at all (legacy/unbound state).
+  //
+  // The previous strict check `state.session_id !== sessionId` rejected the
+  // legitimate case where one side is undefined and the other is a UUID,
+  // which broke iteration counting on every Ralph loop where the state file
+  // lacked a session_id (or the Stop hook lost it). Symptom: ralph:1/100
+  // stuck forever in the HUD even on multi-hour sessions where the Stop
+  // hook fired many times.
+  if (state.session_id && sessionId && state.session_id !== sessionId) {
     return null;
   }
 
@@ -1026,8 +1036,11 @@ async function checkUltrawork(
     return null;
   }
 
-  // Strict session isolation: only process state for matching session
-  if (state.session_id !== sessionId) {
+  // Session isolation. `readUltraworkState()` already enforces the lenient
+  // form ("only reject when BOTH sides have defined session_ids that
+  // differ"). The previous strict check rejected legitimate cases where
+  // one side was undefined — same root cause as the ralph counter bug.
+  if (state.session_id && sessionId && state.session_id !== sessionId) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Fixes a bug where the Ralph iteration counter (`ralph:N/MAX` in the HUD) gets stuck at `1` for the entire duration of a long Ralph session, even though the Stop hook fires many times. Same root cause affects Ultrawork mode reinforcement.

**Source-only diff: 2 files, +158/-4. No `dist/`, no `bridge/`.**

```
src/hooks/persistent-mode/__tests__/ralph-session-mismatch.test.ts   +141  (new file, 3 regression tests)
src/hooks/persistent-mode/index.ts                                    +17/-4
```

## Reproduction

In any session that exhibits a session-id mismatch between the state file and the Stop hook input — which can happen when Ralph is started before the session_id is known, when transcript path lookup fails, or with state files migrated from an older schema — the iteration counter never increments. Symptom: HUD displays `ralph:1/100` for hours while the Stop hook fires dozens of times.

I hit this in a real multi-hour session where the HUD showed `ralph:1/100 | session:2227m` (37 hours stuck at iteration 1).

## Root cause

`checkRalphLoop` (`src/hooks/persistent-mode/index.ts:474`) and `checkUltrawork` (line 1030) re-applied a strict session-id check on top of the lenient check already done by `readRalphState` / `readUltraworkState`:

```ts
// Before — strict check, treats undefined as a mismatch
if (state.session_id !== sessionId) {
  return null;
}
```

The strict check rejects the legitimate case where ONE side is undefined and the other is a UUID. In that case the function bails out before `incrementRalphIteration()` can fire, and the counter never moves.

`readRalphState` (`src/hooks/ralph/loop.ts:144-152`) **already enforces the correct lenient form**:

```ts
if (state && sessionId && state.session_id && state.session_id !== sessionId) {
  return null;
}
```

This is "only reject when BOTH sides have defined session_ids that differ" — which is what cross-session isolation actually requires. By the time `checkRalphLoop` runs, the state has already passed this lenient check, so the outer strict check at line 474 can only generate false negatives.

`readUltraworkState` (`src/hooks/ultrawork/index.ts:60-81`) has the same lenient check, and `checkUltrawork` repeats the same redundant strict check at line 1030.

## Fix

Replace both strict checks with the lenient form:

```ts
// After — same semantics as readRalphState's check
if (state.session_id && sessionId && state.session_id !== sessionId) {
  return null;
}
```

This is intentionally identical to the inner check; the outer guard now only catches the specific case of an explicit session-id collision (which is already rare in practice because state files are session-scoped on disk).

Cross-session isolation is preserved end-to-end:
1. The state file path is session-scoped (worktree + session_id)
2. `readRalphState` rejects state from other sessions
3. The outer check (this fix) catches any rare double-write race

## Tests

New file `src/hooks/persistent-mode/__tests__/ralph-session-mismatch.test.ts` with 3 regression tests:

1. **Increments counter when state file has no session_id but Stop hook supplies one** — the actual user-reported bug
2. **Still rejects state files explicitly bound to a different session** — cross-session isolation regression test
3. **Happy path with matching session_ids** — sanity baseline

**Test-driven evidence**: against unmodified `upstream/dev`, test 1 fails (`"expected 'ralph' to be 'none'"`) because the strict check rejects the state file. Tests 2 and 3 pass because they don't hit the buggy edge case. After this fix all 3 pass.

## Test plan

- [x] 3 new regression tests (`ralph-session-mismatch.test.ts`)
- [x] Existing `ralph-max-iteration.test.ts` (happy path) still passes
- [x] All 208 persistent-mode tests pass, including `session-isolation.test.ts`
- [x] Full test suite: 7604 passing, 7 skipped, 0 failed
- [x] Source-only diff (2 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)