### PR TITLE
Reduce review/session false-failure noise

### DIFF
--- a/scripts/post-tool-use-failure.mjs
+++ b/scripts/post-tool-use-failure.mjs
@@ -20,6 +20,66 @@ const OPTIONAL_STARTUP_READ_TOOL_NAMES = new Set([
   'mcp__omx_memory__project_memory_read',
 ]);
 
+function getToolInputCommand(toolInput) {
+  if (typeof toolInput === 'string') {
+    return toolInput;
+  }
+  if (!toolInput || typeof toolInput !== 'object') {
+    return '';
+  }
+
+  const candidateKeys = ['command', 'cmd', 'bash_command', 'script', 'query'];
+  for (const key of candidateKeys) {
+    const value = toolInput[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+  }
+
+  return '';
+}
+
+function isPermissionDeniedScanLine(line) {
+  return /^(?:find|grep|rg): .*permission denied$/i.test(line.trim());
+}
+
+function shouldSuppressFilesystemScanPermissionNoise(toolName, toolInput, error) {
+  if (String(toolName || '').toLowerCase() !== 'bash') {
+    return false;
+  }
+
+  const command = getToolInputCommand(toolInput).trim();
+  if (!command) {
+    return false;
+  }
+
+  const looksLikeBroadScan =
+    /\bAGENTS\.md\b/i.test(command) ||
+    /\b(?:find|grep|rg)\b[\s\S]*?(?:\.\.|\/)/i.test(command);
+  if (!looksLikeBroadScan) {
+    return false;
+  }
+
+  const lines = String(error || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const permissionLines = lines.filter(isPermissionDeniedScanLine);
+  if (permissionLines.length === 0) {
+    return false;
+  }
+
+  const nonNoiseLines = lines.filter((line) => {
+    if (isPermissionDeniedScanLine(line)) return false;
+    if (/^(?:command failed with exit code \d+:|exit code \d+)$/i.test(line)) return false;
+    if (line === command) return false;
+    return true;
+  });
+
+  return nonNoiseLines.length === 0;
+}
+
 // Validate that targetPath is contained within basePath (prevent path traversal)
 function isPathContained(targetPath, basePath) {
   const normalizedTarget = resolve(targetPath);
@@ -150,6 +210,11 @@ async function main() {
     }
 
     if (shouldSuppressOptionalStartupMethodNotFound(toolName, error)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    if (shouldSuppressFilesystemScanPermissionNoise(toolName, toolInput, error)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }

--- a/skills/project-session-manager/lib/session.sh
+++ b/skills/project-session-manager/lib/session.sh
@@ -161,9 +161,9 @@ psm_read_session_metadata() {
 
 # Get all session IDs for cleanup check
 psm_get_review_sessions() {
-    jq -r '.sessions | to_entries[] | select(.value.type == "review") | "\(.value.id)|\(.value.metadata.pr_number // empty)|\(.value.project)"' "$PSM_SESSIONS"
+    jq -r '.sessions | to_entries[] | select(.value.type == "review" and (.value.state // "active") == "active") | "\(.value.id)|\(.value.metadata.pr_number // empty)|\(.value.project)"' "$PSM_SESSIONS"
 }
 
 psm_get_fix_sessions() {
-    jq -r '.sessions | to_entries[] | select(.value.type == "fix") | "\(.value.id)|\(.value.metadata.issue_number // empty)|\(.value.project)"' "$PSM_SESSIONS"
+    jq -r '.sessions | to_entries[] | select(.value.type == "fix" and (.value.state // "active") == "active") | "\(.value.id)|\(.value.metadata.issue_number // empty)|\(.value.project)"' "$PSM_SESSIONS"
 }

--- a/src/__tests__/post-tool-use-failure.test.ts
+++ b/src/__tests__/post-tool-use-failure.test.ts
@@ -89,4 +89,46 @@ describe('post-tool-use-failure.mjs', () => {
     expect(errorState.error).toBe('Connection refused');
     expect(errorState.retry_count).toBe(1);
   });
+
+  it('suppresses broad AGENTS scan permission-denied noise for Bash', () => {
+    const cwd = makeRepoLocalTempDir();
+    const errorPath = join(cwd, '.omc', 'state', 'last-tool-error.json');
+
+    const result = runHook({
+      tool_name: 'Bash',
+      tool_input: {
+        command: 'pwd && find .. -name AGENTS.md -print',
+      },
+      error: [
+        'find: ../systemd-private-123: Permission denied',
+        'find: ../snap-private-tmp: Permission denied',
+        'Command failed with exit code 1:',
+      ].join('\n'),
+      cwd,
+    });
+
+    expect(result).toEqual({ continue: true, suppressOutput: true });
+    expect(existsSync(errorPath)).toBe(false);
+  });
+
+  it('does not suppress Bash permission-denied errors with actionable non-scan content', () => {
+    const cwd = makeRepoLocalTempDir();
+    const errorPath = join(cwd, '.omc', 'state', 'last-tool-error.json');
+
+    const result = runHook({
+      tool_name: 'Bash',
+      tool_input: {
+        command: 'find .. -name AGENTS.md -print',
+      },
+      error: [
+        'find: ../systemd-private-123: Permission denied',
+        'fatal: not a git repository (or any of the parent directories): .git',
+      ].join('\n'),
+      cwd,
+    });
+
+    expect(result.continue).toBe(true);
+    expect(result.suppressOutput).not.toBe(true);
+    expect(existsSync(errorPath)).toBe(true);
+  });
 });

--- a/src/__tests__/project-session-manager-session-filter.test.ts
+++ b/src/__tests__/project-session-manager-session-filter.test.ts
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SESSION_LIB = join(process.cwd(), 'skills', 'project-session-manager', 'lib', 'session.sh');
+const CONFIG_LIB = join(process.cwd(), 'skills', 'project-session-manager', 'lib', 'config.sh');
+
+function runShell(script: string, home: string): string {
+  return execFileSync('bash', ['-lc', script], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: home,
+    },
+  }).trim();
+}
+
+describe('project-session-manager session filtering', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  it('returns only active review/fix sessions for cleanup scans', () => {
+    const home = mkdtempSync(join(tmpdir(), 'omc-psm-sessions-'));
+    tempDirs.push(home);
+    const psmRoot = join(home, '.psm');
+    mkdirSync(psmRoot, { recursive: true });
+
+    writeFileSync(
+      join(psmRoot, 'sessions.json'),
+      JSON.stringify(
+        {
+          version: 1,
+          sessions: {
+            'repo:pr-101': {
+              id: 'repo:pr-101',
+              type: 'review',
+              project: 'repo',
+              state: 'active',
+              metadata: { pr_number: 101 },
+            },
+            'repo:pr-102': {
+              id: 'repo:pr-102',
+              type: 'review',
+              project: 'repo',
+              state: 'completed',
+              metadata: { pr_number: 102 },
+            },
+            'repo:issue-201': {
+              id: 'repo:issue-201',
+              type: 'fix',
+              project: 'repo',
+              state: 'active',
+              metadata: { issue_number: 201 },
+            },
+            'repo:issue-202': {
+              id: 'repo:issue-202',
+              type: 'fix',
+              project: 'repo',
+              state: 'killed',
+              metadata: { issue_number: 202 },
+            },
+          },
+          stats: { total_created: 4, total_cleaned: 2 },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const reviews = runShell(
+      `source "${CONFIG_LIB}"; source "${SESSION_LIB}"; psm_get_review_sessions`,
+      home,
+    );
+    const fixes = runShell(
+      `source "${CONFIG_LIB}"; source "${SESSION_LIB}"; psm_get_fix_sessions`,
+      home,
+    );
+
+    expect(reviews).toBe('repo:pr-101|101|repo');
+    expect(fixes).toBe('repo:issue-201|201|repo');
+  });
+});

--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -486,6 +486,30 @@ describe("parseTmuxTail noise filters", () => {
     expect(parseTmuxTail(input)).toBe("");
   });
 
+  it("drops permission-denied scan noise and clean diagnostic queries", () => {
+    const input = [
+      "find: ../systemd-private-123: Permission denied",
+      "find: ../snap-private-tmp: Permission denied",
+      '❯ rg -n "severity: \\"error\\"|diagnostic|lsp_diagnostics_directory" src tests',
+      "Command failed with exit code 1:",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe("");
+  });
+
+  it("preserves actionable output after permission-denied scan noise is stripped", () => {
+    const input = [
+      "find: ../systemd-private-123: Permission denied",
+      '❯ rg -n "severity: \\"error\\"|diagnostic|lsp_diagnostics_directory" src tests',
+      "Runtime error: review watchdog crashed",
+      "Restart the watcher and rerun the focused checks",
+    ].join("\n");
+
+    expect(parseTmuxTail(input)).toBe(
+      "Runtime error: review watchdog crashed\nRestart the watcher and rerun the focused checks",
+    );
+  });
+
   it("preserves actionable runtime failures next to zero-error summaries", () => {
     const input = [
       "TypeScript check passed: 0 errors, 0 warnings",

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -228,6 +228,10 @@ const GENERIC_HOOK_FAILURE_PROSE_RE =
   /^The Bash output indicates (?:a )?(?:command\/setup|command|setup) failure\b/i;
 const ISSUE_PROMPT_NOISE_RE =
   /^(?:fix|review|investigate|analyze|search|find|look\s+for|debug|harden)\b.*\b(?:issue|pr)\s*#\d+\b.*\b(?:error|errors?|fail(?:ed|ure|ures)?|conflict|conflicts)\b/i;
+const PERMISSION_DENIED_SCAN_LINE_RE =
+  /^(?:find|grep|rg): .*permission denied$/i;
+const CLEAN_DIAGNOSTIC_QUERY_RE =
+  /^(?:[$❯>#]\s*)?(?:rg|ripgrep|grep)\b.*\b(?:severity\s*[:=]\s*["']?error["']?|diagnostic(?:s)?|lsp_diagnostics(?:_directory)?)\b/i;
 const JSONISH_LINE_RE =
   /^(?:[{[]|"(?:[^"\\]|\\.)+"\s*:|'(?:[^'\\]|\\.)+'\s*:)/;
 const REQUEST_RESPONSE_LITERAL_RE =
@@ -305,6 +309,31 @@ function looksLikeAlertRegexLiteral(line: string): boolean {
   return STRUCTURED_ALERT_KEYWORD_RE.test(trimmed) && ALERT_REGEX_LITERAL_RE.test(trimmed);
 }
 
+function isCommandBoilerplateLine(line: string): boolean {
+  return /^(?:command failed with exit code \d+:|exit code \d+)$/i.test(line.trim());
+}
+
+function stripLeadingNoisePrefix(lines: string[]): string[] {
+  let index = 0;
+  while (index < lines.length) {
+    const line = lines[index]!.trim();
+    if (
+      PERMISSION_DENIED_SCAN_LINE_RE.test(line) ||
+      CLEAN_DIAGNOSTIC_QUERY_RE.test(line) ||
+      GENERIC_HOOK_FAILURE_PROSE_RE.test(line) ||
+      ISSUE_PROMPT_NOISE_RE.test(line) ||
+      ZERO_ALERT_SUMMARY_RE.test(line) ||
+      isCommandBoilerplateLine(line)
+    ) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+
+  return index > 0 ? lines.slice(index) : lines;
+}
+
 /**
  * Parse raw tmux output into clean, human-readable lines.
  * - Strips ANSI escape codes
@@ -334,6 +363,8 @@ export function parseTmuxTail(raw: string, maxLines: number = DEFAULT_MAX_TAIL_L
     if (ZERO_ALERT_SUMMARY_RE.test(trimmed)) continue;
     if (GENERIC_HOOK_FAILURE_PROSE_RE.test(trimmed)) continue;
     if (ISSUE_PROMPT_NOISE_RE.test(trimmed)) continue;
+    if (PERMISSION_DENIED_SCAN_LINE_RE.test(trimmed)) continue;
+    if (CLEAN_DIAGNOSTIC_QUERY_RE.test(trimmed)) continue;
     if (SOURCE_PATH_LINE_RE.test(trimmed) && STATIC_CODE_ALERT_RE.test(trimmed)) continue;
     if (SOURCE_PATH_LINE_RE.test(trimmed)) {
       const sourceContent = trimmed.replace(SOURCE_PATH_LINE_RE, "").trim();
@@ -350,7 +381,7 @@ export function parseTmuxTail(raw: string, maxLines: number = DEFAULT_MAX_TAIL_L
   }
 
   const trimmed = trimReviewSeedPrefix(meaningful);
-  return trimmed.slice(-maxLines).join("\n");
+  return stripLeadingNoisePrefix(trimmed).slice(-maxLines).join("\n");
 }
 
 /**


### PR DESCRIPTION
## Summary
- suppress pure Permission denied fallout from broad parent-directory AGENTS/file scans in the post-tool failure hook
- filter clean diagnostics/search residue from tmux alert parsing so keyword/failure alerts only reflect actionable runtime output
- ignore non-active PSM review/fix sessions during cleanup scans to stop stale completed-session churn

## Testing
- npm test -- --run src/__tests__/post-tool-use-failure.test.ts src/notifications/__tests__/formatter.test.ts src/__tests__/project-session-manager-session-filter.test.ts
- npm run build