### PR TITLE
Harden tmux keyword alerting against review/payload noise

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -434,6 +434,19 @@ describe("parseTmuxTail noise filters", () => {
       "Runtime error: worker crashed after SIGTERM\nThe failure is actionable: restart the pane and rerun the task",
     );
   });
+
+  it("preserves vitest runtime failure prose while collapsing structured literals", () => {
+    const input = [
+      'mcp: {"jsonrpc":"2.0","error":{"code":"operation_failed","message":"claim_conflict"}}',
+      '+ const payload = { status: "failed", error: "claim_conflict" };',
+      "Error: Cannot find module vitest",
+      "failed to load config from /tmp/x/vitest.config.ts",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe(
+      "Error: Cannot find module vitest\nfailed to load config from /tmp/x/vitest.config.ts",
+    );
+  });
 });
 
 describe("tmuxTail in formatters", () => {

--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -379,6 +379,61 @@ describe("parseTmuxTail noise filters", () => {
 
     expect(parseTmuxTail(input)).toBe("");
   });
+
+  it("drops review prose enumerating error/fail/conflict verdicts", () => {
+    const input = [
+      "Review the run and reply with one outcome:",
+      "1. error",
+      "2. fail",
+      "3. conflict",
+      "4. blocked",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("drops diff and code literal lines that only mention alert keywords", () => {
+    const input = [
+      "diff --git a/src/app.ts b/src/app.ts",
+      '+ throw new Error("worker_notify_failed");',
+      '+ const payload = { status: "failed", error: "claim_conflict" };',
+      '@@ -10,4 +10,4 @@',
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("drops MCP payload literals that only contain structured failure markers", () => {
+    const input = [
+      'mcp: {"jsonrpc":"2.0","error":{"code":"operation_failed","message":"claim_conflict"}}',
+      'response: {"ok":false,"reason":"worker_notify_failed"}',
+      'payload: {"status":"failed","details":["invalid_transition"]}',
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("preserves actionable runtime failures written as normal prose", () => {
+    const input = [
+      "worker_notify_failed while dispatching startup inbox",
+      "Task failed after retry budget exhausted",
+      "Resolve the merge conflict in src/team/runtime-v2.ts before rerunning tests",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe(input);
+  });
+
+  it("preserves real runtime errors even when adjacent to MCP-ish context", () => {
+    const input = [
+      'payload: {"status":"completed"}',
+      "Runtime error: worker crashed after SIGTERM",
+      "The failure is actionable: restart the pane and rerun the task",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe(
+      "Runtime error: worker crashed after SIGTERM\nThe failure is actionable: restart the pane and rerun the task",
+    );
+  });
 });
 
 describe("tmuxTail in formatters", () => {

--- a/src/notifications/__tests__/notify-registry-integration.test.ts
+++ b/src/notifications/__tests__/notify-registry-integration.test.ts
@@ -21,6 +21,11 @@ const mockCapturePaneContent = vi.fn<(paneId: string, lines?: number) => string>
 vi.mock("../../features/rate-limit-wait/tmux-detector.js", () => ({
   capturePaneContent: (paneId: string, lines?: number) => mockCapturePaneContent(paneId, lines),
 }));
+const mockGetNewPaneTail = vi.fn<(paneId: string, stateDir: string, maxLines?: number) => string>();
+vi.mock("../../features/rate-limit-wait/pane-fresh-capture.js", () => ({
+  getNewPaneTail: (paneId: string, stateDir: string, maxLines?: number) =>
+    mockGetNewPaneTail(paneId, stateDir, maxLines),
+}));
 
 // Mock config - use forwarding fns so we can swap implementations per-test
 const mockGetNotificationConfig = vi.fn();
@@ -90,6 +95,7 @@ describe("notify() -> session-registry integration", () => {
     mockShouldIncludeTmuxTail.mockReturnValue(false);
     mockGetTmuxTailLines.mockReturnValue(15);
     mockCapturePaneContent.mockReturnValue("");
+    mockGetNewPaneTail.mockReturnValue("");
   });
 
   afterEach(() => {
@@ -212,7 +218,7 @@ describe("notify() -> session-registry integration", () => {
   it("captures tmux tail using the configured line count", async () => {
     mockShouldIncludeTmuxTail.mockReturnValue(true);
     mockGetTmuxTailLines.mockReturnValue(23);
-    mockCapturePaneContent.mockReturnValue("line 1\nline 2");
+    mockGetNewPaneTail.mockReturnValue("line 1\nline 2");
 
     vi.stubGlobal(
       "fetch",
@@ -229,7 +235,31 @@ describe("notify() -> session-registry integration", () => {
     });
 
     expect(result).not.toBeNull();
-    expect(mockCapturePaneContent).toHaveBeenCalledWith("%42", 23);
+    expect(mockGetNewPaneTail).toHaveBeenCalledWith("%42", "/test/project/.omc/state", 23);
+    expect(mockCapturePaneContent).not.toHaveBeenCalled();
+  });
+
+  it("falls back to direct pane capture when projectPath is unavailable", async () => {
+    mockShouldIncludeTmuxTail.mockReturnValue(true);
+    mockGetTmuxTailLines.mockReturnValue(12);
+    mockCapturePaneContent.mockReturnValue("runtime failure");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: "discord-msg-tail-fallback" }),
+      }),
+    );
+
+    const result = await notify("session-idle", {
+      sessionId: "sess-tail-no-project",
+    });
+
+    expect(result).not.toBeNull();
+    expect(mockGetNewPaneTail).not.toHaveBeenCalled();
+    expect(mockCapturePaneContent).toHaveBeenCalledWith("%42", 12);
   });
 
   it("does NOT register when tmuxPaneId is unavailable", async () => {

--- a/src/notifications/__tests__/notify-registry-integration.test.ts
+++ b/src/notifications/__tests__/notify-registry-integration.test.ts
@@ -262,6 +262,37 @@ describe("notify() -> session-registry integration", () => {
     expect(mockCapturePaneContent).toHaveBeenCalledWith("%42", 12);
   });
 
+  it("keeps vitest runtime failure prose in delivered tmux tails while filtering literal noise", async () => {
+    mockShouldIncludeTmuxTail.mockReturnValue(true);
+    mockGetTmuxTailLines.mockReturnValue(12);
+    mockGetNewPaneTail.mockReturnValue([
+      'mcp: {"jsonrpc":"2.0","error":{"code":"operation_failed","message":"claim_conflict"}}',
+      '+ const payload = { status: "failed", error: "claim_conflict" };',
+      "Error: Cannot find module vitest",
+      "failed to load config from /tmp/x/vitest.config.ts",
+    ].join("\n"));
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "discord-msg-vitest-tail" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await notify("session-idle", {
+      sessionId: "sess-tail-vitest",
+      projectPath: "/test/project",
+    });
+
+    expect(result).not.toBeNull();
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, { body?: string }];
+    const body = JSON.parse(requestInit.body ?? "{}") as { content?: string };
+    expect(body.content).toContain("Error: Cannot find module vitest");
+    expect(body.content).toContain("failed to load config from /tmp/x/vitest.config.ts");
+    expect(body.content).not.toContain('mcp: {"jsonrpc":"2.0"');
+    expect(body.content).not.toContain('+ const payload = { status: "failed", error: "claim_conflict" };');
+  });
+
   it("does NOT register when tmuxPaneId is unavailable", async () => {
     mockGetCurrentTmuxPaneId.mockReturnValue(null);
 

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -219,7 +219,7 @@ const DIFF_HEADER_LINE_RE = /^(?:diff --git\b|index\s+[0-9a-f]{6,}\.\.[0-9a-f]{6
 const STRUCTURED_ALERT_KEYWORD_RE =
   /\b(?:error|errors?|fail(?:ed|ure|ures)?|conflict|conflicts|operation_failed|claim_conflict|invalid_transition|blocked_dependency|worker_notify_failed)\b/i;
 const JSONISH_LINE_RE =
-  /^(?:[{[]|"(?:[^"\\]|\\.)+"\s*:|'(?:[^'\\]|\\.)+'\s*:|[A-Za-z_$][\w$-]*\s*:\s*(?:[{["']|[^ ]))/;
+  /^(?:[{[]|"(?:[^"\\]|\\.)+"\s*:|'(?:[^'\\]|\\.)+'\s*:)/;
 const REQUEST_RESPONSE_LITERAL_RE =
   /^(?:payload|request|response|input|output|args|params|body|mcp)\s*[:=]\s*[{[]/i;
 const CODE_LITERAL_PREFIX_RE =

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -198,6 +198,9 @@ const REVIEW_SEED_OUTCOME_PATTERNS = [
   { key: "request-changes", pattern: /\brequest[- ]changes\b/i },
   { key: "follow-up-fix", pattern: /\bfollow[- ]up[- ]fix\b/i },
   { key: "blocked", pattern: /\bblocked\b/i },
+  { key: "error", pattern: /\berrors?\b/i },
+  { key: "failure", pattern: /\bfail(?:ed|ure|ures)?\b/i },
+  { key: "conflict", pattern: /\bconflicts?\b/i },
 ] as const;
 
 /** Instructional phrasing commonly found in seeded review prompts. */
@@ -212,6 +215,15 @@ const SOURCE_PATH_LINE_RE = /^(?:\.\/)?[A-Za-z0-9_./-]+:\d+:/;
 const STATIC_CODE_ALERT_RE = /(?:\blog_error\b|\becho\b).*?(?:"error\||"Usage:)|==\s*"error"/;
 const HELP_USAGE_LINE_RE = /^(?:Usage|Examples?|Commands?|Options?|Flags?):/i;
 const STATIC_HELP_CODE_RE = /^(?:log_error\s+"Usage:|if\s+\[\[.*==\s*"error".*\]\];?\s*then$)/;
+const DIFF_HEADER_LINE_RE = /^(?:diff --git\b|index\s+[0-9a-f]{6,}\.\.[0-9a-f]{6,}\b|@@\s+[-+]\d|---\s+\S|\+\+\+\s+\S)/i;
+const STRUCTURED_ALERT_KEYWORD_RE =
+  /\b(?:error|errors?|fail(?:ed|ure|ures)?|conflict|conflicts|operation_failed|claim_conflict|invalid_transition|blocked_dependency|worker_notify_failed)\b/i;
+const JSONISH_LINE_RE =
+  /^(?:[{[]|"(?:[^"\\]|\\.)+"\s*:|'(?:[^'\\]|\\.)+'\s*:|[A-Za-z_$][\w$-]*\s*:\s*(?:[{["']|[^ ]))/;
+const REQUEST_RESPONSE_LITERAL_RE =
+  /^(?:payload|request|response|input|output|args|params|body|mcp)\s*[:=]\s*[{[]/i;
+const CODE_LITERAL_PREFIX_RE =
+  /^(?:[+-]\s*(?:[{[]|"(?:[^"\\]|\\.)+"\s*:|'(?:[^'\\]|\\.)+'\s*:|(?:const|let|var|return|throw|if|await|expect|mock|vi\.)\b|[A-Za-z_$][\w$-]*\s*:)|(?:const|let|var|return|throw|if|await|expect|mock|vi\.)\b)/;
 
 /** Default maximum number of meaningful lines to include in a notification.
  * Matches DEFAULT_TMUX_TAIL_LINES in config.ts. */
@@ -257,6 +269,15 @@ function trimReviewSeedPrefix(lines: string[]): string[] {
   return lines.slice(candidateEnd + 1);
 }
 
+function looksLikeStructuredAlertLiteral(line: string): boolean {
+  const trimmed = line.trim();
+  if (!STRUCTURED_ALERT_KEYWORD_RE.test(trimmed)) return false;
+  if (/^(?:\{.*\}|\[.*\])$/.test(trimmed) && /["'{\[\]}:,]/.test(trimmed)) return true;
+  if (JSONISH_LINE_RE.test(trimmed)) return true;
+  if (CODE_LITERAL_PREFIX_RE.test(trimmed) && /["'`{}[\]()=>]/.test(trimmed)) return true;
+  return false;
+}
+
 /**
  * Parse raw tmux output into clean, human-readable lines.
  * - Strips ANSI escape codes
@@ -278,9 +299,12 @@ export function parseTmuxTail(raw: string, maxLines: number = DEFAULT_MAX_TAIL_L
     if (OMC_HUD_RE.test(trimmed)) continue;
     if (BYPASS_PERM_RE.test(trimmed)) continue;
     if (BARE_PROMPT_RE.test(trimmed)) continue;
+    if (DIFF_HEADER_LINE_RE.test(trimmed)) continue;
+    if (REQUEST_RESPONSE_LITERAL_RE.test(trimmed)) continue;
     if (HELP_USAGE_LINE_RE.test(trimmed)) continue;
     if (STATIC_HELP_CODE_RE.test(trimmed)) continue;
     if (SOURCE_PATH_LINE_RE.test(trimmed) && STATIC_CODE_ALERT_RE.test(trimmed)) continue;
+    if (looksLikeStructuredAlertLiteral(trimmed)) continue;
 
     // Alphanumeric density check: drop lines mostly composed of special characters
     const alnumCount = (trimmed.match(/[a-zA-Z0-9]/g) || []).length;

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -112,7 +112,7 @@ import { dispatchNotifications } from "./dispatcher.js";
 import { getCurrentTmuxSession } from "./tmux.js";
 import { getHookConfig, resolveEventTemplate } from "./hook-config.js";
 import { interpolateTemplate } from "./template-engine.js";
-import { basename } from "path";
+import { basename, join } from "path";
 
 /**
  * High-level notification function.
@@ -188,11 +188,14 @@ export async function notify(
         const { capturePaneContent } = await import(
           "../features/rate-limit-wait/tmux-detector.js"
         );
-        const tailLines = getTmuxTailLines(config);
-        const tail = parseTmuxTail(
-          capturePaneContent(payload.tmuxPaneId, tailLines),
-          tailLines,
+        const { getNewPaneTail } = await import(
+          "../features/rate-limit-wait/pane-fresh-capture.js"
         );
+        const tailLines = getTmuxTailLines(config);
+        const rawTail = payload.projectPath
+          ? getNewPaneTail(payload.tmuxPaneId, join(payload.projectPath, ".omc", "state"), tailLines)
+          : capturePaneContent(payload.tmuxPaneId, tailLines);
+        const tail = parseTmuxTail(rawTail, tailLines);
         if (tail) {
           payload.tmuxTail = tail;
           payload.maxTailLines = tailLines;


### PR DESCRIPTION
## Summary\n- filter seeded review prose, diff/code literals, and MCP-style payload blobs out of notification tmux tails\n- use cursor-tracked pane delta capture for notification stop/idle/end events when project state is available\n- add regressions that keep actionable runtime failure prose visible\n\n## Testing\n- npm test -- --run src/notifications/__tests__/formatter.test.ts src/notifications/__tests__/notify-registry-integration.test.ts\n- npx tsc --noEmit