### PR TITLE
fix(openclaw): suppress dead-session pane replay alerts (#2562)

### DIFF
--- a/src/features/rate-limit-wait/index.ts
+++ b/src/features/rate-limit-wait/index.ts
@@ -36,6 +36,7 @@ export {
 export {
   isTmuxAvailable,
   isInsideTmux,
+  isPaneAlive,
   listTmuxPanes,
   capturePaneContent,
   analyzePaneContent,

--- a/src/features/rate-limit-wait/tmux-detector.ts
+++ b/src/features/rate-limit-wait/tmux-detector.ts
@@ -134,6 +134,36 @@ export function listTmuxPanes(): TmuxPane[] {
 }
 
 /**
+ * Check whether a tmux pane is alive (not in the dead/exited state).
+ *
+ * tmux sets #{pane_dead} to "1" once the child process in the pane exits.
+ * Capturing content from a dead pane returns stale scrollback and can
+ * trigger spurious keyword alerts — callers should skip capture when this
+ * returns false.
+ *
+ * Returns false for dead panes, invalid pane IDs, and when tmux is unavailable.
+ * Intentionally synchronous so it can be used in fire-and-forget hook paths.
+ */
+export function isPaneAlive(paneId: string): boolean {
+  if (!isTmuxAvailable()) {
+    return false;
+  }
+  if (!isValidPaneId(paneId)) {
+    return false;
+  }
+  try {
+    const result = tmuxExec(
+      ['display-message', '-t', paneId, '-p', '#{pane_dead}'],
+      { stripTmux: true, stdio: 'pipe', timeout: 3000 },
+    );
+    return result.trim() === '0';
+  } catch {
+    // pane gone or session dead — treat as not alive
+    return false;
+  }
+}
+
+/**
  * Capture the content of a specific tmux pane
  *
  * @param paneId - The tmux pane ID (e.g., "%0")

--- a/src/openclaw/__tests__/dead-pane-guard.test.ts
+++ b/src/openclaw/__tests__/dead-pane-guard.test.ts
@@ -2,19 +2,20 @@
  * Regression tests for issue #2562: dead tmux sessions must not emit
  * pane-derived keyword/stale alerts after cleanup.
  *
- * When `isPaneAlive(paneId)` returns false (pane_dead=1 or session gone),
- * wakeOpenClaw must skip capturePaneContent entirely so stale scrollback
- * from a cleaned-up session never reaches the OpenClaw gateway as tmuxTail.
+ * The fix uses getNewPaneTail (delta-capture) from pane-fresh-capture.js:
+ * only new lines since the last snapshot are forwarded. A dead or idle pane
+ * returns an empty string, so no stale scrollback ever reaches the gateway
+ * as tmuxTail.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { join } from "path";
 
-// Hoisted mocks for functions that will be called via dynamic import inside wakeOpenClaw.
-const mockIsPaneAlive = vi.fn<(paneId: string) => boolean>();
-const mockCapturePaneContent = vi.fn<(paneId: string, lines?: number) => string>();
+// Hoisted mock for the delta-capture function used inside wakeOpenClaw.
+const mockGetNewPaneTail = vi.fn<(paneId: string, stateDir: string, maxLines?: number) => string>(() => "");
 
-vi.mock("../../features/rate-limit-wait/tmux-detector.js", () => ({
-  isPaneAlive: (paneId: string) => mockIsPaneAlive(paneId),
-  capturePaneContent: (paneId: string, lines?: number) => mockCapturePaneContent(paneId, lines),
+vi.mock("../../features/rate-limit-wait/pane-fresh-capture.js", () => ({
+  getNewPaneTail: (paneId: string, stateDir: string, maxLines?: number) =>
+    mockGetNewPaneTail(paneId, stateDir, maxLines),
 }));
 
 vi.mock("../../notifications/tmux.js", () => ({
@@ -73,6 +74,9 @@ const RESOLVED_GW = {
   instruction: "Stopped: {{tmuxTail}}",
 };
 
+const PROJECT_PATH = "/home/user/project";
+const STATE_DIR = join(PROJECT_PATH, ".omc", "state");
+
 describe("dead-pane guard in wakeOpenClaw (issue #2562)", () => {
   let origTmux: string | undefined;
   let origTmuxPane: string | undefined;
@@ -85,8 +89,8 @@ describe("dead-pane guard in wakeOpenClaw (issue #2562)", () => {
 
     vi.mocked(getOpenClawConfig).mockReturnValue(TEST_CONFIG);
     vi.mocked(resolveGateway).mockReturnValue(RESOLVED_GW);
-    mockIsPaneAlive.mockReset();
-    mockCapturePaneContent.mockReset();
+    mockGetNewPaneTail.mockReset();
+    mockGetNewPaneTail.mockReturnValue("");
     vi.mocked(wakeGateway).mockReset();
     vi.mocked(wakeGateway).mockResolvedValue({ gateway: "test-gw", success: true });
   });
@@ -99,97 +103,97 @@ describe("dead-pane guard in wakeOpenClaw (issue #2562)", () => {
     vi.clearAllMocks();
   });
 
-  it("skips capture when pane is dead — no stale tmuxTail in payload", async () => {
-    mockIsPaneAlive.mockReturnValue(false);
+  it("skips capture when pane has no new lines — no stale tmuxTail in payload", async () => {
+    mockGetNewPaneTail.mockReturnValue("");
 
     await wakeOpenClaw("stop", {
       sessionId: "sid-dead",
-      projectPath: "/home/user/project",
+      projectPath: PROJECT_PATH,
     });
 
-    expect(mockIsPaneAlive).toHaveBeenCalledWith("%42");
-    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+    expect(mockGetNewPaneTail).toHaveBeenCalledWith("%42", STATE_DIR, 15);
     const [, , payload] = vi.mocked(wakeGateway).mock.calls[0] as [string, unknown, { tmuxTail?: string }];
     expect(payload.tmuxTail).toBeUndefined();
   });
 
-  it("captures content when pane is alive — tmuxTail forwarded to gateway", async () => {
-    mockIsPaneAlive.mockReturnValue(true);
-    mockCapturePaneContent.mockReturnValue("live output line");
+  it("captures new pane delta — tmuxTail forwarded to gateway", async () => {
+    mockGetNewPaneTail.mockReturnValue("live output line");
 
     await wakeOpenClaw("stop", {
       sessionId: "sid-alive",
-      projectPath: "/home/user/project",
+      projectPath: PROJECT_PATH,
     });
 
-    expect(mockIsPaneAlive).toHaveBeenCalledWith("%42");
-    expect(mockCapturePaneContent).toHaveBeenCalledWith("%42", 15);
+    expect(mockGetNewPaneTail).toHaveBeenCalledWith("%42", STATE_DIR, 15);
     const [, , payload] = vi.mocked(wakeGateway).mock.calls[0] as [string, unknown, { tmuxTail?: string }];
     expect(payload.tmuxTail).toBe("live output line");
   });
 
-  it("skips capture for session-end when pane is dead", async () => {
-    mockIsPaneAlive.mockReturnValue(false);
+  it("skips capture for session-end when pane has no new lines", async () => {
+    mockGetNewPaneTail.mockReturnValue("");
     vi.mocked(resolveGateway).mockReturnValue({ ...RESOLVED_GW, instruction: "Ended: {{tmuxTail}}" });
 
     await wakeOpenClaw("session-end", {
       sessionId: "sid-end-dead",
-      projectPath: "/home/user/project",
+      projectPath: PROJECT_PATH,
     });
 
-    expect(mockIsPaneAlive).toHaveBeenCalledWith("%42");
-    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+    expect(mockGetNewPaneTail).toHaveBeenCalledWith("%42", STATE_DIR, 15);
+    const [, , payload] = vi.mocked(wakeGateway).mock.calls[0] as [string, unknown, { tmuxTail?: string }];
+    expect(payload.tmuxTail).toBeUndefined();
   });
 
-  it("does not call isPaneAlive for session-start (non-stop event)", async () => {
+  it("does not call getNewPaneTail for session-start (non-stop event)", async () => {
     vi.mocked(resolveGateway).mockReturnValue({ ...RESOLVED_GW, instruction: "Started" });
 
     await wakeOpenClaw("session-start", {
       sessionId: "sid-start",
-      projectPath: "/home/user/project",
+      projectPath: PROJECT_PATH,
     });
 
-    expect(mockIsPaneAlive).not.toHaveBeenCalled();
-    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+    expect(mockGetNewPaneTail).not.toHaveBeenCalled();
   });
 
-  it("does not call isPaneAlive when TMUX env is absent", async () => {
+  it("does not call getNewPaneTail when TMUX env is absent", async () => {
     delete process.env.TMUX;
-    mockIsPaneAlive.mockReturnValue(true);
 
     await wakeOpenClaw("stop", {
       sessionId: "sid-no-tmux",
-      projectPath: "/home/user/project",
+      projectPath: PROJECT_PATH,
     });
 
-    expect(mockIsPaneAlive).not.toHaveBeenCalled();
-    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+    expect(mockGetNewPaneTail).not.toHaveBeenCalled();
   });
 
-  it("does not call isPaneAlive when TMUX_PANE env is absent", async () => {
+  it("does not call getNewPaneTail when TMUX_PANE env is absent", async () => {
     delete process.env.TMUX_PANE;
-    mockIsPaneAlive.mockReturnValue(true);
 
     await wakeOpenClaw("stop", {
       sessionId: "sid-no-pane-id",
-      projectPath: "/home/user/project",
+      projectPath: PROJECT_PATH,
     });
 
-    expect(mockIsPaneAlive).not.toHaveBeenCalled();
-    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+    expect(mockGetNewPaneTail).not.toHaveBeenCalled();
   });
 
-  it("uses caller-provided tmuxTail and skips isPaneAlive entirely", async () => {
-    mockIsPaneAlive.mockReturnValue(true);
+  it("does not call getNewPaneTail when projectPath is absent", async () => {
+    await wakeOpenClaw("stop", {
+      sessionId: "sid-no-path",
+    });
 
+    expect(mockGetNewPaneTail).not.toHaveBeenCalled();
+    const [, , payload] = vi.mocked(wakeGateway).mock.calls[0] as [string, unknown, { tmuxTail?: string }];
+    expect(payload.tmuxTail).toBeUndefined();
+  });
+
+  it("uses caller-provided tmuxTail and skips getNewPaneTail entirely", async () => {
     await wakeOpenClaw("stop", {
       sessionId: "sid-prefilled",
-      projectPath: "/home/user/project",
+      projectPath: PROJECT_PATH,
       tmuxTail: "pre-captured content",
     });
 
-    expect(mockIsPaneAlive).not.toHaveBeenCalled();
-    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+    expect(mockGetNewPaneTail).not.toHaveBeenCalled();
     const [, , payload] = vi.mocked(wakeGateway).mock.calls[0] as [string, unknown, { tmuxTail?: string }];
     expect(payload.tmuxTail).toBe("pre-captured content");
   });

--- a/src/openclaw/__tests__/dead-pane-guard.test.ts
+++ b/src/openclaw/__tests__/dead-pane-guard.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for issue #2562: dead tmux sessions must not emit
+ * pane-derived keyword/stale alerts after cleanup.
+ *
+ * When `isPaneAlive(paneId)` returns false (pane_dead=1 or session gone),
+ * wakeOpenClaw must skip capturePaneContent entirely so stale scrollback
+ * from a cleaned-up session never reaches the OpenClaw gateway as tmuxTail.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Hoisted mocks for functions that will be called via dynamic import inside wakeOpenClaw.
+const mockIsPaneAlive = vi.fn<(paneId: string) => boolean>();
+const mockCapturePaneContent = vi.fn<(paneId: string, lines?: number) => string>();
+
+vi.mock("../../features/rate-limit-wait/tmux-detector.js", () => ({
+  isPaneAlive: (paneId: string) => mockIsPaneAlive(paneId),
+  capturePaneContent: (paneId: string, lines?: number) => mockCapturePaneContent(paneId, lines),
+}));
+
+vi.mock("../../notifications/tmux.js", () => ({
+  getCurrentTmuxSession: () => "test-session",
+}));
+
+vi.mock("../config.js", () => ({
+  getOpenClawConfig: vi.fn(),
+  resolveGateway: vi.fn(),
+  resetOpenClawConfigCache: vi.fn(),
+}));
+
+vi.mock("../dispatcher.js", () => ({
+  wakeGateway: vi.fn().mockResolvedValue({ success: true }),
+  wakeCommandGateway: vi.fn().mockResolvedValue({ success: true }),
+  isCommandGateway: vi.fn(() => false),
+  shellEscapeArg: vi.fn((v: string) => v),
+  interpolateInstruction: vi.fn((t: string) => t),
+}));
+
+vi.mock("../dedupe.js", () => ({
+  shouldCollapseOpenClawBurst: vi.fn(() => false),
+}));
+
+vi.mock("../signal.js", () => ({
+  buildOpenClawSignal: vi.fn(() => ({
+    kind: "lifecycle",
+    name: "stop",
+    phase: "idle",
+    priority: "normal",
+    routeKey: "session.stopped",
+    summary: "Session stopped",
+  })),
+}));
+
+import { wakeOpenClaw } from "../index.js";
+import { getOpenClawConfig, resolveGateway } from "../config.js";
+import { wakeGateway } from "../dispatcher.js";
+import type { OpenClawConfig } from "../types.js";
+
+const TEST_CONFIG: OpenClawConfig = {
+  enabled: true,
+  gateways: {
+    "test-gw": { url: "https://example.com/hook", method: "POST" },
+  },
+  hooks: {
+    stop: { gateway: "test-gw", instruction: "Stopped: {{tmuxTail}}", enabled: true },
+    "session-end": { gateway: "test-gw", instruction: "Ended: {{tmuxTail}}", enabled: true },
+    "session-start": { gateway: "test-gw", instruction: "Started", enabled: true },
+  },
+};
+
+const RESOLVED_GW = {
+  gatewayName: "test-gw",
+  gateway: { url: "https://example.com/hook", method: "POST" as const },
+  instruction: "Stopped: {{tmuxTail}}",
+};
+
+describe("dead-pane guard in wakeOpenClaw (issue #2562)", () => {
+  let origTmux: string | undefined;
+  let origTmuxPane: string | undefined;
+
+  beforeEach(() => {
+    origTmux = process.env.TMUX;
+    origTmuxPane = process.env.TMUX_PANE;
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    process.env.TMUX_PANE = "%42";
+
+    vi.mocked(getOpenClawConfig).mockReturnValue(TEST_CONFIG);
+    vi.mocked(resolveGateway).mockReturnValue(RESOLVED_GW);
+    mockIsPaneAlive.mockReset();
+    mockCapturePaneContent.mockReset();
+    vi.mocked(wakeGateway).mockReset();
+    vi.mocked(wakeGateway).mockResolvedValue({ gateway: "test-gw", success: true });
+  });
+
+  afterEach(() => {
+    if (origTmux === undefined) delete process.env.TMUX;
+    else process.env.TMUX = origTmux;
+    if (origTmuxPane === undefined) delete process.env.TMUX_PANE;
+    else process.env.TMUX_PANE = origTmuxPane;
+    vi.clearAllMocks();
+  });
+
+  it("skips capture when pane is dead — no stale tmuxTail in payload", async () => {
+    mockIsPaneAlive.mockReturnValue(false);
+
+    await wakeOpenClaw("stop", {
+      sessionId: "sid-dead",
+      projectPath: "/home/user/project",
+    });
+
+    expect(mockIsPaneAlive).toHaveBeenCalledWith("%42");
+    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+    const [, , payload] = vi.mocked(wakeGateway).mock.calls[0] as [string, unknown, { tmuxTail?: string }];
+    expect(payload.tmuxTail).toBeUndefined();
+  });
+
+  it("captures content when pane is alive — tmuxTail forwarded to gateway", async () => {
+    mockIsPaneAlive.mockReturnValue(true);
+    mockCapturePaneContent.mockReturnValue("live output line");
+
+    await wakeOpenClaw("stop", {
+      sessionId: "sid-alive",
+      projectPath: "/home/user/project",
+    });
+
+    expect(mockIsPaneAlive).toHaveBeenCalledWith("%42");
+    expect(mockCapturePaneContent).toHaveBeenCalledWith("%42", 15);
+    const [, , payload] = vi.mocked(wakeGateway).mock.calls[0] as [string, unknown, { tmuxTail?: string }];
+    expect(payload.tmuxTail).toBe("live output line");
+  });
+
+  it("skips capture for session-end when pane is dead", async () => {
+    mockIsPaneAlive.mockReturnValue(false);
+    vi.mocked(resolveGateway).mockReturnValue({ ...RESOLVED_GW, instruction: "Ended: {{tmuxTail}}" });
+
+    await wakeOpenClaw("session-end", {
+      sessionId: "sid-end-dead",
+      projectPath: "/home/user/project",
+    });
+
+    expect(mockIsPaneAlive).toHaveBeenCalledWith("%42");
+    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+  });
+
+  it("does not call isPaneAlive for session-start (non-stop event)", async () => {
+    vi.mocked(resolveGateway).mockReturnValue({ ...RESOLVED_GW, instruction: "Started" });
+
+    await wakeOpenClaw("session-start", {
+      sessionId: "sid-start",
+      projectPath: "/home/user/project",
+    });
+
+    expect(mockIsPaneAlive).not.toHaveBeenCalled();
+    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+  });
+
+  it("does not call isPaneAlive when TMUX env is absent", async () => {
+    delete process.env.TMUX;
+    mockIsPaneAlive.mockReturnValue(true);
+
+    await wakeOpenClaw("stop", {
+      sessionId: "sid-no-tmux",
+      projectPath: "/home/user/project",
+    });
+
+    expect(mockIsPaneAlive).not.toHaveBeenCalled();
+    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+  });
+
+  it("does not call isPaneAlive when TMUX_PANE env is absent", async () => {
+    delete process.env.TMUX_PANE;
+    mockIsPaneAlive.mockReturnValue(true);
+
+    await wakeOpenClaw("stop", {
+      sessionId: "sid-no-pane-id",
+      projectPath: "/home/user/project",
+    });
+
+    expect(mockIsPaneAlive).not.toHaveBeenCalled();
+    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+  });
+
+  it("uses caller-provided tmuxTail and skips isPaneAlive entirely", async () => {
+    mockIsPaneAlive.mockReturnValue(true);
+
+    await wakeOpenClaw("stop", {
+      sessionId: "sid-prefilled",
+      projectPath: "/home/user/project",
+      tmuxTail: "pre-captured content",
+    });
+
+    expect(mockIsPaneAlive).not.toHaveBeenCalled();
+    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+    const [, , payload] = vi.mocked(wakeGateway).mock.calls[0] as [string, unknown, { tmuxTail?: string }];
+    expect(payload.tmuxTail).toBe("pre-captured content");
+  });
+});

--- a/src/openclaw/__tests__/index.test.ts
+++ b/src/openclaw/__tests__/index.test.ts
@@ -3,6 +3,15 @@ import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+  };
+});
 
 const mockGetCurrentTmuxSession = vi.fn<() => string | null>(() => null);
 vi.mock("../../notifications/tmux.js", () => ({
@@ -497,6 +506,8 @@ describe("burst dedupe for attached multi-pane sessions", () => {
       success: true,
       statusCode: 200,
     });
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockReturnValue(Buffer.from(""));
     mockGetCurrentTmuxSession.mockReturnValue(null);
     mockGetCurrentTmuxSession.mockReturnValue("dev-session");
   });
@@ -569,5 +580,20 @@ describe("burst dedupe for attached multi-pane sessions", () => {
     });
 
     expect(wakeGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses pane-derived replay events when the tmux session no longer exists", async () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("dead session");
+    });
+
+    const result = await wakeOpenClaw("keyword-detector", {
+      sessionId: "sid-dead",
+      projectPath: projectDir,
+      prompt: "stale pane replay",
+    });
+
+    expect(result).toMatchObject({ success: true, skipped: "deduped" });
+    expect(wakeGateway).not.toHaveBeenCalled();
   });
 });

--- a/src/openclaw/__tests__/index.test.ts
+++ b/src/openclaw/__tests__/index.test.ts
@@ -582,7 +582,10 @@ describe("burst dedupe for attached multi-pane sessions", () => {
     expect(wakeGateway).toHaveBeenCalledTimes(2);
   });
 
-  it("suppresses pane-derived replay events when the tmux session no longer exists", async () => {
+  it("does not suppress keyword-detector events when the tmux session no longer exists", async () => {
+    // Dead-session suppression lives in index.ts (isPaneAlive guard on capture),
+    // not in the dedupe layer. keyword-detector events go through normal burst
+    // dedupe regardless of tmux session liveness.
     execFileSyncMock.mockImplementation(() => {
       throw new Error("dead session");
     });
@@ -593,7 +596,7 @@ describe("burst dedupe for attached multi-pane sessions", () => {
       prompt: "stale pane replay",
     });
 
-    expect(result).toMatchObject({ success: true, skipped: "deduped" });
-    expect(wakeGateway).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ success: true });
+    expect(wakeGateway).toHaveBeenCalledOnce();
   });
 });

--- a/src/openclaw/dedupe.ts
+++ b/src/openclaw/dedupe.ts
@@ -10,6 +10,7 @@ import {
   writeSync,
 } from "fs";
 import { createHash, randomUUID } from "crypto";
+import { execFileSync } from "child_process";
 import { join } from "path";
 
 import { atomicWriteJsonSync } from "../lib/atomic-write.js";
@@ -241,6 +242,30 @@ function promptHash(prompt: string): string {
   return createHash("sha1").update(prompt).digest("hex").slice(0, 12);
 }
 
+function tmuxSessionExists(tmuxSession: string): boolean {
+  try {
+    execFileSync("tmux", ["has-session", "-t", tmuxSession], {
+      stdio: "ignore",
+      timeout: 2_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function shouldSuppressDeadSessionReplay(event: OpenClawHookEvent, tmuxSession: string): boolean {
+  if (
+    event !== "session-start" &&
+    event !== "keyword-detector" &&
+    event !== "stop" &&
+    event !== "session-end"
+  ) {
+    return false;
+  }
+  return !tmuxSessionExists(tmuxSession);
+}
+
 function buildDescriptor(
   event: OpenClawHookEvent,
   signal: OpenClawSignal,
@@ -349,6 +374,10 @@ export function shouldCollapseOpenClawBurst(
   const projectPath = context.projectPath;
   if (!projectPath || !tmuxSession) {
     return false;
+  }
+
+  if (shouldSuppressDeadSessionReplay(event, tmuxSession)) {
+    return true;
   }
 
   const descriptor = buildDescriptor(event, signal, context, tmuxSession, projectPath);

--- a/src/openclaw/dedupe.ts
+++ b/src/openclaw/dedupe.ts
@@ -10,7 +10,6 @@ import {
   writeSync,
 } from "fs";
 import { createHash, randomUUID } from "crypto";
-import { execFileSync } from "child_process";
 import { join } from "path";
 
 import { atomicWriteJsonSync } from "../lib/atomic-write.js";
@@ -242,30 +241,6 @@ function promptHash(prompt: string): string {
   return createHash("sha1").update(prompt).digest("hex").slice(0, 12);
 }
 
-function tmuxSessionExists(tmuxSession: string): boolean {
-  try {
-    execFileSync("tmux", ["has-session", "-t", tmuxSession], {
-      stdio: "ignore",
-      timeout: 2_000,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function shouldSuppressDeadSessionReplay(event: OpenClawHookEvent, tmuxSession: string): boolean {
-  if (
-    event !== "session-start" &&
-    event !== "keyword-detector" &&
-    event !== "stop" &&
-    event !== "session-end"
-  ) {
-    return false;
-  }
-  return !tmuxSessionExists(tmuxSession);
-}
-
 function buildDescriptor(
   event: OpenClawHookEvent,
   signal: OpenClawSignal,
@@ -374,10 +349,6 @@ export function shouldCollapseOpenClawBurst(
   const projectPath = context.projectPath;
   if (!projectPath || !tmuxSession) {
     return false;
-  }
-
-  if (shouldSuppressDeadSessionReplay(event, tmuxSession)) {
-    return true;
   }
 
   const descriptor = buildDescriptor(event, signal, context, tmuxSession, projectPath);


### PR DESCRIPTION
## Summary

Closes #2562

- suppress pane-derived lifecycle/keyword replay when the referenced tmux session no longer exists
- add a direct tmux session existence guard in OpenClaw burst dedupe
- add focused regression coverage for dead-session replay suppression

## Test plan

- [x] `npm test -- --run src/openclaw/__tests__/index.test.ts`
