### PR TITLE
fix(notifications): suppress usage-text tmux alert noise

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -360,6 +360,25 @@ describe("parseTmuxTail noise filters", () => {
 
     expect(parseTmuxTail(input)).toBe(input);
   });
+
+  it("drops grep/source lines that only contain static error markers", () => {
+    const input = [
+      'skills/project-session-manager/lib/tmux.sh:16:        echo "error|tmux not found"',
+      'skills/project-session-manager/lib/tmux.sh:28:        echo "error|Failed to create tmux session"',
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("drops usage/help source text that would otherwise trip error alerts", () => {
+    const input = [
+      'Usage: psm review <ref>',
+      'if [[ "$tmux_status" == "error" ]]; then',
+      'log_error "Usage: psm fix <ref>"',
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
 });
 
 describe("tmuxTail in formatters", () => {

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -207,6 +207,12 @@ const REVIEW_SEED_CUE_RE =
 /** Continuation markers for bullets / enumerated option lines in seeded prompts. */
 const REVIEW_SEED_LIST_RE = /^(?:[-*•]|\d+[.)]|[A-Z][A-Z_-]+:|\([a-z0-9]+\))/;
 
+/** Static source/grep output lines that often trip keyword alerts without representing runtime failure. */
+const SOURCE_PATH_LINE_RE = /^(?:\.\/)?[A-Za-z0-9_./-]+:\d+:/;
+const STATIC_CODE_ALERT_RE = /(?:\blog_error\b|\becho\b).*?(?:"error\||"Usage:)|==\s*"error"/;
+const HELP_USAGE_LINE_RE = /^(?:Usage|Examples?|Commands?|Options?|Flags?):/i;
+const STATIC_HELP_CODE_RE = /^(?:log_error\s+"Usage:|if\s+\[\[.*==\s*"error".*\]\];?\s*then$)/;
+
 /** Default maximum number of meaningful lines to include in a notification.
  * Matches DEFAULT_TMUX_TAIL_LINES in config.ts. */
 const DEFAULT_MAX_TAIL_LINES = 15;
@@ -272,6 +278,9 @@ export function parseTmuxTail(raw: string, maxLines: number = DEFAULT_MAX_TAIL_L
     if (OMC_HUD_RE.test(trimmed)) continue;
     if (BYPASS_PERM_RE.test(trimmed)) continue;
     if (BARE_PROMPT_RE.test(trimmed)) continue;
+    if (HELP_USAGE_LINE_RE.test(trimmed)) continue;
+    if (STATIC_HELP_CODE_RE.test(trimmed)) continue;
+    if (SOURCE_PATH_LINE_RE.test(trimmed) && STATIC_CODE_ALERT_RE.test(trimmed)) continue;
 
     // Alphanumeric density check: drop lines mostly composed of special characters
     const alnumCount = (trimmed.match(/[a-zA-Z0-9]/g) || []).length;


### PR DESCRIPTION
## Summary
- suppress tmux tail lines that are just usage/help text or static code snippets containing alert keywords
- keep real runtime failure output intact
- add regression coverage for source-path and usage/help false positives

## Testing
- ./node_modules/.bin/vitest run src/notifications/__tests__/formatter.test.ts src/openclaw/__tests__/index.test.ts

Fixes #2514