### PR TITLE
Fix/use stdin rate limits

### DIFF
--- a/src/__tests__/hud/stdin-rate-limits.test.ts
+++ b/src/__tests__/hud/stdin-rate-limits.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for stdin rate_limits parsing and contract preservation.
+ *
+ * Proves:
+ * 1. parseStdinRateLimits produces the same RateLimits shape as parseUsageResponse
+ *    for equivalent input data (contract preservation).
+ * 2. parseStdinRateLimits returns null when stdin has no usable data (safe fallback).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseStdinRateLimits } from '../../hud/usage-api.js';
+import { parseUsageResponse } from '../../hud/usage-api.js';
+
+describe('parseStdinRateLimits', () => {
+  it('returns null when rate_limits is undefined', () => {
+    expect(parseStdinRateLimits(undefined)).toBeNull();
+  });
+
+  it('returns null when both buckets are empty', () => {
+    expect(parseStdinRateLimits({ five_hour: {}, seven_day: {} })).toBeNull();
+  });
+
+  it('parses five_hour only', () => {
+    const result = parseStdinRateLimits({
+      five_hour: { used_percentage: 42, resets_at: 1776348000 },
+    });
+    expect(result).toEqual({
+      fiveHourPercent: 42,
+      weeklyPercent: undefined,
+      fiveHourResetsAt: new Date(1776348000 * 1000),
+      weeklyResetsAt: null,
+    });
+  });
+
+  it('parses both buckets', () => {
+    const result = parseStdinRateLimits({
+      five_hour: { used_percentage: 11, resets_at: 1776348000 },
+      seven_day: { used_percentage: 2, resets_at: 1776916800 },
+    });
+    expect(result).toEqual({
+      fiveHourPercent: 11,
+      weeklyPercent: 2,
+      fiveHourResetsAt: new Date(1776348000 * 1000),
+      weeklyResetsAt: new Date(1776916800 * 1000),
+    });
+  });
+
+  it('clamps out-of-range values', () => {
+    const result = parseStdinRateLimits({
+      five_hour: { used_percentage: 150 },
+      seven_day: { used_percentage: -10 },
+    });
+    expect(result!.fiveHourPercent).toBe(100);
+    expect(result!.weeklyPercent).toBe(0);
+  });
+});
+
+describe('contract: stdin vs OAuth produce identical RateLimits shape', () => {
+  // Equivalent data as it would arrive from each source
+  const stdinInput = {
+    five_hour: { used_percentage: 11, resets_at: 1776348000 },
+    seven_day: { used_percentage: 2, resets_at: 1776916800 },
+  };
+
+  const oauthInput = {
+    five_hour: { utilization: 11, resets_at: new Date(1776348000 * 1000).toISOString() },
+    seven_day: { utilization: 2, resets_at: new Date(1776916800 * 1000).toISOString() },
+  };
+
+  it('produces matching fiveHourPercent and weeklyPercent', () => {
+    const fromStdin = parseStdinRateLimits(stdinInput)!;
+    const fromOAuth = parseUsageResponse(oauthInput)!;
+
+    expect(fromStdin.fiveHourPercent).toBe(fromOAuth.fiveHourPercent);
+    expect(fromStdin.weeklyPercent).toBe(fromOAuth.weeklyPercent);
+  });
+
+  it('produces matching reset timestamps', () => {
+    const fromStdin = parseStdinRateLimits(stdinInput)!;
+    const fromOAuth = parseUsageResponse(oauthInput)!;
+
+    expect(fromStdin.fiveHourResetsAt!.getTime()).toBe(fromOAuth.fiveHourResetsAt!.getTime());
+    expect(fromStdin.weeklyResetsAt!.getTime()).toBe(fromOAuth.weeklyResetsAt!.getTime());
+  });
+});

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -28,7 +28,7 @@ import {
   readPrdStateForHud,
   readAutopilotStateForHud,
 } from "./omc-state.js";
-import { getUsage } from "./usage-api.js";
+import { getUsage, parseStdinRateLimits } from "./usage-api.js";
 import { executeCustomProvider } from "./custom-rate-provider.js";
 import { render } from "./render.js";
 import { detectApiKeySource } from "./elements/api-key-source.js";
@@ -339,9 +339,15 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       writeHudState(stateToWrite, cwd, currentSessionId ?? undefined);
     }
 
