### PR TITLE
fix(autoresearch): strip TMUX env for nested tmux compatibility

### DIFF
--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -432,7 +432,7 @@ describe('spawnAutoresearchSetupTmux', () => {
       expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
         'tmux',
         ['send-keys', '-t', '%42', '-l', buildAutoresearchSetupSlashCommand()],
-        { stdio: 'ignore' },
+        expect.objectContaining({ stdio: 'ignore' }),
       );
       expect(logSpy).toHaveBeenCalledWith('\nAutoresearch setup launched in background Claude session.');
       expect(logSpy).toHaveBeenCalledWith('  Attach:   tmux attach -t omc-autoresearch-setup-kf12oi');

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -313,9 +313,18 @@ function resolveMissionRepoRoot(missionDir: string): string {
   }).trim();
 }
 
+// Strip TMUX from the environment so tmux commands always target the default
+// server. Without this, autoresearch launched from inside a nested tmux session
+// (e.g. wtx/Worktrunk worktrees) silently creates sessions on the nested
+// server, making them unreachable from the outer session.
+function tmuxEnv(): NodeJS.ProcessEnv {
+  const { TMUX: _, ...env } = process.env;
+  return env;
+}
+
 function assertTmuxSessionAvailable(sessionName: string): void {
   try {
-    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore' });
+    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore', env: tmuxEnv() });
   } catch {
     throw new Error(
       `tmux session "${sessionName}" did not stay available after launch. `
@@ -332,7 +341,7 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
   const sessionName = `omc-autoresearch-${slug}`;
 
   try {
-    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore' });
+    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore', env: tmuxEnv() });
     throw new Error(
       `tmux session "${sessionName}" already exists.\n`
       + `  Attach: tmux attach -t ${sessionName}\n`
@@ -350,7 +359,7 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
   const command = buildTmuxShellCommand(process.execPath, [omcPath, 'autoresearch', missionDir]);
   const wrappedCommand = wrapWithLoginShell(command);
 
-  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-c', repoRoot, wrappedCommand], { stdio: 'ignore' });
+  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-c', repoRoot, wrappedCommand], { stdio: 'ignore', env: tmuxEnv() });
   assertTmuxSessionAvailable(sessionName);
 
   console.log('\nAutoresearch launched in background tmux session.');
@@ -410,14 +419,14 @@ export function spawnAutoresearchSetupTmux(repoRoot: string): void {
   const paneId = execFileSync(
     'tmux',
     ['new-session', '-d', '-P', '-F', '#{pane_id}', '-s', sessionName, '-c', repoRoot, wrappedClaudeCommand],
-    { encoding: 'utf-8' },
+    { encoding: 'utf-8', env: tmuxEnv() },
   ).trim();
 
   assertTmuxSessionAvailable(sessionName);
 
   if (paneId) {
-    execFileSync('tmux', ['send-keys', '-t', paneId, '-l', buildAutoresearchSetupSlashCommand()], { stdio: 'ignore' });
-    execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], { stdio: 'ignore' });
+    execFileSync('tmux', ['send-keys', '-t', paneId, '-l', buildAutoresearchSetupSlashCommand()], { stdio: 'ignore', env: tmuxEnv() });
+    execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], { stdio: 'ignore', env: tmuxEnv() });
   }
 
   console.log('\nAutoresearch setup launched in background Claude session.');


### PR DESCRIPTION
## Summary

- Strip `TMUX` from the environment for all `execFileSync('tmux', ...)` calls in autoresearch
- Sessions are always created on the default tmux server, regardless of nesting
- Existing tests updated and passing (14/14)

Fixes #2384

## Problem

When `omc autoresearch` runs inside a nested tmux session (e.g. worktree managers like Worktrunk use `tmux -L <server>`), the `TMUX` env var causes all tmux commands to target the nested server. Sessions are created but unreachable from the outer session.

`resolveLaunchPolicy()` in `tmux-utils.ts` already handles this for the general Claude launcher, but autoresearch bypasses it entirely.

## Fix

Introduce a `tmuxEnv()` helper that returns `process.env` with `TMUX` stripped. Applied to all tmux calls in:
- `spawnAutoresearchTmux` — `has-session`, `new-session`
- `spawnAutoresearchSetupTmux` — `new-session`, `send-keys`
- `assertTmuxSessionAvailable` — `has-session`

## Test plan

- [x] `npx vitest run src/cli/__tests__/autoresearch-guided.test.ts` — 14 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Test assertion updated to use `expect.objectContaining` for the new `env` option