### PR TITLE
backport(hud): self-heal session state after prompt-submit and pane drift

### DIFF
--- a/src/__tests__/background-cleanup-directory.test.ts
+++ b/src/__tests__/background-cleanup-directory.test.ts
@@ -28,7 +28,7 @@ describe('background-cleanup directory propagation', () => {
 
     await cleanupStaleBackgroundTasks(undefined, '/custom/project/dir');
 
-    expect(readHudStateMock).toHaveBeenCalledWith('/custom/project/dir');
+    expect(readHudStateMock).toHaveBeenCalledWith('/custom/project/dir', undefined);
   });
 
   it('cleanupStaleBackgroundTasks should pass directory to writeHudState when cleaning', async () => {
@@ -43,7 +43,8 @@ describe('background-cleanup directory propagation', () => {
 
     expect(writeHudStateMock).toHaveBeenCalledWith(
       expect.objectContaining({ backgroundTasks: expect.any(Array) }),
-      '/custom/project/dir'
+      '/custom/project/dir',
+      undefined
     );
   });
 
@@ -52,7 +53,7 @@ describe('background-cleanup directory propagation', () => {
 
     await markOrphanedTasksAsStale('/custom/project/dir');
 
-    expect(readHudStateMock).toHaveBeenCalledWith('/custom/project/dir');
+    expect(readHudStateMock).toHaveBeenCalledWith('/custom/project/dir', undefined);
   });
 
   it('markOrphanedTasksAsStale should pass directory to writeHudState when marking', async () => {
@@ -67,7 +68,8 @@ describe('background-cleanup directory propagation', () => {
 
     expect(writeHudStateMock).toHaveBeenCalledWith(
       expect.objectContaining({ backgroundTasks: expect.any(Array) }),
-      '/custom/project/dir'
+      '/custom/project/dir',
+      undefined
     );
   });
 
@@ -75,10 +77,10 @@ describe('background-cleanup directory propagation', () => {
     readHudStateMock.mockReturnValue(null);
 
     await cleanupStaleBackgroundTasks();
-    expect(readHudStateMock).toHaveBeenCalledWith(undefined);
+    expect(readHudStateMock).toHaveBeenCalledWith(undefined, undefined);
 
     readHudStateMock.mockReset();
     await markOrphanedTasksAsStale();
-    expect(readHudStateMock).toHaveBeenCalledWith(undefined);
+    expect(readHudStateMock).toHaveBeenCalledWith(undefined, undefined);
   });
 });

--- a/src/__tests__/delegation-enforcement-levels.test.ts
+++ b/src/__tests__/delegation-enforcement-levels.test.ts
@@ -582,7 +582,8 @@ describe('delegation-enforcement-levels', () => {
         expect.stringContaining('task-'),
         'Test task',
         'executor',
-        process.cwd()
+        process.cwd(),
+        undefined
       );
     });
   });

