### PR TITLE
feat(wiki): add TTL/GC, compaction, 2-tier storage, CJK tokenization

### DIFF
--- a/src/hooks/wiki/__tests__/query.test.ts
+++ b/src/hooks/wiki/__tests__/query.test.ts
@@ -8,8 +8,11 @@ import path from 'path';
 import os from 'os';
 import { queryWiki } from '../query.js';
 import { writePage, ensureWikiDir } from '../storage.js';
-import { WIKI_SCHEMA_VERSION } from '../types.js';
-import type { WikiPage } from '../types.js';
+import { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG } from '../types.js';
+import type { WikiPage, WikiConfig } from '../types.js';
+
+/** Config that disables global tier for isolated testing. */
+const LOCAL_ONLY_CONFIG: WikiConfig = { ...DEFAULT_WIKI_CONFIG, enableGlobalTier: false };
 
 function makePage(filename: string, opts: {
   title?: string;
@@ -48,7 +51,7 @@ describe('Wiki Query', () => {
   });
 
   it('should return empty for empty wiki', () => {
-    const results = queryWiki(tempDir, 'anything');
+    const results = queryWiki(tempDir, 'anything', {}, LOCAL_ONLY_CONFIG);
     expect(results).toEqual([]);
   });
 
@@ -56,7 +59,7 @@ describe('Wiki Query', () => {
     writePage(tempDir, makePage('auth.md', { title: 'Authentication Flow', tags: ['auth'] }));
     writePage(tempDir, makePage('db.md', { title: 'Database Schema', tags: ['db'] }));
 
-    const results = queryWiki(tempDir, 'authentication');
+    const results = queryWiki(tempDir, 'authentication', {}, LOCAL_ONLY_CONFIG);
     expect(results.length).toBeGreaterThanOrEqual(1);
     expect(results[0].page.filename).toBe('auth.md');
   });
@@ -67,7 +70,7 @@ describe('Wiki Query', () => {
       content: '\n# Something\n\nThis page describes JWT token validation.\n',
     }));
 
-    const results = queryWiki(tempDir, 'JWT');
+    const results = queryWiki(tempDir, 'JWT', {}, LOCAL_ONLY_CONFIG);
     expect(results.length).toBe(1);
     expect(results[0].snippet).toContain('JWT');
   });
@@ -76,7 +79,7 @@ describe('Wiki Query', () => {
     writePage(tempDir, makePage('tagged.md', { title: 'Tagged Page', tags: ['security', 'auth'] }));
     writePage(tempDir, makePage('untagged.md', { title: 'Untagged' }));
 
-    const results = queryWiki(tempDir, 'anything', { tags: ['security'] });
+    const results = queryWiki(tempDir, 'anything', { tags: ['security'] }, LOCAL_ONLY_CONFIG);
     expect(results.length).toBeGreaterThanOrEqual(1);
     expect(results[0].page.filename).toBe('tagged.md');
   });
@@ -85,7 +88,7 @@ describe('Wiki Query', () => {
     writePage(tempDir, makePage('arch.md', { title: 'Architecture', category: 'architecture' }));
     writePage(tempDir, makePage('debug.md', { title: 'Debug Info', category: 'debugging' }));
 
-    const results = queryWiki(tempDir, 'info', { category: 'debugging' });
+    const results = queryWiki(tempDir, 'info', { category: 'debugging' }, LOCAL_ONLY_CONFIG);
     // Should only return debugging category
     for (const r of results) {
       expect(r.page.frontmatter.category).toBe('debugging');
@@ -101,7 +104,7 @@ describe('Wiki Query', () => {
       }));
     }
 
-    const results = queryWiki(tempDir, 'common', { limit: 2 });
+    const results = queryWiki(tempDir, 'common', { limit: 2 }, LOCAL_ONLY_CONFIG);
     expect(results.length).toBe(2);
   });
 
@@ -116,7 +119,7 @@ describe('Wiki Query', () => {
       content: '\n# Auth\n\nFull auth documentation.\n',
     }));
 
-    const results = queryWiki(tempDir, 'auth');
+    const results = queryWiki(tempDir, 'auth', {}, LOCAL_ONLY_CONFIG);
     expect(results.length).toBe(2);
     expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
     expect(results[0].page.filename).toBe('high.md');
@@ -128,7 +131,7 @@ describe('Wiki Query', () => {
       content: '\n# Snippet\n\nSome text before the keyword. Important keyword here with context after.\n',
     }));
 
-    const results = queryWiki(tempDir, 'keyword');
+    const results = queryWiki(tempDir, 'keyword', {}, LOCAL_ONLY_CONFIG);
     expect(results.length).toBe(1);
     expect(results[0].snippet.length).toBeGreaterThan(0);
   });
@@ -140,7 +143,7 @@ describe('Wiki Query', () => {
       content: '\n# Nothing\n\nNo query terms in content.\n',
     }));
 
-    const results = queryWiki(tempDir, 'authentication');
+    const results = queryWiki(tempDir, 'authentication', {}, LOCAL_ONLY_CONFIG);
     expect(results.length).toBe(1);
     expect(results[0].score).toBeGreaterThan(0);
   });

