### PR TITLE
fix(permission-handler): allow read-only gh issue/pr commands; add installer lib assertions

### DIFF
--- a/src/__tests__/installer-plugin-agents.test.ts
+++ b/src/__tests__/installer-plugin-agents.test.ts
@@ -132,6 +132,8 @@ describe('installer legacy agent sync gating (issue #1502)', () => {
     expect(result.installedAgents.length).toBeGreaterThan(0);
     expect(existsSync(join(claudeConfigDir, 'agents'))).toBe(true);
     expect(readdirSync(join(claudeConfigDir, 'agents')).some(file => file.endsWith('.md'))).toBe(true);
+    expect(existsSync(join(claudeConfigDir, 'hooks', 'lib', 'stdin.mjs'))).toBe(true);
+    expect(existsSync(join(claudeConfigDir, 'hooks', 'lib', 'atomic-write.mjs'))).toBe(true);
     expect(installer.hasPluginProvidedAgentFiles()).toBe(false);
     expect(installer.isInstalled()).toBe(true);
   });

--- a/src/hooks/permission-handler/__tests__/index.test.ts
+++ b/src/hooks/permission-handler/__tests__/index.test.ts
@@ -39,6 +39,11 @@ describe('permission-handler', () => {
         'ls "my folder"',
         'ls \'my folder\'',
         'git diff "src/file with spaces.ts"',
+        'gh issue list',
+        'gh issue view 2508',
+        'gh issue status',
+        'gh pr view 2510',
+        'gh pr list --state open',
       ];
 
       safeCases.forEach((cmd) => {

--- a/src/hooks/permission-handler/index.ts
+++ b/src/hooks/permission-handler/index.ts
@@ -36,6 +36,7 @@ const SAFE_PATTERNS = [
   /^pnpm (test|run (test|lint|build|check|typecheck))/,
   /^yarn (test|run (test|lint|build|check|typecheck))/,
   /^tsc( |$)/,
+  /^gh (issue|pr) (view|list|status)\b/,
   /^eslint /,
   /^prettier /,
   /^cargo (test|check|clippy|build)/,


### PR DESCRIPTION
## Summary

- Adds `gh (issue|pr) (view|list|status)` to `SAFE_PATTERNS` in `src/hooks/permission-handler/index.ts` so routine read-only GitHub CLI queries no longer require a permission prompt
- Extends `src/hooks/permission-handler/__tests__/index.test.ts` with 5 matching `gh` safe-case assertions
- Extends the installer smoke test (`src/__tests__/installer-plugin-agents.test.ts`) to assert that `stdin.mjs` and `atomic-write.mjs` are present under `hooks/lib/` after install

Closes #2566

## Test plan

- [x] `npx vitest run src/__tests__/installer-plugin-agents.test.ts src/hooks/permission-handler/__tests__/index.test.ts` → 127/127 passed
- [x] `npx tsc --noEmit` → clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)