### PR TITLE
fix(agents): restore routable model aliases in generated frontmatter

### DIFF
--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -1,7 +1,7 @@
 ---
 name: analyst
 description: Pre-planning consultant for requirements analysis (Opus)
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Strategic Architecture & Debugging Advisor (Opus, READ-ONLY)
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Expert code review specialist with severity-rated feedback, logic defect detection, SOLID principle checks, style, performance, and quality strategy
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise.
-model: claude-opus-4-6
+model: opus
 level: 3
 ---
 

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -1,7 +1,7 @@
 ---
 name: critic
 description: Work plan and code review expert — thorough, structured, multi-perspective (Opus)
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -1,7 +1,7 @@
 ---
 name: debugger
 description: Root-cause analysis, regression isolation, stack trace analysis, build/compilation error resolution
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -1,7 +1,7 @@
 ---
 name: designer
 description: UI/UX Designer-Developer for stunning interfaces (Sonnet)
-model: claude-sonnet-4-6
+model: sonnet
 level: 2
 ---
 

--- a/agents/document-specialist.md
+++ b/agents/document-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: document-specialist
 description: External Documentation & Reference Specialist
-model: claude-sonnet-4-6
+model: sonnet
 level: 2
 disallowedTools: Write, Edit
 ---

--- a/agents/executor.md
+++ b/agents/executor.md
@@ -1,7 +1,7 @@
 ---
 name: executor
 description: Focused task executor for implementation work (Sonnet)
-model: claude-sonnet-4-6
+model: sonnet
 level: 2
 ---
 

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Codebase search specialist for finding files and code patterns
-model: claude-haiku-4-5
+model: haiku
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/git-master.md
+++ b/agents/git-master.md
@@ -1,7 +1,7 @@
 ---
 name: git-master
 description: Git expert for atomic commits, rebasing, and history management with style detection
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: Strategic planning consultant with interview workflow (Opus)
-model: claude-opus-4-6
+model: opus
 level: 4
 ---
 

--- a/agents/qa-tester.md
+++ b/agents/qa-tester.md
@@ -1,7 +1,7 @@
 ---
 name: qa-tester
 description: Interactive CLI testing specialist using tmux for session management
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/scientist.md
+++ b/agents/scientist.md
@@ -1,7 +1,7 @@
 ---
 name: scientist
 description: Data analysis and research execution specialist
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: test-engineer
 description: Test strategy, integration/e2e coverage, flaky test hardening, TDD workflows
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/tracer.md
+++ b/agents/tracer.md
@@ -1,7 +1,7 @@
 ---
 name: tracer
 description: Evidence-driven causal tracing with competing hypotheses, evidence for/against, uncertainty tracking, and next-probe recommendations
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Verification strategy, evidence-based completion checks, test adequacy
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/writer.md
+++ b/agents/writer.md
@@ -1,7 +1,7 @@
 ---
 name: writer
 description: Technical documentation writer for README, API docs, and comments (Haiku)
