### PR TITLE
fix(skill-state): add recency check to orchestrator idle bypass

### DIFF
--- a/src/hooks/skill-state/index.ts
+++ b/src/hooks/skill-state/index.ts
@@ -17,7 +17,7 @@
  */
 
 import { writeModeState, readModeState, clearModeStateFile } from '../../lib/mode-state-io.js';
-import { getActiveAgentCount } from '../subagent-tracker/index.js';
+import { getActiveAgentSnapshot } from '../subagent-tracker/index.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -288,7 +288,14 @@ export function checkSkillActiveState(
   // Orchestrators are allowed to go idle while delegated work is still active.
   // Do not consume a reinforcement here; the skill is still active and should
   // resume enforcement only after the running subagents finish.
-  if (getActiveAgentCount(directory) > 0) {
+  // Use a recency window to avoid trusting stale tracking data (same pattern
+  // as RALPLAN_ACTIVE_AGENT_RECENCY_WINDOW_MS in persistent-mode/index.ts).
+  const ACTIVE_AGENT_RECENCY_MS = 5_000;
+  const agentSnapshot = getActiveAgentSnapshot(directory);
+  const agentStateAge = agentSnapshot.lastUpdatedAt
+    ? Date.now() - new Date(agentSnapshot.lastUpdatedAt).getTime()
+    : Infinity;
+  if (agentSnapshot.count > 0 && agentStateAge <= ACTIVE_AGENT_RECENCY_MS) {
     return { shouldBlock: false, message: '', skillName: state.skill_name };
   }
 


### PR DESCRIPTION
## Summary

- `getActiveAgentCount()` in skill-state idle bypass discards `lastUpdatedAt`, trusting stale tracking data indefinitely
- If `subagent-tracking.json` stops updating (debounce race, lost SubagentStop event), the idle bypass fires every stop hook invocation without incrementing `reinforcement_count`
- Skill active state becomes a ghost blocking new skill activations until stale TTL expires (5-30 min)

Fix: use `getActiveAgentSnapshot()` with a 5-second recency window, matching the proven `RALPLAN_ACTIVE_AGENT_RECENCY_WINDOW_MS` pattern at `persistent-mode/index.ts:919`.

**Source-only diff: 1 file, +9/-2. No `dist/`, no `bridge/`.**

```
src/hooks/skill-state/index.ts  +9/-2
```

## Problem

```typescript
// BEFORE: trusts stale data indefinitely
if (getActiveAgentCount(directory) > 0) {
  return { shouldBlock: false, message: '', skillName: state.skill_name };
}

// AFTER: only trusts fresh (<5s) tracking data
const agentSnapshot = getActiveAgentSnapshot(directory);
const agentStateAge = agentSnapshot.lastUpdatedAt
  ? Date.now() - new Date(agentSnapshot.lastUpdatedAt).getTime()
  : Infinity;
if (agentSnapshot.count > 0 && agentStateAge <= ACTIVE_AGENT_RECENCY_MS) {
  return { shouldBlock: false, message: '', skillName: state.skill_name };
}
```

## Test plan

- [x] Existing skill-state tests pass
- [ ] Manual: verify skill-active state clears correctly when subagents finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)