### PR TITLE
fix(hud): apply wrap mode when terminal width is auto-detected

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -278,7 +278,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
         0;
       if (cols > 0) {
         config.maxWidth = cols;
-        if (!config.wrapMode) config.wrapMode = "wrap";
+        if (config.wrapMode === "truncate") config.wrapMode = "wrap";
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix dead code in HUD terminal width auto-detection
- Source-only diff: 1 file, 1 line changed

## Root cause

At `src/hud/index.ts:281`:
```typescript
if (!config.wrapMode) config.wrapMode = "wrap";  // always false
```

`readHudConfig()` → `mergeWithDefaults()` always sets `wrapMode` via `config.wrapMode ?? DEFAULT_HUD_CONFIG.wrapMode` where default is `'truncate'`. The condition `!config.wrapMode` is never true.

Evidence chain: `DEFAULT_HUD_CONFIG.wrapMode = 'truncate'` (types.ts:596) → `mergeWithDefaults` `??` fallback (state.ts:345) → always truthy string returned.

## Fix

Changed condition to check if wrapMode equals the default:
```diff
- if (!config.wrapMode) config.wrapMode = "wrap";
+ if (config.wrapMode === "truncate") config.wrapMode = "wrap";
```

Explicit user setting of `'wrap'` is preserved. Only the default `'truncate'` is overridden when auto-detecting terminal width.

## Test plan
- [x] `npm run build` passes
- [x] Explicit `wrapMode: 'wrap'` user setting preserved (already 'wrap')
- [x] Default 'truncate' correctly overridden to 'wrap' when terminal width auto-detected

Fixes #2315