### PR TITLE
fix(security): sanitize trigger_message control characters before tmux send-keys

### DIFF
--- a/src/hooks/team-dispatch-hook.ts
+++ b/src/hooks/team-dispatch-hook.ts
@@ -393,7 +393,11 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
       await runProcess('tmux', ['send-keys', '-t', paneTarget, 'C-u'], 1000).catch(() => {});
       await new Promise((r) => setTimeout(r, 50));
     }
-    await runProcess('tmux', ['send-keys', '-t', paneTarget, '-l', request.trigger_message], 3000);
+    // Strip control characters (including newlines) from trigger_message to prevent
+    // keystroke injection — tmux send-keys -l sends literal keystrokes, so a \n
+    // in the message would execute as Enter in the target pane's shell.
+    const sanitizedMessage = request.trigger_message.replace(/[\x00-\x1f\x7f]/g, '');
+    await runProcess('tmux', ['send-keys', '-t', paneTarget, '-l', sanitizedMessage], 3000);
   }
 
   for (let i = 0; i < submitKeyPresses; i++) {


### PR DESCRIPTION
## Summary
- Strip control characters (0x00-0x1f, 0x7f) from `trigger_message` before `tmux send-keys -l`
- Prevents keystroke injection via newlines in the trigger message
- `execFile` prevents shell injection but `-l` flag sends literal keystrokes including `\n` as Enter

## Root cause
`request.trigger_message` flows from MCP parameters to `tmux send-keys -l` unsanitized. A newline would execute as Enter in the target pane shell.

## Testing
- `npx tsc --noEmit`

Source-only diff: 1 file, +5/-1. No dist/, no bridge/.

Closes #2309