### PR TITLE
Fix issue #2506: keep review/fix tmux sessions on their requested task context

### DIFF
--- a/skills/project-session-manager/lib/providers/github.sh
+++ b/skills/project-session-manager/lib/providers/github.sh
@@ -14,7 +14,7 @@ provider_github_detect_ref() {
 provider_github_fetch_pr() {
     local pr_number="$1"
     local repo="$2"
-    gh pr view "$pr_number" --repo "$repo" --json number,title,author,headRefName,baseRefName,body,url 2>/dev/null
+    gh pr view "$pr_number" --repo "$repo" --json number,title,author,headRefName,baseRefName,body,files,url 2>/dev/null
 }
 
 provider_github_fetch_issue() {

--- a/skills/project-session-manager/lib/tmux.sh
+++ b/skills/project-session-manager/lib/tmux.sh
@@ -33,10 +33,12 @@ psm_create_tmux_session() {
     return 0
 }
 
-# Launch Claude Code in tmux session
-# Usage: psm_launch_claude <session_name>
+# Launch Claude Code in tmux session, optionally injecting a context file prompt.
+# Usage: psm_launch_claude <session_name> [context_file_relative_path]
+# context_file_relative_path: path relative to the worktree root (e.g. .psm/review.md)
 psm_launch_claude() {
     local session_name="$1"
+    local context_file="${2:-}"
 
     if ! tmux has-session -t "$session_name" 2>/dev/null; then
         echo "error|Session not found: $session_name"
@@ -46,7 +48,88 @@ psm_launch_claude() {
     # Send claude command to the session
     tmux send-keys -t "$session_name" "claude" Enter
 
+    # Inject initial task context once Claude's REPL is ready
+    if [[ -n "$context_file" ]]; then
+        psm_inject_prompt "$session_name" "$context_file"
+    fi
+
     echo "launched|$session_name"
+    return 0
+}
+
+# Render a PSM template file by substituting {{KEY}} placeholders.
+# Usage: psm_render_template <template_file> [KEY=VALUE ...]
+# Outputs rendered content to stdout; returns 1 if template not found.
+psm_render_template() {
+    local template_file="$1"
+    shift
+
+    if [[ ! -f "$template_file" ]]; then
+        echo "error|Template not found: $template_file" >&2
+        return 1
+    fi
+
+    local content
+    content=$(cat "$template_file")
+
+    for assignment in "$@"; do
+        local key="${assignment%%=*}"
+        local value="${assignment#*=}"
+        # Bash parameter expansion handles multiline values safely
+        content="${content//\{\{${key}\}\}/$value}"
+    done
+
+    printf '%s\n' "$content"
+}
+
+# Returns 0 if the captured pane text shows Claude's interactive input prompt.
+# Matches '>' (standard prompt) or '?' (trust prompt) as the sole content of a line.
+# Usage: _psm_pane_has_claude_prompt <pane_text>
+_psm_pane_has_claude_prompt() {
+    local pane_text="$1"
+    printf '%s' "$pane_text" | grep -qE '^[[:space:]]*(>|\?)[[:space:]]*$'
+}
+
+# Poll the tmux pane until Claude's REPL prompt appears.
+# Usage: psm_wait_for_claude_prompt <session_name> [max_seconds]
+# Returns 0 when prompt detected; 1 on timeout.
+psm_wait_for_claude_prompt() {
+    local session_name="$1"
+    local max_wait="${2:-30}"
+    local waited=0
+
+    while [[ $waited -lt $max_wait ]]; do
+        local pane_content
+        pane_content=$(tmux capture-pane -t "$session_name" -p 2>/dev/null) || return 1
+        if _psm_pane_has_claude_prompt "$pane_content"; then
+            return 0
+        fi
+        sleep 1
+        (( waited++ )) || true
+    done
+
+    return 1
+}
+
+# Wait for Claude's REPL to be ready then inject a context-file trigger prompt.
+# Non-fatal: warns on timeout but does not fail the session creation.
+# Usage: psm_inject_prompt <session_name> <context_file_relative_path>
+psm_inject_prompt() {
+    local session_name="$1"
+    local context_file="$2"
+
+    if ! psm_wait_for_claude_prompt "$session_name"; then
+        echo "warn|Timed out waiting for Claude prompt; task context not injected" >&2
+        return 0
+    fi
+
+    local trigger="Read ${context_file} for full task context, then begin."
+
+    # Use literal mode (-l) to prevent tmux from interpreting key names in the text
+    tmux send-keys -t "$session_name" -l -- "$trigger"
+    sleep 0.15
+    tmux send-keys -t "$session_name" Enter
+
     return 0
 }
 

--- a/skills/project-session-manager/psm.sh
+++ b/skills/project-session-manager/psm.sh
@@ -145,6 +145,8 @@ cmd_review() {
     local head_branch=$(echo "$pr_info" | jq -r '.headRefName')
     local base_branch=$(echo "$pr_info" | jq -r '.baseRefName')
     local pr_url=$(echo "$pr_info" | jq -r '.url')
+    local pr_body=$(echo "$pr_info" | jq -r '.body // ""')
+    local changed_files=$(echo "$pr_info" | jq -r '.files[]?.path // empty' 2>/dev/null | head -50 || true)
 
     log_info "PR: #${pr_number} - ${pr_title}"
     log_info "Author: @${pr_author}"
@@ -190,6 +192,24 @@ cmd_review() {
 
     log_success "Worktree created at $worktree_path"
 
+    # Render PR review context file into the worktree so Claude starts with full task context
+    local context_rel=".psm/review.md"
+    local context_file="${worktree_path}/${context_rel}"
+    mkdir -p "$(dirname "$context_file")"
+    if ! psm_render_template "$SCRIPT_DIR/templates/pr-review.md" \
+            "PR_NUMBER=${pr_number}" \
+            "PR_TITLE=${pr_title}" \
+            "PR_AUTHOR=${pr_author}" \
+            "PR_URL=${pr_url}" \
+            "HEAD_BRANCH=${head_branch}" \
+            "BASE_BRANCH=${base_branch}" \
+            "PR_BODY=${pr_body}" \
+            "CHANGED_FILES=${changed_files}" \
+            > "$context_file"; then
+        log_warn "Failed to render review template; Claude will start without task context"
+        context_rel=""
+    fi
+
     # Create tmux session
     local session_name="psm:${alias}:pr-${pr_number}"
     local session_id="${alias}:pr-${pr_number}"
@@ -209,10 +229,10 @@ cmd_review() {
         else
             log_success "Tmux session created: $session_name"
 
-            # Launch Claude Code
+            # Launch Claude Code with review context so it starts on the PR task
             if [[ "$no_claude" != "true" ]]; then
                 log_info "Launching Claude Code..."
-                psm_launch_claude "$session_name"
+                psm_launch_claude "$session_name" "$context_rel"
             fi
         fi
     fi
@@ -284,6 +304,7 @@ cmd_fix() {
 
     # Fetch issue info
     local issue_info
+    local issue_body="" issue_labels=""
     if [[ "$provider" == "jira" ]]; then
         issue_info=$(provider_call "jira" fetch_issue "$provider_ref") || {
             log_error "Failed to fetch Jira issue ${provider_ref}"
@@ -291,6 +312,7 @@ cmd_fix() {
         }
         local issue_title=$(echo "$issue_info" | jq -r '.fields.summary')
         local issue_url=$(echo "$issue_info" | jq -r '.self // empty')
+        issue_body=$(echo "$issue_info" | jq -r '.fields.description // ""')
     else
         issue_info=$(provider_call "github" fetch_issue "$issue_number" "$repo") || {
             log_error "Failed to fetch issue #${issue_number}"
@@ -298,6 +320,8 @@ cmd_fix() {
         }
         local issue_title=$(echo "$issue_info" | jq -r '.title')
         local issue_url=$(echo "$issue_info" | jq -r '.url')
+        issue_body=$(echo "$issue_info" | jq -r '.body // ""')
+        issue_labels=$(echo "$issue_info" | jq -r '[.labels[].name] | join(", ")' 2>/dev/null || true)
     fi
     local slug=$(psm_slugify "$issue_title" 20)
 
@@ -345,6 +369,22 @@ cmd_fix() {
     log_success "Worktree created at $worktree_path"
     log_info "Branch: $branch_name"
 
+    # Render issue fix context file into the worktree so Claude starts with full task context
+    local fix_context_rel=".psm/fix.md"
+    local fix_context_file="${worktree_path}/${fix_context_rel}"
+    mkdir -p "$(dirname "$fix_context_file")"
+    if ! psm_render_template "$SCRIPT_DIR/templates/issue-fix.md" \
+            "ISSUE_NUMBER=${issue_number}" \
+            "ISSUE_TITLE=${issue_title}" \
+            "ISSUE_URL=${issue_url}" \
+            "ISSUE_LABELS=${issue_labels}" \
+            "ISSUE_BODY=${issue_body}" \
+            "BRANCH_NAME=${branch_name}" \
+            > "$fix_context_file"; then
+        log_warn "Failed to render issue fix template; Claude will start without task context"
+        fix_context_rel=""
+    fi
+
     # Create tmux session
     local session_name="psm:${alias}:issue-${issue_number}"
     local session_id="${alias}:issue-${issue_number}"
@@ -353,7 +393,7 @@ cmd_fix() {
     psm_create_tmux_session "$session_name" "$worktree_path"
 
     if [[ "$no_claude" != "true" ]]; then
-        psm_launch_claude "$session_name"
+        psm_launch_claude "$session_name" "$fix_context_rel"
     fi
 
     # Create metadata

--- a/skills/project-session-manager/tests/test-psm-prompt-injection.sh
+++ b/skills/project-session-manager/tests/test-psm-prompt-injection.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+# Regression tests for PSM prompt injection (issue #2506)
+# Root cause: psm_launch_claude only sent "claude Enter" with no task context injected.
+# Fix: psm_render_template + psm_inject_prompt + context file written to worktree.
+#
+# Usage: bash skills/project-session-manager/tests/test-psm-prompt-injection.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PSM_LIB_DIR="${SCRIPT_DIR}/../lib"
+TEMPLATES_DIR="${SCRIPT_DIR}/../templates"
+
+# ── Test counters ─────────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; (( PASS++ )) || true; }
+fail() { echo "FAIL: $1"; echo "      $2"; (( FAIL++ )) || true; }
+
+assert_equals() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass "$desc"
+    else
+        fail "$desc" "expected='$expected' actual='$actual'"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        pass "$desc"
+    else
+        fail "$desc" "expected to contain: '$needle'"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        pass "$desc"
+    else
+        fail "$desc" "expected NOT to contain: '$needle'"
+    fi
+}
+
+assert_file_exists() {
+    local desc="$1" path="$2"
+    if [[ -f "$path" ]]; then
+        pass "$desc"
+    else
+        fail "$desc" "file not found: $path"
+    fi
+}
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+# Source only the lib/tmux.sh functions needed for testing.
+# We must stub the real `tmux` binary before sourcing so that
+# psm_has_tmux (which calls `command -v tmux`) still works without a real tmux.
+tmux() { :; }
+source "${PSM_LIB_DIR}/tmux.sh"
+
+TMPDIR_TEST=$(mktemp -d)
+TEMPLATE_TMP="${TMPDIR_TEST}/template.md"
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+
+# ── psm_render_template ───────────────────────────────────────────────────────
+
+echo ""
+echo "=== psm_render_template ==="
+
+# 1. Simple single substitution
+printf 'Hello {{NAME}}!' > "$TEMPLATE_TMP"
+result=$(psm_render_template "$TEMPLATE_TMP" "NAME=World")
+assert_equals "renders single variable" "Hello World!" "$result"
+
+# 2. Multiple variables in one call
+printf 'PR #{{PR_NUMBER}}: {{PR_TITLE}} by @{{PR_AUTHOR}}' > "$TEMPLATE_TMP"
+result=$(psm_render_template "$TEMPLATE_TMP" "PR_NUMBER=123" "PR_TITLE=Fix bug" "PR_AUTHOR=alice")
+assert_equals "renders multiple variables" "PR #123: Fix bug by @alice" "$result"
+
+# 3. Unreferenced placeholder is preserved
+printf 'Hello {{NAME}} and {{OTHER}}!' > "$TEMPLATE_TMP"
+result=$(psm_render_template "$TEMPLATE_TMP" "NAME=World")
+assert_contains "preserves unreferenced placeholders" "{{OTHER}}" "$result"
+assert_not_contains "replaces referenced placeholder" "{{NAME}}" "$result"
+
+# 4. Missing template file returns non-zero and error message
+set +e
+err_out=$(psm_render_template "/nonexistent/missing.md" "KEY=val" 2>&1)
+exit_code=$?
+set -e
+[[ $exit_code -ne 0 ]] && pass "returns non-zero for missing template" \
+                        || fail "returns non-zero for missing template" "exited 0"
+assert_contains "error message for missing template" "error|" "$err_out"
+
+# 5. Value containing forward slash (common in branch names)
+printf '{{BRANCH}}' > "$TEMPLATE_TMP"
+result=$(psm_render_template "$TEMPLATE_TMP" "BRANCH=feature/my-branch")
+assert_equals "handles slashes in values" "feature/my-branch" "$result"
+
+# 6. Empty value clears placeholder
+printf 'before {{EMPTY}} after' > "$TEMPLATE_TMP"
+result=$(psm_render_template "$TEMPLATE_TMP" "EMPTY=")
+assert_equals "empty value clears placeholder" "before  after" "$result"
+
+# 7. Value with & (must not be interpreted as backreference)
+printf '{{VAL}}' > "$TEMPLATE_TMP"
+result=$(psm_render_template "$TEMPLATE_TMP" "VAL=foo&bar")
+assert_equals "handles ampersand in value" "foo&bar" "$result"
+
+# ── _psm_pane_has_claude_prompt ───────────────────────────────────────────────
+
+echo ""
+echo "=== _psm_pane_has_claude_prompt ==="
+
+# 8. Detects bare '>' prompt
+if _psm_pane_has_claude_prompt ">"; then
+    pass "detects bare '>' prompt"
+else
+    fail "detects bare '>' prompt" "returned non-zero"
+fi
+
+# 9. Detects '> ' with trailing space
+if _psm_pane_has_claude_prompt "> "; then
+    pass "detects '> ' with trailing space"
+else
+    fail "detects '> ' with trailing space" "returned non-zero"
+fi
+
+# 10. Detects '?' trust prompt
+if _psm_pane_has_claude_prompt "?"; then
+    pass "detects '?' trust prompt"
+else
+    fail "detects '?' trust prompt" "returned non-zero"
+fi
+
+# 11. Detects '>' with leading whitespace
+if _psm_pane_has_claude_prompt "  > "; then
+    pass "detects indented '>' prompt"
+else
+    fail "detects indented '>' prompt" "returned non-zero"
+fi
+
+# 12. Does NOT match '>' that appears mid-line
+if ! _psm_pane_has_claude_prompt "Loading > modules"; then
+    pass "rejects mid-line >"
+else
+    fail "rejects mid-line >" "should have returned non-zero"
+fi
+
+# 13. Does NOT match empty string
+if ! _psm_pane_has_claude_prompt ""; then
+    pass "rejects empty pane"
+else
+    fail "rejects empty pane" "should have returned non-zero"
+fi
+
+# 14. Does NOT match arbitrary text
+if ! _psm_pane_has_claude_prompt "Welcome to Claude Code!"; then
+    pass "rejects non-prompt welcome text"
+else
+    fail "rejects non-prompt welcome text" "should have returned non-zero"
+fi
+
+# ── psm_launch_claude with mocked tmux/inject ─────────────────────────────────
+
+echo ""
+echo "=== psm_launch_claude (mocked) ==="
+
+# Mock state
+TMUX_SEND_CALLS=()
+INJECT_CALLED=false
+INJECT_SESSION=""
+INJECT_FILE=""
+
+# Override tmux to record calls; simulate has-session returning 0
+tmux() {
+    local subcmd="$1"
+    case "$subcmd" in
+        has-session) return 0 ;;
+        send-keys)   TMUX_SEND_CALLS+=("$*") ;;
+        *)           : ;;
+    esac
+}
+
+# Override psm_inject_prompt to track invocations
+psm_inject_prompt() {
+    INJECT_CALLED=true
+    INJECT_SESSION="$1"
+    INJECT_FILE="$2"
+    return 0
+}
+
+# 15. Without context file: inject is NOT called
+TMUX_SEND_CALLS=(); INJECT_CALLED=false
+psm_launch_claude "test-session"
+if [[ "$INJECT_CALLED" == "false" ]]; then
+    pass "no inject without context file"
+else
+    fail "no inject without context file" "psm_inject_prompt was called unexpectedly"
+fi
+
+# 16. With context file: inject IS called
+TMUX_SEND_CALLS=(); INJECT_CALLED=false; INJECT_SESSION=""; INJECT_FILE=""
+psm_launch_claude "test-session" ".psm/review.md"
+if [[ "$INJECT_CALLED" == "true" ]]; then
+    pass "inject called when context file provided"
+else
+    fail "inject called when context file provided" "psm_inject_prompt was NOT called"
+fi
+
+# 17. inject receives correct session name
+assert_equals "inject gets correct session name" "test-session" "$INJECT_SESSION"
+
+# 18. inject receives correct context file path
+assert_equals "inject gets correct context file path" ".psm/review.md" "$INJECT_FILE"
+
+# 19. Result reports 'launched|'
+TMUX_SEND_CALLS=(); INJECT_CALLED=false
+result=$(psm_launch_claude "test-session" ".psm/review.md")
+assert_contains "launch reports launched| on success" "launched|" "$result"
+
+# 20. Session-not-found returns error (has-session fails)
+tmux() {
+    case "$1" in
+        has-session) return 1 ;;
+        *)           : ;;
+    esac
+}
+# Use || true so set -e doesn't kill the script on the expected non-zero return
+result=$(psm_launch_claude "missing-session" 2>&1) || true
+assert_contains "error reported for missing session" "error|" "$result"
+
+# ── Context file creation (cmd_review simulation) ─────────────────────────────
+
+echo ""
+echo "=== Context file creation (cmd_review simulation) ==="
+
+WORKTREE_TMP="${TMPDIR_TEST}/worktree"
+mkdir -p "$WORKTREE_TMP"
+
+# Variables that cmd_review would supply
+t_pr_number="123"
+t_pr_title="Fix null pointer in auth"
+t_pr_author="alice"
+t_pr_url="https://github.com/test/repo/pull/123"
+t_head_branch="fix/auth-null"
+t_base_branch="main"
+t_pr_body="Fixes the NPE in AuthService when token is missing."
+t_changed_files="src/auth.ts
+src/auth.test.ts"
+
+context_rel=".psm/review.md"
+context_file="${WORKTREE_TMP}/${context_rel}"
+mkdir -p "$(dirname "$context_file")"
+
+psm_render_template "${TEMPLATES_DIR}/pr-review.md" \
+    "PR_NUMBER=${t_pr_number}" \
+    "PR_TITLE=${t_pr_title}" \
+    "PR_AUTHOR=${t_pr_author}" \
+    "PR_URL=${t_pr_url}" \
+    "HEAD_BRANCH=${t_head_branch}" \
+    "BASE_BRANCH=${t_base_branch}" \
+    "PR_BODY=${t_pr_body}" \
+    "CHANGED_FILES=${t_changed_files}" \
+    > "$context_file"
+
+# 21. Context file exists in worktree
+assert_file_exists "review context file written to worktree" "$context_file"
+
+context_content=$(cat "$context_file")
+
+# 22-27. All placeholders resolved with correct values
+assert_contains "PR number in rendered context" "$t_pr_number" "$context_content"
+assert_contains "PR title in rendered context" "$t_pr_title" "$context_content"
+assert_contains "PR author in rendered context" "$t_pr_author" "$context_content"
+assert_contains "PR URL in rendered context" "$t_pr_url" "$context_content"
+assert_contains "head branch in rendered context" "$t_head_branch" "$context_content"
+assert_contains "base branch in rendered context" "$t_base_branch" "$context_content"
+
+# 28-31. No unreplaced placeholders remain
+assert_not_contains "no {{PR_NUMBER}} leftover"  "{{PR_NUMBER}}"  "$context_content"
+assert_not_contains "no {{PR_TITLE}} leftover"   "{{PR_TITLE}}"   "$context_content"
+assert_not_contains "no {{PR_AUTHOR}} leftover"  "{{PR_AUTHOR}}"  "$context_content"
+assert_not_contains "no {{HEAD_BRANCH}} leftover" "{{HEAD_BRANCH}}" "$context_content"
+
+# ── Context file creation (cmd_fix simulation) ────────────────────────────────
+
+echo ""
+echo "=== Context file creation (cmd_fix simulation) ==="
+
+t_issue_number="42"
+t_issue_title="Auth fails on token expiry"
+t_issue_url="https://github.com/test/repo/issues/42"
+t_issue_labels="bug, auth"
+t_issue_body="Users get 500 errors after token expires."
+t_branch_name="fix/42-auth-token-expiry"
+
+fix_context_rel=".psm/fix.md"
+fix_context_file="${WORKTREE_TMP}/${fix_context_rel}"
+mkdir -p "$(dirname "$fix_context_file")"
+
+psm_render_template "${TEMPLATES_DIR}/issue-fix.md" \
+    "ISSUE_NUMBER=${t_issue_number}" \
+    "ISSUE_TITLE=${t_issue_title}" \
+    "ISSUE_URL=${t_issue_url}" \
+    "ISSUE_LABELS=${t_issue_labels}" \
+    "ISSUE_BODY=${t_issue_body}" \
+    "BRANCH_NAME=${t_branch_name}" \
+    > "$fix_context_file"
+
+# 32. Fix context file exists
+assert_file_exists "fix context file written to worktree" "$fix_context_file"
+
+fix_content=$(cat "$fix_context_file")
+
+# 33-35. Key values present
+assert_contains "issue number in fix context" "$t_issue_number" "$fix_content"
+assert_contains "issue title in fix context" "$t_issue_title" "$fix_content"
+assert_contains "branch name in fix context" "$t_branch_name" "$fix_content"
+
+# 36-38. No unreplaced placeholders
+assert_not_contains "no {{ISSUE_NUMBER}} leftover"  "{{ISSUE_NUMBER}}"  "$fix_content"
+assert_not_contains "no {{ISSUE_TITLE}} leftover"   "{{ISSUE_TITLE}}"   "$fix_content"
+assert_not_contains "no {{BRANCH_NAME}} leftover"   "{{BRANCH_NAME}}"   "$fix_content"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- render review/fix context files into the worktree before launching Claude
- wait for Claude's prompt, then inject a deterministic trigger to read the context file
- include PR changed-file data in the GitHub provider payload and add regression coverage for prompt injection helpers

## Testing
- bash skills/project-session-manager/tests/test-psm-prompt-injection.sh
- bash -n skills/project-session-manager/lib/tmux.sh
- bash -n skills/project-session-manager/psm.sh
- bash -n skills/project-session-manager/lib/providers/github.sh
