### PR TITLE
fix(mcp): wire wiki, shared_memory, skills, and deepinit tools into standalone server (#2536)

### DIFF
--- a/src/__tests__/standalone-server.test.ts
+++ b/src/__tests__/standalone-server.test.ts
@@ -6,6 +6,10 @@ import { stateTools } from '../tools/state-tools.js';
 import { notepadTools } from '../tools/notepad-tools.js';
 import { memoryTools } from '../tools/memory-tools.js';
 import { traceTools } from '../tools/trace-tools.js';
+import { sharedMemoryTools } from '../tools/shared-memory-tools.js';
+import { deepinitManifestTool } from '../tools/deepinit-manifest.js';
+import { wikiTools } from '../tools/wiki-tools.js';
+import { skillsTools } from '../tools/skills-tools.js';
 
 describe('standalone-server tool composition', () => {
   // These are the exact same tool arrays that standalone-server.ts imports
@@ -19,11 +23,16 @@ describe('standalone-server tool composition', () => {
     ...notepadTools,
     ...memoryTools,
     ...traceTools,
+    ...sharedMemoryTools,
+    deepinitManifestTool,
+    ...wikiTools,
+    ...skillsTools,
   ];
 
   it('should have the expected total tool count', () => {
-    // 12 LSP + 2 AST + 1 python + 5 state + 6 notepad + 4 memory + 3 trace = 33
-    expect(expectedTools).toHaveLength(33);
+    // 12 LSP + 2 AST + 1 python + 5 state + 6 notepad + 4 memory + 3 trace
+    // + 5 shared_memory + 1 deepinit + 7 wiki + 3 skills = 49
+    expect(expectedTools).toHaveLength(49);
   });
 
   it('should include 3 trace tools', () => {
@@ -43,6 +52,52 @@ describe('standalone-server tool composition', () => {
   it('should include session_search tool', () => {
     const names = traceTools.map(t => t.name);
     expect(names).toContain('session_search');
+  });
+
+  it('should include 7 wiki tools', () => {
+    expect(wikiTools).toHaveLength(7);
+  });
+
+  it('should include wiki_ingest tool', () => {
+    const names = wikiTools.map(t => t.name);
+    expect(names).toContain('wiki_ingest');
+  });
+
+  it('should include wiki_query tool', () => {
+    const names = wikiTools.map(t => t.name);
+    expect(names).toContain('wiki_query');
+  });
+
+  it('should include 5 shared_memory tools', () => {
+    expect(sharedMemoryTools).toHaveLength(5);
+  });
+
+  it('should include shared_memory_write tool', () => {
+    const names = sharedMemoryTools.map(t => t.name);
+    expect(names).toContain('shared_memory_write');
+  });
+
+  it('should include shared_memory_read tool', () => {
+    const names = sharedMemoryTools.map(t => t.name);
+    expect(names).toContain('shared_memory_read');
+  });
+
+  it('should include 3 skills tools', () => {
+    expect(skillsTools).toHaveLength(3);
+  });
+
+  it('should include load_omc_skills_local tool', () => {
+    const names = skillsTools.map(t => t.name);
+    expect(names).toContain('load_omc_skills_local');
+  });
+
+  it('should include list_omc_skills tool', () => {
+    const names = skillsTools.map(t => t.name);
+    expect(names).toContain('list_omc_skills');
+  });
+
+  it('should include deepinit_manifest tool', () => {
+    expect(deepinitManifestTool.name).toBe('deepinit_manifest');
   });
 
   it('should have no duplicate tool names', () => {

--- a/src/mcp/standalone-server.ts
+++ b/src/mcp/standalone-server.ts
@@ -25,6 +25,10 @@ import { stateTools } from '../tools/state-tools.js';
 import { notepadTools } from '../tools/notepad-tools.js';
 import { memoryTools } from '../tools/memory-tools.js';
 import { traceTools } from '../tools/trace-tools.js';
+import { sharedMemoryTools } from '../tools/shared-memory-tools.js';
+import { deepinitManifestTool } from '../tools/deepinit-manifest.js';
+import { wikiTools } from '../tools/wiki-tools.js';
+import { skillsTools } from '../tools/skills-tools.js';
 import { registerStandaloneShutdownHandlers } from './standalone-shutdown.js';
 import { cleanupOwnedBridgeSessions } from '../tools/python-repl/bridge-manager.js';
 import { z } from 'zod';
@@ -58,6 +62,10 @@ const allTools: ToolDef[] = [
   ...(notepadTools as unknown as ToolDef[]),
   ...(memoryTools as unknown as ToolDef[]),
   ...(traceTools as unknown as ToolDef[]),
+  ...(sharedMemoryTools as unknown as ToolDef[]),
+  deepinitManifestTool as unknown as ToolDef,
+  ...(wikiTools as unknown as ToolDef[]),
+  ...(skillsTools as unknown as ToolDef[]),
 ];
 
 // Convert Zod schema to JSON Schema for MCP


### PR DESCRIPTION
## Summary

- `standalone-server.ts` was missing 4 tool groups that `omc-tools-server.ts` already exposed: `wikiTools` (7 tools), `sharedMemoryTools` (5 tools), `skillsTools` (3 tools), and `deepinitManifestTool` (1 tool)
- Any client connecting to the stdio standalone MCP server had no access to `wiki_*`, `shared_memory_*`, `load_omc_skills_*`/`list_omc_skills`, or `deepinit_manifest` tools
- Fix adds the 4 missing imports and splices them into `allTools`, bringing the total from 33 → 49 tools, matching `omc-tools-server.ts`
- Expands `standalone-server.test.ts` from 6 → 17 assertions with per-group length checks and spot-name checks for each new group (all 17 pass)

## Root cause

The standalone server was introduced without being kept in sync with `omc-tools-server.ts`. Each time a new tool group was added to the SDK server, the stdio server was not updated.

## Test plan

- [x] `npx vitest run src/__tests__/standalone-server.test.ts` → 17/17 pass
- [x] `npm run build` → exit 0, no TypeScript errors
- [x] No duplicate tool names (verified by existing dedup test)

Fixes #2536

🤖 Generated with [Claude Code](https://claude.com/claude-code)