### PR TITLE
feat(wiki): auto-expire session-log pages with 7-day TTL

### DIFF
--- a/src/hooks/wiki/__tests__/session-log-ttl.test.ts
+++ b/src/hooks/wiki/__tests__/session-log-ttl.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for session-log TTL and auto-GC.
+ *
+ * Session-log pages are auto-captured at session end but accumulate
+ * without bound. This adds a 7-day TTL so they auto-expire, and a
+ * GC pass at session start to clean them up.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import {
+  parseFrontmatter,
+  serializePage,
+  writePage,
+  readPage,
+  readAllPages,
+  ensureWikiDir,
+  isPageExpired,
+  cleanupExpiredPages,
+} from '../storage.js';
+import { ingestKnowledge } from '../ingest.js';
+import { WIKI_SCHEMA_VERSION, CATEGORY_DEFAULT_TTL } from '../types.js';
+import type { WikiPage } from '../types.js';
+
+function makePage(filename: string, overrides: Partial<WikiPage['frontmatter']> = {}): WikiPage {
+  return {
+    filename,
+    frontmatter: {
+      title: filename.replace('.md', ''),
+      tags: ['test'],
+      created: '2025-01-01T00:00:00.000Z',
+      updated: '2025-01-01T00:00:00.000Z',
+      sources: [],
+      links: [],
+      category: 'reference',
+      confidence: 'medium',
+      schemaVersion: WIKI_SCHEMA_VERSION,
+      ...overrides,
+    },
+    content: '\n# Test\n\nContent.\n',
+  };
+}
+
+describe('TTL frontmatter', () => {
+  it('should serialize ttl and expiresAt', () => {
+    const page = makePage('ttl.md', {
+      ttl: 3600,
+      expiresAt: '2025-06-01T00:00:00.000Z',
+    });
+    const raw = serializePage(page);
+    expect(raw).toContain('ttl: 3600');
+    expect(raw).toContain('expiresAt: 2025-06-01T00:00:00.000Z');
+  });
+
+  it('should parse ttl and expiresAt', () => {
+    const page = makePage('ttl.md', {
+      ttl: 7200,
+      expiresAt: '2025-07-01T00:00:00.000Z',
+    });
+    const raw = serializePage(page);
+    const parsed = parseFrontmatter(raw);
+    expect(parsed!.frontmatter.ttl).toBe(7200);
+    expect(parsed!.frontmatter.expiresAt).toBe('2025-07-01T00:00:00.000Z');
+  });
+
+  it('should not serialize ttl/expiresAt when absent', () => {
+    const page = makePage('no-ttl.md');
+    const raw = serializePage(page);
+    expect(raw).not.toContain('ttl:');
+    expect(raw).not.toContain('expiresAt:');
+  });
+});
+
+describe('isPageExpired', () => {
+  it('returns false when no expiresAt', () => {
+    expect(isPageExpired(makePage('a.md'))).toBe(false);
+  });
+
+  it('returns false for future expiresAt', () => {
+    const future = new Date(Date.now() + 86400000).toISOString();
+    expect(isPageExpired(makePage('b.md', { expiresAt: future }))).toBe(false);
+  });
+
+  it('returns true for past expiresAt', () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    expect(isPageExpired(makePage('c.md', { expiresAt: past }))).toBe(true);
+  });
+});
+
+describe('cleanupExpiredPages', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-gc-test-'));
+    ensureWikiDir(tempDir);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should remove expired pages', () => {
+    writePage(tempDir, makePage('expired.md', {
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    }));
+    writePage(tempDir, makePage('valid.md'));
+
+    expect(readAllPages(tempDir)).toHaveLength(2);
+    const result = cleanupExpiredPages(tempDir);
+    expect(result.removed).toBe(1);
+    expect(result.filenames).toContain('expired.md');
+    expect(readAllPages(tempDir)).toHaveLength(1);
+  });
+
+  it('should return 0 when nothing expired', () => {
+    writePage(tempDir, makePage('alive.md'));
+    expect(cleanupExpiredPages(tempDir).removed).toBe(0);
+  });
+});
+
+describe('session-log category defaults', () => {
+  it('should have 7-day TTL', () => {
+    expect(CATEGORY_DEFAULT_TTL['session-log']).toBe(7 * 24 * 60 * 60);
+  });
+
+  it('architecture should have no default TTL', () => {
+    expect(CATEGORY_DEFAULT_TTL['architecture']).toBeUndefined();
+  });
+});
+
+describe('ingest applies category TTL', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-ttl-ingest-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('session-log ingest should auto-apply 7-day TTL', () => {
+    const result = ingestKnowledge(tempDir, {
+      title: 'Session Log Test',
+      content: 'Auto-captured.',
+      tags: ['session-log'],
+      category: 'session-log',
+    });
+
+    const page = readPage(tempDir, result.created[0]);
+    expect(page!.frontmatter.ttl).toBe(7 * 24 * 60 * 60);
+    expect(page!.frontmatter.expiresAt).toBeDefined();
+
+    const expiresAt = new Date(page!.frontmatter.expiresAt!).getTime();
+    const sevenDays = Date.now() + 7 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(expiresAt - sevenDays)).toBeLessThan(5000);
+  });
+
+  it('architecture ingest should NOT apply TTL', () => {
+    const result = ingestKnowledge(tempDir, {
+      title: 'Arch Test',
+      content: 'Permanent.',
+      tags: ['arch'],
+      category: 'architecture',
+    });
+
+    const page = readPage(tempDir, result.created[0]);
+    expect(page!.frontmatter.ttl).toBeUndefined();
+    expect(page!.frontmatter.expiresAt).toBeUndefined();
+  });
+
+  it('explicit ttl should override category default', () => {
+    const result = ingestKnowledge(tempDir, {
+      title: 'Custom TTL',
+      content: 'Short-lived.',
+      tags: ['test'],
+      category: 'session-log',
+      ttl: 3600, // 1 hour, not 7 days
+    });
+
+    const page = readPage(tempDir, result.created[0]);
+    expect(page!.frontmatter.ttl).toBe(3600);
+  });
+});

