### PR TITLE
fix(lsp): register ty as the Python LSP server

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -761,7 +761,7 @@ stopomc
 | `lsp_servers`               | ✅ Implemented | List available language servers             |
 | `lsp_diagnostics_directory` | ✅ Implemented | Project-level type checking                 |
 
-> **Note**: LSP tools require language servers to be installed (typescript-language-server, pylsp, rust-analyzer, gopls, etc.). Use `lsp_servers` to check installation status.
+> **Note**: LSP tools require language servers to be installed (typescript-language-server, ty, rust-analyzer, gopls, etc.). Use `lsp_servers` to check installation status.
 
 ### AST Tools (ast-grep Integration)
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -333,7 +333,7 @@ project_memory_add_note("tsconfig paths settings need to be kept in sync with je
 
 LSP tools provide Language Server Protocol-based code intelligence: type information, go-to-definition, find references, error diagnostics, symbol search, and renaming.
 
-A language server must be installed (e.g., `typescript-language-server`, `pylsp`, `rust-analyzer`, `gopls`). Use `lsp_servers()` to check installation status.
+A language server must be installed (e.g., `typescript-language-server`, `ty`, `rust-analyzer`, `gopls`). Use `lsp_servers()` to check installation status.
 
 ### Tools
 

--- a/src/__tests__/lsp-servers.test.ts
+++ b/src/__tests__/lsp-servers.test.ts
@@ -38,7 +38,7 @@ describe('LSP Server Configurations', () => {
 describe('getServerForFile', () => {
   const cases: [string, string][] = [
     ['app.ts', 'TypeScript Language Server'],
-    ['app.py', 'Python Language Server (pylsp)'],
+    ['app.py', 'Python Language Server (ty)'],
     ['main.rs', 'Rust Analyzer'],
     ['main.go', 'gopls'],
     ['main.c', 'clangd'],
@@ -83,7 +83,7 @@ describe('getServerForLanguage', () => {
   const cases: [string, string][] = [
     ['typescript', 'TypeScript Language Server'],
     ['javascript', 'TypeScript Language Server'],
-    ['python', 'Python Language Server (pylsp)'],
+    ['python', 'Python Language Server (ty)'],
     ['rust', 'Rust Analyzer'],
     ['go', 'gopls'],
     ['golang', 'gopls'],
@@ -141,5 +141,12 @@ describe('getServerForLanguage', () => {
 describe('OmniSharp command casing', () => {
   it('should use lowercase command for cross-platform compatibility', () => {
     expect(LSP_SERVERS.csharp.command).toBe('omnisharp');
+  });
+});
+
+describe('Python server selection', () => {
+  it('should invoke ty via its LSP subcommand', () => {
+    expect(LSP_SERVERS.python.command).toBe('ty');
+    expect(LSP_SERVERS.python.args).toEqual(['server']);
   });
 });

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -233,7 +233,7 @@ async function withLspClient(filePath, operation, fn) {
 | Language | Server | Install |
 |----------|--------|---------|
 | TypeScript/JavaScript | typescript-language-server | `npm i -g typescript-language-server typescript` |
-| Python | pylsp | `pip install python-lsp-server` |
+| Python | ty | `Install ty from https://github.com/astral-sh/ty` |
 | Rust | rust-analyzer | `rustup component add rust-analyzer` |
 | Go | gopls | `go install golang.org/x/tools/gopls@latest` |
 | C/C++ | clangd | System package manager |

--- a/src/tools/lsp/AGENTS.md
+++ b/src/tools/lsp/AGENTS.md
@@ -118,7 +118,7 @@ npm test -- --grep "lsp"
 | Language | Server | Command | Extensions |
 |----------|--------|---------|------------|
 | TypeScript/JS | typescript-language-server | `typescript-language-server` | .ts, .tsx, .js, .jsx |
-| Python | pylsp | `pylsp` | .py, .pyw |
+| Python | ty | `ty server` | .py, .pyw |
 | Rust | rust-analyzer | `rust-analyzer` | .rs |
 | Go | gopls | `gopls` | .go |
 | C/C++ | clangd | `clangd` | .c, .h, .cpp, .cc, .hpp |

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -31,11 +31,11 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
     installHint: 'npm install -g typescript-language-server typescript'
   },
   python: {
-    name: 'Python Language Server (pylsp)',
-    command: 'pylsp',
-    args: [],
+    name: 'Python Language Server (ty)',
+    command: 'ty',
+    args: ['server'],
     extensions: ['.py', '.pyw'],
-    installHint: 'pip install python-lsp-server'
+    installHint: 'Install ty from https://github.com/astral-sh/ty'
   },
   rust: {
     name: 'Rust Analyzer',


### PR DESCRIPTION
## Summary
- switch the Python LSP registry entry from `pylsp` to `ty server`
- align the supported-server docs and tool guidance with `ty`
- add a focused regression assertion for the Python LSP command/args

## Testing
- `./node_modules/.bin/vitest run src/__tests__/lsp-servers.test.ts`
- `./node_modules/.bin/eslint src`
- `./node_modules/.bin/tsc --noEmit`

Closes #2413.
