### PR TITLE
fix(keyword-detector): suppress review-seed echo from tripping code-review alerts (#2541)

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -147,6 +147,26 @@ function isAntiSlopCleanupRequest(text) {
     (ANTI_SLOP_ACTION_PATTERN.test(text) && ANTI_SLOP_SMELL_PATTERN.test(text));
 }
 
+/** Review-outcome labels that appear together in seeded review instruction text. */
+const REVIEW_SEED_OUTCOME_RES = [
+  /\bapprove\b/i,
+  /\brequest[- ]changes\b/i,
+  /\bmerge[- ]ready\b/i,
+  /\bblocked\b/i,
+];
+
+/**
+ * Returns true when the prompt looks like echoed review-instruction text
+ * (an injected outcome menu: approve / request-changes / merge-ready / blocked),
+ * not a genuine user intent to start review mode.
+ *
+ * Heuristic: ≥2 distinct outcome labels in the first 20 lines → seeded context.
+ */
+function isReviewSeedContext(text) {
+  const preview = text.split('\n').slice(0, 20).join('\n');
+  return REVIEW_SEED_OUTCOME_RES.filter(re => re.test(preview)).length >= 2;
+}
+
 function sanitizeForKeywordDetection(text) {
   return text
     // 0. Strip HTML/markdown comments before tag stripping
@@ -668,13 +688,15 @@ async function main() {
       matches.push({ name: 'tdd', args: '' });
     }
 
-    // Code review keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)/i)) {
+    // Code review keywords — skip when the prompt is echoed review-instruction text
+    if (!isReviewSeedContext(cleanPrompt) &&
+        hasActionableKeyword(cleanPrompt, /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)/i)) {
       matches.push({ name: 'code-review', args: '' });
     }
 
-    // Security review keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)/i)) {
+    // Security review keywords — skip when the prompt is echoed review-instruction text
+    if (!isReviewSeedContext(cleanPrompt) &&
+        hasActionableKeyword(cleanPrompt, /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)/i)) {
       matches.push({ name: 'security-review', args: '' });
     }
 

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -119,4 +119,48 @@ OMC Ultrawork = "특수부대 작전 반"
     expect(context).not.toContain('[MAGIC KEYWORD: ULTRAWORK]');
     expect(context).toBe('');
   });
+
+  // Regression: issue #2541 — review-seed echo must not trip code-review / security-review alerts
+  it('does not activate code-review when prompt is echoed review-instruction text with approve/request-changes/merge-ready', () => {
+    const prompt = [
+      'You are performing a code review of PR #2541.',
+      'Reply with exactly one verdict:',
+      '- approve',
+      '- request-changes',
+      '- merge-ready',
+    ].join('\n');
+    const output = runKeywordDetector(prompt);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: CODE-REVIEW]');
+    expect(context).not.toContain('<code-review-mode>');
+    expect(context).toBe('');
+  });
+
+  it('does not activate security-review when prompt is echoed review-instruction text with approve/request-changes/blocked', () => {
+    const prompt = [
+      'You are performing a security review.',
+      'Choose one verdict:',
+      '- approve',
+      '- request-changes',
+      '- blocked',
+    ].join('\n');
+    const output = runKeywordDetector(prompt);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: SECURITY-REVIEW]');
+    expect(context).not.toContain('<security-review-mode>');
+    expect(context).toBe('');
+  });
+
+  it('still activates code-review for a genuine user request (positive control)', () => {
+    const output = runKeywordDetector('code review this diff');
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('<code-review-mode>');
+    expect(context).not.toContain('[MAGIC KEYWORD: CODE-REVIEW]');
+  });
 });

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -127,6 +127,26 @@ function isAntiSlopCleanupRequest(text) {
     (ANTI_SLOP_ACTION_PATTERN.test(text) && ANTI_SLOP_SMELL_PATTERN.test(text));
 }
 
+/** Review-outcome labels that appear together in seeded review instruction text. */
+const REVIEW_SEED_OUTCOME_RES = [
+  /\bapprove\b/i,
+  /\brequest[- ]changes\b/i,
+  /\bmerge[- ]ready\b/i,
+  /\bblocked\b/i,
+];
+
+/**
+ * Returns true when the prompt looks like echoed review-instruction text
+ * (an injected outcome menu: approve / request-changes / merge-ready / blocked),
+ * not a genuine user intent to start review mode.
+ *
+ * Heuristic: ≥2 distinct outcome labels in the first 20 lines → seeded context.
+ */
+function isReviewSeedContext(text) {
+  const preview = text.split('\n').slice(0, 20).join('\n');
+  return REVIEW_SEED_OUTCOME_RES.filter(re => re.test(preview)).length >= 2;
+}
+
 function sanitizeForKeywordDetection(text) {
   return text
     // 0. Strip HTML/markdown comments before tag stripping
@@ -613,13 +633,15 @@ async function main() {
       matches.push({ name: 'tdd', args: '' });
     }
 
-    // Code review keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)/i)) {
+    // Code review keywords — skip when the prompt is echoed review-instruction text
+    if (!isReviewSeedContext(cleanPrompt) &&
+        hasActionableKeyword(cleanPrompt, /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)/i)) {
       matches.push({ name: 'code-review', args: '' });
     }
 
-    // Security review keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)/i)) {
+    // Security review keywords — skip when the prompt is echoed review-instruction text
+    if (!isReviewSeedContext(cleanPrompt) &&
+        hasActionableKeyword(cleanPrompt, /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)/i)) {
       matches.push({ name: 'security-review', args: '' });
     }
 


### PR DESCRIPTION
## Summary

- Adds `isReviewSeedContext()` to both `scripts/keyword-detector.mjs` and `templates/hooks/keyword-detector.mjs`
- Guards the `code-review` and `security-review` keyword patterns: when ≥2 distinct outcome labels (`approve`, `request-changes`, `merge-ready`, `blocked`) appear in the first 20 lines, the prompt is treated as echoed review-instruction text and no mode is activated
- Mirrors the `trimReviewSeedPrefix` logic from commit 40e53bd (formatter.ts), extending the same fix upstream to the keyword-detection layer before any dispatch happens

## Root cause

When a review-session steering prompt (injected via hook context or echoed from a prior response) containing `approve / request-changes / merge-ready` also included the phrase "code review" or "security review", `hasActionableKeyword` matched and fired the mode — producing a false alert before any real verdict existed.

## Test plan

- [x] `src/__tests__/keyword-detector-script.test.ts` — 3 new focused tests:
  - Regression: seeded `code review` + `approve/request-changes/merge-ready` → no `<code-review-mode>` injection
  - Regression: seeded `security review` + `approve/request-changes/blocked` → no `<security-review-mode>` injection
  - Positive control: `"code review this diff"` still activates `<code-review-mode>`
- [x] All 14 tests pass (`vitest run src/__tests__/keyword-detector-script.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)