### PR TITLE
fix(cancel): write legacy cancel signal to .omc/state/ instead of worktree root

### DIFF
--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -612,7 +612,7 @@ export const stateClearTool: ToolDefinition<{
           source: 'state_clear' as const,
         };
         // Write to legacy path (checked by stop hook fallback)
-        const legacySignalPath = join(root, 'state', 'cancel-signal-state.json');
+        const legacySignalPath = join(getOmcRoot(root), 'state', 'cancel-signal-state.json');
         try { atomicWriteJsonSync(legacySignalPath, cancelSignalPayload); } catch { /* best-effort */ }
         // Write to each session path (checked by stop hook primary check)
         for (const sid of listSessionIds(root)) {


### PR DESCRIPTION
## Summary
- Fix one-line path bug where legacy cancel signal was written outside `.omc/`
- Source-only diff: 1 file, +1/-1

## Root cause

`src/tools/state-tools.ts:615` used `join(root, 'state', ...)` where `root` is the worktree root. Every other state path in the file (lines 71, 110, 158) uses `join(getOmcRoot(root), 'state', ...)`. The stop hook reads from `.omc/state/` via `resolveSessionStatePath`, so it never found the misplaced signal.

## Failure scenario

1. User runs cancel without `session_id` (force/broad clear path)
2. Legacy cancel signal written to `{worktree}/state/cancel-signal-state.json`
3. Stop hook reads from `{worktree}/.omc/state/cancel-signal-state.json` — file not found
4. Stop hook re-enforces mode that is mid-deletion → ralph/autopilot loop persists after cancel

## Fix

```diff
- const legacySignalPath = join(root, 'state', 'cancel-signal-state.json');
+ const legacySignalPath = join(getOmcRoot(root), 'state', 'cancel-signal-state.json');
```

## Test plan
- [x] `getOmcRoot` already imported at line 19, used at lines 71, 110, 158
- [x] Fix is consistent with all peer write sites in the same file
- [x] Existing cancel-race tests (`persistent-mode/__tests__/cancel-race.test.ts`) continue to pass

Fixes #2220