### PR TITLE
fix(stop-hook): cap echoed task prompt to 150 chars (#2542)

### DIFF
--- a/src/hooks/persistent-mode/__tests__/prompt-truncation.test.ts
+++ b/src/hooks/persistent-mode/__tests__/prompt-truncation.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression tests for issue #2542
+ *
+ * The ralph stop-hook continuation message was echoing the full task prompt on
+ * every stop event.  The fix applies truncatePromptForEcho so the echoed text
+ * is capped regardless of how long the original task description is.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import { checkPersistentModes } from '../index.js';
+import { DEFAULT_PROMPT_ECHO_MAX_CHARS } from '../../../lib/truncate-prompt.js';
+
+function writeRalphState(
+  tempDir: string,
+  sessionId: string,
+  prompt: string,
+): void {
+  const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, 'ralph-state.json'),
+    JSON.stringify({
+      active: true,
+      iteration: 1,
+      max_iterations: 100,
+      started_at: new Date().toISOString(),
+      prompt,
+      session_id: sessionId,
+      project_path: tempDir,
+    }),
+  );
+}
+
+describe('Ralph stop-hook continuation — prompt truncation (issue #2542)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ralph-truncation-test-'));
+    execSync('git init', { cwd: tempDir });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('short prompt is echoed verbatim in the continuation message', async () => {
+    const sessionId = 'ralph-short-prompt';
+    const short = 'Fix the login bug';
+    writeRalphState(tempDir, sessionId, short);
+
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(true);
+    expect(result.mode).toBe('ralph');
+    expect(result.message).toContain(short);
+  });
+
+  it('long prompt is truncated in the continuation message', async () => {
+    const sessionId = 'ralph-long-prompt';
+    const long =
+      'Fix issue #2542 in /home/user/project. Stop-hook feedback for ' +
+      'ralph/ultrawork is reinjecting full task prompts and wasting context. ' +
+      'Add a shared truncation helper so stop-hook task echoes are capped to ' +
+      'a compact length, preserve enough task identity to stay useful, add ' +
+      'regression tests for long prompts in the affected modes, run focused ' +
+      'tests, commit, push, and open a PR against dev.';
+    writeRalphState(tempDir, sessionId, long);
+
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(true);
+    expect(result.mode).toBe('ralph');
+
+    // The full prompt must NOT appear verbatim in the injected message
+    expect(result.message).not.toContain(long);
+
+    // The echoed portion should end with an ellipsis character
+    expect(result.message).toContain('…');
+
+    // Extract the echoed task line and verify its length is capped
+    const match = result.message.match(/Original task: (.+)/);
+    expect(match).not.toBeNull();
+    const echoed = match![1];
+    expect([...echoed].length).toBeLessThanOrEqual(DEFAULT_PROMPT_ECHO_MAX_CHARS + 1);
+  });
+
+  it('echoed task still starts with the beginning of the original prompt', async () => {
+    const sessionId = 'ralph-identity-check';
+    const long = 'Implement OAuth2 flow. ' + 'Details: '.repeat(50);
+    writeRalphState(tempDir, sessionId, long);
+
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.message).toContain('Implement OAuth2 flow.');
+  });
+});

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -52,6 +52,7 @@ import { readTeamPipelineState } from '../team-pipeline/state.js';
 import type { TeamPipelinePhase } from '../team-pipeline/types.js';
 import { getActiveAgentSnapshot } from '../subagent-tracker/index.js';
 import type { IdleNotificationRepoState } from './idle-repo-state.js';
