### PR TITLE
fix(team): use randomUUID in MCP team-server job ID generation

### DIFF
--- a/src/__tests__/team-server-jobid.test.ts
+++ b/src/__tests__/team-server-jobid.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('team-server job ID entropy', () => {
+  const serverSource = readFileSync(
+    join(__dirname, '..', 'mcp', 'team-server.ts'),
+    'utf-8',
+  );
+
+  it('imports randomUUID from node:crypto', () => {
+    expect(serverSource).toMatch(/import\s*\{[^}]*randomUUID[^}]*\}\s*from\s*['"]node:crypto['"]/);
+  });
+
+  it('uses randomUUID in job ID generation', () => {
+    expect(serverSource).toMatch(/randomUUID\(\)\.slice\(0,\s*8\)/);
+  });
+
+  it('generates unique IDs even at the same timestamp', () => {
+    const { randomUUID } = require('node:crypto');
+    const now = Date.now();
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(`omc-${now.toString(36)}${randomUUID().slice(0, 8)}`);
+    }
+    expect(ids.size).toBe(100);
+  });
+
+  it('generates IDs matching the validation pattern', () => {
+    const { randomUUID } = require('node:crypto');
+    const jobId = `omc-${Date.now().toString(36)}${randomUUID().slice(0, 8)}`;
+    expect(jobId).toMatch(/^omc-[a-z0-9]{1,16}$/);
+  });
+});

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -10,6 +10,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'child_process';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
@@ -243,7 +244,7 @@ async function handleStart(args: unknown): Promise<{ content: Array<{ type: 'tex
 
   const input = startSchema.parse(args);
   validateTeamName(input.teamName);
-  const jobId = `omc-${Date.now().toString(36)}`;
+  const jobId = `omc-${Date.now().toString(36)}${randomUUID().slice(0, 8)}`;
   const runtimeCliPath = join(__ownDir, 'runtime-cli.cjs');
 
   const job: OmcTeamJob = { status: 'running', startedAt: Date.now(), teamName: input.teamName, cwd: input.cwd };


### PR DESCRIPTION
Closes #2326

## Summary
- Add `randomUUID().slice(0, 8)` to MCP team-server job ID generation
- Aligns MCP path with CLI path fixed in #1963
- Prevents job ID collision when two starts arrive in same millisecond

Source-only diff: 2 files, +36/-1. No `dist/`, no `bridge/`.

## Test plan
- `npx vitest run src/__tests__/team-server-jobid.test.ts`