### PR TITLE
feat(usage): detect Bailian (dashscope) provider and skip gracefully

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -39312,6 +39312,15 @@ function isMinimaxHost(urlString) {
     return false;
   }
 }
+function isBailianHost(urlString) {
+  try {
+    const url = new URL(urlString);
+    const hostname4 = url.hostname.toLowerCase();
+    return hostname4 === "dashscope.aliyuncs.com" || hostname4.endsWith(".dashscope.aliyuncs.com");
+  } catch {
+    return false;
+  }
+}
 function getLegacyCachePath() {
   return (0, import_path112.join)(getClaudeConfigDir(), "plugins", "oh-my-claudecode", ".usage-cache.json");
 }
@@ -39991,8 +40000,9 @@ async function getUsage() {
   const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
   const isMinimax = baseUrl != null && isMinimaxHost(baseUrl);
   const isZai = baseUrl != null && isZaiHost(baseUrl);
+  const isBailian = baseUrl != null && isBailianHost(baseUrl);
   const minimaxApiKey = process.env.MINIMAX_API_KEY || authToken;
-  const currentSource = isMinimax ? "minimax" : isZai && authToken ? "zai" : "anthropic";
+  const currentSource = isMinimax ? "minimax" : isZai && authToken ? "zai" : isBailian ? "bailian" : "anthropic";
   const pollIntervalMs = getUsagePollIntervalMs();
   migrateLegacyCache(currentSource);
   const initialCache = readCache(currentSource);
@@ -40026,6 +40036,10 @@ async function getUsage() {
           cache,
           pollIntervalMs
         });
