### PR TITLE
feat(wiki): add compaction utilities for oversized pages

### DIFF
--- a/src/hooks/wiki/__tests__/compaction.test.ts
+++ b/src/hooks/wiki/__tests__/compaction.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for wiki page compaction.
+ *
+ * The append-only merge strategy in ingest.ts adds a new section on every
+ * wiki_ingest call. Over time this causes pages to grow without bound.
+ * Compaction keeps the N most recent sections and replaces older ones
+ * with a summary line.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import {
+  writePage,
+  readPage,
+  ensureWikiDir,
+  countAppendSections,
+  compactPage,
+  compactAllPages,
+} from '../storage.js';
+import { WIKI_SCHEMA_VERSION, COMPACTION_THRESHOLD, COMPACTION_KEEP_RECENT } from '../types.js';
+import type { WikiPage } from '../types.js';
+
+function makePage(filename: string, content: string): WikiPage {
+  return {
+    filename,
+    frontmatter: {
+      title: filename.replace('.md', ''),
+      tags: ['test'],
+      created: '2025-01-01T00:00:00.000Z',
+      updated: '2025-01-01T00:00:00.000Z',
+      sources: [],
+      links: [],
+      category: 'reference',
+      confidence: 'medium',
+      schemaVersion: WIKI_SCHEMA_VERSION,
+    },
+    content,
+  };
+}
+
+function buildContentWithSections(numSections: number): string {
+  let content = '\n# Original Title\n\nOriginal content.\n';
+  for (let i = 0; i < numSections; i++) {
+    content += `\n---\n\n## Update (2025-01-${String(i + 1).padStart(2, '0')}T00:00:00.000Z)\n\nUpdate ${i + 1} content.\n`;
+  }
+  return content;
+}
+
+describe('countAppendSections', () => {
+  it('should return 0 for content with no updates', () => {
+    expect(countAppendSections('\n# Title\n\nJust content.\n')).toBe(0);
+  });
+
+  it('should count update sections correctly', () => {
+    const content = buildContentWithSections(3);
+    expect(countAppendSections(content)).toBe(3);
+  });
+
+  it('should not count non-matching patterns', () => {
+    const content = '\n# Title\n\n---\n\n## Not an Update\n\nNope.\n';
+    expect(countAppendSections(content)).toBe(0);
+  });
+});
+
+describe('compactPage', () => {
+  it('should return null when below threshold', () => {
+    const page = makePage('small.md', buildContentWithSections(2));
+    expect(compactPage(page)).toBeNull();
+  });
+
+  it('should return null at exact threshold', () => {
+    const page = makePage('exact.md', buildContentWithSections(COMPACTION_THRESHOLD - 1));
+    expect(compactPage(page)).toBeNull();
+  });
+
+  it('should compact when above threshold', () => {
+    const page = makePage('big.md', buildContentWithSections(COMPACTION_THRESHOLD + 1));
+    const result = compactPage(page);
+
+    expect(result).not.toBeNull();
+    expect(countAppendSections(result!.content)).toBe(COMPACTION_KEEP_RECENT);
+    expect(result!.content).toContain('**Compacted:**');
+    expect(result!.content).toContain('Original content.');
+  });
+
+  it('should keep only the most recent sections', () => {
+    const numSections = COMPACTION_THRESHOLD + 3;
+    const page = makePage('many.md', buildContentWithSections(numSections));
+    const result = compactPage(page)!;
+
+    // The last COMPACTION_KEEP_RECENT sections should be preserved
+    const lastSectionDate = `2025-01-${String(numSections).padStart(2, '0')}`;
+    expect(result.content).toContain(lastSectionDate);
+
+    // The first section should be removed
+    expect(result.content).not.toContain('Update 1 content.');
+  });
+
+  it('should update the frontmatter updated timestamp', () => {
+    const page = makePage('ts.md', buildContentWithSections(COMPACTION_THRESHOLD + 1));
+    const result = compactPage(page)!;
+    expect(result.frontmatter.updated).not.toBe('2025-01-01T00:00:00.000Z');
+  });
+});
+
+describe('compactAllPages', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-compact-test-'));
+    ensureWikiDir(tempDir);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should compact eligible pages and skip others', () => {
+    writePage(tempDir, makePage('big.md', buildContentWithSections(COMPACTION_THRESHOLD + 2)));
+    writePage(tempDir, makePage('small.md', '\n# Small\n\nTiny page.\n'));
+
+    const result = compactAllPages(tempDir);
+    expect(result.compacted).toBe(1);
+    expect(result.filenames).toContain('big.md');
+
+    const page = readPage(tempDir, 'big.md');
+    expect(countAppendSections(page!.content)).toBe(COMPACTION_KEEP_RECENT);
+  });
+
+  it('should return 0 when nothing needs compaction', () => {
+    writePage(tempDir, makePage('ok.md', '\n# OK\n\nFine.\n'));
+    expect(compactAllPages(tempDir).compacted).toBe(0);
+  });
+});

--- a/src/hooks/wiki/index.ts
+++ b/src/hooks/wiki/index.ts
@@ -20,7 +20,7 @@ export type {
   WikiConfig,
 } from './types.js';
 
