### PR TITLE
Preserve Gemini team lanes when preflight path probing false-negatives

### DIFF
--- a/src/team/__tests__/runtime-v2.gemini-preflight.test.ts
+++ b/src/team/__tests__/runtime-v2.gemini-preflight.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const mocks = vi.hoisted(() => ({
+  createTeamSession: vi.fn(),
+  spawnWorkerInPane: vi.fn(),
+  sendToWorker: vi.fn(),
+  waitForPaneReady: vi.fn(),
+  applyMainVerticalLayout: vi.fn(),
+  tmuxExecAsync: vi.fn(),
+  queueInboxInstruction: vi.fn(),
+}));
+
+const modelContractMocks = vi.hoisted(() => ({
+  buildWorkerArgv: vi.fn((agentType?: string, config?: { resolvedBinaryPath?: string }) => [config?.resolvedBinaryPath ?? agentType ?? 'claude']),
+  resolveValidatedBinaryPath: vi.fn((agentType?: string) => {
+    if (agentType === 'gemini') throw new Error('Resolved CLI binary \'gemini\' to untrusted location: /tmp/gemini');
+    return `/usr/bin/${agentType ?? 'claude'}`;
+  }),
+  getContract: vi.fn((agentType?: string) => ({ binary: agentType ?? 'claude' })),
+  getWorkerEnv: vi.fn(() => ({ OMC_TEAM_WORKER: 'issue2675-team/worker-1' })),
+  isPromptModeAgent: vi.fn(() => false),
+  getPromptModeArgs: vi.fn(() => []),
+  resolveClaudeWorkerModel: vi.fn(() => undefined),
+}));
+
+vi.mock('../../cli/tmux-utils.js', () => ({
+  tmuxExecAsync: mocks.tmuxExecAsync,
+}));
+
+vi.mock('../tmux-session.js', () => ({
+  createTeamSession: mocks.createTeamSession,
+  spawnWorkerInPane: mocks.spawnWorkerInPane,
+  sendToWorker: mocks.sendToWorker,
+  waitForPaneReady: mocks.waitForPaneReady,
+  paneHasActiveTask: vi.fn(() => false),
+  paneLooksReady: vi.fn(() => true),
+  applyMainVerticalLayout: mocks.applyMainVerticalLayout,
+}));
+
+vi.mock('../model-contract.js', () => ({
+  buildWorkerArgv: modelContractMocks.buildWorkerArgv,
+  resolveValidatedBinaryPath: modelContractMocks.resolveValidatedBinaryPath,
+  getContract: modelContractMocks.getContract,
+  getWorkerEnv: modelContractMocks.getWorkerEnv,
+  isPromptModeAgent: modelContractMocks.isPromptModeAgent,
+  getPromptModeArgs: modelContractMocks.getPromptModeArgs,
+  resolveClaudeWorkerModel: modelContractMocks.resolveClaudeWorkerModel,
+}));
+
+vi.mock('../mcp-comm.js', () => ({
+  queueInboxInstruction: mocks.queueInboxInstruction,
+}));
+
+describe('runtime-v2 Gemini preflight routing', () => {
+  let cwd = '';
+
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.createTeamSession.mockResolvedValue({
+      sessionName: 'issue2675-session',
+      leaderPaneId: '%1',
+      workerPaneIds: [],
+      sessionMode: 'split-pane',
+    });
+    mocks.spawnWorkerInPane.mockResolvedValue(undefined);
+    mocks.waitForPaneReady.mockResolvedValue(true);
+    mocks.applyMainVerticalLayout.mockResolvedValue(undefined);
+    mocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'split-window') {
+        return { stdout: '%2\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+    mocks.queueInboxInstruction.mockResolvedValue({ ok: true, reason: 'transport_direct', transport: 'transport_direct' });
+  });
+
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('keeps an explicitly routed gemini lane on gemini when strict preflight path probing false-negatives', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'issue2675-repro-'));
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'issue2675-team',
+      workerCount: 1,
+      agentTypes: ['gemini'],
+      tasks: [{ subject: 'Review code', description: 'Review code', role: 'executor' }],
+      cwd,
+      pluginConfig: {
+        team: { roleRouting: { executor: { provider: 'gemini' } } },
+      } as any,
+    });
+
+    expect(runtime.config.workers[0]?.worker_cli).toBe('gemini');
+    expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(
+      'gemini',
+      expect.objectContaining({
+        teamName: 'issue2675-team',
+        workerName: 'worker-1',
+        resolvedBinaryPath: 'gemini',
+      }),
+    );
+  });
+});

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -56,7 +56,7 @@ import type { TeamPhase } from './phase-controller.js';
 import { validateTeamName } from './team-name.js';
 import type { CliAgentType } from './model-contract.js';
 import {
-  buildWorkerArgv, resolveValidatedBinaryPath,
+  buildWorkerArgv, getContract, resolveValidatedBinaryPath,
   getWorkerEnv as getModelWorkerEnv, isPromptModeAgent, getPromptModeArgs,
   resolveClaudeWorkerModel,
 } from './model-contract.js';
