### PR TITLE
fix(launch): avoid Claude onboarding on default omc launches

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -82145,7 +82145,7 @@ function ensureMirroredPath(sourcePath, targetPath) {
     (0, import_fs95.copyFileSync)(sourcePath, targetPath);
   }
 }
-function prepareOmcLaunchConfigDir(baseConfigDir = process.env.CLAUDE_CONFIG_DIR || (0, import_path115.join)((0, import_os20.homedir)(), ".claude")) {
+function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
   const companionPath = (0, import_path115.join)(baseConfigDir, "CLAUDE-omc.md");
   if (!hasOmcMarkers(companionPath)) {
     return baseConfigDir;
@@ -82188,6 +82188,9 @@ function prepareOmcLaunchConfigDir(baseConfigDir = process.env.CLAUDE_CONFIG_DIR
     JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2)
   );
   return runtimeConfigDir;
+}
+function isDefaultClaudeConfigDirPath(configDir) {
+  return configDir === (0, import_path115.join)((0, import_os20.homedir)(), ".claude");
 }
 function extractNotifyFlag(args) {
   let notifyEnabled = true;
@@ -82486,7 +82489,12 @@ async function launchCommand(args) {
     console.error("  npm install -g @anthropic-ai/claude-code");
     process.exit(1);
   }
-  process.env.CLAUDE_CONFIG_DIR = prepareOmcLaunchConfigDir();
+  const launchConfigDir = prepareOmcLaunchConfigDir();
+  if (isDefaultClaudeConfigDirPath(launchConfigDir)) {
+    delete process.env.CLAUDE_CONFIG_DIR;
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = launchConfigDir;
+  }
   const normalizedArgs = normalizeClaudeLaunchArgs(argsAfterWebhook);
   const sessionId = `omc-${Date.now()}-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`;
   try {

--- a/dist/cli/launch.js
+++ b/dist/cli/launch.js
@@ -8,6 +8,7 @@ import { homedir } from 'os';
 import { basename, join } from 'path';
 import { resolvePluginDirArg } from '../lib/plugin-dir.js';
 import { stripRetiredTeamMcpServers } from '../installer/mcp-registry.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { resolveLaunchPolicy, buildTmuxSessionName, buildTmuxShellCommand, wrapWithLoginShell, isClaudeAvailable, quoteShellArg, } from './tmux-utils.js';
 import { OMC_PLUGIN_ROOT_ENV } from '../lib/env-vars.js';
 import { OMC_CONFIG_FILE_REL } from '../lib/paths.js';
@@ -56,7 +57,7 @@ function ensureMirroredPath(sourcePath, targetPath) {
         copyFileSync(sourcePath, targetPath);
     }
 }
-export function prepareOmcLaunchConfigDir(baseConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude')) {
+export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
     const companionPath = join(baseConfigDir, 'CLAUDE-omc.md');
     if (!hasOmcMarkers(companionPath)) {
         return baseConfigDir;
@@ -99,6 +100,9 @@ export function prepareOmcLaunchConfigDir(baseConfigDir = process.env.CLAUDE_CON
     }
     writeFileSync(join(runtimeConfigDir, '.omc-launch-profile.json'), JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2));
     return runtimeConfigDir;
+}
+function isDefaultClaudeConfigDirPath(configDir) {
+    return configDir === join(homedir(), '.claude');
 }
 /**
  * Extract the OMC-specific --notify flag from launch args.
@@ -571,7 +575,13 @@ export async function launchCommand(args) {
         console.error('  npm install -g @anthropic-ai/claude-code');
         process.exit(1);
     }
-    process.env.CLAUDE_CONFIG_DIR = prepareOmcLaunchConfigDir();
+    const launchConfigDir = prepareOmcLaunchConfigDir();
+    if (isDefaultClaudeConfigDirPath(launchConfigDir)) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+    }
+    else {
+        process.env.CLAUDE_CONFIG_DIR = launchConfigDir;
+    }
     const normalizedArgs = normalizeClaudeLaunchArgs(argsAfterWebhook);
     const sessionId = `omc-${Date.now()}-${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
     // Phase 1: preLaunch

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -844,6 +844,7 @@ describe('launchCommand — env var propagation', () => {
 
 describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () => {
   const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const originalHome = process.env.HOME;
   let tempRoot: string | null = null;
 
   const originalClaudecode = process.env.CLAUDECODE;
@@ -852,6 +853,7 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     vi.resetAllMocks();
     delete process.env.CLAUDECODE;
     tempRoot = mkdtempSync(join(tmpdir(), 'omc-launch-profile-'));
+    process.env.HOME = join(tempRoot, 'home');
     (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
     (resolveLaunchPolicy as ReturnType<typeof vi.fn>).mockReturnValue('direct');
     // Clear CLAUDECODE to avoid "already inside CC session" exit
@@ -862,6 +864,11 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     if (tempRoot) {
       rmSync(tempRoot, { recursive: true, force: true });
       tempRoot = null;
+    }
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
     }
     if (originalClaudeConfigDir === undefined) {
       delete process.env.CLAUDE_CONFIG_DIR;
@@ -944,6 +951,28 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
 
     expect(prepareOmcLaunchConfigDir(configDir)).toBe(configDir);
     expect(existsSync(join(configDir, '.omc-launch'))).toBe(false);
+  });
+
+  it('does not keep CLAUDE_CONFIG_DIR set when it resolves to the default ~/.claude path', async () => {
+    const configDir = join(tempRoot!, 'home', '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '# User config\n');
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+
+    await launchCommand(['--print']);
+
+    expect(process.env.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+
+  it('preserves explicit non-default CLAUDE_CONFIG_DIR values when no companion exists', async () => {
+    const configDir = join(tempRoot!, 'custom-claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE.md'), '# Custom user config\n');
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+
+    await launchCommand(['--print']);
+
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(configDir);
   });
 });
 

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -19,6 +19,7 @@ import { homedir } from 'os';
 import { basename, join } from 'path';
 import { resolvePluginDirArg } from '../lib/plugin-dir.js';
 import { stripRetiredTeamMcpServers } from '../installer/mcp-registry.js';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import {
   resolveLaunchPolicy,
   buildTmuxSessionName,
@@ -79,7 +80,7 @@ function ensureMirroredPath(sourcePath: string, targetPath: string): void {
   }
 }
 
-export function prepareOmcLaunchConfigDir(baseConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude')): string {
+export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()): string {
   const companionPath = join(baseConfigDir, 'CLAUDE-omc.md');
   if (!hasOmcMarkers(companionPath)) {
     return baseConfigDir;
@@ -129,6 +130,10 @@ export function prepareOmcLaunchConfigDir(baseConfigDir = process.env.CLAUDE_CON
   );
 
   return runtimeConfigDir;
+}
+
+function isDefaultClaudeConfigDirPath(configDir: string): boolean {
+  return configDir === join(homedir(), '.claude');
 }
 
 /**
@@ -619,7 +624,12 @@ export async function launchCommand(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  process.env.CLAUDE_CONFIG_DIR = prepareOmcLaunchConfigDir();
+  const launchConfigDir = prepareOmcLaunchConfigDir();
+  if (isDefaultClaudeConfigDirPath(launchConfigDir)) {
+    delete process.env.CLAUDE_CONFIG_DIR;
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = launchConfigDir;
+  }
 
   const normalizedArgs = normalizeClaudeLaunchArgs(argsAfterWebhook);
   const sessionId = `omc-${Date.now()}-${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;


### PR DESCRIPTION
## Summary\n- avoid exporting `CLAUDE_CONFIG_DIR` when OMC resolves to the default `~/.claude` path\n- preserve isolated \.omc-launch behavior when `CLAUDE-omc.md` is present\n- add targeted launch tests for the default-path guard\n\n## Testing\n- ./node_modules/.bin/vitest run src/cli/__tests__/launch.test.ts\n- ./node_modules/.bin/eslint src/cli/launch.ts src/cli/__tests__/launch.test.ts