### PR TITLE
fix(team): sync worker_count after canonicalization dedup (#2289)

### DIFF
--- a/src/team/__tests__/worker-canonicalization.test.ts
+++ b/src/team/__tests__/worker-canonicalization.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canonicalizeWorkers } from '../worker-canonicalization.js';
+import { canonicalizeWorkers, canonicalizeTeamConfigWorkers } from '../worker-canonicalization.js';
 
 describe('canonicalizeWorkers', () => {
   it('prefers pane identity, backfills metadata, and unions assigned tasks', () => {
@@ -32,5 +32,22 @@ describe('canonicalizeWorkers', () => {
       working_dir: '/tmp/a',
       assigned_tasks: ['2', '1'],
     });
+  });
+
+  it('syncs worker_count with deduplicated workers array', () => {
+    const config = {
+      name: 'test-team',
+      task: 'demo',
+      worker_count: 3,
+      workers: [
+        { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: ['1'] },
+        { name: 'worker-1', index: 0, role: '', assigned_tasks: [] },
+        { name: 'worker-2', index: 2, role: 'executor', assigned_tasks: [] },
+      ],
+    };
+
+    const result = canonicalizeTeamConfigWorkers(config as any);
+    expect(result.workers).toHaveLength(2);
+    expect(result.worker_count).toBe(2);
   });
 });

--- a/src/team/worker-canonicalization.ts
+++ b/src/team/worker-canonicalization.ts
@@ -108,5 +108,6 @@ export function canonicalizeTeamConfigWorkers(config: TeamConfig): TeamConfig {
   return {
     ...config,
     workers,
+    worker_count: workers.length,
   };
 }


### PR DESCRIPTION
## Summary

Fixes a stale `worker_count` field after `canonicalizeTeamConfigWorkers` removes duplicate workers. One-line fix that syncs `worker_count` with the deduplicated `workers.length`.

**Source-only diff: 2 files, +19/-1. No `dist/`, no `bridge/`.**

```
src/team/worker-canonicalization.ts                    +1   (add worker_count sync)
src/team/__tests__/worker-canonicalization.test.ts     +18  (regression test)
```

## Impact

**Cosmetic only** — affects HUD/monitoring display. No behavioral impact on scaling decisions (which correctly use `config.workers.length`).

- `monitor.ts:365` exposes stale `workerCount: config.worker_count` in TeamSummary
- `monitor.ts:385` persists stale `worker_count` to manifest via `saveTeamConfig`

All scaling capacity checks and mutation paths already self-heal by setting `worker_count = workers.length` after operations.

## Root cause

Classic "spread-then-partial-override" bug:

```typescript
return {
  ...config,      // preserves original worker_count (stale)
  workers,        // only overrides workers array (deduplicated)
};
```

## Fix

```typescript
return {
  ...config,
  workers,
  worker_count: workers.length,  // sync with deduplicated array
};
```

## Testing

- `npx vitest run src/team/__tests__/worker-canonicalization.test.ts`

Closes #2289