### PR TITLE
Harden live tmux keyword alerts against prompt/search noise

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -447,6 +447,56 @@ describe("parseTmuxTail noise filters", () => {
       "Error: Cannot find module vitest\nfailed to load config from /tmp/x/vitest.config.ts",
     );
   });
+
+  it("drops search queries that intentionally look for alert keywords", () => {
+    const input = [
+      '❯ rg -n "error|fail|conflict|blocked" src tests',
+      "ripgrep --glob '*.ts' 'worker_notify_failed|claim_conflict' src",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("drops zero-error diagnostic summaries", () => {
+    const input = [
+      "TypeScript check passed: 0 errors, 0 warnings",
+      "totalErrors: 0, totalWarnings: 3",
+      "LSP check passed: 0 errors, 0 warnings (42 files)",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("drops regex literals that only encode alert keywords", () => {
+    const input = [
+      "const alertPattern = /error|fail|conflict|blocked/i;",
+      "matcher: new RegExp('worker_notify_failed|claim_conflict')",
+      'src/alert-monitor.ts:88: const alertPattern = /error|fail|conflict|blocked/i;',
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("drops generic hook failure prose when it is just prompt/setup residue", () => {
+    const input = [
+      "The Bash output indicates a command/setup failure that should be fixed before retrying.",
+      "Fix issue #2583: harden the live tmux keyword alert path so injected prompts stop firing fake error/fail/conflict alerts.",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("preserves actionable runtime failures next to zero-error summaries", () => {
+    const input = [
+      "TypeScript check passed: 0 errors, 0 warnings",
+      "Runtime error: tmux watcher crashed after SIGTERM",
+      "Restart the live pane monitor before rerunning diagnostics",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe(
+      "Runtime error: tmux watcher crashed after SIGTERM\nRestart the live pane monitor before rerunning diagnostics",
+    );
+  });
 });
 
 describe("tmuxTail in formatters", () => {

--- a/src/notifications/__tests__/notify-registry-integration.test.ts
+++ b/src/notifications/__tests__/notify-registry-integration.test.ts
@@ -293,6 +293,41 @@ describe("notify() -> session-registry integration", () => {
     expect(body.content).not.toContain('+ const payload = { status: "failed", error: "claim_conflict" };');
   });
 
+  it("filters live pane prompt/search/diagnostic residue while keeping actionable failures", async () => {
+    mockShouldIncludeTmuxTail.mockReturnValue(true);
+    mockGetTmuxTailLines.mockReturnValue(12);
+    mockGetNewPaneTail.mockReturnValue([
+      "Fix issue #2583: stop fake error/fail/conflict alerts from prompt residue",
+      '❯ rg -n "error|fail|conflict" src tests',
+      "TypeScript check passed: 0 errors, 0 warnings",
+      "The Bash output indicates a command/setup failure that should be fixed before retrying.",
+      "Runtime error: worker crashed after SIGTERM",
+      "Restart the pane watcher and rerun the task",
+    ].join("\n"));
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "discord-msg-live-pane-filter" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await notify("session-idle", {
+      sessionId: "sess-live-pane-filter",
+      projectPath: "/test/project",
+    });
+
+    expect(result).not.toBeNull();
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, { body?: string }];
+    const body = JSON.parse(requestInit.body ?? "{}") as { content?: string };
+    expect(body.content).toContain("Runtime error: worker crashed after SIGTERM");
+    expect(body.content).toContain("Restart the pane watcher and rerun the task");
+    expect(body.content).not.toContain("Fix issue #2583");
+    expect(body.content).not.toContain('rg -n "error|fail|conflict"');
+    expect(body.content).not.toContain("0 errors, 0 warnings");
+    expect(body.content).not.toContain("The Bash output indicates a command/setup failure");
+  });
+
   it("does NOT register when tmuxPaneId is unavailable", async () => {
     mockGetCurrentTmuxPaneId.mockReturnValue(null);
 

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -218,6 +218,16 @@ const STATIC_HELP_CODE_RE = /^(?:log_error\s+"Usage:|if\s+\[\[.*==\s*"error".*\]
 const DIFF_HEADER_LINE_RE = /^(?:diff --git\b|index\s+[0-9a-f]{6,}\.\.[0-9a-f]{6,}\b|@@\s+[-+]\d|---\s+\S|\+\+\+\s+\S)/i;
 const STRUCTURED_ALERT_KEYWORD_RE =
   /\b(?:error|errors?|fail(?:ed|ure|ures)?|conflict|conflicts|operation_failed|claim_conflict|invalid_transition|blocked_dependency|worker_notify_failed)\b/i;
+const SEARCH_COMMAND_RE = /^(?:[$❯>#]\s*)?(?:rg|ripgrep|grep|egrep|fgrep)\b/i;
+const QUOTED_OR_REGEX_QUERY_RE = /(?:"[^"\n]+"|'[^'\n]+'|`[^`\n]+`|\/[^/\n]+\/[a-z]*)/i;
+const ZERO_ALERT_SUMMARY_RE =
+  /\b(?:0|zero)\s+(?:errors?|fail(?:ed|ures?)?|conflicts?)\b|\b(?:errors?|fail(?:ed|ures?)?|conflicts?)\s*[:=]\s*0\b|\btotalErrors\s*[:=]\s*0\b|\b(?:TypeScript|LSP)\s+check\s+passed:\s*0 errors,\s*0 warnings\b/i;
+const ALERT_REGEX_LITERAL_RE =
+  /(?:^|[=(:,]\s*)(?:new\s+RegExp\(|\/)(?=[^)\n;]*\b(?:error|errors?|fail(?:ed|ure|ures)?|conflict|conflicts|operation_failed|claim_conflict|invalid_transition|blocked_dependency|worker_notify_failed)\b)/i;
+const GENERIC_HOOK_FAILURE_PROSE_RE =
+  /^The Bash output indicates (?:a )?(?:command\/setup|command|setup) failure\b/i;
+const ISSUE_PROMPT_NOISE_RE =
+  /^(?:fix|review|investigate|analyze|search|find|look\s+for|debug|harden)\b.*\b(?:issue|pr)\s*#\d+\b.*\b(?:error|errors?|fail(?:ed|ure|ures)?|conflict|conflicts)\b/i;
 const JSONISH_LINE_RE =
   /^(?:[{[]|"(?:[^"\\]|\\.)+"\s*:|'(?:[^'\\]|\\.)+'\s*:)/;
 const REQUEST_RESPONSE_LITERAL_RE =
@@ -241,6 +251,7 @@ function trimReviewSeedPrefix(lines: string[]): string[] {
   const prefix = lines.slice(0, 10);
   const distinctOutcomes = new Set<string>();
   let hasCue = false;
+  let hasListMarker = false;
   let candidateEnd = -1;
 
   for (let index = 0; index < prefix.length; index += 1) {
@@ -254,6 +265,7 @@ function trimReviewSeedPrefix(lines: string[]): string[] {
 
     outcomeKeys.forEach((key) => distinctOutcomes.add(key));
     if (isCueLine) hasCue = true;
+    if (REVIEW_SEED_LIST_RE.test(line)) hasListMarker = true;
     if (isSeedLine) {
       candidateEnd = index;
       continue;
@@ -263,7 +275,8 @@ function trimReviewSeedPrefix(lines: string[]): string[] {
 
   const qualifies =
     candidateEnd >= 0 &&
-    (distinctOutcomes.size >= 3 || (distinctOutcomes.size >= 2 && hasCue));
+    hasCue &&
+    (distinctOutcomes.size >= 2 || hasListMarker);
 
   if (!qualifies) return lines;
   return lines.slice(candidateEnd + 1);
@@ -276,6 +289,20 @@ function looksLikeStructuredAlertLiteral(line: string): boolean {
   if (JSONISH_LINE_RE.test(trimmed)) return true;
   if (CODE_LITERAL_PREFIX_RE.test(trimmed) && /["'`{}[\]()=>]/.test(trimmed)) return true;
   return false;
+}
+
+function looksLikeAlertSearchCommand(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    SEARCH_COMMAND_RE.test(trimmed) &&
+    STRUCTURED_ALERT_KEYWORD_RE.test(trimmed) &&
+    (QUOTED_OR_REGEX_QUERY_RE.test(trimmed) || trimmed.includes("|"))
+  );
+}
+
+function looksLikeAlertRegexLiteral(line: string): boolean {
+  const trimmed = line.trim();
+  return STRUCTURED_ALERT_KEYWORD_RE.test(trimmed) && ALERT_REGEX_LITERAL_RE.test(trimmed);
 }
 
 /**
@@ -300,10 +327,19 @@ export function parseTmuxTail(raw: string, maxLines: number = DEFAULT_MAX_TAIL_L
     if (BYPASS_PERM_RE.test(trimmed)) continue;
     if (BARE_PROMPT_RE.test(trimmed)) continue;
     if (DIFF_HEADER_LINE_RE.test(trimmed)) continue;
+    if (looksLikeAlertSearchCommand(trimmed)) continue;
     if (REQUEST_RESPONSE_LITERAL_RE.test(trimmed)) continue;
     if (HELP_USAGE_LINE_RE.test(trimmed)) continue;
     if (STATIC_HELP_CODE_RE.test(trimmed)) continue;
+    if (ZERO_ALERT_SUMMARY_RE.test(trimmed)) continue;
+    if (GENERIC_HOOK_FAILURE_PROSE_RE.test(trimmed)) continue;
+    if (ISSUE_PROMPT_NOISE_RE.test(trimmed)) continue;
     if (SOURCE_PATH_LINE_RE.test(trimmed) && STATIC_CODE_ALERT_RE.test(trimmed)) continue;
+    if (SOURCE_PATH_LINE_RE.test(trimmed)) {
+      const sourceContent = trimmed.replace(SOURCE_PATH_LINE_RE, "").trim();
+      if (looksLikeStructuredAlertLiteral(sourceContent) || looksLikeAlertRegexLiteral(sourceContent)) continue;
+    }
+    if (looksLikeAlertRegexLiteral(trimmed)) continue;
     if (looksLikeStructuredAlertLiteral(trimmed)) continue;
 
     // Alphanumeric density check: drop lines mostly composed of special characters

--- a/src/openclaw/__tests__/index.test.ts
+++ b/src/openclaw/__tests__/index.test.ts
@@ -45,6 +45,7 @@ import { wakeOpenClaw } from "../index.js";
 import { getOpenClawConfig, resolveGateway } from "../config.js";
 import { wakeGateway, wakeCommandGateway } from "../dispatcher.js";
 import type { OpenClawConfig } from "../types.js";
+import { parseTmuxTail } from "../../notifications/formatter.js";
 
 const mockConfig: OpenClawConfig = {
   enabled: true,
@@ -122,7 +123,12 @@ describe("wakeOpenClaw", () => {
   });
 
   it("captures fresh pane delta for stop events and passes it directly to payload", async () => {
-    const freshContent = "RuntimeError: boom\nBLOCKED: runtime failure";
+    const freshContent = [
+      '❯ rg -n "error|fail|conflict" src tests',
+      "TypeScript check passed: 0 errors, 0 warnings",
+      "RuntimeError: boom",
+      "BLOCKED: runtime failure",
+    ].join("\n");
     mockGetNewPaneTail.mockReturnValue(freshContent);
     vi.stubEnv("TMUX", "/tmp/tmux-1000/default,123,0");
     vi.stubEnv("TMUX_PANE", "%7");
@@ -138,7 +144,8 @@ describe("wakeOpenClaw", () => {
       15,
     );
     const payload = vi.mocked(wakeGateway).mock.calls[0]?.[2];
-    expect(payload.tmuxTail).toBe(freshContent);
+    expect(payload.tmuxTail).toBe(parseTmuxTail(freshContent, 15));
+    expect(payload.tmuxTail).toBe("RuntimeError: boom\nBLOCKED: runtime failure");
   });
 
   it("omits tmuxTail from stop payload when pane has no new lines", async () => {

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -34,6 +34,7 @@ import { buildOpenClawSignal } from "./signal.js";
 import { shouldCollapseOpenClawBurst } from "./dedupe.js";
 import { basename, join } from "path";
 import { getCurrentTmuxSession } from "../notifications/tmux.js";
+import { parseTmuxTail } from "../notifications/formatter.js";
 
 /** Whether debug logging is enabled */
 const DEBUG = process.env.OMC_OPENCLAW_DEBUG === "1";
@@ -128,6 +129,10 @@ export async function wakeOpenClaw(
       } catch {
         // Non-blocking: tmux capture is best-effort
       }
+    }
+    if (tmuxTail) {
+      const parsedTmuxTail = parseTmuxTail(tmuxTail, 15);
+      tmuxTail = parsedTmuxTail || undefined;
     }
 
     // Build template variables from whitelisted context fields


### PR DESCRIPTION
## Summary
- suppress live tmux keyword false positives from injected prompts, search queries, zero-error diagnostics, code/regex literals, and generic hook residue
- keep actionable runtime failures visible in shared tmux-tail parsing
- sanitize OpenClaw stop/session-end tmux captures through the shared parser before paging

## Testing
- npm test -- --run src/notifications/__tests__/formatter.test.ts src/notifications/__tests__/notify-registry-integration.test.ts src/openclaw/__tests__/index.test.ts
- npx tsc --noEmit
- npm run lint -- src/notifications/formatter.ts src/notifications/__tests__/formatter.test.ts src/notifications/__tests__/notify-registry-integration.test.ts src/openclaw/index.ts src/openclaw/__tests__/index.test.ts