--- a/src/__tests__/hud/background-tasks.test.ts
+++ b/src/__tests__/hud/background-tasks.test.ts
@@ -96,7 +96,7 @@ describe('background-tasks', () => {
 
       clearBackgroundTasks('/some/dir');
 
-      expect(mockReadHudState).toHaveBeenCalledWith('/some/dir');
+      expect(mockReadHudState).toHaveBeenCalledWith('/some/dir', undefined);
       const writtenState = mockWriteHudState.mock.calls[0][0];
       expect(writtenState.sessionStartTimestamp).toBe(sessionStart);
       expect(writtenState.sessionId).toBe('dir-session');

--- a/src/__tests__/hud/session-state.test.ts
+++ b/src/__tests__/hud/session-state.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let rootDir = '';
+
+vi.mock('../../lib/worktree-paths.js', () => ({
+  validateWorkingDirectory: (workingDirectory?: string) => workingDirectory ?? rootDir,
+  getOmcRoot: (worktreeRoot?: string) => join(worktreeRoot ?? rootDir, '.omc'),
+  ensureSessionStateDir: (sessionId: string, worktreeRoot?: string) => {
+    const sessionDir = join(worktreeRoot ?? rootDir, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    return sessionDir;
+  },
+  resolveSessionStatePath: (stateName: string, sessionId: string, worktreeRoot?: string) => {
+    const normalizedName = stateName.endsWith('-state') ? stateName : `${stateName}-state`;
+    return join(worktreeRoot ?? rootDir, '.omc', 'state', 'sessions', sessionId, `${normalizedName}.json`);
+  },
+}));
+
+import { readHudState, writeHudState } from '../../hud/state.js';
+
+describe('HUD session-scoped state', () => {
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'hud-session-state-'));
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('writes HUD state into the current session directory and clears stale root fallback', () => {
+    const staleRootDir = join(rootDir, '.omc');
+    mkdirSync(staleRootDir, { recursive: true });
+    writeFileSync(
+      join(staleRootDir, 'hud-state.json'),
+      JSON.stringify({ timestamp: '2024-01-01T00:00:00.000Z', sessionId: 'session-123', backgroundTasks: [] }),
+    );
+
+    const result = writeHudState(
+      {
+        timestamp: new Date().toISOString(),
+        backgroundTasks: [],
+      },
+      rootDir,
+      'session-123',
+    );
+
+    expect(result).toBe(true);
+
+    const sessionFile = join(rootDir, '.omc', 'state', 'sessions', 'session-123', 'hud-state.json');
+    expect(existsSync(sessionFile)).toBe(true);
+    expect(existsSync(join(rootDir, '.omc', 'hud-state.json'))).toBe(false);
+
+    const written = JSON.parse(readFileSync(sessionFile, 'utf-8')) as { sessionId?: string };
+    expect(written.sessionId).toBe('session-123');
+  });
+
+  it('reads only the session-scoped HUD state when a sessionId is provided', () => {
+    mkdirSync(join(rootDir, '.omc', 'state'), { recursive: true });
+    writeFileSync(
+      join(rootDir, '.omc', 'state', 'hud-state.json'),
+      JSON.stringify({ timestamp: '2024-01-01T00:00:00.000Z', backgroundTasks: [{ id: 'stale-root' }] }),
+    );
+    writeFileSync(
+      join(rootDir, '.omc', 'hud-state.json'),
+      JSON.stringify({ timestamp: '2024-01-01T00:00:00.000Z', backgroundTasks: [{ id: 'legacy-root' }] }),
+    );
+    mkdirSync(join(rootDir, '.omc', 'state', 'sessions', 'session-999'), { recursive: true });
+    writeFileSync(
+      join(rootDir, '.omc', 'state', 'sessions', 'session-999', 'hud-state.json'),
+      JSON.stringify({ timestamp: '2024-01-02T00:00:00.000Z', backgroundTasks: [{ id: 'session-state' }], sessionId: 'session-999' }),
+    );
+
+    const sessionState = readHudState(rootDir, 'session-999');
+    expect(sessionState?.backgroundTasks).toEqual([{ id: 'session-state' }]);
+    expect(sessionState?.sessionId).toBe('session-999');
+  });
+
+  it('does not revive root HUD state when the current session-scoped file is missing', () => {
+    mkdirSync(join(rootDir, '.omc', 'state'), { recursive: true });
+    writeFileSync(
+      join(rootDir, '.omc', 'state', 'hud-state.json'),
+      JSON.stringify({ timestamp: '2024-01-01T00:00:00.000Z', backgroundTasks: [{ id: 'stale-root' }] }),
+    );
+    writeFileSync(
+      join(rootDir, '.omc', 'hud-state.json'),
+      JSON.stringify({ timestamp: '2024-01-01T00:00:00.000Z', backgroundTasks: [{ id: 'legacy-root' }] }),
+    );
+
+    expect(readHudState(rootDir, 'session-missing')).toBeNull();
+  });
+});

--- a/src/__tests__/hud/watch-mode-init.test.ts
+++ b/src/__tests__/hud/watch-mode-init.test.ts
@@ -163,7 +163,7 @@ describe('HUD watch mode initialization', () => {
     await hud.main(true, false);
 
     // initializeHUDState must receive the resolved cwd from stdin, not undefined/process.cwd()
-    expect(initializeHUDState).toHaveBeenCalledWith('/tmp/worktree');
+    expect(initializeHUDState).toHaveBeenCalledWith('/tmp/worktree', undefined);
   });
 
   it('passes the current session id to OMC state readers', async () => {

--- a/src/hooks/__tests__/background-process-guard.test.ts
+++ b/src/hooks/__tests__/background-process-guard.test.ts
@@ -101,6 +101,7 @@ describe('Background Process Guard (issue #302)', () => {
         'test task',
         'executor',
         resolvedDirectory,
+        'test-session',
       );
     });
 
@@ -165,6 +166,7 @@ describe('Background Process Guard (issue #302)', () => {
         'test task',
         'executor',
         resolvedDirectory,
+        'test-session',
       );
     });
 
@@ -190,6 +192,7 @@ describe('Background Process Guard (issue #302)', () => {
         'inspect code',
         'explore',
         resolvedDirectory,
+        'test-session',
       );
     });
 
