### PR TITLE
fix(post-tool-verifier): suppress non-actionable error token noise (#2558)

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -170,6 +170,8 @@ function stripClaudeTempCwdErrors(output) {
 // Pattern matching Claude Code's "Error: Exit code N" prefix line
 // Note: no /g flag — module-level regex with /g is stateful (.lastIndex persists across calls)
 const CLAUDE_EXIT_CODE_PREFIX = /^Error: Exit code \d+\s*$/m;
+const QUOTED_SPAN_PATTERN =
+  /"[^"\n]{1,400}"|'[^'\n]{1,400}'|“[^”\n]{1,400}”|‘[^’\n]{1,400}’/g;
 const NON_ACTIONABLE_ERROR_LINES = [
   /^\s*["']?severity["']?\s*[:=]\s*["']error["']?\s*[,}]?\s*$/i,
   /^\s*["']?totalErrors["']?\s*[:=]\s*0\b.*$/i,
@@ -177,6 +179,10 @@ const NON_ACTIONABLE_ERROR_LINES = [
   /^\s*["']?error["']?\s*:\s*["'][^"']*["']\s*[,}]?\s*$/i,
   /^\s*return\s*\{[^\n]*\berror\s*:\s*["'][^"']*["'][^\n]*\}\s*;?$/i,
 ];
+
+function stripQuotedSpans(output) {
+  return output.replace(QUOTED_SPAN_PATTERN, ' ');
+}
 
 function stripNonActionableErrorContext(output) {
   if (!output) return '';
@@ -222,7 +228,7 @@ export function isNonZeroExitWithOutput(output) {
     /abort/i,
   ];
 
-  return !contentErrorPatterns.some(p => p.test(remaining));
+  return !contentErrorPatterns.some(p => p.test(stripQuotedSpans(remaining)));
 }
 
 // Detect failures in Bash output

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -170,6 +170,25 @@ function stripClaudeTempCwdErrors(output) {
 // Pattern matching Claude Code's "Error: Exit code N" prefix line
 // Note: no /g flag — module-level regex with /g is stateful (.lastIndex persists across calls)
 const CLAUDE_EXIT_CODE_PREFIX = /^Error: Exit code \d+\s*$/m;
+const NON_ACTIONABLE_ERROR_LINES = [
+  /^\s*["']?severity["']?\s*[:=]\s*["']error["']?\s*[,}]?\s*$/i,
+  /^\s*["']?totalErrors["']?\s*[:=]\s*0\b.*$/i,
+  /^\s*totalErrors\s*[:=]\s*0\b.*$/i,
+  /^\s*["']?error["']?\s*:\s*["'][^"']*["']\s*[,}]?\s*$/i,
+  /^\s*return\s*\{[^\n]*\berror\s*:\s*["'][^"']*["'][^\n]*\}\s*;?$/i,
+];
+
+function stripNonActionableErrorContext(output) {
+  if (!output) return '';
+  return output
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return true;
+      return !NON_ACTIONABLE_ERROR_LINES.some((pattern) => pattern.test(trimmed));
+    })
+    .join('\n');
+}
 
 /**
  * Detect non-zero exit code with valid stdout (issue #960).
@@ -179,7 +198,7 @@ const CLAUDE_EXIT_CODE_PREFIX = /^Error: Exit code \d+\s*$/m;
  */
 export function isNonZeroExitWithOutput(output) {
   if (!output) return false;
-  const cleaned = stripClaudeTempCwdErrors(output);
+  const cleaned = stripNonActionableErrorContext(stripClaudeTempCwdErrors(output));
 
   // Must contain Claude Code's exit code prefix
   if (!CLAUDE_EXIT_CODE_PREFIX.test(cleaned)) return false;

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -188,8 +188,20 @@ describe('detectBashFailure', () => {
       expect(detectBashFailure(`"severity": "error"`)).toBe(false);
     });
 
+    it('should ignore quoted field names inside inert object literals', () => {
+      expect(detectBashFailure(`{ "error": "rate limit", "severity": "warning" }`)).toBe(false);
+    });
+
     it('should ignore zero-error summaries', () => {
       expect(detectBashFailure('totalErrors: 0, totalWarnings: 3')).toBe(false);
+    });
+
+    it('should still detect real stack traces and command failures', () => {
+      const output = [
+        'Error: build failed',
+        '    at runBuild (/workspace/scripts/build.mjs:12:7)',
+      ].join('\n');
+      expect(detectBashFailure(output)).toBe(true);
     });
 
     it('should return false for empty output', () => {
@@ -269,6 +281,14 @@ describe('isNonZeroExitWithOutput (issue #960)', () => {
         'Error: Exit code 8',
         '"severity": "error"',
         'totalErrors: 0',
+      ].join('\n');
+      expect(isNonZeroExitWithOutput(output)).toBe(false);
+    });
+
+    it('keeps quoted inert literals from being treated as real failure content', () => {
+      const output = [
+        'Error: Exit code 8',
+        `return { error: 'network', totalErrors: 0 };`,
       ].join('\n');
       expect(isNonZeroExitWithOutput(output)).toBe(false);
     });

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -180,6 +180,18 @@ describe('detectBashFailure', () => {
       expect(detectBashFailure('All tests passed')).toBe(false);
     });
 
+    it('should ignore quoted error field string literals', () => {
+      expect(detectBashFailure(`return { rateLimits: fallbackData, error: 'network', stale: true };`)).toBe(false);
+    });
+
+    it('should ignore severity metadata lines', () => {
+      expect(detectBashFailure(`"severity": "error"`)).toBe(false);
+    });
+
+    it('should ignore zero-error summaries', () => {
+      expect(detectBashFailure('totalErrors: 0, totalWarnings: 3')).toBe(false);
+    });
+
     it('should return false for empty output', () => {
       expect(detectBashFailure('')).toBe(false);
     });
@@ -250,6 +262,15 @@ describe('isNonZeroExitWithOutput (issue #960)', () => {
 
     it('no exit code prefix at all', () => {
       expect(isNonZeroExitWithOutput('some normal output')).toBe(false);
+    });
+
+    it('keeps valid stdout classification when remaining lines are only non-actionable error metadata', () => {
+      const output = [
+        'Error: Exit code 8',
+        '"severity": "error"',
+        'totalErrors: 0',
+      ].join('\n');
+      expect(isNonZeroExitWithOutput(output)).toBe(false);
     });
 
     it('empty string', () => {


### PR DESCRIPTION
## Summary

Closes #2558

- suppress non-actionable `error` token false positives in post-tool-verifier bash failure detection
- ignore quoted error field string literals, `severity: error` metadata, and `totalErrors: 0` summaries before failure classification
- add focused regression coverage for these cases

## Test plan

- [x] `npm test -- --run src/__tests__/post-tool-verifier.test.mjs`
