### PR TITLE
fix(pre-tool-enforcer): strip UTF-8 BOM before frontmatter parsing

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -65,7 +65,7 @@ function readAgentDefinitionModel(subagentType) {
   const agentFile = candidateDirs.map(d => join(d, `${agentType}.md`)).find(f => existsSync(f)) ?? null;
   try {
     if (!agentFile) return null;
-    const content = readFileSync(agentFile, 'utf-8');
+    const content = readFileSync(agentFile, 'utf-8').replace(/^\uFEFF/, '');
     // Extract the YAML frontmatter block (content between the opening and closing ---).
     // Searching the whole file would match `model:` lines in the body/prompt text, causing
     // false denies for agents whose prompt happens to contain that word.

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -930,6 +930,43 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(JSON.stringify(output)).not.toContain('MODEL ROUTING');
   });
 
+  it('strips UTF-8 BOM before frontmatter parsing so agent-definition model check still fires', () => {
+    const pluginRoot = join(tempDir, 'fake-plugin-bom');
+    const agentsDir = join(pluginRoot, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    // Write agent file with BOM prefix (\uFEFF)
+    writeFileSync(
+      join(agentsDir, 'bom-agent.md'),
+      '\uFEFF---\nname: bom-agent\nmodel: claude-opus-4-6\n---\nAgent body with BOM.',
+    );
+
+    const output = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Agent',
+        toolInput: {
+          subagent_type: 'oh-my-claudecode:bom-agent',
+          description: 'BOM test',
+          prompt: 'Test BOM handling',
+        },
+        cwd: tempDir,
+        session_id: 'session-bom-test',
+      },
+      {
+        OMC_ROUTING_FORCE_INHERIT: 'true',
+        OMC_SUBAGENT_MODEL: 'global.anthropic.claude-sonnet-4-6',
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+      },
+    );
+
+    // BOM must be stripped so the frontmatter regex matches and the bare
+    // Anthropic model ID triggers a deny — not silently bypassed.
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(hookOutput.permissionDecisionReason as string).toContain('[MODEL ROUTING]');
+    expect(hookOutput.permissionDecisionReason as string).toContain('bom-agent');
+  });
+
   it('does NOT deny Agent call without subagent_type in forceInherit mode (normal inheritance unchanged)', () => {
     const output = runPreToolEnforcerWithEnv(
       {


### PR DESCRIPTION
## Summary
- `readAgentDefinitionModel` uses `readFileSync(file, 'utf-8')` which preserves the UTF-8 BOM (`﻿`) at position 0 (confirmed empirically on Node v20)
- The frontmatter regex `^---` anchors to start-of-string, which fails when BOM is present
- This causes the function to return `null`, silently bypassing the Bedrock agent-definition model check
- Result: agent spawned with a bare Anthropic model ID → Bedrock 400 error with no helpful guidance

**Fix:** One-line `.replace(/^﻿/, '')` after `readFileSync` to strip BOM before regex matching.

## Testing
- `npx vitest run src/__tests__/pre-tool-enforcer.test.ts -t "strips UTF-8 BOM"` — new test passes
- Test creates an agent file with BOM prefix and verifies the deny path still fires
- All 40 existing pre-tool-enforcer tests pass

## Notes
- Scope-risk: narrow — single-line change in `readAgentDefinitionModel`, only affects BOM-prefixed files
- No existing agent files have BOM today, but Windows editors (Notepad) historically add BOM to UTF-8 files
- Follows the hardening pattern from PR #2107 (same function, same file)