@@ -274,6 +277,7 @@ describe('Background Process Guard (issue #302)', () => {
         'background executor task',
         'executor',
         resolvedDirectory,
+        'test-session',
       );
     });
 
@@ -296,6 +300,7 @@ describe('Background Process Guard (issue #302)', () => {
         'foreground task',
         'executor',
         resolvedDirectory,
+        'test-session',
       );
     });
 
@@ -318,6 +323,7 @@ describe('Background Process Guard (issue #302)', () => {
         'tool-use-bg-2',
         'a8de3dd',
         resolvedDirectory,
+        'test-session',
       );
       expect(mockedCompleteBackgroundTask).not.toHaveBeenCalled();
       expect(mockedRemapMostRecentMatchingBackgroundTaskId).not.toHaveBeenCalled();
@@ -342,6 +348,7 @@ describe('Background Process Guard (issue #302)', () => {
         'tool-use-bg-3',
         resolvedDirectory,
         true,
+        'test-session',
       );
     });
 
@@ -359,6 +366,7 @@ describe('Background Process Guard (issue #302)', () => {
         'a8de3dd',
         resolvedDirectory,
         false,
+        'test-session',
       );
     });
 
@@ -376,6 +384,7 @@ describe('Background Process Guard (issue #302)', () => {
         'a8de3dd',
         resolvedDirectory,
         true,
+        'test-session',
       );
     });
 
