### PR TITLE
fix(wiki): guard writePageUnsafe against reserved filenames

### DIFF
--- a/src/hooks/wiki/__tests__/reserved-file-guard.test.ts
+++ b/src/hooks/wiki/__tests__/reserved-file-guard.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { writePageUnsafe, ensureWikiDir, withWikiLock } from '../storage.js';
+import { WIKI_SCHEMA_VERSION } from '../types.js';
+import type { WikiPage } from '../types.js';
+
+function makePage(filename: string): WikiPage {
+  return {
+    filename,
+    frontmatter: {
+      title: 'Test', tags: [], created: '2025-01-01T00:00:00.000Z',
+      updated: '2025-01-01T00:00:00.000Z', sources: [], links: [],
+      category: 'reference', confidence: 'medium', schemaVersion: WIKI_SCHEMA_VERSION,
+    },
+    content: '\n# Test\n\nContent.\n',
+  };
+}
+
+describe('writePageUnsafe reserved file guard', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-guard-'));
+    ensureWikiDir(tempDir);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should throw when writing to index.md', () => {
+    expect(() => {
+      withWikiLock(tempDir, () => writePageUnsafe(tempDir, makePage('index.md')));
+    }).toThrow('Cannot write to reserved wiki file');
+  });
+
+  it('should throw when writing to log.md', () => {
+    expect(() => {
+      withWikiLock(tempDir, () => writePageUnsafe(tempDir, makePage('log.md')));
+    }).toThrow('Cannot write to reserved wiki file');
+  });
+
+  it('should allow non-reserved filenames', () => {
+    expect(() => {
+      withWikiLock(tempDir, () => writePageUnsafe(tempDir, makePage('auth.md')));
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/wiki/storage.ts
+++ b/src/hooks/wiki/storage.ts
@@ -258,6 +258,9 @@ export function readLog(root: string): string | null {
 
 /** Write a wiki page to disk. MUST be called inside withWikiLock. */
 export function writePageUnsafe(root: string, page: WikiPage): void {
+  if (RESERVED_FILES.has(page.filename)) {
+    throw new Error(`Cannot write to reserved wiki file: ${page.filename}`);
+  }
   const wikiDir = ensureWikiDir(root);
   const filePath = safeWikiPath(wikiDir, page.filename);
   if (!filePath) throw new Error(`Invalid wiki page filename: ${page.filename}`);


### PR DESCRIPTION
## Summary

`writePageUnsafe` has no guard against reserved filenames (`index.md`, `log.md`). Titles like "Log" overwrite the wiki operation log.

Fixes #2280

## Change

| File | Lines | What |
|------|-------|------|
| `storage.ts` | +3 | `RESERVED_FILES` check at top of `writePageUnsafe` |
| `reserved-file-guard.test.ts` | +50 (new) | 3 tests |

## Test plan

- [x] 3 new tests + 29 existing storage tests pass