### PR TITLE
docs: split install commands into separate code blocks for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ _Don't learn Claude Code. Just use OMC._
 
 **Step 1: Install**
 
-Marketplace/plugin install (recommended for most Claude Code users):
+Marketplace/plugin install (recommended for most Claude Code users).
+These are Claude Code slash commands — enter them **one at a time** (pasting both lines at once will fail):
 
 ```bash
 /plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+```
+
+Then:
+
+```bash
 /plugin install oh-my-claudecode
 ```
 


### PR DESCRIPTION
## Summary

- Split the two-line install code block into separate blocks with a "Then:" separator
- Added note that these are Claude Code slash commands and must be entered one at a time (pasting both at once will fail)

## Motivation

The current Quick Start shows both install commands in a single code block:

```bash
/plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
/plugin install oh-my-claudecode
```

This leads users to copy-paste both lines at once, which fails because these are interactive slash commands that must be entered sequentially inside a Claude Code session. Splitting them into two blocks makes this obvious.

## Changes

- `README.md`: Quick Start > Step 1: Install section only

## Test plan

- [ ] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)