### PR TITLE
fix(setup): clean up preserve-mode artifacts on overwrite

### DIFF
--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -298,6 +298,11 @@ else
     echo "Installed OMC companion file and preserved existing CLAUDE.md"
   else
     # No markers: wrap new content in markers, append old content as user section
+    # Strip any preserve-mode import block left by a prior preserve install
+    if grep -Fq "$OMC_IMPORT_START" "$TARGET_PATH"; then
+      perl -0pe 's/^<!-- OMC:IMPORT:START -->\R[\s\S]*?^<!-- OMC:IMPORT:END -->(?:\R)?//msg' "$TARGET_PATH" > "${TARGET_PATH}.importless"
+      mv "${TARGET_PATH}.importless" "$TARGET_PATH"
+    fi
     OLD_CONTENT=$(cat "$TARGET_PATH")
     {
       echo '<!-- OMC:START -->'
@@ -311,6 +316,20 @@ else
     echo "Migrated existing CLAUDE.md (added OMC markers, preserved old content)"
   fi
   rm -f "$TEMP_OMC"
+
+  # Clean up orphaned companion file from a prior preserve-mode install.
+  # If left behind, prepareOmcLaunchConfigDir reads stale companion content
+  # instead of the freshly-updated CLAUDE.md during omc launches.
+  if [ "$MODE" = "global" ] && [ "$INSTALL_STYLE" = "overwrite" ]; then
+    COMPANION_TARGET_PATH="$CONFIG_DIR/$COMPANION_FILENAME"
+    if [ -f "$COMPANION_TARGET_PATH" ]; then
+      if [ -n "$BACKUP_DATE" ]; then
+        cp "$COMPANION_TARGET_PATH" "${COMPANION_TARGET_PATH}.backup.${BACKUP_DATE}"
+      fi
+      rm -f "$COMPANION_TARGET_PATH"
+      echo "Removed orphaned companion file from prior preserve-mode install"
+    fi
+  fi
 fi
 
 if ! grep -q '<!-- OMC:START -->' "$VALIDATION_PATH" || ! grep -q '<!-- OMC:END -->' "$VALIDATION_PATH"; then

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -348,6 +348,58 @@ Use the real docs file.
     expect(readFileSync(join(configDir, 'CLAUDE-omc.md'), 'utf-8')).toContain('<!-- OMC:VERSION:9.9.9 -->');
   });
 
+  it('cleans up orphaned companion file when switching from preserve to overwrite mode', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '# User CLAUDE\nKeep my base config.\n');
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ plugins: ['oh-my-claudecode'] }));
+
+    const env = {
+      ...process.env,
+      HOME: fixture.homeRoot,
+      CLAUDE_CONFIG_DIR: configDir,
+    };
+
+    // Run 1: preserve mode — creates companion + import block
+    const first = spawnSync('bash', [fixture.scriptPath, 'global', 'preserve'], {
+      cwd: fixture.projectRoot,
+      env,
+      encoding: 'utf-8',
+    });
+    expect(first.status).toBe(0);
+    expect(existsSync(join(configDir, 'CLAUDE-omc.md'))).toBe(true);
+    expect(readFileSync(join(configDir, 'CLAUDE.md'), 'utf-8')).toContain('<!-- OMC:IMPORT:START -->');
+
+    // Run 2: overwrite mode (default) — must clean up companion and import block
+    const second = spawnSync('bash', [fixture.scriptPath, 'global', 'overwrite'], {
+      cwd: fixture.projectRoot,
+      env,
+      encoding: 'utf-8',
+    });
+    expect(second.status).toBe(0);
+
+    // Companion file must be removed
+    expect(existsSync(join(configDir, 'CLAUDE-omc.md'))).toBe(false);
+
+    // CLAUDE.md must have OMC markers inline, not an import block
+    const baseClaude = readFileSync(join(configDir, 'CLAUDE.md'), 'utf-8');
+    expect(baseClaude).toContain('<!-- OMC:START -->');
+    expect(baseClaude).toContain('<!-- OMC:END -->');
+    expect(baseClaude).not.toContain('<!-- OMC:IMPORT:START -->');
+    expect(baseClaude).not.toContain('@CLAUDE-omc.md');
+
+    // User content should be preserved
+    expect(baseClaude).toContain('# User CLAUDE');
+  });
+
   it('refuses preserve mode when the companion path is a symlink', () => {
     const fixture = createPluginFixture(`<!-- OMC:START -->
 <!-- OMC:VERSION:9.9.9 -->


### PR DESCRIPTION
## Summary
- When switching from `global preserve` to `global overwrite`, the orphaned `CLAUDE-omc.md` and `<!-- OMC:IMPORT -->` block were never cleaned up
- `omc` launches read stale companion content via `prepareOmcLaunchConfigDir` instead of the freshly-updated `CLAUDE.md`
- Direct `claude` launches saw duplicate OMC instructions

**Fix:**
1. Strip `<!-- OMC:IMPORT -->` block before migrating user content in the no-markers branch
2. Delete orphaned companion file (with backup) in global overwrite mode

## Testing
- `npx vitest run src/__tests__/setup-claude-md-script.test.ts` — all 12 tests pass including new transition test
- Manual verification: `preserve` → `overwrite` correctly removes companion and import block