### PR TITLE
fix(openclaw): suppress late lifecycle alerts for completed/cleaned-up sessions (#2553)

### DIFF
--- a/src/openclaw/__tests__/dedupe.test.ts
+++ b/src/openclaw/__tests__/dedupe.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for the openclaw dedupe module.
+ *
+ * Covers the terminal-state freshness suppression added for issue #2553:
+ * late session-start / stop (idle) events fired after a session has already
+ * reached a terminal state must be silently dropped so already-completed or
+ * already-cleaned-up sessions do not emit follow-up lifecycle noise.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  shouldCollapseOpenClawBurst,
+  isObsoleteAfterTerminalState,
+  TERMINAL_STATE_SUPPRESSION_WINDOW_MS,
+} from "../dedupe.js";
+import { buildOpenClawSignal } from "../signal.js";
+import type { OpenClawHookEvent, OpenClawContext } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ctx(projectPath: string, extra: Partial<OpenClawContext> = {}): OpenClawContext {
+  return { projectPath, ...extra };
+}
+
+function collapse(
+  event: OpenClawHookEvent,
+  projectPath: string,
+  tmuxSession: string,
+  extra: Partial<OpenClawContext> = {},
+): boolean {
+  const context = ctx(projectPath, extra);
+  const signal = buildOpenClawSignal(event, context);
+  return shouldCollapseOpenClawBurst(event, signal, context, tmuxSession);
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "omc-openclaw-dedupe-test-"));
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// isObsoleteAfterTerminalState — unit tests on the helper directly
+// ---------------------------------------------------------------------------
+
+describe("isObsoleteAfterTerminalState", () => {
+  const tmux = "my-tmux";
+
+  function makeState(
+    terminalEvent: "stop" | "session-end",
+    offsetMs: number,
+  ) {
+    const scope = `${projectDir}::${tmux}`;
+    const prefix = terminalEvent === "stop" ? "session.stopped" : "session.finished";
+    const lastSeenAt = new Date(Date.now() - offsetMs).toISOString();
+    return {
+      updatedAt: lastSeenAt,
+      records: {
+        [`${prefix}::${scope}`]: {
+          event: terminalEvent as OpenClawHookEvent,
+          routeKey: terminalEvent === "stop" ? "session.idle" : "session.finished",
+          tmuxSession: tmux,
+          lastSeenAt,
+          count: 1,
+        },
+      },
+    };
+  }
+
+  it("returns false for events other than session-start and stop", () => {
+    const state = makeState("session-end", 100);
+    const nowMs = Date.now();
+    for (const event of ["keyword-detector", "pre-tool-use", "post-tool-use", "ask-user-question"] as OpenClawHookEvent[]) {
+      expect(isObsoleteAfterTerminalState(event, state, tmux, projectDir, nowMs)).toBe(false);
+    }
+  });
+
+  it("returns false when state has no terminal record", () => {
+    const emptyState = { updatedAt: new Date().toISOString(), records: {} };
+    const nowMs = Date.now();
+    expect(isObsoleteAfterTerminalState("session-start", emptyState, tmux, projectDir, nowMs)).toBe(false);
+    expect(isObsoleteAfterTerminalState("stop", emptyState, tmux, projectDir, nowMs)).toBe(false);
+  });
+
+  it("session-start is obsolete when session.finished is within the suppression window", () => {
+    const state = makeState("session-end", 1_000); // 1 second ago
+    const nowMs = Date.now();
+    expect(isObsoleteAfterTerminalState("session-start", state, tmux, projectDir, nowMs)).toBe(true);
+  });
+
+  it("session-start is obsolete when session.stopped is within the suppression window", () => {
+    const state = makeState("stop", 1_000); // 1 second ago
+    const nowMs = Date.now();
+    expect(isObsoleteAfterTerminalState("session-start", state, tmux, projectDir, nowMs)).toBe(true);
+  });
+
+  it("stop is obsolete when session.finished is within the suppression window", () => {
+    const state = makeState("session-end", 1_000);
+    const nowMs = Date.now();
+    expect(isObsoleteAfterTerminalState("stop", state, tmux, projectDir, nowMs)).toBe(true);
+  });
+
+  it("stop is NOT suppressed by session.stopped alone (only by session.finished)", () => {
+    const state = makeState("stop", 1_000);
+    const nowMs = Date.now();
+    // stop after stop is handled by normal burst dedupe, not terminal-state guard
+    expect(isObsoleteAfterTerminalState("stop", state, tmux, projectDir, nowMs)).toBe(false);
+  });
+
+  it("returns false when the terminal record is older than the suppression window", () => {
+    const state = makeState("session-end", TERMINAL_STATE_SUPPRESSION_WINDOW_MS + 5_000);
+    const nowMs = Date.now();
+    expect(isObsoleteAfterTerminalState("session-start", state, tmux, projectDir, nowMs)).toBe(false);
+    expect(isObsoleteAfterTerminalState("stop", state, tmux, projectDir, nowMs)).toBe(false);
+  });
+
+  it("uses scope isolation — terminal record for a different tmux session does not suppress", () => {
+    const state = makeState("session-end", 100);
+    const nowMs = Date.now();
+    // Different tmux session name
+    expect(isObsoleteAfterTerminalState("session-start", state, "other-tmux", projectDir, nowMs)).toBe(false);
+  });
+
+  it("uses scope isolation — terminal record for a different projectPath does not suppress", () => {
+    const otherDir = mkdtempSync(join(tmpdir(), "omc-openclaw-other-"));
+    try {
+      const state = makeState("session-end", 100);
+      const nowMs = Date.now();
+      expect(isObsoleteAfterTerminalState("session-start", state, tmux, otherDir, nowMs)).toBe(false);
+    } finally {
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldCollapseOpenClawBurst — integration tests via filesystem state
+// ---------------------------------------------------------------------------
+
+describe("shouldCollapseOpenClawBurst — terminal-state suppression", () => {
+  const tmux = "dev-session";
+
+  it("session-start is suppressed when it arrives after session-end within the window", () => {
+    // Fire session-end to record terminal state
+    const sessionEndCollapsed = collapse("session-end", projectDir, tmux);
+    expect(sessionEndCollapsed).toBe(false); // first occurrence — not collapsed
+
+    // Late session-start for the same {projectPath}::{tmux} scope
+    const lateStart = collapse("session-start", projectDir, tmux);
+    expect(lateStart).toBe(true); // suppressed as obsolete
+  });
+
+  it("session-start is suppressed when it arrives after stop within the window", () => {
+    const stopCollapsed = collapse("stop", projectDir, tmux);
+    expect(stopCollapsed).toBe(false);
+
+    const lateStart = collapse("session-start", projectDir, tmux);
+    expect(lateStart).toBe(true);
+  });
+
+  it("stop is suppressed when it arrives after session-end within the window", () => {
+    collapse("session-end", projectDir, tmux);
+
+    const lateStop = collapse("stop", projectDir, tmux);
+    expect(lateStop).toBe(true);
+  });
+
+  it("terminal state record is preserved after suppressing an obsolete event (re-suppression)", () => {
+    collapse("session-end", projectDir, tmux);
+
+    // First late start — suppressed
+    expect(collapse("session-start", projectDir, tmux)).toBe(true);
+    // Second late start — still suppressed (terminal record not erased)
+    expect(collapse("session-start", projectDir, tmux)).toBe(true);
+  });
+
+  it("events are NOT suppressed when there is no tmuxSession", () => {
+    // Fire session-end with a tmux session first
+    collapse("session-end", projectDir, tmux);
+
+    // Without a tmux session, no suppression occurs
+    const context = ctx(projectDir);
+    const signal = buildOpenClawSignal("session-start", context);
+    const result = shouldCollapseOpenClawBurst("session-start", signal, context, undefined);
+    expect(result).toBe(false);
+  });
+
+  it("events outside the suppression window are not suppressed", () => {
+    vi.useFakeTimers();
+
+    // Record terminal state at t=0
+    collapse("session-end", projectDir, tmux);
+
+    // Advance past the suppression window
+    vi.advanceTimersByTime(TERMINAL_STATE_SUPPRESSION_WINDOW_MS + 5_000);
+
+    // session-start is no longer suppressed
+    const lateStart = collapse("session-start", projectDir, tmux);
+    expect(lateStart).toBe(false);
+  });
+
+  it("suppresses at TERMINAL_STATE_SUPPRESSION_WINDOW_MS - 1 ms (inside window, exclusive upper bound)", () => {
+    vi.useFakeTimers();
+    collapse("session-end", projectDir, tmux);
+
+    vi.advanceTimersByTime(TERMINAL_STATE_SUPPRESSION_WINDOW_MS - 1);
+
+    expect(collapse("session-start", projectDir, tmux)).toBe(true);
+  });
+
+  it("does NOT suppress at exactly TERMINAL_STATE_SUPPRESSION_WINDOW_MS ms (boundary, exclusive)", () => {
+    vi.useFakeTimers();
+    collapse("session-end", projectDir, tmux);
+
+    vi.advanceTimersByTime(TERMINAL_STATE_SUPPRESSION_WINDOW_MS);
+
+    expect(collapse("session-start", projectDir, tmux)).toBe(false);
+  });
+
+  it("a second session-end within the burst window is collapsed by burst-dedupe (not by terminal-state guard)", () => {
+    // First session-end — allowed, record written
+    expect(collapse("session-end", projectDir, tmux)).toBe(false);
+
+    // Second session-end immediately: session-end is not in the terminal-state suppression
+    // list, so isObsoleteAfterTerminalState returns false. However the existing burst-dedupe
+    // kicks in (STOP_WINDOW_MS = 12s) and collapses it.
+    expect(collapse("session-end", projectDir, tmux)).toBe(true);
+
+    // Subsequent session-start is still suppressed by the terminal-state guard
+    expect(collapse("session-start", projectDir, tmux)).toBe(true);
+  });
+
+  it("different tmux sessions are not affected by each other's terminal state", () => {
+    collapse("session-end", projectDir, "session-A");
+
+    // session-B should not be suppressed
+    const result = collapse("session-start", projectDir, "session-B");
+    expect(result).toBe(false);
+  });
+
+  it("keyword-detector is not affected by terminal-state suppression", () => {
+    collapse("session-end", projectDir, tmux);
+
+    const context = ctx(projectDir, { prompt: "ralph do something" });
+    const signal = buildOpenClawSignal("keyword-detector", context);
+    const result = shouldCollapseOpenClawBurst("keyword-detector", signal, context, tmux);
+    // keyword-detector has no descriptor for this scope, so it passes through
+    expect(result).toBe(false);
+  });
+});

--- a/src/openclaw/dedupe.ts
+++ b/src/openclaw/dedupe.ts
@@ -28,6 +28,16 @@ const LOCK_TIMEOUT_MS = 2_000;
 const LOCK_RETRY_MS = 20;
 const LOCK_STALE_MS = 10_000;
 
+/**
+ * How long after a terminal-state event (stop/session-end) to suppress
+ * late lifecycle events for the same {projectPath}::{tmuxSession} scope.
+ *
+ * Chosen to be long enough to absorb hook-ordering races (sub-process startup
+ * delays, detach/re-attach timing) while being short enough not to swallow
+ * genuinely new sessions that start shortly after a cleanup.
+ */
+export const TERMINAL_STATE_SUPPRESSION_WINDOW_MS = 60_000;
+
 const SLEEP_ARRAY = new Int32Array(new SharedArrayBuffer(4));
 
 interface DedupeStateRecord {
@@ -267,9 +277,6 @@ function buildDescriptor(
         windowMs: STOP_WINDOW_MS,
       };
     default:
-      if (signal.routeKey === "pull-request.created" || signal.routeKey === "test.failed") {
-        return null;
-      }
       return null;
   }
 }
@@ -282,6 +289,55 @@ function pruneState(state: DedupeState, nowMs: number): void {
       delete state.records[key];
     }
   }
+}
+
+/**
+ * Terminal-state record keys that suppress late lifecycle noise.
+ *
+ * session.stopped  = a `stop` (idle) event fired for this scope
+ * session.finished = a `session-end` event fired for this scope
+ */
+const TERMINAL_KEYS = ["session.stopped", "session.finished"] as const;
+
+/**
+ * Returns true when `event` is a late lifecycle event that has been rendered
+ * obsolete by a prior terminal-state record in `state`.
+ *
+ * Guards:
+ *   - session-start arriving after session.stopped or session.finished → suppress
+ *   - stop arriving after session.finished → suppress
+ *
+ * The check window is TERMINAL_STATE_SUPPRESSION_WINDOW_MS.  Obsolete events
+ * must NOT update dedupe state so the terminal record stays alive for further
+ * suppression checks within the same window.
+ */
+export function isObsoleteAfterTerminalState(
+  event: OpenClawHookEvent,
+  state: DedupeState,
+  tmuxSession: string,
+  projectPath: string,
+  nowMs: number,
+): boolean {
+  if (event !== "session-start" && event !== "stop") {
+    return false;
+  }
+
+  const scope = `${projectPath}::${tmuxSession}`;
+
+  // stop is only suppressed by session.finished (the harder terminal state);
+  // a prior stop alone does not suppress another stop.
+  const keysToCheck: readonly string[] =
+    event === "session-start" ? TERMINAL_KEYS : (["session.finished"] as const);
+
+  return keysToCheck.some((prefix) => {
+    const record = state.records[`${prefix}::${scope}`];
+    if (!record) return false;
+    const lastSeenMs = Date.parse(record.lastSeenAt);
+    return (
+      Number.isFinite(lastSeenMs) &&
+      nowMs - lastSeenMs < TERMINAL_STATE_SUPPRESSION_WINDOW_MS
+    );
+  });
 }
 
 export function shouldCollapseOpenClawBurst(
@@ -304,6 +360,14 @@ export function shouldCollapseOpenClawBurst(
     const state = readState(projectPath);
     const nowMs = Date.now();
     pruneState(state, nowMs);
+
+    // Freshness/terminal-state suppression: drop late lifecycle events that
+    // arrive after the session has already reached a terminal state.
+    // Do NOT update dedupe state here so the terminal record stays alive for
+    // further suppression checks within the window.
+    if (isObsoleteAfterTerminalState(event, state, tmuxSession, projectPath, nowMs)) {
+      return true;
+    }
 
     const nowIso = new Date(nowMs).toISOString();
     const existing = state.records[descriptor.key];


### PR DESCRIPTION
## Summary

Fixes #2553. After a tmux session reaches a terminal state (`stop` or `session-end`), delayed hook delivery can still fire `session-start` and `stop` events for the same `{projectPath}::{tmuxSession}` scope. These late arrivals bypass the existing burst-dedupe windows (10–12 s) and produce spurious "session started" / "session idle" alerts for sessions that have already ended.

### Changes

**`src/openclaw/dedupe.ts`**
- Added `TERMINAL_STATE_SUPPRESSION_WINDOW_MS = 60_000` (exported constant)
- Added `isObsoleteAfterTerminalState()` helper (exported for direct unit testing): returns `true` when a `session-start` arrives after `session.stopped`/`session.finished`, or a `stop` arrives after `session.finished`, within the suppression window
- Wired into `shouldCollapseOpenClawBurst()` as a pre-check before burst-dedupe; obsolete events do **not** update state so the terminal record stays alive for further suppression within the same window
- Removed dead branch in `buildDescriptor()` whose `if` condition was unreachable (both arms returned `null`)

**`src/openclaw/__tests__/dedupe.test.ts`** (new file)
- 20 focused regression tests: boundary semantics at `TERMINAL_STATE_SUPPRESSION_WINDOW_MS ± 1`, scope isolation (different tmux session, different project path), re-suppression (terminal record survives multiple obsolete events), burst-dedupe interaction with terminal-state guard, and `stop`/`session.stopped` asymmetry

### Design decisions

- **60 s window**: wide enough to absorb hook-ordering races (sub-process startup delays, tmux detach/re-attach timing) while short enough not to silently drop legitimate new sessions. Existing burst windows are 10–12 s; this layer runs at 5× to catch delays outside those windows.
- **`stop` only suppressed by `session.finished`**: a prior `stop` alone does not suppress another `stop`, since multiple idle events are normal within a live session. The existing `STOP_WINDOW_MS = 12 s` burst-dedupe already handles rapid duplicates.
- **No state write on obsolete events**: ensures the terminal record is not overwritten, keeping the suppression window intact for subsequent late arrivals.

## Test plan

- [x] `npm test -- --run src/openclaw/` → 116 tests, 0 failures
- [x] `tsc --noEmit` → 0 errors
- [x] Full suite: 471 test files pass (1 pre-existing failure in `setup-contracts-regression.test.ts` — absolute node path in test environment hooks.json, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)