### PR TITLE
fix(purge): symlink stale plugin version dirs to prevent post-upgrade hook failures (#2543)

### DIFF
--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -11,6 +11,7 @@ vi.mock('fs', async () => {
     statSync: vi.fn(),
     rmSync: vi.fn(),
     unlinkSync: vi.fn(),
+    symlinkSync: vi.fn(),
   };
 });
 
@@ -18,7 +19,7 @@ vi.mock('../utils/config-dir.js', () => ({
   getClaudeConfigDir: vi.fn(() => '/mock/.claude'),
 }));
 
-import { existsSync, readFileSync, readdirSync, statSync, rmSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, rmSync, symlinkSync } from 'fs';
 import { purgeStalePluginCacheVersions } from '../utils/paths.js';
 
 const mockedExistsSync = vi.mocked(existsSync);
@@ -26,6 +27,7 @@ const mockedReadFileSync = vi.mocked(readFileSync);
 const mockedReaddirSync = vi.mocked(readdirSync);
 const mockedStatSync = vi.mocked(statSync);
 const mockedRmSync = vi.mocked(rmSync);
+const mockedSymlinkSync = vi.mocked(symlinkSync);
 
 function dirent(name: string): { name: string; isDirectory: () => boolean } {
   return { name, isDirectory: () => true };
@@ -90,9 +92,14 @@ describe('purgeStalePluginCacheVersions', () => {
     });
 
     const result = purgeStalePluginCacheVersions();
-    expect(result.removed).toBe(1);
-    expect(result.removedPaths).toEqual([staleVersion]);
+    // Stale version shares a namespace with the active version, so it is
+    // symlinked rather than deleted (fix for #2543).
+    expect(result.symlinked).toBe(1);
+    expect(result.removed).toBe(0);
+    expect(result.symlinkPaths).toEqual([staleVersion]);
+    // safeRmSync still removes the real dir before creating the symlink
     expect(mockedRmSync).toHaveBeenCalledWith(staleVersion, { recursive: true, force: true });
+    expect(mockedSymlinkSync).toHaveBeenCalledWith(activeVersion, staleVersion, 'dir');
     // Active version should NOT be removed
     expect(mockedRmSync).not.toHaveBeenCalledWith(activeVersion, expect.anything());
   });
@@ -131,9 +138,11 @@ describe('purgeStalePluginCacheVersions', () => {
     });
 
     const result = purgeStalePluginCacheVersions();
