### PR TITLE
fix(keyword-detector): sync Korean informational patterns and self-improve CJS protection

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -398,6 +398,7 @@ const SKILL_PROTECTION_MAP = {
 
   // === Heavy protection (long-running, 10 reinforcements) ===
   deepinit: 'heavy',
+  'self-improve': 'heavy',
 };
 
 function getSkillProtectionLevel(skillName, rawSkillName) {

--- a/src/features/magic-keywords.ts
+++ b/src/features/magic-keywords.ts
@@ -22,7 +22,7 @@ function removeCodeBlocks(text: string): string {
 
 const INFORMATIONAL_INTENT_PATTERNS: RegExp[] = [
   /\b(?:what(?:'s|\s+is)|what\s+are|how\s+(?:to|do\s+i)\s+use|explain|explanation|tell\s+me\s+about|describe)\b/i,
-  /(?:뭐야|무엇(?:이야|인가요)?|어떻게|설명|사용법)/u,
+  /(?:뭐야|뭔데|무엇(?:이야|인가요)?|어떻게|설명|사용법|알려\s?줘|알려줄래|소개해?\s?줘|소개\s*부탁|설명해\s?줘|뭐가\s*달라|어떤\s*기능|기능\s*(?:알려|설명|뭐)|방법\s*(?:알려|설명|뭐))/u,
   /(?:とは|って何|使い方|説明)/u,
   /(?:什么是|什麼是|怎(?:么|樣)用|如何使用|解释|說明|说明)/u,
 ];


### PR DESCRIPTION
## Summary

- `magic-keywords.ts` had 5 Korean informational patterns vs 18 in `keyword-detector/index.ts` (expanded in 288bd97d). "ralph 알려줘" falsely activates ralph mode
- `self-improve` missing from CJS `SKILL_PROTECTION_MAP` in `pre-tool-enforcer.mjs` — no stop-hook protection in production hook path

**Source-only diff: 2 files, +2/-1. No `dist/`, no `bridge/`.**

```
src/features/magic-keywords.ts    +1/-1  (sync 13 missing Korean alternations)
scripts/pre-tool-enforcer.mjs     +1     (add self-improve: heavy)
```

## Problem

```typescript
// magic-keywords.ts:25 — BEFORE (5 patterns, missing 13)
/(?:뭐야|무엇(?:이야|인가요)?|어떻게|설명|사용법)/u

// keyword-detector/index.ts:121 — canonical (18 patterns)
/(?:뭐야|뭔데|무엇(?:이야|인가요)?|어떻게|설명|사용법|알려\s?줘|알려줄래|...)/u
```

Korean user asks "ralph 알려줘" (tell me about ralph):
- keyword-detector ✅ correctly skips (informational)
- magic-keywords ❌ injects ralph mode (pattern too narrow)

## Test plan

- [ ] Manual: "ralph 알려줘" no longer triggers ralph mode activation
- [ ] Existing keyword-detector tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)