### PR TITLE
feat: SSH tmux/screen reminder in pre-tool-use hook

### DIFF
--- a/templates/hooks/pre-tool-use.mjs
+++ b/templates/hooks/pre-tool-use.mjs
@@ -52,6 +52,38 @@ const FILE_MODIFY_PATTERNS = [
 // Source file pattern for command inspection
 const SOURCE_EXT_PATTERN = /\.(ts|tsx|js|jsx|mjs|cjs|py|pyw|go|rs|java|kt|scala|c|cpp|cc|h|hpp|rb|php|svelte|vue|graphql|gql|sh|bash|zsh)/i;
 
+// SSH patterns for tmux reminder
+const SSH_COMMAND_PATTERN = /\bssh\b/;
+const TMUX_SCREEN_PATTERN = /\b(tmux|screen)\b/;
+const SSH_SHORT_SINGLE_QUOTED = /^ssh\s+\S+\s+'[^']{0,80}'$/;
+const SSH_SHORT_DOUBLE_QUOTED = /^ssh\s+\S+\s+"[^"]{0,80}"$/;
+const SSH_HIGH_RISK_PATTERN = /pip install|podman pull|docker pull|wget|curl\s+.*-[oO]|git clone|huggingface|safetensors|gguf|model.*download|apt.get|yum install|make.*install|npm install|cargo build/i;
+
+function checkSshCommand(command) {
+  if (!SSH_COMMAND_PATTERN.test(command)) return null;
+  if (TMUX_SCREEN_PATTERN.test(command)) return null;
+
+  const isHighRisk = SSH_HIGH_RISK_PATTERN.test(command);
+
+  // Skip short, safe commands — but never skip high-risk ones
+  if (!isHighRisk) {
+    if (SSH_SHORT_SINGLE_QUOTED.test(command.trim())) return null;
+    if (SSH_SHORT_DOUBLE_QUOTED.test(command.trim())) return null;
+  }
+
+  let msg = `[SSH TMUX REMINDER] SSH command detected without tmux/screen.
+
+Long-running remote operations (downloads, installs, builds) will die if SSH disconnects.
+Wrap in tmux to survive disconnections:
+
+  ssh <host> -t 'tmux new-session -A -s work'`;
+
+  if (isHighRisk) {
+    msg += `\n\n⚠ This command includes a long-running operation — tmux is strongly recommended.`;
+  }
+  return msg;
+}
+
 function checkBashCommand(command) {
   // Check if command might modify files
   const mayModify = FILE_MODIFY_PATTERNS.some(pattern => pattern.test(command));
@@ -88,13 +120,20 @@ async function main() {
   // Extract tool name (handle both cases)
   const toolName = data.tool_name || data.toolName || '';
 
-  // Handle Bash tool separately - check for file modification patterns
+  // Handle Bash tool separately - check for SSH and file modification patterns
   if (toolName === 'Bash' || toolName === 'bash') {
     const toolInput = data.tool_input || data.toolInput || {};
     const command = toolInput.command || '';
-    const warning = checkBashCommand(command);
-    if (warning) {
-      console.log(JSON.stringify({ continue: true, message: warning }));
+    const messages = [];
+
+    const sshWarning = checkSshCommand(command);
+    if (sshWarning) messages.push(sshWarning);
+
+    const delegationWarning = checkBashCommand(command);
+    if (delegationWarning) messages.push(delegationWarning);
+
+    if (messages.length > 0) {
+      console.log(JSON.stringify({ continue: true, message: messages.join('\n\n') }));
     } else {
       console.log(JSON.stringify({ continue: true }));
     }

--- a/templates/hooks/pre-tool-use.sh
+++ b/templates/hooks/pre-tool-use.sh
@@ -22,7 +22,7 @@ else
   fi
 fi
 
-# Handle Bash tool separately - check for file modification patterns
+# Handle Bash tool separately - check for SSH and file modification patterns
 if [ "$TOOL_NAME" = "Bash" ] || [ "$TOOL_NAME" = "bash" ]; then
   # Extract command
   COMMAND=""
@@ -32,25 +32,75 @@ if [ "$TOOL_NAME" = "Bash" ] || [ "$TOOL_NAME" = "bash" ]; then
     COMMAND=$(echo "$INPUT" | grep -oP '"command"\s*:\s*"\K[^"]+' | head -1)
   fi
 
-  # Check for file modification patterns
+  MESSAGES=""
+
+  # --- SSH tmux/screen reminder ---
+  if echo "$COMMAND" | grep -qE '\bssh\b'; then
+    # Skip if already using tmux/screen
+    if ! echo "$COMMAND" | grep -qE '\b(tmux|screen)\b'; then
+      # Skip short one-liner commands (safe without tmux)
+      # Check for high-risk patterns first — these always warn
+      IS_HIGH_RISK=false
+      if echo "$COMMAND" | grep -qEi 'pip install|podman pull|docker pull|wget|curl\s+.*-[oO]|git clone|huggingface|safetensors|gguf|model.*download|apt.get|yum install|make.*install|npm install|cargo build'; then
+        IS_HIGH_RISK=true
+      fi
+
+      # Skip short, safe commands — but never skip high-risk ones
+      IS_SHORT=false
+      if [ "$IS_HIGH_RISK" = false ]; then
+        if echo "$COMMAND" | grep -qE "^ssh\s+\S+\s+'[^']{0,80}'$"; then
+          IS_SHORT=true
+        fi
+        if echo "$COMMAND" | grep -qE '^ssh\s+\S+\s+"[^"]{0,80}"$'; then
+          IS_SHORT=true
+        fi
+      fi
+
+      if [ "$IS_SHORT" = false ]; then
+        SSH_MSG="[SSH TMUX REMINDER] SSH command detected without tmux/screen.
+
+Long-running remote operations (downloads, installs, builds) will die if SSH disconnects.
+Wrap in tmux to survive disconnections:
+
+  ssh <host> -t 'tmux new-session -A -s work'"
+
+        if [ "$IS_HIGH_RISK" = true ]; then
+          SSH_MSG="$SSH_MSG
+
+WARNING: This command includes a long-running operation — tmux is strongly recommended."
+        fi
+        MESSAGES="$SSH_MSG"
+      fi
+    fi
+  fi
+
+  # --- Delegation notice for file modifications ---
   if echo "$COMMAND" | grep -qE '(sed\s+-i|>\s*[^&]|>>\s*|tee\s+|cat\s+.*>\s*|echo\s+.*>\s*|printf\s+.*>\s*)'; then
-    # Check if modifying source files
     SOURCE_PATTERN='\.(ts|tsx|js|jsx|mjs|cjs|py|pyw|go|rs|java|kt|scala|c|cpp|cc|h|hpp|rb|php|svelte|vue|graphql|gql|sh|bash|zsh)'
     if echo "$COMMAND" | grep -qE "$SOURCE_PATTERN"; then
-      # Might be modifying source files - warn
-      WARNING="[DELEGATION NOTICE] Bash command may modify source files: $COMMAND
+      DELEG_MSG="[DELEGATION NOTICE] Bash command may modify source files: $COMMAND
 
 Recommended: Delegate to executor agent instead:
   Task(subagent_type=\"oh-my-claudecode:executor\", model=\"sonnet\", prompt=\"...\")
 
 This is a soft warning. Operation will proceed."
-      WARNING_ESCAPED=$(echo "$WARNING" | jq -Rs . 2>/dev/null || echo "\"$WARNING\"")
-      echo "{\"continue\": true, \"message\": $WARNING_ESCAPED}"
-      exit 0
+      if [ -n "$MESSAGES" ]; then
+        MESSAGES="$MESSAGES
+
+$DELEG_MSG"
+      else
+        MESSAGES="$DELEG_MSG"
+      fi
     fi
   fi
-  # Bash command is OK
-  echo '{"continue": true}'
+
+  # Emit result
+  if [ -n "$MESSAGES" ]; then
+    MESSAGES_ESCAPED=$(echo "$MESSAGES" | jq -Rs . 2>/dev/null || echo "\"$MESSAGES\"")
+    echo "{\"continue\": true, \"message\": $MESSAGES_ESCAPED}"
+  else
+    echo '{"continue": true}'
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Extends the existing `PreToolUse` hook to detect SSH commands in Bash and remind the agent to use `tmux`/`screen` — preventing silent process death when SSH sessions disconnect during long-running remote operations.

Closes #2656

## Changes

- `templates/hooks/pre-tool-use.mjs` — add `checkSshCommand()` with high-risk pattern detection
- `templates/hooks/pre-tool-use.sh` — equivalent bash implementation

**No new files, no schema changes.** Just extends the existing Bash handling in both template variants.

## Motivation

While setting up vLLM + Gemma4 on a remote RTX 5090 GPU server via Claude Code, SSH dropped 3 times during long-running operations:

1. `podman pull` (15GB image) — restarted from zero
2. `pip install` — half-upgraded state (transformers 5.5.0→4.57.6), container unrecoverable
3. HuggingFace model download — partial files corrupted

**~4 hours lost**, all preventable with `tmux`.

## Detection logic

```
ssh host               → ✅ reminder (interactive session)
ssh host 'pip install'  → ✅⚠ reminder + high-risk warning
ssh host -t 'tmux ...'  → ❌ skip (already protected)
ssh host 'ls /tmp'      → ❌ skip (short safe command)
ls -la                  → ❌ skip (not SSH)
```

**High-risk patterns** (always warn, even for short commands):
`pip install`, `podman/docker pull`, `wget`, `curl -o`, `git clone`, `huggingface`, `safetensors`, `apt-get`, `npm install`, `cargo build`

## Test results

```
=== 1. Interactive SSH → reminder ✅ ===
{"continue":true,"message":"[SSH TMUX REMINDER] ..."}

=== 2. tmux already used → skip ✅ ===
{"continue":true}

=== 3. Short safe command → skip ✅ ===
{"continue":true}

=== 4. pip install (high-risk) → reminder + warning ✅ ===
{"continue":true,"message":"[SSH TMUX REMINDER] ... ⚠ long-running operation"}

=== 5. Non-SSH command → skip ✅ ===
{"continue":true}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)