### PR TITLE
fix: restrict setup stale-skill cleanup to OMC-managed dirs

### DIFF
--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -38,6 +38,10 @@ function createUserSkillDir(dir: string, skillName: string): void {
   mkdirSync(skillDir, { recursive: true });
   // No frontmatter — just user prose
   writeFileSync(join(skillDir, 'SKILL.md'), `# My Custom Skill\n\nThis is a user-created skill.\n`);
+}
+
+function createManagedSkillMarker(dir: string, skillName: string): void {
+  writeFileSync(join(dir, skillName, '.omc-managed'), 'omc-managed\n');
 }
 
 // ── Stale Agent Cleanup ──────────────────────────────────────────────────────
@@ -152,14 +156,14 @@ describe('cleanupStaleSkills', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('removes skill directories that have OMC frontmatter but are no longer in the package', async () => {
+  it('removes stale skills only when OMC ownership is explicitly marked', async () => {
     vi.resetModules();
     const { cleanupStaleSkills: cleanup, SKILLS_DIR: skillsDir } = await import('../index.js');
 
     mkdirSync(skillsDir, { recursive: true });
 
-    // Create a fake stale skill
     createSkillDir(skillsDir, 'removed-skill', 'removed-skill');
+    createManagedSkillMarker(skillsDir, 'removed-skill');
 
     const removed = cleanup(log);
 
@@ -194,6 +198,40 @@ describe('cleanupStaleSkills', () => {
 
     expect(removed).not.toContain('my-custom-skill');
     expect(existsSync(join(skillsDir, 'my-custom-skill'))).toBe(true);
+  });
+
+  it('preserves third-party skills with standard frontmatter when no OMC marker is present', async () => {
+    vi.resetModules();
+    const { cleanupStaleSkills: cleanup, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+    createSkillDir(skillsDir, 'gstack', 'gstack');
+
+    const removed = cleanup(log);
+
+    expect(removed).not.toContain('gstack');
+    expect(existsSync(join(skillsDir, 'gstack'))).toBe(true);
+  });
+
+  it('preserves symlinked skill directories without an OMC marker', async () => {
+    vi.resetModules();
+    const { cleanupStaleSkills: cleanup, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+
+    const externalRoot = mkdtempSync(join(tmpdir(), 'omc-third-party-skill-'));
+    const externalSkillDir = join(externalRoot, 'linked-skill');
+    mkdirSync(externalSkillDir, { recursive: true });
+    writeFileSync(join(externalSkillDir, 'SKILL.md'), '---\nname: linked-skill\ndescription: external\n---\n\n# linked-skill\n');
+    symlinkSync(externalSkillDir, join(skillsDir, 'linked-skill'), 'dir');
+
+    try {
+      const removed = cleanup(log);
+      expect(removed).not.toContain('linked-skill');
+      expect(existsSync(join(skillsDir, 'linked-skill'))).toBe(true);
+    } finally {
+      rmSync(externalRoot, { recursive: true, force: true });
+    }
   });
 
   it('preserves omc-learned directory (user-created skills)', async () => {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -36,6 +36,7 @@ export const HOOKS_DIR = join(CLAUDE_CONFIG_DIR, 'hooks');
 export const HUD_DIR = join(CLAUDE_CONFIG_DIR, 'hud');
 export const SETTINGS_FILE = join(CLAUDE_CONFIG_DIR, 'settings.json');
 export const VERSION_FILE = join(CLAUDE_CONFIG_DIR, '.omc-version.json');
+const OMC_MANAGED_SKILL_MARKER = '.omc-managed';
 
 /**
  * Core commands - DISABLED for v3.0+
@@ -646,23 +647,19 @@ export function cleanupStaleSkills(log: (msg: string) => void): string[] {
   for (const entry of readdirSync(SKILLS_DIR, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     if (currentSkillNames.has(entry.name)) continue;
+    if (entry.name === 'omc-learned') continue;
 
-    const skillMdPath = join(SKILLS_DIR, entry.name, 'SKILL.md');
+    const skillDir = join(SKILLS_DIR, entry.name);
+    const skillMdPath = join(skillDir, 'SKILL.md');
     if (!existsSync(skillMdPath)) continue;
+    if (!isOmcManagedSkillDir(skillDir)) continue;
 
-    // Check if this looks like an OMC-created skill (has standard frontmatter)
     try {
-      const content = readFileSync(skillMdPath, 'utf-8');
-      if (content.startsWith('---\n') && /^name:\s+\S+/m.test(content)) {
-        // Skip user-learned skills (these are user-created)
-        if (entry.name === 'omc-learned') continue;
-
-        rmSync(join(SKILLS_DIR, entry.name), { recursive: true, force: true });
-        removed.push(entry.name);
-        log(`  Removed stale skill: ${entry.name}/`);
-      }
+      rmSync(skillDir, { recursive: true, force: true });
+      removed.push(entry.name);
+      log(`  Removed stale skill: ${entry.name}/`);
     } catch {
-      // Skip directories that can't be read
+      // Skip directories that can't be removed
     }
   }
 
@@ -954,6 +951,18 @@ function toSafeStandaloneSkillName(name: string): string {
     : normalized;
 }
 
+function getManagedSkillMarkerPath(skillDir: string): string {
+  return join(skillDir, OMC_MANAGED_SKILL_MARKER);
+}
+
+function markSkillAsOmcManaged(skillDir: string): void {
+  writeFileSync(getManagedSkillMarkerPath(skillDir), 'omc-managed\n');
+}
+
+function isOmcManagedSkillDir(skillDir: string): boolean {
+  return existsSync(getManagedSkillMarkerPath(skillDir));
+}
+
 function syncBundledSkillDefinitions(log: (msg: string) => void, options?: { safeStandaloneNames?: boolean }): string[] {
   const skillsDir = join(getPackageDir(), 'skills');
   const installedSkills: string[] = [];
@@ -991,6 +1000,7 @@ function syncBundledSkillDefinitions(log: (msg: string) => void, options?: { saf
     const relativePath = join(targetDirName, 'SKILL.md');
     const targetDir = join(SKILLS_DIR, targetDirName);
     cpSync(sourceDir, targetDir, { recursive: true, force: true });
+    markSkillAsOmcManaged(targetDir);
     installedSkills.push(relativePath.replace(/\\/g, '/'));
     log(`  Synced ${relativePath}`);
   }


### PR DESCRIPTION
## Summary
- add an explicit `.omc-managed` ownership marker for bundled skills synced by setup
- make stale skill cleanup remove only marker-owned skills instead of any directory with standard frontmatter
- add regression coverage for third-party and symlinked skills so setup no longer deletes user-managed skill packs

## Testing
- npx vitest run src/installer/__tests__/stale-cleanup.test.ts