+      }
+      if (isBailian) {
+        writeCache({ data: null, error: true, source: "bailian", errorReason: "unsupported" });
+        return { rateLimits: null, error: "unsupported" };
       }
       let creds = getCredentials();
       if (creds) {
@@ -41882,6 +41896,7 @@ function renderRateLimitsWithBar(limits, barWidth = 8, stale) {
 function renderRateLimitsError(result) {
   if (!result?.error) return null;
   if (result.error === "no_credentials") return null;
+  if (result.error === "unsupported") return null;
   if (result.error === "rate_limited") {
     return result.rateLimits ? null : `${DIM4}[API 429]${RESET}`;
   }

--- a/src/hud/elements/limits.ts
+++ b/src/hud/elements/limits.ts
@@ -301,10 +301,12 @@ export function renderRateLimitsWithBar(
  * - 'network': API timeout, HTTP error, or parse failure → [API err]
  * - 'auth': credentials expired, refresh failed → [API auth]
  * - 'no_credentials': no OAuth credentials (expected for API key users) → null (no display)
+ * - 'unsupported': provider has no standard Anthropic usage API (Bailian/dashscope) → null (no display)
  */
 export function renderRateLimitsError(result: UsageResult | null): string | null {
   if (!result?.error) return null;
   if (result.error === 'no_credentials') return null;
+  if (result.error === 'unsupported') return null;
   if (result.error === 'rate_limited') {
     // Prefer rendering stale usage percentages when available; only show the 429 badge
     // when there is no cached rate limit data to display.

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -214,7 +214,7 @@ export interface RateLimits {
  * - 'auth': Authentication failure (token expired, refresh failed)
  * - 'no_credentials': No OAuth credentials available (expected for API key users)
  */
-export type UsageErrorReason = 'network' | 'timeout' | 'http' | 'auth' | 'no_credentials' | 'rate_limited';
+export type UsageErrorReason = 'network' | 'timeout' | 'http' | 'auth' | 'no_credentials' | 'rate_limited' | 'unsupported';
 
 /**
  * Result of fetching usage data from the API.

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -52,7 +52,7 @@ interface UsageCache {
   /** Preserved error reason for accurate cache-hit reporting */
   errorReason?: UsageErrorReason;
   /** Provider that produced this cache entry */
-  source?: 'anthropic' | 'zai' | 'minimax';
+  source?: 'anthropic' | 'zai' | 'minimax' | 'bailian';
   /** Whether this cache entry was caused by a 429 rate limit response */
   rateLimited?: boolean;
   /** Consecutive 429 count for exponential backoff */
@@ -140,6 +140,20 @@ export function isMinimaxHost(urlString: string): boolean {
   }
 }
 
+/**
+ * Check if a URL points to Alibaba Cloud Bailian (百炼/dashscope).
+ * Matches dashscope.aliyuncs.com domains used by Bailian API endpoints.
+ */
+export function isBailianHost(urlString: string): boolean {
+  try {
+    const url = new URL(urlString);
+    const hostname = url.hostname.toLowerCase();
+    return hostname === 'dashscope.aliyuncs.com' || hostname.endsWith('.dashscope.aliyuncs.com');
+  } catch {
+    return false;
+  }
+}
+
 interface MinimaxModelRemain {
   model_name: string;
   current_interval_total_count: number;
@@ -174,7 +188,7 @@ function getLegacyCachePath(): string {
 /**
  * Get the provider-specific cache file path
  */
-function getCachePath(source: 'anthropic' | 'zai' | 'minimax'): string {
+function getCachePath(source: 'anthropic' | 'zai' | 'minimax' | 'bailian'): string {
   return join(getClaudeConfigDir(), 'plugins', 'oh-my-claudecode', `.usage-cache-${source}.json`);
 }
 
@@ -184,7 +198,7 @@ function getCachePath(source: 'anthropic' | 'zai' | 'minimax'): string {
  * and the legacy cache's source matches the current provider.
  * Does NOT delete the legacy file (rolling update safety).
  */
-function migrateLegacyCache(source: 'anthropic' | 'zai' | 'minimax'): void {
+function migrateLegacyCache(source: 'anthropic' | 'zai' | 'minimax' | 'bailian'): void {
   try {
     const legacyPath = getLegacyCachePath();
     if (!existsSync(legacyPath)) return;
@@ -212,7 +226,7 @@ function migrateLegacyCache(source: 'anthropic' | 'zai' | 'minimax'): void {
 /**
  * Read cached usage data for a specific provider
  */
-function readCache(source: 'anthropic' | 'zai' | 'minimax'): UsageCache | null {
+function readCache(source: 'anthropic' | 'zai' | 'minimax' | 'bailian'): UsageCache | null {
   try {
     const cachePath = getCachePath(source);
     if (!existsSync(cachePath)) return null;
@@ -254,7 +268,7 @@ function readCache(source: 'anthropic' | 'zai' | 'minimax'): UsageCache | null {
 interface WriteCacheOptions {
   data: RateLimits | null;
   error?: boolean;
-  source: 'anthropic' | 'zai' | 'minimax';
+  source: 'anthropic' | 'zai' | 'minimax' | 'bailian';
   rateLimited?: boolean;
   rateLimitedCount?: number;
   rateLimitedUntil?: number;
@@ -372,7 +386,7 @@ function getCachedUsageResult(cache: UsageCache): UsageResult {
 }
 
 function createRateLimitedCacheEntry(
-  source: 'anthropic' | 'zai' | 'minimax',
+  source: 'anthropic' | 'zai' | 'minimax' | 'bailian',
   data: RateLimits | null,
   pollIntervalMs: number,
   previousCount: number,
@@ -1048,7 +1062,7 @@ export function parseMinimaxResponse(response: MinimaxCodingPlanResponse): RateL
  * Provider-specific pre-fetch logic (e.g., credential refresh) runs before calling this.
  */
 async function fetchAndCacheUsage<T>(opts: {
-  source: 'anthropic' | 'zai' | 'minimax';
+  source: 'anthropic' | 'zai' | 'minimax' | 'bailian';
   fetchFn: () => Promise<FetchResult<T>>;
   parseFn: (data: T) => RateLimits | null;
   cache: UsageCache | null;
@@ -1115,9 +1129,10 @@ export async function getUsage(): Promise<UsageResult> {
   const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
   const isMinimax = baseUrl != null && isMinimaxHost(baseUrl);
   const isZai = baseUrl != null && isZaiHost(baseUrl);
+  const isBailian = baseUrl != null && isBailianHost(baseUrl);
   const minimaxApiKey = process.env.MINIMAX_API_KEY || authToken;
-  const currentSource: 'anthropic' | 'zai' | 'minimax' =
-    isMinimax ? 'minimax' : isZai && authToken ? 'zai' : 'anthropic';
+  const currentSource: 'anthropic' | 'zai' | 'minimax' | 'bailian' =
+    isMinimax ? 'minimax' : isZai && authToken ? 'zai' : isBailian ? 'bailian' : 'anthropic';
   const pollIntervalMs = getUsagePollIntervalMs();
 
   // Migrate legacy single-file cache to provider-specific file (one-shot, best-effort)
@@ -1159,6 +1174,12 @@ export async function getUsage(): Promise<UsageResult> {
           cache,
           pollIntervalMs,
         });
+      }
+
+      // Bailian (百炼/dashscope) path: no standard Anthropic usage API
+      if (isBailian) {
+        writeCache({ data: null, error: true, source: 'bailian', errorReason: 'unsupported' });
+        return { rateLimits: null, error: 'unsupported' };
       }
 
       // Anthropic OAuth path (official Claude Code support)


### PR DESCRIPTION
## Summary

Fixes OMC usage API silently failing when using Bailian (百炼/dashscope) as the active provider via cc-switch.

When Bailian is configured via cc-switch, `ANTHROPIC_BASE_URL` points to `dashscope.aliyuncs.com`. OMC's `getUsage()` previously only detected `minimax` and `zai` hosts, falling through to the `anthropic` auth path. Since `~/.claude/config.json` has `primaryApiKey: "any"`, this auth path always fails → silent cascade of usage API errors.

## Changes

- `src/hud/types.ts`: Add `'unsupported'` to `UsageErrorReason`
- `src/hud/usage-api.ts`: Add `isBailianHost()` for `dashscope.aliyuncs.com` detection; update `getUsage()` to return `error: 'unsupported'` for Bailian instead of falling through to Anthropic auth
- `src/hud/elements/limits.ts`: Update `renderRateLimitsError()` to skip `[API err]` display for `unsupported` errors
- `bridge/cli.cjs`: Regenerated

## Test plan

- [ ] With cc-switch routing to Bailian, OMC HUD should show no error badge
- [ ] With cc-switch routing to MiniMax, OMC HUD should continue showing usage normally
- [ ] With cc-switch routing to Anthropic, OMC HUD should continue working normally