### PR TITLE
fix(security): enforce disableExternalLLM in omc ask command

### DIFF
--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -4,6 +4,7 @@ import { readFile, readdir } from 'fs/promises';
 import { constants as osConstants } from 'os';
 import { basename, dirname, isAbsolute, join } from 'path';
 import { fileURLToPath } from 'url';
+import { isExternalLLMDisabled } from '../lib/security-config.js';
 
 export const ASK_USAGE = [
   'Usage: omc ask <claude|codex|gemini> <question or task>',
@@ -210,6 +211,14 @@ function resolveSignalExitCode(signal: NodeJS.Signals | null): number {
 
 export async function askCommand(args: string[]): Promise<void> {
   const parsed = parseAskArgs(args);
+
+  if (parsed.provider !== 'claude' && isExternalLLMDisabled()) {
+    throw new Error(
+      `[ask] External LLM provider "${parsed.provider}" is blocked by security policy ` +
+      `(disableExternalLLM). Only "claude" is allowed in the current security configuration.`,
+    );
+  }
+
   const packageRoot = getPackageRoot();
   const advisorScriptPath = resolveAskAdvisorScriptPath(packageRoot);
   const promptsDir = resolveAskPromptsDir(process.cwd(), packageRoot, process.env);


### PR DESCRIPTION
## Summary

- Add `isExternalLLMDisabled()` check to `omc ask` so non-claude providers are rejected when the security policy forbids external LLM usage

## Problem

`disableExternalLLM` is only enforced in `src/team/model-contract.ts:228` (team worker spawning). The `omc ask codex/gemini` CLI path in `src/cli/ask.ts` has zero security checks — it directly spawns the provider CLI. Agents are actively guided to use `omc ask codex` via runtime guidance (`src/features/builtin-skills/runtime-guidance.ts:37`).

## Fix

```diff
+import { isExternalLLMDisabled } from '../lib/security-config.js';
 ...
 export async function askCommand(args: string[]): Promise<void> {
   const parsed = parseAskArgs(args);
+
+  if (parsed.provider !== 'claude' && isExternalLLMDisabled()) {
+    throw new Error(
+      `[ask] External LLM provider "${parsed.provider}" is blocked by security policy ` +
+      `(disableExternalLLM). Only "claude" is allowed in the current security configuration.`,
+    );
+  }
```

## Test plan

- [ ] `omc ask claude "test"` still works when `disableExternalLLM` is true
- [ ] `omc ask codex "test"` throws error when `disableExternalLLM` is true
- [ ] `omc ask codex "test"` works normally when `disableExternalLLM` is false

Fixes #2293