### PR TITLE
Suppress stale repo-level CI replay noise after zero backlog

### DIFF
--- a/src/hooks/__tests__/stop-hook-openclaw-cooldown.test.ts
+++ b/src/hooks/__tests__/stop-hook-openclaw-cooldown.test.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 vi.mock("../persistent-mode/index.js", () => ({
   checkPersistentModes: vi.fn().mockResolvedValue({ mode: "none", message: "" }),
   createHookOutput: vi.fn().mockReturnValue({ continue: true }),
+  shouldWakeOpenClawOnStop: vi.fn().mockReturnValue(true),
   shouldSendIdleNotification: vi.fn().mockReturnValue(false), // cooldown ACTIVE — gate closed
   recordIdleNotificationSent: vi.fn(),
   getIdleNotificationCooldownSeconds: vi.fn().mockReturnValue(60),
@@ -19,6 +20,7 @@ vi.mock("../todo-continuation/index.js", () => ({
 }));
 
 import { _openclaw, processHook, resetSkipHooksCache, type HookInput } from "../bridge.js";
+import * as persistentMode from "../persistent-mode/index.js";
 
 describe("stop hook OpenClaw cooldown bypass (issue #1120)", () => {
   let tmpDir: string;
@@ -28,6 +30,7 @@ describe("stop hook OpenClaw cooldown bypass (issue #1120)", () => {
     // git init so resolveToWorktreeRoot returns this directory
     execSync("git init", { cwd: tmpDir, stdio: "ignore" });
     resetSkipHooksCache();
+    vi.mocked(persistentMode.shouldWakeOpenClawOnStop).mockReturnValue(true);
     delete process.env.DISABLE_OMC;
     delete process.env.OMC_SKIP_HOOKS;
   });
@@ -75,7 +78,25 @@ describe("stop hook OpenClaw cooldown bypass (issue #1120)", () => {
     await processHook("persistent-mode", input);
 
     // OpenClaw stop should NOT fire for user aborts
-    const stopCall = wakeSpy.mock.calls.find((call) => call[0] === "stop");
+    const stopCall = wakeSpy.mock.calls.find((call: unknown[]) => call[0] === "stop");
+    expect(stopCall).toBeUndefined();
+
+    wakeSpy.mockRestore();
+  });
+
+  it("suppresses _openclaw.wake('stop') for unchanged zero-backlog repo state even when idle notification cooldown is bypassed", async () => {
+    process.env.OMC_OPENCLAW = "1";
+    vi.mocked(persistentMode.shouldWakeOpenClawOnStop).mockReturnValue(false);
+    const wakeSpy = vi.spyOn(_openclaw, "wake");
+
+    const input: HookInput = {
+      sessionId: "test-session-789",
+      directory: tmpDir,
+    };
+
+    await processHook("persistent-mode", input);
+
+    const stopCall = wakeSpy.mock.calls.find((call: unknown[]) => call[0] === "stop");
     expect(stopCall).toBeUndefined();
 
     wakeSpy.mockRestore();

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1073,6 +1073,7 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
   const {
     checkPersistentModes,
     createHookOutput,
+    shouldWakeOpenClawOnStop,
     shouldSendIdleNotification,
     recordIdleNotificationSent,
   } = await import("./persistent-mode/index.js");
@@ -1142,14 +1143,14 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
         stopContext.stop_reason === "context_limit" ||
         stopContext.stopReason === "context_limit";
       if (!isAbort && !isContextLimit) {
-        // Always wake OpenClaw on stop — cooldown only applies to user-facing notifications
-        _openclaw.wake("stop", { sessionId, projectPath: directory });
-
         // Per-session cooldown: prevent notification spam when the session idles repeatedly.
         // Uses session-scoped state so one session does not suppress another.
         const stateDir = join(getOmcRoot(directory), "state");
         const { getIdleNotificationRepoState } = await import("./persistent-mode/idle-repo-state.js");
         const idleRepoState = getIdleNotificationRepoState(directory);
+        if (shouldWakeOpenClawOnStop(stateDir, sessionId, idleRepoState)) {
+          _openclaw.wake("stop", { sessionId, projectPath: directory });
+        }
         if (shouldSendIdleNotification(stateDir, sessionId, idleRepoState)) {
           recordIdleNotificationSent(stateDir, sessionId, idleRepoState);
           const logSessionIdleNotifyFailure = createSwallowedErrorLogger(

--- a/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import { getGlobalOmcConfigCandidates } from '../../../utils/paths.js';
 import {
   getIdleNotificationCooldownSeconds,
+  shouldWakeOpenClawOnStop,
   shouldSendIdleNotification,
   recordIdleNotificationSent,
 } from '../index.js';
@@ -464,6 +465,49 @@ describe('shouldSendIdleNotification', () => {
     });
 
     expect(shouldSendIdleNotification(TEST_STATE_DIR, undefined, changedBacklogState)).toBe(true);
+  });
+});
+
+describe('shouldWakeOpenClawOnStop', () => {
+  const zeroBacklogState = { signature: 'repo-zero', backlogZero: true };
+  const changedBacklogState = { signature: 'repo-new', backlogZero: true };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('suppresses stop wakes when the zero-backlog repo snapshot is unchanged', () => {
+    const oldTimestamp = new Date(Date.now() - 90_000).toISOString();
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => p === COOLDOWN_PATH);
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === COOLDOWN_PATH) {
+        return JSON.stringify({
+          lastSentAt: oldTimestamp,
+          repoSignature: zeroBacklogState.signature,
+          backlogZero: true,
+        });
+      }
+      throw new Error('not found');
+    });
+
+    expect(shouldWakeOpenClawOnStop(TEST_STATE_DIR, TEST_SESSION_ID, zeroBacklogState)).toBe(false);
+  });
+
+  it('still allows stop wakes when only the ordinary cooldown is active', () => {
+    const recentTimestamp = new Date(Date.now() - 5_000).toISOString();
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => p === COOLDOWN_PATH);
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === COOLDOWN_PATH) {
+        return JSON.stringify({
+          lastSentAt: recentTimestamp,
+          repoSignature: changedBacklogState.signature,
+          backlogZero: false,
+        });
+      }
+      throw new Error('not found');
+    });
+
+    expect(shouldWakeOpenClawOnStop(TEST_STATE_DIR, TEST_SESSION_ID, zeroBacklogState)).toBe(true);
   });
 });
 

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -338,6 +338,41 @@ function isRepeatedZeroBacklogCooldown(
   );
 }
 
