### PR TITLE
fix(security): block all tmux subcommands in worker context

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -102,8 +102,7 @@ import { wrapUntrustedFileContent } from "../agents/prompt-helpers.js";
 
 const PKILL_F_FLAG_PATTERN = /\bpkill\b.*\s-f\b/;
 const PKILL_FULL_FLAG_PATTERN = /\bpkill\b.*--full\b/;
-const WORKER_BLOCKED_TMUX_PATTERN =
-  /\btmux\s+(split-window|new-session|new-window|join-pane|send-keys)\b/i;
+const WORKER_BLOCKED_TMUX_PATTERN = /\btmux\s+/i;
 const WORKER_BLOCKED_TEAM_CLI_PATTERN = /\bom[cx]\s+team\b(?!\s+api\b)/i;
 const WORKER_BLOCKED_SKILL_PATTERN = /\$(team|ultrawork|autopilot|ralph)\b/i;
 


### PR DESCRIPTION
## Summary

- Block all `tmux <subcommand>` invocations in worker context instead of maintaining an incomplete denylist of 5 specific subcommands

## Problem

The worker tmux blocklist at `src/hooks/bridge.ts:105-106` only blocks `split-window`, `new-session`, `new-window`, `join-pane`, and `send-keys`. Dangerous alternatives like `run-shell`, `pipe-pane`, `source-file`, `load-buffer`, and `if-shell` bypass the check entirely.

## Fix

Replace the incomplete subcommand denylist with a pattern that blocks all `tmux <subcommand>` invocations:

```diff
-const WORKER_BLOCKED_TMUX_PATTERN =
-  /tmux\s+(split-window|new-session|new-window|join-pane|send-keys)/i;
+const WORKER_BLOCKED_TMUX_PATTERN = /tmux\s+/i;
```

## Test plan

- [ ] Existing team worker tests pass
- [ ] `tmux run-shell`, `tmux pipe-pane`, `tmux source-file` are now blocked

Fixes #2292