### PR TITLE
fix(security): reject non-positive hardMaxIterations in strict mode

### DIFF
--- a/src/lib/security-config.ts
+++ b/src/lib/security-config.ts
@@ -105,7 +105,7 @@ export function getSecurityConfig(): SecurityConfig {
       disableAutoUpdate: base.disableAutoUpdate || (fileOverrides.disableAutoUpdate ?? false),
       disableRemoteMcp: base.disableRemoteMcp || (fileOverrides.disableRemoteMcp ?? false),
       disableExternalLLM: base.disableExternalLLM || (fileOverrides.disableExternalLLM ?? false),
-      hardMaxIterations: Math.min(base.hardMaxIterations, fileOverrides.hardMaxIterations ?? base.hardMaxIterations),
+      hardMaxIterations: Math.min(base.hardMaxIterations, (typeof fileOverrides.hardMaxIterations === "number" && fileOverrides.hardMaxIterations > 0) ? fileOverrides.hardMaxIterations : base.hardMaxIterations),
     };
   } else {
     cachedConfig = {


### PR DESCRIPTION
## Summary
- Reject `hardMaxIterations <= 0` from config files in strict mode
- Prevents project-local `.claude/omc.jsonc` from setting `hardMaxIterations: 0` to disable the hard limit
- Boolean fields already use `||` for protection; this aligns the numeric field

## Root cause
`Math.min(200, 0) = 0`, and 0 means "unlimited" in the enforcement code (`hardMax > 0`).

## Testing
- `npx vitest run src/__tests__/security-config.test.ts`
- `npx tsc --noEmit`

Source-only diff: 1 file, +1/-1. No dist/, no bridge/.

Closes #2306