### PR TITLE
fix: suppress repeated zero-delta idle follow-up nudges

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1124,8 +1124,10 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
         // Per-session cooldown: prevent notification spam when the session idles repeatedly.
         // Uses session-scoped state so one session does not suppress another.
         const stateDir = join(getOmcRoot(directory), "state");
-        if (shouldSendIdleNotification(stateDir, sessionId)) {
-          recordIdleNotificationSent(stateDir, sessionId);
+        const { getIdleNotificationRepoState } = await import("./persistent-mode/idle-repo-state.js");
+        const idleRepoState = getIdleNotificationRepoState(directory);
+        if (shouldSendIdleNotification(stateDir, sessionId, idleRepoState)) {
+          recordIdleNotificationSent(stateDir, sessionId, idleRepoState);
           const logSessionIdleNotifyFailure = createSwallowedErrorLogger(
             'hooks.bridge session-idle notification failed',
           );

--- a/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
@@ -205,6 +205,9 @@ describe('getIdleNotificationCooldownSeconds', () => {
 });
 
 describe('shouldSendIdleNotification', () => {
+  const zeroBacklogState = { signature: 'repo-zero', backlogZero: true };
+  const changedBacklogState = { signature: 'repo-new', backlogZero: true };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -373,9 +376,51 @@ describe('shouldSendIdleNotification', () => {
     // Negative cooldown clamped to 0 → treated as disabled → should send
     expect(shouldSendIdleNotification(TEST_STATE_DIR)).toBe(true);
   });
+
+  it('suppresses repeated zero-backlog nudges even after cooldown expires when repo state is unchanged', () => {
+    const oldTimestamp = new Date(Date.now() - 90_000).toISOString();
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === COOLDOWN_PATH) return true;
+      return false;
+    });
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === COOLDOWN_PATH) {
+        return JSON.stringify({
+          lastSentAt: oldTimestamp,
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        });
+      }
+      throw new Error('not found');
+    });
+
+    expect(shouldSendIdleNotification(TEST_STATE_DIR, undefined, zeroBacklogState)).toBe(false);
+  });
+
+  it('allows immediate idle notification when repo state changes even inside cooldown', () => {
+    const recentTimestamp = new Date(Date.now() - 5_000).toISOString();
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === COOLDOWN_PATH) return true;
+      return false;
+    });
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === COOLDOWN_PATH) {
+        return JSON.stringify({
+          lastSentAt: recentTimestamp,
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        });
+      }
+      throw new Error('not found');
+    });
+
+    expect(shouldSendIdleNotification(TEST_STATE_DIR, undefined, changedBacklogState)).toBe(true);
+  });
 });
 
 describe('recordIdleNotificationSent', () => {
+  const zeroBacklogState = { signature: 'repo-zero', backlogZero: true };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -409,6 +454,19 @@ describe('recordIdleNotificationSent', () => {
     expect(atomicWriteJsonSync).toHaveBeenCalledOnce();
     const [calledPath] = (atomicWriteJsonSync as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(calledPath).toBe(COOLDOWN_PATH);
+  });
+
+  it('persists repo signature metadata when repo state is provided', () => {
+    recordIdleNotificationSent(TEST_STATE_DIR, undefined, zeroBacklogState);
+
+    expect(atomicWriteJsonSync).toHaveBeenCalledWith(
+      COOLDOWN_PATH,
+      expect.objectContaining({
+        lastSentAt: expect.any(String),
+        repoSignature: zeroBacklogState.signature,
+        backlogZero: true,
+      }),
+    );
   });
 
   it('does not throw when atomicWriteJsonSync fails', () => {

--- a/src/hooks/persistent-mode/__tests__/idle-repo-state.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-repo-state.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from 'node:child_process';
+import { getIdleNotificationRepoState } from '../idle-repo-state.js';
+
+describe('getIdleNotificationRepoState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds a stable zero-backlog signature from git and GitHub state', () => {
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce('git@github.com:Yeachan-Heo/oh-my-claudecode.git\n')
+      .mockReturnValueOnce('abc123\n')
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce('[]')
+      .mockReturnValueOnce('[]')
+      .mockReturnValueOnce('[]');
+
+    const result = getIdleNotificationRepoState('/repo');
+
+    expect(result).toEqual({
+      signature: JSON.stringify({
+        repo: 'Yeachan-Heo/oh-my-claudecode',
+        headSha: 'abc123',
+        dirty: false,
+        openPrNumbers: [],
+        openIssueNumbers: [],
+        failingRunIds: [],
+      }),
+      backlogZero: true,
+    });
+  });
+
+  it('returns non-zero backlog when PRs, issues, or failing runs exist', () => {
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce('https://github.com/Yeachan-Heo/oh-my-claudecode.git\n')
+      .mockReturnValueOnce('def456\n')
+      .mockReturnValueOnce(' M src/file.ts\n')
+      .mockReturnValueOnce('[{"number":2472}]')
+      .mockReturnValueOnce('[{"number":2473}]')
+      .mockReturnValueOnce('[{"databaseId":91,"conclusion":"failure"},{"databaseId":92,"conclusion":"success"}]');
+
+    const result = getIdleNotificationRepoState('/repo');
+
+    expect(result?.backlogZero).toBe(false);
+    expect(result?.signature).toBe(
+      JSON.stringify({
+        repo: 'Yeachan-Heo/oh-my-claudecode',
+        headSha: 'def456',
+        dirty: true,
+        openPrNumbers: [2472],
+        openIssueNumbers: [2473],
+        failingRunIds: [91],
+      }),
+    );
+  });
+
+  it('returns null when the repo is not hosted on GitHub', () => {
+    vi.mocked(execFileSync).mockReturnValueOnce('git@gitlab.com:group/project.git\n');
+
+    expect(getIdleNotificationRepoState('/repo')).toBeNull();
+  });
+
+  it('returns null when GitHub queries fail', () => {
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce('git@github.com:Yeachan-Heo/oh-my-claudecode.git\n')
+      .mockReturnValueOnce('abc123\n')
+      .mockReturnValueOnce('')
+      .mockImplementationOnce(() => {
+        throw new Error('gh unavailable');
+      });
+
+    expect(getIdleNotificationRepoState('/repo')).toBeNull();
+  });
+});

--- a/src/hooks/persistent-mode/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/idle-cooldown.test.ts
@@ -28,6 +28,9 @@ describe("idle notification cooldown (issue #842)", () => {
   });
 
   describe("shouldSendIdleNotification", () => {
+    const zeroBacklogState = { signature: "repo-zero", backlogZero: true };
+    const changedBacklogState = { signature: "repo-new", backlogZero: true };
+
     it("returns true when no cooldown file exists", () => {
       expect(shouldSendIdleNotification(stateDir)).toBe(true);
     });
@@ -78,9 +81,40 @@ describe("idle notification cooldown (issue #842)", () => {
       expect(shouldSendIdleNotification(stateDir, sessionId)).toBe(false);
       expect(shouldSendIdleNotification(stateDir, "different-session")).toBe(true);
     });
+
+    it("suppresses repeated zero-backlog notifications when repo state has not changed", () => {
+      const cooldownPath = join(stateDir, "idle-notif-cooldown.json");
+      const past = new Date(Date.now() - 120_000).toISOString();
+      writeFileSync(
+        cooldownPath,
+        JSON.stringify({
+          lastSentAt: past,
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        })
+      );
+
+      expect(shouldSendIdleNotification(stateDir, undefined, zeroBacklogState)).toBe(false);
+    });
+
+    it("bypasses cooldown immediately when repo state changes", () => {
+      const cooldownPath = join(stateDir, "idle-notif-cooldown.json");
+      writeFileSync(
+        cooldownPath,
+        JSON.stringify({
+          lastSentAt: new Date().toISOString(),
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        })
+      );
+
+      expect(shouldSendIdleNotification(stateDir, undefined, changedBacklogState)).toBe(true);
+    });
   });
 
   describe("recordIdleNotificationSent", () => {
+    const zeroBacklogState = { signature: "repo-zero", backlogZero: true };
+
     it("creates cooldown file with lastSentAt timestamp", () => {
       const cooldownPath = join(stateDir, "idle-notif-cooldown.json");
       expect(existsSync(cooldownPath)).toBe(false);
@@ -131,6 +165,16 @@ describe("idle notification cooldown (issue #842)", () => {
 
       expect(existsSync(cooldownPath)).toBe(true);
       expect(existsSync(join(stateDir, "idle-notif-cooldown.json"))).toBe(false);
+    });
+
+    it("stores repo signature metadata when repo state is provided", () => {
+      const cooldownPath = join(stateDir, "idle-notif-cooldown.json");
+
+      recordIdleNotificationSent(stateDir, undefined, zeroBacklogState);
+
+      const data = JSON.parse(readFileSync(cooldownPath, "utf-8")) as Record<string, unknown>;
+      expect(data.repoSignature).toBe(zeroBacklogState.signature);
+      expect(data.backlogZero).toBe(true);
     });
   });
 

--- a/src/hooks/persistent-mode/idle-repo-state.ts
+++ b/src/hooks/persistent-mode/idle-repo-state.ts
@@ -1,0 +1,115 @@
+import { execFileSync } from 'node:child_process';
+import { parseRemoteUrl } from '../../providers/index.js';
+
+const COMMAND_TIMEOUT_MS = 10_000;
+const MAX_LIST_RESULTS = 100;
+const FAILURE_CONCLUSIONS = new Set([
+  'failure',
+  'timed_out',
+  'cancelled',
+  'action_required',
+  'startup_failure',
+]);
+
+interface GitHubListEntry {
+  number?: number;
+}
+
+interface GitHubRunEntry {
+  databaseId?: number;
+  conclusion?: string | null;
+}
+
+export interface IdleNotificationRepoState {
+  signature: string;
+  backlogZero: boolean;
+}
+
+function runCommand(command: string, args: string[], cwd: string): string | null {
+  try {
+    return execFileSync(command, args, {
+      cwd,
+      encoding: 'utf-8',
+      timeout: COMMAND_TIMEOUT_MS,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function runJsonCommand<T>(command: string, args: string[], cwd: string): T | null {
+  const raw = runCommand(command, args, cwd);
+  if (raw === null) return null;
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function toSortedNumbers(values: Array<number | undefined>): number[] {
+  return values
+    .filter((value): value is number => Number.isInteger(value))
+    .sort((left, right) => left - right);
+}
+
+export function getIdleNotificationRepoState(directory: string): IdleNotificationRepoState | null {
+  const remoteUrl = runCommand('git', ['remote', 'get-url', 'origin'], directory);
+  if (!remoteUrl) return null;
+
+  const remote = parseRemoteUrl(remoteUrl);
+  if (!remote || remote.provider !== 'github') return null;
+
+  const repo = `${remote.owner}/${remote.repo}`;
+  const headSha = runCommand('git', ['rev-parse', 'HEAD'], directory);
+  const porcelainStatus = runCommand('git', ['status', '--porcelain'], directory);
+  if (!headSha || porcelainStatus === null) return null;
+
+  const openPrs = runJsonCommand<GitHubListEntry[]>(
+    'gh',
+    ['pr', 'list', '--repo', repo, '--state', 'open', '--limit', String(MAX_LIST_RESULTS), '--json', 'number'],
+    directory,
+  );
+  if (!openPrs) return null;
+
+  const openIssues = runJsonCommand<GitHubListEntry[]>(
+    'gh',
+    ['issue', 'list', '--repo', repo, '--state', 'open', '--limit', String(MAX_LIST_RESULTS), '--json', 'number'],
+    directory,
+  );
+  if (!openIssues) return null;
+
+  const runs = runJsonCommand<GitHubRunEntry[]>(
+    'gh',
+    ['run', 'list', '--repo', repo, '--limit', String(MAX_LIST_RESULTS), '--json', 'databaseId,conclusion'],
+    directory,
+  );
+  if (!runs) return null;
+
+  const failingRunIds = toSortedNumbers(
+    runs
+      .filter((run) => FAILURE_CONCLUSIONS.has((run.conclusion || '').toLowerCase()))
+      .map((run) => run.databaseId),
+  );
+  const openPrNumbers = toSortedNumbers(openPrs.map((entry) => entry.number));
+  const openIssueNumbers = toSortedNumbers(openIssues.map((entry) => entry.number));
+
+  const snapshot = {
+    repo,
+    headSha,
+    dirty: porcelainStatus.length > 0,
+    openPrNumbers,
+    openIssueNumbers,
+    failingRunIds,
+  };
+
+  return {
+    signature: JSON.stringify(snapshot),
+    backlogZero:
+      openPrNumbers.length === 0 &&
+      openIssueNumbers.length === 0 &&
+      failingRunIds.length === 0,
+  };
+}

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -51,6 +51,7 @@ import { checkAutopilot } from '../autopilot/enforcement.js';
 import { readTeamPipelineState } from '../team-pipeline/state.js';
 import type { TeamPipelinePhase } from '../team-pipeline/types.js';
 import { getActiveAgentSnapshot } from '../subagent-tracker/index.js';
+import type { IdleNotificationRepoState } from './idle-repo-state.js';
 
 export interface ToolErrorState {
   tool_name: string;
@@ -271,6 +272,12 @@ export function getIdleNotificationCooldownSeconds(): number {
   return 60;
 }
 
+interface IdleNotificationCooldownRecord {
+  lastSentAt?: string;
+  repoSignature?: string;
+  backlogZero?: boolean;
+}
+
 function getIdleNotificationCooldownPath(stateDir: string, sessionId?: string): string {
   // Keep session segments filesystem-safe; fall back to legacy global path otherwise.
   if (sessionId && /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) {
@@ -283,15 +290,29 @@ function getIdleNotificationCooldownPath(stateDir: string, sessionId?: string): 
  * Check whether the session-idle notification cooldown has elapsed.
  * Returns true if the notification should be sent.
  */
-export function shouldSendIdleNotification(stateDir: string, sessionId?: string): boolean {
+export function shouldSendIdleNotification(
+  stateDir: string,
+  sessionId?: string,
+  repoState?: IdleNotificationRepoState | null,
+): boolean {
   const cooldownSecs = getIdleNotificationCooldownSeconds();
-  if (cooldownSecs === 0) return true; // cooldown disabled
 
   const cooldownPath = getIdleNotificationCooldownPath(stateDir, sessionId);
   try {
     if (!existsSync(cooldownPath)) return true;
-    const data = JSON.parse(readFileSync(cooldownPath, 'utf-8')) as Record<string, unknown>;
-    if (data?.lastSentAt && typeof data.lastSentAt === 'string') {
+    const data = JSON.parse(readFileSync(cooldownPath, 'utf-8')) as IdleNotificationCooldownRecord;
+    if (repoState && typeof data.repoSignature === 'string') {
+      if (data.repoSignature !== repoState.signature) {
+        return true;
+      }
+      if (data.backlogZero === true && repoState.backlogZero) {
+        return false;
+      }
+    }
+
+    if (cooldownSecs === 0) return true; // cooldown disabled
+
+    if (typeof data.lastSentAt === 'string') {
       const elapsed = (Date.now() - new Date(data.lastSentAt).getTime()) / 1000;
       if (Number.isFinite(elapsed) && elapsed < cooldownSecs) return false;
     }
@@ -304,10 +325,21 @@ export function shouldSendIdleNotification(stateDir: string, sessionId?: string)
 /**
  * Record that the session-idle notification was sent at the current timestamp.
  */
-export function recordIdleNotificationSent(stateDir: string, sessionId?: string): void {
+export function recordIdleNotificationSent(
+  stateDir: string,
+  sessionId?: string,
+  repoState?: IdleNotificationRepoState | null,
+): void {
   const cooldownPath = getIdleNotificationCooldownPath(stateDir, sessionId);
   try {
-    atomicWriteJsonSync(cooldownPath, { lastSentAt: new Date().toISOString() });
+    const record: IdleNotificationCooldownRecord = {
+      lastSentAt: new Date().toISOString(),
+    };
+    if (repoState) {
+      record.repoSignature = repoState.signature;
+      record.backlogZero = repoState.backlogZero;
+    }
+    atomicWriteJsonSync(cooldownPath, record);
   } catch {
     // ignore write errors
   }


### PR DESCRIPTION
## Summary
- derive a GitHub/local-repo signature for idle follow-up suppression
- keep suppressing repeated zero-backlog idle nudges even after the time cooldown expires when repo state is unchanged
- allow immediate idle follow-up nudges again when PR/issue/CI/local repo state changes and cover the behavior with targeted persistent-mode tests

## Validation
- 
 RUN  v4.0.18 /home/bellman/Workspace/oh-my-claudecode-issue-2472-zero-delta-followup

 ✓ src/hooks/persistent-mode/__tests__/idle-repo-state.test.ts (4 tests) 5ms
 ✓ src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts (28 tests) 26ms
 ✓ src/hooks/persistent-mode/idle-cooldown.test.ts (16 tests) 49ms

 Test Files  3 passed (3)
      Tests  48 passed (48)
   Start at  12:01:50
   Duration  606ms (transform 803ms, setup 0ms, import 1.01s, tests 80ms, environment 0ms)
- 
- 

Closes #2472