### PR TITLE
feat(hooks): add memory-sync — auto-sync Claude memories to private git vault

### DIFF
--- a/src/hooks/memory-sync/__tests__/sync.test.ts
+++ b/src/hooks/memory-sync/__tests__/sync.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { extractProjectName } from '../sync.js';
+
+describe('extractProjectName', () => {
+  it('extracts name from standard workspace path', () => {
+    expect(extractProjectName('-Users-bob-workspace-speakeasy')).toBe('speakeasy');
+  });
+
+  it('extracts hyphenated project names', () => {
+    expect(extractProjectName('-Users-bob-workspace-ai-job-matcher')).toBe('ai-job-matcher');
+  });
+
+  it('extracts deeply nested workspace paths', () => {
+    expect(extractProjectName('-Users-bob-workspace-rag-customer-service')).toBe('rag-customer-service');
+  });
+
+  it('handles non-workspace paths under home', () => {
+    expect(extractProjectName('-Users-bob-auto-video')).toBe('auto-video');
+  });
+
+  it('handles iCloud/Documents paths', () => {
+    expect(extractProjectName('-Users-bob-Library-Mobile-Documents-iCloud-md-obsidian-Documents-daily'))
+      .toBe('obsidian-daily');
+  });
+
+  it('handles root user path', () => {
+    expect(extractProjectName('-Users-bob')).toBe('global-user');
+  });
+
+  it('handles worktree paths', () => {
+    expect(extractProjectName('-Users-bob-workspace--worktrees-rag-paddleocr'))
+      .toBe('-worktrees-rag-paddleocr');
+  });
+});

