### PR TITLE
feat(team): isolate team namespaces per git worktree

### DIFF
--- a/src/__tests__/package-dir-resolution-regression.test.ts
+++ b/src/__tests__/package-dir-resolution-regression.test.ts
@@ -94,8 +94,14 @@ describe('package dir resolution regression (#1322, #1324)', () => {
 
     expect(snippet).toContain('fileURLToPath(import.meta.url)');
     expect(snippet).toContain('currentDirName === "bridge"');
+    // esbuild renames repeated `join` imports with a numeric suffix that drifts
+    // whenever new modules add a `path.join` import. Match by shape, not literal
+    // suffix, so this regression check stays stable.
+    const joinReturnRe = /return join\d+\(__dirname2, "\.\.", "\.\."\)/;
+    const joinReturnMatch = snippet.match(joinReturnRe);
+    expect(joinReturnMatch).not.toBeNull();
     expect(snippet.indexOf('fileURLToPath(import.meta.url)')).toBeLessThan(
-      snippet.indexOf('return join7(__dirname2, "..", "..")'),
+      joinReturnMatch ? snippet.indexOf(joinReturnMatch[0]) : -1,
     );
   });
 

--- a/src/__tests__/team-multi-worktree-isolation.test.ts
+++ b/src/__tests__/team-multi-worktree-isolation.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Cross-worktree isolation: same repo + same team name + two sibling worktrees.
+ *
+ * Verifies that team-scoped namespaces (worktree-scope token, internal worker
+ * worktree paths, branch names, metadata paths, tmux session names, ~/.claude
+ * teams config dir) differ between two linked worktrees of the same git repo,
+ * which prevents the cross-worktree team-mode collisions described in
+ * https://github.com/Yeachan-Heo/oh-my-claudecode/issues — see
+ * `.omc/prd.json:US-006`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+
+import { getWorktreeScopeToken, SCOPE_ENV_VAR } from '../team/team-scope.js';
+import {
+  createWorkerWorktree,
+  removeWorkerWorktree,
+  cleanupTeamWorktrees,
+  listTeamWorktrees,
+} from '../team/git-worktree.js';
+import { sessionName } from '../team/tmux-session.js';
+
+const TEAM_NAME = 'shared-team';
+const WORKER_NAME = 'worker-a';
+
+function gitInit(dir: string): void {
+  execFileSync('git', ['init', '-q'], { cwd: dir, stdio: 'pipe' });
+  execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir, stdio: 'pipe' });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir, stdio: 'pipe' });
+  execFileSync('git', ['commit', '--allow-empty', '-m', 'init'], { cwd: dir, stdio: 'pipe' });
+}
+
+describe('team multi-worktree isolation', () => {
+  let primaryRoot: string;
+  let linkedRoot: string;
+
+  beforeEach(() => {
+    delete process.env[SCOPE_ENV_VAR];
+
+    primaryRoot = mkdtempSync(join(tmpdir(), 'omc-mw-primary-'));
+    gitInit(primaryRoot);
+
+    linkedRoot = primaryRoot + '-linked';
+    execFileSync(
+      'git',
+      ['worktree', 'add', '-b', 'feat/sibling', linkedRoot],
+      { cwd: primaryRoot, stdio: 'pipe' },
+    );
+  });
+
+  afterEach(() => {
+    delete process.env[SCOPE_ENV_VAR];
+    try { cleanupTeamWorktrees(TEAM_NAME, primaryRoot); } catch { /* ignore */ }
+    try { cleanupTeamWorktrees(TEAM_NAME, linkedRoot); } catch { /* ignore */ }
+    try {
+      execFileSync('git', ['worktree', 'remove', '--force', linkedRoot], {
+        cwd: primaryRoot, stdio: 'pipe',
+      });
+    } catch { /* ignore */ }
+    try { rmSync(linkedRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { rmSync(primaryRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('produces distinct scope tokens for primary and linked worktrees', () => {
+    const tokenPrimary = getWorktreeScopeToken(primaryRoot);
+    const tokenLinked = getWorktreeScopeToken(linkedRoot);
+    expect(tokenPrimary).toMatch(/^[0-9a-f]{8}$/);
+    expect(tokenLinked).toMatch(/^[0-9a-f]{8}$/);
+    expect(tokenPrimary).not.toBe(tokenLinked);
+  });
+
+  it('produces distinct tmux session names per worktree', () => {
+    const sessPrimary = sessionName(TEAM_NAME, WORKER_NAME, primaryRoot);
+    const sessLinked = sessionName(TEAM_NAME, WORKER_NAME, linkedRoot);
+    expect(sessPrimary).not.toBe(sessLinked);
+    expect(sessPrimary.startsWith('omc-team-')).toBe(true);
+    expect(sessLinked.startsWith('omc-team-')).toBe(true);
+  });
+
+  it('createWorkerWorktree produces distinct branches and paths per worktree', () => {
+    const wtPrimary = createWorkerWorktree(TEAM_NAME, WORKER_NAME, primaryRoot);
+    const wtLinked = createWorkerWorktree(TEAM_NAME, WORKER_NAME, linkedRoot);
+
+    // Branch names must differ — git branches are repo-shared, so collision
+    // would have caused the second `git worktree add -b` to fail anyway.
+    expect(wtPrimary.branch).not.toBe(wtLinked.branch);
+    expect(wtPrimary.branch.startsWith('omc-team/')).toBe(true);
+    expect(wtLinked.branch.startsWith('omc-team/')).toBe(true);
+
+    // Worker worktree paths must differ
+    expect(wtPrimary.path).not.toBe(wtLinked.path);
+    expect(existsSync(wtPrimary.path)).toBe(true);
+    expect(existsSync(wtLinked.path)).toBe(true);
+
+    // Metadata listings must each see only their own entry
+    const listPrimary = listTeamWorktrees(TEAM_NAME, primaryRoot);
+    const listLinked = listTeamWorktrees(TEAM_NAME, linkedRoot);
+    expect(listPrimary).toHaveLength(1);
+    expect(listLinked).toHaveLength(1);
+    expect(listPrimary[0].path).toBe(wtPrimary.path);
+    expect(listLinked[0].path).toBe(wtLinked.path);
+
+    // Cleanup happens in afterEach via cleanupTeamWorktrees
+    removeWorkerWorktree(TEAM_NAME, WORKER_NAME, primaryRoot);
+    removeWorkerWorktree(TEAM_NAME, WORKER_NAME, linkedRoot);
+  });
+
+  it('OMC_TEAM_SCOPE_TOKEN env override pins scope across cwd boundaries', () => {
+    // Lead exports its token; the worker (which lives in a per-worker worktree
+    // with a different cwd) must inherit the same scope so they share inbox
+    // and outbox paths instead of writing to ships passing in the night.
+    const leadToken = getWorktreeScopeToken(primaryRoot);
+    process.env[SCOPE_ENV_VAR] = leadToken;
+    try {
+      const workerSeenToken = getWorktreeScopeToken(linkedRoot);
+      expect(workerSeenToken).toBe(leadToken);
+    } finally {
+      delete process.env[SCOPE_ENV_VAR];
+    }
+  });
+});

--- a/src/team/__tests__/bridge-integration.test.ts
+++ b/src/team/__tests__/bridge-integration.test.ts
@@ -9,10 +9,12 @@ import { writeHeartbeat, readHeartbeat } from '../heartbeat.js';
 import { sanitizeName } from '../tmux-session.js';
 import { logAuditEvent, readAuditLog } from '../audit-log.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { getWorktreeScopeToken } from '../team-scope.js';
 
 const TEST_TEAM = 'test-bridge-int';
+const SCOPE = getWorktreeScopeToken();
 // Task files now live in the canonical .omc/state/team path (relative to WORK_DIR)
-const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', TEST_TEAM);
+const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', SCOPE, TEST_TEAM);
 // Resolve symlinks (macOS /var -> /private/var) so validateResolvedPath matches
 const WORK_DIR = join(realpathSync(tmpdir()), '__test_bridge_work__');
 // Canonical tasks dir for this team

--- a/src/team/__tests__/edge-cases.test.ts
+++ b/src/team/__tests__/edge-cases.test.ts
@@ -21,6 +21,7 @@ import {
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { getWorktreeScopeToken } from '../team-scope.js';
 
 // --- task-file-ops imports ---
 import {
@@ -65,12 +66,14 @@ const EDGE_TEAM_IO = 'test-edge-io';
 let TASK_TEST_CWD: string;
 let TASKS_DIR: string;
 
-const TEAMS_IO_DIR = join(getClaudeConfigDir(), 'teams', EDGE_TEAM_IO);
+const SCOPE = getWorktreeScopeToken();
+const TEAMS_IO_DIR = join(getClaudeConfigDir(), 'teams', SCOPE, EDGE_TEAM_IO);
 
 const HB_DIR = join(tmpdir(), 'test-edge-hb');
 const REG_DIR = join(tmpdir(), 'test-edge-reg');
 const REG_TEAM = 'test-edge-reg-team';
-const CONFIG_DIR = join(getClaudeConfigDir(), 'teams', REG_TEAM);
+const REG_SCOPE = getWorktreeScopeToken(REG_DIR);
+const CONFIG_DIR = join(getClaudeConfigDir(), 'teams', REG_SCOPE, REG_TEAM);
 
 function writeTaskHelper(task: TaskFile): void {
   mkdirSync(TASKS_DIR, { recursive: true });
@@ -707,9 +710,10 @@ describe('tmux-session edge cases', () => {
     it('each part is truncated to 50 chars independently', () => {
       const longName = 'a'.repeat(100);
       const result = sessionName(longName, longName);
-      // 'omc-team-' + 50 chars + '-' + 50 chars = 110 total
-      expect(result.length).toBe(110);
-      expect(result).toBe(`omc-team-${'a'.repeat(50)}-${'a'.repeat(50)}`);
+      const scope = getWorktreeScopeToken();
+      // 'omc-team-' + scope (8) + '-' + 50 chars + '-' + 50 chars = 119 total
+      expect(result.length).toBe(119);
+      expect(result).toBe(`omc-team-${scope}-${'a'.repeat(50)}-${'a'.repeat(50)}`);
     });
   });
 

--- a/src/team/__tests__/git-worktree.test.ts
+++ b/src/team/__tests__/git-worktree.test.ts
@@ -9,6 +9,7 @@ import {
   listTeamWorktrees,
   cleanupTeamWorktrees,
 } from '../git-worktree.js';
+import { getWorktreeScopeToken } from '../team-scope.js';
 
 describe('git-worktree', () => {
   let repoDir: string;
@@ -36,9 +37,10 @@ describe('git-worktree', () => {
   describe('createWorkerWorktree', () => {
     it('creates worktree at correct path', () => {
       const info = createWorkerWorktree(teamName, 'worker1', repoDir);
+      const scope = getWorktreeScopeToken(repoDir);
 
       expect(info.path).toContain('.omc/worktrees');
-      expect(info.branch).toBe(`omc-team/${teamName}/worker1`);
+      expect(info.branch).toBe(`omc-team/${scope}/${teamName}/worker1`);
       expect(info.workerName).toBe('worker1');
       expect(info.teamName).toBe(teamName);
       expect(existsSync(info.path)).toBe(true);
@@ -61,7 +63,8 @@ describe('git-worktree', () => {
     });
 
     it('cleans up a stale plain directory before creating the worktree', () => {
-      const stalePath = join(repoDir, '.omc', 'worktrees', teamName, 'worker-stale');
+      const scope = getWorktreeScopeToken(repoDir);
+      const stalePath = join(repoDir, '.omc', 'worktrees', scope, teamName, 'worker-stale');
       // Create a directory that is not registered as a git worktree.
       rmSync(stalePath, { recursive: true, force: true });
       mkdirSync(stalePath, { recursive: true });

--- a/src/team/__tests__/inbox-outbox.test.ts
+++ b/src/team/__tests__/inbox-outbox.test.ts
@@ -11,10 +11,12 @@ import {
 import { sanitizeName } from '../tmux-session.js';
 import { validateResolvedPath } from '../fs-utils.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { getWorktreeScopeToken } from '../team-scope.js';
 import type { OutboxMessage, InboxMessage } from '../types.js';
 
 const TEST_TEAM = 'test-team-io';
-const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', TEST_TEAM);
+const SCOPE = getWorktreeScopeToken();
+const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', SCOPE, TEST_TEAM);
 
 beforeEach(() => {
   mkdirSync(join(TEAMS_DIR, 'inbox'), { recursive: true });

--- a/src/team/__tests__/message-router.test.ts
+++ b/src/team/__tests__/message-router.test.ts
@@ -6,6 +6,7 @@ import { routeMessage, broadcastToTeam } from '../message-router.js';
 import { registerMcpWorker } from '../team-registration.js';
 import { writeHeartbeat } from '../heartbeat.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { getWorktreeScopeToken } from '../team-scope.js';
 
 describe('message-router', () => {
   let testDir: string;
@@ -16,12 +17,13 @@ describe('message-router', () => {
   });
 
   afterEach(() => {
-    rmSync(testDir, { recursive: true, force: true });
-    // Clean up inbox files that may have been created
+    // Clean up inbox files that may have been created (scope derived from testDir)
     try {
-      const inboxDir = join(getClaudeConfigDir(), 'teams', teamName, 'inbox');
-      rmSync(inboxDir, { recursive: true, force: true });
+      const scope = getWorktreeScopeToken(testDir);
+      const teamDir = join(getClaudeConfigDir(), 'teams', scope, teamName);
+      rmSync(teamDir, { recursive: true, force: true });
     } catch { /* ignore */ }
+    rmSync(testDir, { recursive: true, force: true });
   });
 
   function registerWorker(name: string, agentType: string = 'mcp-codex') {
@@ -48,7 +50,8 @@ describe('message-router', () => {
       expect(result.details).toContain('inbox');
 
       // Verify inbox file was written
-      const inboxPath = join(getClaudeConfigDir(), 'teams', teamName, 'inbox', 'codex-1.jsonl');
+      const scope = getWorktreeScopeToken(testDir);
+      const inboxPath = join(getClaudeConfigDir(), 'teams', scope, teamName, 'inbox', 'codex-1.jsonl');
       expect(existsSync(inboxPath)).toBe(true);
       const content = readFileSync(inboxPath, 'utf-8').trim();
       const msg = JSON.parse(content);
@@ -74,8 +77,9 @@ describe('message-router', () => {
       expect(result.nativeRecipients).toEqual([]);
 
       // Verify both inbox files were written
-      const inbox1 = join(getClaudeConfigDir(), 'teams', teamName, 'inbox', 'worker1.jsonl');
-      const inbox2 = join(getClaudeConfigDir(), 'teams', teamName, 'inbox', 'worker2.jsonl');
+      const scope = getWorktreeScopeToken(testDir);
+      const inbox1 = join(getClaudeConfigDir(), 'teams', scope, teamName, 'inbox', 'worker1.jsonl');
+      const inbox2 = join(getClaudeConfigDir(), 'teams', scope, teamName, 'inbox', 'worker2.jsonl');
       expect(existsSync(inbox1)).toBe(true);
       expect(existsSync(inbox2)).toBe(true);
     });

--- a/src/team/__tests__/outbox-reader.test.ts
+++ b/src/team/__tests__/outbox-reader.test.ts
@@ -7,10 +7,12 @@ import {
   resetOutboxCursor,
 } from '../outbox-reader.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { getWorktreeScopeToken } from '../team-scope.js';
 import type { OutboxMessage } from '../types.js';
 
 const TEST_TEAM = 'test-team-outbox-reader';
-const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', TEST_TEAM);
+const SCOPE = getWorktreeScopeToken();
+const TEAMS_DIR = join(getClaudeConfigDir(), 'teams', SCOPE, TEST_TEAM);
 
 beforeEach(() => {
   mkdirSync(join(TEAMS_DIR, 'outbox'), { recursive: true });

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -165,6 +165,9 @@ describe('runtime v2 startup inbox dispatch', () => {
           OMC_TEAM_WORKER: 'dispatch-team/worker-1',
           OMC_TEAM_STATE_ROOT: join(cwd, '.omc', 'state', 'team', 'dispatch-team'),
           OMC_TEAM_LEADER_CWD: cwd,
+          // Worker must inherit the lead's worktree-scope token so team-scoped
+          // paths resolve to the same namespace on both sides of the bridge.
+          OMC_TEAM_SCOPE_TOKEN: expect.stringMatching(/^[0-9a-f]{8}$/),
         }),
       }),
     );

--- a/src/team/__tests__/team-scope.test.ts
+++ b/src/team/__tests__/team-scope.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { getWorktreeScopeToken, SCOPE_ENV_VAR, isValidScopeToken } from '../team-scope.js';
+
+describe('getWorktreeScopeToken', () => {
+  const TOKEN_RE = /^[0-9a-f]{8}$/;
+
+  beforeEach(() => {
+    delete process.env[SCOPE_ENV_VAR];
+  });
+
+  afterEach(() => {
+    delete process.env[SCOPE_ENV_VAR];
+  });
+
+  it('produces a token matching /^[0-9a-f]{8}$/', () => {
+    const token = getWorktreeScopeToken('/tmp/example/worktree-a');
+    expect(token).toMatch(TOKEN_RE);
+  });
+
+  it('is stable across calls with the same input', () => {
+    const a = getWorktreeScopeToken('/tmp/example/worktree-a');
+    const b = getWorktreeScopeToken('/tmp/example/worktree-a');
+    expect(a).toBe(b);
+  });
+
+  it('produces different tokens for different worktree paths', () => {
+    const a = getWorktreeScopeToken('/tmp/example/worktree-a');
+    const b = getWorktreeScopeToken('/tmp/example/worktree-b');
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to a non-empty token when workingDirectory is undefined', () => {
+    const token = getWorktreeScopeToken();
+    expect(token).toMatch(TOKEN_RE);
+  });
+
+  it('honors OMC_TEAM_SCOPE_TOKEN env var when well-formed', () => {
+    process.env[SCOPE_ENV_VAR] = 'deadbeef';
+    expect(getWorktreeScopeToken('/tmp/anything')).toBe('deadbeef');
+    expect(getWorktreeScopeToken()).toBe('deadbeef');
+  });
+
+  it('ignores OMC_TEAM_SCOPE_TOKEN when malformed', () => {
+    process.env[SCOPE_ENV_VAR] = 'NOT-HEX';
+    const token = getWorktreeScopeToken('/tmp/example/worktree-a');
+    expect(token).toMatch(TOKEN_RE);
+    expect(token).not.toBe('NOT-HEX');
+  });
+
+  it('isValidScopeToken accepts 8-hex strings only', () => {
+    expect(isValidScopeToken('deadbeef')).toBe(true);
+    expect(isValidScopeToken('DEADBEEF')).toBe(false);
+    expect(isValidScopeToken('deadbeef0')).toBe(false);
+    expect(isValidScopeToken('zzzzzzzz')).toBe(false);
+    expect(isValidScopeToken(undefined)).toBe(false);
+  });
+
+  describe('with real git worktrees', () => {
+    let primaryRoot: string;
+    let linkedRoot: string;
+
+    beforeEach(() => {
+      primaryRoot = mkdtempSync(join(tmpdir(), 'team-scope-primary-'));
+      execFileSync('git', ['init', '-q'], { cwd: primaryRoot, stdio: 'pipe' });
+      execFileSync('git', ['config', 'user.email', 't@t.com'], { cwd: primaryRoot, stdio: 'pipe' });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: primaryRoot, stdio: 'pipe' });
+      execFileSync('git', ['commit', '--allow-empty', '-m', 'init'], { cwd: primaryRoot, stdio: 'pipe' });
+
+      linkedRoot = primaryRoot + '-linked';
+      execFileSync(
+        'git',
+        ['worktree', 'add', '-b', 'feat/scope-test', linkedRoot],
+        { cwd: primaryRoot, stdio: 'pipe' }
+      );
+    });
+
+    afterEach(() => {
+      try { execFileSync('git', ['worktree', 'remove', '--force', linkedRoot], { cwd: primaryRoot, stdio: 'pipe' }); } catch { /* ignore */ }
+      try { rmSync(linkedRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+      try { rmSync(primaryRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    it('yields different tokens for primary and linked worktrees of the same repo', () => {
+      const tokenPrimary = getWorktreeScopeToken(primaryRoot);
+      const tokenLinked = getWorktreeScopeToken(linkedRoot);
+      expect(tokenPrimary).toMatch(TOKEN_RE);
+      expect(tokenLinked).toMatch(TOKEN_RE);
+      expect(tokenPrimary).not.toBe(tokenLinked);
+    });
+  });
+});

--- a/src/team/__tests__/team-status.test.ts
+++ b/src/team/__tests__/team-status.test.ts
@@ -7,6 +7,7 @@ import { atomicWriteJson } from '../fs-utils.js';
 import { appendOutbox } from '../inbox-outbox.js';
 import { recordTaskUsage } from '../usage-tracker.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { getWorktreeScopeToken } from '../team-scope.js';
 import type { HeartbeatData, TaskFile, OutboxMessage, McpWorkerMember } from '../types.js';
 
 const TEST_TEAM = 'test-team-status';
@@ -23,9 +24,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Clean up outbox files written to ~/.claude/teams/<scope>/ by appendOutbox.
+  // Scope is derived from cwd via OMC_TEAM_SCOPE_TOKEN / getWorktreeRoot().
+  rmSync(join(getClaudeConfigDir(), 'teams', getWorktreeScopeToken(), TEST_TEAM), { recursive: true, force: true });
   rmSync(WORK_DIR, { recursive: true, force: true });
-  // Clean up outbox files written to ~/.claude/teams/ by appendOutbox
-  rmSync(join(getClaudeConfigDir(), 'teams', TEST_TEAM), { recursive: true, force: true });
 });
 
 function writeWorkerRegistry(workers: McpWorkerMember[]): void {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -10,6 +10,7 @@ import {
   getDefaultShell,
   buildWorkerStartCommand,
 } from '../tmux-session.js';
+import { getWorktreeScopeToken } from '../team-scope.js';
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -49,11 +50,13 @@ describe('sanitizeName', () => {
 
 describe('sessionName', () => {
   it('builds correct session name', () => {
-    expect(sessionName('myteam', 'codex1')).toBe('omc-team-myteam-codex1');
+    const scope = getWorktreeScopeToken();
+    expect(sessionName('myteam', 'codex1')).toBe(`omc-team-${scope}-myteam-codex1`);
   });
 
   it('sanitizes both parts', () => {
-    expect(sessionName('my team!', 'work@er')).toBe('omc-team-myteam-worker');
+    const scope = getWorktreeScopeToken();
+    expect(sessionName('my team!', 'work@er')).toBe(`omc-team-${scope}-myteam-worker`);
   });
 });
 
@@ -343,14 +346,16 @@ describe.skipIf(!hasTmux())('createSession with workingDirectory', () => {
 
   it('accepts optional workingDirectory param', () => {
     // Should not throw — workingDirectory is optional
+    const scope = getWorktreeScopeToken();
     const name = createSession('tmuxtest', 'wdtest', '/tmp');
-    expect(name).toBe('omc-team-tmuxtest-wdtest');
+    expect(name).toBe(`omc-team-${scope}-tmuxtest-wdtest`);
     killSession('tmuxtest', 'wdtest');
   });
 
   it('works without workingDirectory param', () => {
+    const scope = getWorktreeScopeToken();
     const name = createSession('tmuxtest', 'nowd');
-    expect(name).toBe('omc-team-tmuxtest-nowd');
+    expect(name).toBe(`omc-team-${scope}-tmuxtest-nowd`);
     killSession('tmuxtest', 'nowd');
   });
 });

--- a/src/team/git-worktree.ts
+++ b/src/team/git-worktree.ts
@@ -14,6 +14,7 @@ import { execFileSync } from 'node:child_process';
 import { atomicWriteJson, ensureDirWithMode, validateResolvedPath } from './fs-utils.js';
 import { sanitizeName } from './tmux-session.js';
 import { withFileLockSync } from '../lib/file-lock.js';
+import { getWorktreeScopeToken } from './team-scope.js';
 
 export interface WorktreeInfo {
   path: string;
@@ -23,14 +24,22 @@ export interface WorktreeInfo {
   createdAt: string;
 }
 
-/** Get worktree path for a worker */
+/** Get worktree path for a worker (scope-isolated for sibling worktrees) */
 function getWorktreePath(repoRoot: string, teamName: string, workerName: string): string {
-  return join(repoRoot, '.omc', 'worktrees', sanitizeName(teamName), sanitizeName(workerName));
+  const scope = getWorktreeScopeToken(repoRoot);
+  return join(repoRoot, '.omc', 'worktrees', scope, sanitizeName(teamName), sanitizeName(workerName));
 }
 
-/** Get branch name for a worker */
-function getBranchName(teamName: string, workerName: string): string {
-  return `omc-team/${sanitizeName(teamName)}/${sanitizeName(workerName)}`;
+/**
+ * Get git branch name for a worker.
+ *
+ * Git branches are shared across all linked worktrees of the same repository,
+ * so the scope token is mandatory here — otherwise two sibling worktrees
+ * spawning the same `<team>/<worker>` would collide on `git worktree add -b`.
+ */
+function getBranchName(repoRoot: string, teamName: string, workerName: string): string {
+  const scope = getWorktreeScopeToken(repoRoot);
+  return `omc-team/${scope}/${sanitizeName(teamName)}/${sanitizeName(workerName)}`;
 }
 
 function isRegisteredWorktreePath(repoRoot: string, wtPath: string): boolean {
@@ -53,9 +62,10 @@ function isRegisteredWorktreePath(repoRoot: string, wtPath: string): boolean {
   return false;
 }
 
-/** Get worktree metadata path */
+/** Get worktree metadata path (scope-isolated for sibling worktrees) */
 function getMetadataPath(repoRoot: string, teamName: string): string {
-  return join(repoRoot, '.omc', 'state', 'team-bridge', sanitizeName(teamName), 'worktrees.json');
+  const scope = getWorktreeScopeToken(repoRoot);
+  return join(repoRoot, '.omc', 'state', 'team-bridge', scope, sanitizeName(teamName), 'worktrees.json');
 }
 
 /** Read worktree metadata */
@@ -76,7 +86,8 @@ function readMetadata(repoRoot: string, teamName: string): WorktreeInfo[] {
 function writeMetadata(repoRoot: string, teamName: string, entries: WorktreeInfo[]): void {
   const metaPath = getMetadataPath(repoRoot, teamName);
   validateResolvedPath(metaPath, repoRoot);
-  const dir = join(repoRoot, '.omc', 'state', 'team-bridge', sanitizeName(teamName));
+  const scope = getWorktreeScopeToken(repoRoot);
+  const dir = join(repoRoot, '.omc', 'state', 'team-bridge', scope, sanitizeName(teamName));
   ensureDirWithMode(dir);
   atomicWriteJson(metaPath, entries);
 }
@@ -93,7 +104,7 @@ export function createWorkerWorktree(
   baseBranch?: string
 ): WorktreeInfo {
   const wtPath = getWorktreePath(repoRoot, teamName, workerName);
-  const branch = getBranchName(teamName, workerName);
+  const branch = getBranchName(repoRoot, teamName, workerName);
 
   validateResolvedPath(wtPath, repoRoot);
 
@@ -122,8 +133,9 @@ export function createWorkerWorktree(
     execFileSync('git', ['branch', '-D', branch], { cwd: repoRoot, stdio: 'pipe' });
   } catch { /* branch doesn't exist, fine */ }
 
-  // Create worktree directory
-  const wtDir = join(repoRoot, '.omc', 'worktrees', sanitizeName(teamName));
+  // Create worktree directory (scope-isolated parent)
+  const scope = getWorktreeScopeToken(repoRoot);
+  const wtDir = join(repoRoot, '.omc', 'worktrees', scope, sanitizeName(teamName));
   ensureDirWithMode(wtDir);
 
   // Create worktree with new branch
@@ -160,7 +172,7 @@ export function removeWorkerWorktree(
   repoRoot: string
 ): void {
   const wtPath = getWorktreePath(repoRoot, teamName, workerName);
-  const branch = getBranchName(teamName, workerName);
+  const branch = getBranchName(repoRoot, teamName, workerName);
 
   // Remove worktree
   try {

--- a/src/team/inbox-outbox.ts
+++ b/src/team/inbox-outbox.ts
@@ -17,6 +17,7 @@ import { getClaudeConfigDir } from '../utils/config-dir.js';
 import type { InboxMessage, OutboxMessage, ShutdownSignal, DrainSignal, InboxCursor } from './types.js';
 import { sanitizeName } from './tmux-session.js';
 import { appendFileWithMode, writeFileWithMode, atomicWriteJson, ensureDirWithMode, validateResolvedPath } from './fs-utils.js';
+import { getWorktreeScopeToken } from './team-scope.js';
 
 /** Maximum bytes to read from inbox in a single call (10 MB) */
 const MAX_INBOX_READ_SIZE = 10 * 1024 * 1024;
@@ -24,7 +25,11 @@ const MAX_INBOX_READ_SIZE = 10 * 1024 * 1024;
 // --- Path helpers ---
 
 function teamsDir(teamName: string): string {
-  const result = join(getClaudeConfigDir(), 'teams', sanitizeName(teamName));
+  // Scope segment isolates same-named teams across sibling worktrees of the
+  // same repo. The scope token is read from OMC_TEAM_SCOPE_TOKEN (set by the
+  // lead at worker spawn time) or derived from the current worktree path.
+  const scope = getWorktreeScopeToken();
+  const result = join(getClaudeConfigDir(), 'teams', scope, sanitizeName(teamName));
   validateResolvedPath(result, join(getClaudeConfigDir(), 'teams'));
   return result;
 }

--- a/src/team/message-router.ts
+++ b/src/team/message-router.ts
@@ -13,7 +13,18 @@ import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { appendFileWithMode, ensureDirWithMode, validateResolvedPath } from './fs-utils.js';
 import { getTeamMembers } from './unified-team.js';
 import { sanitizeName } from './tmux-session.js';
+import { getWorktreeScopeToken } from './team-scope.js';
 import type { InboxMessage } from './types.js';
+
+function scopedInboxDir(teamName: string, workingDirectory: string): string {
+  return join(
+    getClaudeConfigDir(),
+    'teams',
+    getWorktreeScopeToken(workingDirectory),
+    sanitizeName(teamName),
+    'inbox',
+  );
+}
 
 export interface RouteResult {
   method: 'native' | 'inbox';
@@ -53,9 +64,9 @@ export function routeMessage(
     };
   }
 
-  // MCP worker: write to inbox
+  // MCP worker: write to inbox (scope-isolated per worktree)
   const teamsBase = join(getClaudeConfigDir(), 'teams');
-  const inboxDir = join(teamsBase, sanitizeName(teamName), 'inbox');
+  const inboxDir = scopedInboxDir(teamName, workingDirectory);
   ensureDirWithMode(inboxDir);
   const inboxPath = join(inboxDir, `${sanitizeName(recipientName)}.jsonl`);
   validateResolvedPath(inboxPath, teamsBase);
@@ -92,9 +103,9 @@ export function broadcastToTeam(
     if (member.backend === 'claude-native') {
       nativeRecipients.push(member.name);
     } else {
-      // Write to each MCP worker's inbox
+      // Write to each MCP worker's inbox (scope-isolated per worktree)
       const teamsBase = join(getClaudeConfigDir(), 'teams');
-      const inboxDir = join(teamsBase, sanitizeName(teamName), 'inbox');
+      const inboxDir = scopedInboxDir(teamName, workingDirectory);
       ensureDirWithMode(inboxDir);
       const inboxPath = join(inboxDir, `${sanitizeName(member.name)}.jsonl`);
       validateResolvedPath(inboxPath, teamsBase);

--- a/src/team/outbox-reader.ts
+++ b/src/team/outbox-reader.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { validateResolvedPath, writeFileWithMode, atomicWriteJson, ensureDirWithMode } from './fs-utils.js';
 import { sanitizeName } from './tmux-session.js';
+import { getWorktreeScopeToken } from './team-scope.js';
 import type { OutboxMessage } from './types.js';
 
 /** Outbox cursor stored alongside outbox files */
@@ -24,8 +25,14 @@ export interface OutboxCursor {
 
 const MAX_OUTBOX_READ_SIZE = 10 * 1024 * 1024; // 10MB cap per read
 
-function teamsDir(): string {
+/** Base teams root (worktree-scoped via OMC_TEAM_SCOPE_TOKEN or cwd). */
+function teamsRoot(): string {
   return join(getClaudeConfigDir(), 'teams');
+}
+
+/** Scoped team directory: ~/.claude/teams/<scope>/<team>/. */
+function scopedTeamDir(safeName: string): string {
+  return join(teamsRoot(), getWorktreeScopeToken(), safeName);
 }
 
 /**
@@ -38,11 +45,11 @@ export function readNewOutboxMessages(
 ): OutboxMessage[] {
   const safeName = sanitizeName(teamName);
   const safeWorker = sanitizeName(workerName);
-  const outboxPath = join(teamsDir(), safeName, 'outbox', `${safeWorker}.jsonl`);
-  const cursorPath = join(teamsDir(), safeName, 'outbox', `${safeWorker}.outbox-offset`);
+  const outboxPath = join(scopedTeamDir(safeName), 'outbox', `${safeWorker}.jsonl`);
+  const cursorPath = join(scopedTeamDir(safeName), 'outbox', `${safeWorker}.outbox-offset`);
 
-  validateResolvedPath(outboxPath, teamsDir());
-  validateResolvedPath(cursorPath, teamsDir());
+  validateResolvedPath(outboxPath, teamsRoot());
+  validateResolvedPath(cursorPath, teamsRoot());
 
   if (!existsSync(outboxPath)) return [];
 
@@ -97,7 +104,7 @@ export function readNewOutboxMessages(
 
   // Update cursor atomically to prevent corruption on crash
   const newCursor: OutboxCursor = { bytesRead: cursor.bytesRead + consumed };
-  const cursorDir = join(teamsDir(), safeName, 'outbox');
+  const cursorDir = join(scopedTeamDir(safeName), 'outbox');
   ensureDirWithMode(cursorDir);
   atomicWriteJson(cursorPath, newCursor);
 
@@ -111,7 +118,7 @@ export function readAllTeamOutboxMessages(
   teamName: string
 ): { workerName: string; messages: OutboxMessage[] }[] {
   const safeName = sanitizeName(teamName);
-  const outboxDir = join(teamsDir(), safeName, 'outbox');
+  const outboxDir = join(scopedTeamDir(safeName), 'outbox');
 
   if (!existsSync(outboxDir)) return [];
 
@@ -138,9 +145,9 @@ export function resetOutboxCursor(
 ): void {
   const safeName = sanitizeName(teamName);
   const safeWorker = sanitizeName(workerName);
-  const cursorPath = join(teamsDir(), safeName, 'outbox', `${safeWorker}.outbox-offset`);
-  validateResolvedPath(cursorPath, teamsDir());
-  const cursorDir = join(teamsDir(), safeName, 'outbox');
+  const cursorPath = join(scopedTeamDir(safeName), 'outbox', `${safeWorker}.outbox-offset`);
+  validateResolvedPath(cursorPath, teamsRoot());
+  const cursorDir = join(scopedTeamDir(safeName), 'outbox');
   ensureDirWithMode(cursorDir);
   writeFileWithMode(cursorPath, JSON.stringify({ bytesRead: 0 }));
 }

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -54,6 +54,7 @@ import type {
 } from './types.js';
 import type { TeamPhase } from './phase-controller.js';
 import { validateTeamName } from './team-name.js';
+import { getWorktreeScopeToken, SCOPE_ENV_VAR } from './team-scope.js';
 import type { CliAgentType } from './model-contract.js';
 import {
   buildWorkerArgv, getContract, resolveValidatedBinaryPath,
@@ -569,6 +570,10 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     ...getModelWorkerEnv(opts.teamName, opts.workerName, opts.agentType),
     OMC_TEAM_STATE_ROOT: teamStateRoot(opts.cwd, opts.teamName),
     OMC_TEAM_LEADER_CWD: opts.cwd,
+    // Pin worktree-scope token so the worker shares the lead's namespace,
+    // even though the worker runs inside a per-worker git worktree where
+    // getWorktreeRoot() would otherwise resolve to a different path.
+    [SCOPE_ENV_VAR]: getWorktreeScopeToken(opts.cwd),
   };
   const resolvedBinaryPath = opts.resolvedBinaryPaths[opts.agentType]
     ?? resolveValidatedBinaryPath(opts.agentType);

--- a/src/team/team-registration.ts
+++ b/src/team/team-registration.ts
@@ -14,11 +14,13 @@ import type { McpWorkerMember, ConfigProbeResult } from './types.js';
 import { sanitizeName } from './tmux-session.js';
 import { atomicWriteJson, validateResolvedPath } from './fs-utils.js';
 import { withFileLockSync } from '../lib/file-lock.js';
+import { getWorktreeScopeToken } from './team-scope.js';
 
 // --- Config paths ---
 
-function configPath(teamName: string): string {
-  const result = join(getClaudeConfigDir(), 'teams', sanitizeName(teamName), 'config.json');
+function configPath(teamName: string, workingDirectory?: string): string {
+  const scope = getWorktreeScopeToken(workingDirectory);
+  const result = join(getClaudeConfigDir(), 'teams', scope, sanitizeName(teamName), 'config.json');
   validateResolvedPath(result, join(getClaudeConfigDir(), 'teams'));
   return result;
 }
@@ -98,15 +100,15 @@ export function registerMcpWorker(
   const strategy = getRegistrationStrategy(workingDirectory);
 
   if (strategy === 'config') {
-    registerInConfig(teamName, member);
+    registerInConfig(teamName, member, workingDirectory);
   }
 
   // Always write to shadow registry (as backup or primary)
   registerInShadow(workingDirectory, teamName, member);
 }
 
-function registerInConfig(teamName: string, member: McpWorkerMember): void {
-  const filePath = configPath(teamName);
+function registerInConfig(teamName: string, member: McpWorkerMember, workingDirectory: string): void {
+  const filePath = configPath(teamName, workingDirectory);
   if (!existsSync(filePath)) return; // No config.json to write to
 
   const lockPath = filePath + '.lock';
@@ -170,7 +172,7 @@ export function unregisterMcpWorker(
   workingDirectory: string
 ): void {
   // Remove from config.json
-  const configFile = configPath(teamName);
+  const configFile = configPath(teamName, workingDirectory);
   if (existsSync(configFile)) {
     try {
       const raw = readFileSync(configFile, 'utf-8');
@@ -211,7 +213,7 @@ export function listMcpWorkers(teamName: string, workingDirectory: string): McpW
   const workers = new Map<string, McpWorkerMember>();
 
   // Read from config.json
-  const configFile = configPath(teamName);
+  const configFile = configPath(teamName, workingDirectory);
   if (existsSync(configFile)) {
     try {
       const raw = readFileSync(configFile, 'utf-8');

--- a/src/team/team-scope.ts
+++ b/src/team/team-scope.ts
@@ -1,0 +1,72 @@
+// src/team/team-scope.ts
+
+/**
+ * Worktree-scope token for isolating team namespaces across sibling git
+ * worktrees of the same repository.
+ *
+ * Why this exists
+ * ---------------
+ * Team-scoped paths (`~/.claude/teams/<team>/...`, tmux session names,
+ * `.omc/worktrees/<team>/<worker>`, branch `omc-team/<team>/<worker>`,
+ * `.omc/state/team-bridge/<team>/...`) are ALL keyed solely on `teamName`.
+ * If a user runs `/team N:executor "task"` with the same team name from two
+ * sibling worktrees of the same repo, every one of those namespaces collides.
+ *
+ * This module provides a deterministic 8-char hex token derived from the
+ * ABSOLUTE worktree path — NOT the primary-root-collapsed identifier from
+ * `getProjectIdentifier()`. By design we want sibling worktrees to receive
+ * different tokens; `getProjectIdentifier()` intentionally collapses them so
+ * cross-worktree state can be shared, which is exactly what we need to bypass.
+ *
+ * Token contract
+ * --------------
+ * - Stable: same worktree path -> same token across calls and processes.
+ * - Distinct: different worktree paths -> different tokens (with overwhelming
+ *   probability for any practical number of worktrees).
+ * - Safe: matches /^[0-9a-f]{8}$/ — embeddable in tmux session names,
+ *   filesystem paths (case-insensitive FS friendly), and git branch names.
+ *
+ * Process inheritance
+ * -------------------
+ * The lead process and its spawned worker processes must agree on the same
+ * scope token, but the worker runs inside a per-worker git worktree where
+ * `getWorktreeRoot()` resolves to a DIFFERENT path. To bridge that gap, the
+ * lead exports `OMC_TEAM_SCOPE_TOKEN` into each worker's environment at spawn
+ * time. When that env var is present, this module returns it verbatim instead
+ * of recomputing from `process.cwd()`.
+ */
+
+import { createHash } from 'crypto';
+import { getWorktreeRoot } from '../lib/worktree-paths.js';
+
+/** Length of the hex-encoded scope token. 8 chars = 32 bits. */
+const TOKEN_LENGTH = 8;
+
+/** Env var that pins the scope token for a child process (set by the lead). */
+export const SCOPE_ENV_VAR = 'OMC_TEAM_SCOPE_TOKEN';
+
+const TOKEN_RE = /^[0-9a-f]{8}$/;
+
+/** Validate that a value is a well-formed scope token. */
+export function isValidScopeToken(value: unknown): value is string {
+  return typeof value === 'string' && TOKEN_RE.test(value);
+}
+
+/**
+ * Compute the worktree-scope token.
+ *
+ * Resolution order:
+ *   1. `process.env.OMC_TEAM_SCOPE_TOKEN` if it is a well-formed token.
+ *   2. SHA-256 (8 hex chars) of `workingDirectory`, if provided.
+ *   3. SHA-256 (8 hex chars) of `getWorktreeRoot(process.cwd()) || process.cwd()`.
+ *
+ * @param workingDirectory - Absolute path inside a worktree. Optional.
+ * @returns 8-char lowercase hex digest.
+ */
+export function getWorktreeScopeToken(workingDirectory?: string): string {
+  const fromEnv = process.env[SCOPE_ENV_VAR];
+  if (isValidScopeToken(fromEnv)) return fromEnv;
+
+  const root = workingDirectory || getWorktreeRoot() || process.cwd();
+  return createHash('sha256').update(root).digest('hex').slice(0, TOKEN_LENGTH);
+}

--- a/src/team/team-status.ts
+++ b/src/team/team-status.ts
@@ -14,6 +14,7 @@ import { listMcpWorkers } from './team-registration.js';
 import { readHeartbeat, isWorkerAlive } from './heartbeat.js';
 import { listTaskIds, readTask } from './task-file-ops.js';
 import { sanitizeName } from './tmux-session.js';
+import { getWorktreeScopeToken } from './team-scope.js';
 import type { HeartbeatData, TaskFile, OutboxMessage } from './types.js';
 import { generateUsageReport } from './usage-tracker.js';
 
@@ -37,7 +38,7 @@ function peekRecentOutboxMessages(
 ): OutboxMessage[] {
   const safeName = sanitizeName(teamName);
   const safeWorker = sanitizeName(workerName);
-  const outboxPath = join(getClaudeConfigDir(), 'teams', safeName, 'outbox', `${safeWorker}.jsonl`);
+  const outboxPath = join(getClaudeConfigDir(), 'teams', getWorktreeScopeToken(), safeName, 'outbox', `${safeWorker}.jsonl`);
 
   if (!existsSync(outboxPath)) return [];
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -12,6 +12,7 @@ import { join, basename, isAbsolute, win32 } from 'path';
 import fs from 'fs/promises';
 import { validateTeamName } from './team-name.js';
 import { tmuxExec, tmuxExecAsync, tmuxShell, tmuxCmdAsync } from '../cli/tmux-utils.js';
+import { getWorktreeScopeToken } from './team-scope.js';
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
@@ -372,9 +373,13 @@ export function sanitizeName(name: string): string {
   return sanitized.slice(0, 50);
 }
 
-/** Build session name: "omc-team-{teamName}-{workerName}" */
-export function sessionName(teamName: string, workerName: string): string {
-  return `${TMUX_SESSION_PREFIX}-${sanitizeName(teamName)}-${sanitizeName(workerName)}`;
+/**
+ * Build session name: "omc-team-{scope}-{teamName}-{workerName}".
+ * The scope token isolates same-named teams across sibling worktrees.
+ */
+export function sessionName(teamName: string, workerName: string, workingDirectory?: string): string {
+  const scope = getWorktreeScopeToken(workingDirectory);
+  return `${TMUX_SESSION_PREFIX}-${scope}-${sanitizeName(teamName)}-${sanitizeName(workerName)}`;
 }
 
 /** @deprecated Use createTeamSession() instead for split-pane topology */
@@ -418,9 +423,10 @@ export function isSessionAlive(teamName: string, workerName: string): boolean {
   }
 }
 
-/** List all active worker sessions for a team */
-export function listActiveSessions(teamName: string): string[] {
-  const prefix = `${TMUX_SESSION_PREFIX}-${sanitizeName(teamName)}-`;
+/** List all active worker sessions for a team in the current worktree scope */
+export function listActiveSessions(teamName: string, workingDirectory?: string): string[] {
+  const scope = getWorktreeScopeToken(workingDirectory);
+  const prefix = `${TMUX_SESSION_PREFIX}-${scope}-${sanitizeName(teamName)}-`;
   try {
     // Use shell execution for format strings containing #{} to prevent
     // MSYS2/Git Bash from stripping curly braces in execFileSync args.
@@ -495,7 +501,8 @@ export async function createTeamSession(
     // so workflows can run when launched outside an attached tmux client. This
     // also covers cmux, which exposes its own surface metadata without a tmux
     // pane/window that OMC can split directly.
-    const detachedSessionName = `${TMUX_SESSION_PREFIX}-${sanitizeName(teamName)}-${Date.now().toString(36)}`;
+    const detachedScope = getWorktreeScopeToken(cwd);
+    const detachedSessionName = `${TMUX_SESSION_PREFIX}-${detachedScope}-${sanitizeName(teamName)}-${Date.now().toString(36)}`;
     const detachedResult = await tmuxExecAsync([
       'new-session', '-d', '-P', '-F', '#S:0 #{pane_id}',
       '-s', detachedSessionName,

--- a/src/team/unified-team.ts
+++ b/src/team/unified-team.ts
@@ -14,6 +14,7 @@ import type { WorkerBackend, WorkerCapability } from './types.js';
 import { listMcpWorkers } from './team-registration.js';
 import { readHeartbeat, isWorkerAlive } from './heartbeat.js';
 import { getDefaultCapabilities } from './capabilities.js';
+import { getWorktreeScopeToken } from './team-scope.js';
 
 export interface UnifiedTeamMember {
   name: string;
@@ -37,7 +38,7 @@ export function getTeamMembers(
 
   // 1. Read Claude native members from config.json
   try {
-    const configPath = join(getClaudeConfigDir(), 'teams', teamName, 'config.json');
+    const configPath = join(getClaudeConfigDir(), 'teams', getWorktreeScopeToken(workingDirectory), teamName, 'config.json');
     if (existsSync(configPath)) {
       const config = JSON.parse(readFileSync(configPath, 'utf-8'));
       if (Array.isArray(config.members)) {


### PR DESCRIPTION
## Summary

Running `/team` with the same team name from two sibling git worktrees of the same repo currently collides on **every** team-scoped namespace — `~/.claude/teams/<team>/config.json` overwrites, tmux sessions clash, git branches conflict, and `.omc/state/team-bridge/<team>/` metadata commingles.

This PR injects a deterministic 8-hex worktree-scope token (SHA-256 of the absolute worktree path, **not** the primary-root-collapsed identifier used elsewhere) into every team-scoped path/name, so sibling worktrees get isolated namespaces without touching `getProjectIdentifier()` or breaking cross-worktree state that intentionally shares.

## Namespace mapping

| Namespace | Before | After |
|---|---|---|
| Team config | `~/.claude/teams/<team>/config.json` | `~/.claude/teams/<scope>/<team>/config.json` |
| Inbox / outbox / signals | `~/.claude/teams/<team>/{inbox,outbox,signals}/` | `~/.claude/teams/<scope>/<team>/{…}/` |
| Tmux session | `omc-team-<team>-<worker>` | `omc-team-<scope>-<team>-<worker>` |
| Worker worktree | `.omc/worktrees/<team>/<worker>` | `.omc/worktrees/<scope>/<team>/<worker>` |
| Git branch | `omc-team/<team>/<worker>` | `omc-team/<scope>/<team>/<worker>` |
| Team-bridge metadata | `.omc/state/team-bridge/<team>/worktrees.json` | `.omc/state/team-bridge/<scope>/<team>/worktrees.json` |

## Implementation notes

- New helper `src/team/team-scope.ts:getWorktreeScopeToken(workingDirectory?)` — SHA-256 → 8-hex; env-var `OMC_TEAM_SCOPE_TOKEN` takes priority when well-formed (`/^[0-9a-f]{8}$/`), cwd fallback otherwise.
- `runtime-v2.ts` exports `OMC_TEAM_SCOPE_TOKEN = getWorktreeScopeToken(opts.cwd)` into each worker's `envVars` at spawn. The worker's own `cwd` is a per-worker linked worktree whose `getWorktreeRoot()` would otherwise produce a different token — the env pin keeps lead and worker on the same scope.
- The scope segment on the git branch name is load-bearing because git branches are repo-shared across linked worktrees: without it the second sibling's `git worktree add -b` would fail.
- Deliberately **not** threading `workingDirectory` through every inbox/outbox helper — the env-inherited scope works because the bridge runs inside the worker process that got the env. A later refactor can remove the env dependency without changing this PR's contract.

## Migration notes

Pre-upgrade `~/.claude/teams/<name>/` configs and `.omc/worktrees/<name>/` directories are not auto-migrated — recreate the team with `/team` after upgrading, and remove stale worktrees with `git worktree prune && git branch -D omc-team/<name>/*`. A legacy-path fallback was considered and rejected per an architect review pass — silent dual-reads are easy to regret; a future PR can add an explicit copy-forward migration with a deprecation log if needed.

## Test plan

- [x] `npm run build` — clean, exit 0
- [x] `npm run lint` — 0 errors (7 pre-existing warnings on unrelated files)
- [x] `npm test` — 502/503 test files pass (1 pre-existing skip), 8558 tests pass
- [x] New unit tests: `src/team/__tests__/team-scope.test.ts` (8 cases — env pin, cwd fallback, format regex, distinct-paths)
- [x] New integration test: `src/__tests__/team-multi-worktree-isolation.test.ts` — creates a real linked worktree via `git worktree add`, asserts scope tokens / tmux session names / branch names / worker worktree paths / metadata listings all diverge between primary and linked worktrees
- [x] `src/team/__tests__/runtime-v2.dispatch.test.ts` — now asserts `OMC_TEAM_SCOPE_TOKEN` is placed into the worker's `envVars` and matches `/^[0-9a-f]{8}$/`
- [x] Updated path expectations in 8 existing `src/team/__tests__/*.test.ts` files to route through the same helper

## Related

- Relates to #1744 (shared `.omc/` / state bleeding between concurrent sessions — different shape, same family of problems)
- Relates to #576 (earlier `.omc/` path-resolution fix)

## What's not in this PR (intentionally deferred)

- Legacy `omc-team/<team>/<worker>` branch + `.omc/worktrees/<team>/<worker>` auto-cleanup — separate concern, touches `cleanupTeamWorktrees` semantics
- Threading `workingDirectory` explicitly through `inbox-outbox`/`outbox-reader` signatures to remove the env-pin reliance — larger refactor

Happy to split or re-scope on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)