### PR TITLE
test: lock npm hook package surface for #2686

### DIFF
--- a/src/__tests__/npm-package-hook-surface.test.ts
+++ b/src/__tests__/npm-package-hook-surface.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, normalize, relative } from 'node:path';
+
+const PACKAGE_ROOT = process.cwd();
+const HOOKS_JSON_PATH = join(PACKAGE_ROOT, 'hooks', 'hooks.json');
+const SCRIPTS_ROOT = join(PACKAGE_ROOT, 'scripts');
+
+type HookCommandConfig = {
+  command?: string;
+};
+
+type HooksJson = {
+  hooks?: Record<string, Array<{
+    hooks?: HookCommandConfig[];
+  }>>;
+};
+
+type NpmPackDryRunEntry = {
+  path: string;
+};
+
+type NpmPackDryRunResult = {
+  files?: NpmPackDryRunEntry[];
+};
+
+const LOCAL_IMPORT_RE = /(?:import\s+(?:[^'"()]+?\s+from\s+)?|import\s*\(|export\s+\*\s+from\s+|export\s+\{[^}]*\}\s+from\s+|require\s*\()\s*['"](\.[^'"]+)['"]/g;
+const PLUGIN_SCRIPT_RE = /"\$CLAUDE_PLUGIN_ROOT"\/(scripts\/[^\s"]+)/g;
+
+function listHookScriptEntries(): string[] {
+  const hooksJson = JSON.parse(readFileSync(HOOKS_JSON_PATH, 'utf-8')) as HooksJson;
+  const entries = new Set<string>(['scripts/run.cjs']);
+
+  for (const eventHooks of Object.values(hooksJson.hooks ?? {})) {
+    for (const matcherEntry of eventHooks) {
+      for (const hook of matcherEntry.hooks ?? []) {
+        const command = hook.command ?? '';
+        for (const match of command.matchAll(PLUGIN_SCRIPT_RE)) {
+          entries.add(match[1]);
+        }
+      }
+    }
+  }
+
+  return [...entries].sort();
+}
+
+function resolveRelativeScriptImport(fromFile: string, specifier: string): string | null {
+  const resolved = normalize(join(dirname(fromFile), specifier));
+  const candidates = [
+    resolved,
+    `${resolved}.mjs`,
+    `${resolved}.cjs`,
+    `${resolved}.js`,
+    join(resolved, 'index.mjs'),
+    join(resolved, 'index.cjs'),
+    join(resolved, 'index.js'),
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate.startsWith(SCRIPTS_ROOT) && existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function collectRequiredScriptFiles(entryRelPath: string, collected = new Set<string>()): Set<string> {
+  const absolutePath = join(PACKAGE_ROOT, entryRelPath);
+  if (!existsSync(absolutePath)) {
+    throw new Error(`Required hook file is missing in repo: ${entryRelPath}`);
+  }
+
+  const normalizedRel = relative(PACKAGE_ROOT, absolutePath).replace(/\\/g, '/');
+  if (collected.has(normalizedRel)) {
+    return collected;
+  }
+  collected.add(normalizedRel);
+
+  const content = readFileSync(absolutePath, 'utf-8');
+  for (const match of content.matchAll(LOCAL_IMPORT_RE)) {
+    const resolved = resolveRelativeScriptImport(absolutePath, match[1]);
+    if (!resolved) {
+      continue;
+    }
+    collectRequiredScriptFiles(relative(PACKAGE_ROOT, resolved).replace(/\\/g, '/'), collected);
+  }
+
+  return collected;
+}
+
+function getPackedFiles(): Set<string> {
+  const stdout = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: PACKAGE_ROOT,
+    encoding: 'utf-8',
+  });
+
+  const results = JSON.parse(stdout) as NpmPackDryRunResult[];
+  return new Set((results[0]?.files ?? []).map(file => file.path));
+}
+
+describe('npm package hook surface regression', () => {
+  it('packs hooks.json, hook entry scripts, and their local script dependencies', () => {
+    const requiredFiles = new Set<string>(['hooks/hooks.json']);
+
+    for (const entryRelPath of listHookScriptEntries()) {
+      for (const file of collectRequiredScriptFiles(entryRelPath)) {
+        requiredFiles.add(file);
+      }
+    }
+
+    const packedFiles = getPackedFiles();
+    expect([...requiredFiles].sort()).not.toHaveLength(0);
+
+    const missing = [...requiredFiles].filter(file => !packedFiles.has(file)).sort();
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- verified on April 17, 2026 that current `dev` and the published `oh-my-claude-sisyphus@4.12.0` tarball both include `hooks/hooks.json`, `scripts/run.cjs`, and the hook entry scripts referenced from `hooks/hooks.json`
- add a focused regression test that shells out to `npm pack --dry-run --json` and asserts the packed artifact still contains every hook-referenced script plus its local script dependencies
- keep scope narrow: no speculative packaging changes because the current pack/publish surface already reproduces as correct

## Why
Issue #2686 reported a missing `scripts/` surface in the shipped package. I could not reproduce that package-level regression from the current repo config or the published 4.12.0 tarball, but CI previously did not explicitly lock this hook/package contract. This PR adds that artifact-surface guard so future regressions are caught before publish.

## Verification
- `npm pack --dry-run --json`
- extracted `oh-my-claude-sisyphus@4.12.0` and smoke-ran `scripts/run.cjs` -> `scripts/keyword-detector.mjs`
- `npm test -- --run src/__tests__/npm-package-hook-surface.test.ts`
- `npx eslint src/__tests__/npm-package-hook-surface.test.ts`
- `npm run build`
- `lsp_diagnostics` on `src/__tests__/npm-package-hook-surface.test.ts`

Refs #2686
