### PR TITLE
fix: correct help-question regex escaping in keyword detector

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -74584,11 +74584,8 @@ function hasActivationIntentNearKeyword(context, keyword) {
   const escaped = escapeRegExp2(keyword.trim());
   if (!escaped) return false;
   const helpQuestionPatterns = [
-    new RegExp(`\bhows+dos+is+use\b[^
-]{0,40}\b${escaped}\b`, "i"),
-    new RegExp(`\bwhat(?:'s|s+is)\b[^
-]{0,40}\b${escaped}\b[^
-]{0,40}\bhows+tos+use\b`, "i")
+    new RegExp(`\\bhow\\s+do\\s+i\\s+use\\b[^\\n]{0,40}\\b${escaped}\\b`, "i"),
+    new RegExp(`\\bwhat(?:'s|\\s+is)\\b[^\\n]{0,40}\\b${escaped}\\b[^\\n]{0,40}\\bhow\\s+to\\s+use\\b`, "i")
   ];
   if (helpQuestionPatterns.some((pattern) => pattern.test(context))) {
     return false;

--- a/src/__tests__/bridge-help-question-regex.test.ts
+++ b/src/__tests__/bridge-help-question-regex.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, '..', '..');
+
+describe('bridge/cli.cjs help-question regex regression (#2482)', () => {
+  it('keeps escaped help-question regex sequences intact in the baked bridge artifact', () => {
+    const source = readFileSync(join(REPO_ROOT, 'bridge', 'cli.cjs'), 'utf-8');
+    const marker = 'const helpQuestionPatterns = [';
+    const start = source.indexOf(marker);
+    const snippet = start === -1 ? '' : source.slice(start, start + 260);
+
+    expect(snippet).toContain("\\\\bhow\\\\s+do\\\\s+i\\\\s+use\\\\b[^\\\\n]{0,40}\\\\b${escaped}\\\\b");
+    expect(snippet).toContain("\\\\bwhat(?:'s|\\\\s+is)\\\\b[^\\\\n]{0,40}\\\\b${escaped}\\\\b[^\\\\n]{0,40}\\\\bhow\\\\s+to\\\\s+use\\\\b");
+    expect(snippet).not.toContain("\\bhows+dos+is+use\\b");
+    expect(snippet).not.toContain("\\bwhat(?:'s|s+is)\\b");
+  });
+});

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -260,6 +260,10 @@ Final draft.`);
         expect(detectKeywordsWithType('How do I use autopilot?')).toEqual([]);
       });
 
+      it('should NOT detect what-is plus how-to-use phrasing for autopilot', () => {
+        expect(detectKeywordsWithType("What's autopilot and how to use it?")).toEqual([]);
+      });
+
       it('should detect explicit activation even when a nearby help question exists', () => {
         const result = detectKeywordsWithType('Use autopilot to fix bug in payments. What is the expected output?');
         expect(result.find((r) => r.type === 'autopilot')).toBeDefined();

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -205,8 +205,8 @@ function hasActivationIntentNearKeyword(context: string, keyword: string): boole
   // Help-question phrasing like "How do I use autopilot?" should not be
   // treated as activation intent.
   const helpQuestionPatterns = [
-    new RegExp(`\bhow\s+do\s+i\s+use\b[^\n]{0,40}\b${escaped}\b`, 'i'),
-    new RegExp(`\bwhat(?:'s|\s+is)\b[^\n]{0,40}\b${escaped}\b[^\n]{0,40}\bhow\s+to\s+use\b`, 'i'),
+    new RegExp(`\\bhow\\s+do\\s+i\\s+use\\b[^\\n]{0,40}\\b${escaped}\\b`, 'i'),
+    new RegExp(`\\bwhat(?:'s|\\s+is)\\b[^\\n]{0,40}\\b${escaped}\\b[^\\n]{0,40}\\bhow\\s+to\\s+use\\b`, 'i'),
   ];
   if (helpQuestionPatterns.some((pattern) => pattern.test(context))) {
     return false;


### PR DESCRIPTION
## Summary
- double-escape the help-question regex fragments used by \ so the RegExp source survives bundling
- sync the baked \ artifact with the source fix
- add focused regression coverage for help-style phrasing plus an artifact-level bridge check

## Testing
- npm run build:cli
- npx eslint src/hooks/keyword-detector/index.ts src/hooks/keyword-detector/__tests__/index.test.ts src/__tests__/bridge-help-question-regex.test.ts
- npx tsc --noEmit
- npx vitest run src/hooks/keyword-detector/__tests__/index.test.ts src/__tests__/bridge-help-question-regex.test.ts