### PR TITLE
fix(agents): replace scanner-bait commit placeholders (#2681)

### DIFF
--- a/agents/git-master.md
+++ b/agents/git-master.md
@@ -62,8 +62,8 @@ level: 3
     - Format: [semantic (feat:, fix:) / plain / short]
 
     ### Commits Created
-    1. `abc1234` - [commit message] - [N files]
-    2. `def5678` - [commit message] - [N files]
+    1. `<commit-sha-1>` - [commit message] - [N files]
+    2. `<commit-sha-2>` - [commit message] - [N files]
 
     ### Verification
     ```


### PR DESCRIPTION
## Summary
- replace bundled scanner-bait commit-like example literals in `agents/git-master.md` with neutral placeholders
- keep the bundled agent prompt semantics intact while reducing false positives from simplistic security scanners
- do **not** claim or implement the unverified soft-hyphen portion from #2681

## What was verified
- current `origin/dev` did **not** reproduce the reported U+00AD soft-hyphen findings in bundled agent files
- current `origin/dev` did expose one bundled scanner-bait literal in shipped agent prompt text (`abc1234` / `def5678`-style examples)
- targeted verification completed:
  - `git diff --check`
  - bundled agent hygiene search
  - `npm test -- --run src/__tests__/load-agent-prompt.test.ts`
  - `npm run lint`
  - `npx tsc --noEmit`

Related to #2681