--- a/src/hooks/memory-sync/index.ts
+++ b/src/hooks/memory-sync/index.ts
@@ -1,0 +1,114 @@
+/**
+ * Memory Sync Hook — SessionEnd handler
+ *
+ * Syncs Claude Code project memories to a user-configured private git
+ * vault on session end.
+ *
+ * Purpose:
+ * - Version-controlled backup of Claude memory (knowledge assets)
+ * - Cross-machine portability
+ * - Memory evolution tracking over time
+ *
+ * Configuration (in .omc/config.json or OMC config):
+ *   memorySync: {
+ *     enabled: true,
+ *     vaultPath: "~/workspace/claude-memory-vault",
+ *     autoPush: false,
+ *     timeout: 10000
+ *   }
+ */
+
+import * as fs from 'fs';
+import type { MemorySyncConfig, SyncResult } from './types.js';
+import { DEFAULT_CONFIG } from './types.js';
+import { syncMemory } from './sync.js';
+
+export { extractProjectName } from './sync.js';
+export type { MemorySyncConfig, SyncResult, FileChange } from './types.js';
+
+export interface MemorySyncInput {
+  session_id: string;
+  cwd: string;
+  hook_event_name: 'SessionEnd';
+}
+
+export interface MemorySyncOutput {
+  continue: boolean;
+  result?: SyncResult;
+}
+
+/**
+ * Load memory sync config from OMC config or environment.
+ */
+export function loadConfig(): MemorySyncConfig {
+  // Try environment variable first
+  const envVaultPath = process.env.OMC_MEMORY_VAULT_PATH;
+  const envEnabled = process.env.OMC_MEMORY_SYNC_ENABLED;
+  const envAutoPush = process.env.OMC_MEMORY_SYNC_AUTO_PUSH;
+
+  if (envVaultPath) {
+    const home = process.env.HOME || '';
+    const resolvedPath = envVaultPath.replace(/^~/, home);
+
+    return {
+      enabled: envEnabled !== 'false',
+      vaultPath: resolvedPath,
+      autoPush: envAutoPush === 'true',
+      timeout: DEFAULT_CONFIG.timeout,
+    };
+  }
+
+  // Try OMC config file
+  const configPaths = [
+    `${process.env.HOME}/.omc/config.json`,
+    `${process.cwd()}/.omc/config.json`,
+  ];
+
+  for (const configPath of configPaths) {
+    try {
+      const content = fs.readFileSync(configPath, 'utf-8');
+      const config = JSON.parse(content);
+
+      if (config.memorySync) {
+        const home = process.env.HOME || '';
+        return {
+          ...DEFAULT_CONFIG,
+          ...config.memorySync,
+          vaultPath: (config.memorySync.vaultPath || '').replace(/^~/, home),
+        };
+      }
+    } catch {
+      // Config file not found or invalid, try next
+    }
+  }
+
+  return DEFAULT_CONFIG;
+}
+
+/**
+ * Main hook handler — called by the SessionEnd bridge script.
+ */
+export function processMemorySync(_input: MemorySyncInput): MemorySyncOutput {
+  const config = loadConfig();
+
+  if (!config.enabled) {
+    return { continue: true };
+  }
+
+  try {
+    const result = syncMemory(config);
+    return { continue: true, result };
+  } catch (error) {
+    // Memory sync should never block session end
+    return {
+      continue: true,
+      result: {
+        synced: false,
+        filesChanged: 0,
+        committed: false,
+        pushed: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}

--- a/src/hooks/memory-sync/sync.ts
+++ b/src/hooks/memory-sync/sync.ts
@@ -1,0 +1,259 @@
+/**
+ * Memory Sync — Core sync logic
+ *
+ * Scans Claude project memories, diffs against vault, copies changed files,
+ * and commits to the vault git repo.
+ */
+
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { MemorySyncConfig, SyncResult, FileChange } from './types.js';
+
+/**
+ * Extract a readable project name from Claude's internal path hash.
+ *
+ * Examples:
+ *   -Users-bob-workspace-speakeasy       → speakeasy
+ *   -Users-bob-workspace-ai-job-matcher  → ai-job-matcher
+ *   -Users-bob-auto-video                → auto-video
+ *   -Users-bob                           → global-user
+ */
+export function extractProjectName(dirName: string): string {
+  if (dirName.includes('-workspace-')) {
+    return dirName.split('-workspace-').pop()!;
+  }
+  if (dirName.includes('-Documents-')) {
+    return 'obsidian-' + dirName.split('-Documents-').pop()!;
+  }
+  // Short root path like -Users-bob
+  const stripped = dirName.replace(/^-Users-[^-]+-?/, '');
+  return stripped || 'global-user';
+}
+
+/**
+ * Scan Claude project directories and find changed memory files.
+ */
+function scanChangedFiles(
+  claudeDir: string,
+  vaultDir: string,
+): FileChange[] {
+  const changes: FileChange[] = [];
+  const projectsDir = path.join(claudeDir, 'projects');
+
+  if (!fs.existsSync(projectsDir)) return changes;
+
+  for (const entry of fs.readdirSync(projectsDir)) {
+    const memoryDir = path.join(projectsDir, entry, 'memory');
+    if (!fs.existsSync(memoryDir) || !fs.statSync(memoryDir).isDirectory()) {
+      continue;
+    }
+
+    const projectName = extractProjectName(entry);
+    const targetMemoryDir = path.join(vaultDir, 'projects', projectName, 'memory');
+
+    // Scan memory/*.md files
+    for (const file of fs.readdirSync(memoryDir)) {
+      if (!file.endsWith('.md')) continue;
+
+      const source = path.join(memoryDir, file);
+      const target = path.join(targetMemoryDir, file);
+
+      if (isFileChanged(source, target)) {
+        changes.push({ source, target, project: projectName, type: 'memory' });
+      }
+    }
+
+    // Check per-project CLAUDE.md
+    const projectClaudeMd = path.join(projectsDir, entry, 'CLAUDE.md');
+    if (fs.existsSync(projectClaudeMd)) {
+      const target = path.join(vaultDir, 'projects', projectName, 'CLAUDE.md');
+      if (isFileChanged(projectClaudeMd, target)) {
+        changes.push({
+          source: projectClaudeMd,
+          target,
+          project: projectName,
+          type: 'claude-md',
+        });
+      }
+    }
+  }
+
+  // Global CLAUDE.md
+  const globalClaudeMd = path.join(claudeDir, 'CLAUDE.md');
+  if (fs.existsSync(globalClaudeMd)) {
+    const target = path.join(vaultDir, 'global', 'CLAUDE.md');
+    if (isFileChanged(globalClaudeMd, target)) {
+      changes.push({
+        source: globalClaudeMd,
+        target,
+        project: 'global',
+        type: 'claude-md',
+      });
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Compare source and target files by content.
+ * Returns true if they differ or target doesn't exist.
+ */
+function isFileChanged(source: string, target: string): boolean {
+  if (!fs.existsSync(target)) return true;
+
+  try {
+    const sourceContent = fs.readFileSync(source, 'utf-8');
+    const targetContent = fs.readFileSync(target, 'utf-8');
+    return sourceContent !== targetContent;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Copy changed files to vault.
+ */
+function copyFiles(changes: FileChange[]): number {
+  let copied = 0;
+  for (const change of changes) {
+    const targetDir = path.dirname(change.target);
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.copyFileSync(change.source, change.target);
+    copied++;
+  }
+  return copied;
+}
+
+/**
+ * Check if vault path is a git repo.
+ */
+function isGitRepo(dir: string): boolean {
+  try {
+    execSync('git rev-parse --is-inside-work-tree', {
+      cwd: dir,
+      encoding: 'utf-8',
+      timeout: 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Commit changes in the vault.
+ */
+function commitChanges(vaultDir: string, filesChanged: number): boolean {
+  try {
+    execSync('git add -A', {
+      cwd: vaultDir,
+      encoding: 'utf-8',
+      timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    // Check if there's actually something to commit
+    execSync('git diff --cached --quiet', {
+      cwd: vaultDir,
+      encoding: 'utf-8',
+      timeout: 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    // If git diff --cached --quiet succeeds (exit 0), nothing staged
+    return false;
+  } catch {
+    // git diff --cached --quiet exits 1 when there ARE changes — commit them
+    try {
+      const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 16);
+      execSync(
+        `git commit -m "sync: ${filesChanged} files updated (${timestamp})"`,
+        {
+          cwd: vaultDir,
+          encoding: 'utf-8',
+          timeout: 15_000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Push vault to remote.
+ */
+function pushToRemote(vaultDir: string): boolean {
+  try {
+    execSync('git push', {
+      cwd: vaultDir,
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Main sync function — called from the SessionEnd hook.
+ */
+export function syncMemory(config: MemorySyncConfig): SyncResult {
+  const claudeDir = path.join(process.env.HOME || '', '.claude');
+  const vaultDir = config.vaultPath;
+
+  // Validate
+  if (!config.enabled) {
+    return { synced: false, filesChanged: 0, committed: false, pushed: false };
+  }
+
+  if (!vaultDir || !fs.existsSync(vaultDir)) {
+    return {
+      synced: false,
+      filesChanged: 0,
+      committed: false,
+      pushed: false,
+      error: `Vault path does not exist: ${vaultDir}`,
+    };
+  }
+
+  if (!isGitRepo(vaultDir)) {
+    return {
+      synced: false,
+      filesChanged: 0,
+      committed: false,
+      pushed: false,
+      error: `Vault path is not a git repository: ${vaultDir}`,
+    };
+  }
+
+  // Scan and copy
+  const changes = scanChangedFiles(claudeDir, vaultDir);
+  if (changes.length === 0) {
+    return { synced: true, filesChanged: 0, committed: false, pushed: false };
+  }
+
+  const copied = copyFiles(changes);
+
+  // Commit
+  const committed = commitChanges(vaultDir, copied);
+
+  // Push (optional)
+  let pushed = false;
+  if (committed && config.autoPush) {
+    pushed = pushToRemote(vaultDir);
+  }
+
+  return {
+    synced: true,
+    filesChanged: copied,
+    committed,
+    pushed,
+  };
+}

--- a/src/hooks/memory-sync/types.ts
+++ b/src/hooks/memory-sync/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Memory Sync — Types
+ *
+ * Syncs Claude Code project memories to a user-configured git vault
+ * on SessionEnd for versioned backup and cross-machine portability.
+ */
+
+export interface MemorySyncConfig {
+  /** Enable/disable memory sync (default: false) */
+  enabled: boolean;
+
+  /** Path to the vault git repository */
+  vaultPath: string;
+
+  /** Auto-push to remote after commit (default: false) */
+  autoPush: boolean;
+
+  /** Timeout in ms for the entire sync operation (default: 10000) */
+  timeout: number;
+}
+
+export const DEFAULT_CONFIG: MemorySyncConfig = {
+  enabled: false,
+  vaultPath: '',
+  autoPush: false,
+  timeout: 10_000,
+};
+
+/** What to sync and what to skip */
+export const SYNC_INCLUDE = {
+  /** Claude project memory files */
+  projectMemory: 'projects/*/memory/*.md',
+  /** Global CLAUDE.md */
+  globalClaudeMd: 'CLAUDE.md',
+  /** Per-project CLAUDE.md */
+  projectClaudeMd: 'projects/*/CLAUDE.md',
+} as const;
+
+export const SYNC_EXCLUDE = [
+  'history.jsonl',
+  'sessions/',
+  'backups/',
+  'plugins/',
+  'settings.json',
+  '*.auth.json',
+  '.credentials',
+] as const;
+
+export interface SyncResult {
+  synced: boolean;
+  filesChanged: number;
+  committed: boolean;
+  pushed: boolean;
+  error?: string;
+}
+
+export interface FileChange {
+  source: string;
+  target: string;
+  project: string;
+  type: 'memory' | 'claude-md' | 'plan';
+}


### PR DESCRIPTION
## Summary

- Adds `memory-sync` SessionEnd hook that syncs Claude Code project memories (`~/.claude/projects/*/memory/*.md`) to a user-configured private git vault
- Scans project memories + global/project CLAUDE.md, diffs against vault, copies only changed files, auto-commits with descriptive message
- Configurable via env vars (`OMC_MEMORY_VAULT_PATH`) or `.omc/config.json`

## Motivation

Claude Code's project memories are **knowledge assets** that accumulate across sessions — architecture decisions, feedback, project context. Today they are:
- Not version-controlled (no history of how understanding evolves)
- Not portable (tied to machine-specific paths in `~/.claude/projects/`)
- Not backed up (disk failure = total loss)

This hook solves all three by syncing to a private git repo on every session end.

## Design

```
SessionEnd triggered
  → Scan ~/.claude/projects/*/memory/*.md
  → Diff against vault (content comparison)
  → Copy changed files (path hash → readable name mapping)
  → git add + commit (auto-generated message)
  → git push (optional, configurable)
```

**What syncs:** project memories, CLAUDE.md (global + per-project)
**What doesn't sync:** history.jsonl, sessions/, backups/, plugins/, credentials

## Configuration

```bash
# Via environment variables
export OMC_MEMORY_VAULT_PATH="~/workspace/claude-memory-vault"
export OMC_MEMORY_SYNC_ENABLED=true
export OMC_MEMORY_SYNC_AUTO_PUSH=false

# Or via .omc/config.json
{ "memorySync": { "enabled": true, "vaultPath": "~/workspace/claude-memory-vault" } }
```

## Test plan

- [x] Unit tests for path extraction (7 tests passing)
- [x] ESLint clean (0 errors, 0 warnings)
- [x] Tested with real Claude memories (54 files across 13 projects synced successfully)
- [ ] Integration test with SessionEnd hook registration
- [ ] Test on fresh machine (cross-machine portability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)