### PR TITLE
fix(installer): prevent cleanupStaleSkills from deleting user-created skills

### DIFF
--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -19,13 +19,20 @@ import { cleanupStaleAgents, cleanupStaleSkills, prunePluginDuplicateSkills, pru
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
 function createAgentFile(dir: string, filename: string, name: string): void {
-  writeFileSync(join(dir, filename), `---\nname: ${name}\ndescription: Test agent\nmodel: claude-sonnet-4-6\n---\n\n# ${name}\nTest content.\n`);
+  writeFileSync(join(dir, filename), `---\nsource: omc\nname: ${name}\ndescription: Test agent\nmodel: claude-sonnet-4-6\n---\n\n# ${name}\nTest content.\n`);
 }
 
 function createSkillDir(dir: string, skillName: string, name: string): void {
   const skillDir = join(dir, skillName);
   mkdirSync(skillDir, { recursive: true });
-  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: ${name}\ndescription: Test skill\n---\n\n# ${name}\nTest content.\n`);
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nsource: omc\nname: ${name}\ndescription: Test skill\n---\n\n# ${name}\nTest content.\n`);
+}
+
+function createUserSkillDirWithFrontmatter(dir: string, skillName: string, name: string): void {
+  const skillDir = join(dir, skillName);
+  mkdirSync(skillDir, { recursive: true });
+  // User-created skill WITH standard frontmatter but WITHOUT `source: omc`
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: ${name}\ndescription: User-created skill\n---\n\n# ${name}\nUser content.\n`);
 }
 
 function createUserFile(dir: string, filename: string): void {
@@ -214,6 +221,21 @@ describe('cleanupStaleSkills', () => {
   it('returns empty array when skills directory does not exist', () => {
     const removed = cleanupStaleSkills(log);
     expect(removed).toEqual([]);
+  });
+
+  it('preserves user-created skill directories that have frontmatter but no source: omc marker', async () => {
+    vi.resetModules();
+    const { cleanupStaleSkills: cleanup, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+
+    // User-created skill with standard frontmatter (name: field) but no `source: omc`
+    createUserSkillDirWithFrontmatter(skillsDir, 'my-gstack-skill', 'my-gstack-skill');
+
+    const removed = cleanup(log);
+
+    expect(removed).not.toContain('my-gstack-skill');
+    expect(existsSync(join(skillsDir, 'my-gstack-skill'))).toBe(true);
   });
 
   it('does not remove directories without SKILL.md', async () => {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -557,11 +557,13 @@ export function cleanupStaleAgents(log: (msg: string) => void): string[] {
     if (file === 'AGENTS.md') continue;
     if (currentAgentFiles.has(file)) continue;
 
-    // Check if this looks like an OMC-created agent (kebab-case .md with frontmatter)
+    // Check if this is an OMC-installed agent (has `source: omc` frontmatter marker).
+    // Agents without this marker are user-created and must never be deleted.
     const filepath = join(AGENTS_DIR, file);
     try {
       const content = readFileSync(filepath, 'utf-8');
-      if (content.startsWith('---\n') && /^name:\s+\S+/m.test(content)) {
+      const { metadata } = parseFrontmatter(content);
+      if (metadata.source === 'omc') {
         unlinkSync(filepath);
         removed.push(file);
         log(`  Removed stale agent: ${file}`);
@@ -650,10 +652,12 @@ export function cleanupStaleSkills(log: (msg: string) => void): string[] {
     const skillMdPath = join(SKILLS_DIR, entry.name, 'SKILL.md');
     if (!existsSync(skillMdPath)) continue;
 
-    // Check if this looks like an OMC-created skill (has standard frontmatter)
+    // Check if this is an OMC-installed skill (has `source: omc` frontmatter marker).
+    // Skills without this marker are user-created and must never be deleted.
     try {
       const content = readFileSync(skillMdPath, 'utf-8');
-      if (content.startsWith('---\n') && /^name:\s+\S+/m.test(content)) {
+      const { metadata } = parseFrontmatter(content);
+      if (metadata.source === 'omc') {
         // Skip user-learned skills (these are user-created)
         if (entry.name === 'omc-learned') continue;
 
@@ -723,7 +727,8 @@ export function prunePluginDuplicateSkills(log: (msg: string) => void): string[]
       // copy (or looks like standard OMC frontmatter). This preserves user-authored
       // skills that happen to share a name with a plugin skill.
       const pluginContent = pluginSkillHashes.get(entry.name);
-      const isOmcCreated = standaloneContent.startsWith('---\n') && /^name:\s+\S+/m.test(standaloneContent);
+      const { metadata: standaloneMeta } = parseFrontmatter(standaloneContent);
+      const isOmcCreated = standaloneMeta.source === 'omc';
 
       if (pluginContent === standaloneContent || isOmcCreated) {
         rmSync(join(SKILLS_DIR, entry.name), { recursive: true, force: true });
@@ -991,6 +996,18 @@ function syncBundledSkillDefinitions(log: (msg: string) => void, options?: { saf
     const relativePath = join(targetDirName, 'SKILL.md');
     const targetDir = join(SKILLS_DIR, targetDirName);
     cpSync(sourceDir, targetDir, { recursive: true, force: true });
+
+    // Stamp installed skills with `source: omc` so cleanupStaleSkills() can
+    // distinguish OMC-managed skills from user-created ones.
+    const targetSkillPath = join(targetDir, 'SKILL.md');
+    if (existsSync(targetSkillPath)) {
+      const skillContent = readFileSync(targetSkillPath, 'utf-8');
+      if (!skillContent.includes('source: omc')) {
+        const stamped = skillContent.replace(/^---\n/, '---\nsource: omc\n');
+        writeFileSync(targetSkillPath, stamped, 'utf-8');
+      }
+    }
+
     installedSkills.push(relativePath.replace(/\\/g, '/'));
     log(`  Synced ${relativePath}`);
   }
@@ -1273,7 +1290,12 @@ export function install(options: InstallOptions = {}): InstallResult {
           if (existsSync(filepath) && !options.force) {
             log(`  Skipping ${filename} (already exists)`);
           } else {
-            writeFileSync(filepath, content);
+            // Stamp installed agents with `source: omc` so cleanupStaleAgents() can
+          // distinguish OMC-managed agents from user-created ones.
+          const stampedContent = content.startsWith('---\n') && !content.includes('source: omc')
+            ? content.replace(/^---\n/, '---\nsource: omc\n')
+            : content;
+          writeFileSync(filepath, stampedContent);
             result.installedAgents.push(filename);
             log(`  Installed ${filename}`);
           }


### PR DESCRIPTION
## Summary

- `cleanupStaleSkills()`, `cleanupStaleAgents()`, and `prunePluginDuplicateSkills()` used a broad heuristic (`---\n` + `name:` field) to identify OMC-managed files, which incorrectly matched **all** Claude Code skills with standard frontmatter
- User-created and third-party skills (e.g. gstack) were permanently deleted during `omc setup`
- Now uses an explicit `source: omc` frontmatter marker — only files stamped during OMC installation are eligible for cleanup

## Problem

Any skill in `~/.claude/skills/` with standard YAML frontmatter (`---\nname: ...`) was treated as an OMC-created skill. During setup, if that skill name wasn't in the current OMC package, it was classified as "stale" and permanently deleted via `rmSync`. This affected:

- User-created custom skills with frontmatter
- Third-party skill packages (e.g. gstack)
- Any non-OMC skill following Claude Code's standard skill format

The same issue existed in `cleanupStaleAgents()` and `prunePluginDuplicateSkills()`.

## Solution

1. **Positive ownership marker**: OMC now stamps `source: omc` in frontmatter when installing skills/agents via `syncBundledSkillDefinitions()` and the agent installation path
2. **Strict cleanup check**: Only files with `source: omc` are candidates for stale cleanup
3. **Test coverage**: Added `createUserSkillDirWithFrontmatter()` helper and test case confirming user skills with frontmatter are preserved

## Files Changed

- `src/installer/index.ts` — `cleanupStaleSkills()`, `cleanupStaleAgents()`, `prunePluginDuplicateSkills()`, `syncBundledSkillDefinitions()`, agent install path
- `src/installer/__tests__/stale-cleanup.test.ts` — Updated test helpers with `source: omc`, added user-frontmatter preservation test

## Test plan

- [x] `cleanupStaleSkills` removes skills with `source: omc` that are no longer in package
- [x] `cleanupStaleSkills` preserves user skills without frontmatter
- [x] `cleanupStaleSkills` preserves user skills WITH frontmatter but WITHOUT `source: omc`
- [x] `cleanupStaleAgents` removes agents with `source: omc` marker only
- [x] `cleanupStaleAgents` preserves user agents without frontmatter
- [x] `prunePluginDuplicateSkills` uses `source: omc` marker check
- [x] All 23 stale-cleanup tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)