### PR TITLE
fix: resolve asymmetric symlink path resolution (#2221)

### DIFF
--- a/src/__tests__/resolve-transcript-path.test.ts
+++ b/src/__tests__/resolve-transcript-path.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, realpathSync } from 'fs';
 import { execSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -135,6 +135,7 @@ describe('resolveTranscriptPath', () => {
       // Create a real git repo with a linked worktree
       mainRepoDir = join(tempDir, 'main-repo');
       mkdirSync(mainRepoDir, { recursive: true });
+      mainRepoDir = realpathSync(mainRepoDir); // resolve symlinks (macOS: /var -> /private/var)
       execSync('git init', { cwd: mainRepoDir, stdio: 'pipe' });
       execSync('git commit --allow-empty -m "init"', {
         cwd: mainRepoDir,
@@ -146,7 +147,7 @@ describe('resolveTranscriptPath', () => {
         },
       });
 
-      worktreeDir = join(tempDir, 'linked-worktree');
+      worktreeDir = join(realpathSync(tempDir), 'linked-worktree');
       execSync(`git worktree add "${worktreeDir}" -b test-branch`, {
         cwd: mainRepoDir,
         stdio: 'pipe',

--- a/src/autoresearch/__tests__/contracts.test.ts
+++ b/src/autoresearch/__tests__/contracts.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -89,7 +90,7 @@ Stay in bounds.
   });
 
   it('loads mission contract from in-repo mission directory', async () => {
-    const repo = await initRepo();
+    const repo = realpathSync(await initRepo());
     try {
       const missionDir = join(repo, 'missions', 'demo');
       await mkdir(missionDir, { recursive: true });

--- a/src/autoresearch/contracts.ts
+++ b/src/autoresearch/contracts.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { basename, join, relative, resolve } from 'path';
 
@@ -201,10 +201,12 @@ export function parseEvaluatorResult(raw: string): AutoresearchEvaluatorResult {
 }
 
 export async function loadAutoresearchMissionContract(missionDirArg: string): Promise<AutoresearchMissionContract> {
-  const missionDir = resolve(missionDirArg);
+  let missionDir = resolve(missionDirArg);
   if (!existsSync(missionDir)) {
     throw contractError(`mission-dir does not exist: ${missionDir}`);
   }
+  // Resolve symlinks so the path matches git's canonical output (e.g., /private/var on macOS)
+  try { missionDir = realpathSync(missionDir); } catch { /* keep resolved path */ }
 
   const repoRoot = readGit(missionDir, ['rev-parse', '--show-toplevel']);
   ensurePathInside(repoRoot, missionDir);

--- a/src/hooks/learner/finder.ts
+++ b/src/hooks/learner/finder.ts
@@ -52,7 +52,7 @@ function safeRealpathSync(filePath: string): string {
  */
 function isWithinBoundary(realPath: string, boundary: string): boolean {
   const normalizedReal = normalize(realPath);
-  const normalizedBoundary = normalize(boundary);
+  const normalizedBoundary = normalize(safeRealpathSync(boundary));
   return normalizedReal === normalizedBoundary ||
          normalizedReal.startsWith(normalizedBoundary + sep);
 }

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -666,7 +666,15 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
     }).trim();
 
     const absoluteCommonDir = resolve(effectiveCwd, gitCommonDir);
-    const mainRepoRoot = dirname(absoluteCommonDir);
+    // For linked worktrees, git-common-dir is <repo>/.git/worktrees/<name>
+    // so dirname gives <repo>/.git/worktrees — navigate up to the actual repo root
+    let mainRepoRoot = dirname(absoluteCommonDir);
+    if (mainRepoRoot.endsWith(join('.git', 'worktrees'))) {
+      mainRepoRoot = dirname(dirname(mainRepoRoot));
+    }
+    // Resolve symlinks for consistent comparison (e.g. /tmp -> /private/tmp on macOS,
+    // ecryptfs $HOME on Linux, autofs /home, etc.)
+    try { mainRepoRoot = realpathSync(mainRepoRoot); } catch { /* keep as-is */ }
 
     const worktreeTop = execSync('git rev-parse --show-toplevel', {
       cwd: effectiveCwd,

--- a/src/team/__tests__/fs-utils.test.ts
+++ b/src/team/__tests__/fs-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { statSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { statSync, mkdirSync, rmSync, existsSync, realpathSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -66,15 +66,29 @@ describe('ensureDirWithMode', () => {
 });
 
 describe('validateResolvedPath', () => {
+  const VALIDATE_DIR = join(tmpdir(), '__validate_test__');
+
+  afterEach(() => {
+    if (existsSync(VALIDATE_DIR)) {
+      rmSync(VALIDATE_DIR, { recursive: true, force: true });
+    }
+  });
+
   it('rejects paths that escape base via ../', () => {
-    expect(() => validateResolvedPath('/home/user/../escape', '/home/user')).toThrow('Path traversal');
+    mkdirSync(VALIDATE_DIR, { recursive: true });
+    const base = realpathSync(VALIDATE_DIR);
+    expect(() => validateResolvedPath(join(base, '..', 'escape'), base)).toThrow('Path traversal');
   });
 
   it('accepts paths within base directory', () => {
-    expect(() => validateResolvedPath('/home/user/project/file.ts', '/home/user')).not.toThrow();
+    mkdirSync(VALIDATE_DIR, { recursive: true });
+    const base = realpathSync(VALIDATE_DIR);
+    expect(() => validateResolvedPath(join(base, 'project', 'file.ts'), base)).not.toThrow();
   });
 
   it('accepts exact base path', () => {
-    expect(() => validateResolvedPath('/home/user', '/home/user')).not.toThrow();
+    mkdirSync(VALIDATE_DIR, { recursive: true });
+    const base = realpathSync(VALIDATE_DIR);
+    expect(() => validateResolvedPath(base, base)).not.toThrow();
   });
 });

--- a/src/team/fs-utils.ts
+++ b/src/team/fs-utils.ts
@@ -9,7 +9,7 @@
  */
 
 import { writeFileSync, existsSync, mkdirSync, renameSync, openSync, writeSync, closeSync, realpathSync, constants } from 'fs';
-import { dirname, resolve, relative, basename } from 'path';
+import { dirname, resolve, relative, basename, join } from 'path';
 
 /** Atomic write: write JSON to temp file with permissions, then rename (prevents corruption on crash) */
 export function atomicWriteJson(filePath: string, data: unknown, mode: number = 0o600): void {
@@ -43,18 +43,24 @@ export function ensureDirWithMode(dirPath: string, mode: number = 0o700): void {
 }
 
 /** Resolve a path through symlinks where possible, falling back to resolve for non-existent paths.
- *  For paths that don't exist yet, resolves the parent via realpath and appends the filename. */
+ *  Walks up the directory tree to the nearest existing ancestor, resolves it via realpathSync,
+ *  then re-appends all non-existent segments. This handles macOS symlinks like /var -> /private/var
+ *  consistently regardless of how many intermediate directories are missing. */
 function safeRealpath(p: string): string {
   try {
     return realpathSync(p);
   } catch {
-    // Path doesn't exist yet — resolve the parent directory and append the filename
-    const parent = dirname(p);
-    const name = basename(p);
+    const segments: string[] = [];
+    let current = resolve(p);
+    while (!existsSync(current)) {
+      segments.unshift(basename(current));
+      const parent = dirname(current);
+      if (parent === current) break; // filesystem root
+      current = parent;
+    }
     try {
-      return resolve(realpathSync(parent), name);
+      return join(realpathSync(current), ...segments);
     } catch {
-      // Parent also doesn't exist, fall back to plain resolve
       return resolve(p);
     }
   }


### PR DESCRIPTION
## Summary

Fixes #2221 — asymmetric `realpathSync` resolution causes false \"Path traversal detected\" errors and silent project-skill drops on any filesystem where `tmp` or `$HOME` pass through a symlink. macOS makes the bug obvious (every machine has `/tmp -> /private/tmp`), but it is latent on Linux: ecryptfs encrypted home, systemd tmp-on-ram, Docker overlay bind mounts, NixOS `/nix/store`, snap-confined apps, autofs/NFS automount, and rootless podman all reproduce it.

GitHub Actions `ubuntu-latest` doesn't catch this because its `/tmp` is a real directory and `TMPDIR` is unset, so the asymmetric code path produces no visible divergence. Issue #2221 documents a one-line reproduction (`ln -s /tmp $HOME/tmp-alias && TMPDIR=$HOME/tmp-alias npx vitest run src/team/__tests__/audit-log.test.ts`) and the full failure inventory (~74 tests on macOS).

## Why one PR

Issue #2221 explicitly asks for this fix and lists the four exact files that need updates. This PR implements only those four production changes and the matching test updates — nothing else. No refactor, no scope creep, no new features.

## Fix

Symmetric `realpathSync` resolution on both sides of every path-prefix comparison. No platform detection — works identically on Linux, macOS, and Windows.

**Production changes (4 files, all named in the issue):**

- **`src/team/fs-utils.ts`** — `safeRealpath` walks up to the nearest existing ancestor, resolves it, and re-appends the missing segments. Previously walked only one level, so when both target and parent were missing (the common case for tests creating dirs lazily), it fell back to the unresolved path while the comparison base used the resolved path.
- **`src/hooks/learner/finder.ts`** — `isWithinBoundary` now resolves `boundary` through `safeRealpathSync` before comparing. The `realPath` argument was already resolved by the caller, but `boundary` was raw.
- **`src/lib/worktree-paths.ts`** (`resolveTranscriptPath` only) — handles the `.git/worktrees/<name>` common-dir pattern for linked worktrees and resolves `mainRepoRoot` via `realpathSync` so it matches git's canonical `--show-toplevel` output. **`getProjectIdentifier` is intentionally untouched** — its existing linked-worktree primary-root resolution (added in #2156-era commits) is preserved.
- **`src/autoresearch/contracts.ts`** — resolves `missionDir` via `realpathSync` before `ensurePathInside`, since `git rev-parse` always returns a canonical path.

**Test updates (3 files):**

- `src/team/__tests__/fs-utils.test.ts` — replaces hardcoded `/home/user` paths with a real tmpdir resolved via `realpathSync`.
- `src/autoresearch/__tests__/contracts.test.ts` — resolves repo dir via `realpathSync` to match git output.
- `src/__tests__/resolve-transcript-path.test.ts` — resolves `mainRepoDir` and `worktreeDir` parents via `realpathSync`.

## Out of scope

- **No `dist/` or `bridge/` churn.** Source-only diff. 7 files, +50/-18.
- **No HUD changes, no preset/default changes, no CLI changes.** Backend plumbing only.
- **No new features.** This is purely the fix described in #2221.
- **CI matrix addition (suggested in #2221)** is not included here — happy to file as a separate follow-up if maintainers want it. A single Linux job with `TMPDIR=\$HOME/symlinked-tmp` would have caught this pre-merge.

## Security properties

Preserved. Both sides of every path-prefix comparison now go through the same `realpath` resolution, so traversal and symlink-escape detection still work — they were broken when only one side was resolved.

## Test plan

- [x] All affected tests pass locally on macOS (`fs-utils.test.ts`, `audit-log.test.ts`, `contracts.test.ts`, `resolve-transcript-path.test.ts`)
- [x] Build clean (`npm run build`)
- [ ] Linux CI (this is what the PR validates against — the same tests should pass on `ubuntu-latest` as before, and additionally pass on a symlinked-`TMPDIR` Linux runner if one is added later)
- [ ] Spot-check on a Linux box with `ln -s /tmp $HOME/tmp-alias && TMPDIR=\$HOME/tmp-alias npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)