### PR TITLE
fix(psm): launch trusted sessions with initial prompt

### DIFF
--- a/skills/project-session-manager/SKILL.md
+++ b/skills/project-session-manager/SKILL.md
@@ -250,7 +250,15 @@ Parse `{{ARGUMENTS}}` to determine:
 
 8. **Launch Claude Code** (unless --no-claude):
    ```bash
-   tmux send-keys -t "psm:$project_alias:pr-$pr_number" "claude" Enter
+   # --dangerously-skip-permissions prevents the "Do you trust this directory?" prompt
+   # and repeated tool-approval prompts from stalling the session (issue #2508).
+   tmux send-keys -t "psm:$project_alias:pr-$pr_number" "claude --dangerously-skip-permissions" Enter
+
+   # After claude boots (PSM_CLAUDE_STARTUP_DELAY, default 5s), deliver the task.
+   # Use -l (literal) so special characters are not misinterpreted by tmux.
+   sleep "${PSM_CLAUDE_STARTUP_DELAY:-5}"
+   tmux send-keys -t "psm:$project_alias:pr-$pr_number" -l \
+     "Review PR #$pr_number: \"$pr_title\" by @$pr_author ($head_branch → $base_branch). URL: $pr_url." Enter
    ```
 
 9. **Output session info**:
@@ -293,7 +301,14 @@ Parse `{{ARGUMENTS}}` to determine:
 
 5. **Create session metadata** (similar to review, type="fix")
 
-6. **Update registry, create tmux, launch claude** (same as review)
+6. **Update registry, create tmux, launch claude**:
+   Same as review, but pass issue context as the initial task prompt:
+   ```bash
+   tmux send-keys -t "psm:$project_alias:issue-$issue_number" "claude --dangerously-skip-permissions" Enter
+   # After claude boots, deliver the task (see PSM_CLAUDE_STARTUP_DELAY):
+   tmux send-keys -t "psm:$project_alias:issue-$issue_number" -l \
+     "Fix issue #$issue_number: \"$issue_title\". URL: $issue_url. Branch: $branch_name." Enter
+   ```
 
 ### Subcommand: `feature <project> <name>`
 