-    expect(result.removed).toBe(2);
-    expect(result.removedPaths).toContain(stale1);
-    expect(result.removedPaths).toContain(stale2);
+    // Both stale hookify versions share a namespace with active1 → symlinked.
+    expect(result.symlinked).toBe(2);
+    expect(result.removed).toBe(0);
+    expect(result.symlinkPaths).toContain(stale1);
+    expect(result.symlinkPaths).toContain(stale2);
   });
 
   it('does nothing when all cache versions are active', () => {
@@ -289,5 +298,119 @@ describe('purgeStalePluginCacheVersions', () => {
     expect(result.removed).toBe(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('unexpected top-level structure');
+  });
+
+  // --- #2543 regression: symlink-instead-of-delete ---
+
+  it('replaces stale version dir with symlink to active version in same namespace', () => {
+    // Scenario: CLAUDE_PLUGIN_ROOT=4.14.4 in a running session; 4.14.5 installed;
+    // purge runs after grace period.  4.14.4 must become a symlink, not disappear.
+    const cacheDir = '/mock/.claude/plugins/cache';
+    const activeVersion = join(cacheDir, 'omc/oh-my-claudecode/4.14.5');
+    const staleVersion = join(cacheDir, 'omc/oh-my-claudecode/4.14.4');
+
+    mockedExistsSync.mockImplementation((p) => {
+      const ps = String(p);
+      if (ps.includes('installed_plugins.json')) return true;
+      if (ps === cacheDir) return true;
+      if (ps === staleVersion || ps === activeVersion) return true;
+      return false;
+    });
+
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      version: 2,
+      plugins: {
+        'oh-my-claudecode@omc': [{ installPath: activeVersion, version: '4.14.5' }],
+      },
+    }));
+
+    mockedReaddirSync.mockImplementation((p, _opts?) => {
+      const ps = String(p);
+      if (ps === cacheDir) return [dirent('omc')] as any;
+      if (ps.endsWith('omc')) return [dirent('oh-my-claudecode')] as any;
+      if (ps.endsWith('oh-my-claudecode')) return [dirent('4.14.4'), dirent('4.14.5')] as any;
+      return [] as any;
+    });
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.symlinked).toBe(1);
+    expect(result.removed).toBe(0);
+    expect(result.symlinkPaths).toEqual([staleVersion]);
+    // Real dir removed first, then symlink created
+    expect(mockedRmSync).toHaveBeenCalledWith(staleVersion, { recursive: true, force: true });
+    expect(mockedSymlinkSync).toHaveBeenCalledWith(activeVersion, staleVersion, 'dir');
+    // Active version untouched
+    expect(mockedRmSync).not.toHaveBeenCalledWith(activeVersion, expect.anything());
+    expect(mockedSymlinkSync).not.toHaveBeenCalledWith(expect.anything(), activeVersion, expect.anything());
+  });
+
+  it('deletes stale version dir when no active version exists in namespace', () => {
+    // When the active installPath is outside the plugin namespace there is no
+    // live version to redirect to, so deletion (original behaviour) applies.
+    const cacheDir = '/mock/.claude/plugins/cache';
+    const staleVersion = join(cacheDir, 'omc/plugin/1.0.0');
+
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      version: 2,
+      plugins: {
+        // installPath is outside the omc/plugin namespace
+        'plugin@other': [{ installPath: '/completely/different/path/2.0.0' }],
+      },
+    }));
+
+    mockedReaddirSync.mockImplementation((p, _opts?) => {
+      const ps = String(p);
+      if (ps === cacheDir) return [dirent('omc')] as any;
+      if (ps.endsWith('omc')) return [dirent('plugin')] as any;
+      if (ps.endsWith('plugin')) return [dirent('1.0.0')] as any;
+      return [] as any;
+    });
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.removed).toBe(1);
+    expect(result.symlinked).toBe(0);
+    expect(result.removedPaths).toEqual([staleVersion]);
+    expect(mockedRmSync).toHaveBeenCalledWith(staleVersion, { recursive: true, force: true });
+    expect(mockedSymlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('skips version directory entries where isDirectory() returns false (existing symlinks)', () => {
+    // readdirSync with withFileTypes returns isDirectory()=false for symlinks on
+    // Linux/macOS. The purge loop must leave these alone.
+    const cacheDir = '/mock/.claude/plugins/cache';
+    const activeVersion = join(cacheDir, 'omc/oh-my-claudecode/4.14.5');
+
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      version: 2,
+      plugins: {
+        'oh-my-claudecode@omc': [{ installPath: activeVersion }],
+      },
+    }));
+
+    mockedReaddirSync.mockImplementation((p, _opts?) => {
+      const ps = String(p);
+      if (ps === cacheDir) return [dirent('omc')] as any;
+      if (ps.endsWith('omc')) return [dirent('oh-my-claudecode')] as any;
+      if (ps.endsWith('oh-my-claudecode')) {
+        // 4.14.4 is a symlink (isDirectory returns false), 4.14.5 is a real dir
+        return [
+          { name: '4.14.4', isDirectory: () => false },
+          dirent('4.14.5'),
+        ] as any;
+      }
+      return [] as any;
+    });
+
+    const result = purgeStalePluginCacheVersions();
+
+    // The symlink entry must not be touched
+    expect(result.removed).toBe(0);
+    expect(result.symlinked).toBe(0);
+    expect(mockedRmSync).not.toHaveBeenCalled();
+    expect(mockedSymlinkSync).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -7,7 +7,7 @@
  */
 
 import { join } from 'path';
-import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, rmSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, rmSync, symlinkSync } from 'fs';
 import { homedir } from 'os';
 import { getClaudeConfigDir } from './config-dir.js';
 
