### PR TITLE
fix: stop ultrawork from blocking exit after completion

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -1018,8 +1018,8 @@ async function main() {
       }
     }
 
-    // Priority 8: Ultrawork - ALWAYS continue while active (not just when tasks exist)
-    // This prevents false stops from bash errors, transient failures, etc.
+    // Priority 8: Ultrawork - reinforce only while tracked work remains incomplete.
+    // This prevents false stops from bash errors or transient failures mid-task.
     // Session isolation: only block if state belongs to this session (issue #311)
     // Project isolation: only block if state belongs to this project
     if (
@@ -1028,6 +1028,19 @@ async function main() {
       isSessionMatch(ultrawork.state, sessionId) &&
       isStateForCurrentProject(ultrawork.state, directory, ultrawork.isGlobal)
     ) {
+      if (totalIncomplete === 0) {
+        // Issue #2419: once tracked work is complete, auto-clear ultrawork so
+        // Stop can exit cleanly instead of forcing repeated cancel prompts.
+        try {
+          ultrawork.state.active = false;
+          ultrawork.state.deactivated_reason = 'task_completion';
+          ultrawork.state.last_checked_at = new Date().toISOString();
+          writeJsonFile(ultrawork.path, ultrawork.state);
+        } catch { /* best-effort cleanup */ }
+        console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+        return;
+      }
+
       const newCount = (ultrawork.state.reinforcement_count || 0) + 1;
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -1075,6 +1075,18 @@ async function checkUltrawork(
     };
   }
 
+  // If all tracked work is complete, auto-deactivate ultrawork and allow exit.
+  // Issue #2419: otherwise the Stop hook can keep blocking even after task
+  // completion, leaving ultrawork active until manual /cancel or session-end.
+  if (!_hasIncompleteTodos) {
+    deactivateUltrawork(workingDir, sessionId);
+    return {
+      shouldBlock: false,
+      message: '[ULTRAWORK COMPLETE] No incomplete tasks remain. Ultrawork state cleared.',
+      mode: 'none'
+    };
+  }
+
   // Enforce hard max iterations for ultrawork (mirrors ralph enforcement).
   const hardMax = getHardMaxIterations();
   if (hardMax > 0 && state.reinforcement_count >= hardMax) {
@@ -1087,8 +1099,8 @@ async function checkUltrawork(
     };
   }
 
-  // Reinforce ultrawork mode - ALWAYS continue while active.
-  // This prevents false stops from bash errors, transient failures, etc.
+  // Reinforce ultrawork mode while incomplete work remains.
+  // This prevents false stops from bash errors or transient failures mid-task.
   const newState = incrementReinforcement(workingDir, sessionId);
   if (!newState) {
     return null;
@@ -1305,7 +1317,7 @@ export async function checkPersistentModes(
 
   // Priority 2: Ultrawork Mode (performance mode with persistence)
   const ultraworkResult = await checkUltrawork(sessionId, workingDir, hasIncompleteTodos, cancelInProgress);
-  if (ultraworkResult?.shouldBlock) {
+  if (ultraworkResult) {
     return ultraworkResult;
   }
 

--- a/src/hooks/persistent-mode/session-isolation.test.ts
+++ b/src/hooks/persistent-mode/session-isolation.test.ts
@@ -6,6 +6,22 @@ import { execSync } from "child_process";
 import { checkPersistentModes } from "./index.js";
 import { activateUltrawork, deactivateUltrawork } from "../ultrawork/index.js";
 
+function writePendingTodo(tempDir: string, content: string): void {
+  mkdirSync(join(tempDir, '.claude'), { recursive: true });
+  writeFileSync(
+    join(tempDir, '.claude', 'todos.json'),
+    JSON.stringify({
+      todos: [
+        {
+          content,
+          status: 'pending',
+          priority: 'high',
+        },
+      ],
+    }),
+  );
+}
+
 describe("Persistent Mode Session Isolation (Issue #311)", () => {
   let tempDir: string;
 
@@ -22,6 +38,7 @@ describe("Persistent Mode Session Isolation (Issue #311)", () => {
     it("should block stop when session_id matches active ultrawork", async () => {
       const sessionId = "session-owner";
       activateUltrawork("Fix the bug", sessionId, tempDir);
+      writePendingTodo(tempDir, "Finish the bug fix");
 
       const result = await checkPersistentModes(sessionId, tempDir);
       expect(result.shouldBlock).toBe(true);
@@ -62,6 +79,7 @@ describe("Persistent Mode Session Isolation (Issue #311)", () => {
 
     it("should support session-scoped state files", async () => {
       const sessionId = "session-scoped-test";
+      writePendingTodo(tempDir, "Finish the session-scoped task");
       // Create state in session-scoped directory
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -151,6 +151,19 @@ describe("Stop Hook Blocking Contract", () => {
       const sessionId = "ultrawork-stale-awaiting-confirmation";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
+      mkdirSync(join(tempDir, '.claude'), { recursive: true });
+      writeFileSync(
+        join(tempDir, '.claude', 'todos.json'),
+        JSON.stringify({
+          todos: [
+            {
+              content: 'resume the queued task',
+              status: 'pending',
+              priority: 'high'
+            }
+          ]
+        }),
+      );
       writeFileSync(
         join(sessionDir, "ultrawork-state.json"),
         JSON.stringify({
@@ -175,6 +188,19 @@ describe("Stop Hook Blocking Contract", () => {
       const sessionId = "ultrawork-fresh-last-checked-still-stale-confirmation";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
+      mkdirSync(join(tempDir, '.claude'), { recursive: true });
+      writeFileSync(
+        join(tempDir, '.claude', 'todos.json'),
+        JSON.stringify({
+          todos: [
+            {
+              content: 'resume the queued task',
+              status: 'pending',
+              priority: 'high'
+            }
+          ]
+        }),
+      );
       writeFileSync(
         join(sessionDir, "ultrawork-state.json"),
         JSON.stringify({
@@ -193,9 +219,22 @@ describe("Stop Hook Blocking Contract", () => {
       expect(result.mode).toBe("ultrawork");
     });
 
-    it("blocks stop for active ultrawork (shouldBlock: true -> continue: false)", async () => {
+    it("blocks stop for active ultrawork while incomplete work remains (shouldBlock: true -> continue: false)", async () => {
       const sessionId = "test-session-block";
       activateUltrawork("Fix the bug", sessionId, tempDir);
+      mkdirSync(join(tempDir, '.claude'), { recursive: true });
+      writeFileSync(
+        join(tempDir, '.claude', 'todos.json'),
+        JSON.stringify({
+          todos: [
+            {
+              content: 'finish the bug fix',
+              status: 'pending',
+              priority: 'high'
+            }
+          ]
+        }),
+      );
 
       const result = await checkPersistentModes(sessionId, tempDir);
       expect(result.shouldBlock).toBe(true);
@@ -203,6 +242,23 @@ describe("Stop Hook Blocking Contract", () => {
       const output = createHookOutput(result);
       expect(output.continue).toBe(false);
       expect(output.message).toBeDefined();
+    });
+
+    it("auto-deactivates ultrawork and allows stop when all tracked work is complete", async () => {
+      const sessionId = "test-session-complete";
+      activateUltrawork("Task complete", sessionId, tempDir);
+      const statePath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ultrawork-state.json');
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('none');
+      expect(result.message).toContain('ULTRAWORK COMPLETE');
+
+      const output = createHookOutput(result);
+      expect(output.continue).toBe(true);
+      expect(output.message).toContain('ULTRAWORK COMPLETE');
+
+      expect(() => readFileSync(statePath, 'utf-8')).toThrow();
     });
 
     it("allows stop for deactivated ultrawork (shouldBlock: false -> continue: true)", async () => {
@@ -911,6 +967,35 @@ describe("Stop Hook Blocking Contract", () => {
       expect(output.reason).not.toContain('/oh-my-claudecode:cancel');
     });
 
+    it("auto-deactivates ultrawork state when no incomplete work remains in cjs script", () => {
+      const sessionId = "ulw-complete-cjs";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      const statePath = join(sessionDir, "ultrawork-state.json");
+      writeFileSync(
+        statePath,
+        JSON.stringify({
+          active: true,
+          session_id: sessionId,
+          reinforcement_count: 2,
+          max_reinforcements: 50,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          project_path: tempDir,
+        })
+      );
+
+      const output = runScript({
+        directory: tempDir,
+        sessionId,
+      });
+      expect(output.continue).toBe(true);
+
+      const updatedState = JSON.parse(readFileSync(statePath, "utf-8"));
+      expect(updatedState.active).toBe(false);
+      expect(updatedState.deactivated_reason).toBe("task_completion");
+    });
+
     it("fails open for unknown Team phase in cjs script", () => {
       const sessionId = "team-phase-cjs";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
@@ -949,6 +1034,20 @@ describe("Stop Hook Blocking Contract", () => {
           last_checked_at: new Date().toISOString(),
           project_path: tempDir,
         })
+      );
+
+      mkdirSync(join(tempDir, '.claude'), { recursive: true });
+      writeFileSync(
+        join(tempDir, '.claude', 'todos.json'),
+        JSON.stringify({
+          todos: [
+            {
+              content: 'keep working',
+              status: 'pending',
+              priority: 'high'
+            }
+          ]
+        }),
       );
 
       const output = runScript({

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -995,8 +995,8 @@ async function main() {
       }
     }
 
-    // Priority 8: Ultrawork - ALWAYS continue while active (not just when tasks exist)
-    // This prevents false stops from bash errors, transient failures, etc.
+    // Priority 8: Ultrawork - reinforce only while tracked work remains incomplete.
+    // This prevents false stops from bash errors or transient failures mid-task.
     // Session isolation: only block if state belongs to this session (issue #311)
     // If state has session_id, it must match. If no session_id (legacy), allow.
     if (
@@ -1007,6 +1007,19 @@ async function main() {
         : !ultrawork.state.session_id || ultrawork.state.session_id === sessionId) &&
       isStateForCurrentProject(ultrawork.state, directory, ultrawork.isGlobal)
     ) {
+      if (totalIncomplete === 0) {
+        // Issue #2419: once tracked work is complete, auto-clear ultrawork so
+        // Stop can exit cleanly instead of forcing repeated cancel prompts.
+        try {
+          ultrawork.state.active = false;
+          ultrawork.state.deactivated_reason = 'task_completion';
+          ultrawork.state.last_checked_at = new Date().toISOString();
+          writeJsonFile(ultrawork.path, ultrawork.state);
+        } catch { /* best-effort cleanup */ }
+        console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+        return;
+      }
+
       const newCount = (ultrawork.state.reinforcement_count || 0) + 1;
       const maxReinforcements = ultrawork.state.max_reinforcements || 50;
 


### PR DESCRIPTION
## Summary
- auto-clear ultrawork stop-hook state when tracked work is finished instead of re-blocking Stop
- keep the shipped hook scripts in sync with the TypeScript stop-hook behavior
- cover the terminal-state regression plus the focused session-isolation expectations

## Testing
- npx vitest run src/hooks/persistent-mode/stop-hook-blocking.test.ts src/hooks/persistent-mode/session-isolation.test.ts src/hooks/ultrawork/session-isolation.test.ts

Fixes #2419