### PR TITLE
backport(team): use context-first tmux availability gating for startup

### DIFF
--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -60,6 +60,13 @@ describe('resolveLaunchPolicy', () => {
     expect(resolveLaunchPolicy({ CMUX_SURFACE_ID: 'C0D4B400-6C27-4957-BD01-32735B2251CD' })).toBe('direct');
   });
 
+  it('keeps inside-tmux authoritative even when tmux availability probing fails', () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error('tmux not found');
+    });
+    expect(resolveLaunchPolicy({ TMUX: '/tmp/tmux-501/default,1234,0' })).toBe('inside-tmux');
+  });
+
   it('prefers inside-tmux over cmux when both TMUX and CMUX_SURFACE_ID are set', () => {
     mockedExecFileSync.mockReturnValue('tmux 3.6a' as any);
     expect(resolveLaunchPolicy({

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -52,9 +52,6 @@ export function resolveLaunchPolicy(
   if (args.some((arg) => arg === '--print' || arg === '-p')) {
     return 'direct';
   }
-  if (!isTmuxAvailable()) {
-    return 'direct';
-  }
   if (env.TMUX) return 'inside-tmux';
   // Terminal emulators that embed their own multiplexer (e.g. cmux, a
   // Ghostty-based terminal) set CMUX_SURFACE_ID but not TMUX.  tmux
@@ -62,6 +59,9 @@ export function resolveLaunchPolicy(
   // not directly compatible, leaving orphaned detached sessions.
   // Fall back to direct mode so Claude launches without tmux wrapping.
   if (env.CMUX_SURFACE_ID) return 'direct';
+  if (!isTmuxAvailable()) {
+    return 'direct';
+  }
   return 'outside-tmux';
 }
 

--- a/src/team/__tests__/tmux-session-prereqs.test.ts
+++ b/src/team/__tests__/tmux-session-prereqs.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(),
+  };
+});
+
+import { execSync } from 'child_process';
+import { validateTmux } from '../tmux-session.js';
+
+const mockedExecSync = vi.mocked(execSync);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('validateTmux', () => {
+  it('skips probing when tmux context is already active', () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('should not probe');
+    });
+
+    expect(() => validateTmux(true)).not.toThrow();
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
+  it('probes tmux when context is absent', () => {
+    mockedExecSync.mockReturnValue(Buffer.from('tmux 3.4'));
+
+    expect(() => validateTmux(false)).not.toThrow();
+    expect(mockedExecSync).toHaveBeenCalledWith('tmux -V', expect.objectContaining({
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: 'pipe',
+    }));
+  });
+
+  it('throws install guidance when tmux is unavailable outside context', () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('tmux missing');
+    });
+
+    expect(() => validateTmux(false)).toThrow(/tmux is not available/i);
+  });
+});

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -505,7 +505,11 @@ export async function createTeamSession(
   const multiplexerContext = detectTeamMultiplexerContext();
   const inTmux = multiplexerContext === 'tmux';
   const useDedicatedWindow = Boolean(options.newWindow && inTmux);
-  validateTmux(inTmux);
+  if (inTmux) {
+    // Active tmux context is authoritative; skip the tmux -V probe to avoid
+    // false negatives when the binary is temporarily unavailable on PATH.
+    validateTmux(true);
+  }
 
   // Prefer the invoking pane from environment to avoid focus races when users
   // switch tmux windows during startup (issue #966).

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -364,7 +364,10 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
 }
 
 /** Validate tmux is available. Throws with install instructions if not. */
-export function validateTmux(): void {
+export function validateTmux(hasTmuxContext = false): void {
+  if (hasTmuxContext) {
+    return;
+  }
   try {
     execSync('tmux -V', { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' });
   } catch {
@@ -502,6 +505,7 @@ export async function createTeamSession(
   const multiplexerContext = detectTeamMultiplexerContext();
   const inTmux = multiplexerContext === 'tmux';
   const useDedicatedWindow = Boolean(options.newWindow && inTmux);
+  validateTmux(inTmux);
 
   // Prefer the invoking pane from environment to avoid focus races when users
   // switch tmux windows during startup (issue #966).

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -505,10 +505,8 @@ export async function createTeamSession(
   const multiplexerContext = detectTeamMultiplexerContext();
   const inTmux = multiplexerContext === 'tmux';
   const useDedicatedWindow = Boolean(options.newWindow && inTmux);
-  if (inTmux) {
-    // Active tmux context is authoritative; skip the tmux -V probe to avoid
-    // false negatives when the binary is temporarily unavailable on PATH.
-    validateTmux(true);
+  if (!inTmux) {
+    validateTmux();
   }
 
   // Prefer the invoking pane from environment to avoid focus races when users


### PR DESCRIPTION
## Summary
Backports the team startup hardening for #2449 so an already-active tmux leader context is treated as authoritative instead of failing purely on a brittle `tmux -V` probe.

## Verification
- `vitest run src/cli/__tests__/tmux-utils.test.ts src/team/__tests__/tmux-session-prereqs.test.ts`
- `eslint src/cli/tmux-utils.ts src/cli/__tests__/tmux-utils.test.ts src/team/tmux-session.ts src/team/__tests__/tmux-session-prereqs.test.ts`
- `tsc --noEmit --pretty false`

Closes #2449