### PR TITLE
refactor(team): use module-level promisifiedExecFile in applyMainVerticalLayout

### DIFF
--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -56,12 +56,8 @@ async function tmuxAsync(args: string[]): Promise<{ stdout: string; stderr: stri
 }
 
 export async function applyMainVerticalLayout(teamTarget: string): Promise<void> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-
   try {
-    await execFileAsync('tmux', ['select-layout', '-t', teamTarget, 'main-vertical']);
+    await promisifiedExecFile('tmux', ['select-layout', '-t', teamTarget, 'main-vertical']);
   } catch {
     // Layout may not apply if only 1 pane; ignore.
   }
@@ -73,8 +69,8 @@ export async function applyMainVerticalLayout(teamTarget: string): Promise<void>
     const width = parseInt(widthResult.stdout.trim(), 10);
     if (Number.isFinite(width) && width >= 40) {
       const half = String(Math.floor(width / 2));
-      await execFileAsync('tmux', ['set-window-option', '-t', teamTarget, 'main-pane-width', half]);
-      await execFileAsync('tmux', ['select-layout', '-t', teamTarget, 'main-vertical']);
+      await promisifiedExecFile('tmux', ['set-window-option', '-t', teamTarget, 'main-pane-width', half]);
+      await promisifiedExecFile('tmux', ['select-layout', '-t', teamTarget, 'main-vertical']);
     }
   } catch {
     /* ignore layout sizing errors */


### PR DESCRIPTION
## Summary
- `applyMainVerticalLayout` dynamically imported `child_process` and `util` on every call, creating a fresh promisified wrapper each time
- The module already has `promisifiedExecFile` at line 22 — the dynamic imports are purely redundant
- The function was also internally inconsistent: it used `tmuxAsync` (module-level) for `display-message` but local `execFileAsync` for `select-layout` and `set-window-option`

## Testing
- `npx vitest run src/team/__tests__/tmux-session.test.ts` — 30 tests pass
- `npx vitest run src/team/__tests__/runtime-v2.dispatch.test.ts` — 11 tests pass
- Zero behavioral change: `promisifiedExecFile` is identical to the locally-created `promisify(execFile)` since both `child_process` and `util` are already statically imported

## Notes
- Scope-risk: narrow — only `applyMainVerticalLayout` is changed; other functions with the same pattern are left for a separate cleanup
- `-7 lines, +3 lines` — net reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)