### PR TITLE
fix(cli): detect psmux tmux.cmd on native Windows

### DIFF
--- a/src/__tests__/cli-win32-warning.test.ts
+++ b/src/__tests__/cli-win32-warning.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 
-vi.mock('../cli/tmux-utils.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../cli/tmux-utils.js')>();
-  return { ...actual, tmuxSpawn: vi.fn() };
-});
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(),
+}));
 
-import { tmuxSpawn } from '../cli/tmux-utils.js';
+import { spawnSync } from 'child_process';
 
 describe('CLI win32 platform warning (#923)', () => {
   const originalPlatform = process.platform;
@@ -24,7 +23,7 @@ describe('CLI win32 platform warning (#923)', () => {
 
   it('should warn on win32 when tmux is not available', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    vi.mocked(tmuxSpawn).mockReturnValue({ status: 1 } as ReturnType<typeof tmuxSpawn>);
+    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
 
     const { warnIfWin32 } = await import('../cli/win32-warning.js');
     warnIfWin32();
@@ -39,7 +38,7 @@ describe('CLI win32 platform warning (#923)', () => {
 
   it('should NOT warn on win32 when tmux (or psmux) is available', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    vi.mocked(tmuxSpawn).mockReturnValue({ status: 0 } as ReturnType<typeof tmuxSpawn>);
+    vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
 
     const { warnIfWin32 } = await import('../cli/win32-warning.js');
     warnIfWin32();
@@ -67,7 +66,7 @@ describe('CLI win32 platform warning (#923)', () => {
 
   it('should not block execution after warning', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    vi.mocked(tmuxSpawn).mockReturnValue({ status: 1 } as ReturnType<typeof tmuxSpawn>);
+    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
 
     const { warnIfWin32 } = await import('../cli/win32-warning.js');
     let continued = false;

--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -9,13 +9,14 @@
  */
 
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
   return {
     ...actual,
     execFileSync: vi.fn(),
+    spawnSync: vi.fn(),
   };
 });
 
@@ -27,6 +28,7 @@ import {
 } from '../tmux-utils.js';
 
 const mockedExecFileSync = vi.mocked(execFileSync);
+const mockedSpawnSync = vi.mocked(spawnSync);
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -78,6 +80,40 @@ describe('resolveLaunchPolicy', () => {
       throw new Error('tmux not found');
     });
     expect(resolveLaunchPolicy({})).toBe('direct');
+  });
+
+  it('detects tmux.cmd via COMSPEC on win32', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+    mockedSpawnSync
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: 'C:\\Program Files\\psmux\\tmux.cmd\r\n',
+        stderr: '',
+        pid: 0,
+        output: [],
+        signal: null,
+      } as ReturnType<typeof spawnSync>)
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: '',
+        stderr: '',
+        pid: 0,
+        output: [],
+        signal: null,
+      } as ReturnType<typeof spawnSync>);
+
+    expect(resolveLaunchPolicy({})).toBe('outside-tmux');
+    expect(mockedSpawnSync).toHaveBeenNthCalledWith(1, 'where', ['tmux'], { timeout: 5000, encoding: 'utf8' });
+    expect(mockedSpawnSync).toHaveBeenNthCalledWith(
+      2,
+      'C:\\Windows\\System32\\cmd.exe',
+      ['/d', '/s', '/c', '"C:\\Program Files\\psmux\\tmux.cmd" -V'],
+      { timeout: 5000 }
+    );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   });
 });
 

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -3,97 +3,8 @@
  * Adapted from oh-my-codex patterns for omc
  */
 
-import {
-  exec,
-  execFile,
-  execFileSync,
-  execSync,
-  spawnSync,
-  type ExecFileSyncOptionsWithStringEncoding,
-  type ExecSyncOptionsWithStringEncoding,
-  type SpawnSyncOptionsWithStringEncoding,
-  type SpawnSyncReturns,
-} from 'child_process';
-import { basename } from 'path';
-import { promisify } from 'util';
-
-const promisifiedExec = promisify(exec);
-const promisifiedExecFile = promisify(execFile);
-
-// ── tmux environment & execution wrappers ────────────────────────────────────
-
-export interface TmuxExecOptions {
-  /** Strip TMUX env var so the command targets the default tmux server.
-   *  Default: false — preserves TMUX (targets the current server).
-   *  Set to true for OMC-owned background sessions and cross-session scans. */
-  stripTmux?: boolean;
-}
-
-export function tmuxEnv(): NodeJS.ProcessEnv {
-  const { TMUX: _, ...env } = process.env;
-  return env;
-}
-
-function resolveEnv(opts?: TmuxExecOptions): NodeJS.ProcessEnv {
-  return opts?.stripTmux ? tmuxEnv() : process.env;
-}
-
-export function tmuxExec(
-  args: string[],
-  opts?: TmuxExecOptions & Omit<ExecFileSyncOptionsWithStringEncoding, 'env' | 'encoding'> & { encoding?: BufferEncoding },
-): string {
-  const { stripTmux: _, ...execOpts } = opts ?? {};
-  return execFileSync('tmux', args, { encoding: 'utf-8', ...execOpts, env: resolveEnv(opts) });
-}
-
-export async function tmuxExecAsync(
-  args: string[],
-  opts?: TmuxExecOptions & { timeout?: number },
-): Promise<{ stdout: string; stderr: string }> {
-  const { stripTmux: _, timeout, ...rest } = opts ?? {};
-  return promisifiedExecFile('tmux', args, {
-    encoding: 'utf-8', env: resolveEnv(opts),
-    ...(timeout !== undefined ? { timeout } : {}), ...rest,
-  });
-}
-
-export function tmuxShell(
-  command: string,
-  opts?: TmuxExecOptions & Omit<ExecSyncOptionsWithStringEncoding, 'env' | 'encoding'> & { encoding?: BufferEncoding },
-): string {
-  const { stripTmux: _, ...execOpts } = opts ?? {};
-  return execSync(`tmux ${command}`, { encoding: 'utf-8', ...execOpts, env: resolveEnv(opts) }) as string;
-}
-
-export async function tmuxShellAsync(
-  command: string,
-  opts?: TmuxExecOptions & { timeout?: number },
-): Promise<{ stdout: string; stderr: string }> {
-  const { stripTmux: _, timeout, ...rest } = opts ?? {};
-  return promisifiedExec(`tmux ${command}`, {
-    encoding: 'utf-8', env: resolveEnv(opts),
-    ...(timeout !== undefined ? { timeout } : {}), ...rest,
-  });
-}
-
-export function tmuxSpawn(
-  args: string[],
-  opts?: TmuxExecOptions & Omit<SpawnSyncOptionsWithStringEncoding, 'env' | 'encoding'> & { encoding?: BufferEncoding },
-): SpawnSyncReturns<string> {
-  const { stripTmux: _, ...spawnOpts } = opts ?? {};
-  return spawnSync('tmux', args, { encoding: 'utf-8', ...spawnOpts, env: resolveEnv(opts) });
-}
-
-export async function tmuxCmdAsync(
-  args: string[],
-  opts?: TmuxExecOptions & { timeout?: number },
-): Promise<{ stdout: string; stderr: string }> {
-  if (args.some(a => a.includes('#{'))) {
-    const escaped = args.map(a => "'" + a.replace(/'/g, "'\\''") + "'").join(' ');
-    return tmuxShellAsync(escaped, opts);
-  }
-  return tmuxExecAsync(args, opts);
-}
+import { execFileSync, spawnSync } from 'child_process';
+import { basename, isAbsolute, win32 as win32Path } from 'path';
 
 export type ClaudeLaunchPolicy = 'inside-tmux' | 'outside-tmux' | 'direct';
 
@@ -103,12 +14,51 @@ export interface TmuxPaneSnapshot {
   startCommand: string;
 }
 
+function resolveTmuxBinaryPath(): string {
+  if (process.platform !== 'win32') {
+    return 'tmux';
+  }
+
+  try {
+    const result = spawnSync('where', ['tmux'], {
+      timeout: 5000,
+      encoding: 'utf8',
+    });
+    if (result.status !== 0) return 'tmux';
+
+    const candidates = result.stdout
+      ?.split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean) ?? [];
+    const first = candidates[0];
+    if (first && (isAbsolute(first) || win32Path.isAbsolute(first))) {
+      return first;
+    }
+  } catch {
+    // Fall back to plain tmux lookup below.
+  }
+
+  return 'tmux';
+}
+
 /**
  * Check if tmux is available on the system
  */
 export function isTmuxAvailable(): boolean {
   try {
-    tmuxExec(['-V'], { stripTmux: true, stdio: 'ignore' });
+    const resolvedBinary = resolveTmuxBinaryPath();
+    if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolvedBinary)) {
+      const comspec = process.env.COMSPEC || 'cmd.exe';
+      const result = spawnSync(comspec, ['/d', '/s', '/c', `"${resolvedBinary}" -V`], { timeout: 5000 });
+      return result.status === 0;
+    }
+
+    if (process.platform === 'win32') {
+      const result = spawnSync(resolvedBinary, ['-V'], { timeout: 5000, shell: true });
+      return result.status === 0;
+    }
+
+    execFileSync(resolvedBinary, ['-V'], { stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -280,8 +230,10 @@ export function findHudWatchPaneIds(panes: TmuxPaneSnapshot[], currentPaneId?: s
  */
 export function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): string[] {
   try {
-    const output = tmuxExec(
+    const output = execFileSync(
+      'tmux',
       ['list-panes', '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}'],
+      { encoding: 'utf-8' }
     );
     return findHudWatchPaneIds(parseTmuxPaneSnapshot(output), currentPaneId);
   } catch {
@@ -296,8 +248,10 @@ export function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): stri
 export function createHudWatchPane(cwd: string, hudCmd: string): string | null {
   try {
     const wrappedCmd = wrapWithLoginShell(hudCmd);
-    const output = tmuxExec(
+    const output = execFileSync(
+      'tmux',
       ['split-window', '-v', '-l', '4', '-d', '-c', cwd, '-P', '-F', '#{pane_id}', wrappedCmd],
+      { encoding: 'utf-8' }
     );
     const paneId = output.split('\n')[0]?.trim() || '';
     return paneId.startsWith('%') ? paneId : null;
@@ -312,7 +266,7 @@ export function createHudWatchPane(cwd: string, hudCmd: string): string | null {
 export function killTmuxPane(paneId: string): void {
   if (!paneId.startsWith('%')) return;
   try {
-    tmuxExec(['kill-pane', '-t', paneId], { stripTmux: true, stdio: 'ignore' });
+    execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'ignore' });
   } catch {
     // Pane may already be gone; ignore
   }

--- a/src/cli/win32-warning.ts
+++ b/src/cli/win32-warning.ts
@@ -1,17 +1,5 @@
 import chalk from 'chalk';
-import { tmuxSpawn } from './tmux-utils.js';
-
-/**
- * Check if tmux (or a compatible implementation like psmux) is available.
- */
-function hasTmuxBinary(): boolean {
-  try {
-    const result = tmuxSpawn(['-V'], { stripTmux: true, stdio: 'pipe', timeout: 3000 });
-    return result.status === 0;
-  } catch {
-    return false;
-  }
-}
+import { isTmuxAvailable } from './tmux-utils.js';
 
 /**
  * Warn if running on native Windows (win32) without tmux available.
@@ -19,7 +7,7 @@ function hasTmuxBinary(): boolean {
  * If a tmux-compatible binary (e.g. psmux) is on PATH, the warning is skipped.
  */
 export function warnIfWin32(): void {
-  if (process.platform === 'win32' && !hasTmuxBinary()) {
+  if (process.platform === 'win32' && !isTmuxAvailable()) {
     console.warn(chalk.yellow.bold('\n⚠  WARNING: Native Windows (win32) detected — no tmux found'));
     console.warn(chalk.yellow('   OMC features that require tmux will not work.'));
     console.warn(chalk.yellow('   Install psmux for native Windows tmux support: winget install psmux'));


### PR DESCRIPTION
Fixes #2437

## Summary
- resolve tmux on win32 with /usr/bin/tmux
/bin/tmux
- probe tmux.cmd/.bat via COMSPEC when needed
- reuse shared tmux availability logic in the win32 warning path

## Verification
- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/tmp/omc-issue-2437-clean-redo[39m

 [32m✓[39m src/__tests__/cli-win32-warning.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 35[2mms[22m[39m
 [32m✓[39m src/cli/__tests__/tmux-utils.test.ts [2m([22m[2m25 tests[22m[2m)[22m[32m 7[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m30 passed[39m[22m[90m (30)[39m
[2m   Start at [22m 18:25:52
[2m   Duration [22m 186ms[2m (transform 73ms, setup 0ms, import 80ms, tests 42ms, environment 0ms)[22m
- 
