### PR TITLE
fix: self-heal stale absolute node paths in hooks.json (#2348)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Run tests
         run: npm test -- --run
 
+      # Some tests execute scripts/plugin-setup.mjs against the real
+      # hooks/hooks.json and rewrite bare `node` to the absolute node binary
+      # path of the runner (e.g. /opt/hostedtoolcache/node/.../bin/node). If we
+      # let that mutated file ship, every end user inherits a node path that
+      # does not exist on their machine. Restore the file to its committed
+      # state before publishing. See issue #2348.
+      - name: Restore hooks.json before publish
+        run: git checkout -- hooks/hooks.json
+
       - name: Publish to npm
         run: |
           VERSION=$(node -p "require('./package.json').version")

--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -300,6 +300,30 @@ try {
             continue;
           }
 
+          // Self-healing: if hooks.json already contains an absolute node path
+          // from a previous patch (possibly on a different machine, e.g. the
+          // GitHub Actions runner at publish time — see issue #2348), and that
+          // path is either missing on this machine or differs from the current
+          // node binary, rewrite it to the current `nodeBin`.  Without this
+          // users who install a tarball that was accidentally published with a
+          // stale absolute path (e.g. /opt/hostedtoolcache/node/.../bin/node)
+          // can never self-heal, because the bare-`node` branch above no longer
+          // matches.
+          const absNodeMatch = hook.command.match(
+            /^"([^"]*\/node|[A-Za-z]:\\[^"]*\\node(?:\.exe)?)"\s+.*\/scripts\/run\.cjs/,
+          );
+          if (absNodeMatch) {
+            const currentBin = absNodeMatch[1];
+            if (currentBin !== nodeBin && (!existsSync(currentBin) || currentBin.includes('/hostedtoolcache/'))) {
+              hook.command = hook.command.replace(
+                /^"[^"]*"/,
+                `"${nodeBin}"`,
+              );
+              patched = true;
+            }
+            continue;
+          }
+
           // Old find-node.sh format — migrate to run.cjs + absolute path (Windows only)
           if (process.platform === 'win32') {
             const m2 = hook.command.match(findNodePattern);


### PR DESCRIPTION
Fixes #2348.

## Problem

`v4.11.1` ships `hooks/hooks.json` with the GitHub Actions runner's node path baked into every command:

```
"/opt/hostedtoolcache/node/20.20.2/x64/bin/node" "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs ...
```

That path does not exist on user machines, so every hook fails with `No such file or directory`.

## Root cause

`src/__tests__/hud-marketplace-resolution.test.ts` executes `scripts/plugin-setup.mjs` against the **real repo** `hooks/hooks.json` during `npm test`. plugin-setup rewrites bare `node` to `process.execPath` (the CI runner's node path), and the mutated file is then packed by the subsequent `npm publish` step in `release.yml`.

Once that broken tarball is published, the existing patch logic cannot recover on user machines: its regex (`hook.command.startsWith('node ')`) only matches bare `node` commands, not absolute-path commands. So on first install / next SessionStart the patch is a no-op and the stale CI path stays.

## Fix

Two changes:

### 1. `scripts/plugin-setup.mjs` — make the patch self-healing

In addition to the existing bare-`node` branch, also detect commands that already use an absolute node path. If that path differs from the current `process.execPath` **and** either does not exist on disk or contains `/hostedtoolcache/`, rewrite it to the current `nodeBin`.

This lets every existing v4.11.1 install recover automatically on its next setup run, with no user action.

### 2. `.github/workflows/release.yml` — restore `hooks.json` before publish

Add a `git checkout -- hooks/hooks.json` step between `npm test` and `npm publish`, so a test-mutated `hooks.json` can never ship again. This is the defense-in-depth piece — even if a future test mutates the file, the publish job is now reproducible from the committed source.

## Test plan

- [x] `node --check scripts/plugin-setup.mjs` — syntactically valid
- [x] Manually traced regex against the broken v4.11.1 hooks.json — every line matches the new self-heal branch and gets rewritten to the current `process.execPath`
- [ ] Run `npm test` in CI to confirm existing tests still pass
- [ ] After merge + release, verify a fresh `npm install -g oh-my-claude-sisyphus@<new>` produces a `hooks.json` containing the user's local node path, not `/opt/hostedtoolcache/...`

## Notes

I left the existing `npm test` test that mutates the repo file alone — fixing it to use a temp copy is a larger refactor. The release-workflow `git checkout` makes it harmless. Happy to follow up with a test refactor if you'd prefer that approach.