### PR TITLE
fix(tmux): keep HUD pane cleanup on the current tmux server

### DIFF
--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -21,6 +21,9 @@ vi.mock('child_process', async (importOriginal) => {
 });
 
 import {
+  createHudWatchPane,
+  killTmuxPane,
+  listHudWatchPaneIdsInCurrentWindow,
   resolveLaunchPolicy,
   tmuxExec,
   tmuxSpawn,
@@ -358,5 +361,40 @@ describe('createHudWatchPane login shell wrapping', () => {
       'utf-8'
     );
     expect(source).toContain('wrapWithLoginShell(hudCmd)');
+  });
+});
+
+describe('HUD pane tmux server targeting', () => {
+  it('creates HUD panes against the current tmux server', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-100/default,123,0');
+    mockedExecFileSync.mockReturnValue('%12\n' as any);
+
+    expect(createHudWatchPane('/tmp/project', 'omc hud --watch')).toBe('%12');
+
+    const lastCall = mockedExecFileSync.mock.calls.at(-1);
+    expect(lastCall?.[1]?.[0]).toBe('split-window');
+    expect(lastCall?.[2]?.env?.TMUX).toBe('/tmp/tmux-100/default,123,0');
+  });
+
+  it('lists HUD panes against the current tmux server', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-100/default,123,0');
+    mockedExecFileSync.mockReturnValue('%2\tnode\tnode /tmp/omc.js hud --watch\n' as any);
+
+    expect(listHudWatchPaneIdsInCurrentWindow()).toEqual(['%2']);
+
+    const lastCall = mockedExecFileSync.mock.calls.at(-1);
+    expect(lastCall?.[1]).toEqual(['list-panes', '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}']);
+    expect(lastCall?.[2]?.env?.TMUX).toBe('/tmp/tmux-100/default,123,0');
+  });
+
+  it('kills HUD panes against the current tmux server', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-100/default,123,0');
+    mockedExecFileSync.mockReturnValue('' as any);
+
+    killTmuxPane('%9');
+
+    const lastCall = mockedExecFileSync.mock.calls.at(-1);
+    expect(lastCall?.[1]).toEqual(['kill-pane', '-t', '%9']);
+    expect(lastCall?.[2]?.env?.TMUX).toBe('/tmp/tmux-100/default,123,0');
   });
 });

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -379,7 +379,7 @@ export function createHudWatchPane(cwd: string, hudCmd: string): string | null {
 export function killTmuxPane(paneId: string): void {
   if (!paneId.startsWith('%')) return;
   try {
-    tmuxExec(['kill-pane', '-t', paneId], { stripTmux: true, stdio: 'ignore' });
+    tmuxExec(['kill-pane', '-t', paneId], { stdio: 'ignore' });
   } catch {
     // Pane may already be gone; ignore
   }


### PR DESCRIPTION
## Summary
- remove `stripTmux` from `killTmuxPane()` so HUD cleanup stays on the same tmux server as HUD pane creation/discovery
- add targeted tmux-utils regression tests that assert create/list/kill all preserve `TMUX`
- keep the fix scoped to the HUD pane lifecycle mismatch behind issue #2485

## Testing
- npm test -- --run src/cli/__tests__/tmux-utils.test.ts
- npx tsc --noEmit
- npx eslint src/cli/tmux-utils.ts src/cli/__tests__/tmux-utils.test.ts

Fixes #2485
