### PR TITLE
fix(installer): prevent cleanupStaleSkills from deleting user-created skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,31 @@ Wrap handler at server.py:42 in try/except ClientDisconnectedError...
 
 [Full feature list →](docs/REFERENCE.md)
 
+### How Skills & Agents Are Installed
+
+OMC can deliver skills and agents through two paths. Understanding which is active prevents confusion when files appear (or disappear) from your config directory.
+
+| Path | Installed by | Location | Loaded by |
+|------|-------------|----------|-----------|
+| **Plugin** | `/plugin install oh-my-claudecode` | `~/.claude/plugins/cache/omc/oh-my-claudecode/<version>/` | Claude Code plugin system (automatic) |
+| **Standalone** | `omc setup` (CLI) | `~/.claude/skills/`, `~/.claude/agents/` | Claude Code directly |
+
+If both paths are active, the same skill appears twice. OMC automatically removes standalone copies when a plugin is present (`prunePluginDuplicate*` functions).
+
+**Ownership marker — `source: omc`**
+
+When OMC installs skills or agents, it stamps the YAML frontmatter with `source: omc`:
+
+```yaml
+---
+source: omc        # ← OMC-installed marker
+name: autopilot
+description: Full autonomous execution
+---
+```
+
+Only files with this marker are eligible for cleanup or pruning. **User-created and third-party skills are never deleted**, even if they use the same frontmatter format.
+
 ---
 
 ## In-session shortcuts

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ npm i -g oh-my-claude-sisyphus@latest
 omc setup
 ```
 
+> **What does setup do?** It syncs CLAUDE.md, hooks, and (if needed) standalone skill/agent files. If you installed via **plugin** (Step 1 recommended path), skills and agents are already served from the plugin cache — `omc setup` detects this and skips copying standalone files. If you installed via **npm only**, setup copies them into `~/.claude/skills/` and `~/.claude/agents/`.
+
 If you run OMC via `omc --plugin-dir <path>` or `claude --plugin-dir <path>`, add `--plugin-dir-mode` to `omc setup` (or export `OMC_PLUGIN_ROOT` before running it) so the installer doesn't duplicate skills/agents that the plugin already provides at runtime. See the [Plugin directory flags section in REFERENCE.md](./docs/REFERENCE.md#plugin-directory-flags) for a complete decision matrix and all available flags.
 
 **Step 3: Build something**

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ If you prefer the npm CLI/runtime path instead of the marketplace flow:
 npm i -g oh-my-claude-sisyphus@latest
 ```
 
