### PR TITLE
fix(stop-hook): allow terminal ralplan abort/handoff states to exit cleanly

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -157,6 +157,17 @@ const TEAM_TERMINAL_PHASES = new Set([
   "terminated",
   "done",
 ]);
+const RALPLAN_TERMINAL_PHASES = new Set([
+  "completed",
+  "complete",
+  "failed",
+  "cancelled",
+  "canceled",
+  "aborted",
+  "terminated",
+  "done",
+  "handoff",
+]);
 const TEAM_ACTIVE_PHASES = new Set([
   "team-plan",
   "team-prd",
@@ -200,6 +211,22 @@ function normalizeTeamPhase(state) {
   const phase = rawPhase.trim().toLowerCase();
   if (!phase || TEAM_TERMINAL_PHASES.has(phase)) return null;
   return TEAM_ACTIVE_PHASES.has(phase) ? phase : null;
+}
+
+function normalizeRalplanPhase(state) {
+  if (!state || typeof state !== "object") return null;
+
+  const rawPhase = state.current_phase ?? state.phase ?? state.status;
+  if (typeof rawPhase !== "string") return null;
+
+  const phase = rawPhase.trim().toLowerCase();
+  if (!phase) return null;
+
+  if (phase === "handoff" || phase.startsWith("handoff:") || phase.startsWith("handoff-")) {
+    return "handoff";
+  }
+
+  return phase;
 }
 
 function getSafeReinforcementCount(value) {
@@ -832,14 +859,10 @@ async function main() {
     // Priority 2.6: Ralplan (standalone consensus planning — first-class enforcement)
     if (ralplan.state?.active && !isAwaitingConfirmation(ralplan.state) && !isStaleState(ralplan.state) && isSessionMatch(ralplan.state, sessionId)) {
       // Terminal phase detection
-      const currentPhase = ralplan.state.current_phase;
-      let ralplanTerminal = false;
-      if (typeof currentPhase === "string") {
-        const terminal = ["complete", "completed", "failed", "cancelled", "canceled", "done"];
-        if (terminal.includes(currentPhase.toLowerCase())) {
-          writeStopBreaker(stateDir, "ralplan", 0, sessionId);
-          ralplanTerminal = true;
-        }
+      const currentPhase = normalizeRalplanPhase(ralplan.state);
+      const ralplanTerminal = currentPhase ? RALPLAN_TERMINAL_PHASES.has(currentPhase) : false;
+      if (ralplanTerminal) {
+        writeStopBreaker(stateDir, "ralplan", 0, sessionId);
       }
 
       if (!ralplanTerminal && !cancelInProgress) {

--- a/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
@@ -609,6 +609,45 @@ describe('ralplan standalone stop enforcement', () => {
     }
   });
 
+  it.each([
+    ['aborted'],
+    ['terminated'],
+    ['canceled'],
+    ['handoff'],
+  ])('allows stop when ralplan current_phase is %s', async (phase) => {
+    const sessionId = `session-ralplan-terminal-${phase}`;
+    const tempDir = makeTempProject();
+
+    try {
+      writeRalplanState(tempDir, sessionId, { current_phase: phase });
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('ralplan');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    [{ current_phase: undefined, phase: 'aborted' }, 'aborted'],
+    [{ current_phase: undefined, status: 'terminated' }, 'terminated'],
+    [{ current_phase: undefined, phase: 'handoff:ralph' }, 'handoff:ralph'],
+  ])('allows stop when ralplan terminal state is written via aliases: %s', async (overrides, _label) => {
+    const sessionId = 'session-ralplan-terminal-alias';
+    const tempDir = makeTempProject();
+
+    try {
+      writeRalplanState(tempDir, sessionId, overrides);
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('ralplan');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('returns mode=ralplan on circuit breaker path', async () => {
     const sessionId = 'session-ralplan-breaker-mode';
     const tempDir = makeTempProject();

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -316,6 +316,17 @@ export function recordIdleNotificationSent(stateDir: string, sessionId?: string)
 /** Max bytes to read from the tail of a transcript for architect approval detection. */
 const TRANSCRIPT_TAIL_BYTES = 32 * 1024; // 32 KB
 const CRITICAL_CONTEXT_STOP_PERCENT = 95;
+const RALPLAN_TERMINAL_PHASES = new Set([
+  'completed',
+  'complete',
+  'failed',
+  'cancelled',
+  'canceled',
+  'aborted',
+  'terminated',
+  'done',
+  'handoff',
+]);
 
 /**
  * Read the tail of a potentially large transcript file.
@@ -930,12 +941,37 @@ const RALPLAN_ACTIVE_AGENT_RECENCY_WINDOW_MS = 5_000;
 interface RalplanState {
   active: boolean;
   session_id?: string;
+  current_phase?: string;
+  phase?: string;
+  status?: string;
+}
+
+function getNormalizedRalplanPhase(state: Record<string, unknown> | null | undefined): string | null {
+  if (!state || typeof state !== 'object') {
+    return null;
+  }
+
+  const rawPhase = state.current_phase ?? state.phase ?? state.status;
+  if (typeof rawPhase !== 'string') {
+    return null;
+  }
+
+  const phase = rawPhase.trim().toLowerCase();
+  if (!phase) {
+    return null;
+  }
+
+  if (phase === 'handoff' || phase.startsWith('handoff:') || phase.startsWith('handoff-')) {
+    return 'handoff';
+  }
+
+  return phase;
 }
 
 /**
  * Check Ralplan state for standalone ralplan mode enforcement.
  * Ralplan state is written by the MCP state_write tool.
- * Only `active` and `session_id` are used for blocking decisions.
+ * `active`, `session_id`, and the normalized phase/status fields are used for blocking decisions.
  */
 async function checkRalplan(
   sessionId?: string,
@@ -959,13 +995,10 @@ async function checkRalplan(
   }
 
   // Terminal phase detection — allow stop when ralplan has completed
-  const currentPhase = (state as unknown as Record<string, unknown>).current_phase;
-  if (typeof currentPhase === 'string') {
-    const terminal = ['complete', 'completed', 'failed', 'cancelled', 'done'];
-    if (terminal.includes(currentPhase.toLowerCase())) {
-      writeStopBreaker(workingDir, 'ralplan', 0, sessionId);
-      return { shouldBlock: false, message: '', mode: 'ralplan' };
-    }
+  const currentPhase = getNormalizedRalplanPhase(state as unknown as Record<string, unknown>);
+  if (currentPhase && RALPLAN_TERMINAL_PHASES.has(currentPhase)) {
+    writeStopBreaker(workingDir, 'ralplan', 0, sessionId);
+    return { shouldBlock: false, message: '', mode: 'ralplan' };
   }
 
 

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -1018,6 +1018,30 @@ describe("Stop Hook Blocking Contract", () => {
       expect(output.continue).toBe(true);
     });
 
+    it.each([
+      [{ current_phase: "aborted" }, "ralplan-aborted-cjs"],
+      [{ phase: "terminated" }, "ralplan-terminated-phase-cjs"],
+      [{ status: "handoff:ralph" }, "ralplan-handoff-status-cjs"],
+    ])("allows stop for terminal ralplan state in cjs script: %s", (overrides, sessionId) => {
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ralplan-state.json"),
+        JSON.stringify({
+          active: true,
+          session_id: sessionId,
+          started_at: new Date().toISOString(),
+          ...overrides,
+        })
+      );
+
+      const output = runScript({
+        directory: tempDir,
+        sessionId,
+      });
+      expect(output.continue).toBe(true);
+    });
+
     it("deactivates ultrawork state when max reinforcements reached", () => {
       const sessionId = "ulw-max-reinforce-cjs";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);


### PR DESCRIPTION
## Summary
- normalize standalone ralplan phase handling across `current_phase`, `phase`, and `status`
- treat explicit terminal/handoff aliases (`aborted`, `terminated`, `canceled`, `cancelled`, `complete`, `completed`, `done`, `handoff`) as non-blocking for stop-hook enforcement
- add focused TS and shipped-CJS regression coverage for the reproduced misfire path

## Exact repro on current dev
From a clean worktree at `origin/dev` (`3f74a6d3`), this repro showed the bug before the fix:

```bash
npm exec -- tsx repro-issue-2447.ts
```

Observed before the fix:
- `aborted` -> `shouldBlock:true`
- `terminated` -> `shouldBlock:true`
- `canceled` -> `shouldBlock:true`
- `handoff` -> `shouldBlock:true`
- `cancelled` / `complete` already allowed stop

## Files changed
- `src/hooks/persistent-mode/index.ts`
- `scripts/persistent-mode.cjs`
- `src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts`
- `src/hooks/persistent-mode/stop-hook-blocking.test.ts`

## Verification
- `npm exec -- vitest run src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts`
- `npm exec -- vitest run src/hooks/persistent-mode/stop-hook-blocking.test.ts`
- `npm exec -- eslint src/hooks/persistent-mode/index.ts src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts`
- `npm exec -- tsc --noEmit`

Closes #2447.