+function hasRepeatedZeroBacklogCooldown(
+  stateDir: string,
+  sessionId?: string,
+  repoState?: IdleNotificationRepoState | null,
+): boolean {
+  const cooldownPath = getIdleNotificationCooldownPath(stateDir, sessionId);
+  const cooldownRecord = readIdleNotificationCooldownRecord(cooldownPath);
+
+  if (isRepeatedZeroBacklogCooldown(cooldownRecord, repoState)) {
+    return true;
+  }
+
+  if (cooldownPath !== getGlobalIdleNotificationCooldownPath(stateDir)) {
+    const globalRecord = readIdleNotificationCooldownRecord(getGlobalIdleNotificationCooldownPath(stateDir));
+    if (isRepeatedZeroBacklogCooldown(globalRecord, repoState)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * OpenClaw stop wakes should usually bypass idle cooldowns, but unchanged
+ * zero-backlog repo state should stay suppressed so stale repo-level CI replay
+ * bursts do not re-arm after the actionable backlog is already zero.
+ */
+export function shouldWakeOpenClawOnStop(
+  stateDir: string,
+  sessionId?: string,
+  repoState?: IdleNotificationRepoState | null,
+): boolean {
+  return !hasRepeatedZeroBacklogCooldown(stateDir, sessionId, repoState);
+}
+
 /**
  * Check whether the session-idle notification cooldown has elapsed.
  * Returns true if the notification should be sent.
@@ -351,18 +386,8 @@ export function shouldSendIdleNotification(
   const cooldownPath = getIdleNotificationCooldownPath(stateDir, sessionId);
   const cooldownRecord = readIdleNotificationCooldownRecord(cooldownPath);
 
-  if (isRepeatedZeroBacklogCooldown(cooldownRecord, repoState)) {
+  if (hasRepeatedZeroBacklogCooldown(stateDir, sessionId, repoState)) {
     return false;
-  }
-
-  // Back off unchanged zero-backlog nudges across follow-up sessions too.
-  // Session-scoped cooldown should not keep rearming identical "all clear"
-  // alerts for brand-new session ids when the repo state has not changed.
-  if (cooldownPath !== getGlobalIdleNotificationCooldownPath(stateDir)) {
-    const globalRecord = readIdleNotificationCooldownRecord(getGlobalIdleNotificationCooldownPath(stateDir));
-    if (isRepeatedZeroBacklogCooldown(globalRecord, repoState)) {
-      return false;
-    }
   }
 
   if (repoState && typeof cooldownRecord?.repoSignature === 'string') {


### PR DESCRIPTION
## Summary
- suppress OpenClaw stop wakes when the repo snapshot is the same unchanged zero-backlog state already muted by idle notifications
- keep ordinary cooldown-only stop wakes intact so issue #1120 behavior still holds for actionable cases
- add focused regressions for the stop-wake gate and the new persistent-mode helper

## Root cause
Issue #1120 moved `_openclaw.wake("stop")` outside the idle notification cooldown so stop gateways always fired. Issue #2497 later made idle notifications repo-signature-aware for unchanged zero-backlog repos, but that hardening never covered the stop wake path. As a result, a clean repo could still wake external clawhip replay logic and surface stale repo-level `CI passed` / `CI cancelled` bursts.

## Testing
- `npx vitest run src/hooks/__tests__/stop-hook-openclaw-cooldown.test.ts src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts`
- `npx eslint src/hooks/bridge.ts src/hooks/persistent-mode/index.ts src/hooks/__tests__/stop-hook-openclaw-cooldown.test.ts src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts`
- `npx tsc --noEmit`

Closes #2516