### PR TITLE
fix(launch): mirror keybindings.json and rules/ to runtime config dir

### DIFF
--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -894,6 +894,19 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     expect(existsSync(join(runtimeDir, 'settings.json'))).toBe(true);
   });
 
+  it('mirrors keybindings.json and rules/ into the runtime config dir', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(join(configDir, 'rules'), { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(configDir, 'keybindings.json'), '{"bindings":[]}');
+    writeFileSync(join(configDir, 'rules', 'my-rule.md'), '# Rule');
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    expect(runtimeDir).not.toBe(configDir);
+    expect(existsSync(join(runtimeDir, 'keybindings.json'))).toBe(true);
+    expect(existsSync(join(runtimeDir, 'rules'))).toBe(true);
+  });
+
   it('leaves CLAUDE_CONFIG_DIR unchanged when no preserved companion exists', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(configDir, { recursive: true });

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -92,10 +92,12 @@ export function prepareOmcLaunchConfigDir(baseConfigDir = process.env.CLAUDE_CON
     'hud',
     'plugins',
     'projects',
+    'rules',
     'skills',
     '.omc-config.json',
     '.omc-version.json',
     '.omc-silent-update.json',
+    'keybindings.json',
     'settings.json',
     'settings.local.json',
   ]) {


### PR DESCRIPTION
## Summary
- `prepareOmcLaunchConfigDir` creates a runtime config dir when `CLAUDE-omc.md` is active, but the mirror list omitted `keybindings.json` and `rules/`
- Claude Code reads both from `CLAUDE_CONFIG_DIR` (confirmed via binary analysis: 32 references to `keybindings.json`)
- Custom keybindings and user rules silently reverted to defaults during `omc` launch sessions

## Testing
- `npx vitest run src/cli/__tests__/launch.test.ts -t "mirrors keybindings"` — new test passes
- Existing launch tests unaffected