### PR TITLE
fix(security): clamp hardMaxIterations and enforce in autopilot

### DIFF
--- a/src/hooks/autopilot/enforcement.ts
+++ b/src/hooks/autopilot/enforcement.ts
@@ -10,6 +10,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { getClaudeConfigDir } from "../../utils/config-dir.js";
+import { getHardMaxIterations } from "../../lib/security-config.js";
 import {
   resolveAutopilotPlanPath,
   resolveOpenQuestionsPlanPath,
@@ -220,6 +221,17 @@ export async function checkAutopilot(
 
   if (isAwaitingConfirmation(state)) {
     return null;
+  }
+
+  // Check hard max iterations (global security limit)
+  const hardMax = getHardMaxIterations();
+  if (hardMax > 0 && state.iteration >= hardMax) {
+    transitionPhase(workingDir, "failed", sessionId);
+    return {
+      shouldBlock: false,
+      message: `[AUTOPILOT STOPPED] Hard max iterations (${hardMax}) reached. Security limit enforced.`,
+      phase: "failed",
+    };
   }
 
   // Check max iterations (safety limit)


### PR DESCRIPTION
## Summary

- Prevent `hardMaxIterations: 0` from disabling iteration limits in strict mode
- Add missing `getHardMaxIterations()` enforcement to autopilot

## Problem

**Bug 1:** In strict mode, `Math.min(200, 0) = 0`. Since `0` means "unlimited" (documented at `security-config.ts:31`), a project `.claude/omc.jsonc` with `hardMaxIterations: 0` completely disables the safety limit — even under `OMC_SECURITY=strict`.

**Bug 2:** `src/hooks/autopilot/enforcement.ts` has zero import of `getHardMaxIterations` or `security-config`. Unlike ralph (`persistent-mode/index.ts:649`), autopilot only checks its own soft `max_iterations` with no global backstop.

## Fix

```diff
# security-config.ts:108 — prevent 0 from winning in strict mode
-hardMaxIterations: Math.min(base.hardMaxIterations, fileOverrides.hardMaxIterations ?? base.hardMaxIterations),
+hardMaxIterations: Math.max(1, Math.min(base.hardMaxIterations, fileOverrides.hardMaxIterations ?? base.hardMaxIterations)),

# autopilot/enforcement.ts — add hard max check (matching ralph behavior)
+import { getHardMaxIterations } from "../../lib/security-config.js";
+const hardMax = getHardMaxIterations();
+if (hardMax > 0 && state.iteration >= hardMax) { ... }
```

## Test plan

- [ ] `security-config.test.ts` passes; add test for `hardMaxIterations: 0` in strict mode
- [ ] Autopilot correctly stops at hard max even when `max_iterations` is higher
- [ ] Non-strict mode with `hardMaxIterations: 0` still means unlimited

Fixes #2290