+> **Plugin vs CLI:** The plugin path loads skills/agents from the plugin cache automatically. The npm CLI path copies them into `~/.claude/skills/` and `~/.claude/agents/` as standalone files. If you use both, OMC deduplicates automatically. Each installed file is stamped with `source: omc` so that user-created and third-party skills are never touched during cleanup. See [How Skills & Agents Are Installed](#how-skills--agents-are-installed) for details.
+
 **Step 2: Setup**
 
 ```bash

--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -432,6 +432,21 @@ describe('prunePluginDuplicateAgents', () => {
     expect(existsSync(join(agentsDir, 'my-custom-agent.md'))).toBe(true);
   });
 
+  it('preserves user-created agents with frontmatter but no source: omc even if name matches plugin', async () => {
+    vi.resetModules();
+    const { prunePluginDuplicateAgents: prune, AGENTS_DIR: agentsDir } = await import('../index.js');
+
+    mkdirSync(agentsDir, { recursive: true });
+
+    // User-created agent whose name matches a plugin agent but lacks source: omc
+    writeFileSync(join(agentsDir, 'architect.md'), `---\nname: architect\ndescription: My custom architect\nmodel: claude-opus-4-6\n---\n\nCustom content.\n`);
+
+    const removed = prune(log);
+
+    expect(removed).not.toContain('architect.md');
+    expect(existsSync(join(agentsDir, 'architect.md'))).toBe(true);
+  });
+
   it('preserves AGENTS.md documentation file', async () => {
     vi.resetModules();
     const { prunePluginDuplicateAgents: prune, AGENTS_DIR: agentsDir } = await import('../index.js');

--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -116,6 +116,21 @@ describe('cleanupStaleAgents', () => {
     expect(existsSync(join(agentsDir, 'my-custom-agent.md'))).toBe(true);
   });
 
+  it('preserves user-created agent files that have frontmatter but no source: omc marker', async () => {
+    vi.resetModules();
+    const { cleanupStaleAgents: cleanup, AGENTS_DIR: agentsDir } = await import('../index.js');
+
+    mkdirSync(agentsDir, { recursive: true });
+
+    // User-created agent with standard frontmatter (name: field) but no `source: omc`
+    writeFileSync(join(agentsDir, 'my-custom-agent.md'), `---\nname: my-custom-agent\ndescription: User-created agent\nmodel: claude-sonnet-4-6\n---\n\n# My Agent\nUser content.\n`);
+
+    const removed = cleanup(log);
+
+    expect(removed).not.toContain('my-custom-agent.md');
+    expect(existsSync(join(agentsDir, 'my-custom-agent.md'))).toBe(true);
+  });
+
   it('preserves AGENTS.md even though it is not a current agent definition', async () => {
     vi.resetModules();
     const { cleanupStaleAgents: cleanup, AGENTS_DIR: agentsDir } = await import('../index.js');
@@ -433,5 +448,100 @@ describe('prunePluginDuplicateAgents', () => {
   it('returns empty when agents directory does not exist', () => {
     const removed = prunePluginDuplicateAgents(log);
     expect(removed).toEqual([]);
+  });
+});
+
+// ── source: omc Stamping ────────────────────────────────────────────────────
+
+describe('source: omc stamping', () => {
+  let tempDir: string;
+  let originalConfigDir: string | undefined;
+  const log = vi.fn();
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'omc-stamp-'));
+    originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+    log.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('install() stamps agents with source: omc when installing legacy agents', async () => {
+    vi.resetModules();
+    const { install, AGENTS_DIR: agentsDir } = await import('../index.js');
+
+    // Run install with force to ensure agents are written
+    install({ force: true, verbose: false, skipClaudeCheck: true, noPlugin: true });
+
+    // Check that at least one installed agent has source: omc
+    if (existsSync(agentsDir)) {
+      const agents = readdirSync(agentsDir).filter(f => f.endsWith('.md') && f !== 'AGENTS.md');
+      if (agents.length > 0) {
+        const content = readFileSync(join(agentsDir, agents[0]), 'utf-8');
+        expect(content).toContain('source: omc');
+      }
+    }
+  });
+
+  it('install() stamps skills with source: omc when syncing bundled skills', async () => {
+    vi.resetModules();
+    const { install, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    // Run install with noPlugin to force bundled skill sync
+    install({ force: true, verbose: false, skipClaudeCheck: true, noPlugin: true });
+
+    // Check that at least one installed skill has source: omc
+    if (existsSync(skillsDir)) {
+      const skills = readdirSync(skillsDir).filter(d => {
+        const skillMd = join(skillsDir, d, 'SKILL.md');
+        return existsSync(skillMd);
+      });
+      if (skills.length > 0) {
+        const content = readFileSync(join(skillsDir, skills[0], 'SKILL.md'), 'utf-8');
+        expect(content).toContain('source: omc');
+      }
+    }
+  });
+
+  it('stamped skills are correctly removed by cleanupStaleSkills when no longer in package', async () => {
+    vi.resetModules();
+    const { cleanupStaleSkills: cleanup, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+
+    // Create a skill with source: omc marker (simulating a previously installed OMC skill)
+    const skillDir = join(skillsDir, 'old-omc-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), `---\nsource: omc\nname: old-omc-skill\ndescription: Was in previous OMC version\n---\n\nOld content.\n`);
+
+    const removed = cleanup(log);
+
+    expect(removed).toContain('old-omc-skill');
+    expect(existsSync(skillDir)).toBe(false);
+  });
+
+  it('non-stamped skills survive cleanup even with identical structure', async () => {
+    vi.resetModules();
+    const { cleanupStaleSkills: cleanup, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+
+    // Create a skill that looks like OMC but has no source: omc marker
+    const skillDir = join(skillsDir, 'third-party-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: third-party-skill\ndescription: Installed by gstack or user\nlevel: 2\n---\n\nContent.\n`);
+
+    const removed = cleanup(log);
+
+    expect(removed).not.toContain('third-party-skill');
+    expect(existsSync(skillDir)).toBe(true);
   });
 });

--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -19,13 +19,20 @@ import { cleanupStaleAgents, cleanupStaleSkills, prunePluginDuplicateSkills, pru
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
 function createAgentFile(dir: string, filename: string, name: string): void {
-  writeFileSync(join(dir, filename), `---\nname: ${name}\ndescription: Test agent\nmodel: claude-sonnet-4-6\n---\n\n# ${name}\nTest content.\n`);
+  writeFileSync(join(dir, filename), `---\nsource: omc\nname: ${name}\ndescription: Test agent\nmodel: claude-sonnet-4-6\n---\n\n# ${name}\nTest content.\n`);
 }
 
 function createSkillDir(dir: string, skillName: string, name: string): void {
   const skillDir = join(dir, skillName);
   mkdirSync(skillDir, { recursive: true });
-  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: ${name}\ndescription: Test skill\n---\n\n# ${name}\nTest content.\n`);
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nsource: omc\nname: ${name}\ndescription: Test skill\n---\n\n# ${name}\nTest content.\n`);
+}
+
+function createUserSkillDirWithFrontmatter(dir: string, skillName: string, name: string): void {
+  const skillDir = join(dir, skillName);
+  mkdirSync(skillDir, { recursive: true });
+  // User-created skill WITH standard frontmatter but WITHOUT `source: omc`
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: ${name}\ndescription: User-created skill\n---\n\n# ${name}\nUser content.\n`);
 }
 
 function createUserFile(dir: string, filename: string): void {
@@ -214,6 +221,21 @@ describe('cleanupStaleSkills', () => {
   it('returns empty array when skills directory does not exist', () => {
     const removed = cleanupStaleSkills(log);
     expect(removed).toEqual([]);
+  });
+
+  it('preserves user-created skill directories that have frontmatter but no source: omc marker', async () => {
+    vi.resetModules();
+    const { cleanupStaleSkills: cleanup, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+
+    // User-created skill with standard frontmatter (name: field) but no `source: omc`
+    createUserSkillDirWithFrontmatter(skillsDir, 'my-gstack-skill', 'my-gstack-skill');
+
+    const removed = cleanup(log);
+
+    expect(removed).not.toContain('my-gstack-skill');
+    expect(existsSync(join(skillsDir, 'my-gstack-skill'))).toBe(true);
   });
 
   it('does not remove directories without SKILL.md', async () => {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -601,7 +601,8 @@ export function prunePluginDuplicateAgents(log: (msg: string) => void): string[]
     const filepath = join(AGENTS_DIR, file);
     try {
       const content = readFileSync(filepath, 'utf-8');
-      if (content.startsWith('---\n') && /^name:\s+\S+/m.test(content)) {
+      const { metadata } = parseFrontmatter(content);
+      if (metadata.source === 'omc') {
         unlinkSync(filepath);
         removed.push(file);
         log(`  Pruned plugin-duplicate agent: ${file}`);
@@ -1291,11 +1292,11 @@ export function install(options: InstallOptions = {}): InstallResult {
             log(`  Skipping ${filename} (already exists)`);
           } else {
             // Stamp installed agents with `source: omc` so cleanupStaleAgents() can
-          // distinguish OMC-managed agents from user-created ones.
-          const stampedContent = content.startsWith('---\n') && !content.includes('source: omc')
-            ? content.replace(/^---\n/, '---\nsource: omc\n')
-            : content;
-          writeFileSync(filepath, stampedContent);
+            // distinguish OMC-managed agents from user-created ones.
+            const stampedContent = content.startsWith('---\n') && !content.includes('source: omc')
+              ? content.replace(/^---\n/, '---\nsource: omc\n')
+              : content;
+            writeFileSync(filepath, stampedContent);
             result.installedAgents.push(filename);
             log(`  Installed ${filename}`);
           }

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -557,11 +557,13 @@ export function cleanupStaleAgents(log: (msg: string) => void): string[] {
     if (file === 'AGENTS.md') continue;
     if (currentAgentFiles.has(file)) continue;
 
-    // Check if this looks like an OMC-created agent (kebab-case .md with frontmatter)
+    // Check if this is an OMC-installed agent (has `source: omc` frontmatter marker).
+    // Agents without this marker are user-created and must never be deleted.
     const filepath = join(AGENTS_DIR, file);
     try {
       const content = readFileSync(filepath, 'utf-8');
-      if (content.startsWith('---\n') && /^name:\s+\S+/m.test(content)) {
+      const { metadata } = parseFrontmatter(content);
+      if (metadata.source === 'omc') {
         unlinkSync(filepath);
         removed.push(file);
         log(`  Removed stale agent: ${file}`);
@@ -650,10 +652,12 @@ export function cleanupStaleSkills(log: (msg: string) => void): string[] {
     const skillMdPath = join(SKILLS_DIR, entry.name, 'SKILL.md');
     if (!existsSync(skillMdPath)) continue;
 
-    // Check if this looks like an OMC-created skill (has standard frontmatter)
+    // Check if this is an OMC-installed skill (has `source: omc` frontmatter marker).
+    // Skills without this marker are user-created and must never be deleted.
     try {
       const content = readFileSync(skillMdPath, 'utf-8');
-      if (content.startsWith('---\n') && /^name:\s+\S+/m.test(content)) {
+      const { metadata } = parseFrontmatter(content);
+      if (metadata.source === 'omc') {
         // Skip user-learned skills (these are user-created)
         if (entry.name === 'omc-learned') continue;
 
@@ -723,7 +727,8 @@ export function prunePluginDuplicateSkills(log: (msg: string) => void): string[]
       // copy (or looks like standard OMC frontmatter). This preserves user-authored
       // skills that happen to share a name with a plugin skill.
       const pluginContent = pluginSkillHashes.get(entry.name);
-      const isOmcCreated = standaloneContent.startsWith('---\n') && /^name:\s+\S+/m.test(standaloneContent);
+      const { metadata: standaloneMeta } = parseFrontmatter(standaloneContent);
+      const isOmcCreated = standaloneMeta.source === 'omc';
 
       if (pluginContent === standaloneContent || isOmcCreated) {
         rmSync(join(SKILLS_DIR, entry.name), { recursive: true, force: true });
@@ -991,6 +996,18 @@ function syncBundledSkillDefinitions(log: (msg: string) => void, options?: { saf
     const relativePath = join(targetDirName, 'SKILL.md');
     const targetDir = join(SKILLS_DIR, targetDirName);
     cpSync(sourceDir, targetDir, { recursive: true, force: true });
+
+    // Stamp installed skills with `source: omc` so cleanupStaleSkills() can
+    // distinguish OMC-managed skills from user-created ones.
+    const targetSkillPath = join(targetDir, 'SKILL.md');
+    if (existsSync(targetSkillPath)) {
+      const skillContent = readFileSync(targetSkillPath, 'utf-8');
+      if (!skillContent.includes('source: omc')) {
+        const stamped = skillContent.replace(/^---\n/, '---\nsource: omc\n');
+        writeFileSync(targetSkillPath, stamped, 'utf-8');
+      }
+    }
+
     installedSkills.push(relativePath.replace(/\\/g, '/'));
     log(`  Synced ${relativePath}`);
   }
@@ -1273,7 +1290,12 @@ export function install(options: InstallOptions = {}): InstallResult {
           if (existsSync(filepath) && !options.force) {
             log(`  Skipping ${filename} (already exists)`);
           } else {
-            writeFileSync(filepath, content);
+            // Stamp installed agents with `source: omc` so cleanupStaleAgents() can
+          // distinguish OMC-managed agents from user-created ones.
+          const stampedContent = content.startsWith('---\n') && !content.includes('source: omc')
+            ? content.replace(/^---\n/, '---\nsource: omc\n')
+            : content;
+          writeFileSync(filepath, stampedContent);
             result.installedAgents.push(filename);
             log(`  Installed ${filename}`);
           }

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -725,7 +725,7 @@ export function prunePluginDuplicateSkills(log: (msg: string) => void): string[]
       const standaloneContent = readFileSync(skillMdPath, 'utf-8').trim();
 
       // Safety check: only remove if the standalone content matches the plugin's
-      // copy (or looks like standard OMC frontmatter). This preserves user-authored
+      // copy (or has `source: omc` marker). This preserves user-authored
       // skills that happen to share a name with a plugin skill.
       const pluginContent = pluginSkillHashes.get(entry.name);
       const { metadata: standaloneMeta } = parseFrontmatter(standaloneContent);


### PR DESCRIPTION
## Background

After running `omc setup`, all user-created custom skills in `~/.claude/skills/` were permanently deleted. The cleanup function (`cleanupStaleSkills`) identified "OMC-owned" files by checking for standard YAML frontmatter (`---\n` + `name:` field) — the same format all Claude Code skills use. So every skill with frontmatter was mistakenly classified as a stale OMC artifact and deleted via `rmSync`.

## Solution

1. **Positive ownership marker**: OMC now stamps `source: omc` in frontmatter when installing skills/agents at install time
2. **Strict cleanup check**: All four cleanup functions (`cleanupStaleSkills`, `cleanupStaleAgents`, `prunePluginDuplicateSkills`, `prunePluginDuplicateAgents`) now only target files with `source: omc`
3. **Test coverage**: 6 new tests (29 total)
4. **Documentation**: README updated to explain plugin vs standalone installation paths and the `source: omc` marker

## Files Changed

- `src/installer/index.ts` — All 4 cleanup functions + 2 stamping injection points
- `src/installer/__tests__/stale-cleanup.test.ts` — 29 tests (6 new)
- `README.md` — Quick Start notes + "How Skills & Agents Are Installed" section

## Test plan

- [x] All 29 stale-cleanup tests passing
- [x] User skills WITH frontmatter but WITHOUT `source: omc` are preserved
- [x] `install()` stamps both agents and skills with `source: omc`
- [x] Stamped files are removed when stale; non-stamped files survive
- [x] No old heuristic patterns remain in codebase