### PR TITLE
fix: suppress optional OMX startup MCP method-not-found pane noise

### DIFF
--- a/scripts/post-tool-use-failure.mjs
+++ b/scripts/post-tool-use-failure.mjs
@@ -12,6 +12,13 @@ import { atomicWriteFileSync } from './lib/atomic-write.mjs';
 const RETRY_WINDOW_MS = 60000; // 60 seconds
 const MAX_ERROR_LENGTH = 500;
 const MAX_INPUT_PREVIEW_LENGTH = 200;
+const OPTIONAL_STARTUP_READ_TOOL_NAMES = new Set([
+  'mcp__omx_state__state_read',
+  'mcp__omx_state__state_get_status',
+  'mcp__omx_state__state_list_active',
+  'mcp__omx_memory__notepad_read',
+  'mcp__omx_memory__project_memory_read',
+]);
 
 // Validate that targetPath is contained within basePath (prevent path traversal)
 function isPathContained(targetPath, basePath) {
@@ -110,6 +117,14 @@ function writeErrorState(stateDir, toolName, toolInputPreview, error, retryCount
   } catch {}
 }
 
+function shouldSuppressOptionalStartupMethodNotFound(toolName, error) {
+  if (!OPTIONAL_STARTUP_READ_TOOL_NAMES.has(toolName)) {
+    return false;
+  }
+
+  return /\bmethod not found\b/i.test(String(error || ''));
+}
+
 async function main() {
   try {
     const input = await readStdin();
@@ -130,6 +145,11 @@ async function main() {
 
     // Skip if no tool name or error
     if (!toolName || !error) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    if (shouldSuppressOptionalStartupMethodNotFound(toolName, error)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }

--- a/src/__tests__/post-tool-use-failure.test.ts
+++ b/src/__tests__/post-tool-use-failure.test.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const NODE = process.execPath;
+const REPO_ROOT = resolve(join(__dirname, '..', '..'));
+const SCRIPT_PATH = join(REPO_ROOT, 'scripts', 'post-tool-use-failure.mjs');
+const TEST_TMP_ROOT = join(REPO_ROOT, '.tmp-post-tool-use-failure-tests');
+
+function runHook(input: Record<string, unknown>) {
+  const raw = execFileSync(NODE, [SCRIPT_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: REPO_ROOT,
+      NODE_ENV: 'test',
+    },
+    timeout: 15000,
+  }).trim();
+
+  return JSON.parse(raw) as {
+    continue: boolean;
+    suppressOutput?: boolean;
+    hookSpecificOutput?: {
+      hookEventName?: string;
+      additionalContext?: string;
+    };
+  };
+}
+
+describe('post-tool-use-failure.mjs', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  function makeRepoLocalTempDir() {
+    mkdirSync(TEST_TMP_ROOT, { recursive: true });
+    const cwd = mkdtempSync(join(TEST_TMP_ROOT, 'case-'));
+    tempDirs.push(cwd);
+    return cwd;
+  }
+
+  it('suppresses optional omx startup read method-not-found noise', () => {
+    const cwd = makeRepoLocalTempDir();
+    const errorPath = join(cwd, '.omc', 'state', 'last-tool-error.json');
+
+    const result = runHook({
+      tool_name: 'mcp__omx_state__state_read',
+      tool_input: { mode: 'deep-interview' },
+      error: 'Method not found',
+      cwd,
+    });
+
+    expect(result).toEqual({ continue: true, suppressOutput: true });
+    expect(existsSync(errorPath)).toBe(false);
+  });
+
+  it('preserves real failures for the same optional startup reads', () => {
+    const cwd = makeRepoLocalTempDir();
+    const errorPath = join(cwd, '.omc', 'state', 'last-tool-error.json');
+
+    const result = runHook({
+      tool_name: 'mcp__omx_state__state_read',
+      tool_input: { mode: 'deep-interview' },
+      error: 'Connection refused',
+      cwd,
+    });
+
+    expect(result.continue).toBe(true);
+    expect(result.suppressOutput).not.toBe(true);
+    expect(result.hookSpecificOutput?.hookEventName).toBe('PostToolUseFailure');
+    expect(result.hookSpecificOutput?.additionalContext).toContain(
+      'Tool "mcp__omx_state__state_read" failed.',
+    );
+
+    expect(existsSync(errorPath)).toBe(true);
+    const errorState = JSON.parse(readFileSync(errorPath, 'utf-8')) as {
+      tool_name: string;
+      error: string;
+      retry_count: number;
+    };
+    expect(errorState.tool_name).toBe('mcp__omx_state__state_read');
+    expect(errorState.error).toBe('Connection refused');
+    expect(errorState.retry_count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- suppress PostToolUseFailure pane noise for optional omx_state/omx_memory startup reads that fail with Method not found
- keep real failures visible by only silencing the exact optional startup read signatures
- add a focused regression test for the quiet-path and real-failure path

## Testing
- npm test -- --run src/__tests__/post-tool-use-failure.test.ts