### PR TITLE
fix(state-root): honor OMC_STATE_DIR in pre-tool-enforcer (follow-up to #2532)

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -12,6 +12,7 @@ import { execSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { evaluateAgentHeavyPreflight } from './lib/pre-tool-enforcer-preflight.mjs';
+import { resolveOmcStateRoot } from './lib/state-root.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
 // Inlined from src/config/models.ts — avoids a dist/ import so the hook works
@@ -167,8 +168,8 @@ function extractJsonField(input, field, defaultValue = '') {
 }
 
 // Get agent tracking info from state file
-function getAgentTrackingInfo(directory) {
-  const trackingFile = join(directory, '.omc', 'state', 'subagent-tracking.json');
+function getAgentTrackingInfo(stateDir) {
+  const trackingFile = join(stateDir, 'subagent-tracking.json');
   try {
     if (existsSync(trackingFile)) {
       const data = JSON.parse(readFileSync(trackingFile, 'utf-8'));
@@ -252,9 +253,7 @@ function hasActiveSwarmMode(stateDir, { allowSessionTagged = false } = {}) {
   return true;
 }
 
-function hasActiveMode(directory, sessionId) {
-  const stateDir = join(directory, '.omc', 'state');
-
+function hasActiveMode(stateDir, sessionId) {
   if (isValidSessionId(sessionId)) {
     const sessionStateDir = join(stateDir, 'sessions', sessionId);
     return (
@@ -288,12 +287,12 @@ function mapCanonicalTeamPhaseToStage(rawPhase) {
   }
 }
 
-function readCanonicalActiveTeamState(directory, sessionId) {
+function readCanonicalActiveTeamState(stateDir, sessionId) {
   if (!sessionId || !SESSION_ID_PATTERN.test(sessionId)) {
     return null;
   }
 
-  const teamRoot = join(directory, '.omc', 'state', 'team');
+  const teamRoot = join(stateDir, 'team');
   if (!existsSync(teamRoot)) {
     return null;
   }
@@ -340,17 +339,17 @@ function readCanonicalActiveTeamState(directory, sessionId) {
  * Reads team-state.json from session-scoped or legacy paths and falls back
  * to canonical team state when the coarse file drifts or disappears.
  */
-function getActiveTeamState(directory, sessionId) {
+function getActiveTeamState(stateDir, sessionId) {
   const paths = [];
   let coarseState = null;
 
   // Session-scoped path (preferred)
   if (sessionId && SESSION_ID_PATTERN.test(sessionId)) {
-    paths.push(join(directory, '.omc', 'state', 'sessions', sessionId, 'team-state.json'));
+    paths.push(join(stateDir, 'sessions', sessionId, 'team-state.json'));
   }
 
   // Legacy path
-  paths.push(join(directory, '.omc', 'state', 'team-state.json'));
+  paths.push(join(stateDir, 'team-state.json'));
 
   for (const statePath of paths) {
     const state = readJsonFile(statePath);
@@ -366,7 +365,7 @@ function getActiveTeamState(directory, sessionId) {
     }
   }
 
-  const canonical = readCanonicalActiveTeamState(directory, sessionId);
+  const canonical = readCanonicalActiveTeamState(stateDir, sessionId);
   if (canonical && canonical.active === true) {
     return canonical;
   }
@@ -375,7 +374,7 @@ function getActiveTeamState(directory, sessionId) {
 }
 
 // Generate agent spawn message with metadata
-function generateAgentSpawnMessage(toolInput, directory, todoStatus, sessionId) {
+function generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId) {
   if (!toolInput || typeof toolInput !== 'object') {
     if (QUIET_LEVEL >= 2) return '';
     return `${todoStatus}Launch multiple agents in parallel when tasks are independent. Use run_in_background for long operations.`;
@@ -385,12 +384,12 @@ function generateAgentSpawnMessage(toolInput, directory, todoStatus, sessionId) 
   const model = toolInput.model || 'inherit';
   const desc = toolInput.description || '';
   const bg = toolInput.run_in_background ? ' [BACKGROUND]' : '';
-  const tracking = getAgentTrackingInfo(directory);
+  const tracking = getAgentTrackingInfo(stateDir);
 
   // Team-routing enforcement (issue #1006):
   // When team state is active and Task is called WITHOUT team_name,
   // inject a redirect message to use team agents instead of subagents.
-  const teamState = getActiveTeamState(directory, sessionId);
+  const teamState = getActiveTeamState(stateDir, sessionId);
   if (teamState && !toolInput.team_name) {
     const teamName = teamState.team_name || teamState.teamName || 'team';
     return `[TEAM ROUTING REQUIRED] Team "${teamName}" is active but you are spawning a regular subagent ` +
@@ -519,7 +518,7 @@ function extractSkillName(toolInput) {
   return normalized.includes(':') ? normalized.split(':').at(-1).toLowerCase() : normalized.toLowerCase();
 }
 
-function writeSkillActiveState(directory, skillName, sessionId, rawSkillName) {
+function writeSkillActiveState(stateDir, skillName, sessionId, rawSkillName) {
   const protection = getSkillProtectionLevel(skillName, rawSkillName);
   if (protection === 'none') return;
 
@@ -527,7 +526,6 @@ function writeSkillActiveState(directory, skillName, sessionId, rawSkillName) {
   const now = new Date().toISOString();
   const normalized = (skillName || '').toLowerCase().replace(/^oh-my-claudecode:/, '');
 
-  const stateDir = join(directory, '.omc', 'state');
   const safeSessionId = sessionId && SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
   const targetDir = safeSessionId
     ? join(stateDir, 'sessions', safeSessionId)
@@ -582,8 +580,7 @@ function writeSkillActiveState(directory, skillName, sessionId, rawSkillName) {
 }
 
 
-function clearAwaitingConfirmationFlag(directory, stateName, sessionId) {
-  const stateDir = join(directory, '.omc', 'state');
+function clearAwaitingConfirmationFlag(stateDir, stateName, sessionId) {
   const safeSessionId = sessionId && SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
   const paths = [
     safeSessionId ? join(stateDir, 'sessions', safeSessionId, `${stateName}-state.json`) : null,
@@ -605,20 +602,20 @@ function clearAwaitingConfirmationFlag(directory, stateName, sessionId) {
   }
 }
 
-function confirmSkillModeStates(directory, skillName, sessionId) {
+function confirmSkillModeStates(stateDir, skillName, sessionId) {
   switch (skillName) {
     case 'ralph':
-      clearAwaitingConfirmationFlag(directory, 'ralph', sessionId);
-      clearAwaitingConfirmationFlag(directory, 'ultrawork', sessionId);
+      clearAwaitingConfirmationFlag(stateDir, 'ralph', sessionId);
+      clearAwaitingConfirmationFlag(stateDir, 'ultrawork', sessionId);
       break;
     case 'ultrawork':
-      clearAwaitingConfirmationFlag(directory, 'ultrawork', sessionId);
+      clearAwaitingConfirmationFlag(stateDir, 'ultrawork', sessionId);
       break;
     case 'autopilot':
-      clearAwaitingConfirmationFlag(directory, 'autopilot', sessionId);
+      clearAwaitingConfirmationFlag(stateDir, 'autopilot', sessionId);
       break;
     case 'ralplan':
-      clearAwaitingConfirmationFlag(directory, 'ralplan', sessionId);
+      clearAwaitingConfirmationFlag(stateDir, 'ralplan', sessionId);
       break;
     default:
       break;
@@ -656,6 +653,12 @@ async function main() {
     const toolName = extractJsonField(input, 'tool_name') || extractJsonField(input, 'toolName', 'unknown');
     const directory = extractJsonField(input, 'cwd') || extractJsonField(input, 'directory', process.cwd());
 
+    // Resolve the .omc state root once, honoring OMC_STATE_DIR.
+    // All helpers receive stateDir so they stay in sync with the centralized
+    // resolver used by session-start.mjs and persistent-mode (issue #2518, PR #2532).
+    const omcRoot = await resolveOmcStateRoot(directory);
+    const stateDir = join(omcRoot, 'state');
+
     // Record Skill invocations to flow trace
     let data = {};
     try { data = JSON.parse(input); } catch {}
@@ -673,8 +676,8 @@ async function main() {
         // Pass rawSkillName to distinguish OMC skills from project custom skills (issue #1581)
         const rawSkill = toolInput.skill || toolInput.skill_name || toolInput.skillName || toolInput.command || '';
         const rawSkillName = typeof rawSkill === 'string' && rawSkill.trim() ? rawSkill.trim() : undefined;
-        writeSkillActiveState(directory, skillName, sid, rawSkillName);
-        confirmSkillModeStates(directory, skillName, sid);
+        writeSkillActiveState(stateDir, skillName, sid, rawSkillName);
+        confirmSkillModeStates(stateDir, skillName, sid);
       }
     }
 
@@ -684,7 +687,7 @@ async function main() {
         : typeof data.sessionId === 'string'
           ? data.sessionId
           : '';
-    const modeActive = hasActiveMode(directory, sessionId);
+    const modeActive = hasActiveMode(stateDir, sessionId);
 
     // Force-inherit check: deny Task/Agent calls with invalid model param when forceInherit is
     // enabled (Bedrock, Vertex, CC Switch, etc.) - issues #1135, #1201, #1767, #1868
@@ -836,7 +839,7 @@ async function main() {
     let message;
     if (toolName === 'Task' || toolName === 'TaskCreate' || toolName === 'TaskUpdate') {
       const toolInput = data.toolInput || data.tool_input || null;
-      message = generateAgentSpawnMessage(toolInput, directory, todoStatus, sessionId);
+      message = generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId);
     } else {
       message = generateMessage(toolName, todoStatus, modeActive);
     }

--- a/src/__tests__/state-root-resolution.test.ts
+++ b/src/__tests__/state-root-resolution.test.ts
@@ -6,11 +6,13 @@
  *   2. session-start.mjs reads session state from the custom OMC_STATE_DIR location
  *   3. persistent-mode.cjs (stop hook) reads mode state from the custom OMC_STATE_DIR
  *      location and correctly blocks the stop when an active mode is present there
+ *   4. pre-tool-enforcer.mjs (PreToolUse hook) reads team-state and writes
+ *      skill-active-state through the centralized OMC_STATE_DIR location
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { getOmcRoot, clearWorktreeCache } from '../lib/worktree-paths.js';
@@ -19,6 +21,7 @@ const NODE = process.execPath;
 const REPO_ROOT = resolve(join(__dirname, '..', '..'));
 const SESSION_START = join(REPO_ROOT, 'scripts', 'session-start.mjs');
 const STOP_HOOK = join(REPO_ROOT, 'scripts', 'persistent-mode.cjs');
+const PRE_TOOL_ENFORCER = join(REPO_ROOT, 'scripts', 'pre-tool-enforcer.mjs');
 
 /** Run a hook script synchronously and return the parsed JSON output. */
 function runHook(
@@ -285,5 +288,143 @@ describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
     );
 
     expect(output.decision).not.toBe('block');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 4. pre-tool-enforcer.mjs (PreToolUse hook) — follow-up to #2532
+  //    Scenario: enforcer must read team-state and write skill-active-state
+  //    from the same centralized OMC_STATE_DIR location as sibling hooks.
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('pre-tool-enforcer injects [TEAM ROUTING REQUIRED] when team-state lives in default .omc (baseline)', () => {
+    const sessionId = 'test-pte-team-default';
+    const stateDir = join(fakeProject, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'team-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        team_name: 'alpha',
+        current_phase: 'team-exec',
+      }),
+    );
+
+    const output = runHook(PRE_TOOL_ENFORCER, {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'executor', description: 'sample task' },
+      session_id: sessionId,
+      cwd: fakeProject,
+    });
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).toContain('[TEAM ROUTING REQUIRED]');
+    expect(context).toContain('alpha');
+  });
+
+  it('pre-tool-enforcer injects [TEAM ROUTING REQUIRED] when team-state lives in centralized OMC_STATE_DIR', () => {
+    const sessionId = 'test-pte-team-central';
+    const centralizedOmcRoot = getCentralizedOmcRoot(fakeProject, fakeStateDir);
+    const stateDir = join(centralizedOmcRoot, 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'team-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        team_name: 'beta',
+        current_phase: 'team-exec',
+      }),
+    );
+
+    // No .omc in fakeProject — active team-state ONLY in centralized dir
+    const output = runHook(
+      PRE_TOOL_ENFORCER,
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: { subagent_type: 'executor', description: 'sample task' },
+        session_id: sessionId,
+        cwd: fakeProject,
+      },
+      { OMC_STATE_DIR: fakeStateDir },
+    );
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).toContain('[TEAM ROUTING REQUIRED]');
+    expect(context).toContain('beta');
+  });
+
+  it('pre-tool-enforcer ignores stale team-state in default .omc when OMC_STATE_DIR is set', () => {
+    const sessionId = 'test-pte-team-mismatch';
+    // Place active team-state in default location only
+    const stateDir = join(fakeProject, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'team-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        team_name: 'gamma',
+        current_phase: 'team-exec',
+      }),
+    );
+
+    // Run with OMC_STATE_DIR pointing elsewhere — centralized path is empty → no redirect
+    const output = runHook(
+      PRE_TOOL_ENFORCER,
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Task',
+        tool_input: { subagent_type: 'executor', description: 'sample task' },
+        session_id: sessionId,
+        cwd: fakeProject,
+      },
+      { OMC_STATE_DIR: fakeStateDir },
+    );
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).not.toContain('[TEAM ROUTING REQUIRED]');
+  });
+
+  it('pre-tool-enforcer writes skill-active-state into the centralized OMC_STATE_DIR path', () => {
+    const sessionId = 'test-pte-skill-central';
+    const centralizedOmcRoot = getCentralizedOmcRoot(fakeProject, fakeStateDir);
+
+    runHook(
+      PRE_TOOL_ENFORCER,
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Skill',
+        // `skill` needs a non-'none' protection level. The OMC-prefixed `skill`
+        // slash-command maps to 'light' protection, which triggers the write.
+        tool_input: { skill: 'oh-my-claudecode:skill' },
+        session_id: sessionId,
+        cwd: fakeProject,
+      },
+      { OMC_STATE_DIR: fakeStateDir },
+    );
+
+    const centralizedPath = join(
+      centralizedOmcRoot,
+      'state',
+      'sessions',
+      sessionId,
+      'skill-active-state.json',
+    );
+    const defaultPath = join(
+      fakeProject,
+      '.omc',
+      'state',
+      'sessions',
+      sessionId,
+      'skill-active-state.json',
+    );
+    expect(existsSync(centralizedPath)).toBe(true);
+    expect(existsSync(defaultPath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2532. `scripts/pre-tool-enforcer.mjs` was left out of the centralized `OMC_STATE_DIR` resolver work, so the PreToolUse hook still read and wrote state through hardcoded `join(directory, '.omc', 'state', …)` paths — seven of them.

When a user runs Claude Code with `OMC_STATE_DIR` set to relocate `.omc/`, sibling hooks (session-start, persistent-mode) now correctly honor it since #2532, but pre-tool-enforcer quietly kept reading from the project-local `.omc/state/` directory. That caused three observable bugs:

1. **Team-routing silently broken** — `getActiveTeamState` never found the centralized `team-state.json`, so `Task` calls during an active team session bypassed the `[TEAM ROUTING REQUIRED]` redirect.
2. **Skill protection split-brain** — `writeSkillActiveState` wrote `skill-active-state.json` to the project tree while the Stop hook (persistent-mode.cjs) looked for it in the centralized dir. Sessions could terminate mid-skill.
3. **Subagent tracking, ralph/ultrawork confirmation flags, and canonical team state** all read/wrote the wrong location.

This PR closes the gap using the exact pattern #2532 established for `persistent-mode.mjs`.

## What changed

`scripts/pre-tool-enforcer.mjs`:

- Added `import { resolveOmcStateRoot } from './lib/state-root.mjs';`.
- In `main()`, resolve once at the top:
  ```js
  const omcRoot = await resolveOmcStateRoot(directory);
  const stateDir = join(omcRoot, 'state');
  ```
- Thread `stateDir` through every state-touching helper. Signatures changed from `(directory, …)` to `(stateDir, …)`:
  - `getAgentTrackingInfo`
  - `hasActiveMode`
  - `readCanonicalActiveTeamState`
  - `getActiveTeamState`
  - `generateAgentSpawnMessage`
  - `writeSkillActiveState`
  - `clearAwaitingConfirmationFlag`
  - `confirmSkillModeStates`
- The four call sites in `main()` now pass `stateDir` instead of `directory`.

Nothing inside those helpers used `directory` for anything but building `.omc/state/…` paths, so the rename is mechanical. The file has **no new async call sites** — `resolveOmcStateRoot` is awaited exactly once at the top of `main()`, which was already async.

### The seven hardcoded paths before this PR

| Line (before) | Function | Path |
|---|---|---|
| 171 | `getAgentTrackingInfo` | `.omc/state/subagent-tracking.json` |
| 256 | `hasActiveMode` | `.omc/state` |
| 296 | `readCanonicalActiveTeamState` | `.omc/state/team` |
| 349 | `getActiveTeamState` | `.omc/state/sessions/<id>/team-state.json` |
| 353 | `getActiveTeamState` | `.omc/state/team-state.json` (legacy) |
| 530 | `writeSkillActiveState` | `.omc/state` |
| 586 | `clearAwaitingConfirmationFlag` | `.omc/state` |

All seven now derive from the pre-resolved `stateDir`.

## Scope notes (what is intentionally NOT in this PR)

- **`.omc/todos.json` at line 189** is the same bug pattern but cross-cuts five call sites (pre-tool-enforcer.mjs, persistent-mode.{cjs,mjs}, templates/hooks/{session-start,persistent-mode}.mjs). It deserves an atomic follow-up rather than a half-fix here.
- **`.omc-config.json` / `.omc/config.json` reads (lines 494–495)** are configuration files, not ephemeral state. ~40 files across the repo follow the same `getClaudeConfigDir()` / `process.cwd()` convention for config; relocating those is a separate architectural decision.

## Tests

Extended `src/__tests__/state-root-resolution.test.ts` with four scenarios that mirror the persistent-mode coverage:

1. **baseline** — team-state in default `.omc/state` still triggers `[TEAM ROUTING REQUIRED]`.
2. **centralized** — team-state placed only under `OMC_STATE_DIR` still triggers it (the actual fix).
3. **mismatch** — with `OMC_STATE_DIR` set, team-state in the default `.omc/state` path is invisible (asserts the hardcode is truly gone).
4. **write** — `Skill` tool invocation writes `skill-active-state.json` into the centralized dir, not the project tree.

Results:
- State-root file: **11 passed, 0 failed** (7 existing + 4 new)
- Full suite: **8336 passed, 1 failed**. The failure is the known flaky tmux test at `src/team/__tests__/scaling.test.ts > scaleUp duplicate worker guard > self-heals across multiple collisions` — it passes when run in isolation and has unrelated pre-existing cleanup issues (commit `1aa3635d`).
- Lint: 0 errors.

## Manual verification

```bash
# With OMC_STATE_DIR set, create a fake team-state in the centralized dir
export OMC_STATE_DIR=/tmp/omc-centralized
# …run a Skill or Task through Claude Code, inspect skill-active-state.json
# Before this PR: file appears under <project>/.omc/state/sessions/<id>/
# After this PR:  file appears under $OMC_STATE_DIR/<project-hash>/state/sessions/<id>/
```

## Test plan

- [x] New regression tests cover centralized-path read, write, and mismatch behavior.
- [x] Baseline tests cover default `.omc/state` behavior.
- [x] Existing persistent-mode and session-start tests still pass.
- [x] Local `npm run build` + `npm run lint` + `npx vitest run src/__tests__/state-root-resolution.test.ts`.

Generated with [Claude Code](https://claude.com/claude-code)
