### PR TITLE
fix(wiki): escape newlines in title to prevent frontmatter corruption

### DIFF
--- a/src/hooks/wiki/__tests__/escape-newline.test.ts
+++ b/src/hooks/wiki/__tests__/escape-newline.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { serializePage, parseFrontmatter } from '../storage.js';
+import { WIKI_SCHEMA_VERSION } from '../types.js';
+import type { WikiPage } from '../types.js';
+
+function makePage(title: string): WikiPage {
+  return {
+    filename: 'test.md',
+    frontmatter: {
+      title, tags: [], created: '2025-01-01T00:00:00.000Z',
+      updated: '2025-01-01T00:00:00.000Z', sources: [], links: [],
+      category: 'reference', confidence: 'medium', schemaVersion: WIKI_SCHEMA_VERSION,
+    },
+    content: '\n# Test\n',
+  };
+}
+
+describe('escapeYaml newline handling', () => {
+  it('should roundtrip title with newline', () => {
+    const page = makePage('Line1\nLine2');
+    const raw = serializePage(page);
+    expect(raw).toContain('title: "Line1\\nLine2"');
+    const parsed = parseFrontmatter(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.frontmatter.title).toBe('Line1\nLine2');
+  });
+
+  it('should roundtrip title with carriage return', () => {
+    const page = makePage('Before\rAfter');
+    const raw = serializePage(page);
+    const parsed = parseFrontmatter(raw);
+    expect(parsed!.frontmatter.title).toBe('Before\rAfter');
+  });
+
+  it('should roundtrip literal backslash-n without corruption (regression)', () => {
+    const page = makePage('Windows\\new');
+    const raw = serializePage(page);
+    const parsed = parseFrontmatter(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.frontmatter.title).toBe('Windows\\new');
+  });
+
+  it('should roundtrip backslash followed by actual newline', () => {
+    const page = makePage('path\\\nline2');
+    const raw = serializePage(page);
+    const parsed = parseFrontmatter(raw);
+    expect(parsed!.frontmatter.title).toBe('path\\\nline2');
+  });
+});

--- a/src/hooks/wiki/storage.ts
+++ b/src/hooks/wiki/storage.ts
@@ -127,7 +127,7 @@ function parseSimpleYaml(yaml: string): Record<string, string> {
     // Strip surrounding quotes and unescape
     if ((value.startsWith('"') && value.endsWith('"')) ||
         (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+      value = value.slice(1, -1).replace(/\\(\\|"|n|r)/g, (_, ch) => { if (ch === 'n') return '\n'; if (ch === 'r') return '\r'; return ch; });
     }
     if (key) result[key] = value;
   }
@@ -142,7 +142,7 @@ function parseYamlArray(value: string | undefined): string[] {
     return trimmed
       .slice(1, -1)
       .split(',')
-      .map(s => s.trim().replace(/^["']|["']$/g, '').replace(/\\"/g, '"').replace(/\\\\/g, '\\'))
+      .map(s => s.trim().replace(/^["']|["']$/g, '').replace(/\\(\\|"|n|r)/g, (_, ch) => { if (ch === 'n') return '\n'; if (ch === 'r') return '\r'; return ch; }))
       .filter(Boolean);
   }
   return trimmed ? [trimmed] : [];
@@ -150,7 +150,7 @@ function parseYamlArray(value: string | undefined): string[] {
 
 /** Escape a string for use inside YAML double quotes. */
 function escapeYaml(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
 }
 
 /**


### PR DESCRIPTION
## Summary

`escapeYaml` does not escape `\n`/`\r`. Titles with newlines produce raw line breaks in YAML frontmatter, corrupting the page on re-read.

Fixes #2281

## Change

| File | Lines | What |
|------|-------|------|
| `storage.ts` | +1/-1 | Add `\n`/`\r` to `escapeYaml`; add matching unescape in `parseSimpleYaml` |
| `escape-newline.test.ts` | +45 (new) | 2 roundtrip tests |

## Test plan

- [x] 2 new tests + 29 existing storage tests pass