### PR TITLE
Fix stop-hook timeout enforcement for issue #2565

### DIFF
--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -20,7 +20,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
-import { join, dirname, resolve } from 'node:path';
+import { join, dirname, resolve, parse } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
@@ -30,6 +30,7 @@ const THRESHOLD = parseInt(process.env.OMC_CONTEXT_GUARD_THRESHOLD || '75', 10);
 const CRITICAL_THRESHOLD = 95;
 const MAX_BLOCKS = 2;
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+const GIT_PROBE_TIMEOUT_MS = 1000;
 
 /**
  * Detect if stop was triggered by context-limit related reasons.
@@ -70,6 +71,28 @@ function isUserAbort(data) {
   );
 }
 
+function hasLocalGitMarker(startDir) {
+  if (!startDir) return false;
+
+  let current = resolve(startDir);
+  const { root } = parse(current);
+
+  while (true) {
+    if (existsSync(join(current, '.git'))) return true;
+    if (current === root) return false;
+    current = dirname(current);
+  }
+}
+
+function runGitRevParse(args, cwd) {
+  return execSync(`git rev-parse ${args.join(' ')}`, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: GIT_PROBE_TIMEOUT_MS,
+  }).trim();
+}
+
 /**
  * Resolve a transcript path that may be mismatched in worktree sessions (issue #1094).
  * When Claude Code runs inside .claude/worktrees/X, the encoded project directory
@@ -95,21 +118,15 @@ function resolveTranscriptPath(transcriptPath, cwd) {
   // transcript path encodes the worktree CWD, but the file lives under
   // the main repo's encoded path.
   const effectiveCwd = cwd || process.cwd();
+  if (!hasLocalGitMarker(effectiveCwd)) return transcriptPath;
+
   try {
-    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
-      cwd: effectiveCwd,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    const gitCommonDir = runGitRevParse(['--git-common-dir'], effectiveCwd);
 
     const absoluteCommonDir = resolve(effectiveCwd, gitCommonDir);
     const mainRepoRoot = dirname(absoluteCommonDir);
 
-    const worktreeTop = execSync('git rev-parse --show-toplevel', {
-      cwd: effectiveCwd,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    const worktreeTop = runGitRevParse(['--show-toplevel'], effectiveCwd);
 
     if (mainRepoRoot !== worktreeTop) {
       const lastSep = transcriptPath.lastIndexOf('/');

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -19,7 +19,7 @@
  */
 
 const { spawnSync } = require('child_process');
-const { existsSync, realpathSync } = require('fs');
+const { existsSync, readFileSync, realpathSync } = require('fs');
 const { join, basename, dirname } = require('path');
 
 const target = process.argv[2];
