### PR TITLE
fix(wiki): normalize CRLF in parseFrontmatter for Windows compatibility

### DIFF
--- a/src/hooks/wiki/__tests__/crlf-parse.test.ts
+++ b/src/hooks/wiki/__tests__/crlf-parse.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { parseFrontmatter } from '../storage.js';
+
+describe('parseFrontmatter CRLF handling', () => {
+  it('should parse LF frontmatter (baseline)', () => {
+    const raw = '---\ntitle: Test\ntags: []\n---\n\n# Content\n';
+    const result = parseFrontmatter(raw);
+    expect(result).not.toBeNull();
+    expect(result!.frontmatter.title).toBe('Test');
+  });
+
+  it('should parse CRLF frontmatter', () => {
+    const raw = '---\r\ntitle: Test\r\ntags: []\r\n---\r\n\r\n# Content\r\n';
+    const result = parseFrontmatter(raw);
+    expect(result).not.toBeNull();
+    expect(result!.frontmatter.title).toBe('Test');
+  });
+
+  it('should parse mixed line endings', () => {
+    const raw = '---\r\ntitle: Mixed\ntags: []\r\n---\n\n# Content\n';
+    const result = parseFrontmatter(raw);
+    expect(result).not.toBeNull();
+    expect(result!.frontmatter.title).toBe('Mixed');
+  });
+});

--- a/src/hooks/wiki/storage.ts
+++ b/src/hooks/wiki/storage.ts
@@ -91,7 +91,9 @@ export function withWikiLock<T>(root: string, fn: () => T): T {
  * Expects content starting with `---\n...\n---\n`.
  */
 export function parseFrontmatter(raw: string): { frontmatter: WikiPageFrontmatter; content: string } | null {
-  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  // Normalize CRLF to LF so files edited on Windows are still parseable
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const match = normalized.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) return null;
 
   const yamlBlock = match[1];


### PR DESCRIPTION
## Summary

`parseFrontmatter` regex requires `
`. Files with Windows CRLF silently fail to parse, making pages invisible.

Fixes #2282

## Change

| File | Lines | What |
|------|-------|------|
| `storage.ts` | +2/-1 | Normalize `
` to `
` before regex |
| `crlf-parse.test.ts` | +25 (new) | 3 tests (LF, CRLF, mixed) |

## Test plan

- [x] 3 new tests + 29 existing storage tests pass