### PR TITLE
fix: guard Atomics.wait with try/catch in session-registry and subagent-tracker

### DIFF
--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -160,7 +160,13 @@ const flushInProgress = new Set<string>();
 function syncSleep(ms: number): void {
   const buffer = new SharedArrayBuffer(4);
   const view = new Int32Array(buffer);
-  Atomics.wait(view, 0, 0, ms);
+  try {
+    Atomics.wait(view, 0, 0, ms);
+  } catch {
+    // Main thread: Atomics.wait throws on Node <22
+    const waitUntil = Date.now() + ms;
+    while (Date.now() < waitUntil) { /* spin */ }
+  }
 }
 
 // ============================================================================

--- a/src/notifications/session-registry.ts
+++ b/src/notifications/session-registry.ts
@@ -116,7 +116,13 @@ function ensureRegistryDir(): void {
  * Synchronous sleep helper used while waiting for lock acquisition.
  */
 function sleepMs(ms: number): void {
-  Atomics.wait(SLEEP_ARRAY, 0, 0, ms);
+  try {
+    Atomics.wait(SLEEP_ARRAY, 0, 0, ms);
+  } catch {
+    // Main thread: Atomics.wait throws on Node <22
+    const waitUntil = Date.now() + ms;
+    while (Date.now() < waitUntil) { /* spin */ }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add try/catch + spin-wait fallback for `Atomics.wait` on main thread (2 files)
- Source-only diff: 2 files, +14/-2

## Root cause

`sleepMs()` in `session-registry.ts:119` and `syncSleep()` in `subagent-tracker/index.ts:163` call `Atomics.wait` without try/catch. Both run on the main thread (via `bridge.ts`). On Node 20/21, this throws `TypeError`.

The correct pattern already exists in `src/lib/file-lock.ts:183-189`:
```typescript
try {
  Atomics.wait(view, 0, 0, ms);
} catch {
  // Main thread: Atomics.wait throws — brief spin instead
  const waitUntil = Date.now() + ms;
  while (Date.now() < waitUntil) { /* spin */ }
}
```

## Fix

Applied the same try/catch + spin-wait fallback to both `sleepMs()` and `syncSleep()`.

## Test plan
- [x] Pattern matches `file-lock.ts:183-189` exactly
- [x] Project declares `"node": ">=20.0.0"` — must handle Node 20/21
- [x] Two out of three sync-sleep sites in the codebase already have the guard; this fixes the remaining two

Fixes #2304