@@ -215,6 +215,10 @@ export interface PurgeCacheResult {
   removed: number;
   /** Paths that were removed */
   removedPaths: string[];
+  /** Number of stale version directories replaced with symlinks to the active version */
+  symlinked: number;
+  /** Paths that were converted to symlinks */
+  symlinkPaths: string[];
   /** Errors encountered (non-fatal) */
   errors: string[];
 }
@@ -242,8 +246,22 @@ function stripTrailing(p: string): string {
  * are still referenced by long-running sessions via CLAUDE_PLUGIN_ROOT. */
 const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Compare two semver-like version strings descending (higher version first).
+ * Non-numeric segments fall back to 0.
+ */
+function compareSemverDesc(a: string, b: string): number {
+  const parse = (s: string) => s.split('.').map(n => parseInt(n, 10) || 0);
+  const pa = parse(a), pb = parse(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
 export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: boolean }): PurgeCacheResult {
-  const result: PurgeCacheResult = { removed: 0, removedPaths: [], errors: [] };
+  const result: PurgeCacheResult = { removed: 0, removedPaths: [], symlinked: 0, symlinkPaths: [], errors: [] };
 
   const configDir = getClaudeConfigDir();
   const pluginsDir = join(configDir, 'plugins');
@@ -328,9 +346,39 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
           } catch { continue; }
         }
 
-        if (safeRmSync(versionDir)) {
-          result.removed++;
-          result.removedPaths.push(versionDir);
+        // When an active version exists in the same plugin namespace, replace the
+        // stale directory with a symlink rather than deleting it.  This keeps any
+        // running session whose CLAUDE_PLUGIN_ROOT still points to this path working.
+        const pluginDirNorm = stripTrailing(pluginDir);
+        const activeVersionDirsHere = dedupePaths(
+          activePathsArray
+            .filter(ap => ap.startsWith(pluginDirNorm + '/'))
+            .map(ap => join(pluginDir, ap.slice(pluginDirNorm.length + 1).split('/')[0])),
+        );
+
+        if (activeVersionDirsHere.length > 0) {
+          const target = [...activeVersionDirsHere].sort((a, b) =>
+            compareSemverDesc(
+              a.split('/').pop() ?? a,
+              b.split('/').pop() ?? b,
+            ),
+          )[0];
+          if (safeRmSync(versionDir)) {
+            try {
+              symlinkSync(target, versionDir, process.platform === 'win32' ? 'junction' : 'dir');
+              result.symlinked++;
+              result.symlinkPaths.push(versionDir);
+            } catch (err) {
+              result.errors.push(
+                `Failed to symlink ${versionDir} → ${target}: ${err instanceof Error ? err.message : err}`,
+              );
+            }
+          }
+        } else {
+          if (safeRmSync(versionDir)) {
+            result.removed++;
+            result.removedPaths.push(versionDir);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `purgeStalePluginCacheVersions` deleted old plugin version directories after the 24-hour grace period, breaking any session whose `CLAUDE_PLUGIN_ROOT` still pointed to the deleted path (e.g. `4.14.4` after upgrading to `4.14.5`).
- **Fix**: When a stale real version directory is about to be removed and an active version exists in the same marketplace/plugin namespace, replace the stale directory with a symlink pointing to the active (highest-semver) version instead of deleting it. Existing sessions transparently resolve through the symlink.
- **Fallback preserved**: When no active sibling version exists in the namespace, the original deletion behaviour applies.
- `PurgeCacheResult` gains `symlinked`/`symlinkPaths` fields; callers that ignore them are unaffected.
- Symlinks are already skipped on subsequent purge runs because `readdirSync` with `withFileTypes` returns `isDirectory()=false` for symlinks on Linux/macOS — no extra guard needed.

## Test plan

- [x] `npm run test:run -- src/__tests__/purge-stale-cache.test.ts` — 14/14 tests pass (3 new regressions added)
- [x] `npm run build` — exits 0, TypeScript clean
- [ ] New regression: stale version dir with active sibling → symlinked, not deleted
- [ ] New regression: stale version dir with no active sibling → deleted (original path)
- [ ] New regression: existing symlink entry (`isDirectory()=false`) → skipped untouched

Closes #2543

🤖 Generated with [Claude Code](https://claude.com/claude-code)