### PR TITLE
fix(state-root): centralize OMC_STATE_DIR resolution across hook entrypoints (#2532)

### DIFF
--- a/scripts/lib/state-root.cjs
+++ b/scripts/lib/state-root.cjs
@@ -1,0 +1,45 @@
+/**
+ * State Root Resolver (CJS)
+ *
+ * Single authoritative entry point for resolving the .omc root directory in
+ * CJS hook scripts, respecting the OMC_STATE_DIR environment variable.
+ *
+ * See scripts/lib/state-root.mjs for full documentation.
+ */
+
+'use strict';
+
+const { join, basename } = require('path');
+const { createHash } = require('crypto');
+
+/**
+ * Resolve the .omc root directory, respecting OMC_STATE_DIR.
+ *
+ * @param {string} directory - Worktree root directory
+ * @returns {Promise<string>} Absolute path to the .omc root
+ */
+async function resolveOmcStateRoot(directory) {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (pluginRoot) {
+    try {
+      const { pathToFileURL } = require('url');
+      const { getOmcRoot } = await import(
+        pathToFileURL(join(pluginRoot, 'dist', 'lib', 'worktree-paths.js')).href
+      );
+      return getOmcRoot(directory);
+    } catch {
+      // dist not built or unavailable — fall through to inline fallback
+    }
+  }
+
+  // Inline fallback: respects OMC_STATE_DIR with simplified project identifier
+  const customDir = process.env.OMC_STATE_DIR;
+  if (customDir) {
+    const hash = createHash('sha256').update(directory).digest('hex').slice(0, 16);
+    const dirName = basename(directory).replace(/[^a-zA-Z0-9_-]/g, '_');
+    return join(customDir, `${dirName}-${hash}`);
+  }
+  return join(directory, '.omc');
+}
+
+module.exports = { resolveOmcStateRoot };

--- a/scripts/lib/state-root.mjs
+++ b/scripts/lib/state-root.mjs
@@ -1,0 +1,50 @@
+/**
+ * State Root Resolver (ESM)
+ *
+ * Single authoritative entry point for resolving the .omc root directory in
+ * hook scripts, respecting the OMC_STATE_DIR environment variable.
+ *
+ * Delegates to getOmcRoot() from dist/lib/worktree-paths.js (the canonical
+ * implementation) when CLAUDE_PLUGIN_ROOT is available. Falls back to inline
+ * logic when dist is not built — this should never happen in production, but
+ * provides a safe fallback during development or first-run scenarios.
+ *
+ * Inline fallback notes:
+ *   - Uses directory path as hash source (not git remote URL). Matches
+ *     canonical behavior for local-only repos; may differ for remote-backed
+ *     repos when dist is missing — acceptable since dist is always present
+ *     in production (CLAUDE_PLUGIN_ROOT is always set).
+ */
+
+import { join, basename } from 'path';
+import { createHash } from 'crypto';
+import { pathToFileURL } from 'url';
+
+/**
+ * Resolve the .omc root directory, respecting OMC_STATE_DIR.
+ *
+ * @param {string} directory - Worktree root directory
+ * @returns {Promise<string>} Absolute path to the .omc root
+ */
+export async function resolveOmcStateRoot(directory) {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (pluginRoot) {
+    try {
+      const { getOmcRoot } = await import(
+        pathToFileURL(join(pluginRoot, 'dist', 'lib', 'worktree-paths.js')).href
+      );
+      return getOmcRoot(directory);
+    } catch {
+      // dist not built or unavailable — fall through to inline fallback
+    }
+  }
+
+  // Inline fallback: respects OMC_STATE_DIR with simplified project identifier
+  const customDir = process.env.OMC_STATE_DIR;
+  if (customDir) {
+    const hash = createHash('sha256').update(directory).digest('hex').slice(0, 16);
+    const dirName = basename(directory).replace(/[^a-zA-Z0-9_-]/g, '_');
+    return join(customDir, `${dirName}-${hash}`);
+  }
+  return join(directory, '.omc');
+}

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -21,11 +21,11 @@ const {
   renameSync,
   statSync,
 } = require("fs");
-const { createHash } = require("crypto");
 const { execFileSync } = require("child_process");
 const { homedir } = require("os");
-const { join, dirname, resolve, normalize, basename, sep } = require("path");
+const { join, dirname, resolve, normalize } = require("path");
 const { getClaudeConfigDir } = require("./lib/config-dir.cjs");
+const { resolveOmcStateRoot } = require("./lib/state-root.cjs");
 
 async function readStdin(timeoutMs = 2000) {
   return new Promise((resolve) => {
@@ -113,45 +113,6 @@ function runJsonCommand(command, args, cwd) {
     return JSON.parse(raw);
   } catch {
     return null;
-  }
-}
-
-function getProjectIdentifier(directory) {
-  const root = directory || process.cwd();
-  const source = runCommand("git", ["remote", "get-url", "origin"], root) || root;
-
-  let primaryRoot = root;
-  const commonDir = runCommand(
-    "git",
-    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-    root,
-  );
-  if (commonDir) {
-    const isGitDir = basename(commonDir) === ".git";
-    const isSubmodule = commonDir.includes(`${sep}.git${sep}modules`);
-    if (isGitDir && !isSubmodule) {
-      const resolved = dirname(commonDir);
-      if (resolved && resolved !== root) {
-        primaryRoot = resolved;
-      }
-    }
-  }
-
-  const hash = createHash("sha256").update(source).digest("hex").slice(0, 16);
-  const dirName = basename(primaryRoot).replace(/[^a-zA-Z0-9_-]/g, "_");
-  return `${dirName}-${hash}`;
-}
-
-function resolveOmcStateDir(directory) {
-  const customDir = process.env.OMC_STATE_DIR;
-  if (!customDir) {
-    return join(directory, ".omc", "state");
-  }
-
-  try {
-    return join(customDir, getProjectIdentifier(directory), "state");
-  } catch {
-    return join(directory, ".omc", "state");
   }
 }
 
@@ -837,7 +798,8 @@ async function main() {
 
     const directory = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || data.sessionId || "";
-    const stateDir = resolveOmcStateDir(directory);
+    const omcRoot = await resolveOmcStateRoot(directory);
+    const stateDir = join(omcRoot, "state");
 
     // CRITICAL: Never block context-limit stops.
     // Blocking these causes a deadlock where Claude Code cannot compact.

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -25,6 +25,7 @@ import { join, dirname, resolve, normalize } from "path";
 import { homedir } from "os";
 import { fileURLToPath, pathToFileURL } from "url";
 import { getClaudeConfigDir } from "./lib/config-dir.mjs";
+import { resolveOmcStateRoot } from "./lib/state-root.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -630,7 +631,8 @@ async function main() {
     const sessionIdRaw = data.sessionId || data.session_id || data.sessionid || "";
     const sessionId = sanitizeSessionId(sessionIdRaw);
     const hasValidSessionId = isValidSessionId(sessionIdRaw);
-    const stateDir = join(directory, ".omc", "state");
+    const omcRoot = await resolveOmcStateRoot(directory);
+    const stateDir = join(omcRoot, "state");
     const globalStateDir = join(homedir(), ".omc", "state");
 
     // CRITICAL: Never block context-limit stops.

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, readdirSync, rmSync, mkdirSync, writeFileSync
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
+import { resolveOmcStateRoot } from './lib/state-root.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -372,6 +373,7 @@ async function main() {
 
     const directory = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || data.sessionId || '';
+    const omcRoot = await resolveOmcStateRoot(directory);
     const messages = [];
     const projectMemoryModules = await loadProjectMemoryModules();
 
@@ -422,14 +424,14 @@ async function main() {
     let ultraworkState = null;
     if (sessionId && /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) {
       // Session-scoped ONLY — no legacy fallback
-      ultraworkState = readJsonFile(join(directory, '.omc', 'state', 'sessions', sessionId, 'ultrawork-state.json'));
+      ultraworkState = readJsonFile(join(omcRoot, 'state', 'sessions', sessionId, 'ultrawork-state.json'));
       // Validate session identity
       if (ultraworkState && ultraworkState.session_id && ultraworkState.session_id !== sessionId) {
         ultraworkState = null;
       }
     } else {
       // No session_id — legacy behavior for backward compat
-      ultraworkState = readJsonFile(join(directory, '.omc', 'state', 'ultrawork-state.json'));
+      ultraworkState = readJsonFile(join(omcRoot, 'state', 'ultrawork-state.json'));
     }
 
     if (ultraworkState?.active) {
@@ -453,16 +455,16 @@ Treat this as prior-session context only. Prioritize the user's newest request, 
     let ralphState = null;
     if (sessionId && /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) {
       // Session-scoped ONLY — no legacy fallback
-      ralphState = readJsonFile(join(directory, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'));
+      ralphState = readJsonFile(join(omcRoot, 'state', 'sessions', sessionId, 'ralph-state.json'));
       // Validate session identity
       if (ralphState && ralphState.session_id && ralphState.session_id !== sessionId) {
         ralphState = null;
       }
     } else {
       // No session_id — legacy behavior for backward compat
-      ralphState = readJsonFile(join(directory, '.omc', 'state', 'ralph-state.json'));
+      ralphState = readJsonFile(join(omcRoot, 'state', 'ralph-state.json'));
       if (!ralphState) {
-        ralphState = readJsonFile(join(directory, '.omc', 'ralph-state.json'));
+        ralphState = readJsonFile(join(omcRoot, 'ralph-state.json'));
       }
     }
     if (ralphState?.active) {
@@ -489,7 +491,7 @@ Treat this as prior-session context only. Prioritize the user's newest request, 
     // That directory accumulates todo files from ALL past sessions across all
     // projects, causing phantom task counts in fresh sessions (see issue #354).
     const localTodoPaths = [
-      join(directory, '.omc', 'todos.json'),
+      join(omcRoot, 'todos.json'),
       join(directory, '.claude', 'todos.json')
     ];
     let incompleteCount = 0;
@@ -538,7 +540,7 @@ ${summary}
     }
 
     // Check for notepad Priority Context
-    const notepadPath = join(directory, '.omc', 'notepad.md');
+    const notepadPath = join(omcRoot, 'notepad.md');
     if (existsSync(notepadPath)) {
       try {
         const notepadContent = readFileSync(notepadPath, 'utf-8');

--- a/src/__tests__/state-root-resolution.test.ts
+++ b/src/__tests__/state-root-resolution.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Regression tests for issue #2532: centralized OMC_STATE_DIR state-root resolution.
+ *
+ * Verifies that:
+ *   1. Default behavior (no OMC_STATE_DIR) is unchanged — state lives in {dir}/.omc/
+ *   2. session-start.mjs reads session state from the custom OMC_STATE_DIR location
+ *   3. persistent-mode.cjs (stop hook) reads mode state from the custom OMC_STATE_DIR
+ *      location and correctly blocks the stop when an active mode is present there
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { getOmcRoot, clearWorktreeCache } from '../lib/worktree-paths.js';
+
+const NODE = process.execPath;
+const REPO_ROOT = resolve(join(__dirname, '..', '..'));
+const SESSION_START = join(REPO_ROOT, 'scripts', 'session-start.mjs');
+const STOP_HOOK = join(REPO_ROOT, 'scripts', 'persistent-mode.cjs');
+
+/** Run a hook script synchronously and return the parsed JSON output. */
+function runHook(
+  scriptPath: string,
+  input: Record<string, unknown>,
+  extraEnv: Record<string, string> = {},
+): Record<string, unknown> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+  // Remove OMC_STATE_DIR from parent env so only extraEnv controls it
+  delete env.OMC_STATE_DIR;
+  Object.assign(env, { CLAUDE_PLUGIN_ROOT: REPO_ROOT }, extraEnv);
+
+  const raw = execFileSync(NODE, [scriptPath], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    env,
+    timeout: 15000,
+  }).trim();
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/**
+ * Compute the centralized .omc root path for a given project dir and state dir.
+ * Temporarily sets OMC_STATE_DIR so getOmcRoot() returns the centralized path.
+ */
+function getCentralizedOmcRoot(projectDir: string, stateDir: string): string {
+  const prev = process.env.OMC_STATE_DIR;
+  try {
+    process.env.OMC_STATE_DIR = stateDir;
+    clearWorktreeCache();
+    return getOmcRoot(projectDir);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.OMC_STATE_DIR;
+    } else {
+      process.env.OMC_STATE_DIR = prev;
+    }
+    clearWorktreeCache();
+  }
+}
+
+describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
+  let tempDir: string;
+  let fakeProject: string;
+  let fakeStateDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'omc-state-root-'));
+    fakeProject = join(tempDir, 'project');
+    fakeStateDir = join(tempDir, 'centralized-state');
+    mkdirSync(fakeProject, { recursive: true });
+    mkdirSync(fakeStateDir, { recursive: true });
+    delete process.env.OMC_STATE_DIR;
+    clearWorktreeCache();
+  });
+
+  afterEach(() => {
+    delete process.env.OMC_STATE_DIR;
+    clearWorktreeCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 1. Default state dir (no OMC_STATE_DIR)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('session-start reads ralph state from default .omc path when OMC_STATE_DIR is not set', () => {
+    const sessionId = 'test-session-default';
+    const stateDir = join(fakeProject, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        prompt: 'Default-path task',
+        iteration: 1,
+        max_iterations: 5,
+      }),
+    );
+
+    const output = runHook(SESSION_START, {
+      hook_event_name: 'SessionStart',
+      session_id: sessionId,
+      cwd: fakeProject,
+    });
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).toContain('[RALPH LOOP RESTORED]');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 2. Custom OMC_STATE_DIR — session-start
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('session-start reads ralph state from centralized path when OMC_STATE_DIR is set', () => {
+    const sessionId = 'test-session-centralized';
+    const centralizedOmcRoot = getCentralizedOmcRoot(fakeProject, fakeStateDir);
+    const stateDir = join(centralizedOmcRoot, 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        prompt: 'Centralized-state task',
+        iteration: 2,
+        max_iterations: 10,
+      }),
+    );
+
+    const output = runHook(
+      SESSION_START,
+      { hook_event_name: 'SessionStart', session_id: sessionId, cwd: fakeProject },
+      { OMC_STATE_DIR: fakeStateDir },
+    );
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).toContain('[RALPH LOOP RESTORED]');
+    expect(context).toContain('Centralized-state task');
+  });
+
+  it('session-start reads ultrawork state from centralized path when OMC_STATE_DIR is set', () => {
+    const sessionId = 'test-session-uw-central';
+    const centralizedOmcRoot = getCentralizedOmcRoot(fakeProject, fakeStateDir);
+    const stateDir = join(centralizedOmcRoot, 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ultrawork-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        started_at: '2026-01-01T00:00:00.000Z',
+        original_prompt: 'Centralized ultrawork task',
+      }),
+    );
+
+    const output = runHook(
+      SESSION_START,
+      { hook_event_name: 'SessionStart', session_id: sessionId, cwd: fakeProject },
+      { OMC_STATE_DIR: fakeStateDir },
+    );
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).toContain('[ULTRAWORK MODE RESTORED]');
+    expect(context).toContain('Centralized ultrawork task');
+  });
+
+  it('session-start does NOT restore state when OMC_STATE_DIR is set but state is only in default .omc', () => {
+    const sessionId = 'test-session-only-default';
+    // Place state ONLY in the default .omc location
+    const defaultStateDir = join(fakeProject, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(defaultStateDir, { recursive: true });
+    writeFileSync(
+      join(defaultStateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        prompt: 'Should not restore from default when OMC_STATE_DIR is set',
+        iteration: 1,
+        max_iterations: 5,
+      }),
+    );
+
+    // Run with OMC_STATE_DIR pointing elsewhere — centralized location is empty
+    const output = runHook(
+      SESSION_START,
+      { hook_event_name: 'SessionStart', session_id: sessionId, cwd: fakeProject },
+      { OMC_STATE_DIR: fakeStateDir },
+    );
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).not.toContain('[RALPH LOOP RESTORED]');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 3. Custom OMC_STATE_DIR — stop hook (persistent-mode.cjs)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('stop hook blocks when active ralph state is in default .omc path (baseline)', () => {
+    const sessionId = 'test-stop-default';
+    const stateDir = join(fakeProject, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        prompt: 'Stop hook baseline task',
+        iteration: 1,
+        max_iterations: 5,
+        started_at: new Date().toISOString(),
+        last_checked_at: new Date().toISOString(),
+      }),
+    );
+
+    const output = runHook(STOP_HOOK, {
+      hook_event_name: 'Stop',
+      session_id: sessionId,
+      cwd: fakeProject,
+    });
+
+    expect(output.decision).toBe('block');
+    expect(String(output.reason)).toContain('[RALPH LOOP');
+  });
+
+  it('stop hook blocks when active ralph state is in centralized OMC_STATE_DIR path', () => {
+    const sessionId = 'test-stop-centralized';
+    const centralizedOmcRoot = getCentralizedOmcRoot(fakeProject, fakeStateDir);
+    const stateDir = join(centralizedOmcRoot, 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        prompt: 'Stop hook centralized task',
+        iteration: 1,
+        max_iterations: 5,
+        started_at: new Date().toISOString(),
+        last_checked_at: new Date().toISOString(),
+      }),
+    );
+
+    // No .omc in fakeProject — active state ONLY in centralized dir
+    const output = runHook(
+      STOP_HOOK,
+      { hook_event_name: 'Stop', session_id: sessionId, cwd: fakeProject },
+      { OMC_STATE_DIR: fakeStateDir },
+    );
+
+    expect(output.decision).toBe('block');
+    expect(String(output.reason)).toContain('[RALPH LOOP');
+  });
+
+  it('stop hook does NOT block when OMC_STATE_DIR is set but state is only in default .omc', () => {
+    const sessionId = 'test-stop-mismatch';
+    // Place active state in default location only
+    const defaultStateDir = join(fakeProject, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(defaultStateDir, { recursive: true });
+    writeFileSync(
+      join(defaultStateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        prompt: 'Should be invisible to centralized hook',
+        iteration: 1,
+        max_iterations: 5,
+      }),
+    );
+
+    // Run stop hook with OMC_STATE_DIR — centralized path is empty → no block
+    const output = runHook(
+      STOP_HOOK,
+      { hook_event_name: 'Stop', session_id: sessionId, cwd: fakeProject },
+      { OMC_STATE_DIR: fakeStateDir },
+    );
+
+    expect(output.decision).not.toBe('block');
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `scripts/persistent-mode.cjs`, `persistent-mode.mjs`, and `session-start.mjs` hardcoded `join(directory, '.omc', ...)` everywhere, bypassing `OMC_STATE_DIR` entirely. The canonical resolver (`getOmcRoot` in `src/lib/worktree-paths.ts`) was only used by TypeScript modules — not by the hook scripts.
- **Fix**: Add `scripts/lib/state-root.{mjs,cjs}` — thin async wrappers that delegate to `getOmcRoot()` from `dist/lib/worktree-paths.js` when `CLAUDE_PLUGIN_ROOT` is set, with an inline `OMC_STATE_DIR` + path-hash fallback when dist is unavailable (dev-only scenario).
- **Wire-up**: All three hook entrypoints now call `resolveOmcStateRoot(directory)` instead of building the `.omc` path by hand.

## Test plan

- [x] `src/__tests__/state-root-resolution.test.ts` — 7 new subprocess regression tests:
  - Default `.omc` path unchanged when `OMC_STATE_DIR` is not set
  - `session-start.mjs` restores ralph/ultrawork state from centralized dir when `OMC_STATE_DIR` is set
  - `session-start.mjs` does **not** restore when state is only in default `.omc` and `OMC_STATE_DIR` points elsewhere
  - Stop hook (`persistent-mode.cjs`) blocks when active ralph state is in the default dir (baseline)
  - Stop hook blocks when active ralph state is in the centralized `OMC_STATE_DIR` path
  - Stop hook does **not** block when state is only in default `.omc` but `OMC_STATE_DIR` set
- [x] Full vitest run: 7972 passed, 7 skipped, 1 pre-existing timeout in `auto-update.test.ts` (unrelated)

**Note on stop-hook fixtures**: state files must include fresh `started_at`/`last_checked_at` timestamps — `persistent-mode.cjs` treats state older than 2 hours as stale and skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)