### PR TITLE
fix: surface hidden blocker stalls during /autopilot

### DIFF
--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -1126,6 +1126,47 @@ Read src/hooks/bridge.ts first.`,
 
       spy.mockRestore();
     });
+
+    it('surfaces blocker details in autopilot hook output', async () => {
+      const testDir = '/tmp/omc-issue-2467-autopilot-stall';
+      try {
+        const sessionId = 'autopilot-blockers-session';
+        const sessionDir = join(testDir, '.omc', 'state', 'sessions', sessionId);
+        const teamRoot = join(testDir, '.omc', 'state', 'team', 'bridge-autopilot-demo-team');
+        mkdirSync(sessionDir, { recursive: true });
+        mkdirSync(join(teamRoot, 'tasks'), { recursive: true });
+        writeFileSync(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+          active: true,
+          phase: 'planning',
+          session_id: sessionId,
+          originalIdea: 'demo task',
+          expansion: { spec_path: null },
+          planning: { plan_path: null },
+        }, null, 2));
+        writeFileSync(join(teamRoot, 'tasks', '1.json'), JSON.stringify({
+          id: '1',
+          subject: 'Blocked task',
+          description: 'Depends on missing task 13',
+          status: 'pending',
+          owner: 'worker-1',
+          blocked_by: ['13'],
+          depends_on: ['13'],
+          created_at: new Date().toISOString(),
+        }, null, 2));
+
+        const result = await processHook('autopilot', {
+          sessionId,
+          directory: testDir,
+        });
+
+        expect(result.continue).toBe(true);
+        expect(result.message).toContain('[AUTOPILOT - Phase: PLANNING]');
+        expect(result.message).toContain('[bridge-autopilot-demo-team] task-1 depends on missing task ids [13]');
+      } finally {
+        rmSync(join(testDir, '.omc', 'state', 'sessions', 'autopilot-blockers-session'), { recursive: true, force: true });
+        rmSync(join(testDir, '.omc', 'state', 'team', 'bridge-autopilot-demo-team'), { recursive: true, force: true });
+      }
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -1128,7 +1128,7 @@ Read src/hooks/bridge.ts first.`,
     });
 
     it('surfaces blocker details in autopilot hook output', async () => {
-      const testDir = '/tmp/omc-issue-2467-autopilot-stall';
+      const testDir = process.cwd();
       try {
         const sessionId = 'autopilot-blockers-session';
         const sessionDir = join(testDir, '.omc', 'state', 'sessions', sessionId);

--- a/src/hooks/autopilot/enforcement.ts
+++ b/src/hooks/autopilot/enforcement.ts
@@ -44,6 +44,7 @@ import {
   generateTransitionPrompt,
   formatPipelineHUD,
 } from "./pipeline.js";
+import { formatAutopilotRuntimeInsight } from "./runtime-insight.js";
 
 export interface AutopilotEnforcementResult {
   /** Whether to block the stop event */
@@ -326,6 +327,7 @@ function generateContinuationPrompt(
   // Read tool error before generating message
   const toolError = readLastToolError(directory);
   const errorGuidance = getToolErrorRetryGuidance(toolError);
+  const runtimeInsight = formatAutopilotRuntimeInsight(directory, sessionId);
 
   // Increment iteration
   state.iteration += 1;
@@ -340,6 +342,7 @@ function generateContinuationPrompt(
 
   const continuationPrompt = `<autopilot-continuation>
 ${errorGuidance ? errorGuidance + "\n" : ""}
+${runtimeInsight ? `${runtimeInsight}\n\n` : ""}
 [AUTOPILOT - PHASE: ${state.phase.toUpperCase()} | ITERATION ${state.iteration}/${state.max_iterations}]
 
 Your previous response did not signal phase completion. Continue working on the current phase.
@@ -483,6 +486,7 @@ ${stagePrompt}
 
   const toolError = readLastToolError(directory);
   const errorGuidance = getToolErrorRetryGuidance(toolError);
+  const runtimeInsight = formatAutopilotRuntimeInsight(directory, sessionId);
 
   // Increment overall iteration
   state.iteration += 1;
@@ -507,6 +511,7 @@ ${stagePrompt}
 
   const continuationPrompt = `<autopilot-pipeline-continuation>
 ${errorGuidance ? errorGuidance + "\n" : ""}
+${runtimeInsight ? `${runtimeInsight}\n\n` : ""}
 ${hudLine}
 
 [AUTOPILOT PIPELINE - STAGE: ${currentAdapter.name.toUpperCase()} | ITERATION ${state.iteration}/${state.max_iterations}]

--- a/src/hooks/autopilot/runtime-insight.ts
+++ b/src/hooks/autopilot/runtime-insight.ts
@@ -1,0 +1,158 @@
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { getOmcRoot } from '../../lib/worktree-paths.js';
+import { readHudState } from '../../hud/state.js';
+import type { BackgroundTask } from '../../hud/types.js';
+import type { TeamTask, WorkerStatus } from '../../team/types.js';
+
+interface MissingDependencyIssue {
+  teamName: string;
+  taskId: string;
+  missingDependencyIds: string[];
+}
+
+interface WorkerIssue {
+  teamName: string;
+  workerName: string;
+  state: WorkerStatus['state'];
+  reason: string;
+}
+
+interface RuntimeInsightSnapshot {
+  missingDependencyIssues: MissingDependencyIssue[];
+  workerIssues: WorkerIssue[];
+  failedBackgroundTasks: BackgroundTask[];
+  runningBackgroundTasks: BackgroundTask[];
+}
+
+function readJsonSafe<T>(path: string): T | null {
+  try {
+    if (!existsSync(path)) {
+      return null;
+    }
+    return JSON.parse(readFileSync(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function getTaskDependencyIds(task: TeamTask): string[] {
+  return task.depends_on ?? task.blocked_by ?? [];
+}
+
+function collectRuntimeInsight(directory: string, sessionId?: string): RuntimeInsightSnapshot {
+  const omcRoot = getOmcRoot(directory);
+  const teamRoot = join(omcRoot, 'state', 'team');
+  const missingDependencyIssues: MissingDependencyIssue[] = [];
+  const workerIssues: WorkerIssue[] = [];
+
+  if (existsSync(teamRoot)) {
+    for (const teamName of readdirSync(teamRoot)) {
+      const teamDir = join(teamRoot, teamName);
+      const tasksDir = join(teamDir, 'tasks');
+      const workersDir = join(teamDir, 'workers');
+
+      const tasks: TeamTask[] = existsSync(tasksDir)
+        ? readdirSync(tasksDir)
+            .filter((entry) => entry.endsWith('.json'))
+            .map((entry) => readJsonSafe<TeamTask>(join(tasksDir, entry)))
+            .filter((task): task is TeamTask => Boolean(task))
+        : [];
+
+      const taskById = new Map(tasks.map((task) => [task.id, task] as const));
+      for (const task of tasks) {
+        const missingDependencyIds = getTaskDependencyIds(task)
+          .filter((dependencyId) => !taskById.has(dependencyId));
+        if (missingDependencyIds.length > 0) {
+          missingDependencyIssues.push({
+            teamName,
+            taskId: task.id,
+            missingDependencyIds,
+          });
+        }
+      }
+
+      if (existsSync(workersDir)) {
+        for (const workerName of readdirSync(workersDir)) {
+          const status = readJsonSafe<WorkerStatus>(join(workersDir, workerName, 'status.json'));
+          if (!status || typeof status.reason !== 'string' || status.reason.trim().length === 0) {
+            continue;
+          }
+          if (status.state !== 'blocked' && status.state !== 'failed') {
+            continue;
+          }
+          workerIssues.push({
+            teamName,
+            workerName,
+            state: status.state,
+            reason: status.reason.trim(),
+          });
+        }
+      }
+    }
+  }
+
+  const hudState = readHudState(directory, sessionId);
+  const backgroundTasks = hudState?.backgroundTasks ?? [];
+  const failedBackgroundTasks = backgroundTasks
+    .filter((task) => task.status === 'failed')
+    .sort((left, right) => {
+      const leftAt = new Date(left.completedAt ?? left.startedAt).getTime();
+      const rightAt = new Date(right.completedAt ?? right.startedAt).getTime();
+      return rightAt - leftAt;
+    });
+  const runningBackgroundTasks = backgroundTasks.filter((task) => task.status === 'running');
+
+  return {
+    missingDependencyIssues,
+    workerIssues,
+    failedBackgroundTasks,
+    runningBackgroundTasks,
+  };
+}
+
+export function formatAutopilotRuntimeInsight(
+  directory: string,
+  sessionId?: string,
+): string {
+  const snapshot = collectRuntimeInsight(directory, sessionId);
+  const lines: string[] = [];
+
+  if (snapshot.missingDependencyIssues.length > 0) {
+    lines.push('Current blockers:');
+    for (const issue of snapshot.missingDependencyIssues.slice(0, 3)) {
+      lines.push(
+        `- [${issue.teamName}] task-${issue.taskId} depends on missing task ids [${issue.missingDependencyIds.join(', ')}]`,
+      );
+    }
+  }
+
+  if (snapshot.workerIssues.length > 0) {
+    if (lines.length === 0) {
+      lines.push('Current blockers:');
+    }
+    for (const issue of snapshot.workerIssues.slice(0, 3)) {
+      lines.push(
+        `- [${issue.teamName}] ${issue.workerName} is ${issue.state}: ${issue.reason}`,
+      );
+    }
+  }
+
+  if (snapshot.failedBackgroundTasks.length > 0) {
+    lines.push(lines.length === 0 ? 'Recent errors:' : 'Recent errors:');
+    for (const task of snapshot.failedBackgroundTasks.slice(0, 3)) {
+      const agentLabel = task.agentType ? ` (${task.agentType})` : '';
+      lines.push(`- background task failed${agentLabel}: ${task.description}`);
+    }
+  }
+
+  if (snapshot.runningBackgroundTasks.length > 0) {
+    lines.push('Live progress:');
+    for (const task of snapshot.runningBackgroundTasks.slice(0, 3)) {
+      const agentLabel = task.agentType ? ` (${task.agentType})` : '';
+      lines.push(`- running${agentLabel}: ${task.description}`);
+    }
+  }
+
+  return lines.length > 0 ? lines.join('\n') : '';
+}

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -68,6 +68,7 @@ import {
   resolveAutopilotPlanPath,
   resolveOpenQuestionsPlanPath,
 } from "../config/plan-output.js";
+import { formatAutopilotRuntimeInsight } from "./autopilot/runtime-insight.js";
 import { writeSkillActiveState } from "./skill-state/index.js";
 import {
   ULTRAWORK_MESSAGE,
@@ -2150,11 +2151,13 @@ async function processAutopilot(input: HookInput): Promise<HookOutput> {
   };
 
   const phasePrompt = getPhasePrompt(state.phase, context);
+  const runtimeInsight = formatAutopilotRuntimeInsight(directory, input.sessionId);
 
-  if (phasePrompt) {
+  if (phasePrompt || runtimeInsight) {
+    const detailParts = [runtimeInsight, phasePrompt].filter(Boolean);
     return {
       continue: true,
-      message: `[AUTOPILOT - Phase: ${state.phase.toUpperCase()}]\n\n${phasePrompt}`,
+      message: `[AUTOPILOT - Phase: ${state.phase.toUpperCase()}]\n\n${detailParts.join("\n\n")}`,
     };
   }
 

--- a/src/team/__tests__/runtime-v2.monitor.test.ts
+++ b/src/team/__tests__/runtime-v2.monitor.test.ts
@@ -113,6 +113,33 @@ describe('monitorTeamV2 pane-based stall inference', () => {
     );
   });
 
+  it('surfaces missing blocker task ids in monitor recommendations', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-monitor-missing-blocker-'));
+    await writeConfigAndTask('pending');
+    const teamRoot = join(cwd, '.omc', 'state', 'team', 'demo-team');
+    await writeFile(join(teamRoot, 'tasks', '1.json'), JSON.stringify({
+      id: '1',
+      subject: 'Blocked task',
+      description: 'Depends on missing task 13',
+      status: 'pending',
+      owner: 'worker-1',
+      blocked_by: ['13'],
+      depends_on: ['13'],
+      created_at: new Date().toISOString(),
+    }, null, 2), 'utf-8');
+
+    const { monitorTeamV2 } = await import('../runtime-v2.js');
+    const snapshot = await monitorTeamV2('demo-team', cwd);
+
+    expect(snapshot?.nonReportingWorkers).toContain('worker-1');
+    expect(snapshot?.recommendations).toContain(
+      'Investigate worker-1: task-1 is blocked by missing task ids [13]; pane is idle at prompt',
+    );
+    expect(snapshot?.recommendations).toContain(
+      'Investigate task-1: depends on missing task ids [13]',
+    );
+  });
+
   it('does not flag a worker when pane evidence shows active work despite missing reports', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-monitor-active-'));
     await writeConfigAndTask('in_progress');

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -406,7 +406,7 @@ async function main(): Promise<void> {
       } catch { /* best-effort panes file write */ }
 
       process.stderr.write(
-        `[runtime-cli/v2] phase=${snap.phase} pending=${snap.tasks.pending} in_progress=${snap.tasks.in_progress} completed=${snap.tasks.completed} failed=${snap.tasks.failed} dead=${snap.deadWorkers.length} totalMs=${snap.performance.total_ms}\n`,
+        `[runtime-cli/v2] phase=${snap.phase} pending=${snap.tasks.pending} blocked=${snap.tasks.blocked} in_progress=${snap.tasks.in_progress} completed=${snap.tasks.completed} failed=${snap.tasks.failed} dead=${snap.deadWorkers.length} totalMs=${snap.performance.total_ms}\n`,
       );
       const leaderGuidance = deriveTeamLeaderGuidance({
         tasks: {
@@ -426,6 +426,9 @@ async function main(): Promise<void> {
       process.stderr.write(
         `[runtime-cli/v2] leader_next_action=${leaderGuidance.nextAction} reason=${leaderGuidance.reason}\n`,
       );
+      for (const recommendation of snap.recommendations) {
+        process.stderr.write(`[runtime-cli/v2] recommendation=${recommendation}\n`);
+      }
       if (leaderGuidance.nextAction === 'keep-checking-status') {
         lastLeaderNudgeReason = '';
       }

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -215,6 +215,17 @@ function findOutstandingWorkerTask(
   return owned[0] ?? null;
 }
 
+function getTaskDependencyIds(task: TeamTask): string[] {
+  return task.depends_on ?? task.blocked_by ?? [];
+}
+
+function getMissingDependencyIds(
+  task: TeamTask,
+  taskById: Map<string, TeamTask>,
+): string[] {
+  return getTaskDependencyIds(task).filter((dependencyId) => !taskById.has(dependencyId));
+}
+
 // ---------------------------------------------------------------------------
 // StartTeam V2 — create state, spawn workers, write initial dispatch requests
 // ---------------------------------------------------------------------------
@@ -1022,9 +1033,14 @@ export async function monitorTeamV2(
     const statusFresh = isFreshTimestamp(status.updated_at);
     const heartbeatFresh = isFreshTimestamp(heartbeat?.last_turn_at);
     const hasWorkStartEvidence = expectedTaskId !== '' && hasWorkerStatusProgress(status, expectedTaskId);
+    const missingDependencyIds = outstandingTask
+      ? getMissingDependencyIds(outstandingTask, taskById)
+      : [];
 
     let stallReason: string | null = null;
-    if (paneSuggestsIdle && expectedTaskId !== '' && !hasWorkStartEvidence) {
+    if (paneSuggestsIdle && missingDependencyIds.length > 0) {
+      stallReason = 'missing_dependency';
+    } else if (paneSuggestsIdle && expectedTaskId !== '' && !hasWorkStartEvidence) {
       stallReason = 'no_work_start_evidence';
     } else if (paneSuggestsIdle && expectedTaskId !== '' && (!statusFresh || !heartbeatFresh)) {
       stallReason = 'stale_or_missing_worker_reports';
@@ -1034,7 +1050,11 @@ export async function monitorTeamV2(
 
     if (stallReason) {
       nonReportingWorkers.push(w.name);
-      if (stallReason === 'no_work_start_evidence') {
+      if (stallReason === 'missing_dependency') {
+        recommendations.push(
+          `Investigate ${w.name}: task-${outstandingTask?.id ?? expectedTaskId} is blocked by missing task ids [${missingDependencyIds.join(', ')}]; pane is idle at prompt`,
+        );
+      } else if (stallReason === 'no_work_start_evidence') {
         recommendations.push(`Investigate ${w.name}: assigned work but no work-start evidence; pane is idle at prompt`);
       } else if (stallReason === 'stale_or_missing_worker_reports') {
         recommendations.push(`Investigate ${w.name}: pane is idle while status/heartbeat are stale or missing`);
@@ -1055,6 +1075,17 @@ export async function monitorTeamV2(
   };
 
   const allTasksTerminal = taskCounts.pending === 0 && taskCounts.blocked === 0 && taskCounts.in_progress === 0;
+
+  for (const task of allTasks) {
+    const missingDependencyIds = getMissingDependencyIds(task, taskById);
+    if (missingDependencyIds.length === 0) {
+      continue;
+    }
+
+    recommendations.push(
+      `Investigate task-${task.id}: depends on missing task ids [${missingDependencyIds.join(', ')}]`,
+    );
+  }
 
   // Infer phase from task distribution
   const phase = inferPhase(allTasks.map((t) => ({


### PR DESCRIPTION
## Summary
- detect missing task dependency ids as explicit team stall recommendations
- print live blocker recommendations in the runtime v2 CLI output
- thread blocker/error details into autopilot continuation output so stuck runs expose what is blocked

## Verification
- ./node_modules/.bin/vitest run src/team/__tests__/runtime-v2.monitor.test.ts src/hooks/__tests__/bridge-routing.test.ts
- ./node_modules/.bin/eslint src/team/runtime-v2.ts src/team/runtime-cli.ts src/team/__tests__/runtime-v2.monitor.test.ts src/hooks/autopilot/enforcement.ts src/hooks/autopilot/runtime-insight.ts src/hooks/bridge.ts src/hooks/__tests__/bridge-routing.test.ts
- ./node_modules/.bin/tsc --noEmit

Closes #2467