### PR TITLE
Keep PR review verification focused by default

### DIFF
--- a/skills/project-session-manager/lib/worktree.sh
+++ b/skills/project-session-manager/lib/worktree.sh
@@ -27,6 +27,30 @@ validate_worktree_path() {
     return 0
 }
 
+# Best-effort dependency bootstrap for clean PR review worktrees.
+# Reuses the source repo node_modules only when package.json matches exactly.
+# This keeps focused test commands like `npm run test:run -- ...` usable
+# without forcing a full install in every review worktree.
+psm_bootstrap_review_dependencies() {
+    local local_repo="$1"
+    local worktree_path="$2"
+
+    local source_package_json="${local_repo}/package.json"
+    local target_package_json="${worktree_path}/package.json"
+    local source_node_modules="${local_repo}/node_modules"
+    local target_node_modules="${worktree_path}/node_modules"
+
+    [[ -f "$source_package_json" ]] || return 0
+    [[ -f "$target_package_json" ]] || return 0
+    [[ -d "$source_node_modules" ]] || return 0
+    [[ ! -e "$target_node_modules" ]] || return 0
+
+    cmp -s "$source_package_json" "$target_package_json" || return 0
+
+    ln -s "$source_node_modules" "$target_node_modules" 2>/dev/null || true
+    return 0
+}
+
 # Create a worktree for PR review
 # Usage: psm_create_pr_worktree <local_repo> <alias> <pr_number> <pr_branch>
 psm_create_pr_worktree() {
@@ -59,6 +83,8 @@ psm_create_pr_worktree() {
         echo "error|Failed to create worktree"
         return 1
     }
+
+    psm_bootstrap_review_dependencies "$local_repo" "$worktree_path"
 
     echo "created|$worktree_path"
     return 0

--- a/skills/project-session-manager/templates/pr-review.md
+++ b/skills/project-session-manager/templates/pr-review.md
@@ -49,8 +49,11 @@ You are reviewing PR #{{PR_NUMBER}}: **{{PR_TITLE}}**
 # View diff
 git diff {{BASE_BRANCH}}...HEAD
 
-# Run tests
-npm test  # or appropriate test command
+# Run the narrowest relevant tests first
+# If this clean review worktree has a symlinked node_modules from the source repo,
+# focused vitest commands should work without a fresh install.
+npm run test:run -- <changed-test-paths>  # preferred focused verification
+npm test  # or appropriate full test command if focused coverage is insufficient
 
 # Check build
 npm run build  # or appropriate build command

--- a/src/__tests__/project-session-manager-review-worktree.test.ts
+++ b/src/__tests__/project-session-manager-review-worktree.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const WORKTREE_LIB_PATH = join(process.cwd(), 'skills', 'project-session-manager', 'lib', 'worktree.sh');
+const WORKTREE_LIB = readFileSync(
+  WORKTREE_LIB_PATH,
+  'utf-8',
+);
+const PR_REVIEW_TEMPLATE = readFileSync(
+  join(process.cwd(), 'skills', 'project-session-manager', 'templates', 'pr-review.md'),
+  'utf-8',
+);
+
+describe('project-session-manager review worktree hardening', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  it('bootstraps review worktrees with best-effort dependency reuse when package.json matches', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-psm-review-'));
+    tempDirs.push(root);
+
+    const repo = join(root, 'repo');
+    const worktree = join(root, 'worktree');
+    mkdirSync(join(repo, 'node_modules', 'vitest'), { recursive: true });
+    mkdirSync(worktree, { recursive: true });
+    writeFileSync(join(repo, 'package.json'), '{"name":"demo","version":"1.0.0"}\n');
+    writeFileSync(join(worktree, 'package.json'), '{"name":"demo","version":"1.0.0"}\n');
+
+    execFileSync(
+      'bash',
+      ['-lc', 'source "$SCRIPT_PATH"; psm_bootstrap_review_dependencies "$REPO_DIR" "$WORKTREE_DIR"'],
+      {
+        env: {
+          ...process.env,
+          SCRIPT_PATH: WORKTREE_LIB_PATH,
+          REPO_DIR: repo,
+          WORKTREE_DIR: worktree,
+        },
+      },
+    );
+
+    const linkedNodeModules = join(worktree, 'node_modules');
+    expect(lstatSync(linkedNodeModules).isSymbolicLink()).toBe(true);
+    expect(resolve(worktree, readlinkSync(linkedNodeModules))).toBe(join(repo, 'node_modules'));
+    expect(WORKTREE_LIB).toContain('psm_bootstrap_review_dependencies "$local_repo" "$worktree_path"');
+  });
+
+  it('skips dependency reuse when package.json differs', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-psm-review-mismatch-'));
+    tempDirs.push(root);
+
+    const repo = join(root, 'repo');
+    const worktree = join(root, 'worktree');
+    mkdirSync(join(repo, 'node_modules', 'vitest'), { recursive: true });
+    mkdirSync(worktree, { recursive: true });
+    writeFileSync(join(repo, 'package.json'), '{"name":"demo","version":"1.0.0"}\n');
+    writeFileSync(join(worktree, 'package.json'), '{"name":"demo","version":"2.0.0"}\n');
+
+    execFileSync(
+      'bash',
+      ['-lc', 'source "$SCRIPT_PATH"; psm_bootstrap_review_dependencies "$REPO_DIR" "$WORKTREE_DIR"'],
+      {
+        env: {
+          ...process.env,
+          SCRIPT_PATH: WORKTREE_LIB_PATH,
+          REPO_DIR: repo,
+          WORKTREE_DIR: worktree,
+        },
+      },
+    );
+
+    expect(() => lstatSync(join(worktree, 'node_modules'))).toThrow();
+  });
+
+  it('guides PR review flows toward focused verification before full-suite fallback', () => {
+    expect(PR_REVIEW_TEMPLATE).toContain('npm run test:run -- <changed-test-paths>');
+    expect(PR_REVIEW_TEMPLATE).toContain('preferred focused verification');
+    expect(PR_REVIEW_TEMPLATE).toContain('symlinked node_modules from the source repo');
+  });
+});


### PR DESCRIPTION
## Summary
- align the PR review execution path more closely with the focused-verification guidance from #2598
- reduce drift into broad or dependency-fragile review commands in clean worktrees
- keep the hardening narrow to PR review ergonomics without changing the approval model or broad test/build behavior

## Why
Recent review lanes improved dependency reuse and template guidance, but the actual review execution path could still drift into broader or more fragile commands. This PR keeps review verification focused by default so PR gating stays quieter and more deterministic.

## Focused verification
- focused verification/report path run in the worktree used for this issue
- validation output reported `totalErrors: 0`
