### PR TITLE
fix: use tier aliases in agent frontmatter for Bedrock/Vertex compat

### DIFF
--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -1,7 +1,7 @@
 ---
 name: analyst
 description: Pre-planning consultant for requirements analysis (Opus)
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Strategic Architecture & Debugging Advisor (Opus, READ-ONLY)
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Expert code review specialist with severity-rated feedback, logic defect detection, SOLID principle checks, style, performance, and quality strategy
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise.
-model: claude-opus-4-6
+model: opus
 level: 3
 ---
 

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -1,7 +1,7 @@
 ---
 name: critic
 description: Work plan and code review expert — thorough, structured, multi-perspective (Opus)
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -1,7 +1,7 @@
 ---
 name: debugger
 description: Root-cause analysis, regression isolation, stack trace analysis, build/compilation error resolution
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -1,7 +1,7 @@
 ---
 name: designer
 description: UI/UX Designer-Developer for stunning interfaces (Sonnet)
-model: claude-sonnet-4-6
+model: sonnet
 level: 2
 ---
 

--- a/agents/document-specialist.md
+++ b/agents/document-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: document-specialist
 description: External Documentation & Reference Specialist
-model: claude-sonnet-4-6
+model: sonnet
 level: 2
 disallowedTools: Write, Edit
 ---

--- a/agents/executor.md
+++ b/agents/executor.md
@@ -1,7 +1,7 @@
 ---
 name: executor
 description: Focused task executor for implementation work (Sonnet)
-model: claude-sonnet-4-6
+model: sonnet
 level: 2
 ---
 

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Codebase search specialist for finding files and code patterns
-model: claude-haiku-4-5
+model: haiku
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/git-master.md
+++ b/agents/git-master.md
@@ -1,7 +1,7 @@
 ---
 name: git-master
 description: Git expert for atomic commits, rebasing, and history management with style detection
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: Strategic planning consultant with interview workflow (Opus)
-model: claude-opus-4-6
+model: opus
 level: 4
 ---
 

--- a/agents/qa-tester.md
+++ b/agents/qa-tester.md
@@ -1,7 +1,7 @@
 ---
 name: qa-tester
 description: Interactive CLI testing specialist using tmux for session management
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/scientist.md
+++ b/agents/scientist.md
@@ -1,7 +1,7 @@
 ---
 name: scientist
 description: Data analysis and research execution specialist
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: security-reviewer
 description: Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)
-model: claude-opus-4-6
+model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: test-engineer
 description: Test strategy, integration/e2e coverage, flaky test hardening, TDD workflows
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/tracer.md
+++ b/agents/tracer.md
@@ -1,7 +1,7 @@
 ---
 name: tracer
 description: Evidence-driven causal tracing with competing hypotheses, evidence for/against, uncertainty tracking, and next-probe recommendations
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Verification strategy, evidence-based completion checks, test adequacy
-model: claude-sonnet-4-6
+model: sonnet
 level: 3
 ---
 

--- a/agents/writer.md
+++ b/agents/writer.md
@@ -1,7 +1,7 @@
 ---
 name: writer
 description: Technical documentation writer for README, API docs, and comments (Haiku)
-model: claude-haiku-4-5
+model: haiku
 level: 2
 ---
 

--- a/src/__tests__/agent-registry.test.ts
+++ b/src/__tests__/agent-registry.test.ts
@@ -153,6 +153,28 @@ describe('Agent Registry Validation', () => {
     expect(agents.executor?.model).not.toBe('claude-3-7-session-parent');
   });
 
