### PR TITLE
fix(security): delegate gitea URL validation to validateUrlForSSRF

### DIFF
--- a/src/providers/gitea.ts
+++ b/src/providers/gitea.ts
@@ -1,16 +1,12 @@
 import { execFileSync } from 'node:child_process';
 import type { GitProvider, PRInfo, IssueInfo, ProviderName } from './types.js';
+import { validateUrlForSSRF } from '../utils/ssrf-guard.js';
 
 function validateGiteaUrl(raw: string): string | null {
   try {
     const u = new URL(raw);
     if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
-    const host = u.hostname.toLowerCase();
-    if (
-      host === 'localhost' || host === '127.0.0.1' || host === '::1' ||
-      host === '0.0.0.0' || host === '::' ||
-      host.startsWith('169.254.') || host.endsWith('.local')
-    ) return null;
+    if (!validateUrlForSSRF(raw).allowed) return null;
     return u.origin;
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- Replace hand-written SSRF blocklist with delegation to existing `validateUrlForSSRF`
- Source-only diff: 1 file, +2/-6

## Root cause

`validateGiteaUrl` in `src/providers/gitea.ts` maintained a separate blocklist that only covered `localhost`, `127.0.0.1`, `::1`, `0.0.0.0`, `::`, `169.254.*`, and `*.local`.

Missing: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `fc00::/7`, `::ffff:` IPv4-mapped.

The codebase already has `validateUrlForSSRF` in `src/utils/ssrf-guard.ts` that correctly blocks all these ranges.

## Fix

Import and delegate to `validateUrlForSSRF` instead of maintaining a separate blocklist. Protocol check retained.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Existing `ssrf-guard.test.ts` covers all RFC 1918 ranges
- [x] `validateGiteaUrl` return type unchanged (`string | null`)

Fixes #2308