### PR TITLE
fix(hooks): wrap wiki hook additionalContext in hookSpecificOutput

### DIFF
--- a/scripts/wiki-pre-compact.mjs
+++ b/scripts/wiki-pre-compact.mjs
@@ -7,7 +7,17 @@ async function main() {
     const data = JSON.parse(input);
     const { onPreCompact } = await import('../dist/hooks/wiki/session-hooks.js');
     const result = onPreCompact(data);
-    console.log(JSON.stringify(result));
+    if (result.additionalContext) {
+      console.log(JSON.stringify({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PreCompact',
+          additionalContext: result.additionalContext,
+        },
+      }));
+    } else {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    }
   } catch (error) {
     console.error('[wiki-pre-compact] Error:', error.message);
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/scripts/wiki-session-start.mjs
+++ b/scripts/wiki-session-start.mjs
@@ -7,7 +7,17 @@ async function main() {
     const data = JSON.parse(input);
     const { onSessionStart } = await import('../dist/hooks/wiki/session-hooks.js');
     const result = onSessionStart(data);
-    console.log(JSON.stringify(result));
+    if (result.additionalContext) {
+      console.log(JSON.stringify({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'SessionStart',
+          additionalContext: result.additionalContext,
+        },
+      }));
+    } else {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    }
   } catch (error) {
     console.error('[wiki-session-start] Error:', error.message);
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/src/__tests__/wiki-hook-output-format.test.ts
+++ b/src/__tests__/wiki-hook-output-format.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const NODE = process.execPath;
+const SESSION_START_SCRIPT = join(__dirname, '..', '..', 'scripts', 'wiki-session-start.mjs');
+const PRE_COMPACT_SCRIPT = join(__dirname, '..', '..', 'scripts', 'wiki-pre-compact.mjs');
+
+describe('wiki hook wrapper output', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'omc-wiki-hook-format-'));
+    mkdirSync(join(tempDir, '.omc', 'wiki'), { recursive: true });
+
+    writeFileSync(
+      join(tempDir, '.omc', 'wiki', 'test-page.md'),
+      [
+        '---',
+        'title: "Test Page"',
+        'tags: ["test"]',
+        'created: 2026-04-13T00:00:00.000Z',
+        'updated: 2026-04-13T00:00:00.000Z',
+        'sources: ["session-1"]',
+        'links: []',
+        'category: reference',
+        'confidence: high',
+        'schemaVersion: 1',
+        '---',
+        '# Test Page',
+        '',
+      ].join('\n'),
+    );
+
+    writeFileSync(join(tempDir, '.omc', 'wiki', 'index.md'), '# Wiki Index\n- test-page.md\n');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function runHook(scriptPath: string) {
+    const raw = execFileSync(NODE, [scriptPath], {
+      cwd: join(__dirname, '..', '..'),
+      input: JSON.stringify({ cwd: tempDir }),
+      encoding: 'utf-8',
+      timeout: 15000,
+    }).trim();
+
+    return JSON.parse(raw) as {
+      continue?: boolean;
+      suppressOutput?: boolean;
+      additionalContext?: string;
+      hookSpecificOutput?: {
+        hookEventName?: string;
+        additionalContext?: string;
+      };
+    };
+  }
+
+  it('wraps SessionStart wiki context under hookSpecificOutput', () => {
+    const output = runHook(SESSION_START_SCRIPT);
+
+    expect(output.continue).toBe(true);
+    expect(output.additionalContext).toBeUndefined();
+    expect(output.hookSpecificOutput).toEqual({
+      hookEventName: 'SessionStart',
+      additionalContext: expect.stringContaining('[LLM Wiki: 1 pages at .omc/wiki/]'),
+    });
+  });
+
+  it('wraps PreCompact wiki context under hookSpecificOutput', () => {
+    const output = runHook(PRE_COMPACT_SCRIPT);
+
+    expect(output.continue).toBe(true);
+    expect(output.additionalContext).toBeUndefined();
+    expect(output.hookSpecificOutput).toEqual({
+      hookEventName: 'PreCompact',
+      additionalContext: '[Wiki: 1 pages | categories: reference | last updated: 2026-04-13T00:00:00.000Z]',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- wrap wiki SessionStart and PreCompact additionalContext under Claude Code's expected hookSpecificOutput envelope
- keep suppressOutput behavior when no wiki context exists
- add focused regression coverage for both wiki wrapper scripts

## Testing
- npm test -- --run src/__tests__/wiki-hook-output-format.test.ts
- npm run build
- npm run lint -- src/__tests__/wiki-hook-output-format.test.ts src/hooks/wiki/session-hooks.ts