### PR TITLE
fix(hooks): prevent duplicate hook firing when plugin and standalone coexist

### DIFF
--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -120,5 +120,184 @@ describe('install() standalone hook reconciliation', () => {
     expect(commands).toContain(
       `node "${join(testClaudeDir, 'hooks', 'keyword-detector.mjs').replace(/\\/g, '/')}"`,
     );
+  });
+});
+
+// ── Plugin-provided hooks: duplicate prevention (#2252) ─────────────────────
+
+describe('install() plugin-provided hook deduplication (#2252)', () => {
+  let fakePluginRoot: string;
+
+  beforeEach(() => {
+    testClaudeDir = mkdtempSync(join(tmpdir(), 'omc-hook-dedup-'));
+    testHomeDir = mkdtempSync(join(tmpdir(), 'omc-home-dedup-'));
+    mkdirSync(testHomeDir, { recursive: true });
+    writeFileSync(join(testHomeDir, 'CLAUDE.md'), '# test home claude');
+    process.env.CLAUDE_CONFIG_DIR = testClaudeDir;
+    process.env.HOME = testHomeDir;
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+  });
+
+  afterEach(() => {
+    if (fakePluginRoot) {
+      rmSync(fakePluginRoot, { recursive: true, force: true });
+    }
+    rmSync(testClaudeDir, { recursive: true, force: true });
+    rmSync(testHomeDir, { recursive: true, force: true });
+    if (originalClaudeConfigDir !== undefined) {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    } else {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    }
+    if (originalPluginRoot !== undefined) {
+      process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+    } else {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    }
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+  });
+
+  function setupPluginWithHooks() {
+    // Create a fake plugin root with hooks/hooks.json
+    fakePluginRoot = mkdtempSync(join(tmpdir(), 'omc-fake-plugin-'));
+    const hooksDir = join(fakePluginRoot, 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(join(hooksDir, 'hooks.json'), JSON.stringify({
+      hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'node test.mjs' }] }] },
+    }));
+
+    // Register plugin in installed_plugins.json
+    const pluginsDir = join(testClaudeDir, 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, 'installed_plugins.json'), JSON.stringify({
+      'oh-my-claudecode': [{ installPath: fakePluginRoot }],
+    }));
+
+    // Mark plugin as enabled in settings.json
+    mkdirSync(testClaudeDir, { recursive: true });
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+    }, null, 2));
+  }
+
+  it('hasPluginProvidedHookFiles returns true when hooks.json exists in plugin root', async () => {
+    setupPluginWithHooks();
+    const { hasPluginProvidedHookFiles } = await loadInstaller();
+    expect(hasPluginProvidedHookFiles()).toBe(true);
+  });
+
+  it('hasPluginProvidedHookFiles returns false when no plugin provides hooks', async () => {
+    const { hasPluginProvidedHookFiles } = await loadInstaller();
+    expect(hasPluginProvidedHookFiles()).toBe(false);
+  });
+
+  it('skips standalone hook scripts when plugin provides hooks.json', async () => {
+    setupPluginWithHooks();
+
+    const { install } = await loadInstaller();
+    install({ force: true, skipClaudeCheck: true });
+
+    // Standalone hook scripts should NOT be copied to ~/.claude/hooks/
+    expect(existsSync(join(testClaudeDir, 'hooks', 'keyword-detector.mjs'))).toBe(false);
+    expect(existsSync(join(testClaudeDir, 'hooks', 'pre-tool-use.mjs'))).toBe(false);
+    expect(existsSync(join(testClaudeDir, 'hooks', 'session-start.mjs'))).toBe(false);
+  });
+
+  it('does not write OMC hook entries to settings.json when plugin provides hooks', async () => {
+    setupPluginWithHooks();
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true });
+
+    const writtenSettings = JSON.parse(
+      readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8'),
+    ) as { hooks?: Record<string, unknown> };
+
+    expect(result.success).toBe(true);
+    // OMC hooks should NOT be in settings.json — plugin handles them via hooks.json
+    expect(writtenSettings.hooks).toBeUndefined();
+  });
+
+  it('removes stale OMC hook entries from settings.json when plugin provides hooks', async () => {
+    // Pre-populate settings.json with stale OMC hook entries (simulating prior standalone install)
+    mkdirSync(testClaudeDir, { recursive: true });
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: {
+        UserPromptSubmit: [
+          {
+            hooks: [{
+              type: 'command',
+              command: 'node "$HOME/.claude/hooks/keyword-detector.mjs"',
+            }],
+          },
+        ],
+        SessionStart: [
+          {
+            hooks: [{
+              type: 'command',
+              command: 'node "$HOME/.claude/hooks/session-start.mjs"',
+            }],
+          },
+        ],
+      },
+    }, null, 2));
+
+    setupPluginWithHooks();
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true });
+
+    const writtenSettings = JSON.parse(
+      readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8'),
+    ) as { hooks?: Record<string, unknown> };
+
+    expect(result.success).toBe(true);
+    // Stale OMC hook entries should be cleaned up by legacy cleanup,
+    // and NOT re-added because plugin provides hooks
+    expect(writtenSettings.hooks).toBeUndefined();
+  });
+
+  it('preserves non-OMC hooks in settings.json when pruning plugin duplicates', async () => {
+    // Set up plugin first (creates settings.json with enabledPlugins)
+    setupPluginWithHooks();
+
+    // Then overwrite settings.json with mixed OMC + non-OMC hooks
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: {
+        UserPromptSubmit: [
+          {
+            hooks: [{
+              type: 'command',
+              command: 'node $HOME/.claude/hooks/other-plugin.mjs',
+            }],
+          },
+          {
+            hooks: [{
+              type: 'command',
+              command: 'node "$HOME/.claude/hooks/keyword-detector.mjs"',
+            }],
+          },
+        ],
+      },
+    }, null, 2));
+
+    const { install } = await loadInstaller();
+    install({ force: true, skipClaudeCheck: true });
+
+    const writtenSettings = JSON.parse(
+      readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8'),
+    ) as { hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
+
+    // Non-OMC hook should be preserved
+    const commands = writtenSettings.hooks?.UserPromptSubmit?.map(g => g.hooks[0]?.command) ?? [];
+    expect(commands).toContain('node $HOME/.claude/hooks/other-plugin.mjs');
+    // OMC hook should NOT be re-added
+    expect(commands).not.toContain('node "$HOME/.claude/hooks/keyword-detector.mjs"');
   });
 });

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -817,6 +817,12 @@ export function hasPluginProvidedSkillFiles(): boolean {
   );
 }
 
