### PR TITLE
fix: prevent persistent-mode hook from re-blocking after cancel

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -141,6 +141,7 @@ async function sendStopNotification(modeName, stateData, sessionId, directory) {
  * from causing the stop hook to malfunction in new sessions.
  */
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+const CANCEL_COMPLETED_TTL_MS = 30 * 60 * 1000; // 30 min — outlives session-restore zombie re-creation
 
 // Stop breaker constants for first-class mode enforcement
 const TEAM_PIPELINE_STOP_BLOCKER_MAX = 20;
@@ -316,6 +317,60 @@ function isSessionCancelInProgress(stateDir, sessionId) {
   // Fall back to legacy path
   const legacySignalPath = join(stateDir, 'cancel-signal-state.json');
   return isActiveSignal(legacySignalPath);
+}
+
+/**
+ * Write a persistent cancel-completed marker for modes active when cancel fires.
+ * Survives longer than the 30-second cancel signal to prevent the hook from
+ * re-blocking modes that the LLM re-creates from session-restore context.
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/2380
+ */
+function writeCancelCompletedMarker(stateDir, sessionId, modes) {
+  if (!modes || modes.length === 0) return;
+  const markerPath = sessionId
+    ? join(stateDir, "sessions", sessionId, "cancel-completed.json")
+    : join(stateDir, "cancel-completed.json");
+  const existing = readJsonFile(markerPath) || { cancelled_modes: {} };
+  const now = new Date().toISOString();
+  for (const mode of modes) {
+    existing.cancelled_modes[mode] = { cancelled_at: now };
+  }
+  writeJsonFile(markerPath, existing);
+}
+
+/**
+ * Check if a mode was recently cancelled in this session (within CANCEL_COMPLETED_TTL_MS).
+ */
+function wasModeCancelledRecently(stateDir, sessionId, modeName) {
+  const paths = [];
+  if (sessionId) {
+    paths.push(join(stateDir, "sessions", sessionId, "cancel-completed.json"));
+  }
+  paths.push(join(stateDir, "cancel-completed.json"));
+  for (const markerPath of paths) {
+    const marker = readJsonFile(markerPath);
+    if (!marker?.cancelled_modes?.[modeName]) continue;
+    const cancelledAt = new Date(marker.cancelled_modes[modeName].cancelled_at).getTime();
+    if (!Number.isFinite(cancelledAt)) continue;
+    if ((Date.now() - cancelledAt) < CANCEL_COMPLETED_TTL_MS) return true;
+  }
+  return false;
+}
+
+/**
+ * Remove zombie state files re-created from session-restore context after cancel.
+ * For each mode recently cancelled, deletes its state file and clears the
+ * in-memory reference so subsequent checks treat it as inactive.
+ */
+function cleanupZombieStates(stateDir, sessionId, modeRefs) {
+  for (const { name, ref } of modeRefs) {
+    if (ref.state?.active && wasModeCancelledRecently(stateDir, sessionId, name)) {
+      try {
+        if (ref.path && existsSync(ref.path)) unlinkSync(ref.path);
+      } catch { /* best effort */ }
+      ref.state = null;
+    }
+  }
 }
 
 /**
@@ -692,9 +747,34 @@ async function main() {
     // Cache the result to pass to sub-checks (avoids TOCTOU re-reads, issue #1058)
     const cancelInProgress = isSessionCancelInProgress(stateDir, sessionId);
     if (cancelInProgress) {
+      // Write persistent marker so zombie state from session-restore gets ignored
+      const activeModes = [];
+      if (ralph.state?.active) activeModes.push("ralph");
+      if (autopilot.state?.active) activeModes.push("autopilot");
+      if (ultrapilot.state?.active) activeModes.push("ultrapilot");
+      if (ultrawork.state?.active) activeModes.push("ultrawork");
+      if (ultraqa.state?.active) activeModes.push("ultraqa");
+      if (pipeline.state?.active) activeModes.push("pipeline");
+      if (team.state?.active) activeModes.push("team");
+      if (ralplan.state?.active) activeModes.push("ralplan");
+      if (omcTeams.state?.active) activeModes.push("omc-teams");
+      writeCancelCompletedMarker(stateDir, sessionId, activeModes);
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }
+
+    // Clean up zombie states re-created from session-restore context (issue #2380)
+    cleanupZombieStates(stateDir, sessionId, [
+      { name: "ralph", ref: ralph },
+      { name: "autopilot", ref: autopilot },
+      { name: "ultrapilot", ref: ultrapilot },
+      { name: "ultrawork", ref: ultrawork },
+      { name: "ultraqa", ref: ultraqa },
+      { name: "pipeline", ref: pipeline },
+      { name: "team", ref: team },
+      { name: "ralplan", ref: ralplan },
+      { name: "omc-teams", ref: omcTeams },
+    ]);
 
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -182,6 +182,7 @@ Do NOT skip this step. Do NOT move on without fixing the error.
  */
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
 const CANCEL_SIGNAL_TTL_MS = 30_000;
+const CANCEL_COMPLETED_TTL_MS = 30 * 60 * 1000; // 30 min — outlives session-restore zombie re-creation
 const TEAM_TERMINAL_PHASES = new Set([
   "completed",
   "complete",
@@ -402,6 +403,60 @@ function isSessionCancelInProgress(stateDir, sessionId) {
   }
 
   return isActiveSignal(join(stateDir, "cancel-signal-state.json"));
+}
+
+/**
+ * Write a persistent cancel-completed marker for modes active when cancel fires.
+ * Survives longer than the 30-second cancel signal to prevent the hook from
+ * re-blocking modes that the LLM re-creates from session-restore context.
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/2380
+ */
+function writeCancelCompletedMarker(stateDir, sessionId, modes) {
+  if (!modes || modes.length === 0) return;
+  const markerPath = sessionId
+    ? join(stateDir, "sessions", sessionId, "cancel-completed.json")
+    : join(stateDir, "cancel-completed.json");
+  const existing = readJsonFile(markerPath) || { cancelled_modes: {} };
+  const now = new Date().toISOString();
+  for (const mode of modes) {
+    existing.cancelled_modes[mode] = { cancelled_at: now };
+  }
+  writeJsonFile(markerPath, existing);
+}
+
+/**
+ * Check if a mode was recently cancelled in this session (within CANCEL_COMPLETED_TTL_MS).
+ */
+function wasModeCancelledRecently(stateDir, sessionId, modeName) {
+  const paths = [];
+  if (sessionId) {
+    paths.push(join(stateDir, "sessions", sessionId, "cancel-completed.json"));
+  }
+  paths.push(join(stateDir, "cancel-completed.json"));
+  for (const markerPath of paths) {
+    const marker = readJsonFile(markerPath);
+    if (!marker?.cancelled_modes?.[modeName]) continue;
+    const cancelledAt = new Date(marker.cancelled_modes[modeName].cancelled_at).getTime();
+    if (!Number.isFinite(cancelledAt)) continue;
+    if ((Date.now() - cancelledAt) < CANCEL_COMPLETED_TTL_MS) return true;
+  }
+  return false;
+}
+
+/**
+ * Remove zombie state files re-created from session-restore context after cancel.
+ * For each mode recently cancelled, deletes its state file and clears the
+ * in-memory reference so subsequent checks treat it as inactive.
+ */
+function cleanupZombieStates(stateDir, sessionId, modeRefs) {
+  for (const { name, ref } of modeRefs) {
+    if (ref.state?.active && wasModeCancelledRecently(stateDir, sessionId, name)) {
+      try {
+        if (ref.path && existsSync(ref.path)) unlinkSync(ref.path);
+      } catch { /* best effort */ }
+      ref.state = null;
+    }
+  }
 }
 
 function shouldWriteStateBack(path) {
@@ -708,9 +763,32 @@ async function main() {
     );
 
     if (isSessionCancelInProgress(stateDir, sessionId)) {
+      // Write persistent marker so zombie state from session-restore gets ignored
+      const activeModes = [];
+      if (ralph.state?.active) activeModes.push("ralph");
+      if (autopilot.state?.active) activeModes.push("autopilot");
+      if (ultrapilot.state?.active) activeModes.push("ultrapilot");
+      if (ultrawork.state?.active) activeModes.push("ultrawork");
+      if (ultraqa.state?.active) activeModes.push("ultraqa");
+      if (pipeline.state?.active) activeModes.push("pipeline");
+      if (team.state?.active) activeModes.push("team");
+      if (omcTeams.state?.active) activeModes.push("omc-teams");
+      writeCancelCompletedMarker(stateDir, sessionId, activeModes);
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }
+
+    // Clean up zombie states re-created from session-restore context (issue #2380)
+    cleanupZombieStates(stateDir, sessionId, [
+      { name: "ralph", ref: ralph },
+      { name: "autopilot", ref: autopilot },
+      { name: "ultrapilot", ref: ultrapilot },
+      { name: "ultrawork", ref: ultrawork },
+      { name: "ultraqa", ref: ultraqa },
+      { name: "pipeline", ref: pipeline },
+      { name: "team", ref: team },
+      { name: "omc-teams", ref: omcTeams },
+    ]);
 
     // Swarm uses swarm-summary.json (not swarm-state.json) + marker file
     const swarmMarker = existsSync(join(stateDir, "swarm-active.marker"));


### PR DESCRIPTION
## Summary

Fixes #2380 — After explicit cancellation (`/cancel` or `state_clear`), the LLM may re-create mode state files from `<session-restore>` context injected during context compaction. The existing 30-second cancel signal TTL expires before the LLM stops re-creating state, causing an infinite loop: cancel → hook re-blocks → cancel → hook re-blocks.

### Root Cause

1. User cancels ultrawork/ralph/etc → `cancel-signal-state.json` written (30s TTL) → state files cleared
2. Cancel signal expires after 30 seconds
3. LLM sees `[ULTRAWORK MODE RESTORED]` in session-restore context and re-creates the state file
4. Hook reads the re-created state, finds `active: true`, blocks the stop
5. Repeat forever — user cannot escape without manually deleting files

### Fix

- Add a **persistent `cancel-completed.json` marker** with a 30-minute TTL (vs 30-second signal)
- When `isSessionCancelInProgress()` fires, write which modes were active to this marker
- On every hook invocation, `cleanupZombieStates()` checks this marker and **deletes any state files re-created after cancellation**, breaking the loop
- Zombie state cleanup happens before any mode-specific blocking checks

### Changes

- `scripts/persistent-mode.mjs` — ESM version
- `scripts/persistent-mode.cjs` — CJS version

Both files receive identical logic:
- `CANCEL_COMPLETED_TTL_MS` constant (30 minutes)
- `writeCancelCompletedMarker()` — persists cancelled mode names with timestamp
- `wasModeCancelledRecently()` — checks if a mode was cancelled within TTL
- `cleanupZombieStates()` — removes zombie state files and clears in-memory refs

### How it works

```
Cancel fires → writes cancel-completed.json { ultrawork: { cancelled_at: "..." } }
                ↓
LLM re-creates ultrawork-state.json from session-restore
                ↓
Hook runs → cleanupZombieStates() sees ultrawork in cancel-completed.json
          → deletes zombie ultrawork-state.json
          → ref.state = null (skips blocking)
          → allows stop ✓
```

## Test plan

- [ ] Start ultrawork mode, cancel with `/oh-my-claudecode:cancel`, verify state files are cleared
- [ ] Simulate session-restore by manually re-creating `ultrawork-state.json` with `active: true` — verify hook does NOT block
- [ ] Verify `cancel-completed.json` is written to session-scoped path when session ID is available
- [ ] Verify marker expires after 30 minutes (new ultrawork sessions are not affected)
- [ ] Verify both `.mjs` and `.cjs` pass `node --check`