### PR TITLE
fix: avoid invalid AskUserQuestion params in MCP setup flow

### DIFF
--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -12,19 +12,55 @@ Configure Model Context Protocol (MCP) servers to extend Claude Code's capabilit
 
 MCP servers provide additional tools that Claude Code agents can use. This skill helps you configure popular MCP servers using the `claude mcp add` command-line interface.
 
-## Step 1: Show Available MCP Servers
+## Step 1: Choose a Setup Path
 
-Present the user with available MCP server options using AskUserQuestion:
+Use **AskUserQuestion** with **one question at a time** and **no more than 3 options per question**. Recent Claude Code builds reject larger option payloads as invalid tool parameters, so keep the MCP selection flow staged.
 
-**Question:** "Which MCP server would you like to configure?"
+### Step 1.1: First menu
+
+**Question:** "What kind of MCP setup would you like?"
 
 **Options:**
-1. **Context7** - Documentation and code context from popular libraries
+1. **Recommended starter setup** - Fast path for the most common OMC MCP additions
+2. **Individual popular server** - Pick one built-in server from a short follow-up menu
+3. **Custom server** - Add your own stdio or HTTP MCP server
+
+### Step 1.2: If the user chooses "Recommended starter setup"
+
+Ask a follow-up **AskUserQuestion**:
+
+**Question:** "Which recommended MCP bundle should I configure?"
+
+**Options:**
+1. **Context7 only (Recommended)** - Zero-config docs/context server
+2. **Context7 + Exa** - Docs/context plus enhanced web search
+3. **Full recommended bundle** - Context7, Exa, Filesystem, and GitHub
+
+Map that choice to the server list you will configure.
+
+### Step 1.3: If the user chooses "Individual popular server"
+
+Ask a follow-up **AskUserQuestion**:
+
+**Question:** "Which server should I configure first?"
+
+**Options:**
+1. **Context7 (Recommended)** - Documentation and code context from popular libraries
 2. **Exa Web Search** - Enhanced web search (replaces built-in websearch)
-3. **Filesystem** - Extended file system access with additional capabilities
-4. **GitHub** - GitHub API integration for issues, PRs, and repository management
-5. **All of the above** - Configure all recommended MCP servers
-6. **Custom** - Add a custom MCP server
+3. **More server choices** - Filesystem, GitHub, or the full recommended bundle
+
+If the user chooses **More server choices**, ask one more **AskUserQuestion**:
+
+**Question:** "Which additional MCP option do you want?"
+
+**Options:**
+1. **Filesystem (Recommended)** - Extended file system access with additional capabilities
+2. **GitHub** - GitHub API integration for issues, PRs, and repository management
+3. **Full recommended bundle** - Configure Context7, Exa, Filesystem, and GitHub together
+
+### Step 1.4: If the user chooses "Custom server"
+
+Skip directly to the **Custom MCP Server** section below.
 
 ## Step 2: Gather Required Information
 

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -193,6 +193,35 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('`psm.sh`');
     });
 
+    it('stages mcp-setup AskUserQuestion menus so each prompt stays within the current option limit', () => {
+      const skill = getBuiltinSkill('mcp-setup');
+      expect(skill).toBeDefined();
+
+      const template = skill!.template;
+      expect(template).toContain('no more than 3 options per question');
+
+      const blocks = template
+        .split(/AskUserQuestion(?: with [^:\n]+)?[:]?/g)
+        .slice(1)
+        .map((block) => block.split(/## Step|### Step|### For |## Custom MCP Server/)[0]);
+
+      expect(blocks.length).toBeGreaterThanOrEqual(3);
+
+      for (const block of blocks) {
+        const optionLines = block
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => /^\d+\. \*\*/.test(line));
+        expect(optionLines.length).toBeLessThanOrEqual(3);
+      }
+
+      expect(template).toContain('Recommended starter setup');
+      expect(template).toContain('Individual popular server');
+      expect(template).toContain('More server choices');
+      expect(template).not.toContain('5. **All of the above**');
+      expect(template).not.toContain('6. **Custom**');
+    });
+
     it('should emphasize process-first install routing in the setup skill', () => {
       const skill = getBuiltinSkill('setup');
       expect(skill).toBeDefined();


### PR DESCRIPTION
## Summary\n- stage the mcp-setup selection flow into follow-up AskUserQuestion menus with at most 3 options each\n- preserve the existing MCP setup choices while avoiding the 4.11.6 update/setup regression path\n- add a regression test that parses rendered builtin skill prompts and enforces the option cap\n\n## Testing\n- npx vitest run src/__tests__/skills.test.ts src/__tests__/auto-slash-aliases.test.ts --reporter=dot\n- npm run build:cli\n\n## Issue\n- closes #2626\n