@@ -239,6 +239,22 @@ function sanitizeTeamName(name: string): string {
   const sanitized = name.toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 30);
   if (!sanitized) throw new Error(`Invalid team name: "${name}" produces empty slug after sanitization`);
   return sanitized;
+}
+
+function shouldUseLaunchTimeCliResolution(reason: string): boolean {
+  return /untrusted location|relative path/i.test(reason);
+}
+
+function resolvePreflightBinaryPath(agentType: CliAgentType): { path: string; degraded: boolean; reason?: string } {
+  try {
+    return { path: resolveValidatedBinaryPath(agentType), degraded: false };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    if (shouldUseLaunchTimeCliResolution(reason)) {
+      return { path: getContract(agentType).binary, degraded: true, reason };
+    }
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -724,7 +740,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
   const missingBinaryReasons: Array<{ agentType: CliAgentType; reason: string }> = [];
   for (const agentType of [...new Set(agentTypes)]) {
     try {
-      resolvedBinaryPaths[agentType] = resolveValidatedBinaryPath(agentType);
+      resolvedBinaryPaths[agentType] = resolvePreflightBinaryPath(agentType).path;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       missingBinaryReasons.push({ agentType, reason });
@@ -738,7 +754,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     if (resolvedBinaryPaths[provider]) continue;
     if (missingBinaryReasons.some((m) => m.agentType === provider)) continue;
     try {
-      resolvedBinaryPaths[provider] = resolveValidatedBinaryPath(provider);
+      resolvedBinaryPaths[provider] = resolvePreflightBinaryPath(provider).path;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       missingBinaryReasons.push({ agentType: provider, reason });


### PR DESCRIPTION
## Summary
- keep runtime-v2 Gemini worker routing on Gemini when strict preflight binary validation returns a trust-path false negative
- preserve the existing Claude fallback for actual missing CLI failures
- add a focused regression test for the runtime-v2 preflight decision path

## What I verified
- The provider rewrite happens in `src/team/runtime-v2.ts`:
  - `startTeamV2()` preflights worker CLIs via `resolveValidatedBinaryPath()`
  - `resolveTaskAssignment()` then swaps to the snapshot Claude fallback whenever the primary provider is absent from `resolvedBinaryPaths`
- Smallest local reproduction: mocked `resolveValidatedBinaryPath('gemini')` to throw an untrusted-path error while keeping Gemini otherwise available; before the fix, the requested Gemini executor lane was rewritten to Claude during `startTeamV2()` startup.

## Fix
- narrow runtime-v2-only change: for preflight failures caused by strict path/trust validation (`untrusted location` / relative-path false negatives), keep the provider in `resolvedBinaryPaths` using the contract binary name and let launch-time resolution proceed
- do not change the existing fallback for real missing CLI errors

## Verification
- `npm test -- --run src/team/__tests__/runtime-v2.gemini-preflight.test.ts`

Fixes #2675
