### PR TITLE
fix: preserve Ralph continuation after interrupted tool turns

### DIFF
--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -439,6 +439,34 @@ describe("Stop Hook Blocking Contract", () => {
       expect(output.message).toContain("RALPH");
     });
 
+    it("keeps blocking active ralph loop when stop reason is interrupt", async () => {
+      const sessionId = "test-ralph-interrupt";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          iteration: 1,
+          max_iterations: 50,
+          session_id: sessionId,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          prompt: "Test ralph task",
+        })
+      );
+
+      const result = await checkPersistentModes(sessionId, tempDir, {
+        stop_reason: "interrupt",
+      });
+      expect(result.shouldBlock).toBe(true);
+      expect(result.mode).toBe("ralph");
+
+      const output = createHookOutput(result);
+      expect(output.continue).toBe(false);
+      expect(output.message).toContain("RALPH");
+    });
+
     it("ignores stale legacy ralph state when no session is provided", async () => {
       const staleAt = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
       writeLegacyModeState(tempDir, "ralph-state.json", {

--- a/src/hooks/todo-continuation/__tests__/isUserAbort.test.ts
+++ b/src/hooks/todo-continuation/__tests__/isUserAbort.test.ts
@@ -27,8 +27,8 @@ describe('isUserAbort', () => {
     expect(isUserAbort({ stop_reason: 'aborted' })).toBe(true);
   });
 
-  it('should return true for exact "interrupt" stop reason', () => {
-    expect(isUserAbort({ stop_reason: 'interrupt' })).toBe(true);
+  it('should return false for exact "interrupt" stop reason', () => {
+    expect(isUserAbort({ stop_reason: 'interrupt' })).toBe(false);
   });
 
   // Compound substring patterns (user_cancel, ctrl_c, manual_stop should still match)

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -160,7 +160,13 @@ export interface TodoContinuationHook {
  * - user_cancel, user_interrupt: Likely user-initiated via UI
  * - ctrl_c: Terminal interrupt (Ctrl+C)
  * - manual_stop: Explicit stop button
- * - abort, cancel, interrupt: Generic abort patterns
+ * - abort, cancel: Generic abort patterns
+ *
+ * Plain `interrupt` is intentionally NOT treated as an explicit user abort.
+ * In practice it can also describe a turn interruption caused by a new user
+ * message arriving during long-running tool execution (issue #2478). Those
+ * interrupted turns should still allow Ralph/persistent-mode resume on the
+ * next stop-hook opportunity unless stronger explicit-cancel signals exist.
  *
  * NOTE: Per official Anthropic docs, the Stop hook "Does not run if
  * the stoppage occurred due to a user interrupt." This means this
@@ -178,7 +184,7 @@ export function isUserAbort(context?: StopContext): boolean {
 
   // Check stop_reason patterns indicating user abort
   // Exact-match patterns: short generic words that cause false positives with .includes()
-  const exactPatterns = ['aborted', 'abort', 'cancel', 'interrupt'];
+  const exactPatterns = ['aborted', 'abort', 'cancel'];
   // Substring patterns: compound words safe for .includes() matching
   const substringPatterns = ['user_cancel', 'user_interrupt', 'ctrl_c', 'manual_stop'];
 


### PR DESCRIPTION
## Summary
- stop treating a plain `interrupt` stop reason as an explicit user abort
- keep Ralph continuation active after interrupted long-running tool turns
- add focused regression coverage for the abort classifier and persistent-mode stop hook

## Testing
- `npm test -- --run src/hooks/todo-continuation/__tests__/isUserAbort.test.ts src/hooks/persistent-mode/stop-hook-blocking.test.ts`
- `npx tsc --noEmit`

Closes #2478.