### PR TITLE
backport(team): preserve team mode state until explicit shutdown

### DIFF
--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
+  buildTerminalCliResult,
   checkWatchdogFailedMarker,
   getTerminalStatus,
   writeResultArtifact,
@@ -207,6 +208,82 @@ describe('runtime-cli result artifact writer', () => {
       expect(readdirSync(jobsDir)).toEqual([]);
     } finally {
       rmSync(jobsDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runtime-cli terminal preservation helper', () => {
+  it('preserves team state for completed terminal output', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'runtime-cli-terminal-complete-'));
+    try {
+      const teamName = 'runtime-cli-preserve-complete';
+      const stateRoot = join(cwd, '.omc', 'state', 'team', teamName);
+      const tasksDir = join(stateRoot, 'tasks');
+      mkdirSync(tasksDir, { recursive: true });
+      writeFileSync(
+        join(tasksDir, '1.json'),
+        JSON.stringify({
+          id: '1',
+          status: 'completed',
+          result: 'PASS: complete without shutdown',
+        }),
+        'utf-8',
+      );
+
+      const result = buildTerminalCliResult(stateRoot, teamName, 'complete', 1, Date.now() - 1_000);
+
+      expect(existsSync(stateRoot)).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.output.status).toBe('completed');
+      expect(result.output.teamName).toBe(teamName);
+      expect(result.output.taskResults).toEqual([
+        {
+          taskId: '1',
+          status: 'completed',
+          summary: 'PASS: complete without shutdown',
+        },
+      ]);
+      expect(result.notice).toContain('preserving team state');
+      expect(result.notice).toContain(`omc team shutdown ${teamName}`);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports cancelled terminal phases without deleting team state', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'runtime-cli-terminal-cancelled-'));
+    try {
+      const teamName = 'runtime-cli-preserve-cancelled';
+      const stateRoot = join(cwd, '.omc', 'state', 'team', teamName);
+      const tasksDir = join(stateRoot, 'tasks');
+      mkdirSync(tasksDir, { recursive: true });
+      writeFileSync(
+        join(tasksDir, '1.json'),
+        JSON.stringify({
+          id: '1',
+          status: 'blocked',
+          summary: 'team stopped for inspection',
+        }),
+        'utf-8',
+      );
+
+      const result = buildTerminalCliResult(stateRoot, teamName, 'cancelled', 1, Date.now() - 1_000);
+
+      expect(existsSync(stateRoot)).toBe(true);
+      expect(result.exitCode).toBe(1);
+      expect(result.output.status).toBe('failed');
+      expect(result.output.teamName).toBe(teamName);
+      expect(result.output.taskResults).toEqual([
+        {
+          taskId: '1',
+          status: 'blocked',
+          summary: 'team stopped for inspection',
+        },
+      ]);
+      expect(result.notice).toContain('phase=cancelled');
+      expect(result.notice).toContain(`omc team shutdown ${teamName}`);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
     }
   });
 });

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -44,6 +44,14 @@ interface CliOutput {
   workerCount: number;
 }
 
+export type TerminalPhaseResult = 'complete' | 'failed' | 'cancelled';
+
+export interface TerminalCliResult {
+  output: CliOutput;
+  exitCode: number;
+  notice: string;
+}
+
 interface WatchdogFailedMarker {
   failedAt: string | number;
 }
@@ -127,6 +135,39 @@ export async function writeResultArtifact(
     'utf-8',
   );
   await rename(tmpPath, resultPath);
