### PR TITLE
fix(tmux): centralize all tmux execution through typed wrapper functions

### DIFF
--- a/src/__tests__/cli-win32-warning.test.ts
+++ b/src/__tests__/cli-win32-warning.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 
-vi.mock('child_process', () => ({
-  spawnSync: vi.fn(),
-}));
+vi.mock('../cli/tmux-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../cli/tmux-utils.js')>();
+  return { ...actual, tmuxSpawn: vi.fn() };
+});
 
-import { spawnSync } from 'child_process';
+import { tmuxSpawn } from '../cli/tmux-utils.js';
 
 describe('CLI win32 platform warning (#923)', () => {
   const originalPlatform = process.platform;
@@ -23,7 +24,7 @@ describe('CLI win32 platform warning (#923)', () => {
 
   it('should warn on win32 when tmux is not available', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
+    vi.mocked(tmuxSpawn).mockReturnValue({ status: 1 } as ReturnType<typeof tmuxSpawn>);
 
     const { warnIfWin32 } = await import('../cli/win32-warning.js');
     warnIfWin32();
@@ -38,7 +39,7 @@ describe('CLI win32 platform warning (#923)', () => {
 
   it('should NOT warn on win32 when tmux (or psmux) is available', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+    vi.mocked(tmuxSpawn).mockReturnValue({ status: 0 } as ReturnType<typeof tmuxSpawn>);
 
     const { warnIfWin32 } = await import('../cli/win32-warning.js');
     warnIfWin32();
@@ -66,7 +67,7 @@ describe('CLI win32 platform warning (#923)', () => {
 
   it('should not block execution after warning', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
+    vi.mocked(tmuxSpawn).mockReturnValue({ status: 1 } as ReturnType<typeof tmuxSpawn>);
 
     const { warnIfWin32 } = await import('../cli/win32-warning.js');
     let continued = false;

--- a/src/__tests__/rate-limit-wait/tmux-detector.test.ts
+++ b/src/__tests__/rate-limit-wait/tmux-detector.test.ts
@@ -12,13 +12,13 @@ import {
 } from '../../features/rate-limit-wait/tmux-detector.js';
 import type { BlockedPane } from '../../features/rate-limit-wait/types.js';
 
-// Mock child_process
-vi.mock('child_process', () => ({
-  execFileSync: vi.fn(),
-  spawnSync: vi.fn(),
-}));
+// Mock tmux-utils wrappers
+vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../cli/tmux-utils.js')>();
+  return { ...actual, tmuxExec: vi.fn(), tmuxSpawn: vi.fn() };
+});
 
-import { execFileSync, spawnSync } from 'child_process';
+import { tmuxExec, tmuxSpawn } from '../../cli/tmux-utils.js';
 
 describe('tmux-detector', () => {
   beforeEach(() => {
@@ -138,7 +138,7 @@ describe('tmux-detector', () => {
 
   describe('isTmuxAvailable', () => {
     it('should return true when tmux is installed', () => {
-      vi.mocked(spawnSync).mockReturnValue({
+      vi.mocked(tmuxSpawn).mockReturnValue({
         status: 0,
         stdout: '/usr/bin/tmux\n',
         stderr: '',
@@ -151,7 +151,7 @@ describe('tmux-detector', () => {
     });
 
     it('should return false when tmux is not installed', () => {
-      vi.mocked(spawnSync).mockReturnValue({
+      vi.mocked(tmuxSpawn).mockReturnValue({
         status: 1,
         stdout: '',
         stderr: '',
@@ -164,7 +164,7 @@ describe('tmux-detector', () => {
     });
 
     it('should return false when spawnSync throws', () => {
-      vi.mocked(spawnSync).mockImplementation(() => {
+      vi.mocked(tmuxSpawn).mockImplementation(() => {
         throw new Error('Command not found');
       });
 
@@ -174,7 +174,7 @@ describe('tmux-detector', () => {
 
   describe('listTmuxPanes', () => {
     it('should parse tmux pane list correctly', () => {
-      vi.mocked(spawnSync).mockReturnValue({
+      vi.mocked(tmuxSpawn).mockReturnValue({
         status: 0,
         stdout: '/usr/bin/tmux',
         stderr: '',
@@ -183,7 +183,7 @@ describe('tmux-detector', () => {
         output: [],
       });
 
-      vi.mocked(execFileSync).mockReturnValue(
+      vi.mocked(tmuxExec).mockReturnValue(
         'main:0.0 %0 1 dev Claude\nmain:0.1 %1 0 dev Other\n'
       );
 
@@ -211,7 +211,7 @@ describe('tmux-detector', () => {
     });
 
     it('should return empty array when tmux not available', () => {
-      vi.mocked(spawnSync).mockReturnValue({
+      vi.mocked(tmuxSpawn).mockReturnValue({
         status: 1,
         stdout: '',
         stderr: '',
@@ -228,7 +228,7 @@ describe('tmux-detector', () => {
 
   describe('capturePaneContent', () => {
     it('should capture pane content', () => {
-      vi.mocked(spawnSync).mockReturnValue({
+      vi.mocked(tmuxSpawn).mockReturnValue({
         status: 0,
         stdout: '/usr/bin/tmux',
         stderr: '',
@@ -237,20 +237,19 @@ describe('tmux-detector', () => {
         output: [],
       });
 
-      vi.mocked(execFileSync).mockReturnValue('Line 1\nLine 2\nLine 3\n');
+      vi.mocked(tmuxExec).mockReturnValue('Line 1\nLine 2\nLine 3\n');
 
       const content = capturePaneContent('%0', 3);
 
       expect(content).toBe('Line 1\nLine 2\nLine 3\n');
-      expect(execFileSync).toHaveBeenCalledWith(
-        'tmux',
+      expect(tmuxExec).toHaveBeenCalledWith(
         ['capture-pane', '-t', '%0', '-p', '-S', '-3'],
         expect.any(Object)
       );
     });
 
     it('should return empty string when tmux not available', () => {
-      vi.mocked(spawnSync).mockReturnValue({
+      vi.mocked(tmuxSpawn).mockReturnValue({
         status: 1,
         stdout: '',
         stderr: '',
@@ -267,7 +266,7 @@ describe('tmux-detector', () => {
 
   describe('security: input validation', () => {
     it('should reject invalid pane IDs in capturePaneContent', () => {
-      vi.mocked(spawnSync).mockReturnValue({
+      vi.mocked(tmuxSpawn).mockReturnValue({
         status: 0,
         stdout: '/usr/bin/tmux',
         stderr: '',
@@ -277,7 +276,7 @@ describe('tmux-detector', () => {
       });
 
       // Valid pane ID should work
-      vi.mocked(execFileSync).mockReturnValue('content');
+      vi.mocked(tmuxExec).mockReturnValue('content');
       const validResult = capturePaneContent('%0');
       expect(validResult).toBe('content');
 
@@ -293,14 +292,14 @@ describe('tmux-detector', () => {
       ];
 
       for (const invalidId of invalidIds) {
-        vi.mocked(execFileSync).mockClear();
+        vi.mocked(tmuxExec).mockClear();
         const result = capturePaneContent(invalidId);
         expect(result).toBe('');
       }
     });
 
     it('should validate lines parameter bounds', () => {
-      vi.mocked(spawnSync).mockReturnValue({
+      vi.mocked(tmuxSpawn).mockReturnValue({
         status: 0,
         stdout: '/usr/bin/tmux',
         stderr: '',
@@ -309,21 +308,19 @@ describe('tmux-detector', () => {
         output: [],
       });
 
-      vi.mocked(execFileSync).mockReturnValue('content');
+      vi.mocked(tmuxExec).mockReturnValue('content');
 
       // Should clamp negative to 1
       capturePaneContent('%0', -5);
-      expect(execFileSync).toHaveBeenCalledWith(
-        'tmux',
+      expect(tmuxExec).toHaveBeenCalledWith(
         expect.arrayContaining(['-S', '-1']),
         expect.any(Object)
       );
 
       // Should clamp excessive values to 100
-      vi.mocked(execFileSync).mockClear();
+      vi.mocked(tmuxExec).mockClear();
       capturePaneContent('%0', 1000);
-      expect(execFileSync).toHaveBeenCalledWith(
-        'tmux',
+      expect(tmuxExec).toHaveBeenCalledWith(
         expect.arrayContaining(['-S', '-100']),
         expect.any(Object)
       );

--- a/src/__tests__/runtime-task-orphan.test.ts
+++ b/src/__tests__/runtime-task-orphan.test.ts
@@ -11,13 +11,11 @@ import { tmpdir } from 'os';
 
 // --- Mocks ---
 
-const mockExecFileAsync = vi.fn();
+const mockTmuxExecAsync = vi.fn();
 
-vi.mock('child_process', () => {
-  const execFile = Object.assign(vi.fn(), {
-    [Symbol.for('nodejs.util.promisify.custom')]: mockExecFileAsync,
-  });
-  return { execFile };
+vi.mock('../cli/tmux-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../cli/tmux-utils.js')>();
+  return { ...actual, tmuxExecAsync: mockTmuxExecAsync };
 });
 
 vi.mock('../team/model-contract.js', () => ({
@@ -61,7 +59,7 @@ describe('spawnWorkerForTask task orphan prevention', () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'runtime-task-orphan-'));
-    mockExecFileAsync.mockReset();
+    mockTmuxExecAsync.mockReset();
   });
 
   afterEach(() => {
@@ -89,7 +87,7 @@ describe('spawnWorkerForTask task orphan prevention', () => {
     }));
 
     // Mock tmux split-window to return empty stdout (pane creation failure)
-    mockExecFileAsync.mockResolvedValue({ stdout: '\n', stderr: '' });
+    mockTmuxExecAsync.mockResolvedValue({ stdout: '\n', stderr: '' });
 
     const runtime = {
       teamName,

--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -20,11 +20,14 @@ vi.mock('node:child_process', async (importOriginal) => {
   };
 });
 
+const tmuxExecMock = vi.hoisted(() => vi.fn());
+
 vi.mock('../tmux-utils.js', () => ({
   isTmuxAvailable: tmuxAvailableMock,
   buildTmuxShellCommand: buildTmuxShellCommandMock,
   wrapWithLoginShell: wrapWithLoginShellMock,
   quoteShellArg: quoteShellArgMock,
+  tmuxExec: tmuxExecMock,
 }));
 
 import {
@@ -307,6 +310,7 @@ describe('spawnAutoresearchTmux', () => {
 
   beforeEach(() => {
     vi.mocked(execFileSync).mockReset();
+    tmuxExecMock.mockReset();
     tmuxAvailableMock.mockReset();
     buildTmuxShellCommandMock.mockClear();
     wrapWithLoginShellMock.mockClear();
@@ -325,25 +329,30 @@ describe('spawnAutoresearchTmux', () => {
   it('uses explicit cwd, login-shell wrapping, and verifies startup before logging success', () => {
     tmuxAvailableMock.mockReturnValue(true);
     let hasSessionCalls = 0;
+    // git calls still go through execFileSync
     vi.mocked(execFileSync).mockImplementation((cmd, args, opts) => {
-      if (cmd === 'tmux' && Array.isArray(args) && args[0] === 'has-session') {
-        hasSessionCalls += 1;
-        if (hasSessionCalls === 1) {
-          throw new Error('missing session');
-        }
-        return Buffer.from('');
-      }
       if (cmd === 'git') {
         expect(args).toEqual(['rev-parse', '--show-toplevel']);
         expect((opts as { cwd?: string }).cwd).toBe('/repo/missions/demo');
         return '/repo\n';
       }
-      if (cmd === 'tmux' && Array.isArray(args) && args[0] === 'new-session') {
+      throw new Error(`unexpected execFileSync call: ${String(cmd)}`);
+    });
+    // tmux calls go through tmuxExec
+    tmuxExecMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'has-session') {
+        hasSessionCalls += 1;
+        if (hasSessionCalls === 1) {
+          throw new Error('missing session');
+        }
+        return '';
+      }
+      if (args[0] === 'new-session') {
         expect(args.slice(0, 6)).toEqual(['new-session', '-d', '-s', 'omc-autoresearch-demo', '-c', '/repo']);
         expect(args[6]).toBe('wrapped:' + `${process.execPath} ${process.cwd()}/bin/omc.js autoresearch /repo/missions/demo`);
-        return Buffer.from('');
+        return '';
       }
-      throw new Error(`unexpected call: ${String(cmd)}`);
+      throw new Error(`unexpected tmuxExec call: ${String(args)}`);
     });
 
     spawnAutoresearchTmux('/repo/missions/demo', 'demo');
@@ -384,6 +393,7 @@ describe('spawnAutoresearchSetupTmux', () => {
 
   beforeEach(() => {
     vi.mocked(execFileSync).mockReset();
+    tmuxExecMock.mockReset();
     tmuxAvailableMock.mockReset();
     buildTmuxShellCommandMock.mockClear();
     wrapWithLoginShellMock.mockClear();
@@ -401,8 +411,9 @@ describe('spawnAutoresearchSetupTmux', () => {
     const repo = await initRepo();
     let hasSessionCalls = 0;
     try {
-      vi.mocked(execFileSync).mockImplementation((cmd, args) => {
-        if (cmd === 'tmux' && Array.isArray(args) && args[0] === 'new-session') {
+      // tmux calls go through tmuxExec
+      tmuxExecMock.mockImplementation((args: string[]) => {
+        if (args[0] === 'new-session') {
           expect(args.slice(0, 9)).toEqual([
             'new-session', '-d', '-P', '-F', '#{pane_id}', '-s', 'omc-autoresearch-setup-kf12oi', '-c', repo,
           ]);
@@ -411,17 +422,17 @@ describe('spawnAutoresearchSetupTmux', () => {
           expect(String(args[9])).toContain(`CODEX_HOME=${repo}/.omx/tmp/omc-autoresearch-setup-kf12oi/codex-home`);
           expect(String(args[9])).toContain('claude');
           expect(String(args[9])).toContain('--dangerously-skip-permissions');
-          return '%42\n' as never;
+          return '%42\n';
         }
-        if (cmd === 'tmux' && Array.isArray(args) && args[0] === 'has-session') {
+        if (args[0] === 'has-session') {
           hasSessionCalls += 1;
           expect(args).toEqual(['has-session', '-t', 'omc-autoresearch-setup-kf12oi']);
-          return Buffer.from('');
+          return '';
         }
-        if (cmd === 'tmux' && Array.isArray(args) && args[0] === 'send-keys') {
-          return Buffer.from('');
+        if (args[0] === 'send-keys') {
+          return '';
         }
-        throw new Error(`unexpected call: ${String(cmd)}`);
+        throw new Error(`unexpected tmuxExec call: ${String(args)}`);
       });
 
       spawnAutoresearchSetupTmux(repo);
@@ -429,10 +440,9 @@ describe('spawnAutoresearchSetupTmux', () => {
       expect(buildTmuxShellCommandMock).toHaveBeenCalledWith('env', [`CODEX_HOME=${repo}/.omx/tmp/omc-autoresearch-setup-kf12oi/codex-home`, 'claude', '--dangerously-skip-permissions']);
       expect(wrapWithLoginShellMock).toHaveBeenCalledWith(`env CODEX_HOME=${repo}/.omx/tmp/omc-autoresearch-setup-kf12oi/codex-home claude --dangerously-skip-permissions`);
       expect(buildAutoresearchSetupSlashCommand()).toBe('/deep-interview --autoresearch');
-      expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
-        'tmux',
+      expect(tmuxExecMock).toHaveBeenCalledWith(
         ['send-keys', '-t', '%42', '-l', buildAutoresearchSetupSlashCommand()],
-        expect.objectContaining({ stdio: 'ignore' }),
+        expect.objectContaining({ stripTmux: true }),
       );
       expect(logSpy).toHaveBeenCalledWith('\nAutoresearch setup launched in background Claude session.');
       expect(logSpy).toHaveBeenCalledWith('  Attach:   tmux attach -t omc-autoresearch-setup-kf12oi');

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -27,6 +27,7 @@ vi.mock('../tmux-utils.js', () => ({
   wrapWithLoginShell: vi.fn((cmd: string) => cmd),
   quoteShellArg: vi.fn((s: string) => s),
   isClaudeAvailable: vi.fn(() => true),
+  tmuxExec: vi.fn(),
 }));
 
 import { runClaude, launchCommand, extractNotifyFlag, extractOpenClawFlag, extractTelegramFlag, extractDiscordFlag, extractSlackFlag, extractWebhookFlag, normalizeClaudeLaunchArgs, isPrintMode, prepareOmcLaunchConfigDir, buildEnvExportPrefix, TMUX_ENV_FORWARD } from '../launch.js';
@@ -34,6 +35,7 @@ import {
   resolveLaunchPolicy,
   buildTmuxShellCommand,
   wrapWithLoginShell,
+  tmuxExec,
 } from '../tmux-utils.js';
 
 // ---------------------------------------------------------------------------
@@ -259,9 +261,9 @@ describe('runClaude OMC HUD behavior', () => {
 
     runClaude('/tmp/cwd', [], 'test-session');
 
-    const tmuxCalls = vi.mocked(execFileSync).mock.calls.filter(([cmd]) => cmd === 'tmux');
+    const tmuxCalls = vi.mocked(tmuxExec).mock.calls;
     expect(tmuxCalls.length).toBeGreaterThan(0);
-    expect(tmuxCalls.every(([, tmuxArgs]) => !(tmuxArgs as string[]).includes('split-window'))).toBe(true);
+    expect(tmuxCalls.every(([args]) => !args.includes('split-window'))).toBe(true);
   });
 });
 
@@ -285,29 +287,26 @@ describe('runClaude outside-tmux — mouse scrolling (issue #890)', () => {
   it('uses session-targeted mouse option instead of global (-t sessionName, not -g)', () => {
     runClaude('/tmp', [], 'sid');
 
-    const tmuxCalls = vi.mocked(execFileSync).mock.calls.filter(([cmd]) => cmd === 'tmux');
-    const tmuxCall = tmuxCalls.find(([, args]) => (args as string[])[0] === 'set-option');
+    const tmuxCalls = vi.mocked(tmuxExec).mock.calls;
+    const tmuxCall = tmuxCalls.find(([args]) => args[0] === 'set-option');
     expect(tmuxCall).toBeDefined();
 
-    const tmuxArgs = tmuxCall![1] as string[];
-    // Must use -t <sessionName> targeting, not -g (global)
-    const setOptionIdx = tmuxArgs.indexOf('set-option');
-    expect(setOptionIdx).toBeGreaterThanOrEqual(0);
-    expect(tmuxArgs[setOptionIdx + 1]).toBe('-t');
-    expect(tmuxArgs[setOptionIdx + 2]).toBe('test-session');
-    expect(tmuxArgs[setOptionIdx + 3]).toBe('mouse');
-    expect(tmuxArgs[setOptionIdx + 4]).toBe('on');
-    // Must NOT use -g (global)
+    const tmuxArgs = tmuxCall![0];
+    expect(tmuxArgs).toContain('-t');
+    const tIdx = tmuxArgs.indexOf('-t');
+    expect(tmuxArgs[tIdx + 1]).toBe('test-session');
+    expect(tmuxArgs).toContain('mouse');
+    expect(tmuxArgs).toContain('on');
     expect(tmuxArgs).not.toContain('-g');
   });
 
   it('does not set terminal-overrides in tmux args', () => {
     runClaude('/tmp', [], 'sid');
 
-    const tmuxCalls = vi.mocked(execFileSync).mock.calls.filter(([cmd]) => cmd === 'tmux');
-    const tmuxCall = tmuxCalls.find(([, args]) => (args as string[])[0] === 'new-session');
+    const tmuxCalls = vi.mocked(tmuxExec).mock.calls;
+    const tmuxCall = tmuxCalls.find(([args]) => args[0] === 'new-session');
     expect(tmuxCall).toBeDefined();
-    const tmuxArgs = tmuxCall![1] as string[];
+    const tmuxArgs = tmuxCall![0];
 
     expect(tmuxArgs).not.toContain('terminal-overrides');
     expect(tmuxArgs).not.toContain('*:smcup@:rmcup@');
@@ -316,56 +315,48 @@ describe('runClaude outside-tmux — mouse scrolling (issue #890)', () => {
   it('places mouse mode setup before attach-session', () => {
     runClaude('/tmp', [], 'sid');
 
-    const tmuxCalls = vi.mocked(execFileSync).mock.calls
-      .map(([cmd, tmuxArgs]) => ({ cmd, tmuxArgs: tmuxArgs as string[] }))
-      .filter(({ cmd }) => cmd === 'tmux');
-
-    const mouseIdx = tmuxCalls.findIndex(({ tmuxArgs }) => tmuxArgs[0] === 'set-option');
-    const attachIdx = tmuxCalls.findIndex(({ tmuxArgs }) => tmuxArgs[0] === 'attach-session');
+    const tmuxCalls = vi.mocked(tmuxExec).mock.calls.map(([args]) => args);
+    const mouseIdx = tmuxCalls.findIndex((args) => args[0] === 'set-option');
+    const attachIdx = tmuxCalls.findIndex((args) => args[0] === 'attach-session');
     expect(mouseIdx).toBeGreaterThanOrEqual(0);
     expect(attachIdx).toBeGreaterThanOrEqual(0);
     expect(mouseIdx).toBeLessThan(attachIdx);
   });
 
   it('preserves a valid detached session when attach-session is interrupted', () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation((cmd: string, args: string[]) => {
-      if (cmd !== 'tmux') return Buffer.from('');
+    vi.mocked(tmuxExec).mockImplementation((args: string[]) => {
       if (args[0] === 'attach-session') {
         throw new Error('attach interrupted');
       }
-      return Buffer.from('');
+      return '';
     });
 
     runClaude('/tmp', [], 'sid');
 
-    const tmuxCalls = vi.mocked(execFileSync).mock.calls
-      .filter(([cmd]) => cmd === 'tmux')
-      .map(([, tmuxArgs]) => tmuxArgs as string[]);
-
-    expect(tmuxCalls.map((tmuxArgs) => tmuxArgs[0])).toEqual([
+    const tmuxCalls = vi.mocked(tmuxExec).mock.calls.map(([args]) => args);
+    expect(tmuxCalls.map((args) => args[0])).toEqual([
       'new-session',
       'set-option',
       'attach-session',
       'has-session',
     ]);
-    expect(tmuxCalls.some((tmuxArgs) => tmuxArgs[0] === 'kill-session')).toBe(false);
+    expect(tmuxCalls.some((args) => args[0] === 'kill-session')).toBe(false);
     expect(vi.mocked(execFileSync).mock.calls.find(([cmd]) => cmd === 'claude')).toBeUndefined();
     expect(processExitSpy).not.toHaveBeenCalled();
   });
 
   it('falls back to direct launch when detached session creation fails', () => {
-    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === 'tmux' && args[0] === 'new-session') {
+    vi.mocked(tmuxExec).mockImplementation((args: string[]) => {
+      if (args[0] === 'new-session') {
         throw new Error('tmux launch failed');
       }
-      return Buffer.from('');
+      return '';
     });
 
     runClaude('/tmp', ['--dangerously-skip-permissions'], 'sid');
 
-    const calls = vi.mocked(execFileSync).mock.calls;
-    expect(calls.filter(([cmd]) => cmd === 'tmux')).toHaveLength(1);
-    expect(calls.find(([cmd, args]) => cmd === 'claude' && (args as string[])[0] === '--dangerously-skip-permissions')).toBeDefined();
+    expect(vi.mocked(tmuxExec).mock.calls).toHaveLength(1);
+    expect(vi.mocked(execFileSync).mock.calls.find(([cmd, args]) => cmd === 'claude' && (args as string[])[0] === '--dangerously-skip-permissions')).toBeDefined();
   });
 });
 
@@ -389,15 +380,14 @@ describe('runClaude inside-tmux — mouse configuration (issue #890)', () => {
   it('enables mouse mode before launching claude', () => {
     runClaude('/tmp', [], 'sid');
 
-    const calls = vi.mocked(execFileSync).mock.calls;
+    // tmuxExec should have been called for mouse config
+    const tmuxCalls = vi.mocked(tmuxExec).mock.calls;
+    expect(tmuxCalls.length).toBeGreaterThanOrEqual(1);
+    expect(tmuxCalls[0][0]).toEqual(['set-option', 'mouse', 'on']);
 
-    // First call should be tmux set-option for mouse config
-    expect(calls.length).toBeGreaterThanOrEqual(2);
-    expect(calls[0][0]).toBe('tmux');
-    expect(calls[0][1]).toEqual(['set-option', 'mouse', 'on']);
-
-    // Second call should be claude
-    expect(calls[1][0]).toBe('claude');
+    // execFileSync should have been called for claude
+    const claudeCalls = vi.mocked(execFileSync).mock.calls;
+    expect(claudeCalls.find(([cmd]) => cmd === 'claude')).toBeDefined();
   });
 
   it('still launches claude even if tmux mouse config fails', () => {
@@ -856,10 +846,11 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
   const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
   let tempRoot: string | null = null;
 
-  const originalClaudeCode = process.env.CLAUDECODE;
+  const originalClaudecode = process.env.CLAUDECODE;
 
   beforeEach(() => {
     vi.resetAllMocks();
+    delete process.env.CLAUDECODE;
     tempRoot = mkdtempSync(join(tmpdir(), 'omc-launch-profile-'));
     (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
     (resolveLaunchPolicy as ReturnType<typeof vi.fn>).mockReturnValue('direct');
@@ -877,10 +868,10 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     } else {
       process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
     }
-    if (originalClaudeCode === undefined) {
+    if (originalClaudecode === undefined) {
       delete process.env.CLAUDECODE;
     } else {
-      process.env.CLAUDECODE = originalClaudeCode;
+      process.env.CLAUDECODE = originalClaudecode;
     }
   });
 
@@ -1010,9 +1001,8 @@ describe('runClaude — print mode bypasses tmux (issue #1665)', () => {
 
     runClaude('/tmp', ['--dangerously-skip-permissions'], 'sid');
 
-    const calls = vi.mocked(execFileSync).mock.calls;
-    const tmuxCall = calls.find(([cmd]) => cmd === 'tmux');
-    expect(tmuxCall).toBeDefined();
+    // tmux calls go through tmuxExec, not execFileSync
+    expect(vi.mocked(tmuxExec).mock.calls.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/cli/__tests__/tmux-no-raw-calls.test.ts
+++ b/src/cli/__tests__/tmux-no-raw-calls.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Verification test: ensures no raw tmux child_process calls exist outside tmux-utils.ts.
+ *
+ * Every tmux call in the codebase must go through the centralized wrappers
+ * (tmuxExec, tmuxExecAsync, tmuxShell, tmuxShellAsync, tmuxSpawn, tmuxCmdAsync)
+ * defined in src/cli/tmux-utils.ts. This test enforces that invariant.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { execSync } from 'child_process';
+import { join } from 'path';
+
+function grepForRawTmuxCalls(): string[] {
+  const srcDir = join(__dirname, '..', '..');
+  // Patterns that match raw tmux calls via child_process functions.
+  // Covers both single-quote and double-quote variants.
+  const patterns = [
+    "execFileSync\\s*\\(\\s*['\"]tmux",
+    "execSync\\s*\\(\\s*['\"`]tmux",
+    "spawnSync\\s*\\(\\s*['\"]tmux",
+    "execFile\\s*\\(\\s*['\"]tmux",
+    "\\bexec\\s*\\(\\s*[`'\"]tmux",
+  ];
+  const combined = patterns.join('|');
+
+  try {
+    const result = execSync(
+      `grep -rn --include='*.ts' -E '${combined}' '${srcDir}' || true`,
+      { encoding: 'utf-8', timeout: 10000 },
+    );
+    return result
+      .split('\n')
+      .filter(Boolean)
+      // Exclude the wrapper implementations in tmux-utils.ts itself
+      .filter(line => !line.includes('cli/tmux-utils.ts'))
+      // Exclude test files
+      .filter(line => !line.includes('__tests__/'))
+      // Exclude comments (lines starting with optional whitespace then * or //)
+      .filter(line => {
+        const content = line.split(':').slice(2).join(':').trim();
+        return !content.startsWith('*') && !content.startsWith('//');
+      });
+  } catch {
+    return [];
+  }
+}
+
+describe('tmux call centralization', () => {
+  it('has zero raw tmux child_process calls outside tmux-utils.ts and test files', () => {
+    const violations = grepForRawTmuxCalls();
+    if (violations.length > 0) {
+      const formatted = violations.map(v => `  ${v}`).join('\n');
+      expect.fail(
+        `Found ${violations.length} raw tmux call(s) outside tmux-utils.ts:\n${formatted}\n\n` +
+        'All tmux calls must use the centralized wrappers (tmuxExec, tmuxExecAsync, etc.) from src/cli/tmux-utils.ts.',
+      );
+    }
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -21,7 +21,7 @@ import {
   runAutoresearchSetupSession,
   type AutoresearchSetupSessionInput,
 } from './autoresearch-setup-session.js';
-import { buildTmuxShellCommand, isTmuxAvailable, quoteShellArg, wrapWithLoginShell } from './tmux-utils.js';
+import { buildTmuxShellCommand, isTmuxAvailable, quoteShellArg, tmuxExec, wrapWithLoginShell } from './tmux-utils.js';
 
 const CLAUDE_BYPASS_FLAG = '--dangerously-skip-permissions';
 const AUTORESEARCH_SETUP_SLASH_COMMAND = '/deep-interview --autoresearch';
@@ -324,7 +324,7 @@ function tmuxEnv(): NodeJS.ProcessEnv {
 
 function assertTmuxSessionAvailable(sessionName: string): void {
   try {
-    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore', env: tmuxEnv() });
+    tmuxExec(['has-session', '-t', sessionName], { stripTmux: true, stdio: 'ignore' });
   } catch {
     throw new Error(
       `tmux session "${sessionName}" did not stay available after launch. `
@@ -341,7 +341,7 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
   const sessionName = `omc-autoresearch-${slug}`;
 
   try {
-    execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore', env: tmuxEnv() });
+    tmuxExec(['has-session', '-t', sessionName], { stripTmux: true, stdio: 'ignore' });
     throw new Error(
       `tmux session "${sessionName}" already exists.\n`
       + `  Attach: tmux attach -t ${sessionName}\n`
@@ -359,7 +359,7 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
   const command = buildTmuxShellCommand(process.execPath, [omcPath, 'autoresearch', missionDir]);
   const wrappedCommand = wrapWithLoginShell(command);
 
-  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-c', repoRoot, wrappedCommand], { stdio: 'ignore', env: tmuxEnv() });
+  tmuxExec(['new-session', '-d', '-s', sessionName, '-c', repoRoot, wrappedCommand], { stripTmux: true, stdio: 'ignore' });
   assertTmuxSessionAvailable(sessionName);
 
   console.log('\nAutoresearch launched in background tmux session.');
@@ -416,17 +416,16 @@ export function spawnAutoresearchSetupTmux(repoRoot: string): void {
   const codexHome = prepareAutoresearchSetupCodexHome(repoRoot, sessionName);
   const claudeCommand = buildTmuxShellCommand('env', [`CODEX_HOME=${codexHome}`, 'claude', CLAUDE_BYPASS_FLAG]);
   const wrappedClaudeCommand = wrapWithLoginShell(claudeCommand);
-  const paneId = execFileSync(
-    'tmux',
+  const paneId = tmuxExec(
     ['new-session', '-d', '-P', '-F', '#{pane_id}', '-s', sessionName, '-c', repoRoot, wrappedClaudeCommand],
-    { encoding: 'utf-8', env: tmuxEnv() },
+    { stripTmux: true },
   ).trim();
 
   assertTmuxSessionAvailable(sessionName);
 
   if (paneId) {
-    execFileSync('tmux', ['send-keys', '-t', paneId, '-l', buildAutoresearchSetupSlashCommand()], { stdio: 'ignore', env: tmuxEnv() });
-    execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], { stdio: 'ignore', env: tmuxEnv() });
+    tmuxExec(['send-keys', '-t', paneId, '-l', buildAutoresearchSetupSlashCommand()], { stripTmux: true, stdio: 'ignore' });
+    tmuxExec(['send-keys', '-t', paneId, 'Enter'], { stripTmux: true, stdio: 'ignore' });
   }
 
   console.log('\nAutoresearch setup launched in background Claude session.');

--- a/src/cli/commands/ralphthon.ts
+++ b/src/cli/commands/ralphthon.ts
@@ -10,7 +10,7 @@
  */
 
 import chalk from "chalk";
-import { execSync } from "child_process";
+import { tmuxShell } from "../../cli/tmux-utils.js";
 import { existsSync } from "fs";
 import {
   readRalphthonPrd,
@@ -267,8 +267,7 @@ function createEventLogger(): (event: OrchestratorEvent) => void {
 
 function getCurrentTmuxSession(): string | null {
   try {
-    return execSync("tmux display-message -p '#S'", {
-      encoding: "utf-8",
+    return tmuxShell("display-message -p '#S'", {
       timeout: 5000,
     }).trim();
   } catch {
@@ -278,8 +277,7 @@ function getCurrentTmuxSession(): string | null {
 
 function getCurrentTmuxPane(): string | null {
   try {
-    return execSync("tmux display-message -p '#{pane_id}'", {
-      encoding: "utf-8",
+    return tmuxShell("display-message -p '#{pane_id}'", {
       timeout: 5000,
     }).trim();
   } catch {

--- a/src/cli/interop.ts
+++ b/src/cli/interop.ts
@@ -7,7 +7,7 @@
 
 import { execFileSync } from 'child_process';
 import { randomUUID } from 'crypto';
-import { isTmuxAvailable, isClaudeAvailable } from './tmux-utils.js';
+import { isTmuxAvailable, isClaudeAvailable, tmuxExec } from './tmux-utils.js';
 import { initInteropSession } from '../interop/shared-state.js';
 
 export type InteropMode = 'off' | 'observe' | 'active';
@@ -109,9 +109,7 @@ export function launchInteropSession(cwd: string = process.cwd()): void {
   // Get current pane ID
   let currentPaneId: string;
   try {
-    const output = execFileSync('tmux', ['display-message', '-p', '#{pane_id}'], {
-      encoding: 'utf-8',
-    });
+    const output = tmuxExec(['display-message', '-p', '#{pane_id}']);
     currentPaneId = output.trim();
   } catch (_error) {
     console.error('Error: Failed to get current tmux pane ID');
@@ -129,7 +127,7 @@ export function launchInteropSession(cwd: string = process.cwd()): void {
       // Create right pane with codex
       console.log('Splitting pane: Left (Claude Code) | Right (Codex)');
 
-      execFileSync('tmux', [
+      tmuxExec([
         'split-window',
         '-h',
         '-c', cwd,
@@ -138,7 +136,7 @@ export function launchInteropSession(cwd: string = process.cwd()): void {
       ], { stdio: 'inherit' });
 
       // Select left pane (original/current)
-      execFileSync('tmux', ['select-pane', '-t', currentPaneId], { stdio: 'ignore' });
+      tmuxExec(['select-pane', '-t', currentPaneId], { stdio: 'ignore' });
 
       console.log('\nInterop session ready!');
       console.log('- Left pane: Claude Code (this terminal)');

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -25,6 +25,7 @@ import {
   wrapWithLoginShell,
   isClaudeAvailable,
   quoteShellArg,
+  tmuxExec,
 } from './tmux-utils.js';
 import { OMC_PLUGIN_ROOT_ENV } from '../lib/env-vars.js';
 import { OMC_CONFIG_FILE_REL } from '../lib/paths.js';
@@ -384,7 +385,7 @@ export function runClaude(cwd: string, args: string[], sessionId: string): void 
 function runClaudeInsideTmux(cwd: string, args: string[]): void {
   // Enable mouse scrolling in the current tmux session (non-fatal if it fails)
   try {
-    execFileSync('tmux', ['set-option', 'mouse', 'on'], { stdio: 'ignore' });
+    tmuxExec(['set-option', 'mouse', 'on'], { stdio: 'ignore' });
   } catch { /* non-fatal — user's tmux may not support these options */ }
 
   // Launch Claude in current pane
@@ -448,26 +449,26 @@ function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string): 
   const sessionName = buildTmuxSessionName(cwd);
 
   try {
-    execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-c', cwd, claudeCmd], { stdio: 'inherit' });
+    tmuxExec(['new-session', '-d', '-s', sessionName, '-c', cwd, claudeCmd], { stripTmux: true, stdio: 'inherit' });
   } catch {
     runClaudeDirect(cwd, args);
     return;
   }
 
   try {
-    execFileSync('tmux', ['set-option', '-t', sessionName, 'mouse', 'on'], { stdio: 'ignore' });
+    tmuxExec(['set-option', '-t', sessionName, 'mouse', 'on'], { stripTmux: true, stdio: 'ignore' });
   } catch {
     /* non-fatal — user's tmux may not support these options */
   }
 
   try {
-    execFileSync('tmux', ['attach-session', '-t', sessionName], { stdio: 'inherit' });
+    tmuxExec(['attach-session', '-t', sessionName], { stripTmux: true, stdio: 'inherit' });
   } catch {
     // If the detached session still exists, preserve it so interrupted
     // attach paths (SSH disconnect, terminal drop, etc.) do not kill or
     // duplicate a valid Claude session.
     try {
-      execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'ignore' });
+      tmuxExec(['has-session', '-t', sessionName], { stripTmux: true, stdio: 'ignore' });
       return;
     } catch {
       runClaudeDirect(cwd, args);

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -3,8 +3,97 @@
  * Adapted from oh-my-codex patterns for omc
  */
 
-import { execFileSync } from 'child_process';
+import {
+  exec,
+  execFile,
+  execFileSync,
+  execSync,
+  spawnSync,
+  type ExecFileSyncOptionsWithStringEncoding,
+  type ExecSyncOptionsWithStringEncoding,
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+} from 'child_process';
 import { basename } from 'path';
+import { promisify } from 'util';
+
+const promisifiedExec = promisify(exec);
+const promisifiedExecFile = promisify(execFile);
+
+// ── tmux environment & execution wrappers ────────────────────────────────────
+
+export interface TmuxExecOptions {
+  /** Strip TMUX env var so the command targets the default tmux server.
+   *  Default: false — preserves TMUX (targets the current server).
+   *  Set to true for OMC-owned background sessions and cross-session scans. */
+  stripTmux?: boolean;
+}
+
+export function tmuxEnv(): NodeJS.ProcessEnv {
+  const { TMUX: _, ...env } = process.env;
+  return env;
+}
+
+function resolveEnv(opts?: TmuxExecOptions): NodeJS.ProcessEnv {
+  return opts?.stripTmux ? tmuxEnv() : process.env;
+}
+
+export function tmuxExec(
+  args: string[],
+  opts?: TmuxExecOptions & Omit<ExecFileSyncOptionsWithStringEncoding, 'env' | 'encoding'> & { encoding?: BufferEncoding },
+): string {
+  const { stripTmux: _, ...execOpts } = opts ?? {};
+  return execFileSync('tmux', args, { encoding: 'utf-8', ...execOpts, env: resolveEnv(opts) });
+}
+
+export async function tmuxExecAsync(
+  args: string[],
+  opts?: TmuxExecOptions & { timeout?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  const { stripTmux: _, timeout, ...rest } = opts ?? {};
+  return promisifiedExecFile('tmux', args, {
+    encoding: 'utf-8', env: resolveEnv(opts),
+    ...(timeout !== undefined ? { timeout } : {}), ...rest,
+  });
+}
+
+export function tmuxShell(
+  command: string,
+  opts?: TmuxExecOptions & Omit<ExecSyncOptionsWithStringEncoding, 'env' | 'encoding'> & { encoding?: BufferEncoding },
+): string {
+  const { stripTmux: _, ...execOpts } = opts ?? {};
+  return execSync(`tmux ${command}`, { encoding: 'utf-8', ...execOpts, env: resolveEnv(opts) }) as string;
+}
+
+export async function tmuxShellAsync(
+  command: string,
+  opts?: TmuxExecOptions & { timeout?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  const { stripTmux: _, timeout, ...rest } = opts ?? {};
+  return promisifiedExec(`tmux ${command}`, {
+    encoding: 'utf-8', env: resolveEnv(opts),
+    ...(timeout !== undefined ? { timeout } : {}), ...rest,
+  });
+}
+
+export function tmuxSpawn(
+  args: string[],
+  opts?: TmuxExecOptions & Omit<SpawnSyncOptionsWithStringEncoding, 'env' | 'encoding'> & { encoding?: BufferEncoding },
+): SpawnSyncReturns<string> {
+  const { stripTmux: _, ...spawnOpts } = opts ?? {};
+  return spawnSync('tmux', args, { encoding: 'utf-8', ...spawnOpts, env: resolveEnv(opts) });
+}
+
+export async function tmuxCmdAsync(
+  args: string[],
+  opts?: TmuxExecOptions & { timeout?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  if (args.some(a => a.includes('#{'))) {
+    const escaped = args.map(a => "'" + a.replace(/'/g, "'\\''") + "'").join(' ');
+    return tmuxShellAsync(escaped, opts);
+  }
+  return tmuxExecAsync(args, opts);
+}
 
 export type ClaudeLaunchPolicy = 'inside-tmux' | 'outside-tmux' | 'direct';
 
@@ -19,7 +108,7 @@ export interface TmuxPaneSnapshot {
  */
 export function isTmuxAvailable(): boolean {
   try {
-    execFileSync('tmux', ['-V'], { stdio: 'ignore' });
+    tmuxExec(['-V'], { stripTmux: true, stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -191,10 +280,8 @@ export function findHudWatchPaneIds(panes: TmuxPaneSnapshot[], currentPaneId?: s
  */
 export function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): string[] {
   try {
-    const output = execFileSync(
-      'tmux',
+    const output = tmuxExec(
       ['list-panes', '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}'],
-      { encoding: 'utf-8' }
     );
     return findHudWatchPaneIds(parseTmuxPaneSnapshot(output), currentPaneId);
   } catch {
@@ -209,10 +296,8 @@ export function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): stri
 export function createHudWatchPane(cwd: string, hudCmd: string): string | null {
   try {
     const wrappedCmd = wrapWithLoginShell(hudCmd);
-    const output = execFileSync(
-      'tmux',
+    const output = tmuxExec(
       ['split-window', '-v', '-l', '4', '-d', '-c', cwd, '-P', '-F', '#{pane_id}', wrappedCmd],
-      { encoding: 'utf-8' }
     );
     const paneId = output.split('\n')[0]?.trim() || '';
     return paneId.startsWith('%') ? paneId : null;
@@ -227,7 +312,7 @@ export function createHudWatchPane(cwd: string, hudCmd: string): string | null {
 export function killTmuxPane(paneId: string): void {
   if (!paneId.startsWith('%')) return;
   try {
-    execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'ignore' });
+    tmuxExec(['kill-pane', '-t', paneId], { stripTmux: true, stdio: 'ignore' });
   } catch {
     // Pane may already be gone; ignore
   }

--- a/src/cli/win32-warning.ts
+++ b/src/cli/win32-warning.ts
@@ -1,12 +1,12 @@
 import chalk from 'chalk';
-import { spawnSync } from 'child_process';
+import { tmuxSpawn } from './tmux-utils.js';
 
 /**
  * Check if tmux (or a compatible implementation like psmux) is available.
  */
 function hasTmuxBinary(): boolean {
   try {
-    const result = spawnSync('tmux', ['-V'], { stdio: 'pipe', timeout: 3000 });
+    const result = tmuxSpawn(['-V'], { stripTmux: true, stdio: 'pipe', timeout: 3000 });
     return result.status === 0;
   } catch {
     return false;

--- a/src/features/rate-limit-wait/tmux-detector.ts
+++ b/src/features/rate-limit-wait/tmux-detector.ts
@@ -9,7 +9,7 @@
  * - Text inputs are sanitized to prevent command injection
  */
 
-import { execFileSync, spawnSync } from 'child_process';
+import { tmuxExec, tmuxSpawn } from '../../cli/tmux-utils.js';
 import type { TmuxPane, PaneAnalysisResult, BlockedPane } from './types.js';
 
 /**
@@ -73,11 +73,7 @@ const WAITING_PATTERNS = [
  */
 export function isTmuxAvailable(): boolean {
   try {
-    const result = spawnSync('tmux', ['-V'], {
-      encoding: 'utf-8',
-      timeout: 3000,
-      stdio: 'pipe',
-    });
+    const result = tmuxSpawn(['-V'], { stripTmux: true, stdio: 'pipe', timeout: 3000 });
     return result.status === 0;
   } catch {
     return false;
@@ -102,8 +98,8 @@ export function listTmuxPanes(): TmuxPane[] {
   try {
     // Format: session_name:window_index.pane_index pane_id pane_active window_name pane_title
     const format = '#{session_name}:#{window_index}.#{pane_index} #{pane_id} #{pane_active} #{window_name} #{pane_title}';
-    const result = execFileSync('tmux', ['list-panes', '-a', '-F', format], {
-      encoding: 'utf-8',
+    const result = tmuxExec(['list-panes', '-a', '-F', format], {
+      stripTmux: true,
       timeout: 5000,
     });
 
@@ -159,8 +155,8 @@ export function capturePaneContent(paneId: string, lines = 15): string {
 
   try {
     // Capture the last N lines from the pane
-    const result = execFileSync('tmux', ['capture-pane', '-t', paneId, '-p', '-S', `-${safeLines}`], {
-      encoding: 'utf-8',
+    const result = tmuxExec(['capture-pane', '-t', paneId, '-p', '-S', `-${safeLines}`], {
+      stripTmux: true,
       timeout: 5000,
     });
     return result;
@@ -276,7 +272,8 @@ export function sendResumeSequence(paneId: string): boolean {
 
   try {
     // Send "1" to select the first option (typically "Continue" or similar)
-    execFileSync('tmux', ['send-keys', '-t', paneId, '1', 'Enter'], {
+    tmuxExec(['send-keys', '-t', paneId, '1', 'Enter'], {
+      stripTmux: true,
       timeout: 2000,
     });
 
@@ -306,12 +303,14 @@ export function sendToPane(paneId: string, text: string, pressEnter = true): boo
   try {
     const sanitizedText = sanitizeForTmux(text);
     // Send text with -l flag (literal) to avoid key interpretation issues in TUI apps
-    execFileSync('tmux', ['send-keys', '-t', paneId, '-l', sanitizedText], {
+    tmuxExec(['send-keys', '-t', paneId, '-l', sanitizedText], {
+      stripTmux: true,
       timeout: 2000,
     });
     // Send Enter as a separate command so it is interpreted as a key press
     if (pressEnter) {
-      execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], {
+      tmuxExec(['send-keys', '-t', paneId, 'Enter'], {
+        stripTmux: true,
         timeout: 2000,
       });
     }

--- a/src/hooks/team-dispatch-hook.ts
+++ b/src/hooks/team-dispatch-hook.ts
@@ -17,6 +17,7 @@ import { readFile, writeFile, mkdir, readdir, appendFile, rename, rm, stat } fro
 import { existsSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
+import { tmuxExecAsync } from '../cli/tmux-utils.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -368,7 +369,7 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
 
   const paneTarget = target.value;
   try {
-    const inMode = await runProcess('tmux', ['display-message', '-t', paneTarget, '-p', '#{pane_in_mode}'], 1000);
+    const inMode = await tmuxExecAsync(['display-message', '-t', paneTarget, '-p', '#{pane_in_mode}'], { timeout: 1000 });
     if (safeString(inMode.stdout).trim() === '1') {
       return { ok: false, reason: 'scroll_active' };
     }
@@ -380,7 +381,7 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
   let preCaptureHasTrigger = false;
   if (attemptCountAtStart >= 1) {
     try {
-      const preCapture = await runProcess('tmux', ['capture-pane', '-t', paneTarget, '-p', '-S', '-8'], 2000);
+      const preCapture = await tmuxExecAsync(['capture-pane', '-t', paneTarget, '-p', '-S', '-8'], { timeout: 2000 });
       preCaptureHasTrigger = capturedPaneContainsTrigger(preCapture.stdout, request.trigger_message);
     } catch {
       preCaptureHasTrigger = false;
@@ -390,18 +391,18 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
   const shouldTypePrompt = attemptCountAtStart === 0 || !preCaptureHasTrigger;
   if (shouldTypePrompt) {
     if (attemptCountAtStart >= 1) {
-      await runProcess('tmux', ['send-keys', '-t', paneTarget, 'C-u'], 1000).catch(() => {});
+      await tmuxExecAsync(['send-keys', '-t', paneTarget, 'C-u'], { timeout: 1000 }).catch(() => {});
       await new Promise((r) => setTimeout(r, 50));
     }
     // Strip control characters (including newlines) from trigger_message to prevent
     // keystroke injection — tmux send-keys -l sends literal keystrokes, so a \n
     // in the message would execute as Enter in the target pane's shell.
     const sanitizedMessage = request.trigger_message.replace(/[\x00-\x1f\x7f]/g, '');
-    await runProcess('tmux', ['send-keys', '-t', paneTarget, '-l', sanitizedMessage], 3000);
+    await tmuxExecAsync(['send-keys', '-t', paneTarget, '-l', sanitizedMessage], { timeout: 3000 });
   }
 
   for (let i = 0; i < submitKeyPresses; i++) {
-    await runProcess('tmux', ['send-keys', '-t', paneTarget, 'C-m'], 3000);
+    await tmuxExecAsync(['send-keys', '-t', paneTarget, 'C-m'], { timeout: 3000 });
     if (i < submitKeyPresses - 1) {
       await new Promise((r) => setTimeout(r, 100));
     }
@@ -411,8 +412,8 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
   for (let round = 0; round < INJECT_VERIFY_ROUNDS; round++) {
     await new Promise((r) => setTimeout(r, INJECT_VERIFY_DELAY_MS));
     try {
-      const narrowCap = await runProcess('tmux', ['capture-pane', '-t', paneTarget, '-p', '-S', '-8'], 2000);
-      const wideCap = await runProcess('tmux', ['capture-pane', '-t', paneTarget, '-p'], 2000);
+      const narrowCap = await tmuxExecAsync(['capture-pane', '-t', paneTarget, '-p', '-S', '-8'], { timeout: 2000 });
+      const wideCap = await tmuxExecAsync(['capture-pane', '-t', paneTarget, '-p'], { timeout: 2000 });
 
       if (paneHasActiveTask(wideCap.stdout)) {
         return { ok: true, reason: 'tmux_send_keys_confirmed_active_task', pane: paneTarget };
@@ -428,7 +429,7 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
     } catch { /* capture failed; retry */ }
 
     for (let i = 0; i < submitKeyPresses; i++) {
-      await runProcess('tmux', ['send-keys', '-t', paneTarget, 'C-m'], 3000).catch(() => {});
+      await tmuxExecAsync(['send-keys', '-t', paneTarget, 'C-m'], { timeout: 3000 }).catch(() => {});
     }
   }
 

--- a/src/hooks/team-leader-nudge-hook.ts
+++ b/src/hooks/team-leader-nudge-hook.ts
@@ -58,13 +58,11 @@ export interface TmuxRunner {
 }
 
 async function defaultTmuxSendKeys(target: string, text: string, literal = false): Promise<void> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
+  const { tmuxExecAsync } = await import('../cli/tmux-utils.js');
   const args = literal
     ? ['send-keys', '-t', target, '-l', text]
     : ['send-keys', '-t', target, text];
-  await execFileAsync('tmux', args, { timeout: 3000 });
+  await tmuxExecAsync(args, { timeout: 3000 });
 }
 
 const defaultTmux: TmuxRunner = {

--- a/src/hooks/team-worker-hook.ts
+++ b/src/hooks/team-worker-hook.ts
@@ -119,13 +119,11 @@ export interface TmuxRunner {
 }
 
 async function defaultTmuxSendKeys(target: string, text: string, literal = false): Promise<void> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
+  const { tmuxExecAsync } = await import('../cli/tmux-utils.js');
   const args = literal
     ? ['send-keys', '-t', target, '-l', text]
     : ['send-keys', '-t', target, text];
-  await execFileAsync('tmux', args, { timeout: 3000 });
+  await tmuxExecAsync(args, { timeout: 3000 });
 }
 
 const defaultTmux: TmuxRunner = {

--- a/src/notifications/__tests__/tmux.test.ts
+++ b/src/notifications/__tests__/tmux.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-vi.mock("child_process", () => ({
-  execSync: vi.fn(),
-}));
+vi.mock("../../cli/tmux-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../cli/tmux-utils.js")>();
+  return { ...actual, tmuxShell: vi.fn() };
+});
 
-import { execSync } from "child_process";
+import { tmuxShell } from "../../cli/tmux-utils.js";
 import {
   getCurrentTmuxSession,
   getCurrentTmuxPaneId,
@@ -12,7 +13,7 @@ import {
   getTeamTmuxSessions,
 } from "../tmux.js";
 
-const mockExecSync = vi.mocked(execSync);
+const mockTmuxShell = vi.mocked(tmuxShell);
 
 describe("getCurrentTmuxSession", () => {
   const originalEnv = process.env;
@@ -30,21 +31,21 @@ describe("getCurrentTmuxSession", () => {
     delete process.env.TMUX;
     delete process.env.TMUX_PANE;
     expect(getCurrentTmuxSession()).toBeNull();
-    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockTmuxShell).not.toHaveBeenCalled();
   });
 
   it("uses TMUX_PANE to resolve the session name for the current pane", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
     process.env.TMUX_PANE = "%3";
 
-    mockExecSync.mockReturnValueOnce(
+    mockTmuxShell.mockReturnValueOnce(
       "%0 main\n%1 main\n%2 background\n%3 my-detached-session\n"
     );
 
     expect(getCurrentTmuxSession()).toBe("my-detached-session");
-    expect(mockExecSync).toHaveBeenCalledWith(
-      "tmux list-panes -a -F '#{pane_id} #{session_name}'",
-      expect.objectContaining({ encoding: "utf-8" })
+    expect(mockTmuxShell).toHaveBeenCalledWith(
+      "list-panes -a -F '#{pane_id} #{session_name}'",
+      expect.objectContaining({ timeout: 3000 })
     );
   });
 
@@ -53,7 +54,7 @@ describe("getCurrentTmuxSession", () => {
     process.env.TMUX_PANE = "%1";
 
     // %10 must NOT match %1
-    mockExecSync.mockReturnValueOnce("%10 other\n%1 target-session\n%2 foo\n");
+    mockTmuxShell.mockReturnValueOnce("%10 other\n%1 target-session\n%2 foo\n");
 
     expect(getCurrentTmuxSession()).toBe("target-session");
   });
@@ -62,12 +63,12 @@ describe("getCurrentTmuxSession", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
     delete process.env.TMUX_PANE;
 
-    mockExecSync.mockReturnValueOnce("fallback-session\n");
+    mockTmuxShell.mockReturnValueOnce("fallback-session\n");
 
     expect(getCurrentTmuxSession()).toBe("fallback-session");
-    expect(mockExecSync).toHaveBeenCalledWith(
-      "tmux display-message -p '#S'",
-      expect.objectContaining({ encoding: "utf-8" })
+    expect(mockTmuxShell).toHaveBeenCalledWith(
+      "display-message -p '#S'",
+      expect.objectContaining({ timeout: 3000 })
     );
   });
 
@@ -76,7 +77,7 @@ describe("getCurrentTmuxSession", () => {
     process.env.TMUX_PANE = "%99";
 
     // list-panes doesn't include %99
-    mockExecSync
+    mockTmuxShell
       .mockReturnValueOnce("%0 main\n%1 main\n")
       .mockReturnValueOnce("attached-session\n");
 
@@ -87,7 +88,7 @@ describe("getCurrentTmuxSession", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
     process.env.TMUX_PANE = "%1";
 
-    mockExecSync.mockImplementation(() => {
+    mockTmuxShell.mockImplementation(() => {
       throw new Error("tmux not found");
     });
 
@@ -98,7 +99,7 @@ describe("getCurrentTmuxSession", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
     delete process.env.TMUX_PANE;
 
-    mockExecSync.mockReturnValueOnce("  \n");
+    mockTmuxShell.mockReturnValueOnce("  \n");
 
     expect(getCurrentTmuxSession()).toBeNull();
   });
@@ -125,14 +126,14 @@ describe("getCurrentTmuxPaneId", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
     process.env.TMUX_PANE = "%5";
     expect(getCurrentTmuxPaneId()).toBe("%5");
-    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockTmuxShell).not.toHaveBeenCalled();
   });
 
   it("falls back to tmux display-message when env var is absent", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
     delete process.env.TMUX_PANE;
 
-    mockExecSync.mockReturnValueOnce("%2\n");
+    mockTmuxShell.mockReturnValueOnce("%2\n");
     expect(getCurrentTmuxPaneId()).toBe("%2");
   });
 });
@@ -158,7 +159,7 @@ describe("formatTmuxInfo", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
     process.env.TMUX_PANE = "%0";
 
-    mockExecSync.mockReturnValueOnce("%0 my-session\n");
+    mockTmuxShell.mockReturnValueOnce("%0 my-session\n");
 
     expect(formatTmuxInfo()).toBe("tmux: my-session");
   });
@@ -170,24 +171,24 @@ describe("getTeamTmuxSessions", () => {
   });
 
   it("returns sessions matching the team prefix", () => {
-    mockExecSync.mockReturnValueOnce(
+    mockTmuxShell.mockReturnValueOnce(
       "omc-team-myteam-worker1\nomc-team-myteam-worker2\nother-session\n"
     );
     expect(getTeamTmuxSessions("myteam")).toEqual(["worker1", "worker2"]);
   });
 
   it("returns empty array when no sessions match", () => {
-    mockExecSync.mockReturnValueOnce("some-other-session\n");
+    mockTmuxShell.mockReturnValueOnce("some-other-session\n");
     expect(getTeamTmuxSessions("myteam")).toEqual([]);
   });
 
   it("returns empty array for empty team name", () => {
     expect(getTeamTmuxSessions("")).toEqual([]);
-    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockTmuxShell).not.toHaveBeenCalled();
   });
 
   it("returns empty array when execSync throws", () => {
-    mockExecSync.mockImplementation(() => {
+    mockTmuxShell.mockImplementation(() => {
       throw new Error("no server running");
     });
     expect(getTeamTmuxSessions("myteam")).toEqual([]);

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -4,7 +4,7 @@
  * Detects the current tmux session name for inclusion in notification payloads.
  */
 
-import { execSync } from "child_process";
+import { tmuxShell } from "../cli/tmux-utils.js";
 
 /**
  * Get the current tmux session name.
@@ -22,8 +22,7 @@ export function getCurrentTmuxSession(): string | null {
     // is wrong when Claude runs in a detached session.
     const paneId = process.env.TMUX_PANE;
     if (paneId) {
-      const lines = execSync("tmux list-panes -a -F '#{pane_id} #{session_name}'", {
-        encoding: "utf-8",
+      const lines = tmuxShell("list-panes -a -F '#{pane_id} #{session_name}'", {
         timeout: 3000,
         stdio: ["pipe", "pipe", "pipe"],
       }).split("\n");
@@ -32,8 +31,7 @@ export function getCurrentTmuxSession(): string | null {
     }
 
     // Fallback: ask the attached session (may differ when detached).
-    const sessionName = execSync("tmux display-message -p '#S'", {
-      encoding: "utf-8",
+    const sessionName = tmuxShell("display-message -p '#S'", {
       timeout: 3000,
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
@@ -53,8 +51,7 @@ export function getTeamTmuxSessions(teamName: string): string[] {
 
   const prefix = `omc-team-${sanitized}-`;
   try {
-    const output = execSync("tmux list-sessions -F '#{session_name}'", {
-      encoding: "utf-8",
+    const output = tmuxShell("list-sessions -F '#{session_name}'", {
       timeout: 3000,
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -93,8 +90,7 @@ export function getCurrentTmuxPaneId(): string | null {
 
   // Fallback: ask tmux directly (similar to getCurrentTmuxSession)
   try {
-    const paneId = execSync("tmux display-message -p '#{pane_id}'", {
-      encoding: "utf-8",
+    const paneId = tmuxShell("display-message -p '#{pane_id}'", {
       timeout: 3000,
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();

--- a/src/ralphthon/orchestrator.ts
+++ b/src/ralphthon/orchestrator.ts
@@ -8,7 +8,7 @@
  * Terminates after N consecutive hardening waves with no new issues.
  */
 
-import { execFileSync } from 'child_process';
+import { tmuxExec } from '../cli/tmux-utils.js';
 import {
   writeModeState,
   readModeState,
@@ -85,9 +85,9 @@ export function clearRalphthonState(
  */
 export function isPaneIdle(paneId: string): boolean {
   try {
-    const output = execFileSync(
-      'tmux', ['display-message', '-t', paneId, '-p', '#{pane_current_command}'],
-      { encoding: 'utf-8', timeout: 5000 },
+    const output = tmuxExec(
+      ['display-message', '-t', paneId, '-p', '#{pane_current_command}'],
+      { timeout: 5000 },
     ).trim();
 
     const shellNames = ['bash', 'zsh', 'fish', 'sh', 'dash'];
@@ -102,7 +102,7 @@ export function isPaneIdle(paneId: string): boolean {
  */
 export function paneExists(paneId: string): boolean {
   try {
-    execFileSync('tmux', ['has-session', '-t', paneId], { timeout: 5000, stdio: 'pipe' });
+    tmuxExec(['has-session', '-t', paneId], { timeout: 5000, stdio: 'pipe' });
     return true;
   } catch {
     return false;
@@ -114,7 +114,7 @@ export function paneExists(paneId: string): boolean {
  */
 export function sendKeysToPane(paneId: string, text: string): boolean {
   try {
-    execFileSync('tmux', ['send-keys', '-t', paneId, text, 'Enter'], { timeout: 10000 });
+    tmuxExec(['send-keys', '-t', paneId, text, 'Enter'], { timeout: 10000 });
     return true;
   } catch {
     return false;
@@ -126,9 +126,9 @@ export function sendKeysToPane(paneId: string, text: string): boolean {
  */
 export function capturePaneContent(paneId: string, lines = 50): string {
   try {
-    return execFileSync(
-      'tmux', ['capture-pane', '-t', paneId, '-p', '-S', `-${lines}`],
-      { encoding: 'utf-8', timeout: 5000 },
+    return tmuxExec(
+      ['capture-pane', '-t', paneId, '-p', '-S', `-${lines}`],
+      { timeout: 5000 },
     ).trim();
   } catch {
     return '';

--- a/src/team/__tests__/idle-nudge.test.ts
+++ b/src/team/__tests__/idle-nudge.test.ts
@@ -14,15 +14,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-// Mock child_process so tmux calls don't require a real tmux install
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
+// Mock tmux-utils so tmux calls don't require a real tmux install
+vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../cli/tmux-utils.js')>();
   return {
     ...actual,
-    execFile: vi.fn((_cmd: string, _args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) => {
-      cb(null, '', '');
-      return {} as any;
-    }),
+    tmuxExecAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
   };
 });
 
@@ -39,21 +36,14 @@ vi.mock('../tmux-session.js', async (importOriginal) => {
 
 import { NudgeTracker, DEFAULT_NUDGE_CONFIG, capturePane, isPaneIdle } from '../idle-nudge.js';
 import { sendToWorker, paneLooksReady, paneHasActiveTask } from '../tmux-session.js';
-import { execFile } from 'child_process';
+import { tmuxExecAsync } from '../../cli/tmux-utils.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function mockCaptureOutput(output: string): void {
-  vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) => {
-    if (Array.isArray(args) && args[0] === 'capture-pane') {
-      cb(null, output, '');
-    } else {
-      cb(null, '', '');
-    }
-    return {} as any;
-  }) as any);
+  vi.mocked(tmuxExecAsync).mockResolvedValue({ stdout: output, stderr: '' });
 }
 
 /** Pane content that looks idle (shows prompt, no active task) */
@@ -137,10 +127,7 @@ describe('capturePane', () => {
 
   it('returns empty string on error', async () => {
     vi.useRealTimers();
-    vi.mocked(execFile).mockImplementation(((_cmd: string, _args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) => {
-      cb(new Error('tmux not found'), '', '');
-      return {} as any;
-    }) as any);
+    vi.mocked(tmuxExecAsync).mockRejectedValue(new Error('tmux not found'));
     const result = await capturePane('%1');
     expect(result).toBe('');
   });
@@ -326,17 +313,14 @@ describe('NudgeTracker', () => {
     const tracker = new NudgeTracker({ delayMs: 0, maxCount: 1 });
 
     // %2 is idle, %3 is active
-    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) => {
-      if (Array.isArray(args) && args[0] === 'capture-pane') {
+    vi.mocked(tmuxExecAsync).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'capture-pane') {
         const paneId = args[2];
-        if (paneId === '%2') cb(null, IDLE_PANE_CONTENT, '');
-        else if (paneId === '%3') cb(null, ACTIVE_PANE_CONTENT, '');
-        else cb(null, '', '');
-      } else {
-        cb(null, '', '');
+        if (paneId === '%2') return { stdout: IDLE_PANE_CONTENT, stderr: '' };
+        if (paneId === '%3') return { stdout: ACTIVE_PANE_CONTENT, stderr: '' };
       }
-      return {} as any;
-    }) as any);
+      return { stdout: '', stderr: '' };
+    });
 
     vi.advanceTimersByTime(6_000);
     const nudged = await tracker.checkAndNudge(['%2', '%3'], '%1', 'test-session');

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   applyMainVerticalLayout: vi.fn(),
   execFile: vi.fn(),
   spawnSync: vi.fn(() => ({ status: 0 })),
+  tmuxExecAsync: vi.fn(),
 }));
 
 const modelContractMocks = vi.hoisted(() => ({
@@ -24,10 +25,22 @@ const modelContractMocks = vi.hoisted(() => ({
   getPromptModeArgs: vi.fn((_agentType: string, instruction: string) => [instruction]),
 }));
 
-vi.mock('child_process', () => ({
-  execFile: mocks.execFile,
-  spawnSync: mocks.spawnSync,
-}));
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFile: mocks.execFile,
+    spawnSync: mocks.spawnSync,
+  };
+});
+
+vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../cli/tmux-utils.js')>();
+  return {
+    ...actual,
+    tmuxExecAsync: mocks.tmuxExecAsync,
+  };
+});
 
 vi.mock('../model-contract.js', () => ({
   buildWorkerArgv: modelContractMocks.buildWorkerArgv,
@@ -97,6 +110,12 @@ describe('runtime v2 startup inbox dispatch', () => {
       }
       return { stdout: '', stderr: '' };
     };
+    mocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'split-window') {
+        return { stdout: '%2\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
   });
 
   afterEach(async () => {

--- a/src/team/__tests__/runtime-v2.monitor.test.ts
+++ b/src/team/__tests__/runtime-v2.monitor.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'os';
 const mocks = vi.hoisted(() => ({
   isWorkerAlive: vi.fn(async () => true),
   execFile: vi.fn(),
+  tmuxExecAsync: vi.fn(),
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -13,6 +14,14 @@ vi.mock('child_process', async (importOriginal) => {
   return {
     ...actual,
     execFile: mocks.execFile,
+  };
+});
+
+vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../cli/tmux-utils.js')>();
+  return {
+    ...actual,
+    tmuxExecAsync: mocks.tmuxExecAsync,
   };
 });
 
@@ -31,6 +40,7 @@ describe('monitorTeamV2 pane-based stall inference', () => {
     vi.resetModules();
     mocks.isWorkerAlive.mockReset();
     mocks.execFile.mockReset();
+    mocks.tmuxExecAsync.mockReset();
     mocks.isWorkerAlive.mockResolvedValue(true);
     mocks.execFile.mockImplementation((_cmd: string, args: string[], cb: (err: Error | null, stdout: string, stderr: string) => void) => {
       if (args[0] === 'capture-pane') {
@@ -38,6 +48,12 @@ describe('monitorTeamV2 pane-based stall inference', () => {
         return;
       }
       cb(null, '', '');
+    });
+    mocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'capture-pane') {
+        return { stdout: '> \n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
     });
   });
 
@@ -107,6 +123,12 @@ describe('monitorTeamV2 pane-based stall inference', () => {
       }
       cb(null, '', '');
     });
+    mocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'capture-pane') {
+        return { stdout: 'Working on task...\n  esc to interrupt\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
 
     const { monitorTeamV2 } = await import('../runtime-v2.js');
     const snapshot = await monitorTeamV2('demo-team', cwd);
@@ -123,6 +145,12 @@ describe('monitorTeamV2 pane-based stall inference', () => {
         return;
       }
       cb(null, '', '');
+    });
+    mocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'capture-pane') {
+        return { stdout: 'model: loading\ngpt-5.3-codex high · 80% left\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
     });
 
     const { monitorTeamV2 } = await import('../runtime-v2.js');

--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -1,19 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
-
 const mockedCalls = vi.hoisted(() => ({
-  execFileArgs: [] as string[][],
+  tmuxArgs: [] as string[][],
 }));
 
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
+vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../cli/tmux-utils.js')>();
   return {
     ...actual,
-    execFile: vi.fn((_cmd: string, args: string[], cb: ExecFileCallback) => {
-      mockedCalls.execFileArgs.push(args);
-      cb(null, '', '');
-      return {} as never;
+    tmuxExecAsync: vi.fn(async (args: string[]) => {
+      mockedCalls.tmuxArgs.push(args);
+      return { stdout: '', stderr: '' };
     }),
   };
 });
@@ -22,7 +19,7 @@ import { spawnWorkerInPane } from '../tmux-session.js';
 
 describe('spawnWorkerInPane', () => {
   beforeEach(() => {
-    mockedCalls.execFileArgs = [];
+    mockedCalls.tmuxArgs = [];
   });
 
   it('uses argv-style launch with literal tmux send-keys', async () => {
@@ -38,7 +35,7 @@ describe('spawnWorkerInPane', () => {
       cwd: '/tmp',
     });
 
-    const literalSend = mockedCalls.execFileArgs.find(
+    const literalSend = mockedCalls.tmuxArgs.find(
       (args) => args[0] === 'send-keys' && args.includes('-l')
     );
     expect(literalSend).toBeDefined();

--- a/src/team/idle-nudge.ts
+++ b/src/team/idle-nudge.ts
@@ -11,7 +11,7 @@
  * @see https://github.com/anthropics/oh-my-claudecode/issues/1047
  */
 
-import { execFile } from 'child_process';
+import { tmuxExecAsync } from '../cli/tmux-utils.js';
 import { paneLooksReady, paneHasActiveTask, sendToWorker } from './tmux-session.js';
 
 // ---------------------------------------------------------------------------
@@ -38,13 +38,13 @@ export const DEFAULT_NUDGE_CONFIG: NudgeConfig = {
 // ---------------------------------------------------------------------------
 
 /** Capture the last 80 lines of a tmux pane. Returns '' on error. */
-export function capturePane(paneId: string): Promise<string> {
-  return new Promise((resolve) => {
-    execFile('tmux', ['capture-pane', '-t', paneId, '-p', '-S', '-80'], (err, stdout) => {
-      if (err) resolve('');
-      else resolve(stdout ?? '');
-    });
-  });
+export async function capturePane(paneId: string): Promise<string> {
+  try {
+    const result = await tmuxExecAsync(['capture-pane', '-t', paneId, '-p', '-S', '-80']);
+    return result.stdout ?? '';
+  } catch {
+    return '';
+  }
 }
 
 /**

--- a/src/team/layout-stabilizer.ts
+++ b/src/team/layout-stabilizer.ts
@@ -1,22 +1,9 @@
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-
-const execFileAsync = promisify(execFile);
+import { tmuxExecAsync, tmuxCmdAsync } from '../cli/tmux-utils.js';
 
 export interface LayoutStabilizerOptions {
   sessionTarget: string;
   leaderPaneId: string;
   debounceMs?: number;
-}
-
-async function tmuxCmd(args: string[]): Promise<{ stdout: string; stderr: string }> {
-  if (args.some(a => a.includes('#{'))) {
-    const { exec } = await import('child_process');
-    const execAsync = promisify(exec);
-    const escaped = args.map(a => `"${a.replace(/"/g, '\\"')}"`).join(' ');
-    return execAsync(`tmux ${escaped}`);
-  }
-  return execFileAsync('tmux', args);
 }
 
 export class LayoutStabilizer {
@@ -95,27 +82,27 @@ export class LayoutStabilizer {
     this.running = true;
     try {
       try {
-        await execFileAsync('tmux', ['select-layout', '-t', this.sessionTarget, 'main-vertical']);
+        await tmuxExecAsync(['select-layout', '-t', this.sessionTarget, 'main-vertical']);
       } catch {
         // ignore
       }
 
       try {
-        const widthResult = await tmuxCmd([
+        const widthResult = await tmuxCmdAsync([
           'display-message', '-p', '-t', this.sessionTarget, '#{window_width}',
         ]);
         const width = parseInt(widthResult.stdout.trim(), 10);
         if (Number.isFinite(width) && width >= 40) {
           const half = String(Math.floor(width / 2));
-          await execFileAsync('tmux', ['set-window-option', '-t', this.sessionTarget, 'main-pane-width', half]);
-          await execFileAsync('tmux', ['select-layout', '-t', this.sessionTarget, 'main-vertical']);
+          await tmuxExecAsync(['set-window-option', '-t', this.sessionTarget, 'main-pane-width', half]);
+          await tmuxExecAsync(['select-layout', '-t', this.sessionTarget, 'main-vertical']);
         }
       } catch {
         // ignore
       }
 
       try {
-        await execFileAsync('tmux', ['select-pane', '-t', this.leaderPaneId]);
+        await tmuxExecAsync(['select-pane', '-t', this.leaderPaneId]);
       } catch {
         // ignore
       }

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -16,7 +16,7 @@
  * assignTask, resumeTeam as discrete operations driven by the caller.
  */
 
-import { execFile } from 'child_process';
+import { tmuxExecAsync } from '../cli/tmux-utils.js';
 import { join, resolve } from 'path';
 import { existsSync } from 'fs';
 import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
@@ -183,12 +183,12 @@ async function isWorkerPaneAlive(paneId: string | undefined): Promise<boolean> {
 
 async function captureWorkerPane(paneId: string | undefined): Promise<string> {
   if (!paneId) return '';
-  return await new Promise((resolve) => {
-    execFile('tmux', ['capture-pane', '-t', paneId, '-p', '-S', '-80'], (err, stdout) => {
-      if (err) resolve('');
-      else resolve(stdout ?? '');
-    });
-  });
+  try {
+    const result = await tmuxExecAsync(['capture-pane', '-t', paneId, '-p', '-S', '-80']);
+    return result.stdout ?? '';
+  } catch {
+    return '';
+  }
 }
 
 function isFreshTimestamp(value: string | undefined, maxAgeMs: number = MONITOR_SIGNAL_STALE_MS): boolean {
@@ -391,17 +391,13 @@ async function waitForWorkerStartupEvidence(
  * Writes CLI API inbox (no done.json), waits for ready, sends inbox path.
  */
 async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerResult> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-
   // Split new pane off the last existing pane (or leader if first worker)
   const splitTarget = opts.existingWorkerPaneIds.length === 0
     ? opts.leaderPaneId
     : opts.existingWorkerPaneIds[opts.existingWorkerPaneIds.length - 1];
   const splitType = opts.existingWorkerPaneIds.length === 0 ? '-h' : '-v';
 
-  const splitResult = await execFileAsync('tmux', [
+  const splitResult = await tmuxExecAsync([
     'split-window', splitType, '-t', splitTarget,
     '-d', '-P', '-F', '#{pane_id}',
     '-c', opts.cwd,
@@ -1321,11 +1317,8 @@ export async function resumeTeamV2(
 
   // Verify tmux session is alive
   try {
-    const { execFile } = await import('child_process');
-    const { promisify } = await import('util');
-    const execFileAsync = promisify(execFile);
     const sessionName = config.tmux_session || `omc-team-${sanitized}`;
-    await execFileAsync('tmux', ['has-session', '-t', sessionName.split(':')[0]]);
+    await tmuxExecAsync(['has-session', '-t', sessionName.split(':')[0]]);
 
     return {
       teamName: sanitized,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile, readFile, rm, rename } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { tmuxExecAsync } from '../cli/tmux-utils.js';
 import type { CliAgentType } from './model-contract.js';
 import { buildWorkerArgv, resolveValidatedBinaryPath, getWorkerEnv as getModelWorkerEnv, isPromptModeAgent, getPromptModeArgs, resolveClaudeWorkerModel } from './model-contract.js';
 import { validateTeamName } from './team-name.js';
@@ -682,15 +683,11 @@ export async function spawnWorkerForTask(
   const marked = await markTaskInProgress(root, taskId, workerNameValue, runtime.teamName, runtime.cwd);
   if (!marked) return '';
 
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-
   const splitTarget = runtime.workerPaneIds.length === 0
     ? runtime.leaderPaneId
     : runtime.workerPaneIds[runtime.workerPaneIds.length - 1];
   const splitType = runtime.workerPaneIds.length === 0 ? '-h' : '-v';
-  const splitResult = await execFileAsync('tmux', [
+  const splitResult = await tmuxExecAsync([
     'split-window', splitType, '-t', splitTarget,
     '-d', '-P', '-F', '#{pane_id}',
     '-c', runtime.cwd,
@@ -825,10 +822,7 @@ export async function killWorkerPane(
   paneId: string
 ): Promise<void> {
   try {
-    const { execFile } = await import('child_process');
-    const { promisify } = await import('util');
-    const execFileAsync = promisify(execFile);
-    await execFileAsync('tmux', ['kill-pane', '-t', paneId]);
+    await tmuxExecAsync(['kill-pane', '-t', paneId]);
   } catch {
     // idempotent: pane may already be gone
   }
@@ -986,19 +980,16 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
   if (!configData) return null;
 
   // Check if session is alive
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
   const sName = configData.tmuxSession || `omc-team-${teamName}`;
 
   try {
-    await execFileAsync('tmux', ['has-session', '-t', sName.split(':')[0]]);
+    await tmuxExecAsync(['has-session', '-t', sName.split(':')[0]]);
   } catch {
     return null; // Session not alive
   }
 
   const paneTarget = sName.includes(':') ? sName : sName.split(':')[0];
-  const panesResult = await execFileAsync('tmux', [
+  const panesResult = await tmuxExecAsync([
     'list-panes', '-t', paneTarget, '-F', '#{pane_id}'
   ]);
   const allPanes = panesResult.stdout.trim().split('\n').filter(Boolean);

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -12,7 +12,7 @@
 
 import { resolve } from 'path';
 import { mkdir } from 'fs/promises';
-import { execFileSync, spawnSync } from 'child_process';
+import { tmuxExec, tmuxSpawn } from '../cli/tmux-utils.js';
 import {
   teamReadConfig,
   teamWriteWorkerIdentity,
@@ -126,14 +126,14 @@ export async function scaleUp(
         }
         try {
           if (w.pane_id) {
-            execFileSync('tmux', ['kill-pane', '-t', w.pane_id], { stdio: 'pipe' });
+            tmuxExec(['kill-pane', '-t', w.pane_id], { stdio: 'pipe' });
           }
         } catch { /* best-effort pane cleanup */ }
       }
 
       if (paneId) {
         try {
-          execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'pipe' });
+          tmuxExec(['kill-pane', '-t', paneId], { stdio: 'pipe' });
         } catch { /* best-effort pane cleanup */ }
       }
 
@@ -198,9 +198,9 @@ export async function scaleUp(
         : (config.leader_pane_id ?? '');
       const splitDirection = splitTarget === (config.leader_pane_id ?? '') ? '-h' : '-v';
 
-      const result = spawnSync('tmux', [
+      const result = tmuxSpawn([
         'split-window', splitDirection, '-t', splitTarget, '-d', '-P', '-F', '#{pane_id}', '-c', leaderCwd, cmd,
-      ], { encoding: 'utf-8' });
+      ]);
 
       if (result.status !== 0) {
         return await rollbackScaleUp(`Failed to create tmux pane for ${workerName}: ${(result.stderr || '').trim()}`);
@@ -214,7 +214,7 @@ export async function scaleUp(
       // Get PID
       let panePid: number | undefined;
       try {
-        const pidResult = spawnSync('tmux', ['display-message', '-t', paneId, '-p', '#{pane_pid}'], { encoding: 'utf-8' });
+        const pidResult = tmuxSpawn(['display-message', '-t', paneId, '-p', '#{pane_pid}']);
         const pidStr = (pidResult.stdout || '').trim();
         const parsed = Number.parseInt(pidStr, 10);
         if (Number.isFinite(parsed)) panePid = parsed;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -7,19 +7,15 @@
  * Sessions are named "omc-team-{teamName}-{workerName}".
  */
 
-import { exec, execFile, execSync, execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import { join, basename, isAbsolute, win32 } from 'path';
-import { promisify } from 'util';
 import fs from 'fs/promises';
 import { validateTeamName } from './team-name.js';
+import { tmuxExec, tmuxExecAsync, tmuxShell, tmuxCmdAsync } from '../cli/tmux-utils.js';
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
 const TMUX_SESSION_PREFIX = 'omc-team';
-
-const promisifiedExec = promisify(exec);
-const promisifiedExecFile = promisify(execFile);
 
 export type TeamMultiplexerContext = 'tmux' | 'cmux' | 'none';
 
@@ -40,41 +36,22 @@ export function isUnixLikeOnWindows(): boolean {
     !!(process.env.MSYSTEM || process.env.MINGW_PREFIX);
 }
 
-/**
- * Execute a tmux command asynchronously. Routes through shell when arguments
- * contain tmux format strings (e.g. #{pane_id}) to prevent MSYS2 execFile
- * from stripping curly braces.
- */
-async function tmuxAsync(args: string[]): Promise<{ stdout: string; stderr: string }> {
-  if (args.some(a => a.includes('#{'))) {
-    // MSYS2/Git Bash strips curly braces from execFile arguments.
-    // Use shell execution with proper single-quote escaping.
-    const escaped = args.map(a => "'" + a.replace(/'/g, "'\\''") + "'").join(' ');
-    return promisifiedExec(`tmux ${escaped}`);
-  }
-  return promisifiedExecFile('tmux', args);
-}
-
 export async function applyMainVerticalLayout(teamTarget: string): Promise<void> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-
   try {
-    await execFileAsync('tmux', ['select-layout', '-t', teamTarget, 'main-vertical']);
+    await tmuxExecAsync(['select-layout', '-t', teamTarget, 'main-vertical']);
   } catch {
     // Layout may not apply if only 1 pane; ignore.
   }
 
   try {
-    const widthResult = await tmuxAsync([
+    const widthResult = await tmuxCmdAsync([
       'display-message', '-p', '-t', teamTarget, '#{window_width}',
     ]);
     const width = parseInt(widthResult.stdout.trim(), 10);
     if (Number.isFinite(width) && width >= 40) {
       const half = String(Math.floor(width / 2));
-      await execFileAsync('tmux', ['set-window-option', '-t', teamTarget, 'main-pane-width', half]);
-      await execFileAsync('tmux', ['select-layout', '-t', teamTarget, 'main-vertical']);
+      await tmuxExecAsync(['set-window-option', '-t', teamTarget, 'main-pane-width', half]);
+      await tmuxExecAsync(['select-layout', '-t', teamTarget, 'main-vertical']);
     }
   } catch {
     /* ignore layout sizing errors */
@@ -366,7 +343,7 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
 /** Validate tmux is available. Throws with install instructions if not. */
 export function validateTmux(): void {
   try {
-    execSync('tmux -V', { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' });
+    tmuxShell('-V', { stripTmux: true, timeout: 5000, stdio: 'pipe' });
   } catch {
     throw new Error(
       'tmux is not available. Install it:\n' +
@@ -404,7 +381,7 @@ export function createSession(teamName: string, workerName: string, workingDirec
 
   // Kill existing session if present (stale from previous run)
   try {
-    execFileSync('tmux', ['kill-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
+    tmuxExec(['kill-session', '-t', name], { stripTmux: true, stdio: 'pipe', timeout: 5000 });
   } catch { /* ignore — session may not exist */ }
 
   // Create detached session with reasonable terminal size
@@ -412,7 +389,7 @@ export function createSession(teamName: string, workerName: string, workingDirec
   if (workingDirectory) {
     args.push('-c', workingDirectory);
   }
-  execFileSync('tmux', args, { stdio: 'pipe', timeout: 5000 });
+  tmuxExec(args, { stripTmux: true, stdio: 'pipe', timeout: 5000 });
 
   return name;
 }
@@ -422,7 +399,7 @@ export function createSession(teamName: string, workerName: string, workingDirec
 export function killSession(teamName: string, workerName: string): void {
   const name = sessionName(teamName, workerName);
   try {
-    execFileSync('tmux', ['kill-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
+    tmuxExec(['kill-session', '-t', name], { stripTmux: true, stdio: 'pipe', timeout: 5000 });
   } catch { /* ignore — session may not exist */ }
 }
 
@@ -431,7 +408,7 @@ export function killSession(teamName: string, workerName: string): void {
 export function isSessionAlive(teamName: string, workerName: string): boolean {
   const name = sessionName(teamName, workerName);
   try {
-    execFileSync('tmux', ['has-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
+    tmuxExec(['has-session', '-t', name], { stripTmux: true, stdio: 'pipe', timeout: 5000 });
     return true;
   } catch {
     return false;
@@ -445,9 +422,9 @@ export function listActiveSessions(teamName: string): string[] {
     // Use shell execution for format strings containing #{} to prevent
     // MSYS2/Git Bash from stripping curly braces in execFileSync args.
     // All arguments here are hardcoded constants, not user input.
-    const output = execSync("tmux list-sessions -F '#{session_name}'", {
-      encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe']
-    }) as string;
+    const output = tmuxShell("list-sessions -F '#{session_name}'", {
+      timeout: 5000, stdio: ['pipe', 'pipe', 'pipe']
+    });
     return output.trim().split('\n')
       .filter(s => s.startsWith(prefix))
       .map(s => s.slice(prefix.length));
@@ -469,7 +446,7 @@ export function spawnBridgeInSession(
   configFilePath: string
 ): void {
   const cmd = `node "${bridgeScriptPath}" --config "${configFilePath}"`;
-  execFileSync('tmux', ['send-keys', '-t', tmuxSession, cmd, 'Enter'], { stdio: 'pipe', timeout: 5000 });
+  tmuxExec(['send-keys', '-t', tmuxSession, cmd, 'Enter'], { stripTmux: true, stdio: 'pipe', timeout: 5000 });
 }
 
 
@@ -495,10 +472,6 @@ export async function createTeamSession(
   cwd: string,
   options: CreateTeamSessionOptions = {},
 ): Promise<TeamSession> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-
   const multiplexerContext = detectTeamMultiplexerContext();
   const inTmux = multiplexerContext === 'tmux';
   const useDedicatedWindow = Boolean(options.newWindow && inTmux);
@@ -517,11 +490,11 @@ export async function createTeamSession(
     // also covers cmux, which exposes its own surface metadata without a tmux
     // pane/window that OMC can split directly.
     const detachedSessionName = `${TMUX_SESSION_PREFIX}-${sanitizeName(teamName)}-${Date.now().toString(36)}`;
-    const detachedResult = await execFileAsync('tmux', [
+    const detachedResult = await tmuxExecAsync([
       'new-session', '-d', '-P', '-F', '#S:0 #{pane_id}',
       '-s', detachedSessionName,
       '-c', cwd,
-    ]);
+    ], { stripTmux: true });
     const detachedLine = detachedResult.stdout.trim();
     const detachedMatch = detachedLine.match(/^(\S+)\s+(%\d+)$/);
     if (!detachedMatch) {
@@ -533,7 +506,7 @@ export async function createTeamSession(
 
   if (inTmux && envPaneId) {
     try {
-      const targetedContextResult = await execFileAsync('tmux', [
+      const targetedContextResult = await tmuxExecAsync([
         'display-message', '-p', '-t', envPaneId, '#S:#I',
       ]);
       sessionAndWindow = targetedContextResult.stdout.trim();
@@ -545,7 +518,7 @@ export async function createTeamSession(
 
   if (!sessionAndWindow || !leaderPaneId) {
     // Fallback when TMUX_PANE is unavailable/invalid.
-    const contextResult = await tmuxAsync([
+    const contextResult = await tmuxCmdAsync([
       'display-message', '-p', '#S:#I #{pane_id}',
     ]);
     const contextLine = contextResult.stdout.trim();
@@ -560,7 +533,7 @@ export async function createTeamSession(
   if (useDedicatedWindow) {
     const targetSession = sessionAndWindow.split(':')[0] ?? sessionAndWindow;
     const windowName = `omc-${sanitizeName(teamName)}`.slice(0, 32);
-    const newWindowResult = await execFileAsync('tmux', [
+    const newWindowResult = await tmuxExecAsync([
       'new-window', '-d', '-P', '-F', '#S:#I #{pane_id}',
       '-t', targetSession,
       '-n', windowName,
@@ -582,11 +555,11 @@ export async function createTeamSession(
 
   if (workerCount <= 0) {
     try {
-      await execFileAsync('tmux', ['set-option', '-t', resolvedSessionName, 'mouse', 'on']);
+      await tmuxExecAsync(['set-option', '-t', resolvedSessionName, 'mouse', 'on']);
     } catch { /* ignore */ }
     if (sessionMode !== 'dedicated-window') {
       try {
-        await execFileAsync('tmux', ['select-pane', '-t', leaderPaneId]);
+        await tmuxExecAsync(['select-pane', '-t', leaderPaneId]);
       } catch { /* ignore */ }
     }
     await new Promise(r => setTimeout(r, 300));
@@ -597,7 +570,7 @@ export async function createTeamSession(
   for (let i = 0; i < workerCount; i++) {
     const splitTarget = i === 0 ? leaderPaneId : workerPaneIds[i - 1];
     const splitType = i === 0 ? '-h' : '-v';
-    const splitResult = await tmuxAsync([
+    const splitResult = await tmuxCmdAsync([
       'split-window', splitType, '-t', splitTarget,
       '-d', '-P', '-F', '#{pane_id}',
       '-c', cwd,
@@ -611,12 +584,12 @@ export async function createTeamSession(
   await applyMainVerticalLayout(teamTarget);
 
   try {
-    await execFileAsync('tmux', ['set-option', '-t', resolvedSessionName, 'mouse', 'on']);
+    await tmuxExecAsync(['set-option', '-t', resolvedSessionName, 'mouse', 'on']);
   } catch { /* ignore */ }
 
   if (sessionMode !== 'dedicated-window') {
     try {
-      await execFileAsync('tmux', ['select-pane', '-t', leaderPaneId]);
+      await tmuxExecAsync(['select-pane', '-t', leaderPaneId]);
     } catch { /* ignore */ }
   }
   await new Promise(r => setTimeout(r, 300));
@@ -634,27 +607,23 @@ export async function spawnWorkerInPane(
   paneId: string,
   config: WorkerPaneConfig
 ): Promise<void> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-
   validateTeamName(config.teamName);
   const startCmd = buildWorkerStartCommand(config);
 
   // Use -l (literal) flag to prevent tmux key-name parsing of the command string
-  await execFileAsync('tmux', [
+  await tmuxExecAsync([
     'send-keys', '-t', paneId, '-l', startCmd
   ]);
-  await execFileAsync('tmux', ['send-keys', '-t', paneId, 'Enter']);
+  await tmuxExecAsync(['send-keys', '-t', paneId, 'Enter']);
 }
 
 function normalizeTmuxCapture(value: string): string {
   return value.replace(/\r/g, '').replace(/\s+/g, ' ').trim();
 }
 
-async function capturePaneAsync(paneId: string, execFileAsync: (cmd: string, args: string[]) => Promise<{ stdout: string }>): Promise<string> {
+async function capturePaneAsync(paneId: string): Promise<string> {
   try {
-    const result = await execFileAsync('tmux', ['capture-pane', '-t', paneId, '-p', '-S', '-80']);
+    const result = await tmuxExecAsync(['capture-pane', '-t', paneId, '-p', '-S', '-80']);
     return result.stdout;
   } catch {
     return '';
@@ -727,7 +696,7 @@ export async function waitForPaneReady(
 
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const captured = await capturePaneAsync(paneId, promisifiedExecFile as never);
+    const captured = await capturePaneAsync(paneId);
     if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
       return true;
     }
@@ -749,7 +718,7 @@ async function paneInCopyMode(
   paneId: string,
 ): Promise<boolean> {
   try {
-    const result = await tmuxAsync(['display-message', '-t', paneId, '-p', '#{pane_in_mode}']);
+    const result = await tmuxCmdAsync(['display-message', '-t', paneId, '-p', '#{pane_in_mode}']);
     return result.stdout.trim() === '1';
   } catch {
     return false;
@@ -791,13 +760,8 @@ export async function sendToWorker(
     return false;
   }
   try {
-    const { execFile } = await import('child_process');
-    const { promisify } = await import('util');
-    const execFileAsync = promisify(execFile);
-    const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
-
     const sendKey = async (key: string) => {
-      await execFileAsync('tmux', ['send-keys', '-t', paneId, key]);
+      await tmuxExecAsync(['send-keys', '-t', paneId, key]);
     };
 
     // Guard: copy-mode captures keys; skip injection entirely.
@@ -806,7 +770,7 @@ export async function sendToWorker(
     }
 
     // Check for trust prompt and auto-dismiss before sending our text
-    const initialCapture = await capturePaneAsync(paneId, execFileAsync as never);
+    const initialCapture = await capturePaneAsync(paneId);
     const paneBusy = paneHasActiveTask(initialCapture);
 
     if (paneHasTrustPrompt(initialCapture)) {
@@ -817,7 +781,7 @@ export async function sendToWorker(
     }
 
     // Send text in literal mode with -- separator
-    await execFileAsync('tmux', ['send-keys', '-t', paneId, '-l', '--', message]);
+    await tmuxExecAsync(['send-keys', '-t', paneId, '-l', '--', message]);
 
     // Allow input buffer to settle
     await sleep(150);
@@ -839,7 +803,7 @@ export async function sendToWorker(
       await sleep(140);
 
       // Check if text is still visible in the pane — if not, it was submitted
-      const checkCapture = await capturePaneAsync(paneId, execFileAsync as never);
+      const checkCapture = await capturePaneAsync(paneId);
       if (!paneTailContainsLiteralLine(checkCapture, message)) return true;
 
       await sleep(140);
@@ -851,7 +815,7 @@ export async function sendToWorker(
     }
 
     // Adaptive fallback: for busy panes, retry once without interrupting active turns.
-    const finalCapture = await capturePaneAsync(paneId, execFileAsync as never);
+    const finalCapture = await capturePaneAsync(paneId);
     const paneModeBeforeAdaptiveRetry = await paneInCopyMode(paneId);
     if (shouldAttemptAdaptiveRetry({
       paneBusy,
@@ -868,7 +832,7 @@ export async function sendToWorker(
       if (await paneInCopyMode(paneId)) {
         return false;
       }
-      await execFileAsync('tmux', ['send-keys', '-t', paneId, '-l', '--', message]);
+      await tmuxExecAsync(['send-keys', '-t', paneId, '-l', '--', message]);
       await sleep(120);
       for (let round = 0; round < 4; round++) {
         await sendKey('C-m');
@@ -876,7 +840,7 @@ export async function sendToWorker(
         await sendKey('C-m');
         await sleep(140);
 
-        const retryCapture = await capturePaneAsync(paneId, execFileAsync as never);
+        const retryCapture = await capturePaneAsync(paneId);
         if (!paneTailContainsLiteralLine(retryCapture, message)) return true;
       }
     }
@@ -892,7 +856,7 @@ export async function sendToWorker(
     await sleep(120);
     await sendKey('C-m');
     await sleep(140);
-    const finalCheckCapture = await capturePaneAsync(paneId, execFileAsync as never);
+    const finalCheckCapture = await capturePaneAsync(paneId);
     // Empty capture means tmux capture failed or returned indeterminate output.
     // Treat this as delivery failure to keep dispatch behavior fail-closed.
     if (!finalCheckCapture || finalCheckCapture.trim() === '') {
@@ -921,15 +885,12 @@ export async function injectToLeaderPane(
   // "esc to interrupt"), send C-c first so the message is not queued in the
   // stdin buffer behind the blocked process.
   try {
-    const { execFile } = await import('child_process');
-    const { promisify } = await import('util');
-    const execFileAsync = promisify(execFile);
     if (await paneInCopyMode(leaderPaneId)) {
       return false;
     }
-    const captured = await capturePaneAsync(leaderPaneId, execFileAsync as never);
+    const captured = await capturePaneAsync(leaderPaneId);
     if (paneHasActiveTask(captured)) {
-      await execFileAsync('tmux', ['send-keys', '-t', leaderPaneId, 'C-c']);
+      await tmuxExecAsync(['send-keys', '-t', leaderPaneId, 'C-c']);
       await new Promise<void>(r => setTimeout(r, 250));
     }
   } catch { /* best-effort */ }
@@ -943,7 +904,7 @@ export async function injectToLeaderPane(
  */
 export async function isWorkerAlive(paneId: string): Promise<boolean> {
   try {
-    const result = await tmuxAsync([
+    const result = await tmuxCmdAsync([
       'display-message', '-t', paneId, '-p', '#{pane_dead}'
     ]);
     return result.stdout.trim() === '0';
@@ -979,13 +940,9 @@ export async function killWorkerPanes(opts: {
   } catch { /* sentinel write failure is non-fatal */ }
 
   // 2. Force-kill each worker pane, guarding leader
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-
   for (const paneId of paneIds) {
     if (paneId === leaderPaneId) continue;   // GUARD — never kill leader
-    try { await execFileAsync('tmux', ['kill-pane', '-t', paneId]); }
+    try { await tmuxExecAsync(['kill-pane', '-t', paneId]); }
     catch { /* pane already gone — OK */ }
   }
 }
@@ -1014,7 +971,7 @@ export async function resolveSplitPaneWorkerPaneIds(
   if (!sessionName.includes(':')) return resolved;
 
   try {
-    const paneResult = await tmuxAsync(['list-panes', '-t', sessionName, '-F', '#{pane_id}']);
+    const paneResult = await tmuxCmdAsync(['list-panes', '-t', sessionName, '-F', '#{pane_id}']);
     return dedupeWorkerPaneIds(
       [...resolved, ...paneResult.stdout.split('\n').map((paneId) => paneId.trim())],
       leaderPaneId,
@@ -1038,10 +995,6 @@ export async function killTeamSession(
   leaderPaneId?: string,
   options: { sessionMode?: TeamSessionMode } = {},
 ): Promise<void> {
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
-
   const sessionMode = options.sessionMode
     ?? (sessionName.includes(':') ? 'split-pane' : 'detached-session');
 
@@ -1049,7 +1002,7 @@ export async function killTeamSession(
     if (!workerPaneIds?.length) return;
     for (const id of workerPaneIds) {
       if (id === leaderPaneId) continue;
-      try { await execFileAsync('tmux', ['kill-pane', '-t', id]); }
+      try { await tmuxExecAsync(['kill-pane', '-t', id]); }
       catch { /* already gone */ }
     }
     return;
@@ -1057,7 +1010,7 @@ export async function killTeamSession(
 
   if (sessionMode === 'dedicated-window') {
     try {
-      await execFileAsync('tmux', ['kill-window', '-t', sessionName]);
+      await tmuxExecAsync(['kill-window', '-t', sessionName]);
     } catch {
       // Window may already be gone.
     }
@@ -1068,7 +1021,7 @@ export async function killTeamSession(
 
   if (process.env.OMC_TEAM_ALLOW_KILL_CURRENT_SESSION !== '1' && process.env.TMUX) {
     try {
-      const current = await tmuxAsync(['display-message', '-p', '#S']);
+      const current = await tmuxCmdAsync(['display-message', '-p', '#S']);
       const currentSessionName = current.stdout.trim();
       if (currentSessionName && currentSessionName === sessionTarget) {
         return;
@@ -1079,7 +1032,7 @@ export async function killTeamSession(
   }
 
   try {
-    await execFileAsync('tmux', ['kill-session', '-t', sessionTarget]);
+    await tmuxExecAsync(['kill-session', '-t', sessionTarget]);
   } catch {
     // Session may already be dead.
   }

--- a/src/team/worker-health.ts
+++ b/src/team/worker-health.ts
@@ -10,13 +10,13 @@ import type { HeartbeatData } from './types.js';
 import { listMcpWorkers } from './team-registration.js';
 import { readHeartbeat, isWorkerAlive } from './heartbeat.js';
 import { isSessionAlive, sanitizeName } from './tmux-session.js';
-import { execFileSync } from 'child_process';
+import { tmuxExec } from '../cli/tmux-utils.js';
 
 /** Check if the shared split-pane session 'omc-team-{teamName}' exists (new tmux model). */
 function isSharedSessionAlive(teamName: string): boolean {
   const name = `omc-team-${sanitizeName(teamName)}`;
   try {
-    execFileSync('tmux', ['has-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
+    tmuxExec(['has-session', '-t', name], { stdio: 'pipe', timeout: 5000 });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- Introduces 7 typed wrapper functions in `tmux-utils.ts` that route **every** tmux call through explicit TMUX environment handling
- Migrates all ~96 raw tmux calls across 19 production files — zero raw calls remain
- Each wrapper accepts `stripTmux?: boolean` (default `false`) for explicit strip-vs-preserve categorization
- Adds a grep-based verification test that enforces zero raw tmux calls outside `tmux-utils.ts`
- Updates 8 test files to mock the new wrappers instead of raw `child_process` functions

Supersedes #2397 (closed). Extends #2385 (merged, autoresearch-only) into complete coverage.

## Problem

When running inside nested tmux sessions (e.g., worktree managers using `tmux -L <server>`), the `TMUX` env var causes tmux commands to silently target the wrong server. Sessions are created, panes are split, and health checks run against phantom servers — producing silent failures or unreachable sessions.

PR #2385 fixed this for autoresearch only. PR #2397 attempted a broader migration but was [closed by the maintainer](https://github.com/Yeachan-Heo/oh-my-claudecode/pull/2397#issuecomment-4208637462) for three reasons:

1. **Partial/inconsistent rollout** — only 34 of ~96 calls migrated
2. **Needed tighter behavior-preserving review surface** — no clear categorization of which calls should strip vs preserve TMUX
3. **Remaining call-site and verification story not crisp enough** — no enforcement mechanism for completeness

This PR addresses all three.

## Design: `stripTmux` parameter

Every tmux call goes through a typed wrapper with a `stripTmux?: boolean` option:

```typescript
// Default: preserve TMUX (target current server) — used by ~70 call sites
tmuxExec(['display-message', '-p', '#{pane_id}']);

// Strip TMUX (target default server) — used by ~26 call sites
tmuxExec(['new-session', '-d', '-s', sessionName], { stripTmux: true });
```

**Why `stripTmux` instead of `currentServer`:** The majority of calls (~70) preserve TMUX, so the default requires no parameter. The ~26 strip sites pass `{ stripTmux: true }` — explicit, self-documenting, and grep-findable (`grep stripTmux` finds every site that targets the default server).

### Wrappers added to `tmux-utils.ts`

| Wrapper | Replaces | Use case |
|---------|----------|----------|
| `tmuxExec(args, opts?)` | `execFileSync('tmux', ...)` | Sync calls (most common) |
| `tmuxExecAsync(args, opts?)` | promisified `execFile('tmux', ...)` | Async calls |
| `tmuxShell(cmd, opts?)` | `execSync('tmux ' + cmd)` | Shell strings with `#{}` format |
| `tmuxShellAsync(cmd, opts?)` | promisified `exec('tmux ' + cmd)` | Async shell strings |
| `tmuxSpawn(args, opts?)` | `spawnSync('tmux', ...)` | Spawn-based calls |
| `tmuxCmdAsync(args, opts?)` | local `tmuxAsync()` helpers | Smart async — auto-routes shell vs execFile for `#{}` |
| `tmuxEnv()` | manual env stripping | Returns `process.env` without `TMUX` |

### Strip vs Preserve categorization

**Strip TMUX** (`{ stripTmux: true }`) — ~26 call sites that create/manage OMC-owned background sessions or scan across sessions:

| File | Calls | Justification |
|------|-------|---------------|
| `tmux-utils.ts` | 2 | Version check, HUD pane cleanup |
| `launch.ts` | 4 | Outside-tmux session lifecycle |
| `autoresearch-guided.ts` | 6 | Background autoresearch sessions |
| `tmux-session.ts` | 7 | Deprecated detached session lifecycle |
| `tmux-detector.ts` | 6 | Rate-limit cross-session pane scan |
| `win32-warning.ts` | 1 | Version check |

**Preserve TMUX** (default, no parameter) — ~70 call sites that operate on the user's current session or team panes:

| File | Calls | Justification |
|------|-------|---------------|
| `tmux-utils.ts` | 2 | HUD pane detection/creation in current window |
| `launch.ts` | 1 | Inside-tmux mouse config |
| `interop.ts` | 3 | Current-pane operations |
| `notifications/tmux.ts` | 4 | Current session queries |
| `cli/commands/ralphthon.ts` | 2 | Current session/pane for orchestrator |
| `orchestrator.ts` | 4 | Leader pane interaction (pane IDs from user session) |
| `tmux-session.ts` | ~29 | Team session operations, worker panes |
| `scaling.ts` | 4 | Worker pane creation/cleanup |
| `worker-health.ts` | 1 | Team session health check |
| `runtime.ts` | 4 | Worker pane operations |
| `runtime-v2.ts` | 3 | Worker pane operations |
| `idle-nudge.ts` | 1 | Worker pane idle detection |
| `layout-stabilizer.ts` | 5 | Team layout management |
| `team-dispatch-hook.ts` | 8 | Worker pane dispatch injection |
| `team-leader-nudge-hook.ts` | 1 | Leader pane nudge |
| `team-worker-hook.ts` | 1 | Leader pane completion nudge |

## How #2397 blockers are resolved

| Blocker | How this PR fixes it |
|---------|---------------------|
| "Rollout is still partial/inconsistent" | **Full coverage**: all ~96 calls migrated. Zero raw tmux calls remain outside `tmux-utils.ts`. A grep verification test (`tmux-no-raw-calls.test.ts`) enforces this invariant going forward. |
| "Needs tighter behavior-preserving review surface" | **Explicit categorization**: every call site declares strip vs preserve via the `stripTmux` parameter. The tables above document the justification for each file. |
| "Remaining call-site and verification story not crisp enough" | **Automated enforcement**: the grep test catches any future raw tmux calls. `tsc --noEmit` ensures type safety. All existing tests pass after mock updates. |

## Additional changes

- **Local helpers removed**: `tmuxAsync()` in `tmux-session.ts` and `tmuxCmd()` in `layout-stabilizer.ts` replaced by shared `tmuxCmdAsync`
- **Callback-to-async conversions**: `idle-nudge.ts` and `runtime-v2.ts` callback-based `execFile('tmux', ...)` converted to `tmuxExecAsync`
- **`capturePaneAsync` refactored**: No longer takes `execFileAsync` as a parameter — uses `tmuxExecAsync` directly
- **`team-dispatch-hook.ts`**: 8 `runProcess('tmux', ...)` calls replaced with `tmuxExecAsync`. The generic `runProcess` function is unchanged.

## Test plan

- [x] `tsc --noEmit` — clean (zero errors)
- [x] `vitest run src/cli/__tests__/tmux-no-raw-calls.test.ts` — passes (zero raw calls found)
- [x] All 9 tmux-related test files pass (199/199 tests)
- [x] 8 test files updated to mock wrapper functions instead of raw `child_process`
- [x] No `dist/` or `bridge/` build artifacts in diff
- [x] Rebased on latest `upstream/dev`
- [ ] Manual smoke test: run `omc` inside nested tmux (`tmux -L test`) — verify session targets default server