### PR TITLE
fix(hud): use stdin rate_limits to avoid OAuth API cold-start 429 loop

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -28,7 +28,7 @@ import {
   readPrdStateForHud,
   readAutopilotStateForHud,
 } from "./omc-state.js";
-import { getUsage } from "./usage-api.js";
+import { getUsage, parseStdinRateLimits } from "./usage-api.js";
 import { executeCustomProvider } from "./custom-rate-provider.js";
 import { render } from "./render.js";
 import { detectApiKeySource } from "./elements/api-key-source.js";
@@ -339,9 +339,15 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       writeHudState(stateToWrite, cwd, currentSessionId ?? undefined);
     }
 
-    // Fetch rate limits from OAuth API (if available)
-    const rateLimitsResult =
-      config.elements.rateLimits !== false ? await getUsage() : null;
+    // Use stdin rate_limits if available (Claude Code >= 2.1.80) — no API call needed.
+    // Fall back to OAuth API for older versions or when stdin data is absent.
+    const stdinRateLimits = stdin.rate_limits
+      ? parseStdinRateLimits(stdin.rate_limits)
+      : null;
+
+    const rateLimitsResult = stdinRateLimits
+      ? { rateLimits: stdinRateLimits } as import("./types.js").UsageResult
+      : (config.elements.rateLimits !== false ? await getUsage() : null);
 
     // Fetch custom rate limit buckets (if configured)
     const customBuckets =

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -66,6 +66,12 @@ export interface StatuslineStdin {
       cache_read_input_tokens?: number;
     };
   };
+
+  /** Rate limit data from Claude Code statusline stdin (>= v2.1.80) */
+  rate_limits?: {
+    five_hour?: { used_percentage?: number; resets_at?: number };
+    seven_day?: { used_percentage?: number; resets_at?: number };
+  };
 }
 
 // ============================================================================

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -22,6 +22,7 @@ import https from 'https';
 import { validateAnthropicBaseUrl } from '../utils/ssrf-guard.js';
 import {
   DEFAULT_HUD_USAGE_POLL_INTERVAL_MS,
+  type StatuslineStdin,
   type RateLimits,
   type UsageResult,
   type UsageErrorReason,
@@ -1097,6 +1098,24 @@ async function fetchAndCacheUsage<T>(opts: {
   const usage = parseFn(result.data);
   writeCache({ data: usage, error: !usage, source, lastSuccessAt: Date.now() });
   return { rateLimits: usage };
+}
+
+/**
+ * Parse rate limit data provided directly via Claude Code's stdin JSON.
+ * Available since Claude Code v2.1.80 — avoids the OAuth API call entirely.
+ */
+export function parseStdinRateLimits(rl: StatuslineStdin['rate_limits']): RateLimits | null {
+  const fiveHour = rl?.five_hour?.used_percentage;
+  const sevenDay = rl?.seven_day?.used_percentage;
+  if (fiveHour == null && sevenDay == null) return null;
+  const toDate = (unixSecs?: number): Date | null =>
+    unixSecs ? new Date(unixSecs * 1000) : null;
+  return {
+    fiveHourPercent: fiveHour != null ? clamp(fiveHour) : 0,
+    weeklyPercent: sevenDay != null ? clamp(sevenDay) : undefined,
+    fiveHourResetsAt: toDate(rl?.five_hour?.resets_at),
+    weeklyResetsAt: toDate(rl?.seven_day?.resets_at),
+  };
 }
 
 /**


### PR DESCRIPTION
Since Claude Code v2.1.80, the stdin JSON passed to statusline commands includes rate_limits with five_hour/seven_day used_percentage and resets_at fields. OMC's StatuslineStdin type didn't include this field, so the HUD always fell back to the OAuth API — which gets 429'd in ephemeral environments (Docker, CI) where the usage cache starts cold on every launch.

Read rate_limits from stdin when present. Fall back to getUsage() only when absent (Claude Code < 2.1.80).

Constraint: Must remain backwards compatible with older Claude Code versions
Rejected: Remove OAuth API path entirely | still needed for CC < 2.1.80
Confidence: high
Scope-risk: narrow