### PR TITLE
backport(team): detect and clean stale team worktrees before startup

### DIFF
--- a/src/team/__tests__/git-worktree.test.ts
+++ b/src/team/__tests__/git-worktree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
@@ -58,6 +58,20 @@ describe('git-worktree', () => {
       const info2 = createWorkerWorktree(teamName, 'worker1', repoDir);
       expect(existsSync(info2.path)).toBe(true);
       expect(info2.path).toBe(info1.path);
+    });
+
+    it('cleans up a stale plain directory before creating the worktree', () => {
+      const stalePath = join(repoDir, '.omc', 'worktrees', teamName, 'worker-stale');
+      // Create a directory that is not registered as a git worktree.
+      rmSync(stalePath, { recursive: true, force: true });
+      mkdirSync(stalePath, { recursive: true });
+      writeFileSync(join(stalePath, 'orphan.txt'), 'orphaned state');
+
+      const info = createWorkerWorktree(teamName, 'worker-stale', repoDir);
+
+      expect(info.path).toBe(stalePath);
+      expect(existsSync(join(stalePath, 'orphan.txt'))).toBe(false);
+      expect(existsSync(info.path)).toBe(true);
     });
   });
 

--- a/src/team/git-worktree.ts
+++ b/src/team/git-worktree.ts
@@ -8,7 +8,7 @@
  * Branch naming: omc-team/{teamName}/{workerName}
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { atomicWriteJson, ensureDirWithMode, validateResolvedPath } from './fs-utils.js';
@@ -31,6 +31,26 @@ function getWorktreePath(repoRoot: string, teamName: string, workerName: string)
 /** Get branch name for a worker */
 function getBranchName(teamName: string, workerName: string): string {
   return `omc-team/${sanitizeName(teamName)}/${sanitizeName(workerName)}`;
+}
+
+function isRegisteredWorktreePath(repoRoot: string, wtPath: string): boolean {
+  try {
+    const output = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    const resolvedWtPath = wtPath.trim();
+    for (const line of output.split('\n')) {
+      if (!line.startsWith('worktree ')) continue;
+      if (line.slice('worktree '.length).trim() === resolvedWtPath) {
+        return true;
+      }
+    }
+  } catch {
+    // Best-effort check only.
+  }
+  return false;
 }
 
 /** Get worktree metadata path */
@@ -86,7 +106,15 @@ export function createWorkerWorktree(
   if (existsSync(wtPath)) {
     try {
       execFileSync('git', ['worktree', 'remove', '--force', wtPath], { cwd: repoRoot, stdio: 'pipe' });
-    } catch { /* ignore */ }
+    } catch {
+      if (isRegisteredWorktreePath(repoRoot, wtPath)) {
+        throw new Error(
+          `Stale worktree still registered at ${wtPath}. ` +
+          `Run \`git worktree prune\` or remove it manually before retrying.`,
+        );
+      }
+      rmSync(wtPath, { recursive: true, force: true });
+    }
   }
 
   // Delete stale branch if it exists


### PR DESCRIPTION
## Summary
Backports #2453 startup worktree hygiene so stale orphan directories are removed before startup and still-registered git worktrees fail with actionable guidance.

## Verification
- `npx vitest run src/team/__tests__/git-worktree.test.ts src/__tests__/worktree-metadata-locking.test.ts`
- `npx eslint src/team/git-worktree.ts src/team/__tests__/git-worktree.test.ts`
- `npx tsc --noEmit --pretty false`
- clean LSP diagnostics in the worker branch

Closes #2453