### PR TITLE
fix(team): add forceInherit guard to resolveClaudeWorkerModel

### DIFF
--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -402,6 +402,8 @@ describe('model-contract', () => {
       vi.stubEnv('CLAUDE_CODE_USE_VERTEX', '');
       vi.stubEnv('ANTHROPIC_MODEL', '');
       vi.stubEnv('CLAUDE_MODEL', '');
+      vi.stubEnv('ANTHROPIC_BASE_URL', '');
+      vi.stubEnv('OMC_ROUTING_FORCE_INHERIT', '');
       expect(resolveClaudeWorkerModel()).toBeUndefined();
       vi.unstubAllEnvs();
     });
@@ -468,6 +470,46 @@ describe('model-contract', () => {
       vi.stubEnv('CLAUDE_MODEL', '');
       // isBedrock() detects Bedrock from the model ID pattern
       expect(resolveClaudeWorkerModel()).toBe('us.anthropic.claude-sonnet-4-5-20250929-v1:0');
+      vi.unstubAllEnvs();
+    });
+  });
+
+  describe('resolveClaudeWorkerModel forceInherit regression (PR #2378)', () => {
+    it('returns undefined when OMC_ROUTING_FORCE_INHERIT=true even with model set', () => {
+      vi.stubEnv('OMC_ROUTING_FORCE_INHERIT', 'true');
+      vi.stubEnv('CLAUDE_MODEL', 'claude-sonnet-4-5');
+      vi.stubEnv('CLAUDE_CODE_USE_BEDROCK', '');
+      vi.stubEnv('CLAUDE_CODE_USE_VERTEX', '');
+      vi.stubEnv('ANTHROPIC_MODEL', '');
+
+      // Must return undefined so worker inherits without normalization
+      expect(resolveClaudeWorkerModel()).toBeUndefined();
+
+      vi.unstubAllEnvs();
+    });
+
+    it('returns undefined when OMC_ROUTING_FORCE_INHERIT=true on Bedrock', () => {
+      // Edge case: forceInherit + Bedrock should still return undefined
+      // User explicitly wants inheritance, not Bedrock model ID
+      vi.stubEnv('OMC_ROUTING_FORCE_INHERIT', 'true');
+      vi.stubEnv('CLAUDE_CODE_USE_BEDROCK', '1');
+      vi.stubEnv('CLAUDE_MODEL', 'us.anthropic.claude-sonnet-4-6-v1:0');
+      vi.stubEnv('ANTHROPIC_MODEL', '');
+
+      expect(resolveClaudeWorkerModel()).toBeUndefined();
+
+      vi.unstubAllEnvs();
+    });
+
+    it('returns model ID on LiteLLM proxy without forceInherit', () => {
+      // Ensure actual proxy scenarios still work (PR #2378 intent)
+      vi.stubEnv('OMC_ROUTING_FORCE_INHERIT', '');
+      vi.stubEnv('ANTHROPIC_BASE_URL', 'https://litellm.example.com/v1');
+      vi.stubEnv('CLAUDE_MODEL', 'claude-sonnet-4-5');
+      vi.stubEnv('ANTHROPIC_MODEL', '');
+
+      expect(resolveClaudeWorkerModel()).toBe('claude-sonnet-4-5');
+
       vi.unstubAllEnvs();
     });
   });

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -381,24 +381,30 @@ export function isPromptModeAgent(agentType: CliAgentType): boolean {
 }
 
 /**
- * Resolve the active model for Claude team workers on non-Claude providers.
+ * Resolve the model ID to pass to a Claude worker subprocess.
  *
- * When running on a non-standard provider (Bedrock, Vertex, DashScope, LiteLLM, etc.),
- * workers need the provider-specific model ID passed explicitly via --model. Without it,
- * Claude Code falls back to its built-in default (claude-sonnet-4-6) which is invalid
- * on these providers.
+ * Returns the model when running on non-Claude provider backends that need
+ * full model IDs (Bedrock, Vertex, LiteLLM, CC Switch, custom proxies).
  *
- * Resolution order:
- *   1. ANTHROPIC_MODEL / CLAUDE_MODEL env vars (user's explicit setting)
- *   2. Provider tier-specific env vars (CLAUDE_CODE_BEDROCK_SONNET_MODEL, etc.)
- *   3. OMC tier env vars (OMC_MODEL_MEDIUM, etc.)
- *   4. undefined — let Claude Code handle its own default
+ * Returns undefined in these cases (worker uses Claude Code's default/inherit):
+ *   1. Standard Anthropic API — aliases work fine
+ *   2. OMC_ROUTING_FORCE_INHERIT=true — user wants model inheritance
+ *   3. No model env vars configured on provider backend
  *
- * Returns undefined when using standard Anthropic API (handles bare aliases fine).
+ * When forceInherit is true, we must NOT return the model ID, because
+ * buildLaunchArgs() would normalize it (e.g. 'claude-sonnet-4-5' -> 'sonnet'),
+ * which changes the effective model instead of preserving the inherited one.
  */
 export function resolveClaudeWorkerModel(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
+  // When forceInherit is enabled, return undefined so worker inherits parent model
+  // without any normalization. The user explicitly wants inheritance, not a
+  // converted alias like 'sonnet' from 'claude-sonnet-4-5'. (PR #2378 regression)
+  if (env.OMC_ROUTING_FORCE_INHERIT === "true") {
+    return undefined;
+  }
+
   // Check all non-Claude providers: Bedrock, Vertex, DashScope, LiteLLM, etc.
   // Uses the same detection logic as delegation-enforcer for consistency.
   if (!isNonClaudeProvider()) {

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -2,7 +2,12 @@ import { spawnSync } from 'child_process';
 import { isAbsolute, normalize, win32 as win32Path } from 'path';
 import { validateTeamName } from './team-name.js';
 import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
-import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
+import {
+  isBedrock,
+  isVertexAI,
+  isProviderSpecificModelId,
+  isNonClaudeProvider,
+} from "../config/models.js";
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
 export type CliAgentType = 'claude' | 'codex' | 'gemini';
@@ -376,31 +381,32 @@ export function isPromptModeAgent(agentType: CliAgentType): boolean {
 }
 
 /**
- * Resolve the active model for Claude team workers on Bedrock/Vertex.
+ * Resolve the active model for Claude team workers on non-Claude providers.
  *
- * When running on a non-standard provider (Bedrock, Vertex), workers need
- * the provider-specific model ID passed explicitly via --model. Without it,
- * Claude Code falls back to its built-in default (claude-sonnet-4-6) which
- * is invalid on these providers.
+ * When running on a non-standard provider (Bedrock, Vertex, DashScope, LiteLLM, etc.),
+ * workers need the provider-specific model ID passed explicitly via --model. Without it,
+ * Claude Code falls back to its built-in default (claude-sonnet-4-6) which is invalid
+ * on these providers.
  *
  * Resolution order:
  *   1. ANTHROPIC_MODEL / CLAUDE_MODEL env vars (user's explicit setting)
  *   2. Provider tier-specific env vars (CLAUDE_CODE_BEDROCK_SONNET_MODEL, etc.)
- *   3. undefined — let Claude Code handle its own default
+ *   3. OMC tier env vars (OMC_MODEL_MEDIUM, etc.)
+ *   4. undefined — let Claude Code handle its own default
  *
- * Returns undefined when not on Bedrock/Vertex (standard Anthropic API
- * handles bare aliases fine).
+ * Returns undefined when using standard Anthropic API (handles bare aliases fine).
  */
 export function resolveClaudeWorkerModel(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-  // Only needed for non-standard providers
-  if (!isBedrock() && !isVertexAI()) {
+  // Check all non-Claude providers: Bedrock, Vertex, DashScope, LiteLLM, etc.
+  // Uses the same detection logic as delegation-enforcer for consistency.
+  if (!isNonClaudeProvider()) {
     return undefined;
   }
 
   // Direct model env vars — highest priority
-  const directModel = env.ANTHROPIC_MODEL || env.CLAUDE_MODEL || '';
+  const directModel = env.ANTHROPIC_MODEL || env.CLAUDE_MODEL || "";
   if (directModel) {
     return directModel;
   }
@@ -409,13 +415,13 @@ export function resolveClaudeWorkerModel(
   const bedrockModel =
     env.CLAUDE_CODE_BEDROCK_SONNET_MODEL ||
     env.ANTHROPIC_DEFAULT_SONNET_MODEL ||
-    '';
+    "";
   if (bedrockModel) {
     return bedrockModel;
   }
 
   // OMC tier env vars
-  const omcModel = env.OMC_MODEL_MEDIUM || '';
+  const omcModel = env.OMC_MODEL_MEDIUM || "";
   if (omcModel) {
     return omcModel;
   }


### PR DESCRIPTION
## Summary

Fixes a regression introduced in PR #2378 where `OMC_ROUTING_FORCE_INHERIT=true` would cause `resolveClaudeWorkerModel()` to return a model ID that gets normalized (e.g., `claude-sonnet-4-5` → `sonnet`), changing the effective model instead of preserving the inherited one.

## Changes

- Add early return guard in `resolveClaudeWorkerModel()` for `OMC_ROUTING_FORCE_INHERIT=true`
- Update JSDoc to document forceInherit behavior
- Add 3 regression tests covering forceInherit scenarios

## Root Cause

`isNonClaudeProvider()` conflates two orthogonal concepts:
1. User intent (`forceInherit=true` means "inherit without modification")
2. Infrastructure detection ("are we on Bedrock/Vertex/proxy?")

When `forceInherit=true`, `isNonClaudeProvider()` returns `true`, triggering model resolution. The returned model ID then gets normalized by `buildLaunchArgs()`, breaking the inheritance contract.

## Test Plan

- [x] `forceInherit=true` + `CLAUDE_MODEL` → returns `undefined` (worker inherits)
- [x] `forceInherit=true` + Bedrock → returns `undefined` (worker inherits)
- [x] LiteLLM proxy without forceInherit → returns model ID (PR #2378 intent preserved)
- [x] All existing tests pass (49 passed)

## References

- Original PR #2378
- Codex P1 review comment
- Issue #1135 (forceInherit feature)
- Issue #1695 (Bedrock model ID handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)