### PR TITLE
fix(setup): resolve stale plugin root after /plugin update

### DIFF
--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -53,9 +53,18 @@ resolve_active_plugin_root() {
     # Compare JSON path version against the latest cached version
     local json_version
     json_version="$(basename "$json_root")"
-    local higher
-    higher=$(printf '%s\n%s\n' "$json_version" "$sorted_latest" | sort -t. -k1,1nr -k2,2nr -k3,3nr | head -1)
-    echo "${cache_base}/${higher}"
+    if printf '%s' "$json_version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+      local higher
+      higher=$(printf '%s\n%s' "$json_version" "$sorted_latest" | sort -t. -k1,1nr -k2,2nr -k3,3nr | head -1)
+      if [ "$higher" = "$json_version" ]; then
+        echo "$json_root"
+      else
+        echo "${cache_base}/${higher}"
+      fi
+      return 0
+    fi
+    # json_root is not a semver path; prefer the latest cached version
+    echo "${cache_base}/${sorted_latest}"
     return 0
   fi
 


### PR DESCRIPTION
> Recreated from #2251 — previous PR contained commits with incorrect author (company account). This PR has clean commit history with the correct personal account.

## Summary

Closes #2237

- `resolve_active_plugin_root()` now compares the `installed_plugins.json` path version against the latest cached version directory and uses whichever is newer
- Previously, a successful JSON lookup with a stale `installPath` would short-circuit the function, skipping the version-sort fallback entirely
- This fixes the persistent `[OMC VERSION DRIFT DETECTED]` warning after `/plugin update`

**Source-only diff: 1 file, +30/-9.**

```
scripts/setup-claude-md.sh   +30/-9   (resolve_active_plugin_root rewrite)
```

## Root Cause

`/plugin update` downloads the new version into the cache directory but does not update `installed_plugins.json`, which retains the old `installPath`. Since the old path still exists on disk, the JSON lookup "succeeds" and the fallback logic is never reached.

## Fix

Before (short-circuits on valid JSON path):
```bash
if [ -n "$active_path" ] && [ -d "$active_path" ]; then
  echo "$active_path"
  return 0
fi
```

After (compares JSON vs cached, picks higher):
```bash
json_root="$active_path"
# ... scan cache for sorted_latest ...
json_version="$(basename "$json_root")"
if printf '%s' "$json_version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
  higher=$(printf '%s\n%s' "$json_version" "$sorted_latest" | sort -t. -k1,1nr -k2,2nr -k3,3nr | head -1)
  if [ "$higher" = "$json_version" ]; then
    echo "$json_root"       # JSON path wins — emit original path
  else
    echo "${cache_base}/${higher}"  # cached version wins
  fi
fi
```

Key details:
- Semver guard on `json_version` prevents undefined sort behavior when `installPath` ends in a non-version directory (e.g., `dev`, `latest`)
- When JSON version wins, emits original `$json_root` path (not reconstructed via `cache_base`) to handle cases where `installPath` lives outside the cache tree

## Reproduction

1. Install OMC plugin (e.g. v4.9.3)
2. Run `/plugin update oh-my-claudecode` → updates to v4.10.2
3. `installed_plugins.json` still shows `installPath: .../4.9.3`
4. `omc update` installs stale v4.9.3 CLAUDE.md

## Test Plan

- [x] Stale JSON simulation (4.9.3 vs cached 4.10.2): returns 4.10.2
- [x] JSON already latest (4.10.2 vs cached 4.10.2): returns json_root path
- [x] Non-semver json_root (`dev`, `latest`): semver guard blocks, falls through to cached version
- [x] Existing test suite: `setup-claude-md-script.test.ts` — 12 tests all passing