@@ -317,7 +332,12 @@ Parse `{{ARGUMENTS}}` to determine:
    git worktree add "$worktree_path" "$branch_name"
    ```
 
-4. **Create session, tmux, launch claude** (same pattern)
+4. **Create session, tmux, launch claude** with feature context as initial prompt:
+   ```bash
+   tmux send-keys -t "psm:$project_alias:feat-$feature_name" "claude --dangerously-skip-permissions" Enter
+   tmux send-keys -t "psm:$project_alias:feat-$feature_name" -l \
+     "Implement feature \"$feature_name\" for project $project. Branch: $branch_name." Enter
+   ```
 
 ### Subcommand: `list [project]`
 

--- a/skills/project-session-manager/lib/tmux.sh
+++ b/skills/project-session-manager/lib/tmux.sh
@@ -33,24 +33,46 @@ psm_create_tmux_session() {
     return 0
 }
 
-# Launch Claude Code in tmux session, optionally injecting a context file prompt.
-# Usage: psm_launch_claude <session_name> [context_file_relative_path]
-# context_file_relative_path: path relative to the worktree root (e.g. .psm/review.md)
+# Launch Claude Code in tmux session, optionally injecting either a context-file
+# trigger prompt or a literal initial prompt.
+# Usage: psm_launch_claude <session_name> [initial_context]
+# initial_context may be either:
+#   - a path relative to the worktree root (e.g. .psm/review.md), or
+#   - a literal prompt string to send after Claude boots.
+#
+# Passes --dangerously-skip-permissions so the session does not stall on
+# directory-trust or repeated tool-approval prompts (issue #2508).
+# Set PSM_CLAUDE_STARTUP_DELAY (default: 5s) to tune literal-prompt delivery.
 psm_launch_claude() {
     local session_name="$1"
-    local context_file="${2:-}"
+    local initial_context="${2:-}"
 
     if ! tmux has-session -t "$session_name" 2>/dev/null; then
         echo "error|Session not found: $session_name"
         return 1
     fi
 
-    # Send claude command to the session
-    tmux send-keys -t "$session_name" "claude" Enter
+    # --dangerously-skip-permissions bypasses both the directory-trust prompt and
+    # every per-tool approval prompt. Without this flag, unattended PSM sessions
+    # can block indefinitely on the first tool call (issue #2508).
+    tmux send-keys -t "$session_name" "claude --dangerously-skip-permissions" Enter
 
-    # Inject initial task context once Claude's REPL is ready
-    if [[ -n "$context_file" ]]; then
-        psm_inject_prompt "$session_name" "$context_file"
+    if [[ -n "$initial_context" ]]; then
+        local session_path=""
+        session_path=$(tmux display-message -p -t "$session_name" '#{pane_current_path}' 2>/dev/null || true)
+
+        # If the second arg resolves to a file in the worktree, preserve the
+        # existing context-file flow. Otherwise treat it as a literal prompt.
+        if [[ -n "$session_path" && -f "$session_path/$initial_context" ]]; then
+            psm_inject_prompt "$session_name" "$initial_context"
+        else
+            local startup_delay="${PSM_CLAUDE_STARTUP_DELAY:-5}"
+            (
+                sleep "$startup_delay"
+                tmux send-keys -t "$session_name" -l -- "$initial_context" 2>/dev/null || true
+                tmux send-keys -t "$session_name" Enter 2>/dev/null || true
+            ) &
+        fi
     fi
 
     echo "launched|$session_name"

--- a/skills/project-session-manager/psm.sh
+++ b/skills/project-session-manager/psm.sh
@@ -232,7 +232,12 @@ cmd_review() {
             # Launch Claude Code with review context so it starts on the PR task
             if [[ "$no_claude" != "true" ]]; then
                 log_info "Launching Claude Code..."
+<<<<<<< HEAD
                 psm_launch_claude "$session_name" "$context_rel"
+=======
+                local review_prompt="Review PR #${pr_number}: \"${pr_title}\" by @${pr_author} (${head_branch} → ${base_branch}). URL: ${pr_url}. Read the diff, check for issues, and leave review comments via: gh pr review ${pr_number} --repo ${repo}"
+                psm_launch_claude "$session_name" "$review_prompt"
+>>>>>>> 1ee0409d (fix(psm): launch trusted sessions with initial prompt)
             fi
         fi
     fi
@@ -393,7 +398,12 @@ cmd_fix() {
     psm_create_tmux_session "$session_name" "$worktree_path"
 
     if [[ "$no_claude" != "true" ]]; then
+<<<<<<< HEAD
         psm_launch_claude "$session_name" "$fix_context_rel"
+=======
+        local fix_prompt="Fix issue #${issue_number}: \"${issue_title}\". URL: ${issue_url}. Working branch: ${branch_name}. Implement the fix and open a PR when done: gh pr create --title \"fix: \" --body \"Fixes #${issue_number}\""
+        psm_launch_claude "$session_name" "$fix_prompt"
+>>>>>>> 1ee0409d (fix(psm): launch trusted sessions with initial prompt)
     fi
 
     # Create metadata
@@ -463,7 +473,8 @@ cmd_feature() {
     local session_id="${project}:feat-${safe_name}"
 
     psm_create_tmux_session "$session_name" "$worktree_path"
-    psm_launch_claude "$session_name"
+    local feature_prompt="Implement feature \"${feature_name}\" for project ${project}. Working branch: ${branch_name}. Build the feature, add tests, and open a PR when ready: gh pr create --title \"feat: ${feature_name}\""
+    psm_launch_claude "$session_name" "$feature_prompt"
 
     psm_add_session "$session_id" "feature" "$project" "feat-${safe_name}" "$branch_name" "$base" "$session_name" "$worktree_path" "$local_path" "{}"
 

--- a/skills/project-session-manager/psm.sh
+++ b/skills/project-session-manager/psm.sh
@@ -232,12 +232,7 @@ cmd_review() {
             # Launch Claude Code with review context so it starts on the PR task
             if [[ "$no_claude" != "true" ]]; then
                 log_info "Launching Claude Code..."
-<<<<<<< HEAD
                 psm_launch_claude "$session_name" "$context_rel"
-=======
-                local review_prompt="Review PR #${pr_number}: \"${pr_title}\" by @${pr_author} (${head_branch} → ${base_branch}). URL: ${pr_url}. Read the diff, check for issues, and leave review comments via: gh pr review ${pr_number} --repo ${repo}"
-                psm_launch_claude "$session_name" "$review_prompt"
->>>>>>> 1ee0409d (fix(psm): launch trusted sessions with initial prompt)
             fi
         fi
     fi
@@ -398,12 +393,7 @@ cmd_fix() {
     psm_create_tmux_session "$session_name" "$worktree_path"
 
     if [[ "$no_claude" != "true" ]]; then
-<<<<<<< HEAD
         psm_launch_claude "$session_name" "$fix_context_rel"
-=======
-        local fix_prompt="Fix issue #${issue_number}: \"${issue_title}\". URL: ${issue_url}. Working branch: ${branch_name}. Implement the fix and open a PR when done: gh pr create --title \"fix: \" --body \"Fixes #${issue_number}\""
-        psm_launch_claude "$session_name" "$fix_prompt"
->>>>>>> 1ee0409d (fix(psm): launch trusted sessions with initial prompt)
     fi
 
     # Create metadata

--- a/src/__tests__/psm-launch-trust.test.ts
+++ b/src/__tests__/psm-launch-trust.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for issue #2508:
+ * PSM tmux sessions stalling on approval/confirm prompts.
+ *
+ * These are contract tests: they read the shell script source and assert that
+ * the fix is in place. A reversion to bare `claude` (no trust flag) or removal
+ * of the initial-context handling will immediately break these tests.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const PSM_ROOT = join(__dirname, '../../skills/project-session-manager');
+const TMUX_SH = join(PSM_ROOT, 'lib/tmux.sh');
+const PSM_SH = join(PSM_ROOT, 'psm.sh');
+
+function readScript(path: string): string {
+  return readFileSync(path, 'utf-8');
+}
+
+describe('PSM launch trust fix (issue #2508)', () => {
+  describe('tmux.sh psm_launch_claude', () => {
+    let source: string;
+    beforeAll(() => { source = readScript(TMUX_SH); });
+
+    it('passes --dangerously-skip-permissions to claude', () => {
+      expect(source).toContain('claude --dangerously-skip-permissions');
+    });
+
+    it('does NOT launch bare claude without the trust flag', () => {
+      const bareClaudePattern = /send-keys[^\n]*"\s*claude\s*"\s*Enter/;
+      expect(source).not.toMatch(bareClaudePattern);
+    });
+
+    it('accepts an initial_context parameter', () => {
+      expect(source).toContain('local initial_context=');
+    });
+
+    it('preserves context-file injection for relative task files', () => {
+      expect(source).toContain("tmux display-message -p -t \"$session_name\" '#{pane_current_path}'");
+      expect(source).toContain('-f "$session_path/$initial_context"');
+      expect(source).toContain('psm_inject_prompt "$session_name" "$initial_context"');
+    });
+
+    it('delivers literal prompts via tmux send-keys in a background subshell', () => {
+      expect(source).toContain('send-keys -t "$session_name" -l -- "$initial_context"');
+      expect(source).toMatch(/\(\s*[\s\S]*?sleep[\s\S]*?send-keys[\s\S]*?\)\s*&/m);
+    });
+
+    it('documents PSM_CLAUDE_STARTUP_DELAY env var for tuning', () => {
+      expect(source).toContain('PSM_CLAUDE_STARTUP_DELAY');
+    });
+  });
+
+  describe('psm.sh command functions — task context delivery', () => {
+    let source: string;
+    beforeAll(() => { source = readScript(PSM_SH); });
+
+    it('cmd_review passes the rendered review context file to psm_launch_claude', () => {
+      expect(source).toMatch(/context_rel="\\.psm\/review\.md"/);
+      expect(source).toMatch(/psm_launch_claude "\$session_name" "\$context_rel"/);
+    });
+
+    it('cmd_fix passes the rendered issue context file to psm_launch_claude', () => {
+      expect(source).toMatch(/fix_context_rel="\\.psm\/fix\.md"/);
+      expect(source).toMatch(/psm_launch_claude "\$session_name" "\$fix_context_rel"/);
+    });
+
+    it('cmd_feature still passes a literal feature prompt to psm_launch_claude', () => {
+      expect(source).toMatch(/feature_prompt=.*feature_name/s);
+      expect(source).toMatch(/psm_launch_claude "\$session_name" "\$feature_prompt"/);
+    });
+
+    it('no command calls psm_launch_claude with only a session name (no task context)', () => {
+      const bareCall = /^\s*psm_launch_claude\s+"\$session_name"\s*$/m;
+      expect(source).not.toMatch(bareCall);
+    });
+  });
+});

--- a/src/__tests__/psm-launch-trust.test.ts
+++ b/src/__tests__/psm-launch-trust.test.ts
@@ -9,6 +9,7 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 const PSM_ROOT = join(__dirname, '../../skills/project-session-manager');
 const TMUX_SH = join(PSM_ROOT, 'lib/tmux.sh');

--- a/src/__tests__/psm-launch-trust.test.ts
+++ b/src/__tests__/psm-launch-trust.test.ts
@@ -57,18 +57,18 @@ describe('PSM launch trust fix (issue #2508)', () => {
     beforeAll(() => { source = readScript(PSM_SH); });
 
     it('cmd_review passes the rendered review context file to psm_launch_claude', () => {
-      expect(source).toMatch(/context_rel="\\.psm\/review\.md"/);
-      expect(source).toMatch(/psm_launch_claude "\$session_name" "\$context_rel"/);
+      expect(source).toContain('local context_rel=".psm/review.md"');
+      expect(source).toContain('psm_launch_claude "$session_name" "$context_rel"');
     });
 
     it('cmd_fix passes the rendered issue context file to psm_launch_claude', () => {
-      expect(source).toMatch(/fix_context_rel="\\.psm\/fix\.md"/);
-      expect(source).toMatch(/psm_launch_claude "\$session_name" "\$fix_context_rel"/);
+      expect(source).toContain('local fix_context_rel=".psm/fix.md"');
+      expect(source).toContain('psm_launch_claude "$session_name" "$fix_context_rel"');
     });
 
     it('cmd_feature still passes a literal feature prompt to psm_launch_claude', () => {
       expect(source).toMatch(/feature_prompt=.*feature_name/s);
-      expect(source).toMatch(/psm_launch_claude "\$session_name" "\$feature_prompt"/);
+      expect(source).toContain('psm_launch_claude "$session_name" "$feature_prompt"');
     });
 
     it('no command calls psm_launch_claude with only a session name (no task context)', () => {


### PR DESCRIPTION
## Summary
- launch PSM sessions with --dangerously-skip-permissions to avoid trust/approval stalls
- pass initial prompts for review, fix, and feature session launches
- add regression tests for the launch contract

## Testing
- ./node_modules/.bin/vitest run src/__tests__/psm-launch-trust.test.ts

Fixes #2508