### PR TITLE
fix(hud, windows): pass shell:true to execFileSync for npm root -g discovery (#2715)

### DIFF
--- a/scripts/lib/hud-wrapper-template.txt
+++ b/scripts/lib/hud-wrapper-template.txt
@@ -46,11 +46,16 @@ function getGlobalNodeModuleRoots() {
   }
 
   try {
-    const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+    const isWin = process.platform === "win32";
+    const npmCommand = isWin ? "npm.cmd" : "npm";
     const npmRoot = String(execFileSync(npmCommand, ["root", "-g"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 1500,
+      // Required on Windows since Node 20.12 / CVE-2024-27980: spawning .cmd
+      // via execFileSync without shell:true throws EINVAL, silently breaking
+      // npm-root discovery for installs under a non-standard npm prefix. #2715
+      shell: isWin,
     })).trim();
     if (npmRoot) roots.unshift(npmRoot);
   } catch { /* continue */ }

--- a/src/__tests__/hud-windows.test.ts
+++ b/src/__tests__/hud-windows.test.ts
@@ -225,4 +225,25 @@ describe('HUD Windows Compatibility', () => {
       expect(content).toContain("'plugins', 'oh-my-claudecode', `.usage-cache-${source}.json`");
     });
   });
+
+  describe('npm root -g discovery (#2715)', () => {
+    // Node 20.12+ / 18.20+ / 21.7+ on Windows requires `shell: true` to spawn
+    // .cmd/.bat via spawnSync/execFileSync (CVE-2024-27980). Without it, the
+    // `npm root -g` discovery throws EINVAL, silently falls through to
+    // "Plugin not installed" for users whose npm prefix is non-standard.
+    it('execFileSync("npm.cmd", …) must pass shell:true on Windows', () => {
+      const templatePath = join(packageRoot, 'scripts', 'lib', 'hud-wrapper-template.txt');
+      const content = readFileSync(templatePath, 'utf-8');
+      // The discovery block spawns npm.cmd — must include shell flag driven by platform.
+      expect(content).toMatch(/execFileSync\(npmCommand,\s*\["root",\s*"-g"\]/);
+      expect(content).toContain('shell: isWin');
+    });
+
+    it('shell-flag comment should reference the CVE and issue for future readers', () => {
+      const templatePath = join(packageRoot, 'scripts', 'lib', 'hud-wrapper-template.txt');
+      const content = readFileSync(templatePath, 'utf-8');
+      expect(content).toContain('CVE-2024-27980');
+      expect(content).toContain('#2715');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Follow-up to #2148 / #2149. The `npm root -g` discovery added by #2149 is silently failing on Windows with Node 20.12+ and leaving HUD stuck on `[OMC HUD] Plugin not installed` for users whose npm prefix isn't covered by the static fallback roots.

- `execFileSync('npm.cmd', ['root', '-g'], …)` without `{ shell: true }` now throws `EINVAL` on Windows (Node 20.12 / 18.20 / 21.7 CVE-2024-27980 hardening).
- The broad `try { … } catch { /* continue */ }` around that call swallows the error, `npmRoot` stays empty, and discovery falls through.
- Static fallback roots in `getGlobalNodeModuleRoots()` cover `npm_config_prefix`, `PREFIX`, `dirname(process.execPath)/{…,../,../lib}/node_modules`, and `APPDATA/npm/node_modules` — but not user-configured prefixes like `C:/usr/local`. My install (`prefix=C:/usr/local` in `~/.npmrc`) hits this path.

Fixes #2715. See that issue for the full repro (including a one-liner `node -e …` that reproduces the EINVAL on any Windows/Node 20.12+ environment).

## Change
```diff
   try {
-    const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+    const isWin = process.platform === "win32";
+    const npmCommand = isWin ? "npm.cmd" : "npm";
     const npmRoot = String(execFileSync(npmCommand, ["root", "-g"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 1500,
+      // Required on Windows since Node 20.12 / CVE-2024-27980: spawning .cmd
+      // via execFileSync without shell:true throws EINVAL, silently breaking
+      // npm-root discovery for installs under a non-standard npm prefix. #2715
+      shell: isWin,
     })).trim();
     if (npmRoot) roots.unshift(npmRoot);
   } catch { /* continue */ }
```

Gated on `win32` so non-Windows spawns remain unchanged (no new shell layer). Unix stays on direct `npm` execution exactly as before.

## Why only `scripts/lib/hud-wrapper-template.txt`?
`scripts/lib/hud-wrapper-template.mjs` and `src/lib/hud-wrapper-template.ts` are *readers* of the `.txt` file — confirmed via `hud-wrapper-template-sync.test.ts`. The wrapper body lives solely in the `.txt`, so only the `.txt` needs editing.

## Tests
Added two assertions to `src/__tests__/hud-windows.test.ts` under a new `describe('npm root -g discovery (#2715)', …)` block:
1. The template contains `execFileSync(npmCommand, ["root", "-g"] …)` paired with `shell: isWin` — prevents silent regression if someone drops the flag.
2. The explanatory comment references `CVE-2024-27980` and `#2715` — keeps the reasoning discoverable in-place for future readers.

Both follow the static-content-assertion style of existing tests in the same file (e.g. the `pathToFileURL` and `CLAUDE_CONFIG_DIR` checks).

## Verification

### Reproduced the bug (pre-fix, Node 20+ Windows)
```bash
"C:\Program Files\nodejs\node.exe" "C:/Users/<me>/.claude/hud/omc-hud.mjs" < /dev/null
# => [OMC HUD] Plugin not installed. Run: /oh-my-claudecode:omc-setup
```

### Direct defect demonstration
```js
require('child_process').execFileSync('npm.cmd', ['root', '-g'], { encoding: 'utf8' });
// => Error: spawnSync npm.cmd EINVAL
require('child_process').execFileSync('npm.cmd', ['root', '-g'], { encoding: 'utf8', shell: true }).trim();
// => "C:\usr\local\node_modules"
```

### Post-fix (`OMC_PLUGIN_ROOT` as a proxy that also exercises the loader)
```bash
OMC_PLUGIN_ROOT="C:/usr/local/node_modules/oh-my-claude-sisyphus" \
  "C:\Program Files\nodejs\node.exe" "C:/Users/<me>/.claude/hud/omc-hud.mjs" < /dev/null
# => [OMC] HUD v4.12.0 | preset: focused  (HUD loads successfully)
```

With the shell-flag fix applied, the npm-root branch would resolve the same path without needing `OMC_PLUGIN_ROOT`.

## Test plan
- [ ] CI Windows runner executes `hud-windows.test.ts` (new assertions + existing suite)
- [ ] CI Linux/macOS runner confirms non-Windows spawn path unchanged
- [ ] Manual: on a Windows machine with `npm config set prefix C:/usr/local` and `npm i -g oh-my-claude-sisyphus`, HUD renders without `OMC_PLUGIN_ROOT` set in `settings.json`

## Scope / risk
- Change is **one line of functional code** (`shell: isWin`) plus a 3-line explanatory comment.
- Non-Windows platforms: unchanged (the `isWin` gate keeps `shell: false` for them).
- No dependency changes, no signature changes, no new fallback paths.

## Disclosure
I did not run the vitest suite locally — the clone doesn't have a `node_modules` and the change is small enough (two static-assertion tests mirroring existing ones in the same file) that I trust CI to catch any regression. Happy to install and re-run locally if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)