### PR TITLE
fix: ignore HTML comments in keyword detector (#2236)

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -149,6 +149,8 @@ function isAntiSlopCleanupRequest(text) {
 
 function sanitizeForKeywordDetection(text) {
   return text
+    // 0. Strip HTML/markdown comments before tag stripping
+    .replace(/<!--[\s\S]*?-->/g, '')
     // 1. Strip XML-style tag blocks: <tag-name ...>...</tag-name> (multi-line, greedy on tag name)
     .replace(/<(\w[\w-]*)[\s>][\s\S]*?<\/\1>/g, '')
     // 2. Strip self-closing XML tags: <tag-name />, <tag-name attr="val" />

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -66,4 +66,25 @@ describe('keyword-detector.mjs mode-message dispatch', () => {
     expect(context).toContain('[MAGIC KEYWORD: RALPLAN]');
     expect(context).toContain('name: ralplan');
   });
+
+  it('ignores HTML comments that mention ralph and autopilot during normal review text', () => {
+    const output = runKeywordDetector(`Please review this draft document for tone and clarity:
+
+<!-- ralph: rewrite intro section with more urgency -->
+<!-- autopilot note: Why Artificially Inflating GitHub Star Counts Is Harmful:
+popularity without merit misleads developers, distorts discovery, unfairly rewards dishonest projects, and erodes trust in GitHub stars as a community signal. -->
+
+Final draft:
+
+Why Artificially Inflating GitHub Star Counts Is Harmful
+=========================================================
+
+This article argues that fake popularity signals damage trust in open source.`);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(context).toBe('');
+  });
 });

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -88,6 +88,21 @@ World`);
       expect(result).not.toContain('<br');
     });
 
+    it('should strip HTML comments that contain keyword triggers', () => {
+      const result = sanitizeForKeywordDetection(`Please review this draft document for tone and clarity:
+
+<!-- ralph: rewrite intro section with more urgency -->
+<!-- autopilot note: Why Artificially Inflating GitHub Star Counts Is Harmful:
+popularity without merit misleads developers, distorts discovery, unfairly rewards dishonest projects, and erodes trust in GitHub stars as a community signal. -->
+
+Final draft.`);
+
+      expect(result).not.toContain('ralph');
+      expect(result).not.toContain('autopilot');
+      expect(result).toContain('Please review this draft document for tone and clarity:');
+      expect(result).toContain('Final draft.');
+    });
+
     it('should strip URLs', () => {
       const result = sanitizeForKeywordDetection('see https://example.com/codex/path');
       expect(result).not.toContain('codex');
@@ -583,6 +598,25 @@ World`);
         const result = detectKeywordsWithType(text);
         const ralphMatch = result.find((r) => r.type === 'ralph');
         expect(ralphMatch).toBeUndefined();
+      });
+
+      it('should not detect keywords inside HTML comments', () => {
+        const text = `Please review this draft document for tone and clarity:
+
+<!-- ralph: rewrite intro section with more urgency -->
+<!-- autopilot note: Why Artificially Inflating GitHub Star Counts Is Harmful:
+popularity without merit misleads developers, distorts discovery, unfairly rewards dishonest projects, and erodes trust in GitHub stars as a community signal. -->
+
+Final draft:
+
+Why Artificially Inflating GitHub Star Counts Is Harmful
+=========================================================
+
+This article argues that fake popularity signals damage trust in open source.`;
+        const result = detectKeywordsWithType(text);
+
+        expect(result.find((r) => r.type === 'ralph')).toBeUndefined();
+        expect(result.find((r) => r.type === 'autopilot')).toBeUndefined();
       });
     });
 

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -101,8 +101,10 @@ export const NON_LATIN_SCRIPT_PATTERN =
  * Strips XML tags, URLs, file paths, and code blocks.
  */
 export function sanitizeForKeywordDetection(text: string): string {
+  // Remove HTML/markdown comments first so keywords inside comments cannot trigger modes
+  let result = text.replace(/<!--[\s\S]*?-->/g, '');
   // Remove XML tag blocks (opening + content + closing; tag names must match)
-  let result = text.replace(/<(\w[\w-]*)[\s>][\s\S]*?<\/\1>/g, '');
+  result = result.replace(/<(\w[\w-]*)[\s>][\s\S]*?<\/\1>/g, '');
   // Remove self-closing XML tags
   result = result.replace(/<\w[\w-]*(?:\s[^>]*)?\s*\/>/g, '');
   // Remove URLs


### PR DESCRIPTION
## Summary
- strip HTML/markdown comments before keyword matching in both detector implementations
- add regression coverage for the hook sanitizer/detector and the script entrypoint
- keep scope limited to the HTML-comment false positive from issue #2236

## Testing
- npx vitest run src/hooks/keyword-detector/__tests__/index.test.ts src/__tests__/keyword-detector-script.test.ts
- npx eslint src/hooks/keyword-detector/index.ts src/hooks/keyword-detector/__tests__/index.test.ts src/__tests__/keyword-detector-script.test.ts
- npx tsc --noEmit

Closes #2236