### PR TITLE
Fix persistent-mode.cjs OMC_STATE_DIR state resolution mismatch

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -21,9 +21,10 @@ const {
   renameSync,
   statSync,
 } = require("fs");
+const { createHash } = require("crypto");
 const { execFileSync } = require("child_process");
 const { homedir } = require("os");
-const { join, dirname, resolve, normalize } = require("path");
+const { join, dirname, resolve, normalize, basename, sep } = require("path");
 const { getClaudeConfigDir } = require("./lib/config-dir.cjs");
 
 async function readStdin(timeoutMs = 2000) {
@@ -112,6 +113,45 @@ function runJsonCommand(command, args, cwd) {
     return JSON.parse(raw);
   } catch {
     return null;
+  }
+}
+
+function getProjectIdentifier(directory) {
+  const root = directory || process.cwd();
+  const source = runCommand("git", ["remote", "get-url", "origin"], root) || root;
+
+  let primaryRoot = root;
+  const commonDir = runCommand(
+    "git",
+    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    root,
+  );
+  if (commonDir) {
+    const isGitDir = basename(commonDir) === ".git";
+    const isSubmodule = commonDir.includes(`${sep}.git${sep}modules`);
+    if (isGitDir && !isSubmodule) {
+      const resolved = dirname(commonDir);
+      if (resolved && resolved !== root) {
+        primaryRoot = resolved;
+      }
+    }
+  }
+
+  const hash = createHash("sha256").update(source).digest("hex").slice(0, 16);
+  const dirName = basename(primaryRoot).replace(/[^a-zA-Z0-9_-]/g, "_");
+  return `${dirName}-${hash}`;
+}
+
+function resolveOmcStateDir(directory) {
+  const customDir = process.env.OMC_STATE_DIR;
+  if (!customDir) {
+    return join(directory, ".omc", "state");
+  }
+
+  try {
+    return join(customDir, getProjectIdentifier(directory), "state");
+  } catch {
+    return join(directory, ".omc", "state");
   }
 }
 
@@ -797,7 +837,7 @@ async function main() {
 
     const directory = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || data.sessionId || "";
-    const stateDir = join(directory, ".omc", "state");
+    const stateDir = resolveOmcStateDir(directory);
 
     // CRITICAL: Never block context-limit stops.
     // Blocking these causes a deadlock where Claude Code cannot compact.

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -9,6 +9,7 @@ import {
   type PersistentModeResult,
 } from "./index.js";
 import { activateUltrawork, deactivateUltrawork } from "../ultrawork/index.js";
+import { getOmcRoot } from "../../lib/worktree-paths.js";
 
 function writeTranscriptWithContext(filePath: string, contextWindow: number, inputTokens: number): void {
   writeFileSync(
@@ -43,6 +44,22 @@ function writeSubagentTrackingState(
   );
 }
 
+function writePendingTodo(tempDir: string, content: string): void {
+  mkdirSync(join(tempDir, ".claude"), { recursive: true });
+  writeFileSync(
+    join(tempDir, ".claude", "todos.json"),
+    JSON.stringify({
+      todos: [
+        {
+          content,
+          status: "pending",
+          priority: "high",
+        },
+      ],
+    }),
+  );
+}
+
 function writeLegacyModeState(
   tempDir: string,
   fileName: string,
@@ -51,6 +68,20 @@ function writeLegacyModeState(
   const stateDir = join(tempDir, ".omc", "state");
   mkdirSync(stateDir, { recursive: true });
   writeFileSync(join(stateDir, fileName), JSON.stringify(state, null, 2));
+}
+
+function resolveCentralizedStateDir(directory: string, customStateDir: string): string {
+  const previous = process.env.OMC_STATE_DIR;
+  process.env.OMC_STATE_DIR = customStateDir;
+  try {
+    return join(getOmcRoot(directory), "state");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OMC_STATE_DIR;
+    } else {
+      process.env.OMC_STATE_DIR = previous;
+    }
+  }
 }
 
 describe("Stop Hook Blocking Contract", () => {
@@ -894,13 +925,16 @@ describe("Stop Hook Blocking Contract", () => {
     let tempDir: string;
     const scriptPath = join(process.cwd(), "scripts", "persistent-mode.cjs");
 
-    function runScript(input: Record<string, unknown>): Record<string, unknown> {
+    function runScript(
+      input: Record<string, unknown>,
+      envOverrides: Record<string, string | undefined> = {},
+    ): Record<string, unknown> {
       try {
         const result = execSync(`node "${scriptPath}"`, {
           encoding: "utf-8",
           timeout: 5000,
           input: JSON.stringify(input),
-          env: { ...process.env, NODE_ENV: "test" },
+          env: { ...process.env, NODE_ENV: "test", ...envOverrides },
         });
         const lines = result.trim().split("\n");
         return JSON.parse(lines[lines.length - 1]);
@@ -917,10 +951,66 @@ describe("Stop Hook Blocking Contract", () => {
     beforeEach(() => {
       tempDir = mkdtempSync(join(tmpdir(), "stop-hook-cjs-test-"));
       execSync("git init", { cwd: tempDir });
+      delete process.env.OMC_STATE_DIR;
     });
 
     afterEach(() => {
+      delete process.env.OMC_STATE_DIR;
       rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("reads centralized session state when OMC_STATE_DIR is set", () => {
+      const sessionId = "centralized-state-cjs";
+      const customStateDir = join(tempDir, "centralized-state");
+      const centralizedStateDir = resolveCentralizedStateDir(tempDir, customStateDir);
+      const sessionDir = join(centralizedStateDir, "sessions", sessionId);
+      writePendingTodo(tempDir, "Finish centralized task");
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ultrawork-state.json"),
+        JSON.stringify({
+          active: true,
+          original_prompt: "Centralized task",
+          session_id: sessionId,
+          reinforcement_count: 0,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+        }),
+      );
+
+      const output = runScript(
+        { directory: tempDir, sessionId },
+        { OMC_STATE_DIR: customStateDir },
+      );
+
+      expect(output.decision).toBe("block");
+      expect(output.reason).toContain("ULTRAWORK");
+    });
+
+    it("ignores legacy local state when OMC_STATE_DIR is set", () => {
+      const sessionId = "legacy-local-cjs";
+      const localSessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      writePendingTodo(tempDir, "Finish centralized-only task");
+      mkdirSync(localSessionDir, { recursive: true });
+      writeFileSync(
+        join(localSessionDir, "ultrawork-state.json"),
+        JSON.stringify({
+          active: true,
+          original_prompt: "Stale local task",
+          session_id: sessionId,
+          reinforcement_count: 0,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+        }),
+      );
+
+      const output = runScript(
+        { directory: tempDir, sessionId },
+        { OMC_STATE_DIR: join(tempDir, "centralized-state") },
+      );
+
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
     });
 
     it("returns continue: true for authentication error stop", () => {


### PR DESCRIPTION
## Summary\n- make scripts/persistent-mode.cjs resolve its state dir through the same OMC_STATE_DIR project-id path scheme as the MCP state tools\n- add focused CJS stop-hook regressions for centralized state reads and stale local-state ignore behavior\n\n## Verification\n- npx vitest run src/hooks/persistent-mode/stop-hook-blocking.test.ts\n- npx tsc --noEmit\n- npx eslint src/hooks/persistent-mode/stop-hook-blocking.test.ts\n- node --check scripts/persistent-mode.cjs\n\nCloses #2518