-    // Fetch rate limits from OAuth API (if available)
-    const rateLimitsResult =
-      config.elements.rateLimits !== false ? await getUsage() : null;
+    // Use stdin rate_limits if available (Claude Code >= 2.1.80) — no API call needed.
+    // Fall back to OAuth API for older versions or when stdin data is absent.
+    const stdinRateLimits = stdin.rate_limits
+      ? parseStdinRateLimits(stdin.rate_limits)
+      : null;
+
+    const rateLimitsResult = stdinRateLimits
+      ? { rateLimits: stdinRateLimits } as import("./types.js").UsageResult
+      : (config.elements.rateLimits !== false ? await getUsage() : null);
 
     // Fetch custom rate limit buckets (if configured)
     const customBuckets =

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -66,6 +66,12 @@ export interface StatuslineStdin {
       cache_read_input_tokens?: number;
     };
   };
+
+  /** Rate limit data from Claude Code statusline stdin (>= v2.1.80) */
+  rate_limits?: {
+    five_hour?: { used_percentage?: number; resets_at?: number };
+    seven_day?: { used_percentage?: number; resets_at?: number };
+  };
 }
 
 // ============================================================================

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -22,6 +22,7 @@ import https from 'https';
 import { validateAnthropicBaseUrl } from '../utils/ssrf-guard.js';
 import {
   DEFAULT_HUD_USAGE_POLL_INTERVAL_MS,
+  type StatuslineStdin,
   type RateLimits,
   type UsageResult,
   type UsageErrorReason,
@@ -1097,6 +1098,24 @@ async function fetchAndCacheUsage<T>(opts: {
   const usage = parseFn(result.data);
   writeCache({ data: usage, error: !usage, source, lastSuccessAt: Date.now() });
   return { rateLimits: usage };
+}
+
+/**
+ * Parse rate limit data provided directly via Claude Code's stdin JSON.
+ * Available since Claude Code v2.1.80 — avoids the OAuth API call entirely.
+ */
+export function parseStdinRateLimits(rl: StatuslineStdin['rate_limits']): RateLimits | null {
+  const fiveHour = rl?.five_hour?.used_percentage;
+  const sevenDay = rl?.seven_day?.used_percentage;
+  if (fiveHour == null && sevenDay == null) return null;
+  const toDate = (unixSecs?: number): Date | null =>
+    unixSecs ? new Date(unixSecs * 1000) : null;
+  return {
+    fiveHourPercent: fiveHour != null ? clamp(fiveHour) : 0,
+    weeklyPercent: sevenDay != null ? clamp(sevenDay) : undefined,
+    fiveHourResetsAt: toDate(rl?.five_hour?.resets_at),
+    weeklyResetsAt: toDate(rl?.seven_day?.resets_at),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

  - In ephemeral environments (Docker, CI, fresh sandboxes) where `~/.claude/` doesn't persist, the HUD's usage cache starts cold on every launch. Multiple HUD renders hit the OAuth API simultaneously, get 429'd,
  enter exponential backoff, and never recover.
  - Since Claude Code v2.1.80, stdin already includes `rate_limits` — OMC's `StatuslineStdin` type didn't have this field, so it always fell back to the OAuth API.
  - This PR reads `rate_limits` from stdin when present (zero API calls). Falls back to `getUsage()` only when absent (Claude Code < 2.1.80).

  ## Contract preservation proof

  Added `src/__tests__/hud/stdin-rate-limits.test.ts` (7 tests) proving:

  - `parseStdinRateLimits` returns `null` when data is `undefined` or empty (safe fallback)
  - Correct parsing of one bucket, both buckets, and out-of-range value clamping
  - **Identical output** to `parseUsageResponse` for equivalent input — same `fiveHourPercent`, `weeklyPercent`, and reset timestamps

  ## Changes

  1. `src/hud/types.ts` — Added `rate_limits` to `StatuslineStdin`
  2. `src/hud/usage-api.ts` — Added `parseStdinRateLimits()` helper
  3. `src/hud/index.ts` — Check stdin before falling back to OAuth API
  4. `src/__tests__/hud/stdin-rate-limits.test.ts` — Contract proof tests

  ## Test plan

  - [x] `tsc --noEmit` — zero type errors
  - [x] Full test suite — 8380 tests passed
  - [x] New tests — 7/7 passed
  - [ ] Manual: HUD shows rate limits from stdin in Claude Code >= 2.1.80
  - [ ] Manual: HUD falls back to OAuth API in Claude Code < 2.1.80

  🤖 Generated with [Claude Code](https://claude.com/claude-code)