### PR TITLE
fix(state-tools): correct cancel signal path and add legacy fallback

### DIFF
--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -97,13 +97,19 @@ export function shouldWriteStateBack(statePath: string | null | undefined): bool
  * Used to prevent stop-hook re-enforcement races during /cancel.
  */
 function isSessionCancelInProgress(directory: string, sessionId?: string): boolean {
-  if (!sessionId) return false;
+  let cancelSignalPath: string | undefined;
 
-  let cancelSignalPath: string;
-  try {
-    cancelSignalPath = resolveSessionStatePath('cancel-signal', sessionId, directory);
-  } catch {
-    return false;
+  if (sessionId) {
+    try {
+      cancelSignalPath = resolveSessionStatePath('cancel-signal', sessionId, directory);
+    } catch {
+      // fall through to legacy path
+    }
+  }
+
+  // Fallback: check legacy (non-session-scoped) cancel signal
+  if (!cancelSignalPath) {
+    cancelSignalPath = join(getOmcRoot(directory), 'state', 'cancel-signal-state.json');
   }
 
   if (!existsSync(cancelSignalPath)) {

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -612,7 +612,7 @@ export const stateClearTool: ToolDefinition<{
           source: 'state_clear' as const,
         };
         // Write to legacy path (checked by stop hook fallback)
-        const legacySignalPath = join(root, 'state', 'cancel-signal-state.json');
+        const legacySignalPath = join(getOmcRoot(root), 'state', 'cancel-signal-state.json');
         try { atomicWriteJsonSync(legacySignalPath, cancelSignalPayload); } catch { /* best-effort */ }
         // Write to each session path (checked by stop hook primary check)
         for (const sid of listSessionIds(root)) {


### PR DESCRIPTION
## Summary

- Fix legacy cancel signal being written outside `.omc/` directory
- Add legacy path fallback in `isSessionCancelInProgress` when `sessionId` is undefined

## Problem

**Bug 1:** `state_clear` writes the legacy cancel signal to `join(root, 'state', ...)` which resolves to `<project>/state/cancel-signal-state.json` — missing the `.omc` prefix. All readers expect `<project>/.omc/state/cancel-signal-state.json`. Other code in the same file (line 71) correctly uses `getOmcRoot(root)`.

**Bug 2:** `isSessionCancelInProgress` at `persistent-mode/index.ts:100` returns `false` immediately when `sessionId` is undefined, never checking the legacy path. The template version (`persistent-mode.mjs:254-291`) correctly falls back to the legacy path. This causes `cancel --force` to fail for session-less operations, leaving ralph/ultrawork in a re-arm loop.

## Fix

```diff
# state-tools.ts:615
-const legacySignalPath = join(root, 'state', 'cancel-signal-state.json');
+const legacySignalPath = join(getOmcRoot(root), 'state', 'cancel-signal-state.json');

# persistent-mode/index.ts — replace early return with legacy fallback
-if (!sessionId) return false;
+if (sessionId) { try session path } 
+if (!cancelSignalPath) { fallback to legacy path }
```

## Test plan

- [ ] Cancel with session_id still works (session-scoped path)
- [ ] Cancel without session_id now correctly writes to `.omc/state/` and stop hook detects it
- [ ] Ralph stop loop no longer persists after `cancel --force`

Fixes #2220