@@ -398,6 +407,7 @@ describe('Background Process Guard (issue #302)', () => {
         resolvedDirectory,
         false,
         'executor',
+        'test-session',
       );
     });
   });

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -777,13 +777,13 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
 
   // Record prompt submission time in HUD state
   try {
-    const hudState = readHudState(directory) || {
+    const hudState = readHudState(directory, input.sessionId) || {
       timestamp: new Date().toISOString(),
       backgroundTasks: [],
     };
     hudState.lastPromptTimestamp = new Date().toISOString();
     hudState.timestamp = new Date().toISOString();
-    writeHudState(hudState, directory);
+    writeHudState(hudState, directory, input.sessionId);
   } catch {
     // Silent failure - don't break keyword detection
   }
@@ -1796,7 +1796,7 @@ function processPreToolUse(input: HookInput): HookOutput {
     if (toolInput?.run_in_background) {
       const config = loadConfig();
       const maxBgTasks = config.permissions?.maxBackgroundTasks ?? 5;
-      const runningCount = getRunningTaskCount(directory);
+      const runningCount = getRunningTaskCount(directory, input.sessionId);
 
       if (runningCount >= maxBgTasks) {
         return {
@@ -1829,6 +1829,7 @@ function processPreToolUse(input: HookInput): HookOutput {
         toolInput.description,
         toolInput.subagent_type,
         directory,
+        input.sessionId,
       );
     }
   }
@@ -2031,25 +2032,27 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
 
     if (asyncAgentId) {
       if (toolUseId) {
-        remapBackgroundTaskId(toolUseId, asyncAgentId, directory);
+        remapBackgroundTaskId(toolUseId, asyncAgentId, directory, input.sessionId);
       } else if (description) {
         remapMostRecentMatchingBackgroundTaskId(
           description,
           asyncAgentId,
           directory,
           agentType,
+          input.sessionId,
         );
       }
     } else {
       const failed = taskLaunchDidFail(input.toolOutput);
       if (toolUseId) {
-        completeBackgroundTask(toolUseId, directory, failed);
+        completeBackgroundTask(toolUseId, directory, failed, input.sessionId);
       } else if (description) {
         completeMostRecentMatchingBackgroundTask(
           description,
           directory,
           failed,
           agentType,
+          input.sessionId,
         );
       }
     }
@@ -2066,12 +2069,13 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
   if (input.toolName === "TaskOutput") {
     const taskOutput = parseTaskOutputLifecycle(input.toolOutput);
     if (taskOutput) {
-      completeBackgroundTask(
-        taskOutput.taskId,
-        directory,
-        taskOutputDidFail(taskOutput.status),
-      );
-    }
+    completeBackgroundTask(
+      taskOutput.taskId,
+      directory,
+      taskOutputDidFail(taskOutput.status),
+      input.sessionId,
+    );
+  }
   }
 
   // Wake OpenClaw gateway for post-tool-use (non-blocking, fires for all tools).

--- a/src/hud/background-cleanup.ts
+++ b/src/hud/background-cleanup.ts
@@ -28,9 +28,10 @@ function getTaskStartMs(task: BackgroundTask): number {
  */
 export async function cleanupStaleBackgroundTasks(
   thresholdMs: number = STALE_TASK_THRESHOLD_MS,
-  directory?: string
+  directory?: string,
+  sessionId?: string
 ): Promise<number> {
-  const state = readHudState(directory);
+  const state = readHudState(directory, sessionId);
 
   if (!state || !state.backgroundTasks) {
     return 0;
@@ -92,7 +93,7 @@ export async function cleanupStaleBackgroundTasks(
 
   if (removedCount > 0 || statusChanged) {
     state.timestamp = new Date().toISOString();
-    writeHudState(state, directory);
+    writeHudState(state, directory, sessionId);
   }
 
   return removedCount;
@@ -104,8 +105,11 @@ export async function cleanupStaleBackgroundTasks(
  *
  * @returns Array of orphaned tasks
  */
-export async function detectOrphanedTasks(directory?: string): Promise<BackgroundTask[]> {
-  const state = readHudState(directory);
+export async function detectOrphanedTasks(
+  directory?: string,
+  sessionId?: string,
+): Promise<BackgroundTask[]> {
+  const state = readHudState(directory, sessionId);
 
   if (!state || !state.backgroundTasks) {
     return [];
@@ -136,14 +140,17 @@ export async function detectOrphanedTasks(directory?: string): Promise<Backgroun
  *
  * @returns Number of tasks marked
  */
-export async function markOrphanedTasksAsStale(directory?: string): Promise<number> {
-  const state = readHudState(directory);
+export async function markOrphanedTasksAsStale(
+  directory?: string,
+  sessionId?: string,
+): Promise<number> {
+  const state = readHudState(directory, sessionId);
 
   if (!state || !state.backgroundTasks) {
     return 0;
   }
 
-  const orphaned = await detectOrphanedTasks(directory);
+  const orphaned = await detectOrphanedTasks(directory, sessionId);
   let marked = 0;
 
   for (const orphanedTask of orphaned) {
@@ -155,7 +162,7 @@ export async function markOrphanedTasksAsStale(directory?: string): Promise<numb
   }
 
   if (marked > 0) {
-    writeHudState(state, directory);
+    writeHudState(state, directory, sessionId);
   }
 
   return marked;

--- a/src/hud/background-tasks.ts
+++ b/src/hud/background-tasks.ts
@@ -19,10 +19,11 @@ export function addBackgroundTask(
   id: string,
   description: string,
   agentType?: string,
-  directory?: string
+  directory?: string,
+  sessionId?: string
 ): boolean {
   try {
-    let state = readHudState(directory) || createEmptyHudState();
+    let state = readHudState(directory, sessionId) || createEmptyHudState();
 
     // Clean up old/expired tasks
     state = cleanupTasks(state);
@@ -39,7 +40,7 @@ export function addBackgroundTask(
     state.backgroundTasks.push(task);
     state.timestamp = new Date().toISOString();
 
-    return writeHudState(state, directory);
+    return writeHudState(state, directory, sessionId);
   } catch {
     return false;
   }
@@ -52,10 +53,11 @@ export function addBackgroundTask(
 export function completeBackgroundTask(
   id: string,
   directory?: string,
-  failed: boolean = false
+  failed: boolean = false,
+  sessionId?: string
 ): boolean {
   try {
-    const state = readHudState(directory);
+    const state = readHudState(directory, sessionId);
     if (!state) {
       return false;
     }
@@ -69,7 +71,7 @@ export function completeBackgroundTask(
     task.completedAt = new Date().toISOString();
     state.timestamp = new Date().toISOString();
 
-    return writeHudState(state, directory);
+    return writeHudState(state, directory, sessionId);
   } catch {
     return false;
   }
@@ -82,14 +84,15 @@ export function completeBackgroundTask(
 export function remapBackgroundTaskId(
   currentId: string,
   nextId: string,
-  directory?: string
+  directory?: string,
+  sessionId?: string
 ): boolean {
   try {
     if (currentId === nextId) {
       return true;
     }
 
-    const state = readHudState(directory);
+    const state = readHudState(directory, sessionId);
     if (!state) {
       return false;
     }
@@ -107,7 +110,7 @@ export function remapBackgroundTaskId(
     task.id = nextId;
     state.timestamp = new Date().toISOString();
 
-    return writeHudState(state, directory);
+    return writeHudState(state, directory, sessionId);
   } catch {
     return false;
   }
@@ -131,10 +134,11 @@ export function completeMostRecentMatchingBackgroundTask(
   description: string,
   directory?: string,
   failed: boolean = false,
-  agentType?: string
+  agentType?: string,
+  sessionId?: string
 ): boolean {
   try {
-    const state = readHudState(directory);
+    const state = readHudState(directory, sessionId);
     if (!state) {
       return false;
     }
@@ -148,7 +152,7 @@ export function completeMostRecentMatchingBackgroundTask(
     task.completedAt = new Date().toISOString();
     state.timestamp = new Date().toISOString();
 
-    return writeHudState(state, directory);
+    return writeHudState(state, directory, sessionId);
   } catch {
     return false;
   }
@@ -158,10 +162,11 @@ export function remapMostRecentMatchingBackgroundTaskId(
   description: string,
   nextId: string,
   directory?: string,
-  agentType?: string
+  agentType?: string,
+  sessionId?: string
 ): boolean {
   try {
-    const state = readHudState(directory);
+    const state = readHudState(directory, sessionId);
     if (!state) {
       return false;
     }
@@ -179,7 +184,7 @@ export function remapMostRecentMatchingBackgroundTaskId(
     task.id = nextId;
     state.timestamp = new Date().toISOString();
 
-    return writeHudState(state, directory);
+    return writeHudState(state, directory, sessionId);
   } catch {
     return false;
   }
@@ -231,8 +236,8 @@ function cleanupTasks(state: OmcHudState): OmcHudState {
 /**
  * Get count of running background tasks.
  */
-export function getRunningTaskCount(directory?: string): number {
-  const state = readHudState(directory);
+export function getRunningTaskCount(directory?: string, sessionId?: string): number {
+  const state = readHudState(directory, sessionId);
   if (!state) return 0;
 
   return state.backgroundTasks.filter((t) => t.status === 'running').length;
@@ -242,16 +247,16 @@ export function getRunningTaskCount(directory?: string): number {
  * Clear all background tasks.
  * Useful for cleanup or reset.
  */
-export function clearBackgroundTasks(directory?: string): boolean {
+export function clearBackgroundTasks(directory?: string, sessionId?: string): boolean {
   try {
     // Read existing state to preserve session fields (sessionStartTimestamp, sessionId)
-    const existing = readHudState(directory);
+    const existing = readHudState(directory, sessionId);
     const state = createEmptyHudState();
     if (existing) {
       state.sessionStartTimestamp = existing.sessionStartTimestamp;
       state.sessionId = existing.sessionId;
     }
-    return writeHudState(state, directory);
+    return writeHudState(state, directory, sessionId);
   } catch {
     return false;
   }

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -258,12 +258,6 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
 
     const cwd = resolveToWorktreeRoot(stdin.cwd || undefined);
 
-    // Initialize HUD state (cleanup stale/orphaned tasks)
-    // Must happen after cwd resolution so cleanup targets the correct project directory
-    if (!skipInit) {
-      await initializeHUDState(cwd);
-    }
-
     // Read configuration (before transcript parsing so we can use staleTaskThresholdMinutes)
     // Clone to avoid mutating shared DEFAULT_HUD_CONFIG when applying runtime width detection
     const config = { ...readHudConfig() };
@@ -297,6 +291,12 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       resolvedTranscriptPath ?? stdin.transcript_path ?? "",
     );
 
+    // Initialize HUD state (cleanup stale/orphaned tasks)
+    // Must happen after cwd resolution so cleanup targets the correct project directory
+    if (!skipInit) {
+      await initializeHUDState(cwd, currentSessionId ?? undefined);
+    }
+
     // Read OMC state files
     const ralph = readRalphStateForHud(cwd, currentSessionId ?? undefined);
     const ultrawork = readUltraworkStateForHud(
@@ -310,7 +310,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     );
 
     // Read HUD state for background tasks
-    const hudState = readHudState(cwd);
+    const hudState = readHudState(cwd, currentSessionId ?? undefined);
     const _backgroundTasks = hudState?.backgroundTasks || [];
 
     // Persist session start time to survive tail-parsing resets (#528)
@@ -336,7 +336,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       stateToWrite.sessionStartTimestamp = sessionStart.toISOString();
       stateToWrite.sessionId = currentSessionId ?? undefined;
       stateToWrite.timestamp = new Date().toISOString();
-      writeHudState(stateToWrite, cwd);
+      writeHudState(stateToWrite, cwd, currentSessionId ?? undefined);
     }
 
     // Fetch rate limits from OAuth API (if available)

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -5,10 +5,15 @@
  * Follows patterns from ultrawork-state.
  */
 
-import { existsSync, readFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, mkdirSync, unlinkSync } from "fs";
 import { join } from "path";
 import { getClaudeConfigDir } from "../utils/config-dir.js";
-import { validateWorkingDirectory, getOmcRoot } from "../lib/worktree-paths.js";
+import {
+  validateWorkingDirectory,
+  getOmcRoot,
+  ensureSessionStateDir,
+  resolveSessionStatePath,
+} from "../lib/worktree-paths.js";
 import {
   atomicWriteFileSync,
   atomicWriteJsonSync,
@@ -39,6 +44,19 @@ function getLocalStateFilePath(directory?: string): string {
   const baseDir = validateWorkingDirectory(directory);
   const omcStateDir = join(getOmcRoot(baseDir), "state");
   return join(omcStateDir, "hud-state.json");
+}
+
+function getLegacyRootStateFilePath(directory?: string): string {
+  const baseDir = validateWorkingDirectory(directory);
+  return join(getOmcRoot(baseDir), "hud-state.json");
+}
+
+function getStateFilePath(directory?: string, sessionId?: string): string {
+  const baseDir = validateWorkingDirectory(directory);
+  if (sessionId) {
+    return resolveSessionStatePath("hud", sessionId, baseDir);
+  }
+  return getLocalStateFilePath(baseDir);
 }
 
 /**
@@ -145,6 +163,14 @@ function ensureStateDir(directory?: string): void {
   }
 }
 
+function ensureHudStateDir(directory?: string, sessionId?: string): void {
+  if (sessionId) {
+    ensureSessionStateDir(sessionId, validateWorkingDirectory(directory));
+    return;
+  }
+  ensureStateDir(directory);
+}
+
 type HudConfigInput = Omit<
   Partial<HudConfig>,
   "elements" | "thresholds" | "contextLimitWarning" | "missionBoard"
@@ -162,7 +188,31 @@ type HudConfigInput = Omit<
 /**
  * Read HUD state from disk (checks new local and legacy local only)
  */
-export function readHudState(directory?: string): OmcHudState | null {
+export function readHudState(
+  directory?: string,
+  sessionId?: string,
+): OmcHudState | null {
+  // Session-scoped HUD state should never fall back to root/legacy files.
+  // This prevents a stale root state from being revived after a pane/session
+  // recreation when the current session has already been identified.
+  if (sessionId) {
+    const sessionStateFile = getStateFilePath(directory, sessionId);
+    if (!existsSync(sessionStateFile)) {
+      return null;
+    }
+
+    try {
+      const content = readFileSync(sessionStateFile, "utf-8");
+      return JSON.parse(content);
+    } catch (error) {
+      console.error(
+        "[HUD] Failed to read session state:",
+        error instanceof Error ? error.message : error,
+      );
+      return null;
+    }
+  }
+
   // Check new local state first (.omc/state/hud-state.json)
   const localStateFile = getLocalStateFilePath(directory);
   if (existsSync(localStateFile)) {
@@ -179,8 +229,7 @@ export function readHudState(directory?: string): OmcHudState | null {
   }
 
   // Check legacy local state (.omc/hud-state.json)
-  const baseDir = validateWorkingDirectory(directory);
-  const legacyStateFile = join(getOmcRoot(baseDir), "hud-state.json");
+  const legacyStateFile = getLegacyRootStateFilePath(directory);
   if (existsSync(legacyStateFile)) {
     try {
       const content = readFileSync(legacyStateFile, "utf-8");
@@ -200,12 +249,38 @@ export function readHudState(directory?: string): OmcHudState | null {
 /**
  * Write HUD state to disk (local only)
  */
-export function writeHudState(state: OmcHudState, directory?: string): boolean {
+export function writeHudState(
+  state: OmcHudState,
+  directory?: string,
+  sessionId?: string,
+): boolean {
   try {
-    // Write to local .omc/state only
-    ensureStateDir(directory);
-    const localStateFile = getLocalStateFilePath(directory);
-    atomicWriteJsonSync(localStateFile, state);
+    // Write to the session-scoped file when the current session is known,
+    // otherwise keep the legacy local path for backwards compatibility.
+    ensureHudStateDir(directory, sessionId);
+    const stateFile = getStateFilePath(directory, sessionId);
+    const nextState = sessionId ? { ...state, sessionId } : state;
+    atomicWriteJsonSync(stateFile, nextState);
+
+    if (sessionId) {
+      const legacyCandidates = [
+        getLegacyRootStateFilePath(directory),
+      ];
+      for (const legacyFile of legacyCandidates) {
+        if (!existsSync(legacyFile)) {
+          continue;
+        }
+        try {
+          const content = readFileSync(legacyFile, "utf-8");
+          const legacyState = JSON.parse(content) as Partial<OmcHudState>;
+          if (!legacyState.sessionId || legacyState.sessionId === sessionId) {
+            unlinkSync(legacyFile);
+          }
+        } catch {
+          // Best-effort ghost cleanup only.
+        }
+      }
+    }
 
     return true;
   } catch (error) {
@@ -416,10 +491,13 @@ export function applyPreset(preset: HudConfig["preset"]): HudConfig {
  * Initialize HUD state with cleanup of stale/orphaned tasks.
  * Should be called on HUD startup.
  */
-export async function initializeHUDState(directory?: string): Promise<void> {
+export async function initializeHUDState(
+  directory?: string,
+  sessionId?: string,
+): Promise<void> {
   // Clean up stale background tasks from previous sessions
-  const removedStale = await cleanupStaleBackgroundTasks(undefined, directory);
-  const markedOrphaned = await markOrphanedTasksAsStale(directory);
+  const removedStale = await cleanupStaleBackgroundTasks(undefined, directory, sessionId);
+  const markedOrphaned = await markOrphanedTasksAsStale(directory, sessionId);
 
   if (removedStale > 0 || markedOrphaned > 0) {
     console.error(


### PR DESCRIPTION
## Summary
Backports #2452 HUD self-healing so recreated/session-shifted panes restore the correct session-scoped HUD state instead of reviving stale root state.

## Verification
- `npx vitest run src/__tests__/hud/session-state.test.ts src/__tests__/hud/background-cleanup.test.ts src/__tests__/background-cleanup-directory.test.ts src/__tests__/hud/background-tasks.test.ts src/__tests__/hud/watch-mode-init.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/hud/state.ts src/hud/background-tasks.ts src/hud/background-cleanup.ts src/hud/index.ts src/hooks/bridge.ts src/__tests__/hud/session-state.test.ts src/__tests__/hud/watch-mode-init.test.ts src/__tests__/background-cleanup-directory.test.ts src/__tests__/hud/background-tasks.test.ts`

Closes #2452