+import { truncatePromptForEcho } from '../../lib/truncate-prompt.js';
 
 export interface ToolErrorState {
   tool_name: string;
@@ -820,7 +821,7 @@ ${prdInstruction}
 4. When FULLY complete (after ${state.critic_mode === 'codex' ? 'Codex critic' : state.critic_mode === 'critic' ? 'Critic' : 'Architect'} verification), run \`/oh-my-claudecode:cancel\` to cleanly exit and clean up state files. If cancel fails, retry with \`/oh-my-claudecode:cancel --force\`.
 5. Do NOT stop until the task is truly done
 
-${newState.prompt ? `Original task: ${newState.prompt}` : ''}
+${newState.prompt ? `Original task: ${truncatePromptForEcho(newState.prompt)}` : ''}
 
 </ralph-continuation>
 

--- a/src/hooks/ultrawork/__tests__/prompt-truncation.test.ts
+++ b/src/hooks/ultrawork/__tests__/prompt-truncation.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression tests for issue #2542
+ *
+ * Stop-hook feedback for ultrawork was reinjecting the full original_prompt on
+ * every stop event, burning context tokens.  The fix caps the echoed text via
+ * truncatePromptForEcho.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getUltraworkPersistenceMessage,
+  type UltraworkState,
+} from '../index.js';
+import { DEFAULT_PROMPT_ECHO_MAX_CHARS } from '../../../lib/truncate-prompt.js';
+
+function makeState(originalPrompt: string): UltraworkState {
+  return {
+    active: true,
+    started_at: new Date().toISOString(),
+    original_prompt: originalPrompt,
+    reinforcement_count: 0,
+    last_checked_at: new Date().toISOString(),
+  };
+}
+
+describe('getUltraworkPersistenceMessage — prompt truncation (issue #2542)', () => {
+  it('includes the full prompt when it is short', () => {
+    const state = makeState('Fix the login bug');
+    const msg = getUltraworkPersistenceMessage(state);
+    expect(msg).toContain('Fix the login bug');
+  });
+
+  it('truncates a long prompt and appends ellipsis', () => {
+    const long = 'Implement '.repeat(40); // well over 150 chars
+    const state = makeState(long);
+    const msg = getUltraworkPersistenceMessage(state);
+
+    // The echoed portion should be capped
+    const match = msg.match(/Original task: (.+)/);
+    expect(match).not.toBeNull();
+    const echoed = match![1];
+    // length ≤ maxChars + 1 (the ellipsis character)
+    expect([...echoed].length).toBeLessThanOrEqual(DEFAULT_PROMPT_ECHO_MAX_CHARS + 1);
+    expect(echoed.endsWith('…')).toBe(true);
+  });
+
+  it('does NOT embed the full long prompt anywhere in the message', () => {
+    const long = 'x'.repeat(DEFAULT_PROMPT_ECHO_MAX_CHARS + 100);
+    const state = makeState(long);
+    const msg = getUltraworkPersistenceMessage(state);
+    expect(msg).not.toContain(long);
+  });
+});

--- a/src/hooks/ultrawork/index.ts
+++ b/src/hooks/ultrawork/index.ts
@@ -12,6 +12,7 @@ import {
   resolveStatePath,
   resolveSessionStatePath,
 } from "../../lib/worktree-paths.js";
+import { truncatePromptForEcho } from "../../lib/truncate-prompt.js";
 
 export interface UltraworkState {
   /** Whether ultrawork mode is currently active */
@@ -235,7 +236,7 @@ REMEMBER THE ULTRAWORK RULES:
 
 Continue working on the next pending task. DO NOT STOP until all tasks are marked complete.
 
-Original task: ${state.original_prompt}
+Original task: ${truncatePromptForEcho(state.original_prompt)}
 
 </ultrawork-persistence>
 

--- a/src/lib/__tests__/truncate-prompt.test.ts
+++ b/src/lib/__tests__/truncate-prompt.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  truncatePromptForEcho,
+  DEFAULT_PROMPT_ECHO_MAX_CHARS,
+} from '../truncate-prompt.js';
+
+describe('truncatePromptForEcho', () => {
+  it('returns short prompts unchanged', () => {
+    expect(truncatePromptForEcho('Fix the bug')).toBe('Fix the bug');
+  });
+
+  it('returns prompt exactly at the limit unchanged', () => {
+    const exact = 'x'.repeat(DEFAULT_PROMPT_ECHO_MAX_CHARS);
+    expect(truncatePromptForEcho(exact)).toBe(exact);
+  });
+
+  it('truncates prompts that exceed the limit and appends ellipsis', () => {
+    const long = 'a'.repeat(DEFAULT_PROMPT_ECHO_MAX_CHARS + 50);
+    const result = truncatePromptForEcho(long);
+    expect(result).toBe('a'.repeat(DEFAULT_PROMPT_ECHO_MAX_CHARS) + '…');
+  });
+
+  it('result length is maxChars + 1 (the ellipsis char) for over-limit input', () => {
+    const long = 'b'.repeat(500);
+    const result = truncatePromptForEcho(long);
+    // "…" is a single Unicode character
+    expect([...result].length).toBe(DEFAULT_PROMPT_ECHO_MAX_CHARS + 1);
+  });
+
+  it('trims surrounding whitespace before checking length', () => {
+    const padded = '  hello world  ';
+    expect(truncatePromptForEcho(padded)).toBe('hello world');
+  });
+
+  it('handles empty string', () => {
+    expect(truncatePromptForEcho('')).toBe('');
+  });
+
+  it('handles whitespace-only string', () => {
+    expect(truncatePromptForEcho('   ')).toBe('');
+  });
+
+  it('respects a custom maxChars parameter', () => {
+    const result = truncatePromptForEcho('Hello World', 5);
+    expect(result).toBe('Hello…');
+  });
+
+  it('custom maxChars: returns unchanged when input is within limit', () => {
+    expect(truncatePromptForEcho('Hi', 5)).toBe('Hi');
+  });
+
+  it('truncates a realistic multi-paragraph ralph task prompt', () => {
+    const realistic =
+      'Fix issue #2542 in /home/user/project. Stop-hook feedback for ' +
+      'ralph/ultrawork is reinjecting full task prompts and wasting context. ' +
+      'Add a shared truncation helper so stop-hook task echoes are capped to ' +
+      'a compact length, preserve enough task identity to stay useful, add ' +
+      'regression tests for long prompts in the affected modes, run focused ' +
+      'tests, commit, push, and open a PR against dev.';
+    const result = truncatePromptForEcho(realistic);
+    expect([...result].length).toBe(DEFAULT_PROMPT_ECHO_MAX_CHARS + 1);
+    expect(result.endsWith('…')).toBe(true);
+    // Should still contain enough identity info from the start
+    expect(result.startsWith('Fix issue #2542')).toBe(true);
+  });
+});

--- a/src/lib/truncate-prompt.ts
+++ b/src/lib/truncate-prompt.ts
@@ -1,0 +1,39 @@
+/**
+ * Prompt Echo Truncation
+ *
+ * Stop-hook feedback messages re-echo the original task prompt so the model
+ * remembers what it was doing.  When that prompt is long (e.g. a multi-paragraph
+ * ralph invocation) the full text is injected on *every* stop event, burning
+ * context tokens unnecessarily.
+ *
+ * This module caps the echoed text to a compact length that still preserves
+ * enough task identity to be useful.
+ *
+ * @see https://github.com/anthropics/claude-code/issues/2542
+ */
+
+/** Default character cap for echoed task prompts in stop-hook feedback. */
+export const DEFAULT_PROMPT_ECHO_MAX_CHARS = 150;
+
+/**
+ * Truncate a task prompt to a compact length suitable for stop-hook echo.
+ *
+ * - If `prompt` fits within `maxChars` it is returned unchanged.
+ * - Otherwise it is sliced to `maxChars` and an ellipsis ("…") is appended.
+ * - Leading/trailing whitespace is trimmed before the length check so that
+ *   prompts that are only whitespace-padded don't sneak past the cap.
+ *
+ * @param prompt   The original task description stored in mode state.
+ * @param maxChars Maximum number of characters to include (default 150).
+ * @returns        The prompt, guaranteed to be ≤ maxChars + 1 chars long.
+ */
+export function truncatePromptForEcho(
+  prompt: string,
+  maxChars: number = DEFAULT_PROMPT_ECHO_MAX_CHARS,
+): string {
+  const trimmed = prompt.trim();
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return trimmed.slice(0, maxChars) + '…';
+}


### PR DESCRIPTION
## Summary

- Stop-hook continuation messages for **ralph** and **ultrawork** were reinjecting the full original task prompt on every stop event, burning context tokens on long multi-paragraph prompts
- Added shared pure helper `src/lib/truncate-prompt.ts` (`truncatePromptForEcho`) that trims and caps to 150 chars with a Unicode ellipsis (`…`)
- Both `getUltraworkPersistenceMessage` (ultrawork) and the ralph continuation path in `persistent-mode/index.ts` now call the helper

## Changed files

| File | Change |
|------|--------|
| `src/lib/truncate-prompt.ts` | New — shared truncation helper |
| `src/hooks/persistent-mode/index.ts` | Import + apply `truncatePromptForEcho` to ralph echo |
| `src/hooks/ultrawork/index.ts` | Import + apply `truncatePromptForEcho` to ultrawork echo |
| `src/lib/__tests__/truncate-prompt.test.ts` | 10 unit tests for the helper |
| `src/hooks/persistent-mode/__tests__/prompt-truncation.test.ts` | 3 ralph integration regression tests |
| `src/hooks/ultrawork/__tests__/prompt-truncation.test.ts` | 3 ultrawork unit regression tests |

## Test plan

- [x] `truncatePromptForEcho` unit tests (10) — boundary, whitespace, custom limit, realistic ralph prompt
- [x] Ralph stop-hook integration tests (3) — short verbatim, long truncated, identity preserved
- [x] Ultrawork persistence message tests (3) — short verbatim, long truncated, full prompt absent
- [x] All 16 tests pass (`vitest --reporter=verbose`)
- [x] TypeScript check passes (`tsc --noEmit`)
- [x] Unrelated noise files (`bridge/__pycache__`, `hooks/hooks.json`, `.clawhip/`) excluded from commit

Closes #2542

🤖 Generated with [Claude Code](https://claude.com/claude-code)