### PR TITLE
fix: prevent keyword-detector false positives on diagnostic/bug-report prompts

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -167,10 +167,18 @@ function sanitizeForKeywordDetection(text) {
 }
 
 const INFORMATIONAL_INTENT_PATTERNS = [
+  // English: questions and explanations
   /\b(?:what(?:'s|\s+is)|what\s+are|how\s+(?:to|do\s+i)\s+use|explain|explanation|tell\s+me\s+about|describe)\b/i,
+  // English: diagnostic / bug-report / troubleshooting context
+  /\b(?:bug|issue|problem|broken|error|fix(?:ing)?|debug(?:ging)?|diagnose|investigate|keeps?\s+(?:re)?(?:running|looping|triggering|firing|starting)|stuck|loops?|regression|wrong|incorrect|unexpected|malfunction)\b/i,
+  // Korean: questions and explanations
   /(?:뭐야|뭔데|무엇(?:이야|인가요)?|어떻게|설명(?!서\s*(?:작성|만들|생성|추가|업데이트|수정|편집|쓰))|사용법|알려\s?줘|알려줄래|소개해?\s?줘|소개\s*부탁|설명해\s?줘|뭐가\s*달라|어떤\s*기능|기능\s*(?:알려|설명|뭐)|방법\s*(?:알려|설명|뭐))/u,
-  /(?:とは|って何|使い方|説明)/u,
-  /(?:什么是|什麼是|怎(?:么|樣)用|如何使用|解释|說明|说明)/u,
+  // Korean: diagnostic / bug-report / troubleshooting context
+  /(?:문제(?:가|야|인데|있|생)?|버그|오류|에러|안\s?됨|안\s?돼|고장|점검|잘못|재실행|반복|오작동|따라다니|계속\s?(?:실행|재실행|뜨|나타|발생))/u,
+  // Japanese: questions + diagnostic
+  /(?:とは|って何|使い方|説明|バグ|エラー|問題|不具合|直して|修正|調べて)/u,
+  // Chinese: questions + diagnostic
+  /(?:什么是|什麼是|怎(?:么|樣)用|如何使用|解释|說明|说明|错误|問題|问题|修复|修復|调查|調查)/u,
 ];
 const INFORMATIONAL_CONTEXT_WINDOW = 80;
 

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -145,10 +145,18 @@ function sanitizeForKeywordDetection(text) {
 }
 
 const INFORMATIONAL_INTENT_PATTERNS = [
+  // English: questions and explanations
   /\b(?:what(?:'s|\s+is)|what\s+are|how\s+(?:to|do\s+i)\s+use|explain|explanation|tell\s+me\s+about|describe)\b/i,
-  /(?:뭐야|뭔데|무엇(?:이야|인가요)?|어떻게|설명(?!서\s*(?:작성|만들|생성|추가|업데이트|수정|편집|쓰))|사용법|알려\s?줘|알려줄래|소개해?\s?줘|소개\s*부탁|설명해\s?줘|뭐가\s*달라|어떤\s*기능|기능\s*(?:알려|설명|뭐)|방법\s*(?:알려|설명|뭐))/u,
-  /(?:とは|って何|使い方|説明)/u,
-  /(?:什么是|什麼是|怎(?:么|樣)用|如何使用|解释|說明|说明)/u,
+  // English: diagnostic / bug-report / troubleshooting context
+  /\b(?:bug|issue|problem|broken|error|fix(?:ing)?|debug(?:ging)?|diagnose|investigate|keeps?\s+(?:re)?(?:running|looping|triggering|firing|starting)|stuck|loops?|regression|wrong|incorrect|unexpected|malfunction)\b/i,
+  // Korean: questions and explanations
+  /(?:뭐야|뭔데|무엇(?:이야|인가요)?|어떻게|설명(?!서\s*(?:작성|만들|생성|추가|업데이트|수정|편집|쓰))|사용법|알려\s?줘|알려줄래|소개해?\s?줘|소개\s*부탄|설명해\s?줘|뭐가\s*달라|어떤\s*기능|기능\s*(?:알려|설명|뭐)|방법\s*(?:알려|설명|뭐))/u,
+  // Korean: diagnostic / bug-report / troubleshooting context
+  /(?:문제(?:가|야|인데|있|생)?|버그|오류|에러|안\s?됨|안\s?돼|고장|점검|잘못|재실행|반복|오작동|따라다니|계속\s?(?:실행|재실행|뜨|나타|발생))/u,
+  // Japanese: questions + diagnostic
+  /(?:とは|って何|使い方|説明|バグ|エラー|問題|不具合|直して|修正|調べて)/u,
+  // Chinese: questions + diagnostic
+  /(?:什么是|什麼是|怎(?:么|樣)用|如何使用|解释|說明|说明|错误|問題|问题|修复|修復|调查|調查)/u,
 ];
 const INFORMATIONAL_CONTEXT_WINDOW = 80;
 


### PR DESCRIPTION
## Summary

- Adds diagnostic/bug-report/troubleshooting patterns to `INFORMATIONAL_INTENT_PATTERNS` in keyword-detector
- Prevents false activation when users *mention* a keyword in troubleshooting context vs *requesting* it
- Covers English, Korean, Japanese, and Chinese diagnostic vocabulary

Fixes #2390

## Problem

When a user writes a diagnostic prompt like `"ralph-loop keeps re-executing, please investigate"` or `"ralph 버그 점검해줘"`, the keyword detector matches `ralph` and activates ralph mode. The existing `isInformationalKeywordContext` only checked question/explanation patterns (what is, explain, 뭐야, 설명), not diagnostic/troubleshooting context.

## Changes

**`scripts/keyword-detector.mjs`** and **`templates/hooks/keyword-detector.mjs`**:

Added two new pattern categories to `INFORMATIONAL_INTENT_PATTERNS`:

| Language | New patterns |
|----------|-------------|
| English | `bug, issue, problem, broken, error, fix(ing), debug(ging), diagnose, investigate, keeps (re)running/looping/triggering, stuck, loops, regression, wrong, incorrect, unexpected, malfunction` |
| Korean | `문제, 버그, 오류, 에러, 안됨, 안돼, 고장, 점검, 잘못, 재실행, 반복, 오작동, 따라다니, 계속 실행/재실행/뜨/나타/발생` |
| Japanese | `バグ, エラー, 問題, 不具合, 直して, 修正, 調べて` (extended existing pattern) |
| Chinese | `错误, 問題, 问题, 修复, 修復, 调查, 調查` (extended existing pattern) |

## Test plan

- [x] 10/10 unit tests pass (7 suppression cases + 3 activation cases)
  - Suppressed: `"ralph-loop이 자꾸 재실행되는 문제가 있어"`, `"ralph 버그 점검해줘"`, `"ralph keeps running, investigate"`, `"autopilot has a bug"`, `"what is ralph"`, `"ralph keeps looping"`, `"ralph에 문제가 있어"`
  - Activated: `"ralph 시작해"`, `"ralph"`, `"ralph 이거 해줘"`
- [ ] Manual: type `"ralph 버그 점검해줘"` → should NOT activate ralph
- [ ] Manual: type `"ralph"` → should activate ralph
- [x] All 3 files pass `node -c` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)