### PR TITLE
fix(prompt-prerequisites): require path prefix or file extension in isLikelyPath

### DIFF
--- a/src/hooks/prompt-prerequisites/index.ts
+++ b/src/hooks/prompt-prerequisites/index.ts
@@ -84,7 +84,13 @@ function isLikelyPath(value: string): boolean {
   if (/^https?:\/\//i.test(value)) return false;
   if (value.startsWith("#")) return false;
   if (value.includes("://")) return false;
-  return value.includes("/") || value.startsWith("./") || value.startsWith("../");
+  // Require an explicit path prefix to avoid false positives on
+  // slash-separated English words like "read/write", "input/output".
+  if (value.startsWith("./") || value.startsWith("../") || value.startsWith("/")) return true;
+  // For bare relative paths (e.g. "src/foo.ts"), require a recognisable
+  // file extension in the last segment to distinguish from natural language.
+  const lastSegment = value.split("/").pop() || "";
+  return /\.[a-z0-9]{1,10}$/i.test(lastSegment);
 }
 
 export function getPromptPrerequisiteConfig(


### PR DESCRIPTION
## Summary
- Tighten `isLikelyPath` to require `./ ../ /` prefix or file extension
- Prevents false positives on "read/write", "input/output", "true/false"
- Still detects real paths like `src/hooks/bridge.ts` (has `.ts` extension)

## Root cause
`isLikelyPath` returned `true` for any string containing `/`, matching common English slash-phrases.

## Testing
- `npx vitest run src/hooks/__tests__/prompt-prerequisites.test.ts`
- `npx tsc --noEmit`

Source-only diff: 1 file, +7/-1. No dist/, no bridge/.

Closes #2300