### PR TITLE
fix(team): scaleUp() should honor agentType launch contracts

### DIFF
--- a/src/team/__tests__/scaling-launch-config.test.ts
+++ b/src/team/__tests__/scaling-launch-config.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+import type { CliAgentType } from '../model-contract.js';
+
+const tmuxUtilsMocks = vi.hoisted(() => ({
+  tmuxExec: vi.fn(),
+  tmuxSpawn: vi.fn(),
+}));
+
+const modelContractMocks = vi.hoisted(() => ({
+  buildWorkerArgv: vi.fn(),
+  getWorkerEnv: vi.fn(),
+}));
+
+const teamOpsMocks = vi.hoisted(() => ({
+  teamReadConfig: vi.fn(),
+  teamWriteWorkerIdentity: vi.fn(),
+  teamReadWorkerStatus: vi.fn(),
+  teamAppendEvent: vi.fn(),
+  writeAtomic: vi.fn(),
+}));
+
+const monitorMocks = vi.hoisted(() => ({
+  withScalingLock: vi.fn(),
+  saveTeamConfig: vi.fn(),
+}));
+
+const tmuxSessionMocks = vi.hoisted(() => ({
+  sanitizeName: vi.fn((name: string) => name),
+  isWorkerAlive: vi.fn(),
+  killWorkerPanes: vi.fn(),
+  buildWorkerStartCommand: vi.fn(() => 'start-worker'),
+  waitForPaneReady: vi.fn(),
+}));
+
+vi.mock('../../cli/tmux-utils.js', () => ({
+  tmuxExec: tmuxUtilsMocks.tmuxExec,
+  tmuxSpawn: tmuxUtilsMocks.tmuxSpawn,
+}));
+
+vi.mock('../model-contract.js', () => ({
+  buildWorkerArgv: modelContractMocks.buildWorkerArgv,
+  getWorkerEnv: modelContractMocks.getWorkerEnv,
+}));
+
+vi.mock('../team-ops.js', () => ({
+  teamReadConfig: teamOpsMocks.teamReadConfig,
+  teamWriteWorkerIdentity: teamOpsMocks.teamWriteWorkerIdentity,
+  teamReadWorkerStatus: teamOpsMocks.teamReadWorkerStatus,
+  teamAppendEvent: teamOpsMocks.teamAppendEvent,
+  writeAtomic: teamOpsMocks.writeAtomic,
+}));
+
+vi.mock('../monitor.js', () => ({
+  withScalingLock: monitorMocks.withScalingLock,
+  saveTeamConfig: monitorMocks.saveTeamConfig,
+}));
+
+vi.mock('../tmux-session.js', () => ({
+  sanitizeName: tmuxSessionMocks.sanitizeName,
+  isWorkerAlive: tmuxSessionMocks.isWorkerAlive,
+  killWorkerPanes: tmuxSessionMocks.killWorkerPanes,
+  buildWorkerStartCommand: tmuxSessionMocks.buildWorkerStartCommand,
+  waitForPaneReady: tmuxSessionMocks.waitForPaneReady,
+}));
+
+import { scaleUp } from '../scaling.js';
+
+describe('scaleUp launch config', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-scaling-launch-config-'));
+
+    vi.clearAllMocks();
+
+    monitorMocks.withScalingLock.mockImplementation(async (
+      _teamName: string,
+      _leaderCwd: string,
+      fn: () => Promise<unknown>,
+    ) => fn());
+    teamOpsMocks.teamReadConfig.mockResolvedValue({
+      name: 'demo-team',
+      task: 'demo',
+      agent_type: 'claude',
+      worker_launch_mode: 'interactive',
+      worker_count: 0,
+      max_workers: 20,
+      workers: [],
+      created_at: new Date().toISOString(),
+      tmux_session: 'demo-session:0',
+      next_task_id: 2,
+      next_worker_index: 1,
+      leader_pane_id: '%0',
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+      team_state_root: `${resolve(cwd)}/.omc/state`,
+    });
+    modelContractMocks.getWorkerEnv.mockImplementation((teamName: string, workerName: string, agentType: string) => ({
+      OMC_TEAM_WORKER: `${teamName}/${workerName}`,
+      OMC_TEAM_NAME: teamName,
+      OMC_WORKER_AGENT_TYPE: agentType,
+    }));
+    tmuxUtilsMocks.tmuxSpawn.mockImplementation((args: string[]) => {
+      if (args[0] === 'split-window') {
+        return { status: 0, stdout: '%12\n', stderr: '' };
+      }
+      if (args[0] === 'display-message') {
+        return { status: 0, stdout: '4321\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+    tmuxSessionMocks.waitForPaneReady.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    if (cwd) {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['codex', ['/usr/bin/codex', '--dangerously-bypass-approvals-and-sandbox']],
+    ['gemini', ['/usr/bin/gemini', '--approval-mode', 'yolo']],
+  ] as const)('uses model-contract launch argv for %s scale-up workers', async (
+    agentType: CliAgentType,
+    workerArgv: readonly string[],
+  ) => {
+    modelContractMocks.buildWorkerArgv.mockReturnValue(workerArgv);
+
+    const result = await scaleUp(
+      'demo-team',
+      1,
+      agentType,
+      [{ subject: 'demo', description: 'demo task' }],
+      cwd,
+      { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv,
+    );
+
+    expect(result).toMatchObject({ ok: true, newWorkerCount: 1, nextWorkerIndex: 2 });
+    expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(agentType, {
+      teamName: 'demo-team',
+      workerName: 'worker-1',
+      cwd: resolve(cwd),
+    });
+    expect(tmuxSessionMocks.buildWorkerStartCommand).toHaveBeenCalledWith(expect.objectContaining({
+      teamName: 'demo-team',
+      workerName: 'worker-1',
+      launchBinary: workerArgv[0],
+      launchArgs: workerArgv.slice(1),
+      cwd: resolve(cwd),
+      envVars: expect.objectContaining({
+        OMC_TEAM_WORKER: 'demo-team/worker-1',
+        OMC_TEAM_NAME: 'demo-team',
+        OMC_WORKER_AGENT_TYPE: agentType,
+        OMC_TEAM_STATE_ROOT: `${resolve(cwd)}/.omc/state`,
+        OMC_TEAM_LEADER_CWD: resolve(cwd),
+      }),
+    }));
+  });
+});

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -14,6 +14,11 @@ import { resolve } from 'path';
 import { mkdir } from 'fs/promises';
 import { tmuxExec, tmuxSpawn } from '../cli/tmux-utils.js';
 import {
+  buildWorkerArgv,
+  getWorkerEnv as getModelWorkerEnv,
+  type CliAgentType,
+} from './model-contract.js';
+import {
   teamReadConfig,
   teamWriteWorkerIdentity,
   teamReadWorkerStatus,
@@ -35,6 +40,7 @@ import { TeamPaths, absPath } from './state-paths.js';
 // ── Environment gate ──────────────────────────────────────────────────────────
 
 const OMC_TEAM_SCALING_ENABLED_ENV = 'OMC_TEAM_SCALING_ENABLED';
+const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini']);
 
 export function isScalingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[OMC_TEAM_SCALING_ENABLED_ENV];
@@ -49,6 +55,16 @@ function assertScalingEnabled(env: NodeJS.ProcessEnv = process.env): void {
       `Dynamic scaling is disabled. Set ${OMC_TEAM_SCALING_ENABLED_ENV}=1 to enable.`,
     );
   }
+}
+
+function asCliAgentType(agentType: string): CliAgentType {
+  if (CLI_AGENT_TYPES.has(agentType as CliAgentType)) {
+    return agentType as CliAgentType;
+  }
+
+  throw new Error(
+    `Unknown agent type: ${agentType}. Supported: ${Array.from(CLI_AGENT_TYPES).join(', ')}`,
+  );
 }
 
 // ── Result types ──────────────────────────────────────────────────────────────
@@ -88,6 +104,7 @@ export async function scaleUp(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<ScaleUpResult | ScaleError> {
   assertScalingEnabled(env);
+  const cliAgentType = asCliAgentType(agentType);
 
   if (!Number.isInteger(count) || count < 1) {
     return { ok: false, error: `count must be a positive integer (got ${count})` };
@@ -115,7 +132,6 @@ export async function scaleUp(
 
     // Resolve the monotonic worker index counter
     let nextIndex = config.next_worker_index ?? (currentCount + 1);
-    const initialNextIndex = nextIndex;
     const addedWorkers: WorkerInfo[] = [];
 
     const rollbackScaleUp = async (error: string, paneId?: string): Promise<ScaleError> => {
@@ -177,20 +193,32 @@ export async function scaleUp(
 
       // Build startup command and create tmux pane
       const extraEnv: Record<string, string> = {
+        ...getModelWorkerEnv(sanitized, workerName, cliAgentType, env),
         OMC_TEAM_STATE_ROOT: teamStateRoot,
         OMC_TEAM_LEADER_CWD: leaderCwd,
-        OMC_TEAM_WORKER: `${sanitized}/${workerName}`,
       };
 
-      const cmd = buildWorkerStartCommand({
-        teamName: sanitized,
-        workerName,
-        envVars: extraEnv,
-        launchArgs: [],
-        launchBinary: 'claude',
-        launchCmd: '',
-        cwd: leaderCwd,
-      });
+      let cmd: string;
+      try {
+        const [launchBinary, ...launchArgs] = buildWorkerArgv(cliAgentType, {
+          teamName: sanitized,
+          workerName,
+          cwd: leaderCwd,
+        });
+        cmd = buildWorkerStartCommand({
+          teamName: sanitized,
+          workerName,
+          envVars: extraEnv,
+          launchArgs,
+          launchBinary,
+          cwd: leaderCwd,
+        });
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        return await rollbackScaleUp(
+          `Failed to resolve worker launch config for ${workerName}: ${reason}`,
+        );
+      }
 
       // Split from the rightmost worker pane or the leader pane
       const splitTarget = config.workers.length > 0


### PR DESCRIPTION
## Summary
- Replace the hardcoded Claude launcher in team scale-up with the existing model-contract worker launch path
- Thread requested agent type through `buildWorkerArgv()` so launch binary and provider flags match the worker type
- Add a focused regression test covering codex and gemini scale-up launch config

## Verification
- `npm exec eslint src/team/scaling.ts src/team/__tests__/scaling-launch-config.test.ts`
- `npm run test:run -- src/team/__tests__/scaling.test.ts src/team/__tests__/scaling-launch-config.test.ts`
- `npx tsc --noEmit`
