### PR TITLE
fix: deactivate stale ralplan stop enforcement after consensus completion

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -847,6 +847,14 @@ async function main() {
         const breakerCount = readStopBreaker(stateDir, "ralplan", sessionId, RALPLAN_STOP_BLOCKER_TTL_MS) + 1;
         if (breakerCount > RALPLAN_STOP_BLOCKER_MAX) {
           writeStopBreaker(stateDir, "ralplan", 0, sessionId);
+
+          // Deactivate the stale ralplan state so a later Stop event cannot
+          // start a brand-new reinforcement cycle (30/30 -> 1/30) after the
+          // workflow has already exhausted its breaker budget.
+          ralplan.state.active = false;
+          ralplan.state.deactivated_reason = "stop_breaker_exhausted";
+          ralplan.state.completed_at = new Date().toISOString();
+          writeJsonFile(ralplan.path, ralplan.state);
           // Circuit breaker tripped — allow stop
         } else {
           writeStopBreaker(stateDir, "ralplan", breakerCount, sessionId);

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -418,6 +418,28 @@ function getInvokedSkillName(toolInput) {
     : normalized.toLowerCase();
 }
 
+function getSkillInvocationArgs(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return '';
+  const candidates = [
+    toolInput.args,
+    toolInput.arguments,
+    toolInput.argument,
+    toolInput.skill_args,
+    toolInput.skillArgs,
+    toolInput.prompt,
+    toolInput.description,
+    toolInput.input,
+  ];
+  return candidates.find(value => typeof value === 'string' && value.trim().length > 0)?.trim() || '';
+}
+
+function isConsensusPlanningSkillInvocation(skillName, toolInput) {
+  if (!skillName) return false;
+  if (skillName === 'ralplan') return true;
+  if (skillName !== 'plan' && skillName !== 'omc-plan') return false;
+  return getSkillInvocationArgs(toolInput).toLowerCase().includes('--consensus');
+}
+
 function getSkillActiveStatePaths(directory, sessionId) {
   const stateDir = join(directory, '.omc', 'state');
   const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
@@ -444,6 +466,53 @@ function clearSkillActiveState(directory, sessionId) {
   for (const statePath of getSkillActiveStatePaths(directory, sessionId)) {
     try {
       unlinkSync(statePath);
+    } catch {
+      // Best-effort cleanup; never fail the hook
+    }
+  }
+}
+
+function getRalplanStatePaths(directory, sessionId) {
+  const stateDir = join(directory, '.omc', 'state');
+  const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  return [
+    safeSessionId ? join(stateDir, 'sessions', safeSessionId, 'ralplan-state.json') : null,
+    join(stateDir, 'ralplan-state.json'),
+  ].filter(Boolean);
+}
+
+function deactivateRalplanState(directory, sessionId) {
+  const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  const terminalPhases = new Set(['complete', 'completed', 'failed', 'cancelled', 'done']);
+  const now = new Date().toISOString();
+
+  for (const statePath of getRalplanStatePaths(directory, sessionId)) {
+    try {
+      if (!existsSync(statePath)) continue;
+      const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+      if (!state || typeof state !== 'object') continue;
+      if (safeSessionId && typeof state.session_id === 'string' && state.session_id !== safeSessionId) {
+        continue;
+      }
+      const currentPhase = typeof state.current_phase === 'string' ? state.current_phase : '';
+      const nextPhase = terminalPhases.has(currentPhase.toLowerCase()) ? currentPhase : 'complete';
+      writeFileSync(
+        statePath,
+        JSON.stringify(
+          {
+            ...state,
+            active: false,
+            current_phase: nextPhase,
+            completed_at: typeof state.completed_at === 'string' ? state.completed_at : now,
+            deactivated_reason:
+              typeof state.deactivated_reason === 'string'
+                ? state.deactivated_reason
+                : 'skill_completed',
+          },
+          null,
+          2,
+        ),
+      );
     } catch {
       // Best-effort cleanup; never fail the hook
     }
@@ -708,12 +777,16 @@ async function main() {
 
     if (toolName === 'Skill' || toolName === 'skill') {
       const toolInput = data.tool_input || data.toolInput || {};
+      const skillName = getInvokedSkillName(toolInput);
       const currentState = readSkillActiveState(directory, sessionId);
-      const completingSkill = (getInvokedSkillName(toolInput) ?? '')
+      const completingSkill = (skillName ?? '')
         .toLowerCase()
         .replace(/^oh-my-claudecode:/, '');
       if (!currentState || !currentState.active || currentState.skill_name === completingSkill) {
         clearSkillActiveState(directory, sessionId);
+      }
+      if (isConsensusPlanningSkillInvocation(skillName, toolInput)) {
+        deactivateRalplanState(directory, sessionId);
       }
     }
 

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -6,7 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import { execSync } from 'child_process';
 import { join } from 'path';
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import process from 'process';
 import { detectBashFailure, detectWriteFailure, isNonZeroExitWithOutput, summarizeAgentResult } from '../../scripts/post-tool-verifier.mjs';
@@ -45,6 +45,10 @@ function legacySkillStatePath(tempDir) {
   return join(tempDir, '.omc', 'state', 'skill-active-state.json');
 }
 
+function ralplanStatePath(tempDir, sessionId) {
+  return join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralplan-state.json');
+}
+
 function writeSkillStateFixtures(tempDir, sessionId, skillName = 'plan') {
   mkdirSync(join(tempDir, '.omc', 'state', 'sessions', sessionId), { recursive: true });
   writeFileSync(
@@ -66,6 +70,20 @@ function writeSkillStateFixtures(tempDir, sessionId, skillName = 'plan') {
     JSON.stringify({
       active: true,
       skill_name: skillName,
+    }),
+  );
+}
+
+function writeRalplanStateFixture(tempDir, sessionId, overrides = {}) {
+  mkdirSync(join(tempDir, '.omc', 'state', 'sessions', sessionId), { recursive: true });
+  writeFileSync(
+    ralplanStatePath(tempDir, sessionId),
+    JSON.stringify({
+      active: true,
+      session_id: sessionId,
+      current_phase: 'ralplan',
+      started_at: '2026-04-01T00:00:00.000Z',
+      ...overrides,
     }),
   );
 }
@@ -496,6 +514,55 @@ describe('Skill active state cleanup on PostToolUse (issue #2103)', () => {
       expect(out).toEqual({ continue: true, suppressOutput: true });
       expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(false);
       expect(existsSync(legacySkillStatePath(tempDir))).toBe(false);
+    });
+  });
+
+  it('deactivates ralplan state when the ralplan skill completes in post-tool-verifier', () => {
+    withTempDir((tempDir) => {
+      const sessionId = 'ralplan-complete-script';
+      writeRalplanStateFixture(tempDir, sessionId);
+
+      const out = runPostToolVerifier({
+        tool_name: 'Skill',
+        tool_input: { skill: 'oh-my-claudecode:ralplan' },
+        tool_response: { ok: true },
+        session_id: sessionId,
+        cwd: tempDir,
+      });
+
+      expect(out).toEqual({ continue: true, suppressOutput: true });
+
+      const state = JSON.parse(readFileSync(ralplanStatePath(tempDir, sessionId), 'utf-8'));
+      expect(state.active).toBe(false);
+      expect(state.current_phase).toBe('complete');
+      expect(state.deactivated_reason).toBe('skill_completed');
+      expect(typeof state.completed_at).toBe('string');
+    });
+  });
+
+  it('deactivates ralplan state when the consensus plan alias completes in the template hook path', () => {
+    withTempDir((tempDir) => {
+      const sessionId = 'ralplan-complete-template';
+      writeRalplanStateFixture(tempDir, sessionId);
+
+      const out = runHookScript(TEMPLATE_HOOK_PATH, {
+        tool_name: 'Skill',
+        tool_input: {
+          skill: 'oh-my-claudecode:plan',
+          args: '--consensus issue #2368',
+        },
+        tool_response: { ok: true },
+        session_id: sessionId,
+        cwd: tempDir,
+      });
+
+      expect(out).toEqual({ continue: true, suppressOutput: true });
+
+      const state = JSON.parse(readFileSync(ralplanStatePath(tempDir, sessionId), 'utf-8'));
+      expect(state.active).toBe(false);
+      expect(state.current_phase).toBe('complete');
+      expect(state.deactivated_reason).toBe('skill_completed');
+      expect(typeof state.completed_at).toBe('string');
     });
   });
 });

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -482,6 +482,55 @@ Read src/hooks/bridge.ts first.`,
       }
     });
 
+    it('deactivates ralplan state when the consensus planning skill completes', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-ralplan-complete-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'ralplan-complete-session';
+
+        await processHook('pre-tool-use', {
+          sessionId,
+          toolName: 'Skill',
+          toolInput: { skill: 'oh-my-claudecode:ralplan' },
+          directory: tempDir,
+        });
+
+        const postResult = await processHook('post-tool-use', {
+          sessionId,
+          toolName: 'Skill',
+          toolInput: { skill: 'oh-my-claudecode:ralplan' },
+          toolOutput: { ok: true },
+          directory: tempDir,
+        });
+
+        expect(postResult.continue).toBe(true);
+
+        const ralplanPath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralplan-state.json');
+        const ralplanState = JSON.parse(readFileSync(ralplanPath, 'utf-8')) as {
+          active?: boolean;
+          current_phase?: string;
+          deactivated_reason?: string;
+          completed_at?: string;
+        };
+
+        expect(ralplanState.active).toBe(false);
+        expect(ralplanState.current_phase).toBe('complete');
+        expect(ralplanState.deactivated_reason).toBe('skill_completed');
+        expect(typeof ralplanState.completed_at).toBe('string');
+
+        const stopResult = await processHook('persistent-mode', {
+          sessionId,
+          directory: tempDir,
+          stop_reason: 'end_turn',
+        } as HookInput);
+
+        expect(stopResult.continue).toBe(true);
+        expect(stopResult.message).toBeUndefined();
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('should handle session-start and return continue:true', async () => {
       const input: HookInput = {
         sessionId: 'test-session',

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -24,7 +24,7 @@ import {
 } from "fs";
 import { dirname, join } from "path";
 import { resolveToWorktreeRoot, getOmcRoot } from "../lib/worktree-paths.js";
-import { writeModeState } from "../lib/mode-state-io.js";
+import { readModeState, writeModeState } from "../lib/mode-state-io.js";
 import { formatOmcCliInvocation } from "../utils/omc-cli-rendering.js";
 import { createSwallowedErrorLogger } from "../lib/swallowed-error.js";
 
@@ -300,6 +300,46 @@ function activateRalplanState(directory: string, sessionId?: string): void {
       session_id: sessionId,
       current_phase: "ralplan",
       started_at: new Date().toISOString(),
+    },
+    directory,
+    sessionId,
+  );
+}
+
+function deactivateRalplanState(directory: string, sessionId?: string): void {
+  const state = readModeState<Record<string, unknown>>("ralplan", directory, sessionId);
+  if (!state) {
+    return;
+  }
+
+  const currentPhase =
+    typeof state.current_phase === "string" ? state.current_phase : undefined;
+  const terminalPhases = new Set([
+    "complete",
+    "completed",
+    "failed",
+    "cancelled",
+    "done",
+  ]);
+  const completedAt =
+    typeof state.completed_at === "string"
+      ? state.completed_at
+      : new Date().toISOString();
+
+  writeModeState(
+    "ralplan",
+    {
+      ...state,
+      active: false,
+      current_phase:
+        currentPhase && terminalPhases.has(currentPhase.toLowerCase())
+          ? currentPhase
+          : "complete",
+      completed_at: completedAt,
+      deactivated_reason:
+        typeof state.deactivated_reason === "string"
+          ? state.deactivated_reason
+          : "skill_completed",
     },
     directory,
     sessionId,
@@ -1952,6 +1992,9 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
       .replace(/^oh-my-claudecode:/, "");
     if (!currentState || !currentState.active || currentState.skill_name === completingSkill) {
       clearSkillActiveState(directory, input.sessionId);
+    }
+    if (isConsensusPlanningSkillInvocation(skillName, input.toolInput)) {
+      deactivateRalplanState(directory, input.sessionId);
     }
   }
 

--- a/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
@@ -625,6 +625,33 @@ describe('ralplan standalone stop enforcement', () => {
     }
   });
 
+  it('deactivates stale ralplan state after the circuit breaker trips so stop does not restart at 1/30', async () => {
+    const sessionId = 'session-ralplan-breaker-no-restart';
+    const tempDir = makeTempProject();
+
+    try {
+      writeRalplanState(tempDir, sessionId);
+      writeStopBreaker(tempDir, sessionId, 'ralplan', 30);
+
+      const firstResult = await checkPersistentModes(sessionId, tempDir);
+      expect(firstResult.shouldBlock).toBe(false);
+      expect(firstResult.mode).toBe('ralplan');
+      expect(firstResult.message).toContain('deactivating stale ralplan state');
+
+      const statePath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralplan-state.json');
+      const persistedState = JSON.parse(readFileSync(statePath, 'utf-8')) as Record<string, unknown>;
+      expect(persistedState.active).toBe(false);
+      expect(persistedState.deactivated_reason).toBe('stop_breaker_exhausted');
+
+      const secondResult = await checkPersistentModes(sessionId, tempDir);
+      expect(secondResult.shouldBlock).toBe(false);
+      expect(secondResult.mode).toBe('none');
+      expect(secondResult.message).toBe('');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('allows orchestrator idle when ralplan is active but delegated subagents are still running', async () => {
     const sessionId = 'session-ralplan-active-subagents';
     const tempDir = makeTempProject();

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -25,7 +25,7 @@ import {
   type UltraworkState
 } from '../ultrawork/index.js';
 import { resolveToWorktreeRoot, resolveSessionStatePath, resolveStatePath, getOmcRoot } from '../../lib/worktree-paths.js';
-import { readModeState } from '../../lib/mode-state-io.js';
+import { readModeState, writeModeState } from '../../lib/mode-state-io.js';
 import {
   readRalphState,
   writeRalphState,
@@ -1002,9 +1002,18 @@ async function checkRalplan(
   const breakerCount = readStopBreaker(workingDir, 'ralplan', sessionId, RALPLAN_STOP_BLOCKER_TTL_MS) + 1;
   if (breakerCount > RALPLAN_STOP_BLOCKER_MAX) {
     writeStopBreaker(workingDir, 'ralplan', 0, sessionId);
+
+    // Deactivate the stale ralplan state so a later Stop event cannot start a
+    // brand-new reinforcement cycle (30/30 -> 1/30) after the workflow has
+    // already exhausted its breaker budget.
+    (state as unknown as Record<string, unknown>).active = false;
+    (state as unknown as Record<string, unknown>).deactivated_reason = 'stop_breaker_exhausted';
+    (state as unknown as Record<string, unknown>).completed_at = new Date().toISOString();
+    writeModeState('ralplan', state as unknown as Record<string, unknown>, workingDir, sessionId);
+
     return {
       shouldBlock: false,
-      message: `[RALPLAN CIRCUIT BREAKER] Stop enforcement exceeded ${RALPLAN_STOP_BLOCKER_MAX} reinforcements. Allowing stop to prevent infinite blocking.`,
+      message: `[RALPLAN CIRCUIT BREAKER] Stop enforcement exceeded ${RALPLAN_STOP_BLOCKER_MAX} reinforcements. Allowing stop and deactivating stale ralplan state to prevent infinite restart loops.`,
       mode: 'ralplan'
     };
   }

--- a/templates/hooks/post-tool-use.mjs
+++ b/templates/hooks/post-tool-use.mjs
@@ -56,6 +56,28 @@ function getInvokedSkillName(toolInput) {
     : normalized.toLowerCase();
 }
 
+function getSkillInvocationArgs(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return '';
+  const candidates = [
+    toolInput.args,
+    toolInput.arguments,
+    toolInput.argument,
+    toolInput.skill_args,
+    toolInput.skillArgs,
+    toolInput.prompt,
+    toolInput.description,
+    toolInput.input,
+  ];
+  return candidates.find(value => typeof value === 'string' && value.trim().length > 0)?.trim() || '';
+}
+
+function isConsensusPlanningSkillInvocation(skillName, toolInput) {
+  if (!skillName) return false;
+  if (skillName === 'ralplan') return true;
+  if (skillName !== 'plan' && skillName !== 'omc-plan') return false;
+  return getSkillInvocationArgs(toolInput).toLowerCase().includes('--consensus');
+}
+
 const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 
 function getSkillActiveStatePaths(directory, sessionId) {
@@ -82,6 +104,51 @@ function clearSkillActiveState(directory, sessionId) {
   for (const statePath of getSkillActiveStatePaths(directory, sessionId)) {
     try {
       unlinkSync(statePath);
+    } catch {}
+  }
+}
+
+function getRalplanStatePaths(directory, sessionId) {
+  const stateDir = join(directory, '.omc', 'state');
+  const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  return [
+    safeSessionId ? join(stateDir, 'sessions', safeSessionId, 'ralplan-state.json') : null,
+    join(stateDir, 'ralplan-state.json'),
+  ].filter(Boolean);
+}
+
+function deactivateRalplanState(directory, sessionId) {
+  const safeSessionId = sessionId && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  const terminalPhases = new Set(['complete', 'completed', 'failed', 'cancelled', 'done']);
+  const now = new Date().toISOString();
+
+  for (const statePath of getRalplanStatePaths(directory, sessionId)) {
+    try {
+      if (!existsSync(statePath)) continue;
+      const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+      if (!state || typeof state !== 'object') continue;
+      if (safeSessionId && typeof state.session_id === 'string' && state.session_id !== safeSessionId) {
+        continue;
+      }
+      const currentPhase = typeof state.current_phase === 'string' ? state.current_phase : '';
+      const nextPhase = terminalPhases.has(currentPhase.toLowerCase()) ? currentPhase : 'complete';
+      atomicWriteFileSync(
+        statePath,
+        JSON.stringify(
+          {
+            ...state,
+            active: false,
+            current_phase: nextPhase,
+            completed_at: typeof state.completed_at === 'string' ? state.completed_at : now,
+            deactivated_reason:
+              typeof state.deactivated_reason === 'string'
+                ? state.deactivated_reason
+                : 'skill_completed',
+          },
+          null,
+          2,
+        ),
+      );
     } catch {}
   }
 }
@@ -185,6 +252,9 @@ async function main() {
       const completingSkill = (skillName || '').replace(/^oh-my-claudecode:/, '');
       if (!currentState || !currentState.active || currentState.skill_name === completingSkill) {
         clearSkillActiveState(directory, sessionId);
+      }
+      if (isConsensusPlanningSkillInvocation(skillName, toolInput)) {
+        deactivateRalplanState(directory, sessionId);
       }
       if (skillName === 'ralph') {
         const now = new Date().toISOString();


### PR DESCRIPTION
## Summary
- deactivate `ralplan-state.json` when a consensus planning skill finishes so the stop hook cannot restart from a stale active state
- keep the shipped post-tool hook surfaces (`scripts/post-tool-verifier.mjs`, `templates/hooks/post-tool-use.mjs`) aligned with the TypeScript bridge cleanup path
- preserve the existing stop-breaker stale-state deactivation path and add regression coverage for completion cleanup

## Root cause
`ralplan` stop enforcement depended on the workflow state being cleared or deactivated, but the workflow-complete path could leave `ralplan-state.json` active after the planning skill returned. Once delegated work drained and the breaker counter had been reset during active-subagent windows, later Stop events could re-enter the blocker from `1/30`.

## Testing
- `npx vitest run src/hooks/__tests__/bridge-routing.test.ts src/__tests__/post-tool-verifier.test.mjs src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/hooks/bridge.ts src/hooks/persistent-mode/index.ts src/hooks/__tests__/bridge-routing.test.ts`

Closes #2368.
