### PR TITLE
docs(getting-started): document plugin + npm CLI as two coexisting surfaces (#2234)

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -23,7 +23,16 @@ If you're new to Oh My ClaudeCode (OMC), follow the steps below in order.
 
 ## Installation
 
-OMC is installed exclusively as a Claude Code Plugin. Direct installation via npm or bun is not supported.
+OMC ships two surfaces and they are designed to coexist:
+
+| Surface | What you get | Recommended install |
+|---|---|---|
+| **Claude Code plugin** (`oh-my-claudecode@omc`) | In-session skills, agents, hooks, statusline, MCP servers — the `/autopilot`, `/ralph`, `/ultrawork`, `/team` slash commands | Marketplace plugin install (Step 1–2 below) |
+| **Terminal CLI** (`omc` binary, package `oh-my-claude-sisyphus`) | Shell commands: `omc setup`, `omc update`, `omc team`, `omc ask`, `omc autoresearch`, etc. | `npm i -g oh-my-claude-sisyphus@latest` |
+
+Most users want **both**: the plugin for the in-session experience, and the npm CLI for shell-side automation and updates. Running them in parallel is fully supported — `omc update` and `omc setup` are idempotent and detect the plugin install to avoid duplicating in-session skills (#2252).
+
+> Older versions of this doc said OMC was "plugin-only". That was incorrect: the `omc` CLI is the canonical entry point for `omc setup`/`omc update` and is published on npm as `oh-my-claude-sisyphus`. See the [Quick Start in README.md](../README.md#quick-start) for the same two-path layout.
 
 ### Step 1: Add the marketplace source
 
@@ -40,6 +49,16 @@ After adding the marketplace, install the plugin:
 ```bash
 /plugin install oh-my-claudecode
 ```
+
+### Step 2b (optional but recommended): install the terminal CLI
+
+If you want `omc setup`, `omc update`, `omc team`, `omc ask`, etc. on your shell:
+
+```bash
+npm i -g oh-my-claude-sisyphus@latest
+```
+
+Both can be installed at the same time. The CLI auto-detects the plugin install and will not double-register skills under `~/.claude/skills/` (if you previously hit the duplicate-skill bug, run `omc update` once on 4.11.2+ — it self-heals leftover standalone skills that the plugin now provides via `prunePluginDuplicateSkills`).
 
 ### Step 3: Run initial setup
 


### PR DESCRIPTION
## Summary

Resolves the long-standing documentation contradiction originally raised in #2234: `docs/GETTING-STARTED.md` used to claim "OMC is installed exclusively as a Claude Code Plugin. Direct installation via npm or bun is not supported", but the README Quick Start and the entire `omc` terminal CLI (`omc setup`, `omc update`, `omc team`, `omc ask`, `omc autoresearch`) depend on an npm install of `oh-my-claude-sisyphus`. Both surfaces are real, both are supported, and they are designed to coexist.

Docs now document the two-surface model honestly:

| Surface | What you get | Install |
|---|---|---|
| **Claude Code plugin** (`oh-my-claudecode@omc`) | In-session skills, agents, hooks, statusline, MCP servers — the `/autopilot`, `/ralph`, `/ultrawork`, `/team` slash commands | Marketplace plugin install |
| **Terminal CLI** (`omc` binary, package `oh-my-claude-sisyphus`) | Shell commands: `omc setup`, `omc update`, `omc team`, `omc ask`, `omc autoresearch` | `npm i -g oh-my-claude-sisyphus@latest` |

The docs also forward-reference the existing upstream self-heal (`prunePluginDuplicateSkills` / `prunePluginDuplicateAgents`) shipped in 4.11.2 via #2252 + #2349, so users who were previously stuck in the duplicate-slash-command state know they can run `omc update` once on 4.11.2+ and have their orphans cleaned up automatically.

## What this PR does NOT include

- No source changes, no installer changes, no test changes, no build changes
- Pure docs delta: 1 file, +20/−1

## Relationship to other PRs

The `#2252` duplicate-skill cleanup is already shipped upstream via commit `6746e503` (v4.11.2). The `#2348` hardcoded-node-path fix is already shipped via #2349 (v4.11.2). This PR is the small surviving piece that wasn't covered by either — the doc correction from the original #2234.

A sibling PR (#2360) tracks the full prune-orphan-skills branch but is now redundant with upstream's shipped fix. This PR is intentionally scoped narrow enough to land independently.

## Verification

- `tsc --noEmit`: 0 errors (no source changes)
- Branch base: `6b3cd060` (4.11.2)
- Single commit is GPG-signed (`G` status, "Good signature from DongJin Hong")
- Author date preserved from the original work: `2026-04-08T10:46:13+09:00`

## Test Plan

- [x] `tsc --noEmit` clean
- [x] Branch rebased fresh on `upstream/dev`
- [x] Commit GPG-signed and author date preserved
- [ ] Reviewer: doc rendering check on GitHub

## Related

- Closes #2234 (primary)
- Refs #2252 / #2348 — the install-surface fixes already shipped upstream in 4.11.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
