### PR TITLE
fix: align learned skill templates with flat-file discovery

### DIFF
--- a/skills/learner/SKILL.md
+++ b/skills/learner/SKILL.md
@@ -109,12 +109,37 @@ This classification ensures expertise can be updated independently without desta
 
 ### Step 4: Save Location
 
-- **User-level**: ${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/ - Rare. Only for truly portable insights.
-- **Project-level**: .omc/skills/ - Default. Version-controlled with repo.
+- **User-level**: `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/<skill-name>.md` - Rare. Only for truly portable insights.
+- **Project-level**: `.omc/skills/<skill-name>.md` - Default. Version-controlled with repo.
+
+### Required File Format
+
+Every learned skill file MUST start with YAML frontmatter so learned-skill flat-file discovery can load it.
+Do **not** write plain markdown without frontmatter.
+
+Minimum required frontmatter:
+
+```yaml
+---
+name: <skill-name>
+description: <one-line description>
+triggers:
+  - <trigger-1>
+  - <trigger-2>
+---
+```
 
 ### Skill Body Template
 
 ```markdown
+---
+name: <skill-name>
+description: <one-line description>
+triggers:
+  - <trigger-1>
+  - <trigger-2>
+---
+
 # [Skill Name]
 
 ## The Insight

--- a/skills/skillify/SKILL.md
+++ b/skills/skillify/SKILL.md
@@ -22,8 +22,23 @@ Capture a successful multi-step workflow as a concrete skill draft instead of re
    - a repo built-in skill
    - a user/project learned skill
    - documentation only
-4. Draft the SKILL.md content with clear triggers, steps, and success criteria.
-5. Point out anything still too fuzzy to encode safely.
+4. When drafting a learned skill file, output a complete skill file that starts with YAML frontmatter.
+   - Never emit plain markdown-only skill files.
+   - Minimum frontmatter:
+     ```yaml
+     ---
+     name: <skill-name>
+     description: <one-line description>
+     triggers:
+       - <trigger-1>
+       - <trigger-2>
+     ---
+     ```
+   - Write learned/user/project skills to:
+     - `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/<skill-name>.md`
+     - `.omc/skills/<skill-name>.md`
+5. Draft the rest of the skill file with clear triggers, steps, and success criteria.
+6. Point out anything still too fuzzy to encode safely.
 
 ## Rules
 - Only capture workflows that are actually repeatable.

--- a/src/__tests__/skills-frontmatter-regression.test.ts
+++ b/src/__tests__/skills-frontmatter-regression.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createBuiltinSkills, clearSkillsCache, getBuiltinSkill } from '../features/builtin-skills/skills.js';
+
+describe('builtin skill drafting contracts for learned skills (issue #2425)', () => {
+  const originalUserType = process.env.USER_TYPE;
+
+  beforeEach(() => {
+    process.env.USER_TYPE = 'ant';
+    clearSkillsCache();
+  });
+
+  afterEach(() => {
+    if (originalUserType === undefined) {
+      delete process.env.USER_TYPE;
+    } else {
+      process.env.USER_TYPE = originalUserType;
+    }
+    clearSkillsCache();
+  });
+
+  it('learner skill instructs writing YAML frontmatter and flat learned-skill file paths', () => {
+    const learner = getBuiltinSkill('learner');
+
+    expect(learner).toBeDefined();
+    expect(learner!.template).toContain('MUST start with YAML frontmatter');
+    expect(learner!.template).toContain('Do **not** write plain markdown without frontmatter.');
+    expect(learner!.template).toContain('.omc/skills/<skill-name>.md');
+    expect(learner!.template).toContain('skills/omc-learned/<skill-name>.md');
+  });
+
+  it('skillify skill instructs drafting flat file-backed skills with YAML frontmatter', () => {
+    const skills = createBuiltinSkills();
+    const skillify = skills.find((skill) => skill.name === 'skillify');
+
+    expect(skillify).toBeDefined();
+    expect(skillify!.template).toContain('output a complete skill file that starts with YAML frontmatter');
+    expect(skillify!.template).toContain('Never emit plain markdown-only skill files.');
+    expect(skillify!.template).toContain('.omc/skills/<skill-name>.md');
+    expect(skillify!.template).toContain('skills/omc-learned/<skill-name>.md');
+  });
+});


### PR DESCRIPTION
Fixes #2425

## Summary
- require learner and skillify prompts to emit YAML frontmatter for learned skills
- document the actual flat learned-skill file destinations used by writer/discovery
- add an issue-scoped regression test that locks the prompt/discovery contract

## Verification
- `npx vitest run src/__tests__/skills-frontmatter-regression.test.ts`
- `npx eslint src/__tests__/skills-frontmatter-regression.test.ts`
- `npx tsc --noEmit`
