### PR TITLE
Fix issue #2504: suppress tmux keyword-alert false positives from PR review seed prompts

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -321,6 +321,45 @@ describe("parseTmuxTail noise filters", () => {
     ].join("\n");
     expect(parseTmuxTail(input)).toBe("Build complete\nTests passed: 42");
   });
+
+  it("drops seeded PR review outcome instructions that would trip keyword alerts", () => {
+    const input = [
+      "Review PR #2498 and reply with exactly one verdict:",
+      "- approve",
+      "- request-changes",
+      "- follow-up-fix",
+      "- BLOCKED",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("prefers later runtime output over seeded PR review instructions", () => {
+    const input = [
+      "Review PR #2498 and reply with exactly one verdict:",
+      "- approve",
+      "- request-changes",
+      "- follow-up-fix",
+      "- BLOCKED",
+      "Traceback (most recent call last):",
+      "ValueError: boom",
+      "BLOCKED: evaluator crashed at runtime",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe(
+      "Traceback (most recent call last):\nValueError: boom\nBLOCKED: evaluator crashed at runtime",
+    );
+  });
+
+  it("preserves real runtime blocked output when no seeded review prefix exists", () => {
+    const input = [
+      "BLOCKED: missing baseline snapshot",
+      "Traceback (most recent call last):",
+      "RuntimeError: boom",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe(input);
+  });
 });
 
 describe("tmuxTail in formatters", () => {

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -192,9 +192,64 @@ const BARE_PROMPT_RE = /^[❯>$%#]+$/;
 /** Minimum ratio of alphanumeric characters for a line to be "meaningful". */
 const MIN_ALNUM_RATIO = 0.15;
 
+/** Review-session seed prompt outcome keywords that cause tmux alert noise. */
+const REVIEW_SEED_OUTCOME_PATTERNS = [
+  { key: "approve", pattern: /\bapprove\b/i },
+  { key: "request-changes", pattern: /\brequest[- ]changes\b/i },
+  { key: "follow-up-fix", pattern: /\bfollow[- ]up[- ]fix\b/i },
+  { key: "blocked", pattern: /\bblocked\b/i },
+] as const;
+
+/** Instructional phrasing commonly found in seeded review prompts. */
+const REVIEW_SEED_CUE_RE =
+  /\b(review|verdict|respond|reply|return|output|classification|classify|decision|choose|label)\b/i;
+
+/** Continuation markers for bullets / enumerated option lines in seeded prompts. */
+const REVIEW_SEED_LIST_RE = /^(?:[-*•]|\d+[.)]|[A-Z][A-Z_-]+:|\([a-z0-9]+\))/;
+
 /** Default maximum number of meaningful lines to include in a notification.
  * Matches DEFAULT_TMUX_TAIL_LINES in config.ts. */
 const DEFAULT_MAX_TAIL_LINES = 15;
+
+function extractReviewSeedOutcomeKeys(line: string): string[] {
+  return REVIEW_SEED_OUTCOME_PATTERNS
+    .filter(({ pattern }) => pattern.test(line))
+    .map(({ key }) => key);
+}
+
+function trimReviewSeedPrefix(lines: string[]): string[] {
+  if (lines.length === 0) return lines;
+
+  const prefix = lines.slice(0, 10);
+  const distinctOutcomes = new Set<string>();
+  let hasCue = false;
+  let candidateEnd = -1;
+
+  for (let index = 0; index < prefix.length; index += 1) {
+    const line = prefix[index]!;
+    const outcomeKeys = extractReviewSeedOutcomeKeys(line);
+    const isCueLine = REVIEW_SEED_CUE_RE.test(line);
+    const isSeedLine =
+      outcomeKeys.length > 0 ||
+      isCueLine ||
+      (candidateEnd >= 0 && REVIEW_SEED_LIST_RE.test(line));
+
+    outcomeKeys.forEach((key) => distinctOutcomes.add(key));
+    if (isCueLine) hasCue = true;
+    if (isSeedLine) {
+      candidateEnd = index;
+      continue;
+    }
+    if (candidateEnd >= 0) break;
+  }
+
+  const qualifies =
+    candidateEnd >= 0 &&
+    (distinctOutcomes.size >= 3 || (distinctOutcomes.size >= 2 && hasCue));
+
+  if (!qualifies) return lines;
+  return lines.slice(candidateEnd + 1);
+}
 
 /**
  * Parse raw tmux output into clean, human-readable lines.
@@ -225,7 +280,8 @@ export function parseTmuxTail(raw: string, maxLines: number = DEFAULT_MAX_TAIL_L
     meaningful.push(stripped.trimEnd());
   }
 
-  return meaningful.slice(-maxLines).join("\n");
+  const trimmed = trimReviewSeedPrefix(meaningful);
+  return trimmed.slice(-maxLines).join("\n");
 }
 
 /**

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -50,6 +50,7 @@ export {
   formatSessionIdle,
   formatAskUserQuestion,
   formatAgentCall,
+  parseTmuxTail,
 } from "./formatter.js";
 export {
   getCurrentTmuxSession,
@@ -106,7 +107,7 @@ import {
   isEventAllowedByVerbosity,
   shouldIncludeTmuxTail,
 } from "./config.js";
-import { formatNotification } from "./formatter.js";
+import { formatNotification, parseTmuxTail } from "./formatter.js";
 import { dispatchNotifications } from "./dispatcher.js";
 import { getCurrentTmuxSession } from "./tmux.js";
 import { getHookConfig, resolveEventTemplate } from "./hook-config.js";
@@ -188,7 +189,10 @@ export async function notify(
           "../features/rate-limit-wait/tmux-detector.js"
         );
         const tailLines = getTmuxTailLines(config);
-        const tail = capturePaneContent(payload.tmuxPaneId, tailLines);
+        const tail = parseTmuxTail(
+          capturePaneContent(payload.tmuxPaneId, tailLines),
+          tailLines,
+        );
         if (tail) {
           payload.tmuxTail = tail;
           payload.maxTailLines = tailLines;

--- a/src/openclaw/__tests__/index.test.ts
+++ b/src/openclaw/__tests__/index.test.ts
@@ -9,6 +9,11 @@ vi.mock("../../notifications/tmux.js", () => ({
   getCurrentTmuxSession: () => mockGetCurrentTmuxSession(),
 }));
 
+const mockCapturePaneContent = vi.fn<(paneId: string, lines?: number) => string>(() => "");
+vi.mock("../../features/rate-limit-wait/tmux-detector.js", () => ({
+  capturePaneContent: (paneId: string, lines?: number) => mockCapturePaneContent(paneId, lines),
+}));
+
 // Mock config and dispatcher modules
 vi.mock("../config.js", () => ({
   getOpenClawConfig: vi.fn(),
@@ -65,6 +70,7 @@ describe("wakeOpenClaw", () => {
       statusCode: 200,
     });
     mockGetCurrentTmuxSession.mockReturnValue(null);
+    mockCapturePaneContent.mockReturnValue("");
   });
 
   afterEach(() => {
@@ -104,6 +110,35 @@ describe("wakeOpenClaw", () => {
     const payload = call[2];
     expect(payload.event).toBe("session-start");
     expect(payload.instruction).toContain("myproject"); // interpolated
+  });
+
+  it("sanitizes tmux tail before sending stop payloads", async () => {
+    mockCapturePaneContent.mockReturnValue([
+      "Review PR #2498 and reply with exactly one verdict:",
+      "- approve",
+      "- request-changes",
+      "- follow-up-fix",
+      "- BLOCKED",
+      "Traceback (most recent call last):",
+      "RuntimeError: boom",
+      "BLOCKED: runtime failure",
+    ].join("\n"));
+    vi.stubEnv("TMUX", "/tmp/tmux-1000/default,123,0");
+    vi.stubEnv("TMUX_PANE", "%7");
+
+    await wakeOpenClaw("stop", {
+      sessionId: "sid-stop",
+      projectPath: "/home/user/myproject",
+    });
+
+    expect(mockCapturePaneContent).toHaveBeenCalledWith("%7", 15);
+    const payload = vi.mocked(wakeGateway).mock.calls[0]?.[2];
+    expect(payload.tmuxTail).toBe(
+      "Traceback (most recent call last):\nRuntimeError: boom\nBLOCKED: runtime failure",
+    );
+    expect(payload.tmuxTail).not.toContain("approve");
+    expect(payload.tmuxTail).not.toContain("request-changes");
+    expect(payload.tmuxTail).not.toContain("follow-up-fix");
   });
 
   it("uses a single timestamp in both template variables and payload", async () => {

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -33,6 +33,7 @@ import { wakeGateway, wakeCommandGateway, interpolateInstruction, isCommandGatew
 import { buildOpenClawSignal } from "./signal.js";
 import { shouldCollapseOpenClawBurst } from "./dedupe.js";
 import { basename } from "path";
+import { parseTmuxTail } from "../notifications/formatter.js";
 import { getCurrentTmuxSession } from "../notifications/tmux.js";
 
 /** Whether debug logging is enabled */
@@ -118,7 +119,8 @@ export async function wakeOpenClaw(
         const { capturePaneContent } = await import("../features/rate-limit-wait/tmux-detector.js");
         const paneId = process.env.TMUX_PANE;
         if (paneId) {
-          tmuxTail = capturePaneContent(paneId, 15) ?? undefined;
+          const captured = capturePaneContent(paneId, 15);
+          tmuxTail = parseTmuxTail(captured, 15) || undefined;
         }
       } catch {
         // Non-blocking: tmux capture is best-effort


### PR DESCRIPTION
## Summary
- trim leading PR review seed outcome menus from parsed tmux tails when they look like operator-seeded review instructions
- sanitize tmux tail content before notifications and OpenClaw payloads are emitted so downstream keyword alerts prefer runtime output
- add regression coverage for seeded review prompts while preserving real runtime BLOCKED/Traceback lines

## Testing
- npx vitest run src/notifications/__tests__/formatter.test.ts src/openclaw/__tests__/index.test.ts src/notifications/__tests__/notify-registry-integration.test.ts
- npx eslint src/notifications/formatter.ts src/notifications/index.ts src/openclaw/index.ts src/notifications/__tests__/formatter.test.ts src/openclaw/__tests__/index.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json
- npm run build

Closes #2504