### PR TITLE
fix(ask): close stdin for provider spawns to prevent hang in piped environments

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -227,7 +227,7 @@ async function main() {
     maxBuffer: 10 * 1024 * 1024,
     env: buildProviderEnv(provider),
     shell: SHOULD_USE_WINDOWS_SHELL,
-    ...(pipePromptViaStdin ? { input: prompt } : {}),
+    ...(pipePromptViaStdin ? { input: prompt } : { stdio: ['ignore', 'pipe', 'pipe'] }),
   });
 
   const stdout = run.stdout || '';

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -195,6 +195,52 @@ function writeSpawnSyncCapturePrelude(dir: string): string {
 }
 
 
+function writeSpawnSyncCapturePreludeNative(dir: string): string {
+  const preludePath = join(dir, 'spawn-sync-capture-prelude-native.mjs');
+  writeFileSync(
+    preludePath,
+    [
+      "import childProcess from 'node:child_process';",
+      "import { writeFileSync } from 'node:fs';",
+      "import { syncBuiltinESMExports } from 'node:module';",
+      '',
+      '// No platform override — tests native (non-Windows) behavior',
+      'const capturePath = process.env.SPAWN_CAPTURE_PATH;',
+      'const calls = [];',
+      'childProcess.spawnSync = (command, args = [], options = {}) => {',
+      '  calls.push({',
+      '    command,',
+      '    args,',
+      '    options: {',
+      "      shell: options.shell ?? false,",
+      "      encoding: options.encoding ?? null,",
+      "      stdio: options.stdio ?? null,",
+      "      input: options.input ?? null,",
+      '    },',
+      '  });',
+      "  const isVersionProbe = Array.isArray(args) && args[0] === '--version';",
+      '  return {',
+      '    status: 0,',
+      "    stdout: isVersionProbe ? 'fake 1.0.0\\n' : 'FAKE_PROVIDER_OK',",
+      "    stderr: '',",
+      '    pid: 0,',
+      '    output: [],',
+      '    signal: null,',
+      '  };',
+      '};',
+      'syncBuiltinESMExports();',
+      "process.on('exit', () => {",
+      '  if (capturePath) {',
+      "    writeFileSync(capturePath, JSON.stringify(calls), 'utf8');",
+      '  }',
+      '});',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  return preludePath;
+}
+
 function writeFakeCodexBinary(dir: string): string {
   const binDir = join(dir, 'bin');
   mkdirSync(binDir, { recursive: true });
@@ -626,6 +672,44 @@ describe('run-provider-advisor script contract', () => {
         command: 'where',
         args: ['codex'],
       });
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['codex', ['codex', '--prompt', 'short prompt']],
+    ['gemini', ['gemini', '--prompt', 'short prompt']],
+    ['claude', ['claude', '--prompt', 'short prompt']],
+  ] as const)('closes stdin for %s on non-Windows to prevent hang in piped environments', (provider, args) => {
+    const wd = mkdtempSync(join(tmpdir(), `omc-ask-${provider}-stdin-close-`));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        args,
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+        options: { shell: boolean; encoding: string | null; stdio: string[] | string | null; input: string | null };
+      }>;
+
+      expect(calls).toHaveLength(2);
+
+      // Version probe always ignores stdio
+      expect(calls[0].options.stdio).toBe('ignore');
+
+      // Provider spawn must close stdin to prevent hangs when parent stdin is a pipe
+      expect(calls[1].options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+      expect(calls[1].options.input).toBeNull();
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- `omc ask codex` hangs indefinitely when invoked from Claude Code's Bash tool (or any piped environment) because `spawnSync` inherits the parent's stdin pipe, and Codex blocks reading from it
- Fix: explicitly set `stdio: ['ignore', 'pipe', 'pipe']` when not piping the prompt via stdin, so the child process gets no stdin file descriptor
- Affects all providers (codex, gemini, claude) on non-Windows when the prompt is short/single-line (the stdin-piping path was already correct)

## Changes

- `scripts/run-provider-advisor.js` — 1 line changed
- `src/cli/__tests__/ask.test.ts` — native-platform capture prelude + 3 parametrized tests

## Test plan

- [x] Added parametrized test for all 3 providers verifying `stdio: ['ignore', 'pipe', 'pipe']` on non-Windows
- [x] All 21 existing tests pass (including Windows stdin-piping tests)
- [x] Manual verification: `omc ask codex 'hello'` from Claude Code Bash tool now completes immediately instead of hanging

> Clean resubmission against `dev` per feedback on #2557 and #2560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)