### PR TITLE
Align built-in Opus HIGH default with Claude Opus 4.7

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -3617,7 +3617,7 @@ var init_models = __esm({
     CLAUDE_FAMILY_DEFAULTS = {
       HAIKU: "claude-haiku-4-5",
       SONNET: "claude-sonnet-4-6",
-      OPUS: "claude-opus-4-6"
+      OPUS: "claude-opus-4-7"
     };
     BUILTIN_TIER_MODEL_DEFAULTS = {
       LOW: CLAUDE_FAMILY_DEFAULTS.HAIKU,

--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -1469,7 +1469,7 @@ var TIER_ENV_KEYS = {
 var CLAUDE_FAMILY_DEFAULTS = {
   HAIKU: "claude-haiku-4-5",
   SONNET: "claude-sonnet-4-6",
-  OPUS: "claude-opus-4-6"
+  OPUS: "claude-opus-4-7"
 };
 var BUILTIN_TIER_MODEL_DEFAULTS = {
   LOW: CLAUDE_FAMILY_DEFAULTS.HAIKU,

--- a/bridge/team-bridge.cjs
+++ b/bridge/team-bridge.cjs
@@ -1086,7 +1086,7 @@ function findPermissionViolations(changedPaths, permissions, cwd) {
 var CLAUDE_FAMILY_DEFAULTS = {
   HAIKU: "claude-haiku-4-5",
   SONNET: "claude-sonnet-4-6",
-  OPUS: "claude-opus-4-6"
+  OPUS: "claude-opus-4-7"
 };
 var BUILTIN_TIER_MODEL_DEFAULTS = {
   LOW: CLAUDE_FAMILY_DEFAULTS.HAIKU,

--- a/bridge/team.js
+++ b/bridge/team.js
@@ -3012,7 +3012,7 @@ var init_models = __esm({
     CLAUDE_FAMILY_DEFAULTS = {
       HAIKU: "claude-haiku-4-5",
       SONNET: "claude-sonnet-4-6",
-      OPUS: "claude-opus-4-6"
+      OPUS: "claude-opus-4-7"
     };
     BUILTIN_TIER_MODEL_DEFAULTS = {
       LOW: CLAUDE_FAMILY_DEFAULTS.HAIKU,

--- a/dist/config/models.js
+++ b/dist/config/models.js
@@ -23,7 +23,7 @@ const TIER_ENV_KEYS = {
 export const CLAUDE_FAMILY_DEFAULTS = {
     HAIKU: 'claude-haiku-4-5',
     SONNET: 'claude-sonnet-4-6',
-    OPUS: 'claude-opus-4-6',
+    OPUS: 'claude-opus-4-7',
 };
 /** Canonical tier->model mapping used as built-in defaults */
 export const BUILTIN_TIER_MODEL_DEFAULTS = {

--- a/docs/agent-templates/tier-instructions.md
+++ b/docs/agent-templates/tier-instructions.md
@@ -40,7 +40,7 @@ This document defines the behavioral differences between agent tiers (LOW/MEDIUM
 ```
 
 ## HIGH Tier (Opus)
-**Model**: claude-opus-4-6
+**Model**: claude-opus-4-7
 **Focus**: Correctness and quality for complex tasks
 
 ```markdown

--- a/src/__tests__/bedrock-model-routing.test.ts
+++ b/src/__tests__/bedrock-model-routing.test.ts
@@ -134,7 +134,7 @@ describe('Bedrock model routing repro', () => {
       const defs = getAgentDefinitions({ config });
       expect(defs['executor'].model).toBe('claude-sonnet-4-6');
       expect(defs['explore'].model).toBe('claude-haiku-4-5');
-      expect(defs['architect'].model).toBe('claude-opus-4-6');
+      expect(defs['architect'].model).toBe('claude-opus-4-7');
 
       // 4. enforceModel normalizes to bare CC-supported aliases (FIX)
       const { enforceModel } = await import('../features/delegation-enforcer.js');

--- a/src/__tests__/hud/model.test.ts
+++ b/src/__tests__/hud/model.test.ts
@@ -4,7 +4,7 @@ import { formatModelName, renderModel } from '../../hud/elements/model.js';
 describe('model element', () => {
   describe('formatModelName', () => {
     it('returns Opus for opus model IDs', () => {
-      expect(formatModelName('claude-opus-4-6-20260205')).toBe('Opus');
+      expect(formatModelName('claude-opus-4-7-20260416')).toBe('Opus');
       expect(formatModelName('claude-3-opus-20240229')).toBe('Opus');
     });
 
@@ -23,14 +23,14 @@ describe('model element', () => {
     });
 
     it('returns versioned name from model IDs', () => {
-      expect(formatModelName('claude-opus-4-6-20260205', 'versioned')).toBe('Opus 4.6');
+      expect(formatModelName('claude-opus-4-7-20260416', 'versioned')).toBe('Opus 4.7');
       expect(formatModelName('claude-sonnet-4-6-20260217', 'versioned')).toBe('Sonnet 4.6');
       expect(formatModelName('claude-haiku-4-5-20251001', 'versioned')).toBe('Haiku 4.5');
     });
 
     it('returns versioned name from display names', () => {
       expect(formatModelName('Sonnet 4.5', 'versioned')).toBe('Sonnet 4.5');
-      expect(formatModelName('Opus 4.6', 'versioned')).toBe('Opus 4.6');
+      expect(formatModelName('Opus 4.7', 'versioned')).toBe('Opus 4.7');
       expect(formatModelName('Haiku 4.5', 'versioned')).toBe('Haiku 4.5');
     });
 
@@ -39,7 +39,7 @@ describe('model element', () => {
     });
 
     it('returns full model ID in full format', () => {
-      expect(formatModelName('claude-opus-4-6-20260205', 'full')).toBe('claude-opus-4-6-20260205');
+      expect(formatModelName('claude-opus-4-7-20260416', 'full')).toBe('claude-opus-4-7-20260416');
     });
 
     it('truncates long unrecognized model names', () => {
@@ -50,22 +50,22 @@ describe('model element', () => {
 
   describe('renderModel', () => {
     it('renders formatted model name', () => {
-      const result = renderModel('claude-opus-4-6-20260205');
+      const result = renderModel('claude-opus-4-7-20260416');
       expect(result).not.toBeNull();
       expect(result).toContain('Opus');
     });
 
     it('renders versioned format', () => {
-      const result = renderModel('claude-opus-4-6-20260205', 'versioned');
+      const result = renderModel('claude-opus-4-7-20260416', 'versioned');
       expect(result).not.toBeNull();
       expect(result).toContain('Opus');
-      expect(result).toContain('4.6');
+      expect(result).toContain('4.7');
     });
 
     it('renders full format', () => {
-      const result = renderModel('claude-opus-4-6-20260205', 'full');
+      const result = renderModel('claude-opus-4-7-20260416', 'full');
       expect(result).not.toBeNull();
-      expect(result).toContain('claude-opus-4-6');
+      expect(result).toContain('claude-opus-4-7');
     });
 
     it('returns null for null input', () => {

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -56,14 +56,14 @@ describe('Type Tests', () => {
       const config: PluginConfig = {
         agents: {
           omc: { model: 'claude-sonnet-4-6' },
-          architect: { model: 'claude-opus-4-6' },
+          architect: { model: 'claude-opus-4-7' },
           explore: { model: 'claude-haiku-4-5' },
           documentSpecialist: { model: 'claude-haiku-4-5' },
         },
       };
 
       expect(config.agents?.omc?.model).toBe('claude-sonnet-4-6');
-      expect(config.agents?.architect?.model).toBe('claude-opus-4-6');
+      expect(config.agents?.architect?.model).toBe('claude-opus-4-7');
     });
 
     it('should support routing configuration', () => {
@@ -76,14 +76,14 @@ describe('Type Tests', () => {
           tierModels: {
             LOW: 'claude-haiku-4',
             MEDIUM: 'claude-sonnet-4-6',
-            HIGH: 'claude-opus-4-6',
+            HIGH: 'claude-opus-4-7',
           },
         },
       };
 
       expect(config.routing?.enabled).toBe(true);
       expect(config.routing?.defaultTier).toBe('MEDIUM');
-      expect(config.routing?.tierModels?.HIGH).toBe('claude-opus-4-6');
+      expect(config.routing?.tierModels?.HIGH).toBe('claude-opus-4-7');
     });
   });
 });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -28,7 +28,7 @@ const TIER_ENV_KEYS: Record<ModelTier, readonly string[]> = {
 export const CLAUDE_FAMILY_DEFAULTS: Record<ClaudeModelFamily, string> = {
   HAIKU: 'claude-haiku-4-5',
   SONNET: 'claude-sonnet-4-6',
-  OPUS: 'claude-opus-4-6',
+  OPUS: 'claude-opus-4-7',
 };
 
 /** Canonical tier->model mapping used as built-in defaults */

--- a/src/hooks/recovery/types.ts
+++ b/src/hooks/recovery/types.ts
@@ -44,7 +44,7 @@ export interface ParsedTokenLimitError {
   errorType: string;
   /** Provider ID (e.g., 'anthropic') */
   providerID?: string;
-  /** Model ID (e.g., 'claude-opus-4-6') */
+  /** Model ID (e.g., 'claude-opus-4-7') */
   modelID?: string;
   /** Index of the problematic message */
   messageIndex?: number;

--- a/src/hooks/think-mode/__tests__/index.test.ts
+++ b/src/hooks/think-mode/__tests__/index.test.ts
@@ -194,8 +194,8 @@ World`);
         expect(getHighVariant('claude-sonnet-4-6')).toBe('claude-sonnet-4-6-high');
       });
 
-      it('should return high variant for claude-opus-4-6', () => {
-        expect(getHighVariant('claude-opus-4-6')).toBe('claude-opus-4-6-high');
+      it('should return high variant for claude-opus-4-7', () => {
+        expect(getHighVariant('claude-opus-4-7')).toBe('claude-opus-4-7-high');
       });
 
       it('should return high variant for claude-3-5-sonnet', () => {
@@ -203,7 +203,7 @@ World`);
       });
 
       it('should return high variant for claude-3-opus', () => {
-        expect(getHighVariant('claude-3-opus')).toBe('claude-opus-4-6-high');
+        expect(getHighVariant('claude-3-opus')).toBe('claude-opus-4-7-high');
       });
 
       it('should handle version with dot notation', () => {

--- a/src/hud/elements/model.ts
+++ b/src/hud/elements/model.ts
@@ -10,7 +10,7 @@ import type { ModelFormat } from '../types.js';
 
 /**
  * Extract version from a model ID string.
- * E.g., 'claude-opus-4-6-20260205' -> '4.6'
+ * E.g., 'claude-opus-4-7-20260416' -> '4.7'
  *       'claude-sonnet-4-6-20260217' -> '4.6'
  *       'claude-haiku-4-5-20251001' -> '4.5'
  */
@@ -19,7 +19,7 @@ function extractVersion(modelId: string): string | null {
   const idMatch = modelId.match(/(?:opus|sonnet|haiku)-(\d+)-(\d+)/i);
   if (idMatch) return `${idMatch[1]}.${idMatch[2]}`;
 
-  // Match display name patterns like "Sonnet 4.5", "Opus 4.6"
+  // Match display name patterns like "Sonnet 4.5", "Opus 4.7"
   const displayMatch = modelId.match(/(?:opus|sonnet|haiku)\s+(\d+(?:\.\d+)?)/i);
   if (displayMatch) return displayMatch[1];
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -419,8 +419,8 @@ export type CwdFormat = 'relative' | 'absolute' | 'folder';
 /**
  * Model name format options:
  * - short: 'Opus', 'Sonnet', 'Haiku'
- * - versioned: 'Opus 4.6', 'Sonnet 4.5', 'Haiku 4.5'
- * - full: raw model ID like 'claude-opus-4-6-20260205'
+ * - versioned: 'Opus 4.7', 'Sonnet 4.5', 'Haiku 4.5'
+ * - full: raw model ID like 'claude-opus-4-7-20260416'
  */
 export type ModelFormat = 'short' | 'versioned' | 'full';
 


### PR DESCRIPTION
## Summary
- bump OMC's built-in HIGH-tier Opus default from `claude-opus-4-6` to `claude-opus-4-7`
- align shipped docs/JSDoc examples that intentionally mirror the built-in default
- update targeted tests covering default resolution, HUD display examples, and think-mode high-variant mapping

## Verification
- `npm run test:run -- src/__tests__/bedrock-model-routing.test.ts src/hooks/think-mode/__tests__/index.test.ts src/__tests__/types.test.ts src/__tests__/hud/model.test.ts`
- `npx tsc --noEmit`

Closes #2684
