### PR TITLE
fix(security): enforce hardMaxIterations for ultrawork persistent mode

### DIFF
--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -1057,6 +1057,18 @@ async function checkUltrawork(
     };
   }
 
+  // Enforce hard max iterations for ultrawork (mirrors ralph enforcement).
+  const hardMax = getHardMaxIterations();
+  if (hardMax > 0 && state.reinforcement_count >= hardMax) {
+    deactivateUltrawork(workingDir, sessionId);
+    return {
+      shouldBlock: true,
+      message: '[ULTRAWORK - HARD LIMIT] Reached hard max iterations (' + hardMax + '). Mode auto-disabled. Restart with /oh-my-claudecode:ultrawork if needed.',
+      mode: 'ultrawork',
+      metadata: { reinforcementCount: state.reinforcement_count }
+    };
+  }
+
   // Reinforce ultrawork mode - ALWAYS continue while active.
   // This prevents false stops from bash errors, transient failures, etc.
   const newState = incrementReinforcement(workingDir, sessionId);


### PR DESCRIPTION
## Summary
- Add `getHardMaxIterations()` check in `checkUltrawork()` mirroring the ralph pattern
- Auto-deactivates ultrawork when `reinforcement_count >= hardMax`
- Closes the gap where ultrawork could run indefinitely under `OMC_SECURITY=strict`

## Root cause
PR #2010 added hard max limits for "persistent modes" but only implemented it in `checkRalphLoop`. `checkUltrawork` had no such check.

## Testing
- `npx vitest run src/hooks/persistent-mode/__tests__/ralph-hard-max.test.ts`
- `npx tsc --noEmit`

Source-only diff: 1 file, +12/-0. No dist/, no bridge/.

Closes #2305