--- a/src/hooks/wiki/index.ts
+++ b/src/hooks/wiki/index.ts
@@ -20,7 +20,7 @@ export type {
   WikiConfig,
 } from './types.js';
 
-export { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG } from './types.js';
+export { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG, CATEGORY_DEFAULT_TTL } from './types.js';
 
 // Storage
 export {
@@ -38,6 +38,8 @@ export {
   titleToSlug,
   parseFrontmatter,
   serializePage,
+  isPageExpired,
+  cleanupExpiredPages,
   // Unsafe variants (for use inside withWikiLock)
   writePageUnsafe,
   deletePageUnsafe,

--- a/src/hooks/wiki/ingest.ts
+++ b/src/hooks/wiki/ingest.ts
@@ -11,6 +11,7 @@ import {
   type WikiPage,
   type WikiPageFrontmatter,
   WIKI_SCHEMA_VERSION,
+  CATEGORY_DEFAULT_TTL,
 } from './types.js';
 import {
   withWikiLock,
@@ -70,6 +71,10 @@ export function ingestKnowledge(root: string, input: WikiIngestInput): WikiInges
 
 /** Create a new wiki page from ingest input. */
 function createPage(slug: string, input: WikiIngestInput, now: string): WikiPage {
+  // Resolve TTL: explicit > category default > none
+  const ttl = input.ttl ?? CATEGORY_DEFAULT_TTL[input.category];
+  const expiresAt = ttl ? new Date(Date.now() + ttl * 1000).toISOString() : undefined;
+
   const frontmatter: WikiPageFrontmatter = {
     title: input.title,
     tags: [...new Set(input.tags)],
@@ -80,6 +85,8 @@ function createPage(slug: string, input: WikiIngestInput, now: string): WikiPage
     category: input.category,
     confidence: input.confidence || 'medium',
     schemaVersion: WIKI_SCHEMA_VERSION,
+    ...(ttl ? { ttl } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
   };
 
   return {

--- a/src/hooks/wiki/session-hooks.ts
+++ b/src/hooks/wiki/session-hooks.ts
@@ -21,8 +21,9 @@ import {
   writePageUnsafe,
   updateIndexUnsafe,
   appendLogUnsafe,
+  cleanupExpiredPages,
 } from './storage.js';
-import { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG } from './types.js';
+import { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG, CATEGORY_DEFAULT_TTL } from './types.js';
 import type { WikiConfig } from './types.js';
 
 /**
@@ -72,6 +73,13 @@ export function onSessionStart(data: { cwd?: string }): { additionalContext?: st
       if (!indexContent) {
         // Index missing — rebuild
         withWikiLock(root, () => { updateIndexUnsafe(root); });
+      }
+
+      // Auto-GC: remove expired pages (e.g., old session-logs with TTL)
+      try {
+        cleanupExpiredPages(root);
+      } catch {
+        // GC failure should not block session start
       }
     }
 
@@ -126,6 +134,12 @@ export function onSessionEnd(data: { cwd?: string; session_id?: string }): { con
     const dateSlug = now.split('T')[0]; // YYYY-MM-DD
     const filename = `session-log-${dateSlug}-${sessionId.slice(-8)}.md`;
 
+    // Apply TTL for session-log category
+    const sessionLogTtl = CATEGORY_DEFAULT_TTL['session-log'];
+    const expiresAt = sessionLogTtl
+      ? new Date(Date.now() + sessionLogTtl * 1000).toISOString()
+      : undefined;
+
     withWikiLock(root, () => {
       // Time check inside lock
       if (Date.now() - startTime > TIMEOUT_MS) return;
@@ -142,6 +156,8 @@ export function onSessionEnd(data: { cwd?: string; session_id?: string }): { con
           category: 'session-log',
           confidence: 'medium',
           schemaVersion: WIKI_SCHEMA_VERSION,
+          ...(sessionLogTtl ? { ttl: sessionLogTtl } : {}),
+          ...(expiresAt ? { expiresAt } : {}),
         },
         content: `\n# Session Log ${dateSlug}\n\nAuto-captured session metadata.\nSession ID: ${sessionId}\n\nReview and promote significant findings to curated wiki pages via \`wiki_ingest\`.\n`,
       });

--- a/src/hooks/wiki/storage.ts
+++ b/src/hooks/wiki/storage.ts
@@ -99,6 +99,7 @@ export function parseFrontmatter(raw: string): { frontmatter: WikiPageFrontmatte
 
   try {
     const fm = parseSimpleYaml(yamlBlock);
+    const ttlVal = fm.ttl ? Number(fm.ttl) : undefined;
     const frontmatter: WikiPageFrontmatter = {
       title: String(fm.title || ''),
       tags: parseYamlArray(fm.tags),
@@ -109,6 +110,8 @@ export function parseFrontmatter(raw: string): { frontmatter: WikiPageFrontmatte
       category: (fm.category || 'reference') as WikiPageFrontmatter['category'],
       confidence: (fm.confidence || 'medium') as WikiPageFrontmatter['confidence'],
       schemaVersion: Number(fm.schemaVersion) || WIKI_SCHEMA_VERSION,
+      ...(ttlVal ? { ttl: ttlVal } : {}),
+      ...(fm.expiresAt ? { expiresAt: String(fm.expiresAt) } : {}),
     };
     return { frontmatter, content };
   } catch {
@@ -158,7 +161,7 @@ function escapeYaml(s: string): string {
  */
 export function serializePage(page: WikiPage): string {
   const fm = page.frontmatter;
-  const yaml = [
+  const lines = [
     `title: "${escapeYaml(fm.title)}"`,
     `tags: [${fm.tags.map(t => `"${escapeYaml(t)}"`).join(', ')}]`,
     `created: ${fm.created}`,
@@ -168,9 +171,12 @@ export function serializePage(page: WikiPage): string {
     `category: ${fm.category}`,
     `confidence: ${fm.confidence}`,
     `schemaVersion: ${fm.schemaVersion}`,
-  ].join('\n');
+  ];
 
-  return `---\n${yaml}\n---\n${page.content}`;
+  if (fm.ttl) lines.push(`ttl: ${fm.ttl}`);
+  if (fm.expiresAt) lines.push(`expiresAt: ${fm.expiresAt}`);
+
+  return `---\n${lines.join('\n')}\n---\n${page.content}`;
 }
 
 // ============================================================================
@@ -362,6 +368,45 @@ export function appendLog(root: string, entry: WikiLogEntry): void {
   withWikiLock(root, () => {
     appendLogUnsafe(root, entry);
   });
+}
+
+// ============================================================================
+// TTL & Garbage Collection
+// ============================================================================
+
+/** Check if a wiki page has expired based on its expiresAt timestamp. */
+export function isPageExpired(page: WikiPage): boolean {
+  if (!page.frontmatter.expiresAt) return false;
+  return new Date(page.frontmatter.expiresAt).getTime() <= Date.now();
+}
+
+/**
+ * Remove expired pages from the wiki.
+ * Returns filenames of removed pages.
+ */
+export function cleanupExpiredPages(root: string): { removed: number; filenames: string[] } {
+  const removed: string[] = [];
+
+  withWikiLock(root, () => {
+    const pages = readAllPages(root);
+    for (const page of pages) {
+      if (isPageExpired(page)) {
+        deletePageUnsafe(root, page.filename);
+        removed.push(page.filename);
+      }
+    }
+    if (removed.length > 0) {
+      updateIndexUnsafe(root);
+      appendLogUnsafe(root, {
+        timestamp: new Date().toISOString(),
+        operation: 'delete',
+        pagesAffected: removed,
+        summary: `Auto-GC: removed ${removed.length} expired page(s)`,
+      });
+    }
+  });
+
+  return { removed: removed.length, filenames: removed };
 }
 
 // ============================================================================

--- a/src/hooks/wiki/types.ts
+++ b/src/hooks/wiki/types.ts
@@ -33,6 +33,10 @@ export interface WikiPageFrontmatter {
   confidence: 'high' | 'medium' | 'low';
   /** Schema version for future migration support */
   schemaVersion: number;
+  /** Time-to-live in seconds. 0 or omitted means no expiry. */
+  ttl?: number;
+  /** ISO timestamp when this page expires (computed from ttl on write). */
+  expiresAt?: string;
 }
 
 /** Supported page categories. */
@@ -45,6 +49,14 @@ export type WikiCategory =
   | 'session-log'
   | 'reference'
   | 'convention';
+
+/**
+ * Default TTL (in seconds) per category.
+ * Categories not listed here have no automatic expiry.
+ */
+export const CATEGORY_DEFAULT_TTL: Partial<Record<WikiCategory, number>> = {
+  'session-log': 7 * 24 * 60 * 60, // 7 days
+};
 
 /** A wiki page: frontmatter + markdown content + filename. */
 export interface WikiPage {
@@ -86,6 +98,8 @@ export interface WikiIngestInput {
   sources?: string[];
   /** Confidence level */
   confidence?: 'high' | 'medium' | 'low';
+  /** Custom TTL in seconds (overrides category default) */
+  ttl?: number;
 }
 
 /** Result of an ingest operation. */


### PR DESCRIPTION
## Summary

Session-log pages auto-captured at session end accumulate without bound. This adds TTL (time-to-live) support so they auto-expire after 7 days, following the same pattern as `shared-memory` (`src/lib/shared-memory.ts`).

## Change

| File | Lines | What |
|------|-------|------|
| `types.ts` | +15 | `ttl?`, `expiresAt?` on frontmatter; `CATEGORY_DEFAULT_TTL`; `ttl?` on ingest input |
| `storage.ts` | +46 | Parse/serialize TTL; `isPageExpired()`; `cleanupExpiredPages()` |
| `ingest.ts` | +10 | Auto-apply category TTL in `createPage()` |
| `session-hooks.ts` | +12 | GC at SessionStart; stamp TTL at SessionEnd |
| `index.ts` | +3 | New exports |
| `session-log-ttl.test.ts` | +155 (new) | 13 tests |

**Total: 6 files, +275/-5**

## How it works

```
SessionEnd:  auto-capture → session-log-2025-01-15-abc12345.md
             frontmatter includes: ttl: 604800, expiresAt: 2025-01-22T...

SessionStart (7+ days later):
             cleanupExpiredPages() → deletes expired session-logs
             index.md auto-rebuilt
```

- Category defaults: `session-log` = 7 days. All others = no expiry.
- Explicit `ttl` parameter on `ingestKnowledge()` overrides the default.
- Existing pages without TTL are unaffected (`isPageExpired` returns false).

Fixes #2264

## Test plan

- [x] 13 new tests (frontmatter roundtrip, expiry logic, GC, ingest TTL application)
- [x] All 75 wiki tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)