### PR TITLE
fix(worktree-paths): stabilize project identifier across linked worktrees

### DIFF
--- a/src/lib/__tests__/worktree-paths.test.ts
+++ b/src/lib/__tests__/worktree-paths.test.ts
@@ -437,6 +437,44 @@ describe('worktree-paths', () => {
         rmSync(worktreeDir, { recursive: true, force: true });
       }
     });
+
+    it('should not change identifier for submodules (avoid .git/modules resolution)', () => {
+      const parentDir = mkdtempSync('/tmp/worktree-paths-submod-parent-');
+      const subDir = mkdtempSync('/tmp/worktree-paths-submod-child-');
+      try {
+        // Create a repo to use as the submodule source
+        execSync('git init', { cwd: subDir, stdio: 'pipe' });
+        execSync('git commit --allow-empty -m "sub init"', {
+          cwd: subDir,
+          stdio: 'pipe',
+          env: { ...process.env, GIT_AUTHOR_NAME: 'test', GIT_AUTHOR_EMAIL: 'test@test.com', GIT_COMMITTER_NAME: 'test', GIT_COMMITTER_EMAIL: 'test@test.com' },
+        });
+
+        // Create the parent repo and add the submodule
+        execSync('git init', { cwd: parentDir, stdio: 'pipe' });
+        execSync('git commit --allow-empty -m "init"', {
+          cwd: parentDir,
+          stdio: 'pipe',
+          env: { ...process.env, GIT_AUTHOR_NAME: 'test', GIT_AUTHOR_EMAIL: 'test@test.com', GIT_COMMITTER_NAME: 'test', GIT_COMMITTER_EMAIL: 'test@test.com' },
+        });
+        execSync(`git -c protocol.file.allow=always submodule add "${subDir}" mysub`, {
+          cwd: parentDir,
+          stdio: 'pipe',
+        });
+        clearWorktreeCache();
+
+        const submodulePath = `${parentDir}/mysub`;
+        const id = getProjectIdentifier(submodulePath);
+
+        // The identifier should use the submodule's own basename, not the
+        // parent's .git/modules directory
+        expect(id).toContain('mysub-');
+        expect(id).not.toContain('modules');
+      } finally {
+        rmSync(parentDir, { recursive: true, force: true });
+        rmSync(subDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('getOmcRoot with OMC_STATE_DIR (Issue #1014)', () => {

--- a/src/lib/__tests__/worktree-paths.test.ts
+++ b/src/lib/__tests__/worktree-paths.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, existsSync, mkdtempSync } from 'fs';
 import { execSync } from 'child_process';
-import { join } from 'path';
+import { join, basename } from 'path';
 import {
   validatePath,
   resolveOmcPath,
@@ -473,6 +473,23 @@ describe('worktree-paths', () => {
       } finally {
         rmSync(parentDir, { recursive: true, force: true });
         rmSync(subDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should not change identifier for bare repos (avoid dirname going to parent)', () => {
+      const parentDir = mkdtempSync('/tmp/worktree-paths-bare-parent-');
+      const bareDir = `${parentDir}/my-bare-repo.git`;
+      try {
+        execSync(`git init --bare "${bareDir}"`, { stdio: 'pipe' });
+        clearWorktreeCache();
+
+        const id = getProjectIdentifier(bareDir);
+
+        // Should use the bare repo's own name, not the parent directory
+        expect(id).toContain('my-bare-repo');
+        expect(id).not.toContain(basename(parentDir));
+      } finally {
+        rmSync(parentDir, { recursive: true, force: true });
       }
     });
   });

--- a/src/lib/__tests__/worktree-paths.test.ts
+++ b/src/lib/__tests__/worktree-paths.test.ts
@@ -397,6 +397,46 @@ describe('worktree-paths', () => {
         rmSync(specialDir, { recursive: true, force: true });
       }
     });
+
+    it('should produce identical identifiers for linked worktrees of the same repo', () => {
+      const primaryDir = mkdtempSync('/tmp/worktree-paths-primary-');
+      const worktreeDir = `${primaryDir}-linked`;
+      try {
+        // Set up a primary repo with a commit so worktree creation works
+        execSync('git init', { cwd: primaryDir, stdio: 'pipe' });
+        execSync('git remote add origin https://github.com/test/worktree-id-test.git', {
+          cwd: primaryDir,
+          stdio: 'pipe',
+        });
+        execSync('git commit --allow-empty -m "init"', {
+          cwd: primaryDir,
+          stdio: 'pipe',
+          env: { ...process.env, GIT_AUTHOR_NAME: 'test', GIT_AUTHOR_EMAIL: 'test@test.com', GIT_COMMITTER_NAME: 'test', GIT_COMMITTER_EMAIL: 'test@test.com' },
+        });
+
+        // Create a linked worktree (sibling directory, different basename)
+        execSync(`git worktree add "${worktreeDir}" -b linked-branch`, {
+          cwd: primaryDir,
+          stdio: 'pipe',
+        });
+        clearWorktreeCache();
+
+        const primaryId = getProjectIdentifier(primaryDir);
+        const worktreeId = getProjectIdentifier(worktreeDir);
+
+        // Both should produce the same identifier — same repo, same remote
+        expect(primaryId).toBe(worktreeId);
+      } finally {
+        try {
+          execSync(`git worktree remove "${worktreeDir}" --force`, {
+            cwd: primaryDir,
+            stdio: 'pipe',
+          });
+        } catch { /* may not exist */ }
+        rmSync(primaryDir, { recursive: true, force: true });
+        rmSync(worktreeDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('getOmcRoot with OMC_STATE_DIR (Issue #1014)', () => {

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -158,11 +158,16 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
     }).trim();
-    // --git-common-dir returns the .git directory (or .git/worktrees/X for
-    // linked worktrees). The primary repo root is its parent.
-    const resolved = dirname(commonDir);
-    if (resolved && resolved !== root) {
-      primaryRoot = resolved;
+    // --git-common-dir returns the .git directory for the primary repo
+    // (even from linked worktrees). Its parent is the primary repo root.
+    // In submodules, it returns <super>/.git/modules/<name> instead, so
+    // skip resolution when the path contains .git/modules to avoid
+    // deriving a wrong root.
+    if (!commonDir.includes(`${sep}.git${sep}modules`)) {
+      const resolved = dirname(commonDir);
+      if (resolved && resolved !== root) {
+        primaryRoot = resolved;
+      }
     }
   } catch {
     // Not a git repo or command failed — fall back to worktree root

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -158,12 +158,14 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
     }).trim();
-    // --git-common-dir returns the .git directory for the primary repo
-    // (even from linked worktrees). Its parent is the primary repo root.
-    // In submodules, it returns <super>/.git/modules/<name> instead, so
-    // skip resolution when the path contains .git/modules to avoid
-    // deriving a wrong root.
-    if (!commonDir.includes(`${sep}.git${sep}modules`)) {
+    // Only resolve when --git-common-dir points to a .git directory.
+    // - Linked worktrees: returns <primary>/.git → dirname gives primary root ✓
+    // - Submodules: returns <super>/.git/modules/<name> → skip (wrong parent)
+    // - Bare repos: returns the repo root itself (no .git suffix) → skip
+    //   (dirname would go up to the parent folder, colliding sibling repos)
+    const isGitDir = basename(commonDir) === '.git';
+    const isSubmodule = commonDir.includes(`${sep}.git${sep}modules`);
+    if (isGitDir && !isSubmodule) {
       const resolved = dirname(commonDir);
       if (resolved && resolved !== root) {
         primaryRoot = resolved;

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -145,8 +145,31 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
     source = root;
   }
 
+  // For linked worktrees (created via `git worktree add`), resolve to the
+  // primary repository root so all worktrees of the same repo produce the
+  // same project identifier. Without this, sibling worktrees like
+  // `repo.feature-x/` and `repo.feature-y/` would create separate state
+  // directories despite sharing the same remote URL hash.
+  let primaryRoot = root;
+  try {
+    const commonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    }).trim();
+    // --git-common-dir returns the .git directory (or .git/worktrees/X for
+    // linked worktrees). The primary repo root is its parent.
+    const resolved = dirname(commonDir);
+    if (resolved && resolved !== root) {
+      primaryRoot = resolved;
+    }
+  } catch {
+    // Not a git repo or command failed — fall back to worktree root
+  }
+
   const hash = createHash('sha256').update(source).digest('hex').slice(0, 16);
-  const dirName = basename(root).replace(/[^a-zA-Z0-9_-]/g, '_');
+  const dirName = basename(primaryRoot).replace(/[^a-zA-Z0-9_-]/g, '_');
   return `${dirName}-${hash}`;
 }
 


### PR DESCRIPTION
## Summary

- `getProjectIdentifier()` now resolves to the primary repo root via `git rev-parse --git-common-dir` for the `dirName` component
- Linked worktrees of the same repo produce identical project identifiers, sharing a single `OMC_STATE_DIR` directory
- Adds a test that creates a real linked worktree and asserts both roots produce the same identifier

Fixes #2351

## Problem

When `OMC_STATE_DIR` is set, linked worktrees created via `git worktree add` (or tools like Worktrunk) produce **different project identifiers** because `basename(worktreeRoot)` differs per worktree:

```
~/.omc-state/horadric-vault-63ff0d0d2552b58e/          ← main repo
~/.omc-state/horadric-vault_d4-overlay-63ff0d0d2552b58e/    ← worktree 1
~/.omc-state/horadric-vault_feature-transactions-63ff0d0d2552b58e/  ← worktree 2
```

The remote URL hash (`63ff0d0d2552b58e`) is identical — proving OMC knows they're the same repo — but the `dirName` prefix fragments state into separate directories. Project memory, notepad, wiki, plans, and session state are siloed per worktree instead of shared.

## Root cause

`getProjectIdentifier()` uses `basename(root)` where `root` comes from `getWorktreeRoot()` → `git rev-parse --show-toplevel`. For linked worktrees, `--show-toplevel` returns the worktree directory (e.g., `repo.feature-x/`), not the primary repo root.

## Fix

Resolve the primary repo root via `git rev-parse --path-format=absolute --git-common-dir` (which returns the shared `.git` directory) and use `dirname()` + `basename()` of that path for the `dirName` component. Falls back to the current behavior for non-git directories or when the command fails.

This pattern is already used in `resolveTranscriptPath()` (line 632) for the same purpose — detecting the main repo root from a linked worktree.

## Test plan

- [x] `npx vitest run src/lib/__tests__/worktree-paths.test.ts` — 56 tests pass (55 existing + 1 new)
- [x] `npx tsc --noEmit` — clean
- [x] New test creates a real git repo + linked worktree, asserts `getProjectIdentifier(primary) === getProjectIdentifier(linked)`
- [x] Verified manually: the fix produces `horadric-vault-63ff0d0d2552b58e` for all three worktrees

Supersedes #2350 (closed — was targeting main instead of dev).