@@ -93,12 +93,52 @@ function resolveTarget(targetPath) {
   return null;
 }
 
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function flattenHookEntries(rawHooks) {
+  if (!rawHooks || typeof rawHooks !== 'object') return [];
+  return Object.values(rawHooks).flatMap((entries) => Array.isArray(entries) ? entries : []);
+}
+
+function resolveHookTimeoutMs(targetPath, extraArgs) {
+  const pluginRoot = dirname(dirname(targetPath));
+  const hooksJsonPath = join(pluginRoot, 'hooks', 'hooks.json');
+  if (!existsSync(hooksJsonPath)) return null;
+
+  try {
+    const hooksJson = JSON.parse(readFileSync(hooksJsonPath, 'utf-8'));
+    const scriptName = basename(targetPath);
+    const scriptPattern = new RegExp(`[/\\\\]scripts[/\\\\]${escapeRegex(scriptName)}(?:\\s|$)`);
+    const argNeedles = extraArgs.filter((arg) => typeof arg === 'string' && arg.length > 0);
+
+    for (const entry of flattenHookEntries(hooksJson?.hooks)) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        const command = typeof hook?.command === 'string' ? hook.command : '';
+        const timeout = Number(hook?.timeout);
+        if (!scriptPattern.test(command)) continue;
+        if (!Number.isFinite(timeout) || timeout <= 0) continue;
+        if (!argNeedles.every((arg) => command.includes(` ${arg}`) || command.endsWith(` ${arg}`))) continue;
+        return Math.floor(timeout * 1000);
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 const resolved = resolveTarget(target);
 if (!resolved) {
   // Target not found anywhere — exit cleanly so hooks are never blocked.
   // This is the graceful fallback for stale CLAUDE_PLUGIN_ROOT paths.
   process.exit(0);
 }
+
+const timeoutMs = resolveHookTimeoutMs(resolved, process.argv.slice(3));
 
 const result = spawnSync(
   process.execPath,
@@ -107,8 +147,16 @@ const result = spawnSync(
     stdio: 'inherit',
     env: process.env,
     windowsHide: true,
+    ...(timeoutMs ? {
+      timeout: timeoutMs,
+      killSignal: process.platform === 'win32' ? 'SIGTERM' : 'SIGKILL',
+    } : {}),
   }
 );
+
+if (result.error?.code === 'ETIMEDOUT' && timeoutMs) {
+  process.stderr.write(`[run.cjs] Hook ${basename(resolved)} timed out after ${timeoutMs}ms; exiting fail-open.\n`);
+}
 
 // Propagate the child exit code (null → 0 to avoid blocking hooks).
 process.exit(result.status ?? 0);

--- a/src/__tests__/context-guard-stop.test.ts
+++ b/src/__tests__/context-guard-stop.test.ts
@@ -1,17 +1,30 @@
-import { execSync } from 'child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { delimiter, join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const SCRIPT_PATH = join(process.cwd(), 'scripts', 'context-guard-stop.mjs');
 
 function runContextGuardStop(input: Record<string, unknown>): Record<string, unknown> {
-  const stdout = execSync(`node "${SCRIPT_PATH}"`, {
+  const stdout = execFileSync(process.execPath, [SCRIPT_PATH], {
     input: JSON.stringify(input),
     encoding: 'utf-8',
     timeout: 5000,
     env: { ...process.env, NODE_ENV: 'test' },
+  });
+  return JSON.parse(stdout.trim()) as Record<string, unknown>;
+}
+
+function runContextGuardStopWithEnv(
+  input: Record<string, unknown>,
+  env: NodeJS.ProcessEnv,
+): Record<string, unknown> {
+  const stdout = execFileSync(process.execPath, [SCRIPT_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    timeout: 5000,
+    env: { ...process.env, NODE_ENV: 'test', ...env },
   });
   return JSON.parse(stdout.trim()) as Record<string, unknown>;
 }
@@ -89,5 +102,40 @@ describe('context-guard-stop safe recovery messaging (issue #1373)', () => {
     expect(second.decision).toBe('block');
     expect(String(first.reason)).toContain('(Block 1/2)');
     expect(String(second.reason)).toContain('(Block 1/2)');
+  });
+
+  it('skips git worktree probing in non-git directories without a local .git marker', () => {
+    const missingTranscriptPath = join(tempDir, 'missing-transcript.jsonl');
+    const fakeBinDir = join(tempDir, 'fake-bin');
+    mkdirSync(fakeBinDir, { recursive: true });
+    const gitLogPath = join(tempDir, 'git-invocations.log');
+
+    writeFileSync(
+      join(fakeBinDir, 'git'),
+      '#!/usr/bin/env node\n' +
+      'require("fs").appendFileSync(process.env.OMC_FAKE_GIT_LOG, process.argv.slice(2).join(" ") + "\\n");\n' +
+      'process.exit(1);\n',
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      join(fakeBinDir, 'git.cmd'),
+      '@echo off\r\nnode "%~dp0\\git" %*\r\n',
+    );
+
+    const out = runContextGuardStopWithEnv(
+      {
+        session_id: `session-${Date.now()}`,
+        transcript_path: missingTranscriptPath,
+        cwd: tempDir,
+        stop_reason: 'normal',
+      },
+      {
+        PATH: `${fakeBinDir}${delimiter}${process.env.PATH ?? ''}`,
+        OMC_FAKE_GIT_LOG: gitLogPath,
+      },
+    );
+
+    expect(out).toEqual({ continue: true, suppressOutput: true });
+    expect(() => readFileSync(gitLogPath, 'utf-8')).toThrow();
   });
 });

--- a/src/__tests__/run-cjs-graceful-fallback.test.ts
+++ b/src/__tests__/run-cjs-graceful-fallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
@@ -85,9 +85,10 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
   });
 
   it('falls back to latest version when target version is missing', () => {
+    const markerPath = join(tmpDir, 'hook-ok.txt');
     // Create a valid latest version with the target script
     const _latestDir = createFakeVersion('4.4.5', {
-      'test-hook.cjs': '#!/usr/bin/env node\nconsole.log("hook-ok"); process.exit(0);',
+      'test-hook.cjs': `#!/usr/bin/env node\nrequire('fs').writeFileSync(${JSON.stringify(markerPath)}, "hook-ok"); process.exit(0);`,
     });
 
     // Target points to a non-existent old version
@@ -100,16 +101,17 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
 
     // Should find the script in 4.4.5 and run it successfully
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('hook-ok');
+    expect(readFileSync(markerPath, 'utf-8')).toBe('hook-ok');
   });
 
   it('falls back to latest version when multiple versions exist', () => {
+    const markerPath = join(tmpDir, 'version-picked.txt');
     // Create two valid versions
     createFakeVersion('4.4.3', {
-      'test-hook.cjs': '#!/usr/bin/env node\nconsole.log("from-4.4.3"); process.exit(0);',
+      'test-hook.cjs': `#!/usr/bin/env node\nrequire('fs').writeFileSync(${JSON.stringify(markerPath)}, "from-4.4.3"); process.exit(0);`,
     });
     createFakeVersion('4.4.5', {
-      'test-hook.cjs': '#!/usr/bin/env node\nconsole.log("from-4.4.5"); process.exit(0);',
+      'test-hook.cjs': `#!/usr/bin/env node\nrequire('fs').writeFileSync(${JSON.stringify(markerPath)}, "from-4.4.5"); process.exit(0);`,
     });
 
     // Target points to a deleted old version
@@ -122,13 +124,14 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
 
     // Should pick the highest version (4.4.5)
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('from-4.4.5');
+    expect(readFileSync(markerPath, 'utf-8')).toBe('from-4.4.5');
   });
 
   it('resolves target through symlinked version directory', () => {
+    const markerPath = join(tmpDir, 'symlink-hit.txt');
     // Create a real latest version
     const _latestDir = createFakeVersion('4.4.5', {
-      'test-hook.cjs': '#!/usr/bin/env node\nconsole.log("via-symlink"); process.exit(0);',
+      'test-hook.cjs': `#!/usr/bin/env node\nrequire('fs').writeFileSync(${JSON.stringify(markerPath)}, "via-symlink"); process.exit(0);`,
     });
 
     // Create a symlink from old version to latest
@@ -143,12 +146,13 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('via-symlink');
+    expect(readFileSync(markerPath, 'utf-8')).toBe('via-symlink');
   });
 
   it('runs target normally when path is valid (fast path)', () => {
+    const markerPath = join(tmpDir, 'direct-hit.txt');
     const versionDir = createFakeVersion('4.4.5', {
-      'test-hook.cjs': '#!/usr/bin/env node\nconsole.log("direct-ok"); process.exit(0);',
+      'test-hook.cjs': `#!/usr/bin/env node\nrequire('fs').writeFileSync(${JSON.stringify(markerPath)}, "direct-ok"); process.exit(0);`,
     });
 
     const target = join(versionDir, 'scripts', 'test-hook.cjs');
@@ -158,7 +162,7 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('direct-ok');
+    expect(readFileSync(markerPath, 'utf-8')).toBe('direct-ok');
   });
 
   it('exits 0 when no CLAUDE_PLUGIN_ROOT is set and target is missing', () => {
@@ -196,5 +200,48 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
 
     // No version has test-hook.cjs, so exit 0 gracefully
     expect(result.status).toBe(0);
+  });
+
+  it('honors hooks.json timeouts so wrapped hooks fail open instead of blocking', () => {
+    const pluginRoot = join(tmpDir, 'plugin-root');
+    const scriptsDir = join(pluginRoot, 'scripts');
+    const hooksDir = join(pluginRoot, 'hooks');
+    mkdirSync(scriptsDir, { recursive: true });
+    mkdirSync(hooksDir, { recursive: true });
+
+    const slowTarget = join(scriptsDir, 'slow-stop-hook.cjs');
+    writeFileSync(
+      slowTarget,
+      'setTimeout(() => { process.stdout.write("slow-stop-done\\n"); process.exit(0); }, 3000);',
+    );
+    writeFileSync(
+      join(hooksDir, 'hooks.json'),
+      JSON.stringify({
+        hooks: {
+          Stop: [
+            {
+              matcher: '',
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/slow-stop-hook.cjs',
+                  timeout: 1,
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2),
+    );
+
+    const startedAt = Date.now();
+    const result = runCjs(slowTarget, {
+      CLAUDE_PLUGIN_ROOT: pluginRoot,
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain('slow-stop-done');
+    expect(elapsedMs).toBeLessThan(2500);
   });
 });


### PR DESCRIPTION
Fixes the stop-hook hang from issue #2565 by enforcing hooks.json timeouts inside scripts/run.cjs and by skipping/short-timing context-guard git probes in non-git directories. Includes focused regressions for the runner timeout path and the non-git context-guard path.