### PR TITLE
feat(skills): add category frontmatter to all 37 builtin skills

### DIFF
--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ai-slop-cleaner
 description: Clean AI-generated code slop with a regression-safe, deletion-first workflow and optional reviewer-only mode
+category: qa
 level: 3
 ---
 

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ask
 description: Process-first advisor routing for Claude, Codex, or Gemini via `omc ask`, with artifact capture and no raw CLI assembly
+category: research
 ---
 
 # Ask

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autopilot
 description: Full autonomous execution from idea to working code
+category: execution
 argument-hint: "<product idea or task description>"
 level: 4
 ---

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cancel
 description: Cancel any active OMC mode (autopilot, ralph, ultrawork, ultraqa, swarm, ultrapilot, pipeline, team)
+category: utility
 argument-hint: "[--force|--all]"
 level: 2
 ---

--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ccg
 description: Claude-Codex-Gemini tri-model orchestration via /ask codex + /ask gemini, then Claude synthesizes results
+category: execution
 level: 5
 ---
 

--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: configure-notifications
 description: Configure notification integrations (Telegram, Discord, Slack) via natural language
+category: setup
 triggers:
   - "configure notifications"
   - "setup notifications"

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: debug
 description: Diagnose the current OMC session or repo state using logs, traces, state, and focused reproduction
+category: debugging
 ---
 
 # Debug

--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deep-dive
 description: "2-stage pipeline: trace (causal investigation) -> deep-interview (requirements crystallization) with 3-point injection"
+category: planning
 argument-hint: "<problem or exploration target>"
 triggers:
   - "deep dive"

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deep-interview
 description: Socratic deep interview with mathematical ambiguity gating before autonomous execution
+category: planning
 argument-hint: "[--quick|--standard|--deep] [--autoresearch] <idea or vague description>"
 pipeline: [deep-interview, omc-plan, autopilot]
 next-skill: omc-plan

--- a/skills/deepinit/SKILL.md
+++ b/skills/deepinit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deepinit
 description: Deep codebase initialization with hierarchical AGENTS.md documentation
+category: setup
 level: 4
 ---
 

--- a/skills/external-context/SKILL.md
+++ b/skills/external-context/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: external-context
 description: Invoke parallel document-specialist agents for external web searches and documentation lookup
+category: research
 argument-hint: <search query or topic>
 level: 4
 ---

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: hud
 description: Configure HUD display options (layout, presets, display elements)
