### PR TITLE
Repair incomplete cached OMC plugin installs

### DIFF
--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -156,7 +156,7 @@ describe('auto-update reconciliation', () => {
 
   it('syncs active plugin cache roots and logs when copy occurs', () => {
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const activeRoot = '/tmp/.claude/plugins/cache/omc/oh-my-claudecode/4.1.5';
+    const activeRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.1.5');
 
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
@@ -382,8 +382,8 @@ describe('auto-update reconciliation', () => {
 
   it('dedupes plugin roots and ignores missing targets during sync', () => {
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const activeRoot = '/tmp/.claude/plugins/cache/omc/oh-my-claudecode/4.1.5';
-    const staleRoot = '/tmp/.claude/plugins/cache/omc/oh-my-claudecode/4.1.4';
+    const activeRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.1.5');
+    const staleRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.1.4');
     process.env.CLAUDE_PLUGIN_ROOT = activeRoot;
 
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -10,7 +10,7 @@
  * - Configurable update notifications
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, cpSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { execSync, execFileSync } from 'child_process';
 import { TaskTool } from '../hooks/beads-context/types.js';
@@ -19,8 +19,8 @@ import {
   HOOKS_DIR,
   isProjectScopedPlugin,
   isRunningAsPlugin,
-  getInstalledOmcPluginRoots,
-  getRuntimePackageRoot,
+  copyPluginSyncPayload,
+  syncInstalledPluginPayload,
 } from '../installer/index.js';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { purgeStalePluginCacheVersions } from '../utils/paths.js';
@@ -127,64 +127,8 @@ function syncMarketplaceClone(verbose: boolean = false): { ok: boolean; message:
   return { ok: true, message: 'Marketplace clone updated' };
 }
 
-const PLUGIN_SYNC_PAYLOAD = [
-  'dist',
-  'bridge',
-  'hooks',
-  'scripts',
-  'skills',
-  'agents',
-  'templates',
-  'docs',
-  '.claude-plugin',
-  '.mcp.json',
-  'README.md',
-  'LICENSE',
-  'package.json',
-] as const;
-
-function copyPluginSyncPayload(sourceRoot: string, targetRoots: string[]): { synced: boolean; errors: string[] } {
-  if (targetRoots.length === 0) {
-    return { synced: false, errors: [] };
-  }
-
-  let synced = false;
-  const errors: string[] = [];
-
-  for (const targetRoot of targetRoots) {
-    let copiedToTarget = false;
-
-    for (const entry of PLUGIN_SYNC_PAYLOAD) {
-      const sourcePath = join(sourceRoot, entry);
-      if (!existsSync(sourcePath)) {
-        continue;
-      }
-
-      try {
-        cpSync(sourcePath, join(targetRoot, entry), {
-          recursive: true,
-          force: true,
-        });
-        copiedToTarget = true;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        errors.push(`Failed to sync ${entry} to ${targetRoot}: ${message}`);
-      }
-    }
-
-    synced = synced || copiedToTarget;
-  }
-
-  return { synced, errors };
-}
-
 function syncActivePluginCache(): { synced: boolean; errors: string[] } {
-  const activeRoots = getInstalledOmcPluginRoots().filter(root => existsSync(root));
-  if (activeRoots.length === 0) {
-    return { synced: false, errors: [] };
-  }
-
-  const result = copyPluginSyncPayload(getRuntimePackageRoot(), activeRoots);
+  const result = syncInstalledPluginPayload();
 
   if (result.synced) {
     console.log('[omc update] Synced plugin cache');

--- a/src/installer/__tests__/plugin-cache-sync.test.ts
+++ b/src/installer/__tests__/plugin-cache-sync.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+const ORIG_ENV = { ...process.env };
+
+function writeFile(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function writePayloadTree(root: string, version = '9.9.9-test'): void {
+  mkdirSync(root, { recursive: true });
+  writeFile(join(root, 'dist', 'lib', 'worktree-paths.js'), 'export const test = true;\n');
+  writeFile(join(root, 'bridge', 'cli.cjs'), 'console.log("bridge");\n');
+  writeFile(join(root, 'hooks', 'hooks.json'), '{}\n');
+  writeFile(join(root, 'scripts', 'run.cjs'), 'console.log("run");\n');
+  writeFile(join(root, 'skills', 'plan', 'SKILL.md'), '# plan\n');
+  writeFile(join(root, 'agents', 'executor.md'), '# executor\n');
+  writeFile(join(root, 'templates', 'deliverables.json'), '{}\n');
+  writeFile(join(root, 'docs', 'CLAUDE.md'), '# docs\n');
+  writeFile(join(root, '.claude-plugin', 'plugin.json'), '{"name":"oh-my-claudecode"}\n');
+  writeFile(join(root, '.mcp.json'), '{}\n');
+  writeFile(join(root, 'README.md'), '# readme\n');
+  writeFile(join(root, 'LICENSE'), 'MIT\n');
+  writeFile(join(root, 'package.json'), JSON.stringify({ name: 'oh-my-claude-sisyphus', version }, null, 2));
+}
+
+async function freshInstaller() {
+  vi.resetModules();
+  return await import('../index.js');
+}
+
+describe('syncInstalledPluginPayload', () => {
+  let tempRoot: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'omc-plugin-cache-sync-'));
+    process.env.CLAUDE_CONFIG_DIR = join(tempRoot, '.claude');
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.OMC_PLUGIN_ROOT;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const key of Object.keys(process.env)) {
+      if (!(key in ORIG_ENV)) delete process.env[key];
+    }
+    Object.assign(process.env, ORIG_ENV);
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('repairs incomplete cache installs from the known marketplace source instead of reusing the installed root', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.12.0');
+    const sourceRoot = join(tempRoot, 'marketplace-source');
+
+    writePayloadTree(sourceRoot);
+    mkdirSync(join(cacheRoot, 'agents'), { recursive: true });
+    writeFileSync(join(cacheRoot, 'agents', 'executor.md'), '# stale executor\n');
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: cacheRoot, version: '4.12.0' }],
+        },
+      }, null, 2),
+    );
+    writeFileSync(
+      join(configDir, 'plugins', 'known_marketplaces.json'),
+      JSON.stringify({
+        omc: {
+          installLocation: sourceRoot,
+          source: { source: 'directory', path: sourceRoot },
+        },
+      }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+    const result = installer.syncInstalledPluginPayload();
+
+    expect(result.synced).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.sourceRoot).toBe(sourceRoot);
+    expect(result.targetRoots).toEqual([cacheRoot]);
+    expect(existsSync(join(cacheRoot, 'package.json'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'skills', 'plan', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'hooks', 'hooks.json'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'scripts', 'run.cjs'))).toBe(true);
+    expect(JSON.parse(readFileSync(join(cacheRoot, 'package.json'), 'utf-8')).version).toBe('9.9.9-test');
+  });
+
+  it('repairs incomplete cache installs during setup before plugin-provided file detection runs', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.12.0');
+    const sourceRoot = join(tempRoot, 'marketplace-source-install');
+
+    writePayloadTree(sourceRoot, '4.12.0');
+    mkdirSync(join(cacheRoot, 'agents'), { recursive: true });
+    writeFileSync(join(cacheRoot, 'agents', 'executor.md'), '# stale executor\n');
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: cacheRoot, version: '4.12.0' }],
+        },
+      }, null, 2),
+    );
+    writeFileSync(
+      join(configDir, 'plugins', 'known_marketplaces.json'),
+      JSON.stringify({
+        omc: {
+          installLocation: sourceRoot,
+          source: { source: 'directory', path: sourceRoot },
+        },
+      }, null, 2),
+    );
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ enabledPlugins: ['oh-my-claudecode@omc'] }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+    const result = installer.install({
+      skipClaudeCheck: true,
+      skipHud: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.installedAgents).toEqual([]);
+    expect(result.installedSkills).toEqual([]);
+    expect(installer.hasPluginProvidedAgentFiles()).toBe(true);
+    expect(installer.hasPluginProvidedSkillFiles()).toBe(true);
+    expect(installer.hasPluginProvidedHookFiles()).toBe(true);
+    expect(existsSync(join(cacheRoot, 'package.json'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'skills', 'plan', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'hooks', 'hooks.json'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'scripts', 'run.cjs'))).toBe(true);
+  });
+});

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -943,6 +943,191 @@ export function getInstalledOmcPluginRoots(): string[] {
   return Array.from(pluginRoots);
 }
 
+const PLUGIN_SYNC_PAYLOAD = [
+  'dist',
+  'bridge',
+  'hooks',
+  'scripts',
+  'skills',
+  'agents',
+  'templates',
+  'docs',
+  '.claude-plugin',
+  '.mcp.json',
+  'README.md',
+  'LICENSE',
+  'package.json',
+] as const;
+
+function countPluginSyncPayloadEntries(root: string): number {
+  let score = 0;
+  for (const entry of PLUGIN_SYNC_PAYLOAD) {
+    if (existsSync(join(root, entry))) {
+      score += 1;
+    }
+  }
+  return score;
+}
+
+function getKnownMarketplaceInstallRoots(): string[] {
+  const knownMarketplacesPath = join(CLAUDE_CONFIG_DIR, 'plugins', 'known_marketplaces.json');
+  if (!existsSync(knownMarketplacesPath)) {
+    return [];
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(knownMarketplacesPath, 'utf-8')) as Record<string, {
+      installLocation?: unknown;
+      source?: { path?: unknown };
+    }>;
+    const roots = new Set<string>();
+
+    for (const [marketplaceId, entry] of Object.entries(raw)) {
+      const isOmcMarketplace = marketplaceId.toLowerCase().includes('omc')
+        || marketplaceId.toLowerCase().includes('oh-my-claudecode');
+      if (!isOmcMarketplace) {
+        continue;
+      }
+
+      if (typeof entry?.installLocation === 'string' && entry.installLocation.trim().length > 0) {
+        roots.add(entry.installLocation.trim());
+      }
+
+      if (typeof entry?.source?.path === 'string' && entry.source.path.trim().length > 0) {
+        roots.add(entry.source.path.trim());
+      }
+    }
+
+    return Array.from(roots);
+  } catch {
+    return [];
+  }
+}
+
+function getGlobalInstalledPackageRoot(): string | null {
+  try {
+    const npmRoot = String(execSync('npm root -g', {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 10000,
+      ...(process.platform === 'win32' ? { windowsHide: true } : {}),
+    }) ?? '').trim();
+
+    if (!npmRoot) {
+      return null;
+    }
+
+    const globalPackageRoot = join(npmRoot, 'oh-my-claude-sisyphus');
+    return existsSync(globalPackageRoot) ? globalPackageRoot : null;
+  } catch {
+    return null;
+  }
+}
+
+function isCacheInstalledPluginRoot(root: string): boolean {
+  const normalizedRoot = normalizePath(root);
+  const cacheBase = normalizePath(join(CLAUDE_CONFIG_DIR, 'plugins', 'cache'));
+  return normalizedRoot === cacheBase || normalizedRoot.startsWith(`${cacheBase}/`);
+}
+
+function resolveBestPluginSyncSource(targetRoots: string[]): string | null {
+  const excludedRoots = new Set(targetRoots.map(normalizePath));
+  const seen = new Set<string>();
+  const globalPackageRoot = getGlobalInstalledPackageRoot();
+  const candidates = [
+    ...getKnownMarketplaceInstallRoots(),
+    ...(globalPackageRoot ? [globalPackageRoot] : []),
+    getRuntimePackageRoot(),
+  ];
+
+  let bestRoot: string | null = null;
+  let bestScore = -1;
+  let bestOrder = Number.POSITIVE_INFINITY;
+
+  for (const [order, candidate] of candidates.entries()) {
+    const normalizedCandidate = normalizePath(candidate);
+    if (seen.has(normalizedCandidate) || excludedRoots.has(normalizedCandidate) || !existsSync(candidate)) {
+      continue;
+    }
+    seen.add(normalizedCandidate);
+
+    const score = countPluginSyncPayloadEntries(candidate);
+    if (score === 0) {
+      continue;
+    }
+
+    if (score > bestScore || (score === bestScore && order < bestOrder)) {
+      bestRoot = candidate;
+      bestScore = score;
+      bestOrder = order;
+    }
+  }
+
+  return bestRoot;
+}
+
+export function copyPluginSyncPayload(sourceRoot: string, targetRoots: string[]): { synced: boolean; errors: string[] } {
+  if (targetRoots.length === 0) {
+    return { synced: false, errors: [] };
+  }
+
+  let synced = false;
+  const errors: string[] = [];
+
+  for (const targetRoot of targetRoots) {
+    let copiedToTarget = false;
+
+    for (const entry of PLUGIN_SYNC_PAYLOAD) {
+      const sourcePath = join(sourceRoot, entry);
+      if (!existsSync(sourcePath)) {
+        continue;
+      }
+
+      try {
+        cpSync(sourcePath, join(targetRoot, entry), {
+          recursive: true,
+          force: true,
+        });
+        copiedToTarget = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        errors.push(`Failed to sync ${entry} to ${targetRoot}: ${message}`);
+      }
+    }
+
+    synced = synced || copiedToTarget;
+  }
+
+  return { synced, errors };
+}
+
+export function syncInstalledPluginPayload(): {
+  synced: boolean;
+  errors: string[];
+  sourceRoot: string | null;
+  targetRoots: string[];
+} {
+  const targetRoots = getInstalledOmcPluginRoots()
+    .filter(root => existsSync(root) && isCacheInstalledPluginRoot(root));
+
+  if (targetRoots.length === 0) {
+    return { synced: false, errors: [], sourceRoot: null, targetRoots: [] };
+  }
+
+  const sourceRoot = resolveBestPluginSyncSource(targetRoots);
+  if (!sourceRoot) {
+    return {
+      synced: false,
+      errors: ['Unable to find a complete OMC package source to repair installed plugin roots'],
+      sourceRoot: null,
+      targetRoots,
+    };
+  }
+
+  const result = copyPluginSyncPayload(sourceRoot, targetRoots);
+  return { ...result, sourceRoot, targetRoots };
+}
+
 /**
  * Detect whether an installed Claude Code plugin already provides OMC agent
  * markdown files, so the legacy ~/.claude/agents copy can be skipped.
@@ -1377,6 +1562,21 @@ export function install(options: InstallOptions = {}): InstallResult {
   // Check if running as a plugin
   const runningAsPlugin = isRunningAsPlugin();
   const projectScoped = isProjectScopedPlugin();
+
+  const pluginPayloadSync = syncInstalledPluginPayload();
+  if (pluginPayloadSync.errors.length > 0) {
+    for (const error of pluginPayloadSync.errors) {
+      log(`Plugin cache sync warning: ${error}`);
+    }
+  }
+  if (pluginPayloadSync.synced) {
+    const targetSummary = pluginPayloadSync.targetRoots.length > 0
+      ? pluginPayloadSync.targetRoots.join(', ')
+      : 'installed plugin roots';
+    const sourceSummary = pluginPayloadSync.sourceRoot ?? 'unknown source';
+    log(`Repaired installed OMC plugin payload from ${sourceSummary} -> ${targetSummary}`);
+  }
+
   const pluginProvidesAgentFiles = hasPluginProvidedAgentFiles();
   const pluginProvidesSkillFiles = hasPluginProvidedSkillFiles();
   const pluginProvidesHookFiles = hasPluginProvidedHookFiles();


### PR DESCRIPTION
## Summary
- repair cache-installed OMC plugin roots before setup decides whether plugin-provided agents, skills, and hooks already exist
- choose the best maintainer-controlled repair source in priority order: known marketplace install/source roots, global npm install root, then the current runtime package root
- reuse the same payload-sync helper during auto-update reconciliation and cover the cache-repair contract with regression tests

## Root cause verified
Issue #2686 already showed the npm pack surface was complete. On current dev, the broken runtime came from an **installed cached plugin root** under `~/.claude/plugins/cache/...` being incomplete while `installed_plugins.json` still pointed runtime resolution at that truncated tree.

The maintainer-controlled bug was in our own repair path:
- setup trusted `hasPluginProvidedAgentFiles/SkillFiles/HookFiles()` before attempting to repair incomplete cache installs
- update reconciliation could also source repairs from the currently running runtime root, which is unsafe when that runtime root is itself the incomplete cache install

This PR fixes that cache/runtime-root contract without changing release design.

## Testing
- `npx tsc --noEmit`
- `npm test -- --run src/installer/__tests__/plugin-cache-sync.test.ts src/__tests__/installer-plugin-agents.test.ts src/__tests__/installer-omc-reference.test.ts src/__tests__/auto-update.test.ts`

Closes #2688
Related: #2689
