### PR TITLE
fix(installer): use getPackageDir() instead of __dirname for HUD helper copies

### DIFF
--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1426,7 +1426,7 @@ export function install(options: InstallOptions = {}): InstallResult {
         const nodeBin = resolveNodeBinary();
         const absoluteCommand = '"' + nodeBin + '" "' + hudScriptPath.replace(/\\/g, '/') + '"';
         try {
-          const configDirHelperMjsSrc = join(__dirname, '..', '..', 'scripts', 'lib', 'config-dir.mjs');
+          const configDirHelperMjsSrc = join(getPackageDir(), 'scripts', 'lib', 'config-dir.mjs');
           const hudLibDir = join(HUD_DIR, 'lib');
           const configDirHelperMjsDest = join(hudLibDir, 'config-dir.mjs');
           if (!existsSync(hudLibDir)) {
@@ -1444,9 +1444,9 @@ export function install(options: InstallOptions = {}): InstallResult {
         let statusLineCommand = absoluteCommand;
         if (!isWindows()) {
           try {
-            const findNodeSrc = join(__dirname, '..', '..', 'scripts', 'find-node.sh');
+            const findNodeSrc = join(getPackageDir(), 'scripts', 'find-node.sh');
             const findNodeDest = join(HUD_DIR, 'find-node.sh');
-            const configDirHelperSrc = join(__dirname, '..', '..', 'scripts', 'lib', 'config-dir.sh');
+            const configDirHelperSrc = join(getPackageDir(), 'scripts', 'lib', 'config-dir.sh');
             const hudLibDir = join(HUD_DIR, 'lib');
             const configDirHelperDest = join(hudLibDir, 'config-dir.sh');
             if (!existsSync(hudLibDir)) {


### PR DESCRIPTION
## Summary

- The compiled installer runs as ESM, where `__dirname` is not automatically defined
- Three `join(__dirname, '..', '..', 'scripts', ...)` calls in the HUD setup block threw a silent `ReferenceError`, leaving `~/.claude/hud/lib/` empty
- This caused `omc-hud.mjs` to fail at startup with `ERR_MODULE_NOT_FOUND: Cannot find module '...hud/lib/config-dir.mjs'`
- Fix: replace the three occurrences with `getPackageDir()`, which already handles both CJS and ESM contexts and is used correctly for the same files in `ensureStandaloneHookScripts()`

## Root cause

`ensureStandaloneHookScripts()` (line ~458) correctly uses `packageDir` from `getPackageDir()`. The HUD copy block added later used `join(__dirname, '..', '..')` instead — works in CJS dev/test but silently fails in the ESM production bundle.

## Test plan

- [ ] Run `omc-setup` / plugin install and verify `~/.claude/hud/lib/config-dir.mjs` is present afterward
- [ ] Verify `node ~/.claude/hud/omc-hud.mjs` outputs HUD status without `ERR_MODULE_NOT_FOUND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)