-model: claude-haiku-4-5
+model: haiku
 level: 2
 ---
 

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -127,25 +127,36 @@ describe('Installer Constants', () => {
 
     it('should have consistent model assignments', () => {
       const modelExpectations: Record<string, string> = {
-        'architect.md': 'claude-opus-4-6',
-        'executor.md': 'claude-sonnet-4-6',
-        'designer.md': 'claude-sonnet-4-6',
-        'writer.md': 'claude-haiku-4-5',
-        'critic.md': 'claude-opus-4-6',
-        'analyst.md': 'claude-opus-4-6',
-        'planner.md': 'claude-opus-4-6',
-        'qa-tester.md': 'claude-sonnet-4-6',
-        'debugger.md': 'claude-sonnet-4-6',
-        'verifier.md': 'claude-sonnet-4-6',
-        'test-engineer.md': 'claude-sonnet-4-6',
-        'security-reviewer.md': 'claude-opus-4-6',
-        'git-master.md': 'claude-sonnet-4-6',
+        'architect.md': 'opus',
+        'executor.md': 'sonnet',
+        'designer.md': 'sonnet',
+        'writer.md': 'haiku',
+        'critic.md': 'opus',
+        'analyst.md': 'opus',
+        'planner.md': 'opus',
+        'qa-tester.md': 'sonnet',
+        'debugger.md': 'sonnet',
+        'verifier.md': 'sonnet',
+        'test-engineer.md': 'sonnet',
+        'security-reviewer.md': 'opus',
+        'git-master.md': 'sonnet',
       };
 
       for (const [filename, expectedModel] of Object.entries(modelExpectations)) {
         const content = AGENT_DEFINITIONS[filename];
         expect(content).toBeTruthy();
         expect(content).toMatch(new RegExp(`^model:\\s+${expectedModel}`, 'm'));
+      }
+    });
+
+    it('ships routable tier aliases in agent frontmatter instead of literal Claude model IDs', () => {
+      for (const [filename, content] of Object.entries(AGENT_DEFINITIONS)) {
+        if (filename === 'AGENTS.md') continue;
+
+        const modelMatch = content.match(/^model:\s+(\S+)/m);
+        expect(modelMatch, `${filename} should declare a model alias`).toBeTruthy();
+        expect(modelMatch![1], `${filename} should use a tier alias`).toMatch(/^(opus|sonnet|haiku)$/);
+        expect(content, `${filename} should not pin a literal Claude model ID`).not.toMatch(/^model:\s+claude-/m);
       }
     });
 

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -586,7 +586,15 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
 
   // === Agent definition model routing (issue: subagent_type bare-model-id on Bedrock) ===
 
-  it('denies Agent call with subagent_type whose definition has a bare Anthropic model ID when forceInherit is enabled', () => {
+  it('denies Agent call when a discovered plugin agent definition has a bare Anthropic model ID', () => {
+    const pluginRoot = join(tempDir, 'bare-model-plugin-agent');
+    const agentsDir = join(pluginRoot, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      join(agentsDir, 'critic.md'),
+      '---\nname: critic\nmodel: claude-opus-4-6\n---\nPlugin critic body.',
+    );
+
     const output = runPreToolEnforcerWithEnv(
       {
         tool_name: 'Agent',
@@ -601,6 +609,7 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
       {
         OMC_ROUTING_FORCE_INHERIT: 'true',
         OMC_SUBAGENT_MODEL: 'global.anthropic.claude-sonnet-4-6',
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
     );
 
@@ -611,7 +620,15 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(hookOutput.permissionDecisionReason as string).toContain('claude-opus-4-6');
   });
 
-  it('denies Task call with subagent_type whose definition has a bare Anthropic model ID when forceInherit is enabled', () => {
+  it('denies Task call when a discovered plugin agent definition has a bare Anthropic model ID', () => {
+    const pluginRoot = join(tempDir, 'bare-model-plugin-task');
+    const agentsDir = join(pluginRoot, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      join(agentsDir, 'executor.md'),
+      '---\nname: executor\nmodel: claude-sonnet-4-6\n---\nPlugin executor body.',
+    );
+
     const output = runPreToolEnforcerWithEnv(
       {
         tool_name: 'Task',
@@ -626,6 +643,7 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
       {
         OMC_ROUTING_FORCE_INHERIT: 'true',
         OMC_SUBAGENT_MODEL: 'global.anthropic.claude-sonnet-4-6',
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
     );
 
@@ -635,7 +653,15 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(hookOutput.permissionDecisionReason as string).toContain('[MODEL ROUTING]');
   });
 
-  it('deny message includes the bare model from the definition and suggests the tier alias', () => {
+  it('deny message includes the bare model from a plugin definition and suggests the tier alias', () => {
+    const pluginRoot = join(tempDir, 'bare-model-plugin-message');
+    const agentsDir = join(pluginRoot, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      join(agentsDir, 'critic.md'),
+      '---\nname: critic\nmodel: claude-opus-4-6\n---\nPlugin critic body.',
+    );
+
     const output = runPreToolEnforcerWithEnv(
       {
         tool_name: 'Agent',
@@ -650,6 +676,7 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
       {
         OMC_ROUTING_FORCE_INHERIT: 'true',
         OMC_SUBAGENT_MODEL: 'global.anthropic.claude-sonnet-4-6',
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
       },
     );
 
@@ -728,6 +755,28 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(JSON.stringify(output)).not.toContain('MODEL ROUTING');
   });
 
+  it('does not deny shipped agent definitions that use routable tier aliases in frontmatter', () => {
+    const output = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Agent',
+        toolInput: {
+          subagent_type: 'oh-my-claudecode:critic',
+          description: 'Review spec',
+          prompt: 'Review this spec',
+        },
+        cwd: tempDir,
+        session_id: 'session-shipped-tier-alias',
+      },
+      {
+        OMC_ROUTING_FORCE_INHERIT: 'true',
+        OMC_SUBAGENT_MODEL: 'global.anthropic.claude-sonnet-4-6-v1:0',
+      },
+    );
+
+    expect(output.continue).toBe(true);
+    expect(JSON.stringify(output)).not.toContain('MODEL ROUTING');
+  });
+
   it('does not throw or deny when subagent_type is a non-string value', () => {
     const output = runPreToolEnforcerWithEnv(
       {
@@ -772,7 +821,7 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(JSON.stringify(output)).not.toContain('MODEL ROUTING');
   });
 
-  it('falls back to script-relative agents dir when CLAUDE_PLUGIN_ROOT points to a non-existent path', () => {
+  it('falls back to script-relative agents dir when CLAUDE_PLUGIN_ROOT points to a non-existent path and allows shipped tier aliases', () => {
     const output = runPreToolEnforcerWithEnv(
       {
         tool_name: 'Agent',
@@ -791,15 +840,11 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
       },
     );
 
-    // Despite stale CLAUDE_PLUGIN_ROOT, falls back to script-relative agents dir and detects bare model
-    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
     expect(output.continue).toBe(true);
-    expect(hookOutput.permissionDecision).toBe('deny');
-    expect(hookOutput.permissionDecisionReason as string).toContain('[MODEL ROUTING]');
-    expect(hookOutput.permissionDecisionReason as string).toContain('claude-opus-4-6');
+    expect(JSON.stringify(output)).not.toContain('MODEL ROUTING');
   });
 
-  it('falls back to script-relative agents dir when CLAUDE_PLUGIN_ROOT/agents exists but lacks the specific agent file', () => {
+  it('falls back to script-relative agents dir when CLAUDE_PLUGIN_ROOT/agents exists but lacks the specific agent file, and allows shipped tier aliases', () => {
     // CLAUDE_PLUGIN_ROOT/agents/ exists (non-empty check passes) but does not contain critic.md
     const pluginRoot = join(tempDir, 'partial-plugin');
     const pluginAgentsDir = join(pluginRoot, 'agents');
@@ -825,12 +870,8 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
       },
     );
 
-    // Should fall back to script-relative agents/, find critic.md, and deny on bare model ID
-    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
     expect(output.continue).toBe(true);
-    expect(hookOutput.permissionDecision).toBe('deny');
-    expect(hookOutput.permissionDecisionReason as string).toContain('[MODEL ROUTING]');
-    expect(hookOutput.permissionDecisionReason as string).toContain('claude-opus-4-6');
+    expect(JSON.stringify(output)).not.toContain('MODEL ROUTING');
   });
 
   it('does not deny when model: appears inside a body --- block (not real frontmatter)', () => {


### PR DESCRIPTION
## Summary
- restore shipped `agents/*.md` frontmatter from literal Claude model IDs back to tier aliases (`opus`, `sonnet`, `haiku`)
- update installer coverage to assert shipped agent frontmatter stays on routable aliases rather than pinned `claude-*` IDs
- refine pre-tool hook regression coverage so plugin-provided bare model IDs still deny while shipped alias-based definitions pass

## Verification
- npm test -- --run src/__tests__/installer.test.ts src/__tests__/pre-tool-enforcer.test.ts src/__tests__/agent-registry.test.ts

Closes #2612