### PR TITLE
backport(stop-hook): ignore stale blocker-skill and mode-state false positives

### DIFF
--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -209,16 +209,18 @@ const TEAM_ACTIVE_PHASES = new Set([
 /**
  * Check if a state is stale based on its timestamps.
  * A state is considered stale if it hasn't been updated recently.
- * We check both `last_checked_at` and `started_at` - using whichever is more recent.
+ * We check `last_checked_at`, `updated_at`, and `started_at` - using whichever is more recent.
  */
 function isStaleState(state) {
   if (!state) return true;
 
-  const lastChecked = state.last_checked_at
-    ? new Date(state.last_checked_at).getTime()
-    : 0;
-  const startedAt = state.started_at ? new Date(state.started_at).getTime() : 0;
-  const mostRecent = Math.max(lastChecked, startedAt);
+  const timestamps = [state.last_checked_at, state.updated_at, state.started_at].filter(
+    (value) => typeof value === "string" && value.length > 0,
+  );
+  const mostRecent = timestamps.reduce((max, value) => {
+    const parsed = new Date(value).getTime();
+    return Number.isFinite(parsed) && parsed > max ? parsed : max;
+  }, 0);
 
   if (mostRecent === 0) return true; // No valid timestamps
 

--- a/src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts
@@ -163,6 +163,33 @@ describe('persistent-mode skill-state stop integration (issue #1033)', () => {
     }
   });
 
+  it('ignores stale legacy skill-active state when session id is unavailable', async () => {
+    const tempDir = makeTempProject();
+
+    try {
+      const stateDir = join(tempDir, '.omc', 'state');
+      mkdirSync(stateDir, { recursive: true });
+      const past = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+      writeFileSync(
+        join(stateDir, 'skill-active-state.json'),
+        JSON.stringify({
+          active: true,
+          skill_name: 'blocker-skill',
+          started_at: past,
+          last_checked_at: past,
+          reinforcement_count: 0,
+          max_reinforcements: 5,
+          stale_ttl_ms: 5 * 60 * 1000,
+        }, null, 2)
+      );
+
+      const result = await checkPersistentModes(undefined, tempDir);
+      expect(result.shouldBlock).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('respects session isolation for skill state', async () => {
     const sessionId = 'session-skill-1033-iso-a';
     const tempDir = makeTempProject();

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -1312,22 +1312,22 @@ export async function checkPersistentModes(
     }
   }
 
-  // Priority 1.7: Team Pipeline (standalone team mode)
-  // When team runs without ralph, this provides stop-hook blocking.
-  // When team runs with ralph, checkRalphLoop() handles it (Priority 1).
-  // Return ANY non-null result (including circuit breaker shouldBlock=false with message).
-  const teamResult = await checkTeamPipeline(sessionId, workingDir, cancelInProgress);
-  if (teamResult) {
-    return teamResult;
-  }
-
-  // Priority 1.8: Ralplan (standalone consensus planning)
+  // Priority 1.7: Ralplan (standalone consensus planning)
   // Ralplan consensus loops (Planner/Architect/Critic) need hard-blocking.
   // When ralplan runs under ralph, checkRalphLoop() handles it (Priority 1).
   // Return ANY non-null result (including circuit breaker shouldBlock=false with message).
   const ralplanResult = await checkRalplan(sessionId, workingDir, cancelInProgress);
   if (ralplanResult) {
     return ralplanResult;
+  }
+
+  // Priority 1.8: Team Pipeline (standalone team mode)
+  // When team runs without ralph, this provides stop-hook blocking.
+  // When team runs with ralph, checkRalphLoop() handles it (Priority 1).
+  // Return ANY non-null result (including circuit breaker shouldBlock=false with message).
+  const teamResult = await checkTeamPipeline(sessionId, workingDir, cancelInProgress);
+  if (teamResult) {
+    return teamResult;
   }
 
   // Priority 2: Ultrawork Mode (performance mode with persistence)

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -971,8 +971,17 @@ async function checkRalplan(
 ): Promise<PersistentModeResult | null> {
   const workingDir = resolveToWorktreeRoot(directory);
   const state = readModeState<RalplanState>('ralplan', workingDir, sessionId);
+  const stateRecord = state as any;
+  const hasTimestampFields = Boolean(
+    stateRecord &&
+    ['last_checked_at', 'updated_at', 'started_at'].some((key) =>
+      typeof stateRecord[key] === 'string' && String(stateRecord[key]).length > 0,
+    ),
+  );
 
-  if (!state || !state.active || isStaleState(state)) {
+  // Session-scoped ralplan state can legitimately omit timestamps in CI.
+  // Only apply stale-state suppression when a freshness timestamp exists.
+  if (!state || !state.active || (hasTimestampFields && isStaleState(state))) {
     return null;
   }
 

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -84,6 +84,7 @@ export interface PersistentModeResult {
 /** Maximum todo-continuation attempts before giving up (prevents infinite loops) */
 const MAX_TODO_CONTINUATION_ATTEMPTS = 5;
 const CANCEL_SIGNAL_TTL_MS = 30_000;
+const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
 
 /** Track todo-continuation attempts per session to prevent infinite loops */
 const todoContinuationAttempts = new Map<string, number>();
@@ -137,6 +138,32 @@ function isSessionCancelInProgress(directory: string, sessionId?: string): boole
   } catch {
     return false;
   }
+}
+
+/**
+ * Treat mode state as stale if it has not been refreshed recently.
+ * Stale files are ignored so they cannot falsely block new sessions.
+ * Uses the freshest of last_checked_at, updated_at, or started_at.
+ */
+function isStaleState(state: unknown): boolean {
+  if (!state || typeof state !== 'object') {
+    return true;
+  }
+
+  const stateRecord = state as Record<string, unknown>;
+  const timestamps = [stateRecord.last_checked_at, stateRecord.updated_at, stateRecord.started_at]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+  const mostRecent = timestamps.reduce((max, value) => {
+    const parsed = new Date(value).getTime();
+    return Number.isFinite(parsed) && parsed > max ? parsed : max;
+  }, 0);
+
+  if (mostRecent === 0) {
+    return true;
+  }
+
+  return Date.now() - mostRecent > STALE_STATE_THRESHOLD_MS;
 }
 
 /**
@@ -472,7 +499,7 @@ async function checkRalphLoop(
     ? resolveSessionStatePath('ralph', sessionId, workingDir)
     : resolveStatePath('ralph', workingDir);
 
-  if (!state || !state.active) {
+  if (!state || !state.active || isStaleState(state)) {
     return null;
   }
 
@@ -528,7 +555,7 @@ async function checkRalphLoop(
   // Check team pipeline state coordination
   // When team mode is active alongside ralph, respect team phase transitions
   const teamState = readTeamPipelineState(workingDir, sessionId);
-  if (teamState && teamState.active !== undefined) {
+  if (teamState && teamState.active !== undefined && !isStaleState(teamState)) {
     const teamPhase: TeamPipelinePhase = teamState.phase;
 
     // If team pipeline reached a terminal state, ralph should also complete
@@ -945,7 +972,7 @@ async function checkRalplan(
   const workingDir = resolveToWorktreeRoot(directory);
   const state = readModeState<RalplanState>('ralplan', workingDir, sessionId);
 
-  if (!state || !state.active) {
+  if (!state || !state.active || isStaleState(state)) {
     return null;
   }
 
@@ -1050,7 +1077,7 @@ async function checkUltrawork(
   const workingDir = resolveToWorktreeRoot(directory);
   const state = readUltraworkState(workingDir, sessionId);
 
-  if (!state || !state.active) {
+  if (!state || !state.active || isStaleState(state)) {
     return null;
   }
 

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -43,6 +43,16 @@ function writeSubagentTrackingState(
   );
 }
 
+function writeLegacyModeState(
+  tempDir: string,
+  fileName: string,
+  state: Record<string, unknown>,
+): void {
+  const stateDir = join(tempDir, ".omc", "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(join(stateDir, fileName), JSON.stringify(state, null, 2));
+}
+
 describe("Stop Hook Blocking Contract", () => {
   describe("createHookOutput", () => {
     it("returns continue: false when shouldBlock is true", () => {
@@ -373,6 +383,22 @@ describe("Stop Hook Blocking Contract", () => {
       expect(output.message).toContain("RALPH");
     });
 
+    it("ignores stale legacy ralph state when no session is provided", async () => {
+      const staleAt = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      writeLegacyModeState(tempDir, "ralph-state.json", {
+        active: true,
+        iteration: 1,
+        max_iterations: 50,
+        started_at: staleAt,
+        last_checked_at: staleAt,
+        prompt: "Stale legacy ralph task",
+      });
+
+      const result = await checkPersistentModes(undefined, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe("none");
+    });
+
     it("blocks stop for active skill state", async () => {
       const sessionId = "test-skill-block";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
@@ -496,6 +522,21 @@ describe("Stop Hook Blocking Contract", () => {
 
       const output = runScript({ directory: tempDir, sessionId });
       expect(output.decision).toBe("block");
+    });
+
+    it("returns continue: true for stale legacy ultrawork state without a session", () => {
+      const staleAt = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+      writeLegacyModeState(tempDir, "ultrawork-state.json", {
+        active: true,
+        started_at: staleAt,
+        original_prompt: "Stale legacy ultrawork task",
+        reinforcement_count: 0,
+        last_checked_at: staleAt,
+      });
+
+      const output = runScript({ directory: tempDir });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
     });
 
     it("returns continue: true for context limit stop", () => {

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -164,16 +164,18 @@ const TEAM_ACTIVE_PHASES = new Set([
 /**
  * Check if a state is stale based on its timestamps.
  * A state is considered stale if it hasn't been updated recently.
- * We check both `last_checked_at` and `started_at` - using whichever is more recent.
+ * We check `last_checked_at`, `updated_at`, and `started_at` - using whichever is more recent.
  */
 function isStaleState(state) {
   if (!state) return true;
 
-  const lastChecked = state.last_checked_at
-    ? new Date(state.last_checked_at).getTime()
-    : 0;
-  const startedAt = state.started_at ? new Date(state.started_at).getTime() : 0;
-  const mostRecent = Math.max(lastChecked, startedAt);
+  const timestamps = [state.last_checked_at, state.updated_at, state.started_at].filter(
+    (value) => typeof value === "string" && value.length > 0,
+  );
+  const mostRecent = timestamps.reduce((max, value) => {
+    const parsed = new Date(value).getTime();
+    return Number.isFinite(parsed) && parsed > max ? parsed : max;
+  }, 0);
 
   if (mostRecent === 0) return true; // No valid timestamps
 


### PR DESCRIPTION
## Summary
Backports #2451 stale-state hardening so stale blocker-skill and workflow mode files no longer block fresh sessions while active sessions remain protected.

## Verification
- `node --check scripts/persistent-mode.mjs`
- `node --check templates/hooks/persistent-mode.mjs`
- `npx eslint src/hooks/persistent-mode/index.ts src/hooks/persistent-mode/stop-hook-blocking.test.ts src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts`
- `npx vitest run src/hooks/persistent-mode/stop-hook-blocking.test.ts src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts`
- `npx tsc --noEmit --pretty false`

Closes #2451