### PR TITLE
docs: add omc symlink bootstrap and .mcp.json conflict resolution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,21 @@ All TypeScript and bundling steps are handled. The output goes to `dist/` and `b
 
 Once built, you need to tell Claude Code to use your local checkout. Here are three flows:
 
+### Bootstrap: make the `omc` command available
+
+All three flows below use the `omc` CLI. If you don't have it installed globally (via `npm i -g oh-my-claude-sisyphus`), create a symlink from your checkout:
+
+```bash
+# Create ~/.local/bin if it doesn't exist
+mkdir -p ~/.local/bin
+
+# Symlink omc to the checkout's bridge entry point
+ln -sf "$PWD/bridge/cli.cjs" ~/.local/bin/omc
+
+# Verify (you may need ~/.local/bin on your PATH)
+omc --version
+```
+
 ### Flow A: `omc --plugin-dir` + `omc setup --plugin-dir-mode` (recommended — lowest friction)
 
 **Advantages**: Single command, automatic env var handling, matches the OMC philosophy.
@@ -100,6 +115,16 @@ omc --plugin-dir "$PWD" setup --plugin-dir-mode
 ```
 
 Then launch Claude Code normally — it will use your local checkout.
+
+**Disable the `.mcp.json` server conflict**: The repo ships `.mcp.json` with an MCP server named `"t"` (the OMC bridge). When using `--plugin-dir`, the plugin also registers its own `"t"` server, causing a name collision. To resolve this, add to your `~/.claude/settings.json` (or `$CLAUDE_CONFIG_DIR/settings.json`):
+
+```json
+{
+  "disabledMcpjsonServers": ["t"]
+}
+```
+
+This tells Claude Code to ignore the repo's `.mcp.json` entry and use the plugin's version instead.
 
 **Inside Claude Code**:
 ```bash


### PR DESCRIPTION
## Summary

Two undocumented setup steps that every `--plugin-dir` contributor hits:

1. **No `omc` command** — Flow A assumes `omc` is globally installed, but a fresh clone has no `omc` binary. Added a Bootstrap subsection before the three flows showing how to symlink `bridge/cli.cjs` to `~/.local/bin/omc`.

2. **MCP server "t" collision** — The repo's `.mcp.json` registers an MCP server named `"t"`. When using `--plugin-dir`, the plugin also registers its own `"t"` server, causing `MCP server "github" skipped — same command/URL as already-configured`. Added `disabledMcpjsonServers` instruction inside Flow A.

**Docs-only diff: 1 file, +25/-0.**

## Test plan

- [x] Verified symlink instructions work: `ln -sf "$PWD/bridge/cli.cjs" ~/.local/bin/omc && omc --version`
- [x] Verified `disabledMcpjsonServers: ["t"]` resolves the MCP collision after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)