### PR TITLE
Back off zero-backlog follow-up spam on unchanged repo state

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -21,6 +21,8 @@ const {
   renameSync,
   statSync,
 } = require("fs");
+const { execFileSync } = require("child_process");
+const { homedir } = require("os");
 const { join, dirname, resolve, normalize } = require("path");
 const { getClaudeConfigDir } = require("./lib/config-dir.cjs");
 
@@ -79,16 +81,139 @@ function getIdleCooldownSeconds() {
   return 60;
 }
 
+const COMMAND_TIMEOUT_MS = 10_000;
+const MAX_LIST_RESULTS = 100;
+const FAILURE_CONCLUSIONS = new Set([
+  'failure',
+  'timed_out',
+  'cancelled',
+  'action_required',
+  'startup_failure',
+]);
+
+function runCommand(command, args, cwd) {
+  try {
+    return execFileSync(command, args, {
+      cwd,
+      encoding: 'utf-8',
+      timeout: COMMAND_TIMEOUT_MS,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function runJsonCommand(command, args, cwd) {
+  const raw = runCommand(command, args, cwd);
+  if (raw === null) return null;
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function parseGitHubRemote(remoteUrl) {
+  const normalized = remoteUrl.trim();
+  const patterns = [
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/,
+    /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/,
+    /^ssh:\/\/git@github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = normalized.match(pattern);
+    if (match) {
+      return { owner: match[1], repo: match[2] };
+    }
+  }
+
+  return null;
+}
+
+function toSortedNumbers(values) {
+  return values
+    .filter((value) => Number.isInteger(value))
+    .sort((left, right) => left - right);
+}
+
+function getIdleNotificationRepoState(directory) {
+  const remoteUrl = runCommand('git', ['remote', 'get-url', 'origin'], directory);
+  if (!remoteUrl) return null;
+
+  const remote = parseGitHubRemote(remoteUrl);
+  if (!remote) return null;
+
+  const repo = `${remote.owner}/${remote.repo}`;
+  const headSha = runCommand('git', ['rev-parse', 'HEAD'], directory);
+  const porcelainStatus = runCommand('git', ['status', '--porcelain'], directory);
+  if (!headSha || porcelainStatus === null) return null;
+
+  const openPrs = runJsonCommand('gh', ['pr', 'list', '--repo', repo, '--state', 'open', '--limit', String(MAX_LIST_RESULTS), '--json', 'number'], directory);
+  if (!openPrs) return null;
+
+  const openIssues = runJsonCommand('gh', ['issue', 'list', '--repo', repo, '--state', 'open', '--limit', String(MAX_LIST_RESULTS), '--json', 'number'], directory);
+  if (!openIssues) return null;
+
+  const runs = runJsonCommand('gh', ['run', 'list', '--repo', repo, '--limit', String(MAX_LIST_RESULTS), '--json', 'databaseId,conclusion'], directory);
+  if (!runs) return null;
+
+  const failingRunIds = toSortedNumbers(
+    runs
+      .filter((run) => FAILURE_CONCLUSIONS.has(((run.conclusion || '') + '').toLowerCase()))
+      .map((run) => run.databaseId),
+  );
+  const openPrNumbers = toSortedNumbers(openPrs.map((entry) => entry.number));
+  const openIssueNumbers = toSortedNumbers(openIssues.map((entry) => entry.number));
+
+  const snapshot = {
+    repo,
+    headSha,
+    dirty: porcelainStatus.length > 0,
+    openPrNumbers,
+    openIssueNumbers,
+    failingRunIds,
+  };
+
+  return {
+    signature: JSON.stringify(snapshot),
+    backlogZero:
+      openPrNumbers.length === 0 &&
+      openIssueNumbers.length === 0 &&
+      failingRunIds.length === 0,
+  };
+}
+
+function isRepeatedZeroBacklog(record, repoState) {
+  return Boolean(
+    repoState?.backlogZero &&
+    record?.backlogZero === true &&
+    typeof record.repoSignature === 'string' &&
+    record.repoSignature === repoState.signature,
+  );
+}
+
 /**
  * Check whether the session-idle cooldown has elapsed.
  * Returns true if the notification should be sent.
  */
-function shouldSendIdleNotification(stateDir) {
+function shouldSendIdleNotification(stateDir, repoState) {
   const cooldownSecs = getIdleCooldownSeconds();
-  if (cooldownSecs === 0) return true; // cooldown disabled
-
   const cooldownPath = join(stateDir, 'idle-notif-cooldown.json');
   const data = readJsonFile(cooldownPath);
+
+  if (isRepeatedZeroBacklog(data, repoState)) {
+    return false;
+  }
+
+  if (repoState && typeof data?.repoSignature === 'string' && data.repoSignature !== repoState.signature) {
+    return true;
+  }
+
+  if (cooldownSecs === 0) return true; // cooldown disabled
+
   if (data?.lastSentAt) {
     const elapsed = (Date.now() - new Date(data.lastSentAt).getTime()) / 1000;
     if (Number.isFinite(elapsed) && elapsed < cooldownSecs) return false;
@@ -99,9 +224,14 @@ function shouldSendIdleNotification(stateDir) {
 /**
  * Record that the session-idle notification was sent.
  */
-function recordIdleNotificationSent(stateDir) {
+function recordIdleNotificationSent(stateDir, repoState) {
   const cooldownPath = join(stateDir, 'idle-notif-cooldown.json');
-  writeJsonFile(cooldownPath, { lastSentAt: new Date().toISOString() });
+  const record = { lastSentAt: new Date().toISOString() };
+  if (repoState) {
+    record.repoSignature = repoState.signature;
+    record.backlogZero = repoState.backlogZero;
+  }
+  writeJsonFile(cooldownPath, record);
 }
 
 /**
@@ -1157,8 +1287,9 @@ async function main() {
     // No blocking needed — Claude is truly idle.
     // Send session-idle notification (fire-and-forget) so external integrations
     // (Telegram, Discord) know the session went idle without any active mode.
-    // Per-session cooldown prevents notification spam when the session idles repeatedly.
-    if (sessionId && shouldSendIdleNotification(stateDir)) {
+    // Back off repeated zero-backlog nudges until repo state changes.
+    const idleRepoState = getIdleNotificationRepoState(directory);
+    if (sessionId && shouldSendIdleNotification(stateDir, idleRepoState)) {
       try {
         const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
         if (pluginRoot) {
@@ -1171,7 +1302,7 @@ async function main() {
               }).catch(() => {})
             )
             .catch(() => {});
-          recordIdleNotificationSent(stateDir);
+          recordIdleNotificationSent(stateDir, idleRepoState);
         }
       } catch {
         // Notification module not available, skip silently

--- a/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
@@ -352,6 +352,40 @@ describe('shouldSendIdleNotification', () => {
     expect(shouldSendIdleNotification(TEST_STATE_DIR, TEST_SESSION_ID)).toBe(false);
   });
 
+  it('suppresses repeated zero-backlog nudges across follow-up sessions when the global repo snapshot is unchanged', () => {
+    const oldTimestamp = new Date(Date.now() - 90_000).toISOString();
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => p === COOLDOWN_PATH);
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === COOLDOWN_PATH) {
+        return JSON.stringify({
+          lastSentAt: oldTimestamp,
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        });
+      }
+      throw new Error('not found');
+    });
+
+    expect(shouldSendIdleNotification(TEST_STATE_DIR, TEST_SESSION_ID, zeroBacklogState)).toBe(false);
+  });
+
+  it('re-enables zero-backlog nudges across follow-up sessions when the repo snapshot changes', () => {
+    const recentTimestamp = new Date(Date.now() - 5_000).toISOString();
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => p === COOLDOWN_PATH);
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === COOLDOWN_PATH) {
+        return JSON.stringify({
+          lastSentAt: recentTimestamp,
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        });
+      }
+      throw new Error('not found');
+    });
+
+    expect(shouldSendIdleNotification(TEST_STATE_DIR, TEST_SESSION_ID, changedBacklogState)).toBe(true);
+  });
+
   it('blocks notification when within custom shorter cooldown', () => {
     const recentTimestamp = new Date(Date.now() - 10_000).toISOString(); // 10s ago
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
@@ -461,6 +495,28 @@ describe('recordIdleNotificationSent', () => {
     expect(atomicWriteJsonSync).toHaveBeenCalledOnce();
     const [calledPath] = (atomicWriteJsonSync as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(calledPath).toBe(SESSION_COOLDOWN_PATH);
+  });
+
+  it('mirrors zero-backlog metadata to the global cooldown file for follow-up sessions', () => {
+    recordIdleNotificationSent(TEST_STATE_DIR, TEST_SESSION_ID, zeroBacklogState);
+
+    expect(atomicWriteJsonSync).toHaveBeenCalledTimes(2);
+    expect(atomicWriteJsonSync).toHaveBeenCalledWith(
+      SESSION_COOLDOWN_PATH,
+      expect.objectContaining({
+        lastSentAt: expect.any(String),
+        repoSignature: zeroBacklogState.signature,
+        backlogZero: true,
+      })
+    );
+    expect(atomicWriteJsonSync).toHaveBeenCalledWith(
+      COOLDOWN_PATH,
+      expect.objectContaining({
+        lastSentAt: expect.any(String),
+        repoSignature: zeroBacklogState.signature,
+        backlogZero: true,
+      })
+    );
   });
 
   it('creates state directory if it does not exist', () => {

--- a/src/hooks/persistent-mode/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/idle-cooldown.test.ts
@@ -82,6 +82,36 @@ describe("idle notification cooldown (issue #842)", () => {
       expect(shouldSendIdleNotification(stateDir, "different-session")).toBe(true);
     });
 
+
+    it("suppresses repeated zero-backlog notifications across follow-up sessions when the global repo snapshot is unchanged", () => {
+      const globalCooldownPath = join(stateDir, "idle-notif-cooldown.json");
+      const past = new Date(Date.now() - 120_000).toISOString();
+      writeFileSync(
+        globalCooldownPath,
+        JSON.stringify({
+          lastSentAt: past,
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        })
+      );
+
+      expect(shouldSendIdleNotification(stateDir, "fresh-session", zeroBacklogState)).toBe(false);
+    });
+
+    it("re-enables zero-backlog notifications across follow-up sessions when the repo snapshot changes", () => {
+      const globalCooldownPath = join(stateDir, "idle-notif-cooldown.json");
+      writeFileSync(
+        globalCooldownPath,
+        JSON.stringify({
+          lastSentAt: new Date().toISOString(),
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        })
+      );
+
+      expect(shouldSendIdleNotification(stateDir, "fresh-session", changedBacklogState)).toBe(true);
+    });
+
     it("suppresses repeated zero-backlog notifications when repo state has not changed", () => {
       const cooldownPath = join(stateDir, "idle-notif-cooldown.json");
       const past = new Date(Date.now() - 120_000).toISOString();
@@ -165,6 +195,30 @@ describe("idle notification cooldown (issue #842)", () => {
 
       expect(existsSync(cooldownPath)).toBe(true);
       expect(existsSync(join(stateDir, "idle-notif-cooldown.json"))).toBe(false);
+    });
+
+
+    it("mirrors zero-backlog metadata to the global cooldown path for follow-up sessions", () => {
+      const sessionId = "session-xyz";
+      const sessionCooldownPath = join(
+        stateDir,
+        "sessions",
+        sessionId,
+        "idle-notif-cooldown.json"
+      );
+      const globalCooldownPath = join(stateDir, "idle-notif-cooldown.json");
+
+      recordIdleNotificationSent(stateDir, sessionId, zeroBacklogState);
+
+      expect(existsSync(sessionCooldownPath)).toBe(true);
+      expect(existsSync(globalCooldownPath)).toBe(true);
+
+      const sessionData = JSON.parse(readFileSync(sessionCooldownPath, "utf-8")) as Record<string, unknown>;
+      const globalData = JSON.parse(readFileSync(globalCooldownPath, "utf-8")) as Record<string, unknown>;
+      expect(sessionData.repoSignature).toBe(zeroBacklogState.signature);
+      expect(globalData.repoSignature).toBe(zeroBacklogState.signature);
+      expect(sessionData.backlogZero).toBe(true);
+      expect(globalData.backlogZero).toBe(true);
     });
 
     it("stores repo signature metadata when repo state is provided", () => {

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -305,12 +305,37 @@ interface IdleNotificationCooldownRecord {
   backlogZero?: boolean;
 }
 
+function getGlobalIdleNotificationCooldownPath(stateDir: string): string {
+  return join(stateDir, 'idle-notif-cooldown.json');
+}
+
 function getIdleNotificationCooldownPath(stateDir: string, sessionId?: string): string {
   // Keep session segments filesystem-safe; fall back to legacy global path otherwise.
   if (sessionId && /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) {
     return join(stateDir, 'sessions', sessionId, 'idle-notif-cooldown.json');
   }
-  return join(stateDir, 'idle-notif-cooldown.json');
+  return getGlobalIdleNotificationCooldownPath(stateDir);
+}
+
+function readIdleNotificationCooldownRecord(cooldownPath: string): IdleNotificationCooldownRecord | null {
+  try {
+    if (!existsSync(cooldownPath)) return null;
+    return JSON.parse(readFileSync(cooldownPath, 'utf-8')) as IdleNotificationCooldownRecord;
+  } catch {
+    return null;
+  }
+}
+
+function isRepeatedZeroBacklogCooldown(
+  record: IdleNotificationCooldownRecord | null,
+  repoState?: IdleNotificationRepoState | null,
+): boolean {
+  return Boolean(
+    repoState?.backlogZero &&
+    record?.backlogZero === true &&
+    typeof record.repoSignature === 'string' &&
+    record.repoSignature === repoState.signature,
+  );
 }
 
 /**
@@ -323,28 +348,34 @@ export function shouldSendIdleNotification(
   repoState?: IdleNotificationRepoState | null,
 ): boolean {
   const cooldownSecs = getIdleNotificationCooldownSeconds();
-
   const cooldownPath = getIdleNotificationCooldownPath(stateDir, sessionId);
-  try {
-    if (!existsSync(cooldownPath)) return true;
-    const data = JSON.parse(readFileSync(cooldownPath, 'utf-8')) as IdleNotificationCooldownRecord;
-    if (repoState && typeof data.repoSignature === 'string') {
-      if (data.repoSignature !== repoState.signature) {
-        return true;
-      }
-      if (data.backlogZero === true && repoState.backlogZero) {
-        return false;
-      }
-    }
+  const cooldownRecord = readIdleNotificationCooldownRecord(cooldownPath);
 
-    if (cooldownSecs === 0) return true; // cooldown disabled
+  if (isRepeatedZeroBacklogCooldown(cooldownRecord, repoState)) {
+    return false;
+  }
 
-    if (typeof data.lastSentAt === 'string') {
-      const elapsed = (Date.now() - new Date(data.lastSentAt).getTime()) / 1000;
-      if (Number.isFinite(elapsed) && elapsed < cooldownSecs) return false;
+  // Back off unchanged zero-backlog nudges across follow-up sessions too.
+  // Session-scoped cooldown should not keep rearming identical "all clear"
+  // alerts for brand-new session ids when the repo state has not changed.
+  if (cooldownPath !== getGlobalIdleNotificationCooldownPath(stateDir)) {
+    const globalRecord = readIdleNotificationCooldownRecord(getGlobalIdleNotificationCooldownPath(stateDir));
+    if (isRepeatedZeroBacklogCooldown(globalRecord, repoState)) {
+      return false;
     }
-  } catch {
-    // ignore — treat as no cooldown file
+  }
+
+  if (repoState && typeof cooldownRecord?.repoSignature === 'string') {
+    if (cooldownRecord.repoSignature !== repoState.signature) {
+      return true;
+    }
+  }
+
+  if (cooldownSecs === 0) return true; // cooldown disabled
+
+  if (typeof cooldownRecord?.lastSentAt === 'string') {
+    const elapsed = (Date.now() - new Date(cooldownRecord.lastSentAt).getTime()) / 1000;
+    if (Number.isFinite(elapsed) && elapsed < cooldownSecs) return false;
   }
   return true;
 }
@@ -367,6 +398,9 @@ export function recordIdleNotificationSent(
       record.backlogZero = repoState.backlogZero;
     }
     atomicWriteJsonSync(cooldownPath, record);
+    if (repoState?.backlogZero && cooldownPath !== getGlobalIdleNotificationCooldownPath(stateDir)) {
+      atomicWriteJsonSync(getGlobalIdleNotificationCooldownPath(stateDir), record);
+    }
   } catch {
     // ignore write errors
   }


### PR DESCRIPTION
## Summary
- trace issue #2497 to the shipped `scripts/persistent-mode.cjs` idle-alert path, which still used only a time-based cooldown
- back off repeated zero-backlog follow-up alerts when the repo snapshot is unchanged, and re-enable immediately when the snapshot changes
- keep the source helper in parity by mirroring zero-backlog cooldown metadata across follow-up sessions and add targeted regressions

## Testing
- `npx vitest run src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts src/hooks/persistent-mode/idle-cooldown.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/hooks/persistent-mode/index.ts src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts src/hooks/persistent-mode/idle-cooldown.test.ts`
- `node --check scripts/persistent-mode.cjs`

Closes #2497.