+}
+
+export function buildCliOutput(
+  stateRoot: string,
+  teamName: string,
+  status: 'completed' | 'failed',
+  workerCount: number,
+  startTimeMs: number,
+): CliOutput {
+  const taskResults = collectTaskResults(stateRoot);
+  const duration = (Date.now() - startTimeMs) / 1000;
+  return {
+    status,
+    teamName,
+    taskResults,
+    duration,
+    workerCount,
+  };
+}
+
+export function buildTerminalCliResult(
+  stateRoot: string,
+  teamName: string,
+  phase: TerminalPhaseResult,
+  workerCount: number,
+  startTimeMs: number,
+): TerminalCliResult {
+  const status = phase === 'complete' ? 'completed' : 'failed';
+  return {
+    output: buildCliOutput(stateRoot, teamName, status, workerCount, startTimeMs),
+    exitCode: status === 'completed' ? 0 : 1,
+    notice: `[runtime-cli] phase=${phase} reached terminal state; preserving team state for inspection. Run "omc team shutdown ${teamName}" when explicit cleanup is desired.\n`,
+  };
 }
 
 async function writePanesFile(
@@ -229,10 +270,6 @@ async function main(): Promise<void> {
   let finalStatus: 'completed' | 'failed' = 'failed';
   let pollActive = true;
 
-  function exitCodeFor(status: 'completed' | 'failed'): number {
-    return status === 'completed' ? 0 : 1;
-  }
-
   async function doShutdown(status: 'completed' | 'failed'): Promise<void> {
     pollActive = false;
     finalStatus = status;
@@ -242,10 +279,7 @@ async function main(): Promise<void> {
       runtime.stopWatchdog();
     }
 
-    // 2. Collect task results (watchdog is now stopped, no more writes to tasks/)
-    const taskResults = collectTaskResults(stateRoot);
-
-    // 3. Shutdown team
+    // 2. Shutdown team
     if (runtime) {
       try {
         if (useV2) {
@@ -266,14 +300,7 @@ async function main(): Promise<void> {
       }
     }
 
-    const duration = (Date.now() - startTime) / 1000;
-    const output: CliOutput = {
-      status: finalStatus,
-      teamName,
-      taskResults,
-      duration,
-      workerCount,
-    };
+    const output = buildCliOutput(stateRoot, teamName, finalStatus, workerCount, startTime);
     const finishedAt = new Date().toISOString();
 
     try {
@@ -282,11 +309,20 @@ async function main(): Promise<void> {
       process.stderr.write(`[runtime-cli] Failed to persist result artifact: ${err}\n`);
     }
 
-    // 4. Write result to stdout
+    // 3. Write result to stdout
     process.stdout.write(JSON.stringify(output) + '\n');
 
-    // 5. Exit
-    process.exit(exitCodeFor(status));
+    // 4. Exit
+    process.exit(status === 'completed' ? 0 : 1);
+  }
+
+  function exitWithoutShutdown(phase: TerminalPhaseResult): void {
+    pollActive = false;
+    finalStatus = phase === 'complete' ? 'completed' : 'failed';
+    const result = buildTerminalCliResult(stateRoot, teamName, phase, workerCount, startTime);
+    process.stderr.write(result.notice);
+    process.stdout.write(JSON.stringify(result.output) + '\n');
+    process.exit(result.exitCode);
   }
 
   // Register signal handlers before poll loop
@@ -423,6 +459,16 @@ async function main(): Promise<void> {
       }
       mismatchStreak = 0;
 
+      if (snap.phase === 'completed') {
+        exitWithoutShutdown('complete');
+        return;
+      }
+
+      if (snap.phase === 'failed') {
+        exitWithoutShutdown('failed');
+        return;
+      }
+
       if (snap.allTasksTerminal) {
         const hasFailures = snap.tasks.failed > 0;
         if (!hasFailures) {
@@ -438,13 +484,13 @@ async function main(): Promise<void> {
             process.stderr.write(
               `[runtime-cli/v2] Sentinel gate blocked: ${gateResult.blockers.join('; ')}\n`,
             );
-            await doShutdown('failed');
+            exitWithoutShutdown('failed');
             return;
           }
-          await doShutdown('completed');
+          exitWithoutShutdown('complete');
         } else {
           process.stderr.write('[runtime-cli/v2] Terminal failure detected from task counts\n');
-          await doShutdown('failed');
+          exitWithoutShutdown('failed');
         }
         return;
       }
@@ -549,7 +595,7 @@ async function main(): Promise<void> {
 
     if (deadWorkerFailure || fixingWithNoWorkers) {
       process.stderr.write(`[runtime-cli] Failure detected: deadWorkerFailure=${deadWorkerFailure} fixingWithNoWorkers=${fixingWithNoWorkers}\n`);
-      await doShutdown('failed');
+      exitWithoutShutdown('failed');
       return;
     }
   }


### PR DESCRIPTION
## Summary
Backports the #2450 team-state contract improvements so terminal completion/cancel paths preserve state until explicit shutdown instead of silently dropping it.

## Verification
- `./node_modules/.bin/vitest --run src/team/__tests__/runtime-cli.test.ts`
- `lsp_diagnostics src/team/runtime-cli.ts`
- `lsp_diagnostics src/team/__tests__/runtime-cli.test.ts`

Closes #2450