### PR TITLE
fix(tmux): strip TMUX env var from all tmux calls for nested session compatibility

### DIFF
--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -21,7 +21,7 @@ import {
   runAutoresearchSetupSession,
   type AutoresearchSetupSessionInput,
 } from './autoresearch-setup-session.js';
-import { buildTmuxShellCommand, isTmuxAvailable, quoteShellArg, wrapWithLoginShell } from './tmux-utils.js';
+import { buildTmuxShellCommand, isTmuxAvailable, quoteShellArg, wrapWithLoginShell, tmuxEnv } from './tmux-utils.js';
 
 const CLAUDE_BYPASS_FLAG = '--dangerously-skip-permissions';
 const AUTORESEARCH_SETUP_SLASH_COMMAND = '/deep-interview --autoresearch';
@@ -315,7 +315,7 @@ function resolveMissionRepoRoot(missionDir: string): string {
 
 function assertTmuxSessionAvailable(sessionName: string): void {
   try {
-    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore' });
+    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore', env: tmuxEnv() });
   } catch {
     throw new Error(
       `tmux session "${sessionName}" did not stay available after launch. `
@@ -332,7 +332,7 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
   const sessionName = `omc-autoresearch-${slug}`;
 
   try {
-    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore' });
+    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore', env: tmuxEnv() });
     throw new Error(
       `tmux session "${sessionName}" already exists.\n`
       + `  Attach: tmux attach -t ${sessionName}\n`
@@ -350,7 +350,7 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
   const command = buildTmuxShellCommand(process.execPath, [omcPath, 'autoresearch', missionDir]);
   const wrappedCommand = wrapWithLoginShell(command);
 
-  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-c', repoRoot, wrappedCommand], { stdio: 'ignore' });
+  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-c', repoRoot, wrappedCommand], { stdio: 'ignore', env: tmuxEnv() });
   assertTmuxSessionAvailable(sessionName);
 
   console.log('\nAutoresearch launched in background tmux session.');
@@ -410,14 +410,14 @@ export function spawnAutoresearchSetupTmux(repoRoot: string): void {
   const paneId = execFileSync(
     'tmux',
     ['new-session', '-d', '-P', '-F', '#{pane_id}', '-s', sessionName, '-c', repoRoot, wrappedClaudeCommand],
-    { encoding: 'utf-8' },
+    { encoding: 'utf-8', env: tmuxEnv() },
   ).trim();
 
   assertTmuxSessionAvailable(sessionName);
 
   if (paneId) {
-    execFileSync('tmux', ['send-keys', '-t', paneId, '-l', buildAutoresearchSetupSlashCommand()], { stdio: 'ignore' });
-    execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], { stdio: 'ignore' });
+    execFileSync('tmux', ['send-keys', '-t', paneId, '-l', buildAutoresearchSetupSlashCommand()], { stdio: 'ignore', env: tmuxEnv() });
+    execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], { stdio: 'ignore', env: tmuxEnv() });
   }
 
   console.log('\nAutoresearch setup launched in background Claude session.');

--- a/src/cli/interop.ts
+++ b/src/cli/interop.ts
@@ -7,7 +7,7 @@
 
 import { execFileSync } from 'child_process';
 import { randomUUID } from 'crypto';
-import { isTmuxAvailable, isClaudeAvailable } from './tmux-utils.js';
+import { isTmuxAvailable, isClaudeAvailable, tmuxEnv } from './tmux-utils.js';
 import { initInteropSession } from '../interop/shared-state.js';
 
 export type InteropMode = 'off' | 'observe' | 'active';
@@ -111,6 +111,7 @@ export function launchInteropSession(cwd: string = process.cwd()): void {
   try {
     const output = execFileSync('tmux', ['display-message', '-p', '#{pane_id}'], {
       encoding: 'utf-8',
+      env: tmuxEnv(),
     });
     currentPaneId = output.trim();
   } catch (_error) {
@@ -135,10 +136,10 @@ export function launchInteropSession(cwd: string = process.cwd()): void {
         '-c', cwd,
         '-t', currentPaneId,
         'codex',
-      ], { stdio: 'inherit' });
+      ], { stdio: 'inherit', env: tmuxEnv() });
 
       // Select left pane (original/current)
-      execFileSync('tmux', ['select-pane', '-t', currentPaneId], { stdio: 'ignore' });
+      execFileSync('tmux', ['select-pane', '-t', currentPaneId], { stdio: 'ignore', env: tmuxEnv() });
 
       console.log('\nInterop session ready!');
       console.log('- Left pane: Claude Code (this terminal)');

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -24,6 +24,7 @@ import {
   wrapWithLoginShell,
   isClaudeAvailable,
   quoteShellArg,
+  tmuxEnv,
 } from './tmux-utils.js';
 
 // Flag mapping
@@ -381,7 +382,7 @@ export function runClaude(cwd: string, args: string[], sessionId: string): void 
 function runClaudeInsideTmux(cwd: string, args: string[]): void {
   // Enable mouse scrolling in the current tmux session (non-fatal if it fails)
   try {
-    execFileSync('tmux', ['set-option', 'mouse', 'on'], { stdio: 'ignore' });
+    execFileSync('tmux', ['set-option', 'mouse', 'on'], { stdio: 'ignore', env: tmuxEnv() });
   } catch { /* non-fatal — user's tmux may not support these options */ }
 
   // Launch Claude in current pane
@@ -444,26 +445,26 @@ function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string): 
   const sessionName = buildTmuxSessionName(cwd);
 
   try {
-    execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-c', cwd, claudeCmd], { stdio: 'inherit' });
+    execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-c', cwd, claudeCmd], { stdio: 'inherit', env: tmuxEnv() });
   } catch {
     runClaudeDirect(cwd, args);
     return;
   }
 
   try {
-    execFileSync('tmux', ['set-option', '-t', sessionName, 'mouse', 'on'], { stdio: 'ignore' });
+    execFileSync('tmux', ['set-option', '-t', sessionName, 'mouse', 'on'], { stdio: 'ignore', env: tmuxEnv() });
   } catch {
     /* non-fatal — user's tmux may not support these options */
   }
 
   try {
-    execFileSync('tmux', ['attach-session', '-t', sessionName], { stdio: 'inherit' });
+    execFileSync('tmux', ['attach-session', '-t', sessionName], { stdio: 'inherit', env: tmuxEnv() });
   } catch {
     // If the detached session still exists, preserve it so interrupted
     // attach paths (SSH disconnect, terminal drop, etc.) do not kill or
     // duplicate a valid Claude session.
     try {
-      execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore' });
+      execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore', env: tmuxEnv() });
       return;
     } catch {
       runClaudeDirect(cwd, args);

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -15,6 +15,19 @@ export interface TmuxPaneSnapshot {
 }
 
 /**
+ * Return a copy of process.env with TMUX stripped.
+ *
+ * When running inside a nested tmux session (e.g. worktree managers that use
+ * `tmux -L <server>`), the TMUX env var causes tmux commands to target the
+ * nested server instead of the default one. Stripping it ensures sessions are
+ * always created on and queried from the default tmux server.
+ */
+export function tmuxEnv(): NodeJS.ProcessEnv {
+  const { TMUX: _, ...env } = process.env;
+  return env;
+}
+
+/**
  * Check if tmux is available on the system
  */
 export function isTmuxAvailable(): boolean {
@@ -227,7 +240,7 @@ export function createHudWatchPane(cwd: string, hudCmd: string): string | null {
 export function killTmuxPane(paneId: string): void {
   if (!paneId.startsWith('%')) return;
   try {
-    execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'ignore' });
+    execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'ignore', env: tmuxEnv() });
   } catch {
     // Pane may already be gone; ignore
   }

--- a/src/features/rate-limit-wait/tmux-detector.ts
+++ b/src/features/rate-limit-wait/tmux-detector.ts
@@ -10,6 +10,7 @@
  */
 
 import { execFileSync, spawnSync } from 'child_process';
+import { tmuxEnv } from '../../cli/tmux-utils.js';
 import type { TmuxPane, PaneAnalysisResult, BlockedPane } from './types.js';
 
 /**
@@ -105,6 +106,7 @@ export function listTmuxPanes(): TmuxPane[] {
     const result = execFileSync('tmux', ['list-panes', '-a', '-F', format], {
       encoding: 'utf-8',
       timeout: 5000,
+      env: tmuxEnv(),
     });
 
     const panes: TmuxPane[] = [];
@@ -162,6 +164,7 @@ export function capturePaneContent(paneId: string, lines = 15): string {
     const result = execFileSync('tmux', ['capture-pane', '-t', paneId, '-p', '-S', `-${safeLines}`], {
       encoding: 'utf-8',
       timeout: 5000,
+      env: tmuxEnv(),
     });
     return result;
   } catch (error) {
@@ -278,6 +281,7 @@ export function sendResumeSequence(paneId: string): boolean {
     // Send "1" to select the first option (typically "Continue" or similar)
     execFileSync('tmux', ['send-keys', '-t', paneId, '1', 'Enter'], {
       timeout: 2000,
+      env: tmuxEnv(),
     });
 
     // Wait a moment for the response
@@ -308,11 +312,13 @@ export function sendToPane(paneId: string, text: string, pressEnter = true): boo
     // Send text with -l flag (literal) to avoid key interpretation issues in TUI apps
     execFileSync('tmux', ['send-keys', '-t', paneId, '-l', sanitizedText], {
       timeout: 2000,
+      env: tmuxEnv(),
     });
     // Send Enter as a separate command so it is interpreted as a key press
     if (pressEnter) {
       execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], {
         timeout: 2000,
+        env: tmuxEnv(),
       });
     }
     return true;

--- a/src/ralphthon/orchestrator.ts
+++ b/src/ralphthon/orchestrator.ts
@@ -9,6 +9,7 @@
  */
 
 import { execFileSync } from 'child_process';
+import { tmuxEnv } from '../cli/tmux-utils.js';
 import {
   writeModeState,
   readModeState,
@@ -87,7 +88,7 @@ export function isPaneIdle(paneId: string): boolean {
   try {
     const output = execFileSync(
       'tmux', ['display-message', '-t', paneId, '-p', '#{pane_current_command}'],
-      { encoding: 'utf-8', timeout: 5000 },
+      { encoding: 'utf-8', timeout: 5000, env: tmuxEnv() },
     ).trim();
 
     const shellNames = ['bash', 'zsh', 'fish', 'sh', 'dash'];
@@ -102,7 +103,7 @@ export function isPaneIdle(paneId: string): boolean {
  */
 export function paneExists(paneId: string): boolean {
   try {
-    execFileSync('tmux', ['has-session', '-t', paneId], { timeout: 5000, stdio: 'pipe' });
+    execFileSync('tmux', ['has-session', '-t', paneId], { timeout: 5000, stdio: 'pipe', env: tmuxEnv() });
     return true;
   } catch {
     return false;
@@ -114,7 +115,7 @@ export function paneExists(paneId: string): boolean {
  */
 export function sendKeysToPane(paneId: string, text: string): boolean {
   try {
-    execFileSync('tmux', ['send-keys', '-t', paneId, text, 'Enter'], { timeout: 10000 });
+    execFileSync('tmux', ['send-keys', '-t', paneId, text, 'Enter'], { timeout: 10000, env: tmuxEnv() });
     return true;
   } catch {
     return false;
@@ -128,7 +129,7 @@ export function capturePaneContent(paneId: string, lines = 50): string {
   try {
     return execFileSync(
       'tmux', ['capture-pane', '-t', paneId, '-p', '-S', `-${lines}`],
-      { encoding: 'utf-8', timeout: 5000 },
+      { encoding: 'utf-8', timeout: 5000, env: tmuxEnv() },
     ).trim();
   } catch {
     return '';

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -13,6 +13,7 @@
 import { resolve } from 'path';
 import { mkdir } from 'fs/promises';
 import { execFileSync, spawnSync } from 'child_process';
+import { tmuxEnv } from '../cli/tmux-utils.js';
 import {
   teamReadConfig,
   teamWriteWorkerIdentity,
@@ -126,14 +127,14 @@ export async function scaleUp(
         }
         try {
           if (w.pane_id) {
-            execFileSync('tmux', ['kill-pane', '-t', w.pane_id], { stdio: 'pipe' });
+            execFileSync('tmux', ['kill-pane', '-t', w.pane_id], { stdio: 'pipe', env: tmuxEnv() });
           }
         } catch { /* best-effort pane cleanup */ }
       }
 
       if (paneId) {
         try {
-          execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'pipe' });
+          execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'pipe', env: tmuxEnv() });
         } catch { /* best-effort pane cleanup */ }
       }
 
@@ -200,7 +201,7 @@ export async function scaleUp(
 
       const result = spawnSync('tmux', [
         'split-window', splitDirection, '-t', splitTarget, '-d', '-P', '-F', '#{pane_id}', '-c', leaderCwd, cmd,
-      ], { encoding: 'utf-8' });
+      ], { encoding: 'utf-8', env: tmuxEnv() });
 
       if (result.status !== 0) {
         return await rollbackScaleUp(`Failed to create tmux pane for ${workerName}: ${(result.stderr || '').trim()}`);
@@ -214,7 +215,7 @@ export async function scaleUp(
       // Get PID
       let panePid: number | undefined;
       try {
-        const pidResult = spawnSync('tmux', ['display-message', '-t', paneId, '-p', '#{pane_pid}'], { encoding: 'utf-8' });
+        const pidResult = spawnSync('tmux', ['display-message', '-t', paneId, '-p', '#{pane_pid}'], { encoding: 'utf-8', env: tmuxEnv() });
         const pidStr = (pidResult.stdout || '').trim();
         const parsed = Number.parseInt(pidStr, 10);
         if (Number.isFinite(parsed)) panePid = parsed;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -13,6 +13,7 @@ import { join, basename, isAbsolute, win32 } from 'path';
 import { promisify } from 'util';
 import fs from 'fs/promises';
 import { validateTeamName } from './team-name.js';
+import { tmuxEnv } from '../cli/tmux-utils.js';
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
@@ -366,7 +367,7 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
 /** Validate tmux is available. Throws with install instructions if not. */
 export function validateTmux(): void {
   try {
-    execSync('tmux -V', { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' });
+    execSync('tmux -V', { encoding: 'utf-8', timeout: 5000, stdio: 'pipe', env: tmuxEnv() });
   } catch {
     throw new Error(
       'tmux is not available. Install it:\n' +
@@ -404,7 +405,7 @@ export function createSession(teamName: string, workerName: string, workingDirec
 
   // Kill existing session if present (stale from previous run)
   try {
-    execFileSync('tmux', ['kill-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
+    execFileSync('tmux', ['kill-session', '-t', name], { stdio: 'pipe', timeout: 5000, env: tmuxEnv() });
   } catch { /* ignore — session may not exist */ }
 
   // Create detached session with reasonable terminal size
@@ -412,7 +413,7 @@ export function createSession(teamName: string, workerName: string, workingDirec
   if (workingDirectory) {
     args.push('-c', workingDirectory);
   }
-  execFileSync('tmux', args, { stdio: 'pipe', timeout: 5000 });
+  execFileSync('tmux', args, { stdio: 'pipe', timeout: 5000, env: tmuxEnv() });
 
   return name;
 }
@@ -422,7 +423,7 @@ export function createSession(teamName: string, workerName: string, workingDirec
 export function killSession(teamName: string, workerName: string): void {
   const name = sessionName(teamName, workerName);
   try {
-    execFileSync('tmux', ['kill-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
+    execFileSync('tmux', ['kill-session', '-t', name], { stdio: 'pipe', timeout: 5000, env: tmuxEnv() });
   } catch { /* ignore — session may not exist */ }
 }
 
@@ -431,7 +432,7 @@ export function killSession(teamName: string, workerName: string): void {
 export function isSessionAlive(teamName: string, workerName: string): boolean {
   const name = sessionName(teamName, workerName);
   try {
-    execFileSync('tmux', ['has-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
+    execFileSync('tmux', ['has-session', '-t', name], { stdio: 'pipe', timeout: 5000, env: tmuxEnv() });
     return true;
   } catch {
     return false;
@@ -446,7 +447,7 @@ export function listActiveSessions(teamName: string): string[] {
     // MSYS2/Git Bash from stripping curly braces in execFileSync args.
     // All arguments here are hardcoded constants, not user input.
     const output = execSync("tmux list-sessions -F '#{session_name}'", {
-      encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe']
+      encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], env: tmuxEnv()
     }) as string;
     return output.trim().split('\n')
       .filter(s => s.startsWith(prefix))
@@ -469,7 +470,7 @@ export function spawnBridgeInSession(
   configFilePath: string
 ): void {
   const cmd = `node "${bridgeScriptPath}" --config "${configFilePath}"`;
-  execFileSync('tmux', ['send-keys', '-t', tmuxSession, cmd, 'Enter'], { stdio: 'pipe', timeout: 5000 });
+  execFileSync('tmux', ['send-keys', '-t', tmuxSession, cmd, 'Enter'], { stdio: 'pipe', timeout: 5000, env: tmuxEnv() });
 }
 
 

--- a/src/team/worker-health.ts
+++ b/src/team/worker-health.ts
@@ -11,12 +11,13 @@ import { listMcpWorkers } from './team-registration.js';
 import { readHeartbeat, isWorkerAlive } from './heartbeat.js';
 import { isSessionAlive, sanitizeName } from './tmux-session.js';
 import { execFileSync } from 'child_process';
+import { tmuxEnv } from '../cli/tmux-utils.js';
 
 /** Check if the shared split-pane session 'omc-team-{teamName}' exists (new tmux model). */
 function isSharedSessionAlive(teamName: string): boolean {
   const name = `omc-team-${sanitizeName(teamName)}`;
   try {
-    execFileSync('tmux', ['has-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
+    execFileSync('tmux', ['has-session', '-t', name], { stdio: 'pipe', timeout: 5000, env: tmuxEnv() });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- Centralizes `tmuxEnv()` helper in `tmux-utils.ts` — strips `TMUX` from process.env
- Applies it to **all 34 tmux call sites** across 9 production files
- Ensures all tmux operations target the default server regardless of nesting

Extends #2385 (which fixed autoresearch only) to cover the entire codebase.

Ref: #2384

## Problem

When OMC runs inside a nested tmux session (common with worktree managers like Worktrunk that use `tmux -L <server>`), the `TMUX` env var causes all tmux commands to target the nested server. This affects:

- **Session creation** (`launch.ts`, `tmux-session.ts`) — Claude and team sessions created on wrong server
- **Worker scaling** (`scaling.ts`) — split-window panes land on wrong server
- **Health checks** (`worker-health.ts`) — has-session returns false for valid sessions
- **Ralphthon orchestration** (`orchestrator.ts`) — pane interactions fail silently
- **Rate-limit detection** (`tmux-detector.ts`) — pane listing misses active sessions
- **Interop** (`interop.ts`) — Claude/Codex split panes created on wrong server

## Fix

Export `tmuxEnv()` from `tmux-utils.ts` and apply it to every `execFileSync('tmux', ...)`, `execSync('tmux ...')`, and `spawnSync('tmux', ...)` call in production code.

```typescript
export function tmuxEnv(): NodeJS.ProcessEnv {
  const { TMUX: _, ...env } = process.env;
  return env;
}
```

## Files modified

| File | Calls fixed | Subcommands |
|------|-------------|-------------|
| `src/cli/tmux-utils.ts` | 1 | kill-pane |
| `src/cli/interop.ts` | 3 | display-message, split-window, select-pane |
| `src/cli/launch.ts` | 5 | new-session, set-option (x2), attach-session, has-session |
| `src/cli/autoresearch-guided.ts` | 6 | replaced local tmuxEnv with shared import |
| `src/team/tmux-session.ts` | 7 | kill-session (x2), new-session, has-session, send-keys, version check, list-sessions |
| `src/team/scaling.ts` | 4 | kill-pane (x2), split-window, display-message |
| `src/team/worker-health.ts` | 1 | has-session |
| `src/ralphthon/orchestrator.ts` | 4 | has-session, display-message, send-keys, capture-pane |
| `src/features/rate-limit-wait/tmux-detector.ts` | 6 | list-panes, capture-pane, send-keys (x3) |

## Test plan

- [x] `npx tsc --noEmit` — clean, zero errors
- [x] Pre-existing test failures confirmed on base branch (path traversal issues in fs-utils.ts, unrelated)
- [x] No new test failures introduced
- [x] `hooks/hooks.json` excluded from diff (local node path leak)