### PR TITLE
fix(keyword-detector): ignore pasted transcript blocks

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -168,7 +168,7 @@ function isReviewSeedContext(text) {
 }
 
 function sanitizeForKeywordDetection(text) {
-  return text
+  return stripPastedCommandPayloads(text)
     // 0. Strip HTML/markdown comments before tag stripping
     .replace(/<!--[\s\S]*?-->/g, '')
     // 1. Strip XML-style tag blocks: <tag-name ...>...</tag-name> (multi-line, greedy on tag name)
@@ -188,6 +188,131 @@ function sanitizeForKeywordDetection(text) {
     .replace(/```[\s\S]*?```/g, '')
     // 6. Strip inline code (existing)
     .replace(/`[^`]+`/g, '');
+}
+
+const PASTED_MAGIC_KEYWORD_HEADER_PATTERN =
+  /^\s*\[MAGIC KEYWORDS?(?: DETECTED)?:.*$/i;
+const ROLE_BOUNDARY_PATTERN =
+  /^<\s*\/?\s*(system|human|assistant|user|tool_use|tool_result)\b[^>]*>/i;
+const SKILL_TRANSCRIPT_LINE_PATTERN =
+  /^\s*Skill:\s+oh-my-(?:claudecode|codex):/i;
+const USER_REQUEST_LINE_PATTERN = /^\s*User request:\s*$/i;
+const SHELL_TRANSCRIPT_LINE_PATTERN = /^\s*[$%❯]\s+/;
+const GIT_DIFF_START_PATTERNS = [
+  /^diff\s+--git\s+a\//,
+  /^index\s+[0-9a-f]+\.\.[0-9a-f]+(?:\s+\d+)?$/i,
+  /^(?:---|\+\+\+)\s+[ab]\//,
+  /^@@\s+-\d+/,
+];
+const GIT_DIFF_CONTINUATION_PATTERNS = [
+  /^new file mode\s+\d+$/i,
+  /^deleted file mode\s+\d+$/i,
+  /^similarity index\s+\d+%$/i,
+  /^rename (?:from|to)\s+/i,
+  /^Binary files .+ differ$/i,
+  /^(?:diff\s+--git\s+a\/|index\s+[0-9a-f]+\.\.[0-9a-f]+|(?:---|\+\+\+)\s+[ab]\/|@@\s+-\d+)/i,
+  /^[ +\-].*/,
+];
+
+function stripPastedCommandPayloads(text) {
+  const lines = text.split('\n');
+  const sanitized = [];
+  let insideRoleBlock = false;
+  let insideDiffBlock = false;
+  let insideMagicKeywordBlock = false;
+  let magicBlockSawUserRequest = false;
+  let magicBlockSawRequestPayload = false;
+  let previousLineWasUserRequest = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (insideMagicKeywordBlock) {
+      if (ROLE_BOUNDARY_PATTERN.test(trimmed)) {
+        insideRoleBlock = !/^<\s*\//.test(trimmed);
+        insideMagicKeywordBlock = false;
+        magicBlockSawUserRequest = false;
+        magicBlockSawRequestPayload = false;
+        continue;
+      }
+
+      if (USER_REQUEST_LINE_PATTERN.test(line)) {
+        magicBlockSawUserRequest = true;
+        magicBlockSawRequestPayload = false;
+        continue;
+      }
+
+      if (magicBlockSawUserRequest) {
+        if (trimmed) {
+          magicBlockSawRequestPayload = true;
+          continue;
+        }
+
+        if (magicBlockSawRequestPayload) {
+          insideMagicKeywordBlock = false;
+          magicBlockSawUserRequest = false;
+          magicBlockSawRequestPayload = false;
+          sanitized.push(line);
+          continue;
+        }
+      }
+
+      continue;
+    }
+
+    if (PASTED_MAGIC_KEYWORD_HEADER_PATTERN.test(line)) {
+      insideMagicKeywordBlock = true;
+      magicBlockSawUserRequest = false;
+      magicBlockSawRequestPayload = false;
+      continue;
+    }
+
+    if (ROLE_BOUNDARY_PATTERN.test(trimmed)) {
+      insideRoleBlock = !/^<\s*\//.test(trimmed);
+      continue;
+    }
+
+    if (insideRoleBlock) {
+      continue;
+    }
+
+    if (!trimmed) {
+      sanitized.push(line);
+      insideDiffBlock = false;
+      previousLineWasUserRequest = false;
+      continue;
+    }
+
+    if (previousLineWasUserRequest) {
+      previousLineWasUserRequest = false;
+      continue;
+    }
+
+    if (USER_REQUEST_LINE_PATTERN.test(line) || SKILL_TRANSCRIPT_LINE_PATTERN.test(line)) {
+      previousLineWasUserRequest = USER_REQUEST_LINE_PATTERN.test(line);
+      continue;
+    }
+
+    if (SHELL_TRANSCRIPT_LINE_PATTERN.test(line) && !/^\s*\$\w/.test(line)) {
+      continue;
+    }
+
+    if (insideDiffBlock) {
+      if (GIT_DIFF_CONTINUATION_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+        continue;
+      }
+      insideDiffBlock = false;
+    }
+
+    if (GIT_DIFF_START_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+      insideDiffBlock = true;
+      continue;
+    }
+
+    sanitized.push(line);
+  }
+
+  return sanitized.join('\n');
 }
 
 const INFORMATIONAL_INTENT_PATTERNS = [

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -161,6 +161,44 @@ OMC Ultrawork = "특수부대 작전 반"
     expect(context).toBe('');
   });
 
+  it('does not branch pasted skill transcript payloads into a fresh Ralph invocation', () => {
+    const output = runKeywordDetector(`Investigate why this pasted transcript branched sessions:
+
+[MAGIC KEYWORD: RALPH]
+Skill: oh-my-claudecode:ralph
+User request:
+ralph fix parser`);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(context).toBe('');
+  });
+
+  it('does not branch pasted shell transcript lines into fresh skill invocations', () => {
+    const output = runKeywordDetector(`Summarize this log:
+$ ralph fix parser
+$ ultrawork search the codebase`);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toBe('');
+  });
+
+  it('does not branch pasted git diff hunks into fresh skill invocations', () => {
+    const output = runKeywordDetector(`Please explain this diff:
+diff --git a/a b/b
+--- a/a
++++ b/b
+@@ -1,2 +1,2 @@
++ ralph fix parser
++ autopilot build me an app`);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toBe('');
+  });
+
   // Regression: issue #2541 — review-seed echo must not trip code-review / security-review alerts
   it('does not activate code-review when prompt is echoed review-instruction text with approve/request-changes/merge-ready', () => {
     const prompt = [

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -368,6 +368,59 @@ Read src/hooks/bridge.ts first.`,
       }
     });
 
+    it('does not create mode state when the prompt only pastes prior skill transcript output', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-keyword-pasted-skill-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'keyword-pasted-skill-session';
+
+        const result = await processHook('keyword-detector', {
+          sessionId,
+          prompt: `Investigate why this pasted transcript branched sessions:
+
+[MAGIC KEYWORD: RALPH]
+Skill: oh-my-claudecode:ralph
+User request:
+ralph fix parser`,
+          directory: tempDir,
+        });
+
+        expect(result.continue).toBe(true);
+        expect(result.message).toBeUndefined();
+
+        const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+        expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
+        expect(existsSync(join(sessionDir, 'ultrawork-state.json'))).toBe(false);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not create mode state when the prompt only pastes shell transcript command lines', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-keyword-pasted-shell-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'keyword-pasted-shell-session';
+
+        const result = await processHook('keyword-detector', {
+          sessionId,
+          prompt: `Summarize this log:
+$ ralph fix parser
+$ ultrawork search the codebase`,
+          directory: tempDir,
+        });
+
+        expect(result.continue).toBe(true);
+        expect(result.message).toBeUndefined();
+
+        const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+        expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
+        expect(existsSync(join(sessionDir, 'ultrawork-state.json'))).toBe(false);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('seeds inert autopilot state for keyword routing so stop enforcement stays inert until the skill confirms', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-keyword-autopilot-'));
       try {

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -78,6 +78,54 @@ World`);
   });
 
   describe('sanitizeForKeywordDetection', () => {
+    it('should strip pasted magic-keyword transcript payloads and preserve surrounding prose', () => {
+      const result = sanitizeForKeywordDetection(`Investigate why this pasted transcript branched sessions:
+
+[MAGIC KEYWORD: RALPH]
+Skill: oh-my-claudecode:ralph
+User request:
+ralph fix parser
+
+Summarize the failure mode only.`);
+
+      expect(result).toContain('Investigate why this pasted transcript branched sessions:');
+      expect(result).toContain('Summarize the failure mode only.');
+      expect(result).not.toContain('[MAGIC KEYWORD: RALPH]');
+      expect(result).not.toContain('Skill: oh-my-claudecode:ralph');
+      expect(result).not.toContain('ralph fix parser');
+    });
+
+    it('should strip pasted git diff hunks that mention execution keywords', () => {
+      const result = sanitizeForKeywordDetection(`Please explain this diff:
+diff --git a/a b/b
+--- a/a
++++ b/b
+@@ -1,2 +1,2 @@
++ ralph fix parser
++ autopilot build me an app
+
+What actually caused the regression?`);
+
+      expect(result).toContain('Please explain this diff:');
+      expect(result).toContain('What actually caused the regression?');
+      expect(result).not.toContain('ralph fix parser');
+      expect(result).not.toContain('autopilot build me an app');
+    });
+
+    it('should strip quoted assistant transcript blocks', () => {
+      const result = sanitizeForKeywordDetection(`Please explain this transcript:
+<assistant>
+[MAGIC KEYWORD: AUTOPILOT]
+Skill: oh-my-claudecode:autopilot
+</assistant>
+Why did this happen?`);
+
+      expect(result).toContain('Please explain this transcript:');
+      expect(result).toContain('Why did this happen?');
+      expect(result).not.toContain('AUTOPILOT');
+      expect(result).not.toContain('Skill: oh-my-claudecode:autopilot');
+    });
+
     it('should strip XML tag blocks', () => {
       const result = sanitizeForKeywordDetection('<system-reminder>ralph</system-reminder>');
       expect(result).not.toContain('ralph');
@@ -447,6 +495,34 @@ OMC Ultrawork = "특수부대 작전 반"
           'Compare DeerFlow vs ultrawork, then use ultrawork on issue #2474 in src/hooks/keyword-detector/index.ts',
         );
         expect(result.find((r) => r.type === 'ultrawork')).toBeDefined();
+      });
+
+      it('should NOT detect pasted skill transcript blocks as fresh activations', () => {
+        const result = detectKeywordsWithType(`Investigate why this pasted transcript branched sessions:
+
+[MAGIC KEYWORD: RALPH]
+Skill: oh-my-claudecode:ralph
+User request:
+ralph fix parser`);
+
+        expect(result).toEqual([]);
+      });
+
+      it('should NOT detect pasted git diff hunks as fresh activations', () => {
+        const result = detectKeywordsWithType(`Please explain this diff:
+diff --git a/a b/b
+--- a/a
++++ b/b
+@@ -1,2 +1,2 @@
++ ralph fix parser
++ autopilot build me an app`);
+
+        expect(result).toEqual([]);
+      });
+
+      it('should still detect explicit $ralph invocation typed by the user', () => {
+        const result = detectKeywordsWithType('$ralph fix parser state handling');
+        expect(result.find((r) => r.type === 'ralph')).toBeDefined();
       });
     });
 

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -86,6 +86,131 @@ export function removeCodeBlocks(text: string): string {
   return result;
 }
 
+const PASTED_MAGIC_KEYWORD_HEADER_PATTERN =
+  /^\s*\[MAGIC KEYWORDS?(?: DETECTED)?:.*$/i;
+const ROLE_BOUNDARY_PATTERN =
+  /^<\s*\/?\s*(system|human|assistant|user|tool_use|tool_result)\b[^>]*>/i;
+const SKILL_TRANSCRIPT_LINE_PATTERN =
+  /^\s*Skill:\s+oh-my-(?:claudecode|codex):/i;
+const USER_REQUEST_LINE_PATTERN = /^\s*User request:\s*$/i;
+const SHELL_TRANSCRIPT_LINE_PATTERN = /^\s*[$%❯]\s+/;
+const GIT_DIFF_START_PATTERNS: RegExp[] = [
+  /^diff\s+--git\s+a\//,
+  /^index\s+[0-9a-f]+\.\.[0-9a-f]+(?:\s+\d+)?$/i,
+  /^(?:---|\+\+\+)\s+[ab]\//,
+  /^@@\s+-\d+/,
+];
+const GIT_DIFF_CONTINUATION_PATTERNS: RegExp[] = [
+  /^new file mode\s+\d+$/i,
+  /^deleted file mode\s+\d+$/i,
+  /^similarity index\s+\d+%$/i,
+  /^rename (?:from|to)\s+/i,
+  /^Binary files .+ differ$/i,
+  /^(?:diff\s+--git\s+a\/|index\s+[0-9a-f]+\.\.[0-9a-f]+|(?:---|\+\+\+)\s+[ab]\/|@@\s+-\d+)/i,
+  /^[ +\-].*/,
+];
+
+function stripPastedCommandPayloads(text: string): string {
+  const lines = text.split('\n');
+  const sanitized: string[] = [];
+  let insideRoleBlock = false;
+  let insideDiffBlock = false;
+  let insideMagicKeywordBlock = false;
+  let magicBlockSawUserRequest = false;
+  let magicBlockSawRequestPayload = false;
+  let previousLineWasUserRequest = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (insideMagicKeywordBlock) {
+      if (ROLE_BOUNDARY_PATTERN.test(trimmed)) {
+        insideRoleBlock = !/^<\s*\//.test(trimmed);
+        insideMagicKeywordBlock = false;
+        magicBlockSawUserRequest = false;
+        magicBlockSawRequestPayload = false;
+        continue;
+      }
+
+      if (USER_REQUEST_LINE_PATTERN.test(line)) {
+        magicBlockSawUserRequest = true;
+        magicBlockSawRequestPayload = false;
+        continue;
+      }
+
+      if (magicBlockSawUserRequest) {
+        if (trimmed) {
+          magicBlockSawRequestPayload = true;
+          continue;
+        }
+
+        if (magicBlockSawRequestPayload) {
+          insideMagicKeywordBlock = false;
+          magicBlockSawUserRequest = false;
+          magicBlockSawRequestPayload = false;
+          sanitized.push(line);
+          continue;
+        }
+      }
+
+      continue;
+    }
+
+    if (PASTED_MAGIC_KEYWORD_HEADER_PATTERN.test(line)) {
+      insideMagicKeywordBlock = true;
+      magicBlockSawUserRequest = false;
+      magicBlockSawRequestPayload = false;
+      continue;
+    }
+
+    if (ROLE_BOUNDARY_PATTERN.test(trimmed)) {
+      insideRoleBlock = !/^<\s*\//.test(trimmed);
+      continue;
+    }
+
+    if (insideRoleBlock) {
+      continue;
+    }
+
+    if (!trimmed) {
+      sanitized.push(line);
+      insideDiffBlock = false;
+      previousLineWasUserRequest = false;
+      continue;
+    }
+
+    if (previousLineWasUserRequest) {
+      previousLineWasUserRequest = false;
+      continue;
+    }
+
+    if (USER_REQUEST_LINE_PATTERN.test(line) || SKILL_TRANSCRIPT_LINE_PATTERN.test(line)) {
+      previousLineWasUserRequest = USER_REQUEST_LINE_PATTERN.test(line);
+      continue;
+    }
+
+    if (SHELL_TRANSCRIPT_LINE_PATTERN.test(line) && !/^\s*\$\w/.test(line)) {
+      continue;
+    }
+
+    if (insideDiffBlock) {
+      if (GIT_DIFF_CONTINUATION_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+        continue;
+      }
+      insideDiffBlock = false;
+    }
+
+    if (GIT_DIFF_START_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+      insideDiffBlock = true;
+      continue;
+    }
+
+    sanitized.push(line);
+  }
+
+  return sanitized.join('\n');
+}
+
 
 /**
  * Regex matching non-Latin script characters for prompt translation detection.
@@ -101,8 +226,9 @@ export const NON_LATIN_SCRIPT_PATTERN =
  * Strips XML tags, URLs, file paths, and code blocks.
  */
 export function sanitizeForKeywordDetection(text: string): string {
+  let result = stripPastedCommandPayloads(text);
   // Remove HTML/markdown comments first so keywords inside comments cannot trigger modes
-  let result = text.replace(/<!--[\s\S]*?-->/g, '');
+  result = result.replace(/<!--[\s\S]*?-->/g, '');
   // Remove XML tag blocks (opening + content + closing; tag names must match)
   result = result.replace(/<(\w[\w-]*)[\s>][\s\S]*?<\/\1>/g, '');
   // Remove self-closing XML tags

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -148,7 +148,7 @@ function isReviewSeedContext(text) {
 }
 
 function sanitizeForKeywordDetection(text) {
-  return text
+  return stripPastedCommandPayloads(text)
     // 0. Strip HTML/markdown comments before tag stripping
     .replace(/<!--[\s\S]*?-->/g, '')
     // 1. Strip XML-style tag blocks: <tag-name ...>...</tag-name> (multi-line, greedy on tag name)
@@ -168,6 +168,131 @@ function sanitizeForKeywordDetection(text) {
     .replace(/```[\s\S]*?```/g, '')
     // 6. Strip inline code (existing)
     .replace(/`[^`]+`/g, '');
+}
+
+const PASTED_MAGIC_KEYWORD_HEADER_PATTERN =
+  /^\s*\[MAGIC KEYWORDS?(?: DETECTED)?:.*$/i;
+const ROLE_BOUNDARY_PATTERN =
+  /^<\s*\/?\s*(system|human|assistant|user|tool_use|tool_result)\b[^>]*>/i;
+const SKILL_TRANSCRIPT_LINE_PATTERN =
+  /^\s*Skill:\s+oh-my-(?:claudecode|codex):/i;
+const USER_REQUEST_LINE_PATTERN = /^\s*User request:\s*$/i;
+const SHELL_TRANSCRIPT_LINE_PATTERN = /^\s*[$%❯]\s+/;
+const GIT_DIFF_START_PATTERNS = [
+  /^diff\s+--git\s+a\//,
+  /^index\s+[0-9a-f]+\.\.[0-9a-f]+(?:\s+\d+)?$/i,
+  /^(?:---|\+\+\+)\s+[ab]\//,
+  /^@@\s+-\d+/,
+];
+const GIT_DIFF_CONTINUATION_PATTERNS = [
+  /^new file mode\s+\d+$/i,
+  /^deleted file mode\s+\d+$/i,
+  /^similarity index\s+\d+%$/i,
+  /^rename (?:from|to)\s+/i,
+  /^Binary files .+ differ$/i,
+  /^(?:diff\s+--git\s+a\/|index\s+[0-9a-f]+\.\.[0-9a-f]+|(?:---|\+\+\+)\s+[ab]\/|@@\s+-\d+)/i,
+  /^[ +\-].*/,
+];
+
+function stripPastedCommandPayloads(text) {
+  const lines = text.split('\n');
+  const sanitized = [];
+  let insideRoleBlock = false;
+  let insideDiffBlock = false;
+  let insideMagicKeywordBlock = false;
+  let magicBlockSawUserRequest = false;
+  let magicBlockSawRequestPayload = false;
+  let previousLineWasUserRequest = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (insideMagicKeywordBlock) {
+      if (ROLE_BOUNDARY_PATTERN.test(trimmed)) {
+        insideRoleBlock = !/^<\s*\//.test(trimmed);
+        insideMagicKeywordBlock = false;
+        magicBlockSawUserRequest = false;
+        magicBlockSawRequestPayload = false;
+        continue;
+      }
+
+      if (USER_REQUEST_LINE_PATTERN.test(line)) {
+        magicBlockSawUserRequest = true;
+        magicBlockSawRequestPayload = false;
+        continue;
+      }
+
+      if (magicBlockSawUserRequest) {
+        if (trimmed) {
+          magicBlockSawRequestPayload = true;
+          continue;
+        }
+
+        if (magicBlockSawRequestPayload) {
+          insideMagicKeywordBlock = false;
+          magicBlockSawUserRequest = false;
+          magicBlockSawRequestPayload = false;
+          sanitized.push(line);
+          continue;
+        }
+      }
+
+      continue;
+    }
+
+    if (PASTED_MAGIC_KEYWORD_HEADER_PATTERN.test(line)) {
+      insideMagicKeywordBlock = true;
+      magicBlockSawUserRequest = false;
+      magicBlockSawRequestPayload = false;
+      continue;
+    }
+
+    if (ROLE_BOUNDARY_PATTERN.test(trimmed)) {
+      insideRoleBlock = !/^<\s*\//.test(trimmed);
+      continue;
+    }
+
+    if (insideRoleBlock) {
+      continue;
+    }
+
+    if (!trimmed) {
+      sanitized.push(line);
+      insideDiffBlock = false;
+      previousLineWasUserRequest = false;
+      continue;
+    }
+
+    if (previousLineWasUserRequest) {
+      previousLineWasUserRequest = false;
+      continue;
+    }
+
+    if (USER_REQUEST_LINE_PATTERN.test(line) || SKILL_TRANSCRIPT_LINE_PATTERN.test(line)) {
+      previousLineWasUserRequest = USER_REQUEST_LINE_PATTERN.test(line);
+      continue;
+    }
+
+    if (SHELL_TRANSCRIPT_LINE_PATTERN.test(line) && !/^\s*\$\w/.test(line)) {
+      continue;
+    }
+
+    if (insideDiffBlock) {
+      if (GIT_DIFF_CONTINUATION_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+        continue;
+      }
+      insideDiffBlock = false;
+    }
+
+    if (GIT_DIFF_START_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+      insideDiffBlock = true;
+      continue;
+    }
+
+    sanitized.push(line);
+  }
+
+  return sanitized.join('\n');
 }
 
 const INFORMATIONAL_INTENT_PATTERNS = [


### PR DESCRIPTION
## Summary\n- ignore pasted magic-keyword transcript blocks, shell transcript lines, git diff hunks, and quoted role-boundary session output during keyword detection\n- keep legitimate keyword routing while preventing a single pasted prompt from branching into multiple sessions\n- add targeted regression coverage across hook, script, and bridge routing paths\n\n## Testing\n- npx vitest run src/hooks/keyword-detector/__tests__/index.test.ts src/__tests__/keyword-detector-script.test.ts src/hooks/__tests__/bridge-routing.test.ts\n- npx tsc --noEmit --project tsconfig.json