### PR TITLE
fix(tests): replace process.cwd() with import.meta.url-based package root

### DIFF
--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { parseSandboxContract } from '../../autoresearch/contracts.js';
+
+// Package root resolved relative to this test file — avoids process.cwd() sensitivity
+// when tests are executed from a parent directory (e.g. a monorepo harness workspace).
+const packageRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
 
 const { tmuxAvailableMock, buildTmuxShellCommandMock, wrapWithLoginShellMock, quoteShellArgMock } = vi.hoisted(() => ({
   tmuxAvailableMock: vi.fn(),
@@ -349,7 +354,7 @@ describe('spawnAutoresearchTmux', () => {
       }
       if (args[0] === 'new-session') {
         expect(args.slice(0, 6)).toEqual(['new-session', '-d', '-s', 'omc-autoresearch-demo', '-c', '/repo']);
-        expect(args[6]).toBe('wrapped:' + `${process.execPath} ${process.cwd()}/bin/omc.js autoresearch /repo/missions/demo`);
+        expect(args[6]).toBe('wrapped:' + `${process.execPath} ${packageRoot}/bin/omc.js autoresearch /repo/missions/demo`);
         return '';
       }
       throw new Error(`unexpected tmuxExec call: ${String(args)}`);
@@ -358,7 +363,7 @@ describe('spawnAutoresearchTmux', () => {
     spawnAutoresearchTmux('/repo/missions/demo', 'demo');
 
     expect(buildTmuxShellCommandMock).toHaveBeenCalledWith(process.execPath, [expect.stringMatching(/bin\/omc\.js$/), 'autoresearch', '/repo/missions/demo']);
-    expect(wrapWithLoginShellMock).toHaveBeenCalledWith(`${process.execPath} ${process.cwd()}/bin/omc.js autoresearch /repo/missions/demo`);
+    expect(wrapWithLoginShellMock).toHaveBeenCalledWith(`${process.execPath} ${packageRoot}/bin/omc.js autoresearch /repo/missions/demo`);
     expect(logSpy).toHaveBeenCalledWith('\nAutoresearch launched in background tmux session.');
     expect(logSpy).toHaveBeenCalledWith('  Attach:   tmux attach -t omc-autoresearch-demo');
   });

--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -10,8 +10,13 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync, symlinkSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
+
+// Resolve the package root relative to this test file so the tests pass regardless
+// of the working directory (e.g. when run from a monorepo harness workspace).
+const packageRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
 
 // We test the exported cleanup functions directly
 import { cleanupStaleAgents, cleanupStaleSkills, prunePluginDuplicateSkills, prunePluginDuplicateAgents } from '../index.js';
@@ -357,7 +362,7 @@ describe('prunePluginDuplicateSkills', () => {
 
     mkdirSync(skillsDir, { recursive: true });
 
-    const packagePlanSkill = readFileSync(join(process.cwd(), 'skills', 'plan', 'SKILL.md'), 'utf-8');
+    const packagePlanSkill = readFileSync(join(packageRoot, 'skills', 'plan', 'SKILL.md'), 'utf-8');
     const aliasSkillDir = join(skillsDir, 'omc-plan');
     mkdirSync(aliasSkillDir, { recursive: true });
     writeFileSync(join(aliasSkillDir, 'SKILL.md'), packagePlanSkill);


### PR DESCRIPTION
## Problem

Two test files resolve package-relative paths via `process.cwd()`:

- `src/cli/__tests__/autoresearch-guided.test.ts` — asserts the `bin/omc.js` path passed to `wrapWithLoginShell`
- `src/installer/__tests__/stale-cleanup.test.ts` — reads `skills/plan/SKILL.md` to build a fixture

This works when tests run directly from the package root, but fails when the package is vendored inside a monorepo and the test runner's working directory is the parent workspace (e.g. `harness/`). In that case `process.cwd()` no longer equals the package root, causing path mismatches and `ENOENT` errors.

## Fix

Introduce a `packageRoot` constant derived from `import.meta.url` in each affected test file:

\`\`\`ts
const packageRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
\`\`\`

Replace all `process.cwd()` usages that build package-relative paths with `packageRoot`. The constant resolves the same path as before when tests run from the package root, and continues to resolve correctly when run from any other directory.

## Files changed

- `src/cli/__tests__/autoresearch-guided.test.ts`
- `src/installer/__tests__/stale-cleanup.test.ts`