-export { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG } from './types.js';
+export { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG, COMPACTION_THRESHOLD, COMPACTION_KEEP_RECENT } from './types.js';
 
 // Storage
 export {
@@ -38,6 +38,9 @@ export {
   titleToSlug,
   parseFrontmatter,
   serializePage,
+  countAppendSections,
+  compactPage,
+  compactAllPages,
   // Unsafe variants (for use inside withWikiLock)
   writePageUnsafe,
   deletePageUnsafe,

--- a/src/hooks/wiki/storage.ts
+++ b/src/hooks/wiki/storage.ts
@@ -23,6 +23,8 @@ import {
   type WikiPageFrontmatter,
   type WikiLogEntry,
   WIKI_SCHEMA_VERSION,
+  COMPACTION_THRESHOLD,
+  COMPACTION_KEEP_RECENT,
 } from './types.js';
 
 // ============================================================================
@@ -362,6 +364,83 @@ export function appendLog(root: string, entry: WikiLogEntry): void {
   withWikiLock(root, () => {
     appendLogUnsafe(root, entry);
   });
+}
+
+// ============================================================================
+// Compaction
+// ============================================================================
+
+/**
+ * Count the number of append sections in a page's content.
+ * Sections are delimited by the `---\n\n## Update (` pattern produced by ingest merge.
+ */
+export function countAppendSections(content: string): number {
+  const matches = content.match(/\n---\n\n## Update \(/g);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Compact a page by keeping only the most recent append sections.
+ * Older sections are replaced with a summary line.
+ *
+ * Returns the compacted page, or null if no compaction needed.
+ */
+export function compactPage(page: WikiPage): WikiPage | null {
+  const sectionCount = countAppendSections(page.content);
+  if (sectionCount < COMPACTION_THRESHOLD) return null;
+
+  const sectionPattern = /\n---\n\n## Update \(/;
+  const parts = page.content.split(sectionPattern);
+
+  // parts[0] = original content, parts[1..] = append sections
+  const originalContent = parts[0];
+  const appendSections = parts.slice(1);
+
+  const sectionsToRemove = appendSections.length - COMPACTION_KEEP_RECENT;
+  if (sectionsToRemove <= 0) return null;
+
+  const keptSections = appendSections.slice(sectionsToRemove);
+  const now = new Date().toISOString();
+
+  const compactedContent = originalContent.trimEnd() +
+    `\n\n---\n\n> **Compacted:** ${sectionsToRemove} older section(s) removed on ${now}\n` +
+    keptSections.map(s => `\n---\n\n## Update (${s}`).join('');
+
+  return {
+    filename: page.filename,
+    frontmatter: { ...page.frontmatter, updated: now },
+    content: compactedContent,
+  };
+}
+
+/**
+ * Run compaction on all pages in the wiki.
+ * Returns filenames of compacted pages.
+ */
+export function compactAllPages(root: string): { compacted: number; filenames: string[] } {
+  const compacted: string[] = [];
+
+  withWikiLock(root, () => {
+    const pages = readAllPages(root);
+    for (const page of pages) {
+      const result = compactPage(page);
+      if (result) {
+        writePageUnsafe(root, result);
+        compacted.push(page.filename);
+      }
+    }
+    if (compacted.length > 0) {
+      updateIndexUnsafe(root);
+      appendLogUnsafe(root, {
+        timestamp: new Date().toISOString(),
+        operation: 'ingest',
+        pagesAffected: compacted,
+        summary: `Auto-compaction: compacted ${compacted.length} page(s)`,
+      });
+    }
+  });
+
+  return { compacted: compacted.length, filenames: compacted };
 }
 
 // ============================================================================

--- a/src/hooks/wiki/types.ts
+++ b/src/hooks/wiki/types.ts
@@ -46,6 +46,12 @@ export type WikiCategory =
   | 'reference'
   | 'convention';
 
+/** Maximum number of append sections before compaction triggers. */
+export const COMPACTION_THRESHOLD = 5;
+
+/** Number of most-recent sections to keep during compaction. */
+export const COMPACTION_KEEP_RECENT = 3;
+
 /** A wiki page: frontmatter + markdown content + filename. */
 export interface WikiPage {
   /** Filename without path (e.g., "auth-architecture.md") */


### PR DESCRIPTION
## Summary

The append-only merge in `ingest.ts` causes frequently-updated pages to grow without bound. `wiki_lint` warns about oversized pages but nothing can act on it.

This adds three utility functions — **no automatic behavior, no hooks, no lifecycle policy**.

## Change

| File | Lines | What |
|------|-------|------|
| `types.ts` | +6 | `COMPACTION_THRESHOLD` (5), `COMPACTION_KEEP_RECENT` (3) |
| `storage.ts` | +79 | `countAppendSections`, `compactPage`, `compactAllPages` |
| `index.ts` | +4 | Exports |
| `compaction.test.ts` | +136 (new) | 10 tests |

**Total: 4 files, +225/-1. Zero hook/session/tool changes.**

## What the functions do

```typescript
countAppendSections(content)  // → number of "## Update (" sections
compactPage(page)             // → compacted page if >= 5 sections (keeps 3), or null
compactAllPages(root)         // → { compacted: number, filenames: string[] }
```

Compacted content preserves the original section and adds a notice:
```
> **Compacted:** 3 older section(s) removed on 2025-04-07T...
```

No callers are wired up — these are building blocks for future use by `wiki_lint` or user-facing skills.

Fixes #2266

## Test plan

- [x] 10 new tests (count, threshold boundary, compaction output, batch)
- [x] All 72 wiki tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)