### PR TITLE
fix(prompt-prerequisites): move progress recording after blocking check

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1526,19 +1526,9 @@ function processPreToolUse(input: HookInput): HookOutput {
     : [];
   let modifiedToolInput: Record<string, unknown> | undefined;
 
-  const promptPrerequisiteProgress = recordPromptPrerequisiteProgress(
-    directory,
-    input.sessionId,
-    input.toolName,
-    input.toolInput,
-  );
-
-  if (promptPrerequisiteProgress?.isComplete) {
-    preToolMessages.push(
-      "[PROMPT PREREQUISITES COMPLETE] Required context tools/files were read. Editing and agent delegation are unblocked.",
-    );
-  }
-
+  // Check blocking BEFORE recording progress — otherwise a denied tool
+  // (e.g. Edit) that also matches a prerequisite would have its progress
+  // persisted even though the tool never actually executed.
   const promptPrerequisiteState = readPromptPrerequisiteState(directory, input.sessionId);
   if (
     promptPrerequisiteState?.active
@@ -1552,6 +1542,19 @@ function processPreToolUse(input: HookInput): HookOutput {
         permissionDecisionReason: buildPromptPrerequisiteDenyReason(promptPrerequisiteState, input.toolName),
       },
     } as HookOutput & { hookSpecificOutput: Record<string, unknown> };
+  }
+
+  const promptPrerequisiteProgress = recordPromptPrerequisiteProgress(
+    directory,
+    input.sessionId,
+    input.toolName,
+    input.toolInput,
+  );
+
+  if (promptPrerequisiteProgress?.isComplete) {
+    preToolMessages.push(
+      "[PROMPT PREREQUISITES COMPLETE] Required context tools/files were read. Editing and agent delegation are unblocked.",
+    );
   }
 
   // Force-inherit: deny Task/Agent calls that carry a `model` parameter when


### PR DESCRIPTION
## Summary
- Move `recordPromptPrerequisiteProgress` call to after `isPromptPrerequisiteBlockingTool` check
- Prevents denied tools from having prerequisite progress persisted to disk
- Keeps scope limited to reordering two blocks in `processPreToolUse`

## Root cause
The progress recording call preceded the blocking check, so a denied tool (e.g. Edit) that matched a prerequisite would have its completion written to disk before the deny was returned.

## Testing
- `npx vitest run src/hooks/__tests__/prompt-prerequisites.test.ts`
- `npx tsc --noEmit`

Source-only diff: 1 file, +16/-13. No dist/, no bridge/.

Closes #2299