### PR TITLE
fix: auto-dismiss Claude bypass-permissions prompt in team workers

### DIFF
--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -62,7 +62,8 @@ import {
 } from './model-contract.js';
 import {
   createTeamSession, spawnWorkerInPane, sendToWorker,
-  waitForPaneReady, paneHasActiveTask, paneLooksReady, applyMainVerticalLayout, type WorkerPaneConfig,
+  waitForPaneReady, paneHasActiveTask, paneLooksReady, applyMainVerticalLayout,
+  dismissBypassPermissionsPrompt, type WorkerPaneConfig,
 } from './tmux-session.js';
 import {
   composeInitialInbox,
@@ -502,6 +503,15 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     notify: async (_target, triggerMessage) => {
       if (usePromptMode) {
         return { ok: true, transport: 'prompt_stdin', reason: 'prompt_mode_launch_args' };
+      }
+      if (opts.agentType === 'claude') {
+        const dismissed = await dismissBypassPermissionsPrompt(paneId);
+        if (dismissed) {
+          const readyAfterBypass = await waitForPaneReady(paneId, { timeoutMs: 30_000 });
+          if (!readyAfterBypass) {
+            return { ok: false, transport: 'tmux_send_keys', reason: 'worker_notify_failed:bypass-confirm' };
+          }
+        }
       }
       if (opts.agentType === 'gemini') {
         const confirmed = await notifyPaneWithRetry(opts.sessionName, paneId, '1');

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -7,6 +7,7 @@ import { validateTeamName } from './team-name.js';
 import {
   createTeamSession, spawnWorkerInPane, sendToWorker,
   isWorkerAlive, killTeamSession, resolveSplitPaneWorkerPaneIds, waitForPaneReady, applyMainVerticalLayout,
+  dismissBypassPermissionsPrompt,
   type TeamSession, type WorkerPaneConfig,
 } from './tmux-session.js';
 import {
@@ -787,6 +788,18 @@ export async function spawnWorkerForTask(
       await killWorkerPane(runtime, workerNameValue, paneId);
       await resetTaskToPending(root, taskId, runtime.teamName, runtime.cwd);
       throw new Error(`worker_pane_not_ready:${workerNameValue}`);
+    }
+
+    if (agentType === 'claude') {
+      const dismissed = await dismissBypassPermissionsPrompt(paneId);
+      if (dismissed) {
+        const readyAfterBypass = await waitForPaneReady(paneId, { timeoutMs: 30_000 });
+        if (!readyAfterBypass) {
+          await killWorkerPane(runtime, workerNameValue, paneId);
+          await resetTaskToPending(root, taskId, runtime.teamName, runtime.cwd);
+          throw new Error(`worker_pane_not_ready_after_bypass:${workerNameValue}`);
+        }
+      }
     }
 
     if (agentType === 'gemini') {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -669,6 +669,38 @@ function paneHasTrustPrompt(captured: string): boolean {
   return hasQuestion && hasChoices;
 }
 
+function paneHasBypassPermissionsPrompt(captured: string): boolean {
+  const lines = captured.split('\n').map(l => l.replace(/\r/g, '').trim()).filter(l => l.length > 0);
+  const tail = lines.slice(-15);
+  return tail.some(l => /Bypass Permissions mode/i.test(l)) &&
+         tail.some(l => /No,\s*exit/i.test(l));
+}
+
+/**
+ * Detect and auto-dismiss Claude Code's bypass-permissions confirmation prompt.
+ * When `--dangerously-skip-permissions` is passed, Claude Code shows an interactive
+ * select widget with "1. No, exit" pre-selected. In non-interactive tmux panes this
+ * causes workers to immediately exit. This function sends Down+Enter to select
+ * "2. Yes, I accept" instead.
+ * Returns true if the prompt was detected and dismissed, false otherwise.
+ */
+export async function dismissBypassPermissionsPrompt(paneId: string): Promise<boolean> {
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const execFileAsync = promisify(execFile);
+  const captured = await capturePaneAsync(paneId, execFileAsync as Parameters<typeof capturePaneAsync>[1]);
+  if (!paneHasBypassPermissionsPrompt(captured)) {
+    return false;
+  }
+  const sendKey = async (key: string) => {
+    await execFileAsync('tmux', ['send-keys', '-t', paneId, key]);
+  };
+  await sendKey('Down');
+  await new Promise(r => setTimeout(r, 150));
+  await sendKey('C-m');
+  return true;
+}
+
 function paneIsBootstrapping(captured: string): boolean {
   const lines = captured
     .split('\n')


### PR DESCRIPTION
## Summary

- `omc team N:claude` workers silently fail because `--dangerously-skip-permissions` shows an interactive confirmation prompt with "1. No, exit" pre-selected. In non-interactive tmux panes, this immediately exits the worker.
- Adds bypass-permissions prompt detection and auto-dismissal for Claude workers, mirroring the existing Gemini trust-confirm handling in `runtime.ts` and `runtime-v2.ts`.
- `dismissBypassPermissionsPrompt()` captures the pane, detects the prompt via regex, and sends `Down`+`Enter` to accept.

## Reproduction

1. Run `omc team 2:claude "any task"` on a system without globally pre-configured bypass permissions
2. Both workers show the bypass-permissions prompt and immediately exit with "1. No, exit"
3. `tmux capture-pane` shows workers never reached Claude's input prompt

## Test plan

- [ ] Run `omc team 2:claude "simple task"` — workers should auto-accept the prompt and start working
- [ ] Run `omc team 2:gemini "simple task"` — existing Gemini trust-confirm still works (no regression)
- [ ] Run `omc team 2:codex "simple task"` — Codex workers unaffected (no regression)
- [ ] Verify `paneHasBypassPermissionsPrompt` returns false for normal Claude input prompts (no false positive on `❯`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)