### PR TITLE
Make artifact-first handoffs explicit for interop and prompt persistence

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -439,6 +439,7 @@ OMC stores task progress and project knowledge in the `.omc/` directory. The sta
 │   ├── autopilot-state.json  # autopilot progress
 │   ├── ralph-state.json      # ralph loop state
 │   ├── team/                 # team task state
+│   ├── interop/              # cross-tool task/message envelopes
 │   └── sessions/             # per-session state
 │       └── {sessionId}/
 ├── notepad.md                # Compaction-resistant memo pad
@@ -450,16 +451,50 @@ OMC stores task progress and project knowledge in the `.omc/` directory. The sta
 │       ├── decisions.md
 │       ├── issues.md
 │       └── problems.md
+├── prompts/                  # persisted prompt/response artifacts
 ├── autopilot/                # autopilot artifacts
 │   └── spec.md
 ├── research/                 # Research results
 └── logs/                     # Execution logs
 ```
 
+### Control Plane vs Data Plane
+
+OMC keeps orchestration metadata separate from large durable artifacts:
+
+- **Control plane**: queue state, worker assignment, session state, and cross-tool task/message envelopes under `.omc/state/**`.
+- **Data plane**: plans, specs, prompts, results, traces, and other durable artifacts under paths such as `.omc/plans/`, `.omc/notepads/`, `.omc/prompts/`, and `.omc/state/interop/artifacts/**`.
+- **Concrete handoff examples**:
+  - shared interop state keeps task/message metadata inline while storing oversized task descriptions, task results, and message bodies under `.omc/state/interop/artifacts/**`
+  - prompt persistence stores durable prompt/response files under `.omc/prompts/**` and records descriptor metadata alongside job status
+
 **Global State:**
 - `~/.omc/state/{name}.json` — user preferences and global config
 
 Legacy locations are auto-migrated on read.
+
+This separation keeps schedulers and status checks small while allowing richer artifacts to remain durable and inspectable.
+
+### Artifact Descriptors and Bounded Handoffs
+
+When a handoff needs to reference a large artifact, prefer a descriptor/handle over pasting the full payload inline. The canonical descriptor shape is:
+
+| Field | Purpose |
+|------|---------|
+| `kind` | Artifact category (plan, prompt, result, trace, etc.) |
+| `path` | Durable path to the artifact |
+| `contentHash?` | Optional integrity/checksum hint when available |
+| `createdAt` | Creation timestamp |
+| `producer` | Owning tool, skill, or worker |
+| `sizeBytes?` | Optional payload size for threshold decisions |
+| `retention` | Lifecycle hint for cleanup/ownership |
+| `expiresAt?` | Optional expiry for short-lived artifacts |
+
+**Bounded handoff rule:**
+
+1. Keep small payloads inline when the call site's explicit threshold allows it.
+2. Switch to a descriptor + short human-readable summary when the payload would bloat control-plane state.
+3. Preserve ownership/retention metadata with the descriptor so later cleanup and audits remain deterministic.
 
 ### Notepad
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -305,6 +305,36 @@ Optional compatibility enablement (manual only):
 - **Deterministic parse-failure handling**: malformed result artifacts are treated as terminal `failed`.
 - **Cleanup scope**: shutdown/cleanup only clears `.omc/state/team/{teamName}` for the target team (never sibling teams).
 
+### Artifact descriptors and bounded handoff
+
+OMC handoffs follow an artifact-first discipline:
+
+- **Control plane** data stays small and operational: queue state, worker claims, session state, and interop task/message envelopes.
+- **Data plane** artifacts stay durable: plans, prompts, specs, traces, and result files.
+- Large payloads should be referenced by descriptor instead of copied into control-plane state.
+- Current low-risk call sites follow this split explicitly:
+  - shared interop state writes oversized task descriptions, task results, and shared messages to `.omc/state/interop/artifacts/**`
+  - prompt persistence keeps durable prompt/response files in `.omc/prompts/**` and exposes descriptor metadata through job status records
+
+Canonical descriptor fields:
+
+| Field | Meaning |
+|------|---------|
+| `kind` | Artifact type such as `plan`, `prompt`, `result`, or `trace` |
+| `path` | Durable artifact path |
+| `contentHash?` | Optional integrity hint |
+| `createdAt` | Artifact creation timestamp |
+| `producer` | Owning worker/tool/skill |
+| `sizeBytes?` | Optional size for threshold checks |
+| `retention` | Retention/ownership hint |
+| `expiresAt?` | Optional expiry for short-lived artifacts |
+
+Bounded handoff policy:
+
+1. Keep small payloads inline only when the call site's explicit threshold allows it.
+2. For larger payloads, pass a short summary plus the descriptor.
+3. Keep durable content in artifact paths such as `.omc/plans/`, `.omc/prompts/`, and related artifact stores rather than embedding full bodies into queue or status records.
+
 ## Agents (29 Total)
 
 Always use `oh-my-claudecode:` prefix when calling via Task tool.

--- a/src/__tests__/artifact-descriptor-handoff.test.ts
+++ b/src/__tests__/artifact-descriptor-handoff.test.ts
@@ -1,0 +1,181 @@
+import { existsSync, readFileSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { describe, expect, it } from 'vitest';
+
+type ArtifactModule = Record<string, unknown>;
+
+const ARTIFACT_DESCRIPTOR_SOURCE_PATH = join(process.cwd(), 'src', 'shared', 'artifact-descriptor.ts');
+const ARTIFACT_DESCRIPTOR_IMPORT_PATH = '../shared/artifact-descriptor.js';
+
+function getExistingArtifactSource(): string {
+  expect(existsSync(ARTIFACT_DESCRIPTOR_SOURCE_PATH)).toBe(true);
+  return readFileSync(ARTIFACT_DESCRIPTOR_SOURCE_PATH, 'utf-8');
+}
+
+async function loadArtifactModule(): Promise<ArtifactModule> {
+  return (await import(ARTIFACT_DESCRIPTOR_IMPORT_PATH)) as ArtifactModule;
+}
+
+function getCreateArtifactHandoff(mod: ArtifactModule): (input: Record<string, unknown>) => Record<string, unknown> {
+  const createHandoff = mod.createArtifactHandoff;
+  expect(typeof createHandoff).toBe('function');
+  return createHandoff as (input: Record<string, unknown>) => Record<string, unknown>;
+}
+
+function getCreateArtifactDescriptorFromPath(
+  mod: ArtifactModule,
+): (path: string, input: Record<string, unknown>) => Record<string, unknown> {
+  const createDescriptor = mod.createArtifactDescriptorFromPath;
+  expect(typeof createDescriptor).toBe('function');
+  return createDescriptor as (path: string, input: Record<string, unknown>) => Record<string, unknown>;
+}
+
+function getWriteTextArtifact(mod: ArtifactModule): (input: Record<string, unknown>) => Record<string, unknown> {
+  const writeArtifact = mod.writeTextArtifact;
+  expect(typeof writeArtifact).toBe('function');
+  return writeArtifact as (input: Record<string, unknown>) => Record<string, unknown>;
+}
+
+function readMode(result: Record<string, unknown>): string | undefined {
+  const mode = result.mode ?? result.strategy ?? result.kind;
+  return typeof mode === 'string' ? mode : undefined;
+}
+
+function readInlineContent(result: Record<string, unknown>): string | undefined {
+  return typeof result.body === 'string' ? result.body : undefined;
+}
+
+function readDescriptor(result: Record<string, unknown>): Record<string, unknown> | undefined {
+  return result.descriptor && typeof result.descriptor === 'object'
+    ? result.descriptor as Record<string, unknown>
+    : undefined;
+}
+
+describe('artifact descriptor contract', () => {
+  it('defines the canonical descriptor fields in the shared artifact module', () => {
+    const source = getExistingArtifactSource();
+
+    expect(ARTIFACT_DESCRIPTOR_SOURCE_PATH).toMatch(/src\/shared\//);
+    expect(source).toMatch(/ArtifactDescriptor/);
+
+    for (const field of ['kind', 'path', 'createdAt', 'producer', 'retention']) {
+      expect(source).toContain(field);
+    }
+
+    for (const optionalField of ['contentHash', 'sizeBytes', 'expiresAt']) {
+      expect(source).toContain(optionalField);
+    }
+
+    expect(source).toMatch(/threshold/i);
+    expect(source).toMatch(/inline/i);
+    expect(source).toMatch(/descriptor/i);
+  });
+
+  it('creates stable descriptors for the same durable artifact input', async () => {
+    const mod = await loadArtifactModule();
+    const createArtifactDescriptorFromPath = getCreateArtifactDescriptorFromPath(mod);
+    const dir = mkdtempSync(join(tmpdir(), 'artifact-descriptor-contract-'));
+
+    try {
+      const path = join(dir, 'plan.md');
+      const content = 'phase-1 plan artifact';
+      writeFileSync(path, content, 'utf-8');
+
+      const input = {
+        kind: 'prompt',
+        createdAt: '2026-04-07T00:00:00.000Z',
+        producer: { system: 'omc', component: 'worker-1' },
+        retention: 'session',
+        expiresAt: '2026-04-08T00:00:00.000Z',
+      };
+
+      const first = createArtifactDescriptorFromPath(path, input);
+      const second = createArtifactDescriptorFromPath(path, input);
+
+      expect(first).toMatchObject({
+        kind: input.kind,
+        path,
+        createdAt: input.createdAt,
+        producer: input.producer,
+        retention: input.retention,
+        expiresAt: input.expiresAt,
+      });
+
+      expect(first.contentHash).toBe(second.contentHash);
+      expect(first.sizeBytes).toBe(Buffer.byteLength(content, 'utf-8'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps small payloads inline when they are under the explicit threshold', async () => {
+    const mod = await loadArtifactModule();
+    const writeTextArtifact = getWriteTextArtifact(mod);
+    const createArtifactHandoff = getCreateArtifactHandoff(mod);
+    const content = 'short summary';
+    const dir = mkdtempSync(join(tmpdir(), 'artifact-handoff-inline-'));
+
+    try {
+      const descriptor = writeTextArtifact({
+        kind: 'prompt',
+        path: join(dir, 'short.md'),
+        content,
+        createdAt: '2026-04-07T00:00:00.000Z',
+        producer: { system: 'omc', component: 'worker-1' },
+        retention: 'session',
+      });
+
+      const handoff = createArtifactHandoff({
+        body: content,
+        summary: 'short summary',
+        thresholdBytes: Buffer.byteLength(content, 'utf-8') + 1,
+        descriptorFactory: () => descriptor,
+      });
+
+      expect(readMode(handoff)).toBe('inline');
+      expect(readInlineContent(handoff)).toBe(content);
+      expect(handoff.summary).toBe('short summary');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('switches to descriptor mode when payload exceeds the explicit threshold', async () => {
+    const mod = await loadArtifactModule();
+    const writeTextArtifact = getWriteTextArtifact(mod);
+    const createArtifactHandoff = getCreateArtifactHandoff(mod);
+    const content = 'x'.repeat(128);
+    const dir = mkdtempSync(join(tmpdir(), 'artifact-handoff-descriptor-'));
+
+    try {
+      const descriptor = writeTextArtifact({
+        kind: 'result',
+        path: join(dir, 'large.md'),
+        content,
+        createdAt: '2026-04-07T00:00:00.000Z',
+        producer: { system: 'omc', component: 'worker-1' },
+        retention: 'until-completion',
+      });
+
+      const handoff = createArtifactHandoff({
+        body: content,
+        summary: 'large result omitted from inline handoff',
+        thresholdBytes: 32,
+        descriptorFactory: () => descriptor,
+      });
+
+      expect(readMode(handoff)).toBe('descriptor');
+      expect(readInlineContent(handoff)).toBeUndefined();
+      expect(readDescriptor(handoff)).toMatchObject({
+        kind: 'result',
+        path: descriptor.path,
+        producer: { system: 'omc', component: 'worker-1' },
+        retention: 'until-completion',
+      });
+      expect(handoff.summary).toBe('large result omitted from inline handoff');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/artifact-descriptor-integration.test.ts
+++ b/src/__tests__/artifact-descriptor-integration.test.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+type IntegrationCandidate = {
+  label: string;
+  path: string;
+};
+
+const INTEGRATION_CANDIDATES: IntegrationCandidate[] = [
+  {
+    label: 'prompt persistence',
+    path: join(process.cwd(), 'src', 'mcp', 'prompt-persistence.ts'),
+  },
+  {
+    label: 'shared interop state',
+    path: join(process.cwd(), 'src', 'interop', 'shared-state.ts'),
+  },
+];
+
+function readCandidateSources(): Array<IntegrationCandidate & { source: string }> {
+  return INTEGRATION_CANDIDATES
+    .filter((candidate) => existsSync(candidate.path))
+    .map((candidate) => ({
+      ...candidate,
+      source: readFileSync(candidate.path, 'utf-8'),
+    }));
+}
+
+describe('artifact descriptor low-risk integration', () => {
+  it('wires descriptor helpers into both planned low-risk handoff paths', () => {
+    const candidates = readCandidateSources();
+    expect(candidates.length).toBe(INTEGRATION_CANDIDATES.length);
+
+    const promptPersistence = candidates.find((candidate) => candidate.label === 'prompt persistence');
+    const sharedInteropState = candidates.find((candidate) => candidate.label === 'shared interop state');
+
+    expect(promptPersistence?.source).toMatch(/artifact-descriptor\.js/);
+    expect(promptPersistence?.source).toMatch(/createArtifactDescriptorFromPath/);
+    expect(promptPersistence?.source).toMatch(/describePromptArtifact/);
+
+    expect(sharedInteropState?.source).toMatch(/artifact-descriptor\.js/);
+    expect(sharedInteropState?.source).toMatch(/createArtifactHandoff/);
+  });
+
+  it('keeps inline-vs-descriptor thresholding explicit at the chosen call site', () => {
+    const candidates = readCandidateSources();
+    const thresholdMatches = candidates.filter(({ source }) =>
+      /(thresholdBytes|INLINE_ARTIFACT|ARTIFACT_INLINE_THRESHOLD|MAX_INLINE)/i.test(source) &&
+      /(summary|inlineContent|descriptor)/.test(source),
+    );
+
+    expect(thresholdMatches.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/artifact-descriptor.test.ts
+++ b/src/__tests__/artifact-descriptor.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  createArtifactHandoff,
+  DEFAULT_INLINE_ARTIFACT_THRESHOLD_BYTES,
+  writeTextArtifact,
+} from '../shared/artifact-descriptor.js';
+
+describe('artifact descriptor helpers', () => {
+  it('writes descriptors with stable metadata', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'artifact-descriptor-'));
+
+    try {
+      const descriptor = writeTextArtifact({
+        path: join(dir, 'artifact.md'),
+        content: 'hello artifact world',
+        kind: 'prompt',
+        producer: { system: 'omc', component: 'test' },
+        retention: 'persistent',
+      });
+
+      expect(descriptor.kind).toBe('prompt');
+      expect(descriptor.path).toContain('artifact.md');
+      expect(descriptor.contentHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(descriptor.sizeBytes).toBeGreaterThan(0);
+      expect(readFileSync(descriptor.path, 'utf-8')).toBe('hello artifact world');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps small payloads inline without creating descriptors', () => {
+    const descriptorFactory = vi.fn(() => {
+      throw new Error('should not be called');
+    });
+
+    const handoff = createArtifactHandoff({
+      body: 'small payload',
+      thresholdBytes: DEFAULT_INLINE_ARTIFACT_THRESHOLD_BYTES,
+      descriptorFactory,
+    });
+
+    expect(handoff.mode).toBe('inline');
+    expect(descriptorFactory).not.toHaveBeenCalled();
+    if (handoff.mode === 'inline') {
+      expect(handoff.body).toBe('small payload');
+    }
+  });
+
+  it('switches large payloads to descriptor mode', () => {
+    const descriptorFactory = vi.fn<() => {
+      kind: string;
+      path: string;
+      createdAt: string;
+      producer: { system: 'omc'; component: string };
+      retention: 'until-completion';
+      sizeBytes: number;
+      contentHash: string;
+    }>(() => ({
+      kind: 'task-result',
+      path: '/tmp/result.md',
+      createdAt: new Date().toISOString(),
+      producer: { system: 'omc', component: 'test' },
+      retention: 'until-completion' as const,
+      sizeBytes: 4096,
+      contentHash: 'abc123',
+    }));
+
+    const handoff = createArtifactHandoff({
+      body: 'x'.repeat(DEFAULT_INLINE_ARTIFACT_THRESHOLD_BYTES + 32),
+      thresholdBytes: DEFAULT_INLINE_ARTIFACT_THRESHOLD_BYTES,
+      descriptorFactory,
+    });
+
+    expect(handoff.mode).toBe('descriptor');
+    expect(descriptorFactory).toHaveBeenCalledTimes(1);
+    if (handoff.mode === 'descriptor') {
+      expect(handoff.descriptor.path).toBe('/tmp/result.md');
+      expect(handoff.summary.length).toBeLessThan(handoff.sizeBytes);
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export {
   backgroundUpdateCheck,
   compareVersions
 } from './features/auto-update.js';
-export * from './shared/types.js';
+export * from './shared/index.js';
 
 // Hooks module exports
 export * from './hooks/index.js';

--- a/src/interop/__tests__/mcp-bridge.test.ts
+++ b/src/interop/__tests__/mcp-bridge.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from 'vitest';
-import { canUseOmxDirectWriteBridge, getInteropMode, interopSendOmxMessageTool } from '../mcp-bridge.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  canUseOmxDirectWriteBridge,
+  getInteropMode,
+  interopReadMessagesTool,
+  interopReadResultsTool,
+  interopSendMessageTool,
+  interopSendOmxMessageTool,
+  interopSendTaskTool,
+} from '../mcp-bridge.js';
+import { initInteropSession, readSharedMessages, readSharedTasks, updateSharedTask } from '../shared-state.js';
 
 describe('interop mcp bridge gating', () => {
   it('getInteropMode normalizes invalid values to off', () => {
@@ -58,5 +70,72 @@ describe('interop mcp bridge gating', () => {
       if (savedTools === undefined) delete process.env.OMC_INTEROP_TOOLS_ENABLED;
       else process.env.OMC_INTEROP_TOOLS_ENABLED = savedTools;
     }
+  });
+});
+
+describe('interop mcp bridge artifact surfacing', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'mcp-bridge-artifacts-'));
+    initInteropSession('session-1', tempDir);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports artifact-backed task descriptions and results', async () => {
+    const description = 'describe ' + 'x'.repeat(5000);
+    const sendResponse = await interopSendTaskTool.handler({
+      target: 'omx',
+      type: 'implement',
+      description,
+      workingDirectory: tempDir,
+    });
+
+    const sendText = sendResponse.content[0]?.text ?? '';
+    expect(sendText).toContain('Description artifact:');
+
+    const [task] = readSharedTasks(tempDir);
+    expect(task.descriptionArtifact?.path).toBeTruthy();
+
+    updateSharedTask(tempDir, task.id, {
+      status: 'completed',
+      result: 'result ' + 'y'.repeat(5000),
+    });
+
+    const readResponse = await interopReadResultsTool.handler({
+      status: 'completed',
+      workingDirectory: tempDir,
+    });
+
+    const readText = readResponse.content[0]?.text ?? '';
+    expect(readText).toContain('Description artifact:');
+    expect(readText).toContain('Result artifact:');
+    expect(readText).toContain('.omc/state/interop/artifacts/task-description/');
+    expect(readText).toContain('.omc/state/interop/artifacts/task-result/');
+  });
+
+  it('reports artifact-backed shared messages', async () => {
+    const sendResponse = await interopSendMessageTool.handler({
+      target: 'omx',
+      content: 'message ' + 'z'.repeat(5000),
+      workingDirectory: tempDir,
+    });
+
+    const sendText = sendResponse.content[0]?.text ?? '';
+    expect(sendText).toContain('Content artifact:');
+
+    const [message] = readSharedMessages(tempDir);
+    expect(message.contentArtifact?.path).toBeTruthy();
+
+    const readResponse = await interopReadMessagesTool.handler({
+      workingDirectory: tempDir,
+    });
+
+    const readText = readResponse.content[0]?.text ?? '';
+    expect(readText).toContain('Content artifact:');
+    expect(readText).toContain('.omc/state/interop/artifacts/message-content/');
   });
 });

--- a/src/interop/__tests__/shared-state-artifacts.test.ts
+++ b/src/interop/__tests__/shared-state-artifacts.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  addSharedMessage,
+  addSharedTask,
+  cleanupInterop,
+  initInteropSession,
+  updateSharedTask,
+} from '../shared-state.js';
+
+describe('shared-state artifact handoff', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'shared-state-artifacts-'));
+    initInteropSession('session-1', tempDir);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('stores large task descriptions and results as artifacts', () => {
+    const largeDescription = 'describe ' + 'x'.repeat(5000);
+    const task = addSharedTask(tempDir, {
+      source: 'omc',
+      target: 'omx',
+      type: 'implement',
+      description: largeDescription,
+    });
+
+    expect(task.descriptionArtifact?.kind).toBe('task-description');
+    expect(task.description.length).toBeLessThan(largeDescription.length);
+    expect(task.descriptionArtifact?.path).toBeTruthy();
+    expect(readFileSync(task.descriptionArtifact!.path, 'utf-8')).toBe(largeDescription);
+
+    const updated = updateSharedTask(tempDir, task.id, {
+      status: 'completed',
+      result: 'result ' + 'y'.repeat(5000),
+    });
+
+    expect(updated?.resultArtifact?.kind).toBe('task-result');
+    expect(updated?.completedAt).toBeTruthy();
+    expect(readFileSync(updated!.resultArtifact!.path, 'utf-8')).toBe('result ' + 'y'.repeat(5000));
+  });
+
+  it('keeps small messages inline and cleans up large artifacts', () => {
+    const smallMessage = addSharedMessage(tempDir, {
+      source: 'omc',
+      target: 'omx',
+      content: 'short note',
+    });
+
+    expect(smallMessage.contentArtifact).toBeUndefined();
+    expect(smallMessage.content).toBe('short note');
+
+    const largeMessage = addSharedMessage(tempDir, {
+      source: 'omc',
+      target: 'omx',
+      content: 'message ' + 'z'.repeat(5000),
+    });
+
+    const artifactPath = largeMessage.contentArtifact?.path;
+    expect(artifactPath).toBeTruthy();
+    expect(existsSync(artifactPath!)).toBe(true);
+
+    const cleanup = cleanupInterop(tempDir);
+    expect(cleanup.messagesDeleted).toBe(2);
+    expect(existsSync(artifactPath!)).toBe(false);
+  });
+});

--- a/src/interop/mcp-bridge.ts
+++ b/src/interop/mcp-bridge.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 import { ToolDefinition } from '../tools/types.js';
+import type { ArtifactDescriptor } from '../shared/artifact-descriptor.js';
 import {
   addSharedTask,
   readSharedTasks,
@@ -41,6 +42,42 @@ export function canUseOmxDirectWriteBridge(env: NodeJS.ProcessEnv = process.env)
   return interopEnabled && toolsEnabled && mode === 'active';
 }
 
+function resolveWorkingDirectory(workingDirectory?: string): string {
+  return workingDirectory || process.cwd();
+}
+
+function getInteropSource(target: 'omc' | 'omx'): 'omc' | 'omx' {
+  return target === 'omc' ? 'omx' : 'omc';
+}
+
+function formatToolError(action: string, error: unknown) {
+  return {
+    content: [{
+      type: 'text' as const,
+      text: `Error ${action}: ${error instanceof Error ? error.message : String(error)}`,
+    }],
+    isError: true,
+  };
+}
+
+function truncatePreview(text: string, maxChars: number): string {
+  return text.length > maxChars ? `${text.slice(0, maxChars)}...` : text;
+}
+
+function formatArtifactDescriptorLines(label: string, descriptor?: ArtifactDescriptor): string[] {
+  if (!descriptor) return [];
+
+  const lines = [`- **${label} artifact:** \`${descriptor.path}\``];
+  if (descriptor.sizeBytes !== undefined) {
+    lines.push(`- **${label} size:** ${descriptor.sizeBytes} bytes`);
+  }
+  if (descriptor.contentHash) {
+    lines.push(`- **${label} hash:** \`${descriptor.contentHash.slice(0, 16)}…\``);
+  }
+
+  return lines;
+}
+
 // ============================================================================
 // interop_send_task - Send a task to the other tool
 // ============================================================================
@@ -67,10 +104,8 @@ export const interopSendTaskTool: ToolDefinition<{
     const { target, type, description, context, files, workingDirectory } = args;
 
     try {
-      const cwd = workingDirectory || process.cwd();
-
-      // Determine source (opposite of target)
-      const source = target === 'omc' ? 'omx' : 'omc';
+      const cwd = resolveWorkingDirectory(workingDirectory);
+      const source = getInteropSource(target);
 
       const task = addSharedTask(cwd, {
         source,
@@ -88,6 +123,7 @@ export const interopSendTaskTool: ToolDefinition<{
             `**Task ID:** ${task.id}\n` +
             `**Type:** ${task.type}\n` +
             `**Description:** ${task.description}\n` +
+            (task.descriptionArtifact ? `**Description artifact:** ${task.descriptionArtifact.path}\n` : '') +
             `**Status:** ${task.status}\n` +
             `**Created:** ${task.createdAt}\n\n` +
             (task.files ? `**Files:** ${task.files.join(', ')}\n\n` : '') +
@@ -95,13 +131,7 @@ export const interopSendTaskTool: ToolDefinition<{
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Error sending task: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
+      return formatToolError('sending task', error);
     }
   }
 };
@@ -128,7 +158,7 @@ export const interopReadResultsTool: ToolDefinition<{
     const { source, status, limit = 10, workingDirectory } = args;
 
     try {
-      const cwd = workingDirectory || process.cwd();
+      const cwd = resolveWorkingDirectory(workingDirectory);
 
       const tasks = readSharedTasks(cwd, {
         source: source as 'omc' | 'omx' | undefined,
@@ -161,14 +191,16 @@ export const interopReadResultsTool: ToolDefinition<{
         lines.push(`- **Status:** ${task.status}`);
         lines.push(`- **Description:** ${task.description}`);
         lines.push(`- **Created:** ${task.createdAt}`);
+        lines.push(...formatArtifactDescriptorLines('Description', task.descriptionArtifact));
 
         if (task.files && task.files.length > 0) {
           lines.push(`- **Files:** ${task.files.join(', ')}`);
         }
 
         if (task.result) {
-          lines.push(`- **Result:** ${task.result.slice(0, 200)}${task.result.length > 200 ? '...' : ''}`);
+          lines.push(`- **Result:** ${truncatePreview(task.result, 200)}`);
         }
+        lines.push(...formatArtifactDescriptorLines('Result', task.resultArtifact));
 
         if (task.error) {
           lines.push(`- **Error:** ${task.error}`);
@@ -188,13 +220,7 @@ export const interopReadResultsTool: ToolDefinition<{
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Error reading tasks: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
+      return formatToolError('reading tasks', error);
     }
   }
 };
@@ -221,10 +247,8 @@ export const interopSendMessageTool: ToolDefinition<{
     const { target, content, metadata, workingDirectory } = args;
 
     try {
-      const cwd = workingDirectory || process.cwd();
-
-      // Determine source (opposite of target)
-      const source = target === 'omc' ? 'omx' : 'omc';
+      const cwd = resolveWorkingDirectory(workingDirectory);
+      const source = getInteropSource(target);
 
       const message = addSharedMessage(cwd, {
         source,
@@ -239,18 +263,13 @@ export const interopSendMessageTool: ToolDefinition<{
           text: `## Message Sent to ${target.toUpperCase()}\n\n` +
             `**Message ID:** ${message.id}\n` +
             `**Content:** ${message.content}\n` +
+            (message.contentArtifact ? `**Content artifact:** ${message.contentArtifact.path}\n` : '') +
             `**Timestamp:** ${message.timestamp}\n\n` +
             `The message has been queued for ${target.toUpperCase()}.`
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Error sending message: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
+      return formatToolError('sending message', error);
     }
   }
 };
@@ -279,7 +298,7 @@ export const interopReadMessagesTool: ToolDefinition<{
     const { source, unreadOnly = false, limit = 10, markAsRead = false, workingDirectory } = args;
 
     try {
-      const cwd = workingDirectory || process.cwd();
+      const cwd = resolveWorkingDirectory(workingDirectory);
 
       const messages = readSharedMessages(cwd, {
         source: source as 'omc' | 'omx' | undefined,
@@ -316,6 +335,7 @@ export const interopReadMessagesTool: ToolDefinition<{
         lines.push(`- **Content:** ${message.content}`);
         lines.push(`- **Timestamp:** ${message.timestamp}`);
         lines.push(`- **Read:** ${message.read ? 'Yes' : 'No'}`);
+        lines.push(...formatArtifactDescriptorLines('Content', message.contentArtifact));
 
         if (message.metadata) {
           lines.push(`- **Metadata:** ${JSON.stringify(message.metadata)}`);
@@ -335,13 +355,7 @@ export const interopReadMessagesTool: ToolDefinition<{
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Error reading messages: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
+      return formatToolError('reading messages', error);
     }
   }
 };
@@ -360,7 +374,7 @@ export const interopListOmxTeamsTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const cwd = args.workingDirectory || process.cwd();
+      const cwd = resolveWorkingDirectory(args.workingDirectory);
       const teamNames = await listOmxTeams(cwd);
 
       if (teamNames.length === 0) {
@@ -395,13 +409,7 @@ export const interopListOmxTeamsTool: ToolDefinition<{
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Error listing OMX teams: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
+      return formatToolError('listing OMX teams', error);
     }
   }
 };
@@ -440,7 +448,7 @@ export const interopSendOmxMessageTool: ToolDefinition<{
         };
       }
 
-      const cwd = args.workingDirectory || process.cwd();
+      const cwd = resolveWorkingDirectory(args.workingDirectory);
 
       if (args.broadcast) {
         const messages = await broadcastOmxMessage(args.teamName, args.fromWorker, args.body, cwd);
@@ -470,13 +478,7 @@ export const interopSendOmxMessageTool: ToolDefinition<{
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Error sending OMX message: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
+      return formatToolError('sending OMX message', error);
     }
   }
 };
@@ -501,7 +503,7 @@ export const interopReadOmxMessagesTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const cwd = args.workingDirectory || process.cwd();
+      const cwd = resolveWorkingDirectory(args.workingDirectory);
       const limit = args.limit ?? 20;
       const messages = await listOmxMailboxMessages(args.teamName, args.workerName, cwd);
 
@@ -524,7 +526,7 @@ export const interopReadOmxMessagesTool: ToolDefinition<{
         lines.push(`### ${deliveredIcon} ${msg.message_id}`);
         lines.push(`- **From:** ${msg.from_worker}`);
         lines.push(`- **To:** ${msg.to_worker}`);
-        lines.push(`- **Body:** ${msg.body.slice(0, 300)}${msg.body.length > 300 ? '...' : ''}`);
+        lines.push(`- **Body:** ${truncatePreview(msg.body, 300)}`);
         lines.push(`- **Created:** ${msg.created_at}`);
         if (msg.delivered_at) lines.push(`- **Delivered:** ${msg.delivered_at}`);
         lines.push('');
@@ -537,13 +539,7 @@ export const interopReadOmxMessagesTool: ToolDefinition<{
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Error reading OMX messages: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
+      return formatToolError('reading OMX messages', error);
     }
   }
 };
@@ -568,7 +564,7 @@ export const interopReadOmxTasksTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const cwd = args.workingDirectory || process.cwd();
+      const cwd = resolveWorkingDirectory(args.workingDirectory);
       const limit = args.limit ?? 20;
       let tasks = await listOmxTasks(args.teamName, cwd);
 
@@ -599,9 +595,9 @@ export const interopReadOmxTasksTool: ToolDefinition<{
         lines.push(`### ${statusIcon} Task ${task.id}: ${task.subject}`);
         lines.push(`- **Status:** ${task.status}`);
         if (task.owner) lines.push(`- **Owner:** ${task.owner}`);
-        lines.push(`- **Description:** ${task.description.slice(0, 200)}${task.description.length > 200 ? '...' : ''}`);
+        lines.push(`- **Description:** ${truncatePreview(task.description, 200)}`);
         lines.push(`- **Created:** ${task.created_at}`);
-        if (task.result) lines.push(`- **Result:** ${task.result.slice(0, 200)}${task.result.length > 200 ? '...' : ''}`);
+        if (task.result) lines.push(`- **Result:** ${truncatePreview(task.result, 200)}`);
         if (task.error) lines.push(`- **Error:** ${task.error}`);
         if (task.completed_at) lines.push(`- **Completed:** ${task.completed_at}`);
         lines.push('');
@@ -614,13 +610,7 @@ export const interopReadOmxTasksTool: ToolDefinition<{
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Error reading OMX tasks: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
+      return formatToolError('reading OMX tasks', error);
     }
   }
 };

--- a/src/interop/shared-state.ts
+++ b/src/interop/shared-state.ts
@@ -12,6 +12,12 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from 'fs
 import { z } from 'zod';
 import { atomicWriteJsonSync } from '../lib/atomic-write.js';
 import { withFileLockSync } from '../lib/file-lock.js';
+import {
+  createArtifactHandoff,
+  writeTextArtifact,
+  type ArtifactDescriptor,
+  type ArtifactRetention,
+} from '../shared/artifact-descriptor.js';
 
 export interface InteropConfig {
   sessionId: string;
@@ -27,11 +33,13 @@ export interface SharedTask {
   target: 'omc' | 'omx';
   type: 'analyze' | 'implement' | 'review' | 'test' | 'custom';
   description: string;
+  descriptionArtifact?: ArtifactDescriptor;
   context?: Record<string, unknown>;
   files?: string[];
   createdAt: string;
   status: 'pending' | 'in_progress' | 'completed' | 'failed';
   result?: string;
+  resultArtifact?: ArtifactDescriptor;
   error?: string;
   completedAt?: string;
 }
@@ -41,12 +49,38 @@ export interface SharedMessage {
   source: 'omc' | 'omx';
   target: 'omc' | 'omx';
   content: string;
+  contentArtifact?: ArtifactDescriptor;
   metadata?: Record<string, unknown>;
   timestamp: string;
   read: boolean;
 }
 
+const INTEROP_ARTIFACT_THRESHOLD_BYTES = 2048;
+type SharedStateArtifactCategory = 'task-description' | 'task-result' | 'message-content';
+
+type SharedStateTextHandoff = {
+  text: string;
+  artifact?: ArtifactDescriptor;
+};
+
 // Zod schemas for runtime validation
+const ArtifactProducerSchema = z.object({
+  system: z.enum(['omc', 'omx']),
+  component: z.string(),
+  worker: z.string().optional(),
+});
+
+const ArtifactDescriptorSchema = z.object({
+  kind: z.string(),
+  path: z.string(),
+  contentHash: z.string().optional(),
+  createdAt: z.string(),
+  producer: ArtifactProducerSchema,
+  sizeBytes: z.number().optional(),
+  retention: z.enum(['ephemeral', 'session', 'until-completion', 'persistent']),
+  expiresAt: z.string().optional(),
+});
+
 const InteropConfigSchema = z.object({
   sessionId: z.string(),
   createdAt: z.string(),
@@ -61,11 +95,13 @@ const SharedTaskSchema = z.object({
   target: z.enum(['omc', 'omx']),
   type: z.enum(['analyze', 'implement', 'review', 'test', 'custom']),
   description: z.string(),
+  descriptionArtifact: ArtifactDescriptorSchema.optional(),
   context: z.record(z.unknown()).optional(),
   files: z.array(z.string()).optional(),
   createdAt: z.string(),
   status: z.enum(['pending', 'in_progress', 'completed', 'failed']),
   result: z.string().optional(),
+  resultArtifact: ArtifactDescriptorSchema.optional(),
   error: z.string().optional(),
   completedAt: z.string().optional(),
 });
@@ -75,10 +111,65 @@ const SharedMessageSchema = z.object({
   source: z.enum(['omc', 'omx']),
   target: z.enum(['omc', 'omx']),
   content: z.string(),
+  contentArtifact: ArtifactDescriptorSchema.optional(),
   metadata: z.record(z.unknown()).optional(),
   timestamp: z.string(),
   read: z.boolean(),
 });
+
+function getInteropArtifactsDir(cwd: string, category: string): string {
+  return join(getInteropDir(cwd), 'artifacts', category);
+}
+
+function createSharedStateTextHandoff(params: {
+  cwd: string;
+  category: SharedStateArtifactCategory;
+  entityId: string;
+  body: string;
+  source: 'omc' | 'omx';
+  retention: ArtifactRetention;
+}): ReturnType<typeof createArtifactHandoff> {
+  return createArtifactHandoff({
+    body: params.body,
+    thresholdBytes: INTEROP_ARTIFACT_THRESHOLD_BYTES,
+    descriptorFactory: () => writeTextArtifact({
+      path: join(getInteropArtifactsDir(params.cwd, params.category), `${params.entityId}.md`),
+      content: params.body,
+      kind: params.category,
+      producer: {
+        system: params.source,
+        component: 'interop-shared-state',
+      },
+      retention: params.retention,
+    }),
+  });
+}
+
+function resolveSharedStateTextHandoff(params: {
+  cwd: string;
+  category: SharedStateArtifactCategory;
+  entityId: string;
+  body: string;
+  source: 'omc' | 'omx';
+  retention: ArtifactRetention;
+}): SharedStateTextHandoff {
+  const handoff = createSharedStateTextHandoff(params);
+
+  return handoff.mode === 'inline'
+    ? { text: handoff.body }
+    : { text: handoff.summary, artifact: handoff.descriptor };
+}
+
+function unlinkArtifact(descriptor?: ArtifactDescriptor): void {
+  if (!descriptor?.path) return;
+  try {
+    if (existsSync(descriptor.path)) {
+      unlinkSync(descriptor.path);
+    }
+  } catch {
+    // best-effort cleanup only
+  }
+}
 
 /**
  * Get the interop directory path for a worktree
@@ -97,11 +188,7 @@ export function initInteropSession(
   omxCwd?: string
 ): InteropConfig {
   const interopDir = getInteropDir(omcCwd);
-
-  // Ensure directory exists
-  if (!existsSync(interopDir)) {
-    mkdirSync(interopDir, { recursive: true });
-  }
+  mkdirSync(interopDir, { recursive: true });
 
   const config: InteropConfig = {
     sessionId,
@@ -152,13 +239,21 @@ export function addSharedTask(
     status: 'pending',
   };
 
-  const taskPath = join(interopDir, 'tasks', `${fullTask.id}.json`);
+  const descriptionHandoff = resolveSharedStateTextHandoff({
+    cwd,
+    category: 'task-description',
+    entityId: fullTask.id,
+    body: task.description,
+    source: task.source,
+    retention: 'until-completion',
+  });
 
-  // Ensure tasks directory exists
+  fullTask.description = descriptionHandoff.text;
+  fullTask.descriptionArtifact = descriptionHandoff.artifact;
+
+  const taskPath = join(interopDir, 'tasks', `${fullTask.id}.json`);
   const tasksDir = join(interopDir, 'tasks');
-  if (!existsSync(tasksDir)) {
-    mkdirSync(tasksDir, { recursive: true });
-  }
+  mkdirSync(tasksDir, { recursive: true });
 
   atomicWriteJsonSync(taskPath, fullTask);
 
@@ -232,6 +327,34 @@ export function updateSharedTask(
         ...updates,
       };
 
+      if (typeof updates.description === 'string') {
+        const descriptionHandoff = resolveSharedStateTextHandoff({
+          cwd,
+          category: 'task-description',
+          entityId: task.id,
+          body: updates.description,
+          source: task.source,
+          retention: 'until-completion',
+        });
+
+        updatedTask.description = descriptionHandoff.text;
+        updatedTask.descriptionArtifact = descriptionHandoff.artifact;
+      }
+
+      if (typeof updates.result === 'string') {
+        const resultHandoff = resolveSharedStateTextHandoff({
+          cwd,
+          category: 'task-result',
+          entityId: task.id,
+          body: updates.result,
+          source: task.source,
+          retention: 'until-completion',
+        });
+
+        updatedTask.result = resultHandoff.text;
+        updatedTask.resultArtifact = resultHandoff.artifact;
+      }
+
       // Set completedAt if status changed to completed/failed
       if (
         (updates.status === 'completed' || updates.status === 'failed') &&
@@ -265,13 +388,21 @@ export function addSharedMessage(
     read: false,
   };
 
-  const messagePath = join(interopDir, 'messages', `${fullMessage.id}.json`);
+  const contentHandoff = resolveSharedStateTextHandoff({
+    cwd,
+    category: 'message-content',
+    entityId: fullMessage.id,
+    body: message.content,
+    source: message.source,
+    retention: 'session',
+  });
 
-  // Ensure messages directory exists
+  fullMessage.content = contentHandoff.text;
+  fullMessage.contentArtifact = contentHandoff.artifact;
+
+  const messagePath = join(interopDir, 'messages', `${fullMessage.id}.json`);
   const messagesDir = join(interopDir, 'messages');
-  if (!existsSync(messagesDir)) {
-    mkdirSync(messagesDir, { recursive: true });
-  }
+  mkdirSync(messagesDir, { recursive: true });
 
   atomicWriteJsonSync(messagePath, fullMessage);
 
@@ -370,19 +501,15 @@ export function cleanupInterop(cwd: string, options?: {
       for (const file of files) {
         try {
           const filePath = join(tasksDir, file);
+          const content = readFileSync(filePath, 'utf-8');
+          const taskParsed = SharedTaskSchema.safeParse(JSON.parse(content));
+          if (!taskParsed.success) continue;
+          const task = taskParsed.data;
+          const taskTime = new Date(task.createdAt).getTime();
 
-          if (options?.olderThan) {
-            const content = readFileSync(filePath, 'utf-8');
-            const taskParsed = SharedTaskSchema.safeParse(JSON.parse(content));
-            if (!taskParsed.success) continue;
-            const task = taskParsed.data;
-            const taskTime = new Date(task.createdAt).getTime();
-
-            if (taskTime < cutoffTime) {
-              unlinkSync(filePath);
-              tasksDeleted++;
-            }
-          } else {
+          if (!options?.olderThan || taskTime < cutoffTime) {
+            unlinkArtifact(task.descriptionArtifact);
+            unlinkArtifact(task.resultArtifact);
             unlinkSync(filePath);
             tasksDeleted++;
           }
@@ -402,19 +529,14 @@ export function cleanupInterop(cwd: string, options?: {
       for (const file of files) {
         try {
           const filePath = join(messagesDir, file);
+          const content = readFileSync(filePath, 'utf-8');
+          const msgParsed = SharedMessageSchema.safeParse(JSON.parse(content));
+          if (!msgParsed.success) continue;
+          const message = msgParsed.data;
+          const messageTime = new Date(message.timestamp).getTime();
 
-          if (options?.olderThan) {
-            const content = readFileSync(filePath, 'utf-8');
-            const msgParsed = SharedMessageSchema.safeParse(JSON.parse(content));
-            if (!msgParsed.success) continue;
-            const message = msgParsed.data;
-            const messageTime = new Date(message.timestamp).getTime();
-
-            if (messageTime < cutoffTime) {
-              unlinkSync(filePath);
-              messagesDeleted++;
-            }
-          } else {
+          if (!options?.olderThan || messageTime < cutoffTime) {
+            unlinkArtifact(message.contentArtifact);
             unlinkSync(filePath);
             messagesDeleted++;
           }

--- a/src/mcp/__tests__/prompt-persistence-artifacts.test.ts
+++ b/src/mcp/__tests__/prompt-persistence-artifacts.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  getStatusFilePath,
+  persistPrompt,
+  persistResponse,
+  writeJobStatus,
+} from '../prompt-persistence.js';
+
+describe('prompt persistence artifact descriptors', () => {
+  it('returns a descriptor for persisted prompts and embeds descriptors in job status', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'prompt-persistence-artifacts-'));
+
+    try {
+      const prompt = persistPrompt({
+        provider: 'codex',
+        agentRole: 'executor',
+        model: 'gpt-5.4',
+        prompt: 'ship it',
+        fullPrompt: 'full prompt body',
+        workingDirectory: tempDir,
+      });
+
+      expect(prompt).toBeDefined();
+      expect(prompt?.artifact.kind).toBe('prompt');
+      expect(prompt?.artifact.path).toBe(prompt?.filePath);
+      expect(prompt?.artifact.contentHash).toMatch(/^[a-f0-9]{64}$/);
+
+      const responsePath = persistResponse({
+        provider: 'codex',
+        agentRole: 'executor',
+        model: 'gpt-5.4',
+        promptId: prompt!.id,
+        slug: prompt!.slug,
+        response: 'done',
+        workingDirectory: tempDir,
+      });
+
+      writeJobStatus({
+        provider: 'codex',
+        jobId: prompt!.id,
+        slug: prompt!.slug,
+        status: 'completed',
+        promptFile: prompt!.filePath,
+        responseFile: responsePath!,
+        model: 'gpt-5.4',
+        agentRole: 'executor',
+        spawnedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      }, tempDir);
+
+      const statusPath = getStatusFilePath('codex', prompt!.slug, prompt!.id, tempDir);
+      const status = JSON.parse(readFileSync(statusPath, 'utf-8')) as {
+        promptArtifact?: { kind?: string; path?: string };
+        responseArtifact?: { kind?: string; path?: string };
+      };
+
+      expect(status.promptArtifact?.kind).toBe('prompt');
+      expect(status.promptArtifact?.path).toBe(prompt!.filePath);
+      expect(status.responseArtifact?.kind).toBe('response');
+      expect(status.responseArtifact?.path).toBe(responsePath);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/mcp/prompt-persistence.ts
+++ b/src/mcp/prompt-persistence.ts
@@ -9,6 +9,10 @@ import { mkdirSync, writeFileSync, readFileSync, existsSync, renameSync, readdir
 import { join } from 'path';
 import { randomBytes } from 'crypto';
 import { getWorktreeRoot } from '../lib/worktree-paths.js';
+import {
+  createArtifactDescriptorFromPath,
+  type ArtifactDescriptor,
+} from '../shared/artifact-descriptor.js';
 import { initJobDb, isJobDbInitialized, upsertJob, getJob, getActiveJobs as getActiveJobsFromDb, cleanupOldJobs as cleanupOldJobsInDb } from '../lib/job-state-db.js';
 
 // Lazy-init guard: fires initJobDb at most once per process.
@@ -21,6 +25,8 @@ let _dbInitAttempted = false;
 // Allows job management handlers to find JSON status files for cross-directory jobs.
 // Keyed by provider:jobId to avoid collisions (8-hex IDs are short).
 const jobWorkingDirs = new Map<string, string>();
+const PROMPT_PERSISTENCE_PRODUCER = { system: 'omc', component: 'prompt-persistence' } as const;
+type PromptPersistenceArtifactKind = 'prompt' | 'response';
 
 function ensureJobDb(workingDirectory?: string): void {
   if (_dbInitAttempted || isJobDbInitialized()) return;
@@ -121,6 +127,7 @@ export interface PersistPromptResult {
   filePath: string;
   id: string;
   slug: string;
+  artifact: ArtifactDescriptor;
 }
 
 /**
@@ -134,6 +141,8 @@ export interface JobStatus {
   pid?: number;
   promptFile: string;
   responseFile: string;
+  promptArtifact?: ArtifactDescriptor;
+  responseArtifact?: ArtifactDescriptor;
   model: string;
   agentRole: string;
   spawnedAt: string;
@@ -233,7 +242,12 @@ export function persistPrompt(options: PersistPromptOptions): PersistPromptResul
 
     writeFileSync(filePath, content, { encoding: 'utf-8', mode: 0o600 });
 
-    return { filePath, id, slug };
+    return {
+      filePath,
+      id,
+      slug,
+      artifact: describePromptArtifact(filePath),
+    };
   } catch (err) {
     console.warn(`[prompt-persistence] Failed to persist prompt: ${(err as Error).message}`);
     return undefined;
@@ -262,13 +276,33 @@ export function getExpectedResponsePath(provider: 'codex' | 'gemini', slug: stri
  * @param options - The response details to persist
  * @returns The file path, or undefined on failure
  */
