### PR TITLE
Fix MCP registry type round-trip for remote servers

### DIFF
--- a/src/installer/__tests__/mcp-registry.test.ts
+++ b/src/installer/__tests__/mcp-registry.test.ts
@@ -180,6 +180,44 @@ describe('unified MCP registry sync', () => {
     expect(codexConfig).toContain('startup_timeout_sec = 30');
   });
 
+
+  it('reproduces issue #2679: sync strips remote entry type during round-trip', () => {
+    const settings = {
+      mcpServers: {
+        mySseServer: {
+          url: 'http://localhost:11235/mcp/sse',
+          type: 'sse',
+        },
+      },
+    };
+
+    const { settings: syncedSettings, result } = syncUnifiedMcpRegistryTargets(settings);
+
+    expect(result.bootstrappedFromClaude).toBe(true);
+    expect(result.serverNames).toEqual(['mySseServer']);
+    expect(syncedSettings).toEqual({});
+
+    expect(JSON.parse(readFileSync(getUnifiedMcpRegistryPath(), 'utf-8'))).toEqual({
+      mySseServer: {
+        url: 'http://localhost:11235/mcp/sse',
+        type: 'sse',
+      },
+    });
+    expect(JSON.parse(readFileSync(getClaudeMcpConfigPath(), 'utf-8'))).toEqual({
+      mcpServers: {
+        mySseServer: {
+          url: 'http://localhost:11235/mcp/sse',
+          type: 'sse',
+        },
+      },
+    });
+
+    const codexConfig = readFileSync(getCodexConfigPath(), 'utf-8');
+    expect(codexConfig).toContain('[mcp_servers.mySseServer]');
+    expect(codexConfig).toContain('url = "http://localhost:11235/mcp/sse"');
+    expect(codexConfig).toContain('type = "sse"');
+  });
+
   it('preserves explicit launcher timeouts and leaves custom MCP servers untouched', () => {
     const settings = {
       mcpServers: {
@@ -392,6 +430,34 @@ describe('unified MCP registry sync', () => {
       theme: 'dark',
       mcpServers: {
         customLocal: { command: 'stale-custom', args: ['legacy'] },
+      },
+    });
+
+    expect(settings).toEqual({ theme: 'dark' });
+    expect(result.bootstrappedFromClaude).toBe(false);
+    expect(JSON.parse(readFileSync(getClaudeMcpConfigPath(), 'utf-8'))).toEqual({
+      mcpServers: {
+        customLocal: { command: 'custom-local', args: ['serve'] },
+        gitnexus: { command: 'gitnexus', args: ['mcp'] },
+      },
+    });
+  });
+
+
+  it('respects explicit removal from ~/.claude.json when legacy settings still contain a stale copy', () => {
+    writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({
+      gitnexus: { command: 'gitnexus', args: ['mcp'] },
+    }, null, 2));
+    writeFileSync(getClaudeMcpConfigPath(), JSON.stringify({
+      mcpServers: {
+        customLocal: { command: 'custom-local', args: ['serve'] },
+      },
+    }, null, 2));
+
+    const { settings, result } = syncUnifiedMcpRegistryTargets({
+      theme: 'dark',
+      mcpServers: {
+        gitnexus: { command: 'stale-gitnexus', args: ['legacy'] },
       },
     });
 

--- a/src/installer/mcp-registry.ts
+++ b/src/installer/mcp-registry.ts
@@ -15,6 +15,7 @@ export interface UnifiedMcpRegistryEntry {
   args?: string[];
   env?: Record<string, string>;
   url?: string;
+  type?: string;
   timeout?: number;
 }
 
@@ -131,6 +132,9 @@ function normalizeRegistryEntry(value: unknown): UnifiedMcpRegistryEntry | null 
   const url = typeof raw.url === 'string' && raw.url.trim().length > 0
     ? raw.url.trim()
     : undefined;
+  const type = typeof raw.type === 'string' && raw.type.trim().length > 0
+    ? raw.type.trim()
+    : undefined;
 
   if (!command && !url) {
     return null;
@@ -151,6 +155,7 @@ function normalizeRegistryEntry(value: unknown): UnifiedMcpRegistryEntry | null 
     ...(args.length > 0 ? { args } : {}),
     ...(env && Object.keys(env).length > 0 ? { env } : {}),
     ...(url ? { url } : {}),
+    ...(type ? { type } : {}),
     ...(effectiveTimeout ? { timeout: effectiveTimeout } : {}),
   };
 }
@@ -406,6 +411,9 @@ function renderCodexServerBlock(name: string, entry: UnifiedMcpRegistryEntry): s
   if (entry.url) {
     lines.push(`url = ${renderTomlString(entry.url)}`);
   }
+  if (entry.type) {
+    lines.push(`type = ${renderTomlString(entry.type)}`);
+  }
   if (entry.env && Object.keys(entry.env).length > 0) {
     lines.push(`env = ${renderTomlEnvTable(entry.env)}`);
   }
@@ -499,6 +507,9 @@ function parseCodexMcpRegistryEntries(content: string): UnifiedMcpRegistry {
     } else if (key === 'url') {
       const parsed = parseTomlQuotedString(value);
       if (parsed) currentEntry.url = parsed;
+    } else if (key === 'type') {
+      const parsed = parseTomlQuotedString(value);
+      if (parsed) currentEntry.type = parsed;
     } else if (key === 'env') {
       const parsed = parseTomlEnvTable(value);
       if (parsed) currentEntry.env = parsed;


### PR DESCRIPTION
## Summary\n- preserve remote MCP transport type metadata in the unified registry normalizer\n- render and parse the same type field in the managed Codex MCP block\n- add a regression test for the type round-trip and a local guard showing the reported stale legacy-settings reinjection path does not reproduce on current dev\n\n## Verification\n- npm test -- --run src/installer/__tests__/mcp-registry.test.ts src/__tests__/installer-mcp-config.test.ts src/installer/__tests__/settings-race.test.ts src/__tests__/doctor-conflicts.test.ts\n- npx tsc --noEmit --pretty false --project tsconfig.json\n\nFixes #2679