### PR TITLE
fix(hud): handle ST-terminated OSC 8 sequences in ANSI regex

### DIFF
--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -45,7 +45,7 @@ import { renderLastTool } from "./elements/last-tool.js";
  * ANSI escape sequence regex (matches SGR and other CSI sequences).
  * Used to skip escape codes when measuring/truncating visible width.
  */
-const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07/;
+const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/;
 
 const PLAIN_SEPARATOR = " | ";
 const DIM_SEPARATOR = dim(PLAIN_SEPARATOR);

--- a/src/hud/sanitize.ts
+++ b/src/hud/sanitize.ts
@@ -25,7 +25,7 @@
 const CSI_NON_SGR_REGEX = /\x1b\[\??[0-9;]*[A-LN-Za-ln-z]/g;
 
 // Matches OSC sequences (ESC]...BEL) - operating system commands
-const OSC_REGEX = /\x1b\][^\x07]*\x07/g;
+const OSC_REGEX = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 
 // Matches simple escape sequences (ESC + single char, but not [ or ])
 const SIMPLE_ESC_REGEX = /\x1b[^[\]]/g;

--- a/src/utils/string-width.ts
+++ b/src/utils/string-width.ts
@@ -130,7 +130,7 @@ export function stripAnsi(str: string): string {
   // ANSI escape code pattern: ESC [ ... m (SGR sequences)
   // Also handles other common sequences
   return str.replace(
-    /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07/g,
+    /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g,
     ""
   );
 }


### PR DESCRIPTION
## Summary
- Update ANSI regex in render.ts, string-width.ts, and sanitize.ts to match both BEL and ST terminators
- Fixes width miscalculation and garbled truncation when `useHyperlinks: true`

## Root cause
`osc8Link` in cwd.ts emits OSC 8 with ST terminator (`\x1b\\`), but all three ANSI regex patterns only match BEL (`\x07`). Raw escape bytes were counted as visible characters.

## Testing
- `npx vitest run src/__tests__/hud/render.test.ts src/__tests__/hud/cwd.test.ts`
- `npx tsc --noEmit`

Source-only diff: 3 files, +3/-3. No dist/, no bridge/.

Closes #2303