### PR TITLE
Fix omc-teams multi-repo Codex handoff contract

### DIFF
--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -79,6 +79,27 @@ Validate before decomposing or running anything:
 
 Break work into N independent subtasks (file- or concern-scoped) to avoid write conflicts.
 
+### Phase 2.5: Resolve workspace root for multi-repo plans
+
+`omc team` launches all workers with one shared working directory. For single-repo
+tasks, the current repo is usually correct. For multi-repo tasks, especially when a
+plan lives in one repo but the implementation touches sibling repos, resolve the
+working directory before launch:
+
+- If the task references a plan artifact under one repo (for example
+  `tool/.omc/plans/task-1200-gwd-gifs.md`) and target paths in sibling repos
+  (for example `api/` and `admin/`), choose the shared workspace root that contains
+  all participating repos (for example the parent `inter/` directory).
+- Use an **absolute plan path** in the task text so the workers can still find the
+  plan after `--cwd` changes the launch directory.
+- Include the explicit repo paths or repo names in the task text and subtasks.
+- Do not anchor the launch cwd to only the repo containing `.omc/plans/...` when
+  target repos are siblings; that strands `codex`, `claude`, and `gemini` workers in
+  the plan repo instead of the implementation workspace.
+- If no safe shared workspace root can be identified, do not launch `/omc-teams`.
+  Report the single-cwd constraint and ask for, or derive from evidence, the intended
+  workspace root.
+
 ### Phase 3: Start CLI team runtime
 
 Activate mode state (recommended):
@@ -91,6 +112,13 @@ Start workers via CLI:
 
 ```bash
 omc team <N>:<claude|codex|gemini> "<task>"
+```
+
+For the multi-repo case resolved in Phase 2.5, launch from the shared workspace root
+with the existing `--cwd` contract and keep the plan reference absolute:
+
+```bash
+omc team <N>:<claude|codex|gemini> "<task with absolute plan path and explicit repo paths>" --cwd <workspace-root>
 ```
 
 Team name defaults to a slug from the task text (example: `review-auth-flow`).

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -486,6 +486,16 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('/oh-my-claudecode:team');
     });
 
+    it('should preserve the multi-repo omc-teams cwd and plan-path contract', () => {
+      const skill = getBuiltinSkill('omc-teams');
+      expect(skill).toBeDefined();
+      expect(skill?.template).toContain('shared workspace root');
+      expect(skill?.template).toContain('absolute plan path');
+      expect(skill?.template).toContain('--cwd <workspace-root>');
+      expect(skill?.template).toContain('Do not anchor the launch cwd to only the repo containing `.omc/plans/...`');
+      expect(skill?.template).toContain('single-cwd constraint');
+    });
+
     it('should be case-insensitive', () => {
       const skillLower = getBuiltinSkill('autopilot');
       const skillUpper = getBuiltinSkill('AUTOPILOT');


### PR DESCRIPTION
## Summary
- trace the actual `/omc-teams` failure to the single-cwd handoff contract rather than a Codex-only runtime bug
- document the multi-repo launch contract for sibling repos: shared workspace root plus absolute plan path
- add regression coverage for the updated `omc-teams` skill template

## Root cause
`omc team` already launches all workers with one shared working directory. `/omc-teams` only documented the current-repo launch form, so a plan stored in one repo (for example `tool/.omc/plans/...`) could launch `N:codex` workers inside that repo even when the task actually needed sibling repos like `api/` and `admin/`.

## Testing
- npm run test:run -- src/__tests__/skills.test.ts
- npm run build:cli

Closes #2708.