+function describePersistedArtifact(path: string, kind: PromptPersistenceArtifactKind): ArtifactDescriptor {
+  return createArtifactDescriptorFromPath(path, {
+    kind,
+    producer: PROMPT_PERSISTENCE_PRODUCER,
+    retention: 'persistent',
+  });
+}
+
+export function describePromptArtifact(path: string): ArtifactDescriptor {
+  return describePersistedArtifact(path, 'prompt');
+}
+
+export function describeResponseArtifact(path: string): ArtifactDescriptor {
+  return describePersistedArtifact(path, 'response');
+}
+
 export function persistResponse(options: PersistResponseOptions): string | undefined {
   try {
     const promptsDir = getPromptsDir(options.workingDirectory);
     mkdirSync(promptsDir, { recursive: true });
 
-    const filename = `${options.provider}-response-${options.slug}-${options.promptId}.md`;
-    const filePath = join(promptsDir, filename);
+    const filePath = getExpectedResponsePath(
+      options.provider,
+      options.slug,
+      options.promptId,
+      options.workingDirectory,
+    );
 
     const frontmatter = buildResponseFrontmatter(options);
     const content = `${frontmatter}\n\n${options.response}`;
@@ -310,15 +344,25 @@ export function writeJobStatus(status: JobStatus, workingDirectory?: string): vo
     const promptsDir = getPromptsDir(workingDirectory);
     mkdirSync(promptsDir, { recursive: true });
 
+    const persistedStatus: JobStatus = {
+      ...status,
+      promptArtifact: existsSync(status.promptFile)
+        ? describePromptArtifact(status.promptFile)
+        : status.promptArtifact,
+      responseArtifact: existsSync(status.responseFile)
+        ? describeResponseArtifact(status.responseFile)
+        : status.responseArtifact,
+    };
+
     const statusPath = getStatusFilePath(status.provider, status.slug, status.jobId, workingDirectory);
     const tempPath = statusPath + '.tmp';
 
-    writeFileSync(tempPath, JSON.stringify(status, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    writeFileSync(tempPath, JSON.stringify(persistedStatus, null, 2), { encoding: 'utf-8', mode: 0o600 });
     renameOverwritingSync(tempPath, statusPath);
 
     // SQLite write-through: also persist to jobs.db if available
     if (isJobDbInitialized()) {
-      upsertJob(status);
+      upsertJob(persistedStatus);
     }
   } catch (err) {
     console.warn(`[prompt-persistence] Failed to write job status: ${(err as Error).message}`);

--- a/src/shared/artifact-descriptor.ts
+++ b/src/shared/artifact-descriptor.ts
@@ -1,0 +1,122 @@
+import { createHash } from 'crypto';
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+
+export const DEFAULT_INLINE_ARTIFACT_THRESHOLD_BYTES = 2048;
+const DEFAULT_HANDOFF_SUMMARY_MAX_CHARS = 160;
+
+export type ArtifactRetention = 'ephemeral' | 'session' | 'until-completion' | 'persistent';
+
+export interface ArtifactProducer {
+  system: 'omc' | 'omx';
+  component: string;
+  worker?: string;
+}
+
+export interface ArtifactDescriptor {
+  kind: string;
+  path: string;
+  contentHash?: string;
+  createdAt: string;
+  producer: ArtifactProducer;
+  sizeBytes?: number;
+  retention: ArtifactRetention;
+  expiresAt?: string;
+}
+
+export interface InlineArtifactHandoff {
+  mode: 'inline';
+  body: string;
+  summary: string;
+  sizeBytes: number;
+  thresholdBytes: number;
+}
+
+export interface DescriptorArtifactHandoff {
+  mode: 'descriptor';
+  summary: string;
+  descriptor: ArtifactDescriptor;
+  sizeBytes: number;
+  thresholdBytes: number;
+}
+
+export type ArtifactHandoff = InlineArtifactHandoff | DescriptorArtifactHandoff;
+
+export interface CreateArtifactDescriptorOptions {
+  kind: string;
+  producer: ArtifactProducer;
+  retention: ArtifactRetention;
+  createdAt?: string;
+  expiresAt?: string;
+}
+
+export interface WriteTextArtifactOptions extends CreateArtifactDescriptorOptions {
+  path: string;
+  content: string;
+}
+
+export interface CreateArtifactHandoffOptions {
+  body: string;
+  summary?: string;
+  thresholdBytes?: number;
+  descriptorFactory: () => ArtifactDescriptor;
+}
+
+export function summarizeArtifactBody(body: string, maxChars: number = DEFAULT_HANDOFF_SUMMARY_MAX_CHARS): string {
+  const normalized = body.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+export function createArtifactDescriptorFromPath(
+  path: string,
+  options: CreateArtifactDescriptorOptions,
+): ArtifactDescriptor {
+  const content = readFileSync(path);
+  const stats = statSync(path);
+
+  return {
+    kind: options.kind,
+    path,
+    contentHash: createHash('sha256').update(content).digest('hex'),
+    createdAt: options.createdAt ?? new Date(stats.mtimeMs).toISOString(),
+    producer: options.producer,
+    sizeBytes: stats.size,
+    retention: options.retention,
+    expiresAt: options.expiresAt,
+  };
+}
+
+export function writeTextArtifact(options: WriteTextArtifactOptions): ArtifactDescriptor {
+  mkdirSync(dirname(options.path), { recursive: true });
+  writeFileSync(options.path, options.content, { encoding: 'utf-8', mode: 0o600 });
+
+  return createArtifactDescriptorFromPath(options.path, options);
+}
+
+export function createArtifactHandoff(options: CreateArtifactHandoffOptions): ArtifactHandoff {
+  const thresholdBytes = options.thresholdBytes ?? DEFAULT_INLINE_ARTIFACT_THRESHOLD_BYTES;
+  const sizeBytes = Buffer.byteLength(options.body, 'utf-8');
+  const summary = options.summary ?? summarizeArtifactBody(options.body);
+
+  if (sizeBytes <= thresholdBytes) {
+    return {
+      mode: 'inline',
+      body: options.body,
+      summary,
+      sizeBytes,
+      thresholdBytes,
+    };
+  }
+
+  return {
+    mode: 'descriptor',
+    summary,
+    descriptor: options.descriptorFactory(),
+    sizeBytes,
+    thresholdBytes,
+  };
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,5 +1,2 @@
-/**
- * Shared Types Export
- */
-
 export * from './types.js';
+export * from './artifact-descriptor.js';


### PR DESCRIPTION
## Summary
- add a canonical artifact descriptor model under `src/shared/`
- wire artifact-backed handoff behavior into interop state and prompt persistence
- surface descriptor metadata in the interop MCP bridge
- document control-plane vs data-plane expectations and bounded handoff rules
- add targeted regression coverage for artifact descriptors and their low-risk integration paths

## Why this PR exists
The previous branch history was dominated by autogenerated team checkpoint and merge commits. This PR rewrites that work into a single reviewable change set so the real feature surface is easy to inspect.

## Key files
- `src/shared/artifact-descriptor.ts`
- `src/interop/shared-state.ts`
- `src/interop/mcp-bridge.ts`
- `src/mcp/prompt-persistence.ts`
- `docs/ARCHITECTURE.md`
- `docs/REFERENCE.md`
- targeted tests under `src/__tests__/`, `src/interop/__tests__/`, and `src/mcp/__tests__/`

## Verification
- `npm ci`
- `npm exec -- tsc --noEmit`
- `npm exec -- eslint src/shared/artifact-descriptor.ts src/shared/index.ts src/index.ts src/interop/shared-state.ts src/interop/mcp-bridge.ts src/mcp/prompt-persistence.ts src/__tests__/artifact-descriptor-handoff.test.ts src/__tests__/artifact-descriptor-integration.test.ts src/__tests__/artifact-descriptor.test.ts src/interop/__tests__/mcp-bridge.test.ts src/interop/__tests__/shared-state-artifacts.test.ts src/mcp/__tests__/prompt-persistence-artifacts.test.ts`
- `npm exec -- vitest run src/__tests__/artifact-descriptor-handoff.test.ts src/__tests__/artifact-descriptor-integration.test.ts src/__tests__/artifact-descriptor.test.ts src/interop/__tests__/mcp-bridge.test.ts src/interop/__tests__/shared-state-artifacts.test.ts src/mcp/__tests__/prompt-persistence-artifacts.test.ts`

## Notes
- generated `dist/` / `bridge/` churn was intentionally excluded from this cleanup branch to keep the review surface focused on the source/docs change set
- there is currently one high-severity npm audit issue reported by `npm ci`; it was not introduced by this PR and was not changed here
