### PR TITLE
fix(hooks): avoid post-tool verifier false positives in TDD flows

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -184,6 +184,23 @@ function stripQuotedSpans(output) {
   return output.replace(QUOTED_SPAN_PATTERN, ' ');
 }
 
+function isPytestRunOutput(output) {
+  if (!output) return false;
+
+  const cleaned = stripClaudeTempCwdErrors(output);
+  const hasPytestHeader =
+    /(^|\n)=+\s*test session starts\s*=+/i.test(cleaned) ||
+    /(^|\n).*pytest-\d/i.test(cleaned) ||
+    /(^|\n)collected\s+\d+\s+items?\b/i.test(cleaned);
+  const hasPytestBody =
+    /(^|\n)=+\s*short test summary info\s*=+/i.test(cleaned) ||
+    /(^|\n)=+\s*failures\s*=+/i.test(cleaned) ||
+    /(^|\n)(?:FAILED|ERROR)\s+.+::.+/m.test(cleaned) ||
+    /(^|\n)\S+\.py::\S+\s+(?:PASSED|FAILED|ERROR)\b/m.test(cleaned);
+
+  return hasPytestHeader && hasPytestBody;
+}
+
 function stripNonActionableErrorContext(output) {
   if (!output) return '';
   return output
@@ -236,6 +253,10 @@ export function detectBashFailure(output) {
   if (!output) return false;
 
   const cleaned = stripClaudeTempCwdErrors(output);
+
+  if (isPytestRunOutput(cleaned)) {
+    return false;
+  }
 
   const explicitExitPatterns = [
     /(^|\n)Error: Exit code [1-9]\d*(\n|$)/i,
@@ -667,7 +688,7 @@ function processRememberTags(output, directory) {
 // Patterns are tightened to tool-level failure phrases to avoid false positives
 // when edited file content contains error-handling code (issue #1005)
 export function detectWriteFailure(output) {
-  const cleaned = stripClaudeTempCwdErrors(output);
+  const cleaned = stripQuotedSpans(stripClaudeTempCwdErrors(output));
   const errorPatterns = [
     /\berror:/i,              // "error:" with word boundary — avoids "setError", "console.error"
     /\bfailed to\b/i,        // "failed to write" — avoids "failedOidc", UI strings

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -13,6 +13,26 @@ import { detectBashFailure, detectWriteFailure, isNonZeroExitWithOutput, summari
 
 const SCRIPT_PATH = join(process.cwd(), 'scripts', 'post-tool-verifier.mjs');
 const TEMPLATE_HOOK_PATH = join(process.cwd(), 'templates', 'hooks', 'post-tool-use.mjs');
+const PYTEST_RED_RUN_OUTPUT = [
+  'Error: Exit code 1',
+  '============================= test session starts ==============================',
+  'platform linux -- Python 3.12.0, pytest-8.4.0',
+  'collected 1 item',
+  '',
+  'tests/test_example.py F                                                   [100%]',
+  '',
+  '=================================== FAILURES ===================================',
+  '___________________________________ test_red ___________________________________',
+  '',
+  '    def test_red():',
+  '>       assert 1 == 2',
+  'E       assert 1 == 2',
+  '',
+  'tests/test_example.py:3: AssertionError',
+  '=========================== short test summary info ============================',
+  'FAILED tests/test_example.py::test_red - assert 1 == 2',
+  '============================== 1 failed in 0.12s ==============================',
+].join('\n');
 
 function runPostToolVerifier(input, env = {}) {
   return runHookScript(SCRIPT_PATH, input, env);
@@ -165,6 +185,10 @@ describe('detectBashFailure', () => {
     it('should not flag successful grep output containing "Command failed" text', () => {
       const output = 'scripts/post-tool-verifier.mjs:683:        message = \'Command failed. Please investigate the error and fix before continuing.\'';
       expect(detectBashFailure(output)).toBe(false);
+    });
+
+    it('should not flag pytest red-phase output as a bash tool failure', () => {
+      expect(detectBashFailure(PYTEST_RED_RUN_OUTPUT)).toBe(false);
     });
 
     it('should not flag successful output when the word "error" appears mid-line', () => {
@@ -402,6 +426,11 @@ describe('detectWriteFailure', () => {
       expect(detectWriteFailure(testContent)).toBe(false);
     });
 
+    it('should not flag inline error-like assertion strings inside edited tests', () => {
+      expect(detectWriteFailure('expect(output).toContain("error: boom")')).toBe(false);
+      expect(detectWriteFailure('await expect(run()).rejects.toThrow("Error: missing fixture")')).toBe(false);
+    });
+
     it('should still detect real tool-level errors alongside code content', () => {
       expect(detectWriteFailure('error: EACCES writing to /etc/hosts')).toBe(true);
       expect(detectWriteFailure('failed to write file: permission denied')).toBe(true);
@@ -444,6 +473,31 @@ describe('agent output summarization / truncation (issue #1373)', () => {
     expect(out.continue).toBe(true);
     expect(out.hookSpecificOutput?.additionalContext).toContain('TaskOutput summary:');
     expect(out.hookSpecificOutput?.additionalContext).toContain('TaskOutput clipped');
+  });
+});
+
+describe('post-tool hook regression coverage (issue #2615)', () => {
+  it('does not treat inline error-like strings in Edit output as an edit failure', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Edit',
+      tool_response: 'expect(output).toContain("error: boom")',
+      session_id: 'issue-2615-edit',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Code modified.');
+    expect(out.hookSpecificOutput?.additionalContext).not.toContain('Edit operation failed');
+  });
+
+  it('does not treat pytest red runs as bash tool failures during TDD workflows', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Bash',
+      tool_response: PYTEST_RED_RUN_OUTPUT,
+      session_id: 'issue-2615-bash',
+      cwd: process.cwd(),
+    });
+
+    expect(out).toEqual({ continue: true, suppressOutput: true });
   });
 });
 


### PR DESCRIPTION
## Summary\n- ignore quoted error-like strings when checking Edit/Write tool output for write failures\n- treat recognizable pytest session output as normal red-phase Bash output instead of a tool failure\n- add detector-level and hook-level regressions for both false-positive cases\n\n## Verification\n- npx vitest run src/__tests__/post-tool-verifier.test.mjs\n- npx tsc --noEmit --pretty false\n\nFixes #2615