### PR TITLE
fix(config): warn on deprecated delegation routing

### DIFF
--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -25,6 +25,8 @@ const ALL_KEYS = [
   "ANTHROPIC_DEFAULT_OPUS_MODEL",
   "ANTHROPIC_DEFAULT_SONNET_MODEL",
   "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+  "OMC_DELEGATION_ROUTING_ENABLED",
+  "OMC_DELEGATION_ROUTING_DEFAULT_PROVIDER",
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -249,6 +251,69 @@ describe("plan output configuration", () => {
         directory: "docs/plans",
         filenameTemplate: "plan-{{name}}.md",
       });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("delegation routing deprecation warnings", () => {
+  let saved: Record<string, string | undefined>;
+  let originalCwd: string;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    saved = saveAndClear(ALL_KEYS);
+    originalCwd = process.cwd();
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    consoleWarnSpy.mockRestore();
+    restore(saved);
+  });
+
+  it("warns when env delegation default provider is deprecated", () => {
+    process.env.OMC_DELEGATION_ROUTING_DEFAULT_PROVIDER = "gemini";
+
+    loadConfig();
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("delegationRouting to Codex/Gemini is deprecated"),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Use /team for Codex/Gemini CLI workers instead."),
+    );
+  });
+
+  it("warns when project config uses deprecated delegation role provider", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omc-delegation-routing-warning-"));
+
+    try {
+      const claudeDir = join(tempDir, ".claude");
+      require("node:fs").mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(
+        join(claudeDir, "omc.jsonc"),
+        JSON.stringify({
+          delegationRouting: {
+            enabled: true,
+            roles: {
+              explore: {
+                provider: "codex",
+                tool: "Task",
+              },
+            },
+          },
+        }),
+      );
+
+      process.chdir(tempDir);
+      loadConfig();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("delegationRouting to Codex/Gemini is deprecated"),
+      );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -9,7 +9,11 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join, dirname } from "path";
-import type { PluginConfig, ExternalModelsConfig } from "../shared/types.js";
+import type {
+  PluginConfig,
+  ExternalModelsConfig,
+  DelegationProvider,
+} from "../shared/types.js";
 import { getConfigDir } from "../utils/paths.js";
 import { parseJsonc } from "../utils/jsonc.js";
 import {
@@ -411,6 +415,30 @@ export function loadEnvConfig(): Partial<PluginConfig> {
 /**
  * Load and merge all configuration sources
  */
+function warnOnDeprecatedDelegationRouting(config: PluginConfig): void {
+  const deprecatedProviders = new Set<DelegationProvider>();
+  const defaultProvider = config.delegationRouting?.defaultProvider;
+  if (defaultProvider === "codex" || defaultProvider === "gemini") {
+    deprecatedProviders.add(defaultProvider);
+  }
+
+  const roles = config.delegationRouting?.roles ?? {};
+  for (const route of Object.values(roles)) {
+    const provider = route?.provider;
+    if (provider === "codex" || provider === "gemini") {
+      deprecatedProviders.add(provider);
+    }
+  }
+
+  if (deprecatedProviders.size === 0) {
+    return;
+  }
+
+  console.warn(
+    "[OMC] delegationRouting to Codex/Gemini is deprecated and falls back to Claude Task. Use /team for Codex/Gemini CLI workers instead.",
+  );
+}
+
 export function loadConfig(): PluginConfig {
   const paths = getConfigPaths();
 
@@ -449,6 +477,8 @@ export function loadConfig(): PluginConfig {
       forceInherit: true,
     };
   }
+
+  warnOnDeprecatedDelegationRouting(config);
 
   return config;
 }


### PR DESCRIPTION
## Summary\n- surface delegationRouting Codex/Gemini deprecation at config load time instead of leaving it silent\n- warn when deprecated defaultProvider or role provider values are configured\n- add loader coverage for env and project-config warning paths\n\n## Testing\n- npx vitest run src/config/__tests__/loader.test.ts src/features/delegation-routing/__tests__/resolver.test.ts src/__tests__/consolidation-contracts.test.ts\n\nCloses #2520