### PR TITLE
feat(skills): add status/supersededBy fields for deprecation lifecycle

### DIFF
--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -184,17 +184,24 @@ function loadSkillFromFile(skillPath: string, skillName: string): BuiltinSkill[]
       if (seen.has(key)) continue;
       seen.add(key);
 
+      const fmStatus = (metadata.status as BuiltinSkill['status']) || undefined;
+      const fmSupersededBy = (metadata['superseded-by'] as string) || undefined;
+      const isFmDeprecated = fmStatus === 'deprecated';
+
       skillEntries.push({
         name,
         aliases: name === safePrimaryName ? safeAliases : undefined,
         aliasOf: name === safePrimaryName ? undefined : safePrimaryName,
-        deprecatedAlias: name === safePrimaryName ? undefined : true,
-        deprecationMessage: name === safePrimaryName
-          ? undefined
-          : `Skill alias "${name}" is deprecated. Use "${safePrimaryName}" instead.`,
+        deprecatedAlias: (name !== safePrimaryName && isFmDeprecated) || undefined,
+        deprecationMessage: isFmDeprecated
+          ? (fmSupersededBy
+              ? `"${name}" is deprecated. Use "${fmSupersededBy}" instead.`
+              : `"${name}" is deprecated.`)
+          : undefined,
+        status: fmStatus,
+        supersededBy: fmSupersededBy,
         description: metadata.description || '',
         template,
-        // Optional fields from frontmatter
         model: metadata.model,
         agent: metadata.agent,
         argumentHint: metadata['argument-hint'],

--- a/src/features/builtin-skills/types.ts
+++ b/src/features/builtin-skills/types.ts
@@ -33,6 +33,10 @@ export interface BuiltinSkill {
   deprecatedAlias?: boolean;
   /** Human-readable deprecation guidance */
   deprecationMessage?: string;
+  /** Lifecycle status: active (default), deprecated, or experimental */
+  status?: 'active' | 'deprecated' | 'experimental';
+  /** Skill that supersedes this one when status is deprecated */
+  supersededBy?: string;
   /** Short description of the skill */
   description: string;
   /** Full template content for the skill */

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -149,8 +149,12 @@ function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
         const agent = getFrontmatterString(fm, 'agent');
         const pipeline = parseSkillPipelineMetadata(fm);
 
+        const status = getFrontmatterString(fm, 'status') as CommandMetadata['status'] || undefined;
+        const supersededBy = getFrontmatterString(fm, 'superseded-by');
+
         for (const commandName of commandNames) {
           const isAlias = commandName !== canonicalName;
+          const isDeprecated = status === 'deprecated';
           const metadata: CommandMetadata = {
             name: commandName,
             description,
@@ -160,10 +164,14 @@ function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
             pipeline: isAlias ? undefined : pipeline,
             aliases: isAlias ? undefined : aliases,
             aliasOf: isAlias ? canonicalName : undefined,
-            deprecatedAlias: isAlias || undefined,
-            deprecationMessage: isAlias
-              ? `Alias "/${commandName}" is deprecated. Use "/${canonicalName}" instead.`
+            deprecatedAlias: (isAlias && isDeprecated) || undefined,
+            deprecationMessage: isDeprecated
+              ? supersededBy
+                ? `"/${commandName}" is deprecated. Use "/${supersededBy}" instead.`
+                : `"/${commandName}" is deprecated.`
               : undefined,
+            status,
+            supersededBy: supersededBy || undefined,
           };
 
           skillCommands.push({

--- a/src/hooks/auto-slash-command/types.ts
+++ b/src/hooks/auto-slash-command/types.ts
@@ -64,6 +64,10 @@ export interface CommandMetadata {
   aliasOf?: string;
   deprecatedAlias?: boolean;
   deprecationMessage?: string;
+  /** Lifecycle status: active (default), deprecated, or experimental */
+  status?: 'active' | 'deprecated' | 'experimental';
+  /** Skill that supersedes this one when status is deprecated */
+  supersededBy?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `status` and `supersededBy` fields to `BuiltinSkill` and `CommandMetadata` types
- Replace blanket alias-is-deprecated logic with frontmatter-driven status
- Only skills with `status: deprecated` in SKILL.md frontmatter show deprecation warnings
- Non-deprecated aliases now route silently without false warnings

## Motivation
Previously all aliases were auto-marked as deprecated, showing misleading warnings like "Alias /psm is deprecated". This change makes deprecation explicit and controlled via SKILL.md frontmatter.

## SKILL.md usage
```yaml
---
name: old-skill
status: deprecated
superseded-by: new-skill
---
```

## Test plan
- [ ] Existing aliases (e.g., `psm` for `project-session-manager`) no longer show deprecated warnings
- [ ] Skills with `status: deprecated` in frontmatter correctly show deprecation message
- [ ] Skills without `status` field behave identically to before (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)