### PR TITLE
fix(skills): clarify ralph step 7 chaining and ai-slop-cleaner skill invocation

### DIFF
--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -102,9 +102,11 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
      4. The list of files changed during the ralph session for context
    - Ralph floor: always at least STANDARD, even for small changes
    - The selected reviewer verifies against the SPECIFIC acceptance criteria from prd.json, not vague "is it done?"
+   - **On APPROVAL: immediately proceed to Step 7.5 in the same turn. Do NOT pause to report the verdict to the user — reporting happens only at Step 8 (`/oh-my-claudecode:cancel`) or on rejection (Step 9). Treating an approved verdict as a reporting checkpoint is a polite-stop anti-pattern.**
 
-7.5 **Mandatory Deslop Pass**:
-   - Unless `{{PROMPT}}` contains `--no-deslop`, run `oh-my-claudecode:ai-slop-cleaner` in standard mode (not `--review`) on the files changed during the current Ralph session only.
+7.5 **Mandatory Deslop Pass** (runs unconditionally after Step 7 approval, unless `{{PROMPT}}` contains `--no-deslop`):
+   - **Invoke the `ai-slop-cleaner` skill via the Skill tool: `Skill("ai-slop-cleaner")`.** Run in standard mode (not `--review`) on the files changed during the current Ralph session only.
+   - **ai-slop-cleaner is a SKILL, not an agent.** Do NOT call it via `Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")` — that subagent type does not exist and the call will fail with "Agent type not found". If you see that error, retry with the Skill tool — do NOT substitute a similarly-named agent like `code-simplifier` as a "closest match".
    - Keep the scope bounded to the Ralph changed-file set; do not broaden the cleanup pass to unrelated files.
    - If the reviewer approved the implementation but the deslop pass introduces follow-up edits, keep those edits inside the same changed-file scope before proceeding.
 
@@ -126,6 +128,7 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 - Skip architect consultation for simple feature additions, well-tested changes, or time-critical verification
 - Proceed with architect agent verification alone -- never block on unavailable tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
+- **Skill vs agent invocation**: `ai-slop-cleaner` is a skill, invoke via `Skill("ai-slop-cleaner")`. `architect`, `critic`, `executor` etc. are agents, invoke via `Task(subagent_type="oh-my-claudecode:<name>")`. If you ever get "Agent type ... not found" for an `oh-my-claudecode:<name>` identifier, the item is a skill — retry with the Skill tool. Do NOT substitute a similarly-named agent as a "closest match".
 </Tool_Usage>
 
 <Examples>
@@ -198,6 +201,7 @@ Why bad: Did not refine scaffold criteria into task-specific ones. This is PRD t
 - Continue working when the hook system sends "The boulder never stops" -- this means the iteration continues
 - If the selected reviewer rejects verification, fix the issues and re-verify (do not stop)
 - If the same issue recurs across 3+ iterations, report it as a potential fundamental problem
+- **Do NOT stop after Step 7 approval.** The boulder continues through 7 → 7.5 → 7.6 → 8 in the same turn as a single chain. Step 7 is a checkpoint inside the loop, not a reporting moment. Treating an architect/critic APPROVED verdict as "time to summarise and wait for user acknowledgment" is a polite-stop anti-pattern — the only reporting moments in Ralph are Step 8 (successful cancel) or Step 9 (rejection).
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>


### PR DESCRIPTION
## Summary

Two adjacent bugs in `skills/ralph/SKILL.md` that combined to break a real autonomous Ralph session. **Documentation-only fix** — no code, no tests.

**Source-only diff: 1 file, +6/-2.**

## Bug 1 — polite-stop after Step 7 approval

Step 7 (reviewer verification) ended with no explicit "what next" directive on approval. Step 7.5 opened with the conditional frame *"Unless `--no-deslop`, run..."* which reads as optional/decision-dependent. The Escalation section enumerated every blocker scenario but never said *"on approval, proceed without pausing to report"*.

The `"the boulder never stops"` invariant lives in the Escalation section ~90 lines away from the Step 7 → 7.5 boundary, semantically inverted (it tells the AI when stopping IS OK, not that chaining is mandatory).

