### PR TITLE
fix: avoid HUD git polling index lock contention

### DIFF
--- a/src/hud/__tests__/git-status.test.ts
+++ b/src/hud/__tests__/git-status.test.ts
@@ -113,6 +113,15 @@ describe('getGitStatusCounts', () => {
     getGitStatusCounts('/tmp');
     expect(mockedExecSync).toHaveBeenCalledTimes(1);
   });
+
+  it('disables optional git locks for background HUD polling', () => {
+    mockedExecSync.mockReturnValue('## main\n' as any);
+    getGitStatusCounts('/tmp');
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      'git --no-optional-locks status --porcelain -b',
+      expect.objectContaining({ cwd: '/tmp' }),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/hud/elements/git.ts
+++ b/src/hud/elements/git.ts
@@ -198,7 +198,7 @@ export function renderGitBranch(cwd?: string): string | null {
 
 /**
  * Get git working tree status counts.
- * Parses `git status --porcelain -b` for staged, modified, untracked,
+ * Parses `git --no-optional-locks status --porcelain -b` for staged, modified, untracked,
  * ahead, and behind counts.
  *
  * @param cwd - Working directory
@@ -213,7 +213,7 @@ export function getGitStatusCounts(cwd?: string): GitStatusCounts | null {
 
   let result: GitStatusCounts | null = null;
   try {
-    const output = execSync('git status --porcelain -b', {
+    const output = execSync('git --no-optional-locks status --porcelain -b', {
       cwd,
       encoding: 'utf-8',
       timeout: 1000,


### PR DESCRIPTION
## Summary
- switch the HUD git status probe to `git --no-optional-locks status --porcelain -b`
- keep the fix scoped only to the polled HUD read-only status path
- add a regression test asserting the HUD probe uses the lock-free git command

## Verification
- npm run test -- src/hud/__tests__/git-status.test.ts src/__tests__/hud/git.test.ts
- npm run build