### PR TITLE
feat(hud): split usage cache by provider to eliminate cross-session thrashing

### DIFF
--- a/src/__tests__/hud-windows.test.ts
+++ b/src/__tests__/hud-windows.test.ts
@@ -221,7 +221,8 @@ describe('HUD Windows Compatibility', () => {
       const content = readFileSync(usageApiPath, 'utf-8');
 
       // Should use join() with separate segments, not forward-slash literals
-      expect(content).toContain("'plugins', 'oh-my-claudecode', '.usage-cache.json'");
+      // Provider-specific cache files use template literals with the same join() pattern
+      expect(content).toContain("'plugins', 'oh-my-claudecode', `.usage-cache-${source}.json`");
     });
   });
 });

--- a/src/__tests__/hud/usage-api-lock.test.ts
+++ b/src/__tests__/hud/usage-api-lock.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 
 const CLAUDE_CONFIG_DIR = '/tmp/test-claude';
-const CACHE_PATH = `${CLAUDE_CONFIG_DIR}/plugins/oh-my-claudecode/.usage-cache.json`;
+const CACHE_PATH = `${CLAUDE_CONFIG_DIR}/plugins/oh-my-claudecode/.usage-cache-zai.json`;
 const LOCK_PATH = `${CACHE_PATH}.lock`;
 
 function createFsMock(initialFiles: Record<string, string>) {

--- a/src/__tests__/hud/usage-api-stale.test.ts
+++ b/src/__tests__/hud/usage-api-stale.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 
 const CLAUDE_CONFIG_DIR = '/tmp/test-claude';
-const CACHE_PATH = `${CLAUDE_CONFIG_DIR}/plugins/oh-my-claudecode/.usage-cache.json`;
+const CACHE_PATH = `${CLAUDE_CONFIG_DIR}/plugins/oh-my-claudecode/.usage-cache-zai.json`;
 const CACHE_DIR = `${CLAUDE_CONFIG_DIR}/plugins/oh-my-claudecode`;
 
 function createFsMock(initialFiles: Record<string, string>) {

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -522,9 +522,9 @@ describe('getUsage routing', () => {
     const mockedExistsSync = vi.mocked(fs.existsSync);
     const mockedReadFileSync = vi.mocked(fs.readFileSync);
 
-    mockedExistsSync.mockImplementation((path) => String(path).endsWith('.usage-cache.json'));
+    mockedExistsSync.mockImplementation((path) => String(path).endsWith('.usage-cache-anthropic.json'));
     mockedReadFileSync.mockImplementation((path) => {
-      if (String(path).endsWith('.usage-cache.json')) {
+      if (String(path).endsWith('.usage-cache-anthropic.json')) {
         return JSON.stringify({
           timestamp: Date.now() - 60_000,
           source: 'anthropic',
@@ -564,7 +564,7 @@ describe('getUsage routing', () => {
 
     mockedExistsSync.mockImplementation((path) => {
       const file = String(path);
-      return file.endsWith('settings.json') || file.endsWith('.usage-cache.json');
+      return file.endsWith('settings.json') || file.endsWith('.usage-cache-anthropic.json');
     });
     mockedReadFileSync.mockImplementation((path) => {
       const file = String(path);
@@ -575,7 +575,7 @@ describe('getUsage routing', () => {
           },
         });
       }
-      if (file.endsWith('.usage-cache.json')) {
+      if (file.endsWith('.usage-cache-anthropic.json')) {
         return JSON.stringify({
           timestamp: Date.now() - 120_000,
           source: 'anthropic',
@@ -673,7 +673,7 @@ describe('getUsage routing', () => {
 
     mockedExistsSync.mockImplementation((path) => {
       const file = String(path);
-      return file.endsWith('settings.json') || file.endsWith('.usage-cache.json');
+      return file.endsWith('settings.json') || file.endsWith('.usage-cache-zai.json');
     });
     mockedReadFileSync.mockImplementation((path) => {
       const file = String(path);
@@ -684,7 +684,7 @@ describe('getUsage routing', () => {
           },
         });
       }
-      if (file.endsWith('.usage-cache.json')) {
+      if (file.endsWith('.usage-cache-zai.json')) {
         return JSON.stringify({
           timestamp: Date.now() - 300_000,
           rateLimitedUntil: Date.now() - 1,
@@ -731,7 +731,7 @@ describe('getUsage routing', () => {
 
     mockedExistsSync.mockImplementation((path) => {
       const file = String(path);
-      return file.endsWith('settings.json') || file.endsWith('.usage-cache.json');
+      return file.endsWith('settings.json') || file.endsWith('.usage-cache-zai.json');
     });
     mockedReadFileSync.mockImplementation((path) => {
       const file = String(path);
@@ -742,7 +742,7 @@ describe('getUsage routing', () => {
           },
         });
       }
-      if (file.endsWith('.usage-cache.json')) {
+      if (file.endsWith('.usage-cache-zai.json')) {
         return JSON.stringify({
           timestamp: Date.now() - 90_000,
           source: 'zai',

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -107,18 +107,56 @@ export function isZaiHost(urlString: string): boolean {
 }
 
 /**
- * Get the cache file path
+ * Get the legacy (pre-split) cache file path
  */
-function getCachePath(): string {
+function getLegacyCachePath(): string {
   return join(getClaudeConfigDir(), 'plugins', 'oh-my-claudecode', '.usage-cache.json');
 }
 
 /**
- * Read cached usage data
+ * Get the provider-specific cache file path
  */
-function readCache(): UsageCache | null {
+function getCachePath(source: 'anthropic' | 'zai'): string {
+  return join(getClaudeConfigDir(), 'plugins', 'oh-my-claudecode', `.usage-cache-${source}.json`);
+}
+
+/**
+ * Migrate legacy single-file cache to provider-specific file.
+ * One-shot: only runs when the provider-specific file does not yet exist
+ * and the legacy cache's source matches the current provider.
+ * Does NOT delete the legacy file (rolling update safety).
+ */
+function migrateLegacyCache(source: 'anthropic' | 'zai'): void {
   try {
-    const cachePath = getCachePath();
+    const legacyPath = getLegacyCachePath();
+    if (!existsSync(legacyPath)) return;
+
+    // One-shot guard: skip if new file already exists
+    if (existsSync(getCachePath(source))) return;
+
+    const content = readFileSync(legacyPath, 'utf-8');
+    const cache = JSON.parse(content) as UsageCache;
+
+    // Source mismatch guard: only migrate if legacy cache belongs to this provider
+    if (cache.source !== source) return;
+
+    const newPath = getCachePath(source);
+    const cacheDir = dirname(newPath);
+    if (!existsSync(cacheDir)) {
+      mkdirSync(cacheDir, { recursive: true });
+    }
+    writeFileSync(newPath, content);
+  } catch {
+    // Best-effort migration — failures are harmless
+  }
+}
+
+/**
+ * Read cached usage data for a specific provider
+ */
+function readCache(source: 'anthropic' | 'zai'): UsageCache | null {
+  try {
+    const cachePath = getCachePath(source);
     if (!existsSync(cachePath)) return null;
 
     const content = readFileSync(cachePath, 'utf-8');
@@ -164,11 +202,11 @@ interface WriteCacheOptions {
 }
 
 /**
- * Write usage data to cache
+ * Write usage data to cache (provider-specific file)
  */
 function writeCache(opts: WriteCacheOptions): void {
   try {
-    const cachePath = getCachePath();
+    const cachePath = getCachePath(opts.source!);
     const cacheDir = dirname(cachePath);
 
     if (!existsSync(cacheDir)) {
@@ -785,14 +823,17 @@ export async function getUsage(): Promise<UsageResult> {
   const currentSource: 'anthropic' | 'zai' = isZai && authToken ? 'zai' : 'anthropic';
   const pollIntervalMs = getUsagePollIntervalMs();
 
-  const initialCache = readCache();
+  // Migrate legacy single-file cache to provider-specific file (one-shot, best-effort)
+  migrateLegacyCache(currentSource);
+
+  const initialCache = readCache(currentSource);
   if (initialCache && isCacheValid(initialCache, pollIntervalMs) && initialCache.source === currentSource) {
     return getCachedUsageResult(initialCache);
   }
 
   try {
-    return await withFileLock(lockPathFor(getCachePath()), async () => {
-      const cache = readCache();
+    return await withFileLock(lockPathFor(getCachePath(currentSource)), async () => {
+      const cache = readCache(currentSource);
       if (cache && isCacheValid(cache, pollIntervalMs) && cache.source === currentSource) {
         return getCachedUsageResult(cache);
       }
@@ -800,11 +841,10 @@ export async function getUsage(): Promise<UsageResult> {
       // z.ai path (must precede OAuth check to avoid stale Anthropic credentials)
       if (isZai && authToken) {
         const result = await fetchUsageFromZai();
-        const cachedZai = cache?.source === 'zai' ? cache : null;
 
         if (result.rateLimited) {
-          const prevLastSuccess = cachedZai?.lastSuccessAt;
-          const rateLimitedCache = createRateLimitedCacheEntry('zai', cachedZai?.data || null, pollIntervalMs, cachedZai?.rateLimitedCount || 0, prevLastSuccess);
+          const prevLastSuccess = cache?.lastSuccessAt;
+          const rateLimitedCache = createRateLimitedCacheEntry('zai', cache?.data || null, pollIntervalMs, cache?.rateLimitedCount || 0, prevLastSuccess);
           writeCache({
             data: rateLimitedCache.data,
             error: rateLimitedCache.error,
@@ -825,13 +865,13 @@ export async function getUsage(): Promise<UsageResult> {
         }
 
         if (!result.data) {
-          const fallbackData = hasUsableStaleData(cachedZai) ? cachedZai.data : null;
+          const fallbackData = hasUsableStaleData(cache) ? cache.data : null;
           writeCache({
             data: fallbackData,
             error: true,
             source: 'zai',
             errorReason: 'network',
-            lastSuccessAt: cachedZai?.lastSuccessAt,
+            lastSuccessAt: cache?.lastSuccessAt,
           });
           if (fallbackData) {
             return { rateLimits: fallbackData, error: 'network', stale: true };
@@ -847,7 +887,6 @@ export async function getUsage(): Promise<UsageResult> {
       // Anthropic OAuth path (official Claude Code support)
       let creds = getCredentials();
       if (creds) {
-        const cachedAnthropic = cache?.source === 'anthropic' ? cache : null;
         if (!validateCredentials(creds)) {
           if (creds.refreshToken) {
             const refreshed = await refreshAccessToken(creds.refreshToken);
@@ -867,8 +906,8 @@ export async function getUsage(): Promise<UsageResult> {
         const result = await fetchUsageFromApi(creds.accessToken);
 
         if (result.rateLimited) {
-          const prevLastSuccess = cachedAnthropic?.lastSuccessAt;
-          const rateLimitedCache = createRateLimitedCacheEntry('anthropic', cachedAnthropic?.data || null, pollIntervalMs, cachedAnthropic?.rateLimitedCount || 0, prevLastSuccess);
+          const prevLastSuccess = cache?.lastSuccessAt;
+          const rateLimitedCache = createRateLimitedCacheEntry('anthropic', cache?.data || null, pollIntervalMs, cache?.rateLimitedCount || 0, prevLastSuccess);
           writeCache({
             data: rateLimitedCache.data,
             error: rateLimitedCache.error,
@@ -889,13 +928,13 @@ export async function getUsage(): Promise<UsageResult> {
         }
 
         if (!result.data) {
-          const fallbackData = hasUsableStaleData(cachedAnthropic) ? cachedAnthropic.data : null;
+          const fallbackData = hasUsableStaleData(cache) ? cache.data : null;
           writeCache({
             data: fallbackData,
             error: true,
             source: 'anthropic',
             errorReason: 'network',
-            lastSuccessAt: cachedAnthropic?.lastSuccessAt,
+            lastSuccessAt: cache?.lastSuccessAt,
           });
           if (fallbackData) {
             return { rateLimits: fallbackData, error: 'network', stale: true };


### PR DESCRIPTION
## Summary

Closes #2555

Split the single HUD usage cache file into provider-specific files to eliminate cache thrashing when two Claude Code sessions use different providers (z.ai vs Anthropic) simultaneously.

- `.usage-cache.json` → `.usage-cache-anthropic.json` / `.usage-cache-zai.json`
- Lock files auto-split via existing `lockPathFor` pattern, eliminating cross-provider blocking
- One-shot legacy migration with source mismatch guard and rolling update safety

## Problem

When two sessions run simultaneously with different providers, they share a single cache file. Each session invalidates the other's cache on every 90s poll cycle:

1. Session A (z.ai) writes `source: 'zai'` to cache
2. Session B (Anthropic) reads cache → `source !== 'anthropic'` → cache miss → fresh API call
3. Session B writes `source: 'anthropic'` → overwrites Session A's data
4. Repeat every 90s indefinitely

**Impact:** Cache never hits, unnecessary API calls double, and cross-provider lock contention occurs since network calls happen inside `withFileLock` (up to 10s API timeout blocks the other session).

## Solution

| Change | Detail |
|--------|--------|
| `getCachePath(source)` | Now accepts `'anthropic' \| 'zai'` parameter, returns provider-specific path |
| `readCache(source)` / `writeCache(opts)` | Route to provider-specific file based on source |
| `migrateLegacyCache(source)` | One-shot migration: copies legacy file to new path only if (1) new file doesn't exist and (2) legacy cache's source matches current provider |
| `getUsage()` | Passes `currentSource` throughout; removed `cachedZai`/`cachedAnthropic` conditional variables since cache always matches current provider |
| Legacy file preservation | `.usage-cache.json` is NOT deleted — ensures rolling update compatibility with older versions |

### Alternatives considered

| Alternative | Why rejected |
|-------------|-------------|
| Single file with dual-key structure (`{ anthropic: {...}, zai: {...} }`) | Lock contention remains — one provider's API call (up to 10s) blocks the other |
| Directory-based split (`.usage-cache/anthropic.json`) | Inconsistent with project's flat file cache pattern (`.custom-rate-cache.json`) |

## Future cleanup

The `migrateLegacyCache()` function and `getLegacyCachePath()` can be removed after 2-3 releases once all users have migrated to the new cache format. The legacy `.usage-cache.json` file will naturally become stale and can be safely deleted.

## Test plan

- [x] `usage-api.test.ts` — updated cache paths for anthropic/zai tests (27 tests)
- [x] `usage-api-stale.test.ts` �� CACHE_PATH → `.usage-cache-zai.json` (8 tests)
- [x] `usage-api-lock.test.ts` — CACHE_PATH/LOCK_PATH → zai paths (3 tests)
- [x] `hud-windows.test.ts` — updated assertion for new `getCachePath` pattern (22 tests)
- [x] TypeScript build: clean
- [x] Lint: 0 errors
- [x] All 60 related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)