### PR TITLE
Fix HUD skill cleanup step deleting omc-hud.mjs

### DIFF
--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -99,7 +99,7 @@ Use the Edit tool to add/update this field while preserving other settings.
 
 **Step 6:** Clean up old HUD scripts (if any):
 ```bash
-node -e "const p=require('path'),f=require('fs'),d=process.env.CLAUDE_CONFIG_DIR||p.join(require('os').homedir(),'.claude'),t=p.join(d,'hud','omc-hud.mjs');try{if(f.existsSync(t)){f.unlinkSync(t);console.log('Removed legacy script')}else{console.log('No legacy script found')}}catch{}"
+node -e "const p=require('path'),f=require('fs'),d=process.env.CLAUDE_CONFIG_DIR||p.join(require('os').homedir(),'.claude'),t=p.join(d,'hud','omc-hud.js');try{if(f.existsSync(t)){f.unlinkSync(t);console.log('Removed legacy omc-hud.js')}else{console.log('No legacy script found')}}catch{}"
 ```
 
 **Step 7:** Tell the user to restart Claude Code for changes to take effect.

--- a/src/skills/__tests__/mingw-escape.test.ts
+++ b/src/skills/__tests__/mingw-escape.test.ts
@@ -134,6 +134,17 @@ describe('MINGW64 escape safety: no "!" in node -e inline scripts (issue #729)',
       expect(content).not.toContain('The command must use an absolute path, not `~`');
     });
 
+    it('hud SKILL.md cleanup step removes only the legacy HUD wrapper filename', () => {
+      const content = readFileSync(join(REPO_ROOT, 'skills', 'hud', 'SKILL.md'), 'utf-8');
+      const cleanupLine = content
+        .split('\n')
+        .find(l => l.includes('Removed legacy omc-hud.js') && l.startsWith('node -e'));
+
+      expect(cleanupLine).toBeDefined();
+      expect(cleanupLine).toContain("t=p.join(d,'hud','omc-hud.js')");
+      expect(cleanupLine).not.toContain("t=p.join(d,'hud','omc-hud.mjs')");
+    });
+
     it("omc-setup version-detect script uses v==='' not !v", () => {
       const setupDir = join(REPO_ROOT, 'skills', 'omc-setup');
       const files = [


### PR DESCRIPTION
## Summary
- retarget the HUD skill cleanup step to the legacy `omc-hud.js` filename instead of the current wrapper
- add a focused regression assertion so the HUD skill docs keep Step 3 install and Step 6 cleanup aligned

## Verification
- npm run test -- --run src/skills/__tests__/mingw-escape.test.ts src/__tests__/hud-windows.test.ts src/skills/__tests__/skill-config-dir.test.ts
- npx tsc --noEmit
- npm run lint -- src/skills/__tests__/mingw-escape.test.ts src/__tests__/hud-windows.test.ts src/skills/__tests__/skill-config-dir.test.ts  # warnings only, unrelated pre-existing

Closes #2483