### PR TITLE
Fix tmux keyword-alert noise from prompt-mode startup echo

### DIFF
--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -388,7 +388,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(mocks.sendToWorker).toHaveBeenCalledTimes(1);
   });
 
-  it('passes the full lifecycle instruction to codex prompt-mode workers and waits for claim evidence', async () => {
+  it('keeps codex prompt-mode launch args to a short inbox pointer and waits for claim evidence', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-codex-prompt-'));
 
     modelContractMocks.isPromptModeAgent.mockImplementation((agentType?: string) => agentType === 'codex');
@@ -416,30 +416,43 @@ describe('runtime v2 startup inbox dispatch', () => {
       teamName: 'dispatch-team',
       workerCount: 1,
       agentTypes: ['codex'],
-      tasks: [{ subject: 'Dispatch test', description: 'Verify codex lifecycle prompt mode' }],
+      tasks: [{
+        subject: 'Dispatch test',
+        description: 'Reviewer seed says the worker may be blocked; verify prompt echo stays quiet.',
+      }],
       cwd,
     });
 
     expect(modelContractMocks.getPromptModeArgs).toHaveBeenCalledWith(
       'codex',
-      expect.stringContaining('team api claim-task'),
+      expect.stringContaining('.omc/state/team/dispatch-team/workers/worker-1/inbox.md'),
     );
-    expect(modelContractMocks.getPromptModeArgs).toHaveBeenCalledWith(
-      'codex',
-      expect.stringContaining('transition-task-status'),
-    );
+    const promptModeInstruction = modelContractMocks.getPromptModeArgs.mock.calls[0]?.[1];
+    expect(promptModeInstruction).toContain('Open .omc/state/team/dispatch-team/workers/worker-1/inbox.md');
+    expect(promptModeInstruction).not.toContain('claim-task');
+    expect(promptModeInstruction).not.toContain('transition-task-status');
+    expect(promptModeInstruction).not.toContain('blocked');
+    expect(promptModeInstruction).not.toContain('Reviewer seed');
     expect(mocks.spawnWorkerInPane).toHaveBeenCalledWith(
       'dispatch-session',
       '%2',
       expect.objectContaining({
         launchBinary: '/usr/bin/codex',
         launchArgs: expect.arrayContaining([
-          expect.stringContaining('claim-task'),
-          expect.stringContaining('Task ID: 1'),
-          expect.stringContaining('Subject: Dispatch test'),
+          expect.stringContaining('.omc/state/team/dispatch-team/workers/worker-1/inbox.md'),
         ]),
       }),
     );
+    const launchArgs = mocks.spawnWorkerInPane.mock.calls[0]?.[2]?.launchArgs ?? [];
+    expect(launchArgs.some((arg: string) => arg.includes('claim-task'))).toBe(false);
+    expect(launchArgs.some((arg: string) => arg.includes('transition-task-status'))).toBe(false);
+    expect(launchArgs.some((arg: string) => arg.includes('blocked'))).toBe(false);
+    expect(launchArgs.some((arg: string) => arg.includes('Reviewer seed'))).toBe(false);
+    const inboxPath = join(cwd, '.omc', 'state', 'team', 'dispatch-team', 'workers', 'worker-1', 'inbox.md');
+    const inbox = await readFile(inboxPath, 'utf-8');
+    expect(inbox).toContain('team api claim-task');
+    expect(inbox).toContain('transition-task-status');
+    expect(inbox).toContain('Reviewer seed says the worker may be blocked');
     expect(runtime.config.workers[0]?.assigned_tasks).toEqual(['1']);
     expect(mocks.sendToWorker).not.toHaveBeenCalled();
   });

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, it, expect } from 'vitest';
-import { generateMailboxTriggerMessage, generateTriggerMessage, generateWorkerOverlay, getWorkerEnv } from '../worker-bootstrap.js';
+import {
+  generateMailboxTriggerMessage,
+  generatePromptModeStartupPrompt,
+  generateTriggerMessage,
+  generateWorkerOverlay,
+  getWorkerEnv,
+} from '../worker-bootstrap.js';
 
 describe('worker-bootstrap', () => {
   const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
@@ -62,6 +68,15 @@ describe('worker-bootstrap', () => {
         .toContain('$OMC_TEAM_STATE_ROOT/team/test-team/mailbox/worker-1.json');
       expect(generateMailboxTriggerMessage('test-team', 'worker-1', 2, '$OMC_TEAM_STATE_ROOT'))
         .toContain('report progress');
+    });
+
+    it('uses a short prompt-mode startup pointer instead of lifecycle/task text', () => {
+      const prompt = generatePromptModeStartupPrompt('test-team', 'worker-1');
+      expect(prompt).toContain('.omc/state/team/test-team/workers/worker-1/inbox.md');
+      expect(prompt).toContain('Open');
+      expect(prompt).not.toContain('claim-task');
+      expect(prompt).not.toContain('transition-task-status');
+      expect(prompt).not.toContain('blocked');
     });
 
     it('includes sentinel file write instruction first', () => {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -69,6 +69,7 @@ import {
   ensureWorkerStateDir,
   writeWorkerOverlay,
   generateTriggerMessage,
+  generatePromptModeStartupPrompt,
 } from './worker-bootstrap.js';
 import { queueInboxInstruction, type DispatchOutcome } from './mcp-comm.js';
 import { cleanupTeamWorktrees } from './git-worktree.js';
@@ -425,6 +426,7 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     opts.teamName, opts.workerName, opts.task, opts.taskId,
   );
   const inboxTriggerMessage = generateTriggerMessage(opts.teamName, opts.workerName);
+  const promptModeStartupPrompt = generatePromptModeStartupPrompt(opts.teamName, opts.workerName);
   if (usePromptMode) {
     await composeInitialInbox(opts.teamName, opts.workerName, instruction, opts.cwd);
   }
@@ -464,9 +466,11 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     model: modelForAgent,
   });
 
-  // For prompt-mode agents (codex, gemini), pass instruction via CLI flag
+  // For prompt-mode agents (codex, gemini), keep the full instruction in
+  // inbox.md and pass only a short file-pointer prompt via CLI args. This
+  // avoids echoing reviewer/seed prompt text into tmux scrollback.
   if (usePromptMode) {
-    launchArgs.push(...getPromptModeArgs(opts.agentType, instruction));
+    launchArgs.push(...getPromptModeArgs(opts.agentType, promptModeStartupPrompt));
   }
 
   const paneConfig: WorkerPaneConfig = {

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -29,6 +29,15 @@ export function generateTriggerMessage(
   return `Read ${inboxPath}, start work now, report concrete progress (not ACK-only), and keep executing your assigned or next feasible work.`;
 }
 
+export function generatePromptModeStartupPrompt(
+  teamName: string,
+  workerName: string,
+  teamStateRoot = '.omc/state',
+): string {
+  const inboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'workers', workerName, 'inbox.md');
+  return `Open ${inboxPath}. Follow it and begin the assigned work.`;
+}
+
 export function generateMailboxTriggerMessage(
   teamName: string,
   workerName: string,


### PR DESCRIPTION
## Summary
- keep the full prompt-mode startup instruction in `inbox.md` instead of echoing it through CLI launch args
- pass a short inbox-pointer prompt for prompt-mode workers so tmux scrollback does not immediately expose reviewer/seed prompt text to keyword-alert tooling
- add regressions covering the new prompt helper and the v2 codex prompt-mode dispatch path

## Verification
- `npm test -- run src/team/__tests__/worker-bootstrap.test.ts src/team/__tests__/runtime-v2.dispatch.test.ts`
- `npm run build`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

Closes #2500