+export function hasPluginProvidedHookFiles(): boolean {
+  return getInstalledOmcPluginRoots().some(pluginRoot =>
+    existsSync(join(pluginRoot, 'hooks', 'hooks.json'))
+  );
+}
+
 export function hasEnabledOmcPlugin(): boolean {
   if (process.env.CLAUDE_PLUGIN_ROOT?.trim()) {
     return true;
@@ -1198,6 +1204,7 @@ export function install(options: InstallOptions = {}): InstallResult {
   const projectScoped = isProjectScopedPlugin();
   const pluginProvidesAgentFiles = hasPluginProvidedAgentFiles();
   const pluginProvidesSkillFiles = hasPluginProvidedSkillFiles();
+  const pluginProvidesHookFiles = hasPluginProvidedHookFiles();
   const enabledOmcPlugin = hasEnabledOmcPlugin();
   // Dev plugin-dir mode: user launched OMC via `claude --plugin-dir <path>` or
   // `omc --plugin-dir <path>`. The plugin already exposes agents/skills at runtime,
@@ -1332,7 +1339,14 @@ export function install(options: InstallOptions = {}): InstallResult {
       // Standalone installs still need ~/.claude/hooks/* scripts because their
       // settings.json hook entries execute those local paths directly. Plugin installs
       // keep using hooks/hooks.json + scripts/ under CLAUDE_PLUGIN_ROOT.
-      ensureStandaloneHookScripts(log);
+      // Skip when the plugin already provides hooks AND is enabled to prevent
+      // duplicate firing (#2252). If the plugin is disabled, standalone scripts
+      // are still needed for settings.json hook entries to work at runtime.
+      if (!(pluginProvidesHookFiles && enabledOmcPlugin)) {
+        ensureStandaloneHookScripts(log);
+      } else {
+        log('Skipping standalone hook scripts (plugin-provided hooks are available)');
+      }
       result.hooksConfigured = true; // Will be set properly after consolidated settings.json write
     } else {
       log('Skipping agent/command/hook files (managed by plugin system)');
@@ -1484,7 +1498,11 @@ export function install(options: InstallOptions = {}): InstallResult {
           log(`  Cleaned up ${legacyRemoved} legacy hook entries from settings.json`);
         }
 
-        const shouldConfigureSettingsHooks = !runningAsPlugin || allowPluginHookRefresh;
+        // Skip writing hooks to settings.json when the plugin provides hooks via
+        // hooks.json — the legacy cleanup above already removed stale OMC entries,
+        // and re-adding them would cause duplicate hook firing (#2252).
+        const pluginHandlesHooks = pluginProvidesHookFiles && enabledOmcPlugin;
+        const shouldConfigureSettingsHooks = (!runningAsPlugin || allowPluginHookRefresh) && !pluginHandlesHooks;
         if (shouldConfigureSettingsHooks) {
           const desiredHooks = getHooksSettingsConfig().hooks as Record<string, HookGroup[]>;
 


### PR DESCRIPTION
## Summary

- Fixes duplicate hook firing when both the OMC plugin and standalone `omc setup` CLI coexist — the same pattern as #2252 (which fixed skills/agents) but was never applied to hooks
- Adds `hasPluginProvidedHookFiles()` detection function mirroring `hasPluginProvidedSkillFiles()`/`hasPluginProvidedAgentFiles()`
- Guards `ensureStandaloneHookScripts()` and `shouldConfigureSettingsHooks` to skip standalone hook installation when the plugin provides hooks via `hooks.json`

## Root Cause

When running `omc setup` from CLI with the OMC plugin also installed:
1. Plugin delivers hooks via `hooks/hooks.json` under `CLAUDE_PLUGIN_ROOT`
2. CLI installer copies hook scripts to `~/.claude/hooks/` and writes hook entries to `settings.json`
3. Claude Code reads **both** sources, causing every hook to fire twice

The existing legacy cleanup (removing stale OMC entries from `settings.json`) ran correctly but `shouldConfigureSettingsHooks` immediately re-added them. No separate `prunePluginDuplicateHookEntries()` was needed — the guard alone is sufficient since the legacy cleanup handles stale entries.

## Changes

| File | Change |
|------|--------|
| `src/installer/index.ts` | Add `hasPluginProvidedHookFiles()` (3 lines), wire `pluginProvidesHookFiles` into install flow, guard hook script copy and settings.json write |
| `src/installer/__tests__/standalone-hook-reconcile.test.ts` | Add 6 new test cases covering plugin+standalone coexistence, standalone-only, mixed hooks preservation |

## Test plan

- [x] `hasPluginProvidedHookFiles` returns `true` when `hooks.json` exists in plugin root
- [x] `hasPluginProvidedHookFiles` returns `false` when no plugin provides hooks
- [x] Standalone hook scripts are NOT copied when plugin provides hooks
- [x] OMC hook entries are NOT written to settings.json when plugin provides hooks
- [x] Stale OMC hook entries from prior standalone installs are cleaned up
- [x] Non-OMC hooks in settings.json are preserved during cleanup
- [x] Existing standalone install tests continue to pass (standalone-only still works)
- [x] All 8 tests in `standalone-hook-reconcile.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)