### PR TITLE
fix(autopilot): scope runtime insight to the active session

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -13674,44 +13674,68 @@ function readJsonSafe2(path22) {
 function getTaskDependencyIds(task) {
   return task.depends_on ?? task.blocked_by ?? [];
 }
+function getTeamNamesForRuntimeInsight(directory, sessionId) {
+  const teamRoot = (0, import_path59.join)(getOmcRoot(directory), "state", "team");
+  if (!(0, import_fs49.existsSync)(teamRoot)) {
+    return [];
+  }
+  const teamNames = (0, import_fs49.readdirSync)(teamRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  if (!sessionId) {
+    return teamNames;
+  }
+  const scopedTeamNames = /* @__PURE__ */ new Set();
+  const teamState = readJsonSafe2(
+    resolveSessionStatePath("team", sessionId, directory)
+  );
+  const activeTeamName = teamState?.team_name ?? teamState?.teamName;
+  if (typeof activeTeamName === "string" && activeTeamName.trim().length > 0) {
+    scopedTeamNames.add(activeTeamName.trim());
+  }
+  for (const teamName of teamNames) {
+    const manifest = readJsonSafe2(
+      (0, import_path59.join)(teamRoot, teamName, "manifest.json")
+    );
+    if (manifest?.leader?.session_id === sessionId) {
+      scopedTeamNames.add(teamName);
+    }
+  }
+  return teamNames.filter((teamName) => scopedTeamNames.has(teamName));
+}
 function collectRuntimeInsight(directory, sessionId) {
-  const omcRoot = getOmcRoot(directory);
-  const teamRoot = (0, import_path59.join)(omcRoot, "state", "team");
   const missingDependencyIssues = [];
   const workerIssues = [];
-  if ((0, import_fs49.existsSync)(teamRoot)) {
-    for (const teamName of (0, import_fs49.readdirSync)(teamRoot)) {
-      const teamDir3 = (0, import_path59.join)(teamRoot, teamName);
-      const tasksDir = (0, import_path59.join)(teamDir3, "tasks");
-      const workersDir = (0, import_path59.join)(teamDir3, "workers");
-      const tasks = (0, import_fs49.existsSync)(tasksDir) ? (0, import_fs49.readdirSync)(tasksDir).filter((entry) => entry.endsWith(".json")).map((entry) => readJsonSafe2((0, import_path59.join)(tasksDir, entry))).filter((task) => Boolean(task)) : [];
-      const taskById = new Map(tasks.map((task) => [task.id, task]));
-      for (const task of tasks) {
-        const missingDependencyIds = getTaskDependencyIds(task).filter((dependencyId) => !taskById.has(dependencyId));
-        if (missingDependencyIds.length > 0) {
-          missingDependencyIssues.push({
-            teamName,
-            taskId: task.id,
-            missingDependencyIds
-          });
-        }
+  const teamRoot = (0, import_path59.join)(getOmcRoot(directory), "state", "team");
+  for (const teamName of getTeamNamesForRuntimeInsight(directory, sessionId)) {
+    const teamDir3 = (0, import_path59.join)(teamRoot, teamName);
+    const tasksDir = (0, import_path59.join)(teamDir3, "tasks");
+    const workersDir = (0, import_path59.join)(teamDir3, "workers");
+    const tasks = (0, import_fs49.existsSync)(tasksDir) ? (0, import_fs49.readdirSync)(tasksDir).filter((entry) => entry.endsWith(".json")).map((entry) => readJsonSafe2((0, import_path59.join)(tasksDir, entry))).filter((task) => Boolean(task)) : [];
+    const taskById = new Map(tasks.map((task) => [task.id, task]));
+    for (const task of tasks) {
+      const missingDependencyIds = getTaskDependencyIds(task).filter((dependencyId) => !taskById.has(dependencyId));
+      if (missingDependencyIds.length > 0) {
+        missingDependencyIssues.push({
+          teamName,
+          taskId: task.id,
+          missingDependencyIds
+        });
       }
-      if ((0, import_fs49.existsSync)(workersDir)) {
-        for (const workerName2 of (0, import_fs49.readdirSync)(workersDir)) {
-          const status = readJsonSafe2((0, import_path59.join)(workersDir, workerName2, "status.json"));
-          if (!status || typeof status.reason !== "string" || status.reason.trim().length === 0) {
-            continue;
-          }
-          if (status.state !== "blocked" && status.state !== "failed") {
-            continue;
-          }
-          workerIssues.push({
-            teamName,
-            workerName: workerName2,
-            state: status.state,
-            reason: status.reason.trim()
-          });
+    }
+    if ((0, import_fs49.existsSync)(workersDir)) {
+      for (const workerName2 of (0, import_fs49.readdirSync)(workersDir)) {
+        const status = readJsonSafe2((0, import_path59.join)(workersDir, workerName2, "status.json"));
+        if (!status || typeof status.reason !== "string" || status.reason.trim().length === 0) {
+          continue;
         }
+        if (status.state !== "blocked" && status.state !== "failed") {
+          continue;
+        }
+        workerIssues.push({
+          teamName,
+          workerName: workerName2,
+          state: status.state,
+          reason: status.reason.trim()
+        });
       }
     }
   }

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -1174,6 +1174,13 @@ Read src/hooks/bridge.ts first.`,
           expansion: { spec_path: null },
           planning: { plan_path: null },
         }, null, 2));
+        writeFileSync(join(sessionDir, 'team-state.json'), JSON.stringify({
+          active: true,
+          session_id: sessionId,
+          team_name: 'bridge-autopilot-demo-team',
+          current_phase: 'team-exec',
+        }, null, 2));
+        writeCanonicalTeamState(testDir, sessionId, 'bridge-autopilot-demo-team', 'executing');
         writeFileSync(join(teamRoot, 'tasks', '1.json'), JSON.stringify({
           id: '1',
           subject: 'Blocked task',

--- a/src/hooks/autopilot/__tests__/runtime-insight.test.ts
+++ b/src/hooks/autopilot/__tests__/runtime-insight.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { formatAutopilotRuntimeInsight } from '../runtime-insight.js';
+import { writeHudState } from '../../../hud/state.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+describe('formatAutopilotRuntimeInsight', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(process.cwd(), '.tmp-runtime-insight-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('limits team blocker scans to teams owned by the active session', () => {
+    writeJson(join(cwd, '.omc/state/team/session-a-team/manifest.json'), {
+      schema_version: 2,
+      name: 'session-a-team',
+      task: 'session-a task',
+      leader: { session_id: 'session-A', worker_id: 'leader-a', role: 'leader' },
+      created_at: new Date().toISOString(),
+    });
+    writeJson(join(cwd, '.omc/state/team/session-a-team/tasks/task-1.json'), {
+      id: '1',
+      subject: 'task 1',
+      description: 'broken dependency',
+      status: 'pending',
+      depends_on: ['999'],
+      created_at: new Date().toISOString(),
+    });
+    writeJson(join(cwd, '.omc/state/team/session-a-team/workers/worker-1/status.json'), {
+      state: 'blocked',
+      reason: 'waiting on scoped issue',
+      updated_at: new Date().toISOString(),
+    });
+
+    writeJson(join(cwd, '.omc/state/team/session-b-team/manifest.json'), {
+      schema_version: 2,
+      name: 'session-b-team',
+      task: 'session-b task',
+      leader: { session_id: 'session-B', worker_id: 'leader-b', role: 'leader' },
+      created_at: new Date().toISOString(),
+    });
+    writeJson(join(cwd, '.omc/state/team/session-b-team/tasks/task-7.json'), {
+      id: '7',
+      subject: 'task 7',
+      description: 'foreign dependency',
+      status: 'pending',
+      depends_on: ['404'],
+      created_at: new Date().toISOString(),
+    });
+    writeJson(join(cwd, '.omc/state/team/session-b-team/workers/worker-9/status.json'), {
+      state: 'failed',
+      reason: 'foreign failure',
+      updated_at: new Date().toISOString(),
+    });
+
+    writeHudState(
+      {
+        timestamp: new Date().toISOString(),
+        backgroundTasks: [
+          {
+            id: 'bg-1',
+            description: 'verify scoped runtime insight',
+            status: 'running',
+            startedAt: new Date().toISOString(),
+            agentType: 'executor',
+          },
+        ],
+      },
+      cwd,
+      'session-A',
+    );
+
+    const insight = formatAutopilotRuntimeInsight(cwd, 'session-A');
+
+    expect(insight).toContain('[session-a-team] task-1 depends on missing task ids [999]');
+    expect(insight).toContain('[session-a-team] worker-1 is blocked: waiting on scoped issue');
+    expect(insight).not.toContain('session-b-team');
+    expect(insight).not.toContain('foreign failure');
+    expect(insight).toContain('Live progress:');
+    expect(insight).toContain('running (executor): verify scoped runtime insight');
+  });
+
+  it('keeps legacy workspace-wide scanning when no session id is provided', () => {
+    writeJson(join(cwd, '.omc/state/team/team-a/tasks/task-1.json'), {
+      id: '1',
+      subject: 'task 1',
+      description: 'missing dep',
+      status: 'pending',
+      depends_on: ['2'],
+      created_at: new Date().toISOString(),
+    });
+    writeJson(join(cwd, '.omc/state/team/team-b/workers/worker-2/status.json'), {
+      state: 'failed',
+      reason: 'global failure',
+      updated_at: new Date().toISOString(),
+    });
+
+    const insight = formatAutopilotRuntimeInsight(cwd);
+
+    expect(insight).toContain('[team-a] task-1 depends on missing task ids [2]');
+    expect(insight).toContain('[team-b] worker-2 is failed: global failure');
+  });
+});

--- a/src/hooks/autopilot/runtime-insight.ts
+++ b/src/hooks/autopilot/runtime-insight.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { getOmcRoot } from '../../lib/worktree-paths.js';
+import { getOmcRoot, resolveSessionStatePath } from '../../lib/worktree-paths.js';
 import { readHudState } from '../../hud/state.js';
 import type { BackgroundTask } from '../../hud/types.js';
 import type { TeamTask, WorkerStatus } from '../../team/types.js';
@@ -40,54 +40,86 @@ function getTaskDependencyIds(task: TeamTask): string[] {
   return task.depends_on ?? task.blocked_by ?? [];
 }
 
+function getTeamNamesForRuntimeInsight(directory: string, sessionId?: string): string[] {
+  const teamRoot = join(getOmcRoot(directory), 'state', 'team');
+  if (!existsSync(teamRoot)) {
+    return [];
+  }
+
+  const teamNames = readdirSync(teamRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  if (!sessionId) {
+    return teamNames;
+  }
+
+  const scopedTeamNames = new Set<string>();
+  const teamState = readJsonSafe<Record<string, unknown>>(
+    resolveSessionStatePath('team', sessionId, directory),
+  );
+  const activeTeamName = teamState?.team_name ?? teamState?.teamName;
+  if (typeof activeTeamName === 'string' && activeTeamName.trim().length > 0) {
+    scopedTeamNames.add(activeTeamName.trim());
+  }
+
+  for (const teamName of teamNames) {
+    const manifest = readJsonSafe<{ leader?: { session_id?: unknown } }>(
+      join(teamRoot, teamName, 'manifest.json'),
+    );
+    if (manifest?.leader?.session_id === sessionId) {
+      scopedTeamNames.add(teamName);
+    }
+  }
+
+  return teamNames.filter((teamName) => scopedTeamNames.has(teamName));
+}
+
 function collectRuntimeInsight(directory: string, sessionId?: string): RuntimeInsightSnapshot {
-  const omcRoot = getOmcRoot(directory);
-  const teamRoot = join(omcRoot, 'state', 'team');
   const missingDependencyIssues: MissingDependencyIssue[] = [];
   const workerIssues: WorkerIssue[] = [];
 
-  if (existsSync(teamRoot)) {
-    for (const teamName of readdirSync(teamRoot)) {
-      const teamDir = join(teamRoot, teamName);
-      const tasksDir = join(teamDir, 'tasks');
-      const workersDir = join(teamDir, 'workers');
+  const teamRoot = join(getOmcRoot(directory), 'state', 'team');
+  for (const teamName of getTeamNamesForRuntimeInsight(directory, sessionId)) {
+    const teamDir = join(teamRoot, teamName);
+    const tasksDir = join(teamDir, 'tasks');
+    const workersDir = join(teamDir, 'workers');
 
-      const tasks: TeamTask[] = existsSync(tasksDir)
-        ? readdirSync(tasksDir)
-            .filter((entry) => entry.endsWith('.json'))
-            .map((entry) => readJsonSafe<TeamTask>(join(tasksDir, entry)))
-            .filter((task): task is TeamTask => Boolean(task))
-        : [];
+    const tasks: TeamTask[] = existsSync(tasksDir)
+      ? readdirSync(tasksDir)
+          .filter((entry) => entry.endsWith('.json'))
+          .map((entry) => readJsonSafe<TeamTask>(join(tasksDir, entry)))
+          .filter((task): task is TeamTask => Boolean(task))
+      : [];
 
-      const taskById = new Map(tasks.map((task) => [task.id, task] as const));
-      for (const task of tasks) {
-        const missingDependencyIds = getTaskDependencyIds(task)
-          .filter((dependencyId) => !taskById.has(dependencyId));
-        if (missingDependencyIds.length > 0) {
-          missingDependencyIssues.push({
-            teamName,
-            taskId: task.id,
-            missingDependencyIds,
-          });
-        }
+    const taskById = new Map(tasks.map((task) => [task.id, task] as const));
+    for (const task of tasks) {
+      const missingDependencyIds = getTaskDependencyIds(task)
+        .filter((dependencyId) => !taskById.has(dependencyId));
+      if (missingDependencyIds.length > 0) {
+        missingDependencyIssues.push({
+          teamName,
+          taskId: task.id,
+          missingDependencyIds,
+        });
       }
+    }
 
-      if (existsSync(workersDir)) {
-        for (const workerName of readdirSync(workersDir)) {
-          const status = readJsonSafe<WorkerStatus>(join(workersDir, workerName, 'status.json'));
-          if (!status || typeof status.reason !== 'string' || status.reason.trim().length === 0) {
-            continue;
-          }
-          if (status.state !== 'blocked' && status.state !== 'failed') {
-            continue;
-          }
-          workerIssues.push({
-            teamName,
-            workerName,
-            state: status.state,
-            reason: status.reason.trim(),
-          });
+    if (existsSync(workersDir)) {
+      for (const workerName of readdirSync(workersDir)) {
+        const status = readJsonSafe<WorkerStatus>(join(workersDir, workerName, 'status.json'));
+        if (!status || typeof status.reason !== 'string' || status.reason.trim().length === 0) {
+          continue;
         }
+        if (status.state !== 'blocked' && status.state !== 'failed') {
+          continue;
+        }
+        workerIssues.push({
+          teamName,
+          workerName,
+          state: status.state,
+          reason: status.reason.trim(),
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary\n- scope autopilot runtime insight team scans to the active session when a session id is provided\n- preserve legacy workspace-wide scanning when no session id is available\n- add a focused regression test for session-scoped runtime insight formatting\n\n## Testing\n- npx vitest run src/hooks/autopilot/__tests__/runtime-insight.test.ts\n- npx eslint src/hooks/autopilot/runtime-insight.ts src/hooks/autopilot/__tests__/runtime-insight.test.ts\n- npx tsc --noEmit\n- node --check bridge/cli.cjs\n\nCloses #2484