--- a/src/hooks/wiki/__tests__/v2-improvements.test.ts
+++ b/src/hooks/wiki/__tests__/v2-improvements.test.ts
@@ -1,0 +1,585 @@
+/**
+ * Tests for Wiki v2 Improvements
+ *
+ * - TTL & auto-GC
+ * - Compaction
+ * - 2-tier storage (global + local)
+ * - CJK tokenization
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import {
+  parseFrontmatter,
+  serializePage,
+  writePage,
+  readPage,
+  readAllPages,
+  ensureWikiDir,
+  isPageExpired,
+  cleanupExpiredPages,
+  countAppendSections,
+  compactPage,
+  compactAllPages,
+  getGlobalWikiDir,
+  ensureGlobalWikiDir,
+  readAllGlobalPages,
+  writeGlobalPage,
+  deleteGlobalPage,
+} from '../storage.js';
+import { ingestKnowledge } from '../ingest.js';
+import { queryWiki, tokenize } from '../query.js';
+import {
+  WIKI_SCHEMA_VERSION,
+  CATEGORY_DEFAULT_TTL,
+  COMPACTION_THRESHOLD,
+  COMPACTION_KEEP_RECENT,
+  GLOBAL_SCOPE_CATEGORIES,
+} from '../types.js';
+import type { WikiPage } from '../types.js';
+
+function makePage(filename: string, overrides: Partial<WikiPage['frontmatter']> = {}, content?: string): WikiPage {
+  return {
+    filename,
+    frontmatter: {
+      title: filename.replace('.md', '').replace(/-/g, ' '),
+      tags: ['test'],
+      created: '2025-01-01T00:00:00.000Z',
+      updated: '2025-01-01T00:00:00.000Z',
+      sources: [],
+      links: [],
+      category: 'reference',
+      confidence: 'medium',
+      schemaVersion: WIKI_SCHEMA_VERSION,
+      ...overrides,
+    },
+    content: content || `\n# Test\n\nSome content.\n`,
+  };
+}
+
+// ============================================================================
+// TTL & GC Tests
+// ============================================================================
+
+describe('TTL & Garbage Collection', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-gc-test-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should serialize and parse ttl/expiresAt fields', () => {
+    const page = makePage('ttl-page.md', {
+      ttl: 3600,
+      expiresAt: '2025-06-01T00:00:00.000Z',
+    });
+
+    const serialized = serializePage(page);
+    expect(serialized).toContain('ttl: 3600');
+    expect(serialized).toContain('expiresAt: 2025-06-01T00:00:00.000Z');
+
+    const parsed = parseFrontmatter(serialized);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.frontmatter.ttl).toBe(3600);
+    expect(parsed!.frontmatter.expiresAt).toBe('2025-06-01T00:00:00.000Z');
+  });
+
+  it('should not serialize optional fields when absent', () => {
+    const page = makePage('no-ttl.md');
+    const serialized = serializePage(page);
+    expect(serialized).not.toContain('ttl:');
+    expect(serialized).not.toContain('expiresAt:');
+    expect(serialized).not.toContain('compactedAt:');
+    expect(serialized).not.toContain('scope:');
+  });
+
+  it('isPageExpired should return false when no expiresAt', () => {
+    const page = makePage('no-expiry.md');
+    expect(isPageExpired(page)).toBe(false);
+  });
+
+  it('isPageExpired should return false for future expiresAt', () => {
+    const future = new Date(Date.now() + 86400000).toISOString();
+    const page = makePage('future.md', { expiresAt: future });
+    expect(isPageExpired(page)).toBe(false);
+  });
+
+  it('isPageExpired should return true for past expiresAt', () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const page = makePage('expired.md', { expiresAt: past });
+    expect(isPageExpired(page)).toBe(true);
+  });
+
+  it('cleanupExpiredPages should remove expired pages', () => {
+    ensureWikiDir(tempDir);
+
+    // Write one expired and one non-expired page
+    const expired = makePage('expired.md', {
+      ttl: 1,
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    const valid = makePage('valid.md');
+
+    writePage(tempDir, expired);
+    writePage(tempDir, valid);
+
+    expect(readAllPages(tempDir)).toHaveLength(2);
+
+    const result = cleanupExpiredPages(tempDir);
+    expect(result.removed).toBe(1);
+    expect(result.filenames).toContain('expired.md');
+
+    const remaining = readAllPages(tempDir);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].filename).toBe('valid.md');
+  });
+
+  it('cleanupExpiredPages should return 0 when nothing expired', () => {
+    ensureWikiDir(tempDir);
+    writePage(tempDir, makePage('alive.md'));
+    const result = cleanupExpiredPages(tempDir);
+    expect(result.removed).toBe(0);
+  });
+
+  it('session-log category should have default TTL of 7 days', () => {
+    expect(CATEGORY_DEFAULT_TTL['session-log']).toBe(7 * 24 * 60 * 60);
+  });
+
+  it('ingest with session-log category should auto-apply TTL', () => {
+    const result = ingestKnowledge(tempDir, {
+      title: 'Session Log Test',
+      content: 'Test session log.',
+      tags: ['session-log'],
+      category: 'session-log',
+    });
+
+    const page = readPage(tempDir, result.created[0]);
+    expect(page).not.toBeNull();
+    expect(page!.frontmatter.ttl).toBe(7 * 24 * 60 * 60);
+    expect(page!.frontmatter.expiresAt).toBeDefined();
+
+    // expiresAt should be ~7 days from now
+    const expiresAt = new Date(page!.frontmatter.expiresAt!).getTime();
+    const sevenDaysFromNow = Date.now() + 7 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(expiresAt - sevenDaysFromNow)).toBeLessThan(5000); // 5s tolerance
+  });
+
+  it('architecture category should NOT have default TTL', () => {
+    expect(CATEGORY_DEFAULT_TTL['architecture']).toBeUndefined();
+
+    const result = ingestKnowledge(tempDir, {
+      title: 'Arch Test',
+      content: 'Architecture knowledge.',
+      tags: ['arch'],
+      category: 'architecture',
+    });
+
+    const page = readPage(tempDir, result.created[0]);
+    expect(page).not.toBeNull();
+    expect(page!.frontmatter.ttl).toBeUndefined();
+    expect(page!.frontmatter.expiresAt).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Compaction Tests
+// ============================================================================
+
+describe('Compaction', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-compact-test-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('countAppendSections should count update sections', () => {
+    const content = `
+# Original
+
+Content here.
+
+---
+
+## Update (2025-01-01T00:00:00.000Z)
+
+First update.
+
+---
+
+## Update (2025-01-02T00:00:00.000Z)
+
+Second update.
+`;
+    expect(countAppendSections(content)).toBe(2);
+  });
+
+  it('countAppendSections should return 0 for no updates', () => {
+    expect(countAppendSections('\n# Title\n\nJust content.\n')).toBe(0);
+  });
+
+  it('compactPage should return null when below threshold', () => {
+    const page = makePage('small.md', {}, '\n# Title\n\nContent.\n');
+    expect(compactPage(page)).toBeNull();
+  });
+
+  it('compactPage should compact when above threshold', () => {
+    // Build content with COMPACTION_THRESHOLD + 1 update sections
+    let content = '\n# Original Title\n\nOriginal content.\n';
+    for (let i = 0; i < COMPACTION_THRESHOLD + 1; i++) {
+      content += `\n---\n\n## Update (2025-01-${String(i + 1).padStart(2, '0')}T00:00:00.000Z)\n\nUpdate ${i + 1} content.\n`;
+    }
+
+    const page = makePage('big.md', {}, content);
+    const result = compactPage(page);
+
+    expect(result).not.toBeNull();
+    // Should keep only COMPACTION_KEEP_RECENT sections
+    expect(countAppendSections(result!.content)).toBe(COMPACTION_KEEP_RECENT);
+    // Should have compaction notice
+    expect(result!.content).toContain('**Compacted:**');
+    // Should have compactedAt in frontmatter
+    expect(result!.frontmatter.compactedAt).toBeDefined();
+    // Original content should be preserved
+    expect(result!.content).toContain('Original content.');
+  });
+
+  it('compactAllPages should compact eligible pages', () => {
+    ensureWikiDir(tempDir);
+
+    // Write a page that needs compaction
+    let bigContent = '\n# Big Page\n\nOriginal.\n';
+    for (let i = 0; i < COMPACTION_THRESHOLD + 2; i++) {
+      bigContent += `\n---\n\n## Update (2025-01-${String(i + 1).padStart(2, '0')}T00:00:00.000Z)\n\nUpdate ${i}.\n`;
+    }
+    writePage(tempDir, makePage('big-page.md', { title: 'Big Page' }, bigContent));
+
+    // Write a small page that doesn't need compaction
+    writePage(tempDir, makePage('small-page.md', { title: 'Small Page' }));
+
+    const result = compactAllPages(tempDir);
+    expect(result.compacted).toBe(1);
+    expect(result.filenames).toContain('big-page.md');
+
+    // Verify the compacted page
+    const page = readPage(tempDir, 'big-page.md');
+    expect(page).not.toBeNull();
+    expect(countAppendSections(page!.content)).toBe(COMPACTION_KEEP_RECENT);
+  });
+});
+
+// ============================================================================
+// CJK Tokenization Tests
+// ============================================================================
+
+describe('CJK Tokenization', () => {
+  it('should tokenize Latin text normally', () => {
+    const tokens = tokenize('Hello World');
+    expect(tokens).toContain('hello');
+    expect(tokens).toContain('world');
+  });
+
+  it('should generate bi-grams for Korean text', () => {
+    const tokens = tokenize('인증 아키텍처');
+    // Should contain individual chars and bi-grams
+    expect(tokens).toContain('인');
+    expect(tokens).toContain('증');
+    expect(tokens).toContain('인증');
+    expect(tokens).toContain('아키');
+    expect(tokens).toContain('키텍');
+    expect(tokens).toContain('텍처');
+  });
+
+  it('should generate bi-grams for Chinese text', () => {
+    const tokens = tokenize('数据库');
+    expect(tokens).toContain('数据');
+    expect(tokens).toContain('据库');
+    expect(tokens).toContain('数');
+    expect(tokens).toContain('据');
+    expect(tokens).toContain('库');
+  });
+
+  it('should generate bi-grams for Japanese text', () => {
+    const tokens = tokenize('テスト');
+    expect(tokens).toContain('テス');
+    expect(tokens).toContain('スト');
+  });
+
+  it('should handle mixed Latin and CJK text', () => {
+    const tokens = tokenize('Auth 인증 module');
+    expect(tokens).toContain('auth');
+    expect(tokens).toContain('module');
+    expect(tokens).toContain('인증');
+  });
+
+  it('should find CJK content in wiki query', () => {
+    // This is an integration test — we test through queryWiki
+    // but it requires setting up a wiki. We test the tokenizer independently.
+    const tokens = tokenize('데이터베이스 설계');
+    expect(tokens.length).toBeGreaterThan(2);
+    expect(tokens).toContain('데이');
+    expect(tokens).toContain('이터');
+  });
+});
+
+// ============================================================================
+// 2-Tier Storage Tests
+// ============================================================================
+
+describe('2-Tier Storage (Global + Local)', () => {
+  let tempDir: string;
+  let originalConfigDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-tier-test-'));
+    // Mock CLAUDE_CONFIG_DIR to use temp dir for global wiki
+    originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = path.join(tempDir, 'global-config');
+    fs.mkdirSync(process.env.CLAUDE_CONFIG_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (originalConfigDir !== undefined) {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    } else {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    }
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('getGlobalWikiDir should use claude config dir', () => {
+    const globalDir = getGlobalWikiDir();
+    expect(globalDir).toContain('global-config');
+    expect(globalDir).toContain('wiki');
+  });
+
+  it('should write and read from global wiki', () => {
+    const page = makePage('global-convention.md', {
+      title: 'Global Convention',
+      category: 'convention',
+      scope: 'global',
+    });
+
+    writeGlobalPage(page);
+
+    const globalPages = readAllGlobalPages();
+    expect(globalPages).toHaveLength(1);
+    expect(globalPages[0].frontmatter.title).toBe('Global Convention');
+  });
+
+  it('should delete from global wiki', () => {
+    const page = makePage('to-delete.md', { scope: 'global' });
+    writeGlobalPage(page);
+    expect(readAllGlobalPages()).toHaveLength(1);
+
+    const deleted = deleteGlobalPage('to-delete.md');
+    expect(deleted).toBe(true);
+    expect(readAllGlobalPages()).toHaveLength(0);
+  });
+
+  it('deleteGlobalPage should return false for non-existent', () => {
+    expect(deleteGlobalPage('nonexistent.md')).toBe(false);
+  });
+
+  it('convention category should default to global scope', () => {
+    expect(GLOBAL_SCOPE_CATEGORIES.has('convention')).toBe(true);
+    expect(GLOBAL_SCOPE_CATEGORIES.has('reference')).toBe(true);
+  });
+
+  it('architecture category should default to local scope', () => {
+    expect(GLOBAL_SCOPE_CATEGORIES.has('architecture')).toBe(false);
+    expect(GLOBAL_SCOPE_CATEGORIES.has('debugging')).toBe(false);
+  });
+
+  it('ingest with scope=global should write to global tier', () => {
+    const localRoot = path.join(tempDir, 'local-repo');
+    fs.mkdirSync(localRoot, { recursive: true });
+
+    ingestKnowledge(localRoot, {
+      title: 'Team Convention',
+      content: 'Always use conventional commits.',
+      tags: ['convention'],
+      category: 'convention',
+      scope: 'global',
+    });
+
+    // Should be in global, not local
+    const globalPages = readAllGlobalPages();
+    expect(globalPages).toHaveLength(1);
+    expect(globalPages[0].frontmatter.title).toBe('Team Convention');
+
+    const localPages = readAllPages(localRoot);
+    expect(localPages).toHaveLength(0);
+  });
+
+  it('ingest with scope=local should write to local tier', () => {
+    const localRoot = path.join(tempDir, 'local-repo');
+    fs.mkdirSync(localRoot, { recursive: true });
+
+    ingestKnowledge(localRoot, {
+      title: 'Local Architecture',
+      content: 'Repo-specific arch details.',
+      tags: ['arch'],
+      category: 'architecture',
+      scope: 'local',
+    });
+
+    const localPages = readAllPages(localRoot);
+    expect(localPages).toHaveLength(1);
+
+    const globalPages = readAllGlobalPages();
+    expect(globalPages).toHaveLength(0);
+  });
+
+  it('queryWiki should search both tiers', () => {
+    const localRoot = path.join(tempDir, 'local-repo');
+    fs.mkdirSync(localRoot, { recursive: true });
+    ensureWikiDir(localRoot);
+
+    // Write local page
+    writePage(localRoot, makePage('local-auth.md', {
+      title: 'Local Auth',
+      tags: ['auth'],
+      category: 'architecture',
+    }, '\n# Local Auth\n\nLocal authentication details.\n'));
+
+    // Write global page
+    writeGlobalPage(makePage('global-auth-convention.md', {
+      title: 'Auth Convention',
+      tags: ['auth', 'convention'],
+      category: 'convention',
+      scope: 'global',
+    }, '\n# Auth Convention\n\nGlobal auth conventions.\n'));
+
+    const results = queryWiki(localRoot, 'auth');
+    expect(results.length).toBe(2);
+
+    // Local should score higher due to 1.5x boost
+    const localResult = results.find(r => r.page.filename === 'local-auth.md');
+    const globalResult = results.find(r => r.page.filename === 'global-auth-convention.md');
+    expect(localResult).toBeDefined();
+    expect(globalResult).toBeDefined();
+    expect(localResult!.score).toBeGreaterThanOrEqual(globalResult!.score);
+  });
+
+  it('queryWiki should filter expired pages from results', () => {
+    const localRoot = path.join(tempDir, 'local-repo');
+    fs.mkdirSync(localRoot, { recursive: true });
+    ensureWikiDir(localRoot);
+
+    // Write an expired page
+    writePage(localRoot, makePage('expired-page.md', {
+      title: 'Expired Knowledge',
+      tags: ['test'],
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    }, '\n# Expired\n\nThis should not appear.\n'));
+
+    // Write a valid page
+    writePage(localRoot, makePage('valid-page.md', {
+      title: 'Valid Knowledge',
+      tags: ['test'],
+    }, '\n# Valid\n\nThis should appear.\n'));
+
+    const results = queryWiki(localRoot, 'test');
+    expect(results).toHaveLength(1);
+    expect(results[0].page.filename).toBe('valid-page.md');
+  });
+
+  it('queryWiki should disable global tier when configured', () => {
+    const localRoot = path.join(tempDir, 'local-repo');
+    fs.mkdirSync(localRoot, { recursive: true });
+    ensureWikiDir(localRoot);
+
+    writePage(localRoot, makePage('local.md', { title: 'Local', tags: ['test'] }));
+    writeGlobalPage(makePage('global.md', { title: 'Global', tags: ['test'] }));
+
+    const results = queryWiki(localRoot, 'test', {}, {
+      autoCapture: true,
+      staleDays: 30,
+      maxPageSize: 10240,
+      enableGlobalTier: false,
+      autoGC: true,
+      autoCompaction: true,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].page.filename).toBe('local.md');
+  });
+});
+
+// ============================================================================
+// Scope Auto-Detection Tests
+// ============================================================================
+
+describe('Scope Auto-Detection', () => {
+  let tempDir: string;
+  let originalConfigDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-scope-test-'));
+    originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = path.join(tempDir, 'global-config');
+    fs.mkdirSync(process.env.CLAUDE_CONFIG_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (originalConfigDir !== undefined) {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    } else {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    }
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('convention category without explicit scope should default to local (ingest layer)', () => {
+    // At the ingest layer, scope defaults to 'local' for backward compat.
+    // Auto-detection (convention → global) happens at the tools layer only.
+    ingestKnowledge(tempDir, {
+      title: 'Convention Without Scope',
+      content: 'Should stay local at ingest layer.',
+      tags: ['convention'],
+      category: 'convention',
+      // No explicit scope → defaults to 'local'
+    });
+
+    expect(readAllPages(tempDir)).toHaveLength(1);
+    expect(readAllGlobalPages()).toHaveLength(0);
+  });
+
+  it('architecture category without explicit scope should go to local', () => {
+    ingestKnowledge(tempDir, {
+      title: 'Auto Local Arch',
+      content: 'Should auto-route to local.',
+      tags: ['arch'],
+      category: 'architecture',
+      // No explicit scope
+    });
+
+    expect(readAllPages(tempDir)).toHaveLength(1);
+    expect(readAllGlobalPages()).toHaveLength(0);
+  });
+
+  it('explicit scope should override auto-detection', () => {
+    // Convention normally goes global, but explicit local overrides
+    ingestKnowledge(tempDir, {
+      title: 'Local Convention',
+      content: 'Forced to local.',
+      tags: ['convention'],
+      category: 'convention',
+      scope: 'local', // Override
+    });
+
+    expect(readAllPages(tempDir)).toHaveLength(1);
+    expect(readAllGlobalPages()).toHaveLength(0);
+  });
+});

--- a/src/hooks/wiki/index.ts
+++ b/src/hooks/wiki/index.ts
@@ -18,26 +18,46 @@ export type {
   WikiLintReport,
   WikiCategory,
   WikiConfig,
+  WikiScope,
 } from './types.js';
 
-export { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG } from './types.js';
+export {
+  WIKI_SCHEMA_VERSION,
+  DEFAULT_WIKI_CONFIG,
+  CATEGORY_DEFAULT_TTL,
+  COMPACTION_THRESHOLD,
+  COMPACTION_KEEP_RECENT,
+  GLOBAL_SCOPE_CATEGORIES,
+} from './types.js';
 
 // Storage
 export {
   getWikiDir,
+  getGlobalWikiDir,
   ensureWikiDir,
+  ensureGlobalWikiDir,
   withWikiLock,
   readPage,
   listPages,
   readAllPages,
+  readAllGlobalPages,
   readIndex,
   readLog,
   writePage,
   deletePage,
+  writeGlobalPage,
+  deleteGlobalPage,
   appendLog,
   titleToSlug,
   parseFrontmatter,
   serializePage,
+  // TTL & GC
+  isPageExpired,
+  cleanupExpiredPages,
+  // Compaction
+  countAppendSections,
+  compactPage,
+  compactAllPages,
   // Unsafe variants (for use inside withWikiLock)
   writePageUnsafe,
   deletePageUnsafe,
@@ -47,5 +67,5 @@ export {
 
 // Operations
 export { ingestKnowledge } from './ingest.js';
-export { queryWiki } from './query.js';
+export { queryWiki, tokenize } from './query.js';
 export { lintWiki } from './lint.js';

--- a/src/hooks/wiki/ingest.ts
+++ b/src/hooks/wiki/ingest.ts
@@ -11,6 +11,7 @@ import {
   type WikiPage,
   type WikiPageFrontmatter,
   WIKI_SCHEMA_VERSION,
+  CATEGORY_DEFAULT_TTL,
 } from './types.js';
 import {
   withWikiLock,
@@ -19,6 +20,7 @@ import {
   updateIndexUnsafe,
   appendLogUnsafe,
   titleToSlug,
+  writeGlobalPage,
 } from './storage.js';
 
 /**
@@ -37,32 +39,43 @@ export function ingestKnowledge(root: string, input: WikiIngestInput): WikiInges
   const now = new Date().toISOString();
   const result: WikiIngestResult = { created: [], updated: [], totalAffected: 0 };
 
-  withWikiLock(root, () => {
-    const existing = readPage(root, slug);
+  // Determine target scope: explicit only — auto-detection is opt-in via tools layer
+  const scope = input.scope ?? 'local';
 
-    if (existing) {
-      // Merge into existing page
-      const merged = mergePage(existing, input, now);
-      writePageUnsafe(root, merged);
-      result.updated.push(slug);
-    } else {
-      // Create new page
-      const page = createPage(slug, input, now);
-      writePageUnsafe(root, page);
-      result.created.push(slug);
-    }
+  if (scope === 'global') {
+    // Global tier: no wiki-wide lock needed (separate directory)
+    const page = createPage(slug, input, now);
+    writeGlobalPage(page);
+    result.created.push(slug);
+  } else {
+    // Local tier: use wiki lock
+    withWikiLock(root, () => {
+      const existing = readPage(root, slug);
 
-    updateIndexUnsafe(root);
+      if (existing) {
+        // Merge into existing page
+        const merged = mergePage(existing, input, now);
+        writePageUnsafe(root, merged);
+        result.updated.push(slug);
+      } else {
+        // Create new page
+        const page = createPage(slug, input, now);
+        writePageUnsafe(root, page);
+        result.created.push(slug);
+      }
 
-    appendLogUnsafe(root, {
-      timestamp: now,
-      operation: 'ingest',
-      pagesAffected: [...result.created, ...result.updated],
-      summary: existing
-        ? `Updated "${input.title}" with new content`
-        : `Created new page "${input.title}"`,
+      updateIndexUnsafe(root);
+
+      appendLogUnsafe(root, {
+        timestamp: now,
+        operation: 'ingest',
+        pagesAffected: [...result.created, ...result.updated],
+        summary: existing
+          ? `Updated "${input.title}" with new content`
+          : `Created new page "${input.title}"`,
+      });
     });
-  });
+  }
 
   result.totalAffected = result.created.length + result.updated.length;
   return result;
@@ -70,6 +83,13 @@ export function ingestKnowledge(root: string, input: WikiIngestInput): WikiInges
 
 /** Create a new wiki page from ingest input. */
 function createPage(slug: string, input: WikiIngestInput, now: string): WikiPage {
+  // Resolve TTL: explicit > category default > none
+  const ttl = input.ttl ?? CATEGORY_DEFAULT_TTL[input.category];
+  const expiresAt = ttl ? new Date(Date.now() + ttl * 1000).toISOString() : undefined;
+
+  // Resolve scope: explicit only — defaults to local for backward compat
+  const scope = input.scope ?? 'local';
+
   const frontmatter: WikiPageFrontmatter = {
     title: input.title,
     tags: [...new Set(input.tags)],
@@ -80,6 +100,9 @@ function createPage(slug: string, input: WikiIngestInput, now: string): WikiPage
     category: input.category,
     confidence: input.confidence || 'medium',
     schemaVersion: WIKI_SCHEMA_VERSION,
+    ...(ttl ? { ttl } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    scope,
   };
 
   return {

--- a/src/hooks/wiki/query.ts
+++ b/src/hooks/wiki/query.ts
@@ -11,11 +11,48 @@
 import {
   type WikiQueryOptions,
   type WikiQueryMatch,
+  type WikiConfig,
+  DEFAULT_WIKI_CONFIG,
 } from './types.js';
 import {
   readAllPages,
+  readAllGlobalPages,
   appendLog,
+  isPageExpired,
 } from './storage.js';
+
+/**
+ * Tokenize text for search, with CJK bi-gram support.
+ *
+ * Latin/numeric words: split on whitespace.
+ * CJK characters (Han, Hangul, Kana): extract bi-grams (2-char sliding window).
+ * Single CJK characters are also included to avoid missing single-char matches.
+ */
+export function tokenize(text: string): string[] {
+  const lower = text.toLowerCase();
+  const tokens: string[] = [];
+
+  // Latin/numeric tokens
+  const latinMatches = lower.match(/[a-z0-9]+/g);
+  if (latinMatches) tokens.push(...latinMatches);
+
+  // CJK segments (Han + Hangul + Katakana + Hiragana)
+  const cjkMatches = lower.match(/[\u3000-\u9FFF\uAC00-\uD7AF\u3040-\u30FF]+/g);
+  if (cjkMatches) {
+    for (const segment of cjkMatches) {
+      // Always include individual characters for single-char queries
+      for (let i = 0; i < segment.length; i++) {
+        tokens.push(segment[i]);
+      }
+      // Add bi-grams for better phrase matching
+      for (let i = 0; i < segment.length - 1; i++) {
+        tokens.push(segment.slice(i, i + 2));
+      }
+    }
+  }
+
+  return tokens;
+}
 
 /**
  * Search wiki pages by keyword and/or tags.
@@ -25,28 +62,49 @@ import {
  * 2. Title match: pages whose title contains the query text
  * 3. Content match: pages whose content contains the query text
  *
- * Results are scored and sorted by relevance (descending).
+ * Searches both local and global tiers. Local results get a score boost.
+ * Expired pages are filtered out.
  *
  * @param root - Project root directory
  * @param queryText - Search text (matched against title + content)
  * @param options - Optional filters (tags, category, limit)
+ * @param config - Wiki configuration (for global tier toggle)
  * @returns Matching pages with snippets, sorted by relevance
  */
 export function queryWiki(
   root: string,
   queryText: string,
   options: WikiQueryOptions = {},
+  config: WikiConfig = DEFAULT_WIKI_CONFIG,
 ): WikiQueryMatch[] {
   const { tags: filterTags, category, limit = 20 } = options;
-  const pages = readAllPages(root);
+
+  // Collect pages from both tiers
+  const localPages = readAllPages(root);
+  const globalPages = config.enableGlobalTier ? readAllGlobalPages() : [];
+
+  // Tag pages with their source tier for score boosting
+  const tieredPages: Array<{ page: typeof localPages[0]; boost: number }> = [
+    ...localPages.map(page => ({ page, boost: 1.5 })),   // Local pages get 1.5x boost
+    ...globalPages.map(page => ({ page, boost: 1.0 })),
+  ];
+
   const queryLower = queryText.toLowerCase();
-  const queryTerms = queryLower.split(/\s+/).filter(Boolean);
+  const queryTerms = tokenize(queryText);
 
   const matches: WikiQueryMatch[] = [];
+  const seenFilenames = new Set<string>();
 
-  for (const page of pages) {
+  for (const { page, boost } of tieredPages) {
+    // Skip expired pages
+    if (isPageExpired(page)) continue;
+
     // Category filter
     if (category && page.frontmatter.category !== category) continue;
+
+    // Deduplicate: if same filename exists in both tiers, prefer local (higher boost)
+    if (seenFilenames.has(page.filename)) continue;
+    seenFilenames.add(page.filename);
 
     let score = 0;
     let snippet = '';
@@ -99,7 +157,7 @@ export function queryWiki(
         if (snippet.length > 120) snippet = snippet.slice(0, 117) + '...';
       }
 
-      matches.push({ page, snippet, score });
+      matches.push({ page, snippet, score: Math.round(score * boost) });
     }
   }
 
@@ -112,7 +170,7 @@ export function queryWiki(
     timestamp: new Date().toISOString(),
     operation: 'query',
     pagesAffected: limited.map(m => m.page.filename),
-    summary: `Query "${queryText}" → ${limited.length} results (of ${matches.length} total)`,
+    summary: `Query "${queryText}" → ${limited.length} results (of ${matches.length} total, ${localPages.length} local + ${globalPages.length} global)`,
   });
 
   return limited;

--- a/src/hooks/wiki/session-hooks.ts
+++ b/src/hooks/wiki/session-hooks.ts
@@ -21,8 +21,10 @@ import {
   writePageUnsafe,
   updateIndexUnsafe,
   appendLogUnsafe,
+  cleanupExpiredPages,
+  compactAllPages,
 } from './storage.js';
-import { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG } from './types.js';
+import { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG, CATEGORY_DEFAULT_TTL } from './types.js';
 import type { WikiConfig } from './types.js';
 
 /**
@@ -65,6 +67,8 @@ export function onSessionStart(data: { cwd?: string }): { additionalContext?: st
       return {}; // No wiki yet, nothing to inject
     }
 
+    const config = loadWikiConfig(root);
+
     // Lazy index rebuild
     const pages = listPages(root);
     if (pages.length > 0) {
@@ -72,6 +76,24 @@ export function onSessionStart(data: { cwd?: string }): { additionalContext?: st
       if (!indexContent) {
         // Index missing — rebuild
         withWikiLock(root, () => { updateIndexUnsafe(root); });
+      }
+    }
+
+    // Auto-GC: remove expired pages (e.g., old session-logs with TTL)
+    if (config.autoGC && pages.length > 0) {
+      try {
+        cleanupExpiredPages(root);
+      } catch {
+        // GC failure should not block session start
+      }
+    }
+
+    // Auto-compaction: compact pages with too many append sections
+    if (config.autoCompaction && pages.length > 0) {
+      try {
+        compactAllPages(root);
+      } catch {
+        // Compaction failure should not block session start
       }
     }
 
@@ -126,6 +148,12 @@ export function onSessionEnd(data: { cwd?: string; session_id?: string }): { con
     const dateSlug = now.split('T')[0]; // YYYY-MM-DD
     const filename = `session-log-${dateSlug}-${sessionId.slice(-8)}.md`;
 
+    // Apply TTL for session-log category
+    const sessionLogTtl = CATEGORY_DEFAULT_TTL['session-log'];
+    const expiresAt = sessionLogTtl
+      ? new Date(Date.now() + sessionLogTtl * 1000).toISOString()
+      : undefined;
+
     withWikiLock(root, () => {
       // Time check inside lock
       if (Date.now() - startTime > TIMEOUT_MS) return;
@@ -142,6 +170,9 @@ export function onSessionEnd(data: { cwd?: string; session_id?: string }): { con
           category: 'session-log',
           confidence: 'medium',
           schemaVersion: WIKI_SCHEMA_VERSION,
+          ...(sessionLogTtl ? { ttl: sessionLogTtl } : {}),
+          ...(expiresAt ? { expiresAt } : {}),
+          scope: 'local',
         },
         content: `\n# Session Log ${dateSlug}\n\nAuto-captured session metadata.\nSession ID: ${sessionId}\n\nReview and promote significant findings to curated wiki pages via \`wiki_ingest\`.\n`,
       });

--- a/src/hooks/wiki/storage.ts
+++ b/src/hooks/wiki/storage.ts
@@ -22,8 +22,12 @@ import {
   type WikiPage,
   type WikiPageFrontmatter,
   type WikiLogEntry,
+  type WikiScope,
   WIKI_SCHEMA_VERSION,
+  COMPACTION_THRESHOLD,
+  COMPACTION_KEEP_RECENT,
 } from './types.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 // ============================================================================
 // Constants
@@ -38,9 +42,23 @@ const RESERVED_FILES = new Set([INDEX_FILE, LOG_FILE]);
 // Path helpers
 // ============================================================================
 
-/** Get the wiki directory path. */
+/** Get the local wiki directory path. */
 export function getWikiDir(root: string): string {
   return join(getOmcRoot(root), WIKI_DIR);
+}
+
+/** Get the global wiki directory path (~/.claude/.omc/wiki/). */
+export function getGlobalWikiDir(): string {
+  return join(getClaudeConfigDir(), '.omc', WIKI_DIR);
+}
+
+/** Ensure a wiki directory exists. For local wikis, also ensures git-ignore. */
+export function ensureGlobalWikiDir(): string {
+  const globalDir = getGlobalWikiDir();
+  if (!existsSync(globalDir)) {
+    mkdirSync(globalDir, { recursive: true });
+  }
+  return globalDir;
 }
 
 /** Ensure wiki directory exists and is git-ignored. */
@@ -99,6 +117,7 @@ export function parseFrontmatter(raw: string): { frontmatter: WikiPageFrontmatte
 
   try {
     const fm = parseSimpleYaml(yamlBlock);
+    const ttlVal = fm.ttl ? Number(fm.ttl) : undefined;
     const frontmatter: WikiPageFrontmatter = {
       title: String(fm.title || ''),
       tags: parseYamlArray(fm.tags),
@@ -109,6 +128,10 @@ export function parseFrontmatter(raw: string): { frontmatter: WikiPageFrontmatte
       category: (fm.category || 'reference') as WikiPageFrontmatter['category'],
       confidence: (fm.confidence || 'medium') as WikiPageFrontmatter['confidence'],
       schemaVersion: Number(fm.schemaVersion) || WIKI_SCHEMA_VERSION,
+      ...(ttlVal ? { ttl: ttlVal } : {}),
+      ...(fm.expiresAt ? { expiresAt: String(fm.expiresAt) } : {}),
+      ...(fm.compactedAt ? { compactedAt: String(fm.compactedAt) } : {}),
+      ...(fm.scope ? { scope: String(fm.scope) as WikiScope } : {}),
     };
     return { frontmatter, content };
   } catch {
@@ -158,7 +181,7 @@ function escapeYaml(s: string): string {
  */
 export function serializePage(page: WikiPage): string {
   const fm = page.frontmatter;
-  const yaml = [
+  const lines = [
     `title: "${escapeYaml(fm.title)}"`,
     `tags: [${fm.tags.map(t => `"${escapeYaml(t)}"`).join(', ')}]`,
     `created: ${fm.created}`,
@@ -168,9 +191,15 @@ export function serializePage(page: WikiPage): string {
     `category: ${fm.category}`,
     `confidence: ${fm.confidence}`,
     `schemaVersion: ${fm.schemaVersion}`,
-  ].join('\n');
+  ];
 
-  return `---\n${yaml}\n---\n${page.content}`;
+  // Optional fields — only serialize when present
+  if (fm.ttl) lines.push(`ttl: ${fm.ttl}`);
+  if (fm.expiresAt) lines.push(`expiresAt: ${fm.expiresAt}`);
+  if (fm.compactedAt) lines.push(`compactedAt: ${fm.compactedAt}`);
+  if (fm.scope) lines.push(`scope: ${fm.scope}`);
+
+  return `---\n${lines.join('\n')}\n---\n${page.content}`;
 }
 
 // ============================================================================
@@ -362,6 +391,176 @@ export function appendLog(root: string, entry: WikiLogEntry): void {
   withWikiLock(root, () => {
     appendLogUnsafe(root, entry);
   });
+}
+
+// ============================================================================
+// Global Wiki Operations
+// ============================================================================
+
+/** Read all pages from the global wiki tier. */
+export function readAllGlobalPages(): WikiPage[] {
+  const globalDir = getGlobalWikiDir();
+  if (!existsSync(globalDir)) return [];
+
+  return readdirSync(globalDir)
+    .filter(f => f.endsWith('.md') && !RESERVED_FILES.has(f))
+    .sort()
+    .map(f => readPageFromDir(globalDir, f))
+    .filter((p): p is WikiPage => p !== null);
+}
+
+/** Read a single page from a specific directory. */
+function readPageFromDir(dir: string, filename: string): WikiPage | null {
+  const filePath = safeWikiPath(dir, filename);
+  if (!filePath || !existsSync(filePath)) return null;
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = parseFrontmatter(raw);
+    if (!parsed) return null;
+    return { filename, frontmatter: parsed.frontmatter, content: parsed.content };
+  } catch {
+    return null;
+  }
+}
+
+/** Write a page to the global wiki. */
+export function writeGlobalPage(page: WikiPage): void {
+  const globalDir = ensureGlobalWikiDir();
+  const filePath = safeWikiPath(globalDir, page.filename);
+  if (!filePath) throw new Error(`Invalid wiki page filename: ${page.filename}`);
+  atomicWriteFileSync(filePath, serializePage(page));
+}
+
+/** Delete a page from the global wiki. Returns true if deleted. */
+export function deleteGlobalPage(filename: string): boolean {
+  const globalDir = getGlobalWikiDir();
+  const filePath = safeWikiPath(globalDir, filename);
+  if (!filePath || !existsSync(filePath)) return false;
+  unlinkSync(filePath);
+  return true;
+}
+
+// ============================================================================
+// TTL & Garbage Collection
+// ============================================================================
+
+/** Check if a wiki page has expired based on its TTL. */
+export function isPageExpired(page: WikiPage): boolean {
+  if (!page.frontmatter.expiresAt) return false;
+  return new Date(page.frontmatter.expiresAt).getTime() <= Date.now();
+}
+
+/**
+ * Remove expired pages from a wiki directory.
+ * Returns the count of pages removed.
+ */
+export function cleanupExpiredPages(root: string): { removed: number; filenames: string[] } {
+  const removed: string[] = [];
+
+  withWikiLock(root, () => {
+    const pages = readAllPages(root);
+    for (const page of pages) {
+      if (isPageExpired(page)) {
+        deletePageUnsafe(root, page.filename);
+        removed.push(page.filename);
+      }
+    }
+    if (removed.length > 0) {
+      updateIndexUnsafe(root);
+      appendLogUnsafe(root, {
+        timestamp: new Date().toISOString(),
+        operation: 'delete',
+        pagesAffected: removed,
+        summary: `Auto-GC: removed ${removed.length} expired page(s)`,
+      });
+    }
+  });
+
+  return { removed: removed.length, filenames: removed };
+}
+
+// ============================================================================
+// Compaction
+// ============================================================================
+
+/**
+ * Count the number of append sections in a page's content.
+ * Sections are delimited by `---\n\n## Update (` pattern.
+ */
+export function countAppendSections(content: string): number {
+  const matches = content.match(/\n---\n\n## Update \(/g);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Compact a page by keeping only the most recent N append sections.
+ * Older sections are replaced with a summary line.
+ *
+ * Returns the compacted page, or null if no compaction needed.
+ */
+export function compactPage(page: WikiPage): WikiPage | null {
+  const sectionCount = countAppendSections(page.content);
+  if (sectionCount < COMPACTION_THRESHOLD) return null;
+
+  // Split content into original + append sections
+  const sectionPattern = /\n---\n\n## Update \(/;
+  const parts = page.content.split(sectionPattern);
+
+  // parts[0] = original content, parts[1..] = append sections (without the delimiter prefix)
+  const originalContent = parts[0];
+  const appendSections = parts.slice(1);
+
+  const sectionsToRemove = appendSections.length - COMPACTION_KEEP_RECENT;
+  if (sectionsToRemove <= 0) return null;
+
+  const keptSections = appendSections.slice(sectionsToRemove);
+  const now = new Date().toISOString();
+
+  // Rebuild content: original + compaction notice + kept sections
+  const compactedContent = originalContent.trimEnd() +
+    `\n\n---\n\n> **Compacted:** ${sectionsToRemove} older section(s) removed on ${now}\n` +
+    keptSections.map(s => `\n---\n\n## Update (${s}`).join('');
+
+  return {
+    filename: page.filename,
+    frontmatter: {
+      ...page.frontmatter,
+      updated: now,
+      compactedAt: now,
+    },
+    content: compactedContent,
+  };
+}
+
+/**
+ * Run compaction on all pages in a wiki directory.
+ * Returns count of pages compacted.
+ */
+export function compactAllPages(root: string): { compacted: number; filenames: string[] } {
+  const compacted: string[] = [];
+
+  withWikiLock(root, () => {
+    const pages = readAllPages(root);
+    for (const page of pages) {
+      const result = compactPage(page);
+      if (result) {
+        writePageUnsafe(root, result);
+        compacted.push(page.filename);
+      }
+    }
+    if (compacted.length > 0) {
+      updateIndexUnsafe(root);
+      appendLogUnsafe(root, {
+        timestamp: new Date().toISOString(),
+        operation: 'ingest',
+        pagesAffected: compacted,
+        summary: `Auto-compaction: compacted ${compacted.length} page(s)`,
+      });
+    }
+  });
+
+  return { compacted: compacted.length, filenames: compacted };
 }
 
 // ============================================================================

--- a/src/hooks/wiki/types.ts
+++ b/src/hooks/wiki/types.ts
@@ -33,6 +33,14 @@ export interface WikiPageFrontmatter {
   confidence: 'high' | 'medium' | 'low';
   /** Schema version for future migration support */
   schemaVersion: number;
+  /** Time-to-live in seconds. 0 or omitted means no expiry. */
+  ttl?: number;
+  /** ISO timestamp when this page expires (computed from ttl on write). */
+  expiresAt?: string;
+  /** ISO timestamp of last compaction. */
+  compactedAt?: string;
+  /** Storage scope: local (repo-specific) or global (cross-repo). */
+  scope?: WikiScope;
 }
 
 /** Supported page categories. */
@@ -45,6 +53,23 @@ export type WikiCategory =
   | 'session-log'
   | 'reference'
   | 'convention';
+
+/** Storage scope for wiki pages. */
+export type WikiScope = 'local' | 'global';
+
+/**
+ * Default TTL (in seconds) per category.
+ * Categories not listed here have no automatic expiry.
+ */
+export const CATEGORY_DEFAULT_TTL: Partial<Record<WikiCategory, number>> = {
+  'session-log': 7 * 24 * 60 * 60, // 7 days
+};
+
+/** Maximum number of append sections before compaction triggers. */
+export const COMPACTION_THRESHOLD = 5;
+
+/** Number of most-recent sections to keep during compaction. */
+export const COMPACTION_KEEP_RECENT = 3;
 
 /** A wiki page: frontmatter + markdown content + filename. */
 export interface WikiPage {
@@ -86,6 +111,10 @@ export interface WikiIngestInput {
   sources?: string[];
   /** Confidence level */
   confidence?: 'high' | 'medium' | 'low';
+  /** Storage scope (default: auto-detected from category) */
+  scope?: WikiScope;
+  /** Custom TTL in seconds (overrides category default) */
+  ttl?: number;
 }
 
 /** Result of an ingest operation. */
@@ -174,6 +203,12 @@ export interface WikiConfig {
   staleDays: number;
   /** Maximum page content size in bytes before lint warns (default: 10240) */
   maxPageSize: number;
+  /** Whether to enable global (cross-repo) wiki tier (default: true) */
+  enableGlobalTier: boolean;
+  /** Whether to run auto-GC on session start (default: true) */
+  autoGC: boolean;
+  /** Whether to run auto-compaction on session start (default: true) */
+  autoCompaction: boolean;
 }
 
 /** Default wiki configuration. */
@@ -181,4 +216,16 @@ export const DEFAULT_WIKI_CONFIG: WikiConfig = {
   autoCapture: true,
   staleDays: 30,
   maxPageSize: 10_240, // 10KB
+  enableGlobalTier: true,
+  autoGC: true,
+  autoCompaction: true,
 };
+
+/**
+ * Categories that default to global scope when scope is not specified.
+ * All other categories default to local scope.
+ */
+export const GLOBAL_SCOPE_CATEGORIES: Set<WikiCategory> = new Set([
+  'convention',
+  'reference',
+]);

--- a/src/tools/wiki-tools.ts
+++ b/src/tools/wiki-tools.ts
@@ -20,7 +20,8 @@ import {
 import { ingestKnowledge } from '../hooks/wiki/ingest.js';
 import { queryWiki } from '../hooks/wiki/query.js';
 import { lintWiki } from '../hooks/wiki/lint.js';
-import type { WikiCategory } from '../hooks/wiki/types.js';
+import type { WikiCategory, WikiScope } from '../hooks/wiki/types.js';
+import { GLOBAL_SCOPE_CATEGORIES } from '../hooks/wiki/types.js';
 import { ToolDefinition } from './types.js';
 
 const WIKI_CATEGORIES: [string, ...string[]] = [
@@ -32,6 +33,8 @@ const WIKI_CATEGORIES: [string, ...string[]] = [
 // wiki_ingest
 // ============================================================================
 
+const WIKI_SCOPES: [string, ...string[]] = ['local', 'global'];
+
 export const wikiIngestTool: ToolDefinition<{
   title: z.ZodString;
   content: z.ZodString;
@@ -39,10 +42,11 @@ export const wikiIngestTool: ToolDefinition<{
   category: z.ZodEnum<typeof WIKI_CATEGORIES>;
   sources: z.ZodOptional<z.ZodArray<z.ZodString>>;
   confidence: z.ZodOptional<z.ZodEnum<['high', 'medium', 'low']>>;
+  scope: z.ZodOptional<z.ZodEnum<typeof WIKI_SCOPES>>;
   workingDirectory: z.ZodOptional<z.ZodString>;
 }> = {
   name: 'wiki_ingest',
-  description: 'Process knowledge into wiki pages. Creates new pages or merges into existing ones (append strategy — never replaces). A single ingest can update multiple pages via cross-references.',
+  description: 'Process knowledge into wiki pages. Creates new pages or merges into existing ones (append strategy — never replaces). Use scope "global" for cross-repo knowledge (conventions, references) or "local" for repo-specific knowledge. Default: auto-detected from category.',
   schema: {
     title: z.string().max(200).describe('Page title (used to generate filename slug, max 200 chars)'),
     content: z.string().max(50_000).describe('Markdown content to ingest (max 50KB)'),
@@ -50,11 +54,16 @@ export const wikiIngestTool: ToolDefinition<{
     category: z.enum(WIKI_CATEGORIES).describe('Page category'),
     sources: z.array(z.string().max(100)).max(10).optional().describe('Source identifiers (e.g., session IDs)'),
     confidence: z.enum(['high', 'medium', 'low']).optional().describe('Confidence level (default: medium)'),
+    scope: z.enum(WIKI_SCOPES).optional().describe('Storage scope: "local" (repo-specific) or "global" (cross-repo). Default: auto from category'),
     workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
   },
   handler: async (args) => {
     try {
       const root = validateWorkingDirectory(args.workingDirectory);
+
+      // Auto-detect scope at tools layer: explicit > category-based > local
+      const resolvedScope: WikiScope = (args.scope as WikiScope | undefined)
+        ?? (GLOBAL_SCOPE_CATEGORIES.has(args.category as WikiCategory) ? 'global' : 'local');
 
       const result = ingestKnowledge(root, {
         title: args.title,
@@ -63,6 +72,7 @@ export const wikiIngestTool: ToolDefinition<{
         category: args.category as WikiCategory,
         sources: args.sources,
         confidence: args.confidence as 'high' | 'medium' | 'low' | undefined,
+        scope: resolvedScope,
       });
 
       return {
@@ -208,15 +218,17 @@ export const wikiAddTool: ToolDefinition<{
   content: z.ZodString;
   tags: z.ZodOptional<z.ZodArray<z.ZodString>>;
   category: z.ZodOptional<z.ZodEnum<typeof WIKI_CATEGORIES>>;
+  scope: z.ZodOptional<z.ZodEnum<typeof WIKI_SCOPES>>;
   workingDirectory: z.ZodOptional<z.ZodString>;
 }> = {
   name: 'wiki_add',
-  description: 'Quick-add a wiki page. Simpler than wiki_ingest — creates a single page directly.',
+  description: 'Quick-add a wiki page. Simpler than wiki_ingest — creates a single page directly. Use scope "global" for cross-repo knowledge.',
   schema: {
     title: z.string().max(200).describe('Page title (max 200 chars)'),
     content: z.string().max(50_000).describe('Page content in markdown (max 50KB)'),
     tags: z.array(z.string().max(50)).max(20).optional().describe('Tags (default: [])'),
     category: z.enum(WIKI_CATEGORIES).optional().describe('Category (default: reference)'),
+    scope: z.enum(WIKI_SCOPES).optional().describe('Storage scope: "local" or "global". Default: auto from category'),
     workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
   },
   handler: async (args) => {
@@ -235,12 +247,18 @@ export const wikiAddTool: ToolDefinition<{
         };
       }
 
+      // Auto-detect scope at tools layer
+      const cat = (args.category || 'reference') as WikiCategory;
+      const resolvedScope: WikiScope = (args.scope as WikiScope | undefined)
+        ?? (GLOBAL_SCOPE_CATEGORIES.has(cat) ? 'global' : 'local');
+
       // Delegate to ingest for consistent page creation
       const result = ingestKnowledge(root, {
         title: args.title,
         content: args.content,
         tags: args.tags || [],
-        category: (args.category || 'reference') as WikiCategory,
+        category: cat,
+        scope: resolvedScope,
       });
 
       return {


### PR DESCRIPTION
## Summary

Addresses four architectural limitations in the LLM Wiki feature (#2214, v4.11.0):

- **TTL & Auto-GC**: Session-log pages auto-expire after 7 days. `cleanupExpiredPages()` runs at SessionStart. Expired pages filtered from query results.
- **Compaction**: Pages with 5+ append sections auto-compacted to keep 3 most recent, preventing infinite growth.
- **2-Tier Storage**: Global wiki (`~/.claude/.omc/wiki/`) for cross-repo knowledge (conventions, references). Local wiki unchanged. Query searches both tiers with 1.5x local score boost. Configurable via `wiki.enableGlobalTier`.
- **CJK Tokenization**: Bi-gram tokenizer for Korean/Chinese/Japanese text. Fixes keyword search for non-Latin languages.

### Architecture Decisions

| Decision | Rationale |
|----------|-----------|
| Scope auto-detection only at MCP tools layer | Backward compat — `ingestKnowledge()` API defaults to local |
| TTL on frontmatter, not external DB | Zero-dependency, human-readable, consistent with existing pattern |
| Compaction threshold=5, keep=3 | Balance between growth control and information preservation |
| Global tier disabled by config | Opt-out via `wiki.enableGlobalTier: false` in `.omc-config.json` |

### Files Changed (9 files, +1037/-53)

| File | Change |
|------|--------|
| `src/hooks/wiki/types.ts` | +47: TTL, scope, compaction types, `CATEGORY_DEFAULT_TTL`, `GLOBAL_SCOPE_CATEGORIES` |
| `src/hooks/wiki/storage.ts` | +207: Global wiki ops, `isPageExpired`, `cleanupExpiredPages`, `compactPage`, `compactAllPages` |
| `src/hooks/wiki/query.ts` | +70: `tokenize()` with CJK bi-grams, 2-tier search with boost, expired filtering |
| `src/hooks/wiki/ingest.ts` | +20: TTL auto-apply, scope routing to global tier |
| `src/hooks/wiki/session-hooks.ts` | +33: Auto-GC + compaction at SessionStart, TTL on session-log capture |
| `src/hooks/wiki/index.ts` | +24: New exports |
| `src/tools/wiki-tools.ts` | +26: `scope` parameter, auto-detection at tools layer |
| `src/hooks/wiki/__tests__/query.test.ts` | +16: `LOCAL_ONLY_CONFIG` for test isolation |
| `src/hooks/wiki/__tests__/v2-improvements.test.ts` | +580: 35 new tests |

Closes #2260

## Test plan

- [x] 35 new tests covering TTL/GC, compaction, 2-tier storage, CJK tokenization, scope auto-detection
- [x] All 97 wiki tests pass (0 regressions)
- [x] Full suite: 78 pre-existing failures (same as before this PR), 0 new failures
- [x] TypeScript strict mode: `tsc --noEmit` passes with no errors
- [ ] Manual test: verify session-log TTL expiry after 7 days
- [ ] Manual test: verify global wiki pages accessible from different repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)