### PR TITLE
fix(installer): preserve user skills with OMC-style frontmatter during updates

### DIFF
--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -351,6 +351,42 @@ describe('prunePluginDuplicateSkills', () => {
     expect(existsSync(join(skillsDir, 'ralph'))).toBe(true);
   });
 
+  it('removes exact-match standalone alias duplicates like omc-plan while preserving alias lookup behavior', async () => {
+    vi.resetModules();
+    const { prunePluginDuplicateSkills: prune, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+
+    const packagePlanSkill = readFileSync(join(process.cwd(), 'skills', 'plan', 'SKILL.md'), 'utf-8');
+    const aliasSkillDir = join(skillsDir, 'omc-plan');
+    mkdirSync(aliasSkillDir, { recursive: true });
+    writeFileSync(join(aliasSkillDir, 'SKILL.md'), packagePlanSkill);
+
+    const removed = prune(log);
+
+    expect(removed).toContain('omc-plan');
+    expect(existsSync(aliasSkillDir)).toBe(false);
+  });
+
+  it('preserves user-authored standalone alias skills like omc-plan when content differs from plugin copy', async () => {
+    vi.resetModules();
+    const { prunePluginDuplicateSkills: prune, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+
+    const aliasSkillDir = join(skillsDir, 'omc-plan');
+    mkdirSync(aliasSkillDir, { recursive: true });
+    writeFileSync(
+      join(aliasSkillDir, 'SKILL.md'),
+      '---\nname: plan\ndescription: My custom alias skill\n---\n\n# Custom omc-plan\nUser-authored content.\n',
+    );
+
+    const removed = prune(log);
+
+    expect(removed).not.toContain('omc-plan');
+    expect(existsSync(aliasSkillDir)).toBe(true);
+  });
+
   it('preserves omc-learned directory', async () => {
     vi.resetModules();
     const { prunePluginDuplicateSkills: prune, SKILLS_DIR: skillsDir } = await import('../index.js');

--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -295,14 +295,16 @@ describe('prunePluginDuplicateSkills', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('removes standalone skills that match plugin-provided skills', async () => {
+  it('removes standalone skills that match plugin-provided skills when marked as OMC-owned', async () => {
     vi.resetModules();
     const { prunePluginDuplicateSkills: prune, SKILLS_DIR: skillsDir } = await import('../index.js');
 
     mkdirSync(skillsDir, { recursive: true });
 
     // Create a standalone copy of 'ralph' (which the plugin also provides)
+    // and mark it as OMC-owned — this is what a prior `omc setup` would have done
     createSkillDir(skillsDir, 'ralph', 'ralph');
+    createManagedSkillMarker(skillsDir, 'ralph');
 
     const removed = prune(log);
 
@@ -318,6 +320,30 @@ describe('prunePluginDuplicateSkills', () => {
 
     // User-created skill with a name that collides with plugin skill but no OMC frontmatter
     createUserSkillDir(skillsDir, 'ralph');
+
+    const removed = prune(log);
+
+    expect(removed).not.toContain('ralph');
+    expect(existsSync(join(skillsDir, 'ralph'))).toBe(true);
+  });
+
+  it('preserves user skills with standard frontmatter that have different content from plugin version (issue #2573)', async () => {
+    // Regression: the old `isOmcCreated` heuristic treated any skill with
+    // `---\nname:` frontmatter as OMC-owned and deleted it during update,
+    // even when the content differed from the plugin's copy.
+    vi.resetModules();
+    const { prunePluginDuplicateSkills: prune, SKILLS_DIR: skillsDir } = await import('../index.js');
+
+    mkdirSync(skillsDir, { recursive: true });
+
+    // User's custom version of 'ralph' — standard frontmatter, but unique body
+    const customSkillDir = join(skillsDir, 'ralph');
+    mkdirSync(customSkillDir, { recursive: true });
+    writeFileSync(
+      join(customSkillDir, 'SKILL.md'),
+      '---\nname: ralph\ndescription: My custom ralph workflow\n---\n\n# My Custom Ralph\nThis is my personalized version.\n',
+    );
+    // No .omc-managed marker — this is user-owned
 
     const removed = prune(log);
 
@@ -362,6 +388,7 @@ describe('prunePluginDuplicateSkills', () => {
 
     mkdirSync(skillsDir, { recursive: true });
     createSkillDir(skillsDir, 'ralph', 'ralph');
+    createManagedSkillMarker(skillsDir, 'ralph');
 
     const first = prune(log);
     expect(first).toContain('ralph');

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -694,11 +694,16 @@ export function prunePluginDuplicateSkills(log: (msg: string) => void): string[]
     if (existsSync(skillMdPath)) {
       const content = readFileSync(skillMdPath, 'utf-8');
       const { metadata } = parseFrontmatter(content);
+      let safeStandaloneName: string | null = null;
       if (typeof metadata.name === 'string' && metadata.name.trim().length > 0) {
-        pluginSkillNames.add(toSafeStandaloneSkillName(metadata.name));
+        safeStandaloneName = toSafeStandaloneSkillName(metadata.name);
+        pluginSkillNames.add(safeStandaloneName);
       }
       // Store a simple content hash for safety comparison
       pluginSkillHashes.set(entry.name, content.trim());
+      if (safeStandaloneName !== null) {
+        pluginSkillHashes.set(safeStandaloneName, content.trim());
+      }
     }
   }
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -716,14 +716,15 @@ export function prunePluginDuplicateSkills(log: (msg: string) => void): string[]
     try {
       const standaloneContent = readFileSync(skillMdPath, 'utf-8').trim();
 
-      // Safety check: only remove if the standalone content matches the plugin's
-      // copy (or looks like standard OMC frontmatter). This preserves user-authored
-      // skills that happen to share a name with a plugin skill.
+      // Safety check: only remove if the standalone content exactly matches the
+      // plugin's copy, OR the directory is explicitly marked as OMC-owned via the
+      // .omc-managed marker file. Frontmatter structure alone is not a reliable
+      // ownership signal — user skills routinely use the same ---/name: format.
       const pluginContent = pluginSkillHashes.get(entry.name);
-      const isOmcCreated = standaloneContent.startsWith('---\n') && /^name:\s+\S+/m.test(standaloneContent);
+      const skillDir = join(SKILLS_DIR, entry.name);
 
-      if (pluginContent === standaloneContent || isOmcCreated) {
-        rmSync(join(SKILLS_DIR, entry.name), { recursive: true, force: true });
+      if (pluginContent === standaloneContent || isOmcManagedSkillDir(skillDir)) {
+        rmSync(skillDir, { recursive: true, force: true });
         removed.push(entry.name);
         log(`  Pruned plugin-duplicate skill: ${entry.name}/`);
       }


### PR DESCRIPTION
## Problem

Fixes #2573. When running `omc update`, `prunePluginDuplicateSkills()` deleted user-created skills from `~/.claude/skills/` if:

1. The skill name matched a plugin-provided skill (e.g. `ralph`, `commit`), AND
2. The skill's `SKILL.md` had standard YAML frontmatter (`---\nname: ...`)

The root cause was an overly broad `isOmcCreated` heuristic that treated **any** skill with `---\n` + `name:` frontmatter as OMC-owned and eligible for deletion — even if the content was entirely user-authored.

## Root Cause

```typescript
// BEFORE (broken): frontmatter structure ≠ OMC ownership
const isOmcCreated = standaloneContent.startsWith('---\n') && /^name:\s+\S+/m.test(standaloneContent);
if (pluginContent === standaloneContent || isOmcCreated) {
  rmSync(...)  // ← deleted user skills
}
```

Standard YAML frontmatter is the format for **all** skills, including user-created ones. The heuristic provided no real ownership signal.

## Fix

Replace the frontmatter heuristic with `isOmcManagedSkillDir()` — the same `.omc-managed` marker-file check that `cleanupStaleSkills()` already uses correctly:

```typescript
// AFTER (correct): explicit ownership marker
if (pluginContent === standaloneContent || isOmcManagedSkillDir(skillDir)) {
  rmSync(...)  // ← only deletes OMC-installed copies
}
```

A skill is now pruned only when:
- Its `SKILL.md` content **exactly matches** the plugin's copy, OR  
- The `.omc-managed` marker file is present (written by `omc setup` at install time)

## Changes

| File | Change |
|------|--------|
| `src/installer/index.ts` | Replace `isOmcCreated` heuristic with `isOmcManagedSkillDir()` in `prunePluginDuplicateSkills()` |
| `src/installer/__tests__/stale-cleanup.test.ts` | Add regression test for #2573; update two existing tests to include `.omc-managed` marker (reflecting real install behavior) |

## Test plan

- [x] `npm test -- run src/installer/__tests__/stale-cleanup.test.ts` — all 25 tests pass
- [x] New regression test: user skill with `---/name:` frontmatter, name colliding with plugin skill, different content → **preserved**
- [x] Existing test: OMC-installed skill (with `.omc-managed` marker) → **pruned** (correct behavior unchanged)
- [x] Existing test: user skill without frontmatter → **preserved** (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)