### PR TITLE
fix(security): check iteration directly against hardMax independent of max_iterations

### DIFF
--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -644,29 +644,32 @@ async function checkRalphLoop(
     };
   }
 
-  // Check max iterations (cancel already checked at function entry via cached flag)
-  if (state.iteration >= state.max_iterations) {
-    const hardMax = getHardMaxIterations();
-    if (hardMax > 0 && state.max_iterations >= hardMax) {
-      // Hard limit reached — auto-disable to prevent unbounded execution
-      state.active = false;
-      if (!shouldWriteStateBack(ralphStatePath)) {
-        return {
-          shouldBlock: false,
-          message: '',
-          mode: 'none'
-        };
-      }
-      writeRalphState(workingDir, state, sessionId);
+  // Hard max: check iteration count directly against the security limit,
+  // independent of max_iterations, so it cannot be bypassed by a high
+  // initial max_iterations value.
+  const hardMax = getHardMaxIterations();
+  if (hardMax > 0 && state.iteration >= hardMax) {
+    // Hard limit reached — auto-disable to prevent unbounded execution
+    state.active = false;
+    if (!shouldWriteStateBack(ralphStatePath)) {
       return {
-        shouldBlock: true,
-        message: `[RALPH - HARD LIMIT] Reached hard max iterations (${hardMax}). Mode auto-disabled. Restart with /oh-my-claudecode:ralph if needed.`,
-        mode: 'ralph',
-        metadata: { iteration: state.iteration, maxIterations: state.max_iterations }
+        shouldBlock: false,
+        message: '',
+        mode: 'none'
       };
     }
-    // Extend the limit and continue enforcement so user-visible cancellation
-    // remains the only explicit termination path.
+    writeRalphState(workingDir, state, sessionId);
+    return {
+      shouldBlock: true,
+      message: `[RALPH - HARD LIMIT] Reached hard max iterations (${hardMax}). Mode auto-disabled. Restart with /oh-my-claudecode:ralph if needed.`,
+      mode: 'ralph',
+      metadata: { iteration: state.iteration, maxIterations: state.max_iterations }
+    };
+  }
+
+  // Check max iterations — extend limit so user-visible cancellation
+  // remains the only explicit termination path.
+  if (state.iteration >= state.max_iterations) {
     state.max_iterations += 10;
     if (!shouldWriteStateBack(ralphStatePath)) {
       return {


### PR DESCRIPTION
## Summary
- Move hard max check before and independent of the `max_iterations` gate
- Check `state.iteration >= hardMax` directly instead of relying on `state.max_iterations >= hardMax`
- Prevents bypass when `max_iterations` is initialized above `hardMax`

## Root cause
Hard max check was nested inside `if (state.iteration >= state.max_iterations)`. When `max_iterations=300` and `hardMax=200`, iteration could reach 300 before the hard max was checked.

## Testing
- `npx vitest run src/hooks/persistent-mode/__tests__/ralph-hard-max.test.ts`
- `npx tsc --noEmit`

Source-only diff: 1 file, +8/-7. No dist/, no bridge/.

Closes #2307