### PR TITLE
fix: stop plugin updates from re-injecting legacy settings hooks

### DIFF
--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -32,7 +32,6 @@ import { execSync, execFileSync } from 'child_process';
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { install, isProjectScopedPlugin, checkNodeVersion, CLAUDE_CONFIG_DIR } from '../installer/index.js';
-import * as hooksModule from '../installer/hooks.js';
 import {
   reconcileUpdateRuntime,
   performUpdate,
@@ -95,12 +94,13 @@ describe('auto-update reconciliation', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     delete process.env.OMC_UPDATE_RECONCILE;
+    delete process.env.CLAUDE_PLUGIN_ROOT;
     if (originalPlatformDescriptor) {
       Object.defineProperty(process, 'platform', originalPlatformDescriptor);
     }
   });
 
-  it('reconciles runtime state and refreshes hooks after update', () => {
+  it('reconciles runtime state without re-injecting settings hooks', () => {
     mockedExistsSync.mockReturnValue(false);
 
     const result = reconcileUpdateRuntime({ verbose: false });
@@ -484,10 +484,18 @@ describe('auto-update reconciliation', () => {
     expect(mockedExecSync).toHaveBeenCalledWith('npm install -g oh-my-claude-sisyphus@latest', expect.any(Object));
   });
 
-  it('runs reconciliation as part of performUpdate', async () => {
+  it('runs reconciliation as part of performUpdate without plugin hook reinjection', async () => {
     // Set env var so performUpdate takes the direct reconciliation path
     // (simulates being in the re-exec'd process after npm install)
     process.env.OMC_UPDATE_RECONCILE = '1';
+    process.env.CLAUDE_PLUGIN_ROOT = join(
+      CLAUDE_CONFIG_DIR,
+      'plugins',
+      'cache',
+      'omc',
+      'oh-my-claudecode',
+      '4.1.5',
+    );
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
@@ -512,8 +520,8 @@ describe('auto-update reconciliation', () => {
       force: true,
       verbose: false,
       skipClaudeCheck: true,
-      forceHooks: true,
-      refreshHooksInPlugin: true,
+      forceHooks: false,
+      refreshHooksInPlugin: false,
     });
 
     delete process.env.OMC_UPDATE_RECONCILE;
@@ -867,88 +875,4 @@ describe('auto-update reconciliation', () => {
     });
   });
 
-  it('preserves non-OMC hooks when refreshing plugin hooks during reconciliation', () => {
-    const existingSettings = {
-      hooks: {
-        UserPromptSubmit: [
-          {
-            hooks: [
-              {
-                type: 'command',
-                command: 'node $HOME/.claude/hooks/other-plugin.mjs',
-              },
-            ],
-          },
-        ],
-      },
-    };
-
-    const settingsPath = join(CLAUDE_CONFIG_DIR, 'settings.json');
-    const baseHooks = hooksModule.getHooksSettingsConfig();
-    const freshHooks = {
-      ...baseHooks,
-      hooks: {
-        ...baseHooks.hooks,
-        UserPromptSubmit: [
-          {
-            hooks: [
-              {
-                type: 'command' as const,
-                command: 'node $HOME/.claude/hooks/keyword-detector.mjs',
-              },
-            ],
-          },
-        ],
-      },
-    };
-
-    mockedExistsSync.mockImplementation((path) => {
-      const normalized = String(path).replace(/\\/g, '/');
-      if (normalized === settingsPath) {
-        return true;
-      }
-      if (normalized.endsWith('/.claude/hud')) {
-        return false;
-      }
-      if (normalized.includes('/hooks/')) {
-        return false;
-      }
-      return true;
-    });
-    mockedIsProjectScopedPlugin.mockReturnValue(false);
-
-    mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
-      if (String(path) === settingsPath) {
-        return JSON.stringify(existingSettings);
-      }
-      if (String(path).includes('/hooks/')) {
-        return 'hook-script';
-      }
-      return '';
-    });
-
-    vi.spyOn(hooksModule, 'getHooksSettingsConfig').mockReturnValue(freshHooks);
-
-    const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
-    process.env.CLAUDE_PLUGIN_ROOT = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.1.5');
-
-    const result = install({
-      force: true,
-      skipClaudeCheck: true,
-      refreshHooksInPlugin: true,
-    });
-
-    if (originalPluginRoot !== undefined) {
-      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
-    } else {
-      delete process.env.CLAUDE_PLUGIN_ROOT;
-    }
-
-    const settingsWrite = mockedWriteFileSync.mock.calls.find((call) => String(call[0]).includes('settings.json'));
-    if (settingsWrite) {
-      const writtenSettings = JSON.parse(String(settingsWrite[1]));
-      expect(writtenSettings.hooks.UserPromptSubmit[0].hooks[0].command).toBe('node $HOME/.claude/hooks/other-plugin.mjs');
-    }
-    expect(result.hooksConfigured).toBe(true);
-  });
 });

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -651,9 +651,16 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
 export function reconcileUpdateRuntime(options?: { verbose?: boolean; skipGracePeriod?: boolean }): UpdateReconcileResult {
   const errors: string[] = [];
 
-  const runningAsPlugin = isRunningAsPlugin();
   const projectScopedPlugin = isProjectScopedPlugin();
-  const shouldRefreshPluginHooks = runningAsPlugin && !projectScopedPlugin;
+  // Plugin installs execute hooks from <pluginRoot>/hooks/hooks.json. Re-running
+  // the standalone settings.json hook merge during `omc update` re-injects the
+  // legacy ~/.claude/hooks/* entries and causes duplicate hook execution.
+  //
+  // Reconciliation should still refresh shared installer artifacts (CLAUDE.md,
+  // HUD, MCP registry, statusLine, etc.), but it must leave settings.json hook
+  // ownership alone for plugin installs so the plugin hook manifest remains the
+  // single source of truth.
+  const shouldRefreshPluginHooks = false;
 
   if (!projectScopedPlugin) {
     try {

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -121,4 +121,64 @@ describe('install() standalone hook reconciliation', () => {
       `node "${join(testClaudeDir, 'hooks', 'keyword-detector.mjs').replace(/\\/g, '/')}"`,
     );
   });
+
+  it('removes legacy OMC settings hooks in plugin mode without re-injecting them', async () => {
+    const settingsPath = join(testClaudeDir, 'settings.json');
+    const pluginRoot = join(
+      testClaudeDir,
+      'plugins',
+      'cache',
+      'omc',
+      'oh-my-claudecode',
+      '4.1.5',
+    );
+
+    mkdirSync(pluginRoot, { recursive: true });
+    mkdirSync(testClaudeDir, { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: 'node $HOME/.claude/hooks/keyword-detector.mjs',
+              },
+            ],
+          },
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: 'node $HOME/.claude/hooks/other-plugin.mjs',
+              },
+            ],
+          },
+        ],
+      },
+    }, null, 2));
+    process.env.CLAUDE_PLUGIN_ROOT = pluginRoot;
+
+    const { install } = await loadInstaller();
+    const result = install({
+      force: true,
+      skipClaudeCheck: true,
+    });
+
+    const writtenSettings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      statusLine?: { command?: string };
+    };
+    const commands = writtenSettings.hooks?.UserPromptSubmit?.map(group => group.hooks[0]?.command) ?? [];
+
+    expect(result.success).toBe(true);
+    expect(result.hooksConfigured).toBe(true);
+    expect(commands).toEqual(['node $HOME/.claude/hooks/other-plugin.mjs']);
+    expect(commands).not.toContain(
+      `node "${join(testClaudeDir, 'hooks', 'keyword-detector.mjs').replace(/\\/g, '/')}"`,
+    );
+    expect(writtenSettings.statusLine?.command).toContain(
+      `${join(testClaudeDir, 'hud', 'omc-hud.mjs').replace(/\\/g, '/')}`,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #2421