### PR TITLE
feat(logging): add opt-in structured event logger

### DIFF
--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -23,6 +23,7 @@ import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../u
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from '../../features/builtin-skills/runtime-guidance.js';
 import { getSkillsDir } from '../../features/builtin-skills/skills.js';
+import { logEvent } from '../../lib/event-logger.js';
 
 /** Claude config directory */
 const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
@@ -313,6 +314,13 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   }
 
   sections.push('---\n');
+
+  logEvent('skill:execute', 'auto-slash-command', {
+    skill: cmd.name,
+    scope: cmd.scope,
+    args: displayArgs || undefined,
+    status: cmd.metadata.status,
+  });
 
   // Resolve arguments in content, then execute any live-data commands
   const resolvedContent = resolveArguments(cmd.content || '', displayArgs);

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -13,6 +13,7 @@ import {
   type TaskSizeResult,
   type TaskSizeThresholds,
 } from '../task-size-detector/index.js';
+import { logEvent } from '../../lib/event-logger.js';
 
 export type KeywordType =
   | 'cancel'      // Priority 1
@@ -193,6 +194,10 @@ export function detectKeywordsWithType(
       detected.push({
         ...match,
         type,
+      });
+      logEvent('keyword:detect', 'keyword-detector', {
+        keyword: type,
+        position: match.position,
       });
     }
   }

--- a/src/lib/event-logger.ts
+++ b/src/lib/event-logger.ts
@@ -1,0 +1,153 @@
+// src/lib/event-logger.ts
+
+/**
+ * Structured event logging for OMC runtime observability.
+ *
+ * Opt-in via OMC_ENABLE_EVENT_LOG=1 environment variable.
+ * Reuses the same append-only JSONL pattern and security model
+ * as team/audit-log.ts (0o600 permissions, validated paths).
+ *
+ * Events are written to .omc/logs/events-{YYYY-MM-DD}.jsonl
+ */
+
+import { join } from 'node:path';
+import { existsSync, readFileSync, statSync, renameSync, writeFileSync, lstatSync, unlinkSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { appendFileWithMode, ensureDirWithMode, validateResolvedPath } from '../team/fs-utils.js';
+import { resolveLogsPath } from './worktree-paths.js';
+
+export type OMCEventType =
+  | 'skill:route'
+  | 'skill:execute'
+  | 'skill:complete'
+  | 'skill:error'
+  | 'keyword:detect'
+  | 'hook:enter'
+  | 'hook:exit'
+  | 'agent:delegate'
+  | 'mode:enter'
+  | 'mode:exit';
+
+export interface OMCEvent {
+  timestamp: string;
+  type: OMCEventType;
+  source: string;
+  sessionId?: string;
+  payload?: Record<string, unknown>;
+}
+
+let _enabled: boolean | undefined;
+
+function isEnabled(): boolean {
+  if (_enabled === undefined) {
+    _enabled = process.env.OMC_ENABLE_EVENT_LOG === '1';
+  }
+  return _enabled;
+}
+
+function getLogPath(worktreeRoot?: string): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return join(resolveLogsPath(worktreeRoot), `events-${date}.jsonl`);
+}
+
+/**
+ * Log a structured OMC event. No-op when OMC_ENABLE_EVENT_LOG !== '1'.
+ */
+export function logEvent(
+  type: OMCEventType,
+  source: string,
+  payload?: Record<string, unknown>,
+  worktreeRoot?: string,
+): void {
+  if (!isEnabled()) return;
+
+  const logsDir = resolveLogsPath(worktreeRoot);
+  const logPath = getLogPath(worktreeRoot);
+
+  try {
+    validateResolvedPath(logPath, logsDir);
+    ensureDirWithMode(logsDir);
+
+    const event: OMCEvent = {
+      timestamp: new Date().toISOString(),
+      type,
+      source,
+      payload: payload && Object.keys(payload).length > 0 ? payload : undefined,
+    };
+
+    appendFileWithMode(logPath, JSON.stringify(event) + '\n');
+  } catch {
+    // Silent fail — logging must never break the host process
+  }
+}
+
+/**
+ * Read events from a specific date's log file.
+ */
+export function readEvents(
+  date: string,
+  filter?: {
+    type?: OMCEventType;
+    source?: string;
+    limit?: number;
+  },
+  worktreeRoot?: string,
+): OMCEvent[] {
+  const logPath = join(resolveLogsPath(worktreeRoot), `events-${date}.jsonl`);
+  if (!existsSync(logPath)) return [];
+
+  const content = readFileSync(logPath, 'utf-8');
+  const lines = content.split('\n').filter(l => l.trim());
+  const events: OMCEvent[] = [];
+
+  for (const line of lines) {
+    let event: OMCEvent;
+    try {
+      event = JSON.parse(line);
+    } catch { continue; }
+
+    if (filter) {
+      if (filter.type && event.type !== filter.type) continue;
+      if (filter.source && event.source !== filter.source) continue;
+    }
+
+    events.push(event);
+    if (filter?.limit !== undefined && events.length >= filter.limit) break;
+  }
+
+  return events;
+}
+
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Rotate event log if it exceeds maxSizeBytes. Keeps the most recent half.
+ */
+export function rotateEventLog(
+  date: string,
+  maxSizeBytes: number = DEFAULT_MAX_SIZE,
+  worktreeRoot?: string,
+): void {
+  const logPath = join(resolveLogsPath(worktreeRoot), `events-${date}.jsonl`);
+  if (!existsSync(logPath)) return;
+
+  const stat = statSync(logPath);
+  if (stat.size <= maxSizeBytes) return;
+
+  const content = readFileSync(logPath, 'utf-8');
+  const lines = content.split('\n').filter(l => l.trim());
+  const keepFrom = Math.floor(lines.length / 2);
+  const rotated = lines.slice(keepFrom).join('\n') + '\n';
+
+  const logsDir = resolveLogsPath(worktreeRoot);
+  const tmpPath = logPath + '.' + randomUUID() + '.tmp';
+  validateResolvedPath(tmpPath, logsDir);
+
+  if (existsSync(tmpPath)) {
+    const tmpStat = lstatSync(tmpPath);
+    if (tmpStat.isSymbolicLink()) unlinkSync(tmpPath);
+  }
+
+  writeFileSync(tmpPath, rotated, { encoding: 'utf-8', mode: 0o600 });
+  renameSync(tmpPath, logPath);
+}


### PR DESCRIPTION
## Summary
- Add src/lib/event-logger.ts reusing audit-log.ts security patterns
- Opt-in via OMC_ENABLE_EVENT_LOG=1 — zero overhead when disabled
- Log skill executions and keyword detections to .omc/logs/events-{date}.jsonl

## Event types
- skill:execute — skill invocation with name, scope, args
- keyword:detect — magic keyword detection with position

## Test plan
- [ ] Events written with OMC_ENABLE_EVENT_LOG=1
- [ ] No file created or performance impact without env var
- [ ] File permissions 0o600

Generated with Claude Code