**Symptom from a real session:** architect verification returned APPROVED, the AI wrote a summary ending on *"Ready to proceed with Step 7.5 (deslop) and Step 7.6 (regression)"*, then **stopped and waited for user acknowledgment**. The user had to type *"why have you stopped?"* to restart the chain. The AI later admitted it was a *"polite-stop reflex"* and a *"false consultation moment"*.

## Bug 2 — `ai-slop-cleaner` invoked as agent instead of skill

Step 7.5 said `run oh-my-claudecode:ai-slop-cleaner` without specifying the invocation mechanism. **Sixteen lines later** in the same file, the Tool_Usage section uses `Task(subagent_type="oh-my-claudecode:architect")` for actual agents. The nearest precedent in the same document for `oh-my-claudecode:<name>` is agent-tool syntax, so the AI pattern-matched and called:

```
Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")
```

— which fails with `Error: Agent type 'oh-my-claudecode:ai-slop-cleaner' not found`. `ai-slop-cleaner` lives only at `skills/ai-slop-cleaner/SKILL.md`; there is no `agents/ai-slop-cleaner.md`. The `omc-reference` skill catalog and the keyword triggers in `CLAUDE.md` correctly identify it as a skill, but the Step 7.5 invocation instruction in isolation is ambiguous.

**Worse**: the AI's recovery path on *"agent not found"* was to substitute `code-simplifier` as a *"closest match"* and run that instead. `code-simplifier` is not equivalent to `ai-slop-cleaner` — the deslop step was effectively skipped, defeating the purpose of Step 7.5.

## Fix

All edits are additive (new lines + reframed wording, no removed instructions).

1. **Step 7 tail** — append explicit forward-chaining directive:
   > **On APPROVAL: immediately proceed to Step 7.5 in the same turn. Do NOT pause to report the verdict to the user — reporting happens only at Step 8 (`/oh-my-claudecode:cancel`) or on rejection (Step 9). Treating an approved verdict as a reporting checkpoint is a polite-stop anti-pattern.**

2. **Step 7.5 opener** — reframe from conditional to affirmative + explicit Skill-tool syntax + skill-vs-agent warning:
   > 7.5 **Mandatory Deslop Pass** (runs unconditionally after Step 7 approval, unless `{{PROMPT}}` contains `--no-deslop`):
   >    - **Invoke the `ai-slop-cleaner` skill via the Skill tool: `Skill("ai-slop-cleaner")`.**
   >    - **ai-slop-cleaner is a SKILL, not an agent.** Do NOT call it via `Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")` — that subagent type does not exist and the call will fail with "Agent type not found". If you see that error, retry with the Skill tool — do NOT substitute a similarly-named agent like `code-simplifier` as a "closest match".

3. **Tool_Usage section** — add general disambiguation rule:
   > **Skill vs agent invocation**: `ai-slop-cleaner` is a skill, invoke via `Skill("ai-slop-cleaner")`. `architect`, `critic`, `executor` etc. are agents, invoke via `Task(subagent_type="oh-my-claudecode:<name>")`. If you ever get "Agent type ... not found" for an `oh-my-claudecode:<name>` identifier, the item is a skill — retry with the Skill tool. Do NOT substitute a similarly-named agent as a "closest match".

4. **Escalation section** — add affirmative anti-stop directive:
   > **Do NOT stop after Step 7 approval.** The boulder continues through 7 → 7.5 → 7.6 → 8 in the same turn as a single chain. Step 7 is a checkpoint inside the loop, not a reporting moment.

## Test plan

- [x] Re-read Steps 7 → 7.5 → 7.6 → 8 linearly — every step now ends with explicit "proceed to <next>" or equivalent
- [x] `grep -n 'run \`oh-my-claudecode:' skills/` — no remaining ambiguous invocations
- [x] Single source file, doc-only — no code/test impact

## Why a separate PR

These are tightly-coupled instruction-text bugs that share the same root failure mode (Ralph Step 7 → 7.5 transition is broken). They're trivially small (8 lines) and equally trivial to land or roll back, but they need to be reviewed together because they both touch the same ~10-line section of the skill definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)