### PR TITLE
fix(installer): reject cache-repair roots that escape plugins/cache

### DIFF
--- a/src/installer/__tests__/plugin-cache-sync.test.ts
+++ b/src/installer/__tests__/plugin-cache-sync.test.ts
@@ -142,4 +142,45 @@ describe('syncInstalledPluginPayload', () => {
     expect(existsSync(join(cacheRoot, 'hooks', 'hooks.json'))).toBe(true);
     expect(existsSync(join(cacheRoot, 'scripts', 'run.cjs'))).toBe(true);
   });
+
+  it('rejects cache install roots that escape the cache directory via .. segments', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheBase = join(configDir, 'plugins', 'cache');
+    const escapedInstallPath = `${cacheBase}/../../../escaped-target`;
+    const escapedResolvedRoot = join(tempRoot, 'escaped-target');
+    const sourceRoot = join(tempRoot, 'marketplace-source-escape');
+
+    writePayloadTree(sourceRoot);
+    mkdirSync(cacheBase, { recursive: true });
+    mkdirSync(escapedResolvedRoot, { recursive: true });
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: escapedInstallPath, version: '4.12.0' }],
+        },
+      }, null, 2),
+    );
+    writeFileSync(
+      join(configDir, 'plugins', 'known_marketplaces.json'),
+      JSON.stringify({
+        omc: {
+          installLocation: sourceRoot,
+          source: { source: 'directory', path: sourceRoot },
+        },
+      }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+    const result = installer.syncInstalledPluginPayload();
+
+    expect(result.synced).toBe(false);
+    expect(result.errors).toEqual([]);
+    expect(result.sourceRoot).toBeNull();
+    expect(result.targetRoots).toEqual([]);
+    expect(existsSync(join(escapedResolvedRoot, 'package.json'))).toBe(false);
+    expect(existsSync(join(escapedResolvedRoot, 'skills', 'plan', 'SKILL.md'))).toBe(false);
+  });
 });

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -8,8 +8,8 @@
  * Bash hook scripts were removed in v3.9.0.
  */
 
-import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, chmodSync, readdirSync, cpSync, unlinkSync, rmSync } from 'fs';
-import { join, dirname } from 'path';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, chmodSync, readdirSync, cpSync, unlinkSync, rmSync, realpathSync } from 'fs';
+import { join, dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
@@ -173,6 +173,14 @@ function escapeRegex(value: string): string {
 
 function normalizePath(value: string): string {
   return value.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+function canonicalizeExistingPath(value: string): string {
+  try {
+    return normalizePath(realpathSync.native(value));
+  } catch {
+    return normalizePath(resolve(value));
+  }
 }
 
 function isDefaultClaudeConfigDirPath(configDir: string): boolean {
@@ -1027,7 +1035,13 @@ function getGlobalInstalledPackageRoot(): string | null {
 function isCacheInstalledPluginRoot(root: string): boolean {
   const normalizedRoot = normalizePath(root);
   const cacheBase = normalizePath(join(CLAUDE_CONFIG_DIR, 'plugins', 'cache'));
-  return normalizedRoot === cacheBase || normalizedRoot.startsWith(`${cacheBase}/`);
+  if (!(normalizedRoot === cacheBase || normalizedRoot.startsWith(`${cacheBase}/`))) {
+    return false;
+  }
+
+  const canonicalRoot = canonicalizeExistingPath(root);
+  const canonicalCacheBase = canonicalizeExistingPath(cacheBase);
+  return canonicalRoot === canonicalCacheBase || canonicalRoot.startsWith(`${canonicalCacheBase}/`);
 }
 
 function resolveBestPluginSyncSource(targetRoots: string[]): string | null {


### PR DESCRIPTION
## Summary
- canonicalize cache repair target roots before containment checks in `syncInstalledPluginPayload()`
- keep the fix narrow to the repair-path predicate instead of broadening installer path handling elsewhere
- add a regression test covering `..`-segment escape paths in OMC `installPath` entries

## Root cause verified
The current repair path trusts normalized raw strings from `installed_plugins.json`:
- `normalizePath()` only normalizes slashes and trailing separators
- `isCacheInstalledPluginRoot()` then uses a prefix check against `<configDir>/plugins/cache`

That means an OMC install path like:

```text
<configDir>/plugins/cache/../../../escaped-target
```

can still pass the current predicate when the intermediate cache directory exists. In a local repro against current `dev`, `syncInstalledPluginPayload()` then copied the full OMC payload into the resolved out-of-cache directory.

This patch fixes that specific repair-path containment bug by comparing canonical paths before accepting a target root.

## Changed files
- `src/installer/index.ts`
- `src/installer/__tests__/plugin-cache-sync.test.ts`

## Verification
- `npm run build`
- `./node_modules/.bin/vitest run src/installer/__tests__/plugin-cache-sync.test.ts src/__tests__/auto-update.test.ts src/__tests__/installer-omc-reference.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/eslint src/installer/index.ts src/installer/__tests__/plugin-cache-sync.test.ts`
- direct local reproduction of the `syncInstalledPluginPayload()` escape path before and after the fix

Closes #2705