+category: utility
 argument-hint: "[setup|minimal|focused|full|status]"
 role: config-writer  # DOCUMENTATION ONLY - This skill writes to ~/.claude/ paths
 scope: ~/.claude/**  # DOCUMENTATION ONLY - Allowed write scope

--- a/skills/learner/SKILL.md
+++ b/skills/learner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: learner
 description: Extract a learned skill from the current conversation
+category: utility
 level: 7
 ---
 

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mcp-setup
 description: Configure popular MCP servers for enhanced agent capabilities
+category: setup
 level: 2
 ---
 

--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: omc-doctor
 description: Diagnose and fix oh-my-claudecode installation issues
+category: setup
 level: 3
 ---
 

--- a/skills/omc-reference/SKILL.md
+++ b/skills/omc-reference/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: omc-reference
 description: OMC agent catalog, available tools, team pipeline routing, commit protocol, and skills registry. Auto-loads when delegating to agents, using OMC tools, orchestrating teams, making commits, or invoking skills.
+category: utility
 user-invocable: false
 ---
 

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: omc-setup
 description: Install or refresh oh-my-claudecode for plugin, npm, and local-dev setups from the canonical setup flow
+category: setup
 level: 2
 ---
 

--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: omc-teams
 description: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution
+category: execution
 aliases: []
 level: 4
 ---

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: omc-plan
 description: Strategic planning with optional interview workflow
+category: planning
 argument-hint: "[--direct|--consensus|--review] [--interactive] [--deliberate] <task description>"
 pipeline: [deep-interview, omc-plan, autopilot]
 next-skill: autopilot

--- a/skills/project-session-manager/SKILL.md
+++ b/skills/project-session-manager/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: project-session-manager
 description: Worktree-first dev environment manager for issues, PRs, and features with optional tmux sessions
+category: utility
 aliases: [psm]
 level: 2
 ---

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ralph
 description: Self-referential loop until task completion with configurable verification reviewer
+category: execution
 argument-hint: "[--no-prd] [--no-deslop] [--critic=architect|critic|codex] <task description>"
 level: 4
 ---

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ralplan
 description: Consensus planning entrypoint that auto-gates vague ralph/autopilot/team requests before execution
+category: planning
 argument-hint: "[--interactive] [--deliberate] [--architect codex] [--critic codex] <task description>"
 level: 4
 ---

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: release
 description: Automated release workflow for oh-my-claudecode
+category: utility
 level: 3
 ---
 

--- a/skills/remember/SKILL.md
+++ b/skills/remember/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remember
 description: Review reusable project knowledge and decide what belongs in project memory, notepad, or durable docs
+category: utility
 ---
 
 # Remember

--- a/skills/sciomc/SKILL.md
+++ b/skills/sciomc/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sciomc
 description: Orchestrate parallel scientist agents for comprehensive analysis with AUTO mode
+category: research
 argument-hint: <research goal>
 level: 4
 ---

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: self-improve
 description: Autonomous evolutionary code improvement engine with tournament selection
+category: execution
 level: 4
 ---
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: setup
 description: Use first for install/update routing — sends setup, doctor, or MCP requests to the correct OMC setup flow
+category: setup
 level: 2
 ---
 

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill
 description: Manage local skills - list, add, remove, search, edit, setup wizard
+category: utility
 argument-hint: "<command> [args]"
 level: 2
 ---

--- a/skills/skillify/SKILL.md
+++ b/skills/skillify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skillify
 description: Turn a repeatable workflow from the current session into a reusable OMC skill draft
+category: utility
 ---
 
 # Skillify

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: team
 description: N coordinated agents on shared task list using Claude Code native teams
+category: execution
 argument-hint: "[N:agent-type] [ralph] <task description>"
 aliases: []
 level: 4

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: trace
 description: Evidence-driven tracing lane that orchestrates competing tracer hypotheses in Claude built-in team mode
+category: debugging
 argument-hint: "<observation to trace>"
 agent: tracer
 level: 2

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ultraqa
 description: QA cycling workflow - test, verify, fix, repeat until goal met
+category: qa
 argument-hint: "[--tests|--build|--lint|--typecheck|--custom <pattern>] [--interactive]"
 level: 3
 ---

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ultrawork
 description: Parallel execution engine for high-throughput task completion
+category: execution
 argument-hint: "<task description with parallel work items>"
 level: 4
 ---

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verify
 description: Verify that a change really works before you claim completion
+category: qa
 ---
 
 # Verify

--- a/skills/visual-verdict/SKILL.md
+++ b/skills/visual-verdict/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: visual-verdict
 description: Structured visual QA verdict for screenshot-to-reference comparisons
+category: qa
 level: 2
 ---
 

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: wiki
 description: LLM Wiki — persistent markdown knowledge base that compounds across sessions (Karpathy model)
+category: research
 triggers: ["wiki", "wiki this", "wiki add", "wiki lint", "wiki query"]
 ---
 

--- a/skills/writer-memory/SKILL.md
+++ b/skills/writer-memory/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: writer-memory
 description: Agentic memory system for writers - track characters, relationships, scenes, and themes
+category: utility
 argument-hint: "init|char|rel|scene|query|validate|synopsis|status|export [args]"
 level: 7
 ---


### PR DESCRIPTION
## Summary
- Add `category` field to all 37 builtin SKILL.md files
- Categories: setup (6), planning (4), execution (7), qa (4), debugging (2), research (4), utility (10)
- Frontmatter-only change — no runtime code modified

## Motivation
With 37+ builtin skills, users need a way to discover skills by purpose rather than memorizing names. The `category` field enables goal-based grouping in tooling and documentation.

## Category distribution
| Category | Count | Examples |
|----------|-------|---------|
| setup | 6 | omc-setup, mcp-setup, omc-doctor |
| planning | 4 | ralplan, deep-interview, plan |
| execution | 7 | autopilot, ralph, ultrawork, team |
| qa | 4 | ultraqa, verify, ai-slop-cleaner |
| debugging | 2 | trace, debug |
| research | 4 | ask, external-context, wiki |
| utility | 10 | cancel, skill, hud, learner |

## Test plan
- [ ] All 37 SKILL.md files have `category` field
- [ ] Unknown frontmatter fields are safely ignored by existing parser
- [ ] No runtime behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)