### PR TITLE
fix: reduce post-tool bash failure false positives

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -208,21 +208,37 @@ export function isNonZeroExitWithOutput(output) {
 
 // Detect failures in Bash output
 export function detectBashFailure(output) {
+  if (!output) return false;
+
   const cleaned = stripClaudeTempCwdErrors(output);
-  const errorPatterns = [
-    /error:/i,
-    /failed/i,
-    /cannot/i,
-    /permission denied/i,
-    /command not found/i,
-    /no such file/i,
-    /exit code: [1-9]/i,
-    /exit status [1-9]/i,
-    /fatal:/i,
-    /abort/i,
+
+  const explicitExitPatterns = [
+    /(^|\n)Error: Exit code [1-9]\d*(\n|$)/i,
+    /(^|\n).*\bexit code:\s*[1-9]\d*\b/i,
+    /(^|\n).*\bexit status\s+[1-9]\d*\b/i,
   ];
 
-  return errorPatterns.some(pattern => pattern.test(cleaned));
+  if (explicitExitPatterns.some(pattern => pattern.test(cleaned))) {
+    return true;
+  }
+
+  const linePatterns = [
+    /^error:\s+/i,
+    /^(?:bash|zsh|sh): .*command not found/i,
+    /^(?:bash|zsh|sh): .*no such file/i,
+    /^(?:bash|zsh|sh): .*permission denied/i,
+    /^(?:rm|cp|mv|cat|chmod|chown|git|node|npm|pnpm|yarn|python|python3|pip|pip3|cargo|go|rustc|docker|ffmpeg): .*permission denied/i,
+    /^(?:rm|cp|mv|cat|git|node|npm|pnpm|yarn|python|python3|pip|pip3|cargo|go|rustc|docker|ffmpeg): .*no such file/i,
+    /^fatal:\s+/i,
+    /^abort(?:ed)?\b/i,
+    /^(?:build|command|task|operation) failed\b/i,
+  ];
+
+  return cleaned
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .some(line => linePatterns.some(pattern => pattern.test(line)));
 }
 
 // Detect background operation

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -133,7 +133,7 @@ describe('detectBashFailure', () => {
       expect(detectBashFailure('error: file not found')).toBe(true);
     });
 
-    it('should detect "failed" pattern', () => {
+    it('should detect "failed" pattern when it is a failure summary line', () => {
       expect(detectBashFailure('Build failed')).toBe(true);
     });
 
@@ -141,12 +141,39 @@ describe('detectBashFailure', () => {
       expect(detectBashFailure('zsh: command not found: foo')).toBe(true);
     });
 
-    it('should detect exit code failures', () => {
+    it('should detect Claude exit code failures', () => {
+      expect(detectBashFailure('Error: Exit code 1')).toBe(true);
+    });
+
+    it('should detect textual exit code failures', () => {
       expect(detectBashFailure('exit code: 1')).toBe(true);
     });
 
     it('should detect "fatal:" pattern', () => {
       expect(detectBashFailure('fatal: not a git repository')).toBe(true);
+    });
+
+    it('should not flag successful pytest output containing failure words', () => {
+      const output = [
+        'tests/test_render.py::TestRender::test_ffmpeg_failure_raises PASSED',
+        'tests/test_render.py::TestRender::test_qa_failure_propagates PASSED',
+        '80 passed in 0.24s',
+      ].join('\n');
+      expect(detectBashFailure(output)).toBe(false);
+    });
+
+    it('should not flag successful grep output containing "Command failed" text', () => {
+      const output = 'scripts/post-tool-verifier.mjs:683:        message = \'Command failed. Please investigate the error and fix before continuing.\'';
+      expect(detectBashFailure(output)).toBe(false);
+    });
+
+    it('should not flag successful output when the word "error" appears mid-line', () => {
+      const output = [
+        'frame=   15 fps=0.0 q=-0.0 size=       0kB time=00:00:00.50 bitrate=   0.8kbits/s speed=5.6x',
+        'codec-side-data: some harmless error metric label',
+        'video:4kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.000000%',
+      ].join('\n');
+      expect(detectBashFailure(output)).toBe(false);
     });
 
     it('should return false for clean output', () => {


### PR DESCRIPTION
## Summary
- tighten bash failure detection to focus on explicit exit evidence and shell/tool failure-shaped lines
- stop flagging successful outputs that merely mention failure/error words mid-line
- add regression coverage for pytest/grep/ffmpeg-style successful outputs

## Testing
- npx vitest run src/__tests__/post-tool-verifier.test.mjs