+  test('agent .md frontmatter uses tier aliases not full model IDs (Bedrock/Vertex compat)', () => {
+    // Full Anthropic API model IDs (e.g. claude-sonnet-4-6) in .md frontmatter
+    // cause 400 errors on Bedrock/Vertex because Claude Code's plugin system
+    // passes them directly without env var resolution.
+    // Tier aliases (sonnet/opus/haiku) are resolved correctly on all providers.
+    const agentsDir = path.join(__dirname, '../../agents');
+    const mdFiles = fs.readdirSync(agentsDir).filter((f) => f.endsWith('.md') && f !== 'AGENTS.md');
+    const validAliases = ['sonnet', 'opus', 'haiku'];
+
+    for (const file of mdFiles) {
+      const content = fs.readFileSync(path.join(agentsDir, file), 'utf-8');
+      const modelMatch = content.match(/^model:\s*(.+)$/m);
+      if (modelMatch) {
+        const model = modelMatch[1].trim();
+        expect(
+          validAliases.includes(model),
+          `${file}: frontmatter model "${model}" is a full model ID — use tier alias (${validAliases.join('/')}) instead for Bedrock/Vertex compatibility`
+        ).toBe(true);
+      }
+    }
+  });
+
   test('no hardcoded prompts in base agent .ts files', () => {
     const baseAgents = ['architect', 'executor', 'explore', 'designer', 'document-specialist',
                         'writer', 'planner', 'critic', 'analyst', 'scientist', 'qa-tester'];

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -127,19 +127,19 @@ describe('Installer Constants', () => {
 
     it('should have consistent model assignments', () => {
       const modelExpectations: Record<string, string> = {
-        'architect.md': 'claude-opus-4-6',
-        'executor.md': 'claude-sonnet-4-6',
-        'designer.md': 'claude-sonnet-4-6',
-        'writer.md': 'claude-haiku-4-5',
-        'critic.md': 'claude-opus-4-6',
-        'analyst.md': 'claude-opus-4-6',
-        'planner.md': 'claude-opus-4-6',
-        'qa-tester.md': 'claude-sonnet-4-6',
-        'debugger.md': 'claude-sonnet-4-6',
-        'verifier.md': 'claude-sonnet-4-6',
-        'test-engineer.md': 'claude-sonnet-4-6',
-        'security-reviewer.md': 'claude-opus-4-6',
-        'git-master.md': 'claude-sonnet-4-6',
+        'architect.md': 'opus',
+        'executor.md': 'sonnet',
+        'designer.md': 'sonnet',
+        'writer.md': 'haiku',
+        'critic.md': 'opus',
+        'analyst.md': 'opus',
+        'planner.md': 'opus',
+        'qa-tester.md': 'sonnet',
+        'debugger.md': 'sonnet',
+        'verifier.md': 'sonnet',
+        'test-engineer.md': 'sonnet',
+        'security-reviewer.md': 'opus',
+        'git-master.md': 'sonnet',
       };
 
       for (const [filename, expectedModel] of Object.entries(modelExpectations)) {


### PR DESCRIPTION
## Summary

Agent `.md` frontmatter files used full Anthropic API model IDs (e.g. `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5`) which cause **400 errors on AWS Bedrock and Google Vertex AI**.

### Root Cause

Claude Code's plugin system resolves agent definition frontmatter `model:` values differently from explicit Agent tool `model` parameters:

- **Explicit Agent tool `model: "sonnet"`** → resolved via `ANTHROPIC_DEFAULT_SONNET_MODEL` / `CLAUDE_CODE_BEDROCK_SONNET_MODEL` env vars → works on all providers
- **Frontmatter `model: claude-sonnet-4-6`** → passed directly to the API without env var resolution → **invalid on Bedrock/Vertex**

The delegation enforcer (`delegation-enforcer.ts`) correctly normalizes models and auto-enables `forceInherit` for non-Claude providers, but this hook operates on the Agent tool parameter path — it cannot intercept model values that Claude Code resolves directly from `.md` frontmatter.

### Fix

Changed all 19 agent `.md` frontmatter files to use tier aliases:
- `claude-opus-4-6` → `opus` (7 agents: analyst, architect, code-reviewer, code-simplifier, critic, planner, security-reviewer)
- `claude-sonnet-4-6` → `sonnet` (10 agents: debugger, designer, document-specialist, executor, git-master, qa-tester, scientist, test-engineer, tracer, verifier)
- `claude-haiku-4-5` → `haiku` (2 agents: explore, writer)

Note: the `.ts` source files in `src/agents/definitions.ts` already used tier aliases (`'sonnet'`, `'opus'`, `'haiku'`) — only the `.md` frontmatter was wrong.

### Regression Test

Added a test in `agent-registry.test.ts` that scans all agent `.md` files and asserts frontmatter `model:` values are one of `['sonnet', 'opus', 'haiku']`, preventing reintroduction of full model IDs.

## Test plan

- [x] All 10 agent registry tests pass (including new regression test)
- [x] All 40 delegation enforcer tests pass
- [x] All 19 Bedrock model routing tests pass
- [x] Verified locally on AWS Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`) — agents spawn and execute with tool uses instead of 0-tool-use failures
- [ ] Verify on Vertex AI (untested but same mechanism)

## Impact

- **Bedrock users**: agents were silently failing (0 tool uses) due to 400 errors from invalid model IDs
- **Vertex AI users**: same issue expected
- **Direct API users**: no change (tier aliases already resolved correctly)
- **No breaking changes**: tier aliases are the canonical format already used in `.ts` source