### PR TITLE
fix(hud): remove stale inline wrapper from skill, use canonical template

### DIFF
--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -46,110 +46,23 @@ node -e "const p=require('path'),f=require('fs'),d=process.env.CLAUDE_CONFIG_DIR
 node -e "const p=require('path'),f=require('fs'),d=process.env.CLAUDE_CONFIG_DIR||p.join(require('os').homedir(),'.claude'),b=p.join(d,'plugins','cache','omc','oh-my-claudecode');try{const v=f.readdirSync(b).filter(x=>/^\d/.test(x)).sort((a,c)=>a.localeCompare(c,void 0,{numeric:true}));if(v.length===0){console.log('Plugin not installed - run: /plugin install oh-my-claudecode');process.exit()}const l=v[v.length-1],h=p.join(b,l,'dist','hud','index.js');console.log('Version:',l);console.log(f.existsSync(h)?'READY':'NOT_FOUND - try reinstalling: /plugin install oh-my-claudecode')}catch{console.log('Plugin not installed - run: /plugin install oh-my-claudecode')}"
 ```
 
-**Step 3:** If omc-hud.mjs is MISSING or argument is `setup`, create the HUD directory and script:
+**Step 3:** If omc-hud.mjs is MISSING or argument is `setup`, install the HUD wrapper and its dependency from the canonical template:
 
-First, create the directory:
 ```bash
-node -e "require('fs').mkdirSync(require('path').join(process.env.CLAUDE_CONFIG_DIR||require('path').join(require('os').homedir(),'.claude'),'hud'),{recursive:true})"
+HUD_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud"
+mkdir -p "$HUD_DIR/lib"
+cp "${CLAUDE_PLUGIN_ROOT}/scripts/lib/hud-wrapper-template.txt" "$HUD_DIR/omc-hud.mjs"
+cp "${CLAUDE_PLUGIN_ROOT}/scripts/lib/config-dir.mjs" "$HUD_DIR/lib/config-dir.mjs"
 ```
 
-Then, use the Write tool to create `${CLAUDE_CONFIG_DIR:-~/.claude}/hud/omc-hud.mjs` with this exact content:
+**IMPORTANT:** Always copy from the canonical template at `scripts/lib/hud-wrapper-template.txt`. Do NOT write the wrapper content inline — the template is the single source of truth and is guarded by drift tests (`src/__tests__/hud-wrapper-template-sync.test.ts`, `src/__tests__/paths-consistency.test.ts`).
 
-```javascript
-#!/usr/bin/env node
-/**
- * OMC HUD - Statusline Script
- * Wrapper that imports from dev paths, plugin cache, or npm package
- */
-
-import { existsSync, readdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
-
-async function main() {
-  const home = homedir();
-  let pluginCacheVersion = null;
-  let pluginCacheDir = null;
-
-  // 1. Development paths (only when OMC_DEV=1)
-  if (process.env.OMC_DEV === "1") {
-    const devPaths = [
-      join(home, "Workspace/oh-my-claudecode/dist/hud/index.js"),
-      join(home, "workspace/oh-my-claudecode/dist/hud/index.js"),
-      join(home, "projects/oh-my-claudecode/dist/hud/index.js"),
-    ];
-
-    for (const devPath of devPaths) {
-      if (existsSync(devPath)) {
-        try {
-          await import(pathToFileURL(devPath).href);
-          return;
-        } catch { /* continue */ }
-      }
-    }
-  }
-
-  // 2. Plugin cache (for production installs)
-  // Respect CLAUDE_CONFIG_DIR so installs under a custom config dir are found
-  const configDir = process.env.CLAUDE_CONFIG_DIR || join(home, ".claude");
-  const pluginCacheBase = join(configDir, "plugins", "cache", "omc", "oh-my-claudecode");
-  if (existsSync(pluginCacheBase)) {
-    try {
-      const versions = readdirSync(pluginCacheBase);
-      if (versions.length > 0) {
-        // Filter to only versions with built dist/hud/index.js
-        // This prevents picking an unbuilt new version after plugin update
-        const builtVersions = versions.filter(version => {
-          const pluginPath = join(pluginCacheBase, version, "dist/hud/index.js");
-          return existsSync(pluginPath);
-        });
-
-        if (builtVersions.length > 0) {
-          const latestVersion = builtVersions.sort((a, b) => a.localeCompare(b, undefined, { numeric: true })).reverse()[0];
-          pluginCacheVersion = latestVersion;
-          pluginCacheDir = join(pluginCacheBase, latestVersion);
-          const pluginPath = join(pluginCacheDir, "dist/hud/index.js");
-          await import(pathToFileURL(pluginPath).href);
-          return;
-        }
-      }
-    } catch { /* continue */ }
-  }
-
-  // 3. npm package (global or local install)
-  try {
-    await import("oh-my-claudecode/dist/hud/index.js");
-    return;
-  } catch { /* continue */ }
-
-  // 4. Fallback: provide detailed error message with fix instructions
-  if (pluginCacheDir && existsSync(pluginCacheDir)) {
-    // Plugin exists but dist/ folder is missing - needs build
-    const distDir = join(pluginCacheDir, "dist");
-    if (!existsSync(distDir)) {
-      console.log(`[OMC HUD] Plugin installed but not built. Run: cd "${pluginCacheDir}" && npm install && npm run build`);
-    } else {
-      console.log(`[OMC HUD] Plugin dist/ exists but HUD not found. Run: cd "${pluginCacheDir}" && npm run build`);
-    }
-  } else if (existsSync(pluginCacheBase)) {
-    // Plugin cache directory exists but no built versions found
-    console.log("[OMC HUD] Plugin cache found but no built versions. Run: /oh-my-claudecode:omc-setup");
-  } else {
-    // No plugin installation found at all
-    console.log("[OMC HUD] Plugin not installed. Run: /oh-my-claudecode:omc-setup");
-  }
-}
-
-main();
-```
-
-**Step 3:** Make it executable (Unix only, skip on Windows):
+**Step 4:** Make it executable (Unix only, skip on Windows):
 ```bash
 node -e "if(process.platform==='win32'){console.log('Skipped (Windows)')}else{require('fs').chmodSync(require('path').join(process.env.CLAUDE_CONFIG_DIR||require('path').join(require('os').homedir(),'.claude'),'hud','omc-hud.mjs'),0o755);console.log('Done')}"
 ```
 
-**Step 4:** Update settings.json to use the HUD:
+**Step 5:** Update settings.json to use the HUD:
 
 Read `${CLAUDE_CONFIG_DIR:-~/.claude}/settings.json`, then update/add the `statusLine` field.
 
@@ -184,12 +97,12 @@ On Windows the path uses forward slashes (not backslashes):
 
 Use the Edit tool to add/update this field while preserving other settings.
 
-**Step 5:** Clean up old HUD scripts (if any):
+**Step 6:** Clean up old HUD scripts (if any):
 ```bash
 node -e "const p=require('path'),f=require('fs'),d=process.env.CLAUDE_CONFIG_DIR||p.join(require('os').homedir(),'.claude'),t=p.join(d,'hud','omc-hud.mjs');try{if(f.existsSync(t)){f.unlinkSync(t);console.log('Removed legacy script')}else{console.log('No legacy script found')}}catch{}"
 ```
 
-**Step 6:** Tell the user to restart Claude Code for changes to take effect.
+**Step 7:** Tell the user to restart Claude Code for changes to take effect.
 
 ## Display Presets
 

--- a/src/__tests__/hud-skill-no-inline-wrapper.test.ts
+++ b/src/__tests__/hud-skill-no-inline-wrapper.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = join(__dirname, '..', '..');
+
+const SKILL_PATH = join(root, 'skills', 'hud', 'SKILL.md');
+
+describe('HUD skill — no inline wrapper', () => {
+  const content = readFileSync(SKILL_PATH, 'utf8');
+
+  it('does not embed an inline HUD wrapper script', () => {
+    // The canonical wrapper lives in scripts/lib/hud-wrapper-template.txt.
+    // The skill must copy from there, not embed its own version.
+    // Match signatures unique to the wrapper body that should never appear inline.
+    expect(content).not.toMatch(/async function main\(\)\s*\{/);
+    expect(content).not.toMatch(/OMC_DEV.*===.*"1"/);
+    expect(content).not.toMatch(/import.*from\s*["']node:fs["']/);
+  });
+
+  it('references the canonical template for installation', () => {
+    expect(content).toMatch(/hud-wrapper-template\.txt/);
+  });
+
+  it('copies config-dir.mjs dependency', () => {
+    expect(content).toMatch(/config-dir\.mjs/);
+  });
+});


### PR DESCRIPTION
## Summary

The HUD skill (`skills/hud/SKILL.md`) embedded a ~90-line inline copy of the HUD wrapper script that predated #2356. That PR moved the canonical wrapper to `scripts/lib/hud-wrapper-template.txt` and added `OMC_PLUGIN_ROOT` resolution, but the skill file was never updated. Running `/hud setup` therefore installed a stale wrapper missing `OMC_PLUGIN_ROOT`, marketplace fallback, semver-aware cache sorting, and `oh-my-claude-sisyphus` npm resolution — causing "Plugin not installed" for any `--plugin-dir` user whose checkout is not at `~/Workspace`, `~/workspace`, or `~/projects`.

Discovered during a real `/omc-setup` session: the HUD reported "Plugin not installed" despite the plugin being active and `dist/hud/index.js` existing at the local dev path.

## Root cause

`skills/hud/SKILL.md` Step 3 instructed Claude to write the wrapper body inline via the Write tool. The inline copy was frozen at the pre-#2356 version with `OMC_DEV=1` + three hardcoded dev paths. The existing drift-guard tests (`hud-wrapper-template-sync`, `paths-consistency`) protect `*.ts` / `*.mjs` mirrors of the template but cannot detect stale code blocks embedded in markdown skill files.

## Fix

**1. `skills/hud/SKILL.md`** — Replace ~90 lines of inline JavaScript with a 4-line `cp` from the canonical template and its `config-dir.mjs` dependency. Fix step numbering (was two "Step 3"s, now sequential 1–7).

**2. `src/__tests__/hud-skill-no-inline-wrapper.test.ts`** (new) — Drift-guard test (3 assertions) that prevents re-introducing an inline wrapper:
- No inline wrapper body signatures (`async function main()`, `OMC_DEV`, `import from "node:fs"`)
- References `hud-wrapper-template.txt` (canonical source)
- References `config-dir.mjs` (required dependency)

## What's out of scope

- **No `dist/` or `bridge/` churn.** Source-only diff.
- **No changes to the canonical template itself.** The template at `scripts/lib/hud-wrapper-template.txt` is unchanged.
- **No changes to HUD presets, elements, or rendering.** Zero user-visible behavior change.

## Files changed

```
skills/hud/SKILL.md                                  +10/-97  (replace inline wrapper with cp)
src/__tests__/hud-skill-no-inline-wrapper.test.ts    +31/-0   (new drift-guard test)
```

**Source-only diff: 2 files, +41/-97.**

## Test plan

- [x] `npx vitest run src/__tests__/hud-skill-no-inline-wrapper.test.ts` — 3/3 pass
- [x] `npx vitest run src/__tests__/hud-wrapper-template-sync.test.ts src/__tests__/paths-consistency.test.ts` — 8/8 pass (no regression)
- [x] `npm test` — 458/463 pass, 4 pre-existing failures (idle-cooldown, stale-cleanup, session-search × 2), confirmed identical on clean `dev`
- [x] Manual: installed wrapper via new `cp` path, verified HUD resolves `OMC_PLUGIN_ROOT` and renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)