### PR TITLE
Fix self-improve topic-scoped path resolution

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -546,7 +546,7 @@ Includes **34 canonical skills + 1 deprecated alias** (`psm`). Runtime truth com
 | `ralph`                   | Persistence loop until verified completion                       | `/oh-my-claudecode:ralph`                   |
 | `ralplan`                 | Consensus planning alias for `/omc-plan --consensus`             | `/oh-my-claudecode:ralplan`                 |
 | `release`                 | Automated release workflow                                       | `/oh-my-claudecode:release`                 |
-| `self-improve`            | Autonomous evolutionary code improvement engine with tournament selection | `/oh-my-claudecode:self-improve`    |
+| `self-improve`            | Autonomous evolutionary code improvement engine with tournament selection; artifacts are topic-scoped under `.omc/self-improve/topics/<topic-slug>/` by default, with flat `.omc/self-improve/` preserved for legacy single-track resumes | `/oh-my-claudecode:self-improve`    |
 | `setup`                   | Unified setup entrypoint for install, diagnostics, and MCP configuration | `/oh-my-claudecode:setup`              |
 | `sciomc`                  | Parallel scientist orchestration                                 | `/oh-my-claudecode:sciomc`                  |
 | `skill`                   | Manage local skills (list/add/remove/search/edit)                | `/oh-my-claudecode:skill`                   |

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -118,7 +118,7 @@ Active modes are still cancelled in dependency order:
 8. Team (Claude Code native)
 9. OMC Teams (tmux CLI workers)
 10. Plan Consensus (standalone)
-11. Self-Improve (standalone — clear state, clean orphaned worktrees, preserve iteration_state for resume, set status: "user_stopped" in .omc/self-improve/state/agent-settings.json)
+11. Self-Improve (standalone — clear state, clean orphaned worktrees, preserve iteration_state for resume, set status: "user_stopped" in the resolved `<self-improve-root>/state/agent-settings.json`; new runs use `.omc/self-improve/topics/<topic-slug>/`, with flat `.omc/self-improve/` retained only for legacy single-track resumes)
 
 ## Force Clear All
 

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -28,10 +28,16 @@ You are the **loop controller** for the self-improvement system. You manage the 
 
 ## State Tracking
 
-All state lives under `.omc/self-improve/`:
+Self-improve artifacts live under a resolved root returned by `scripts/resolve-paths.mjs`.
+
+- New runs default to `.omc/self-improve/topics/default/`.
+- When the user provides a topic or slug, use `.omc/self-improve/topics/{topic_slug}/`.
+- Legacy single-track state at `.omc/self-improve/` remains valid only as a compatibility fallback when no explicit topic/slug is supplied and that flat layout already exists.
+
+Treat `<self-improve-root>/` below as that resolved root:
 
 ```
-.omc/self-improve/
+<self-improve-root>/
 ├── config/                    # User configuration
 │   ├── settings.json          # agents, benchmark, thresholds, sealed_files
 │   ├── goal.md                # Improvement objective + target metric
@@ -85,29 +91,31 @@ Read these files at startup and at the beginning of each iteration:
 
 | File | Purpose |
 |---|---|
-| `.omc/self-improve/config/settings.json` | User config: `number_of_agents`, `benchmark_command`, `benchmark_format`, `benchmark_direction`, `max_iterations`, `plateau_threshold`, `plateau_window`, `target_value`, `primary_metric`, `sealed_files`, `regression_threshold`, `circuit_breaker_threshold`, `target_branch`, `current_repo_url`, `fork_url`, `upstream_url` |
-| `.omc/self-improve/state/agent-settings.json` | Runtime: `iterations`, `best_score`, `plateau_consecutive_count`, `circuit_breaker_count`, `status`, `goal_slug` (derived: lowercase underscore from goal objective, persisted for cross-session consistency) |
-| `.omc/self-improve/state/iteration_state.json` | Per-iteration progress for resumability |
-| `.omc/self-improve/config/goal.md` | Improvement objective, target metric, scope |
-| `.omc/self-improve/config/harness.md` | Guardrail rules (H001, H002, H003) |
+| `<self-improve-root>/config/settings.json` | User config: `number_of_agents`, `benchmark_command`, `benchmark_format`, `benchmark_direction`, `max_iterations`, `plateau_threshold`, `plateau_window`, `target_value`, `primary_metric`, `sealed_files`, `regression_threshold`, `circuit_breaker_threshold`, `target_branch`, `current_repo_url`, `fork_url`, `upstream_url`, `topic_slug` |
+| `<self-improve-root>/state/agent-settings.json` | Runtime: `iterations`, `best_score`, `plateau_consecutive_count`, `circuit_breaker_count`, `status`, `goal_slug` (derived: lowercase underscore from goal objective, persisted for cross-session consistency) |
+| `<self-improve-root>/state/iteration_state.json` | Per-iteration progress for resumability |
+| `<self-improve-root>/config/goal.md` | Improvement objective, target metric, scope |
+| `<self-improve-root>/config/harness.md` | Guardrail rules (H001, H002, H003) |
 
 ---
 
 ## Setup Phase
 
 1. Check if target repo path exists. If not configured, ask user for the path to the repository to improve.
-2. Create `.omc/self-improve/` directory structure by copying from `templates/` in this skill directory.
-3. Read `.omc/self-improve/state/agent-settings.json`. Check `si_setting_goal`, `si_setting_benchmark`, `si_setting_harness`.
+2. Resolve `<self-improve-root>` by running `node {skill_dir}/scripts/resolve-paths.mjs --project-root {repo_path} [--topic "..."] [--slug "..."] --ensure-dirs`.
+3. Create the `<self-improve-root>/` directory structure by copying from `templates/` in this skill directory into the resolved `config/` root.
+4. Read `<self-improve-root>/state/agent-settings.json`. Check `si_setting_goal`, `si_setting_benchmark`, `si_setting_harness`.
 4. **Trust confirmation** (mandatory, cannot be skipped):
    a. If `trust_confirmed` is already `true` in agent-settings.json, skip to step 5 (resume path).
    b. Display the target repo path and ask user to confirm:
       `"Self-improve will run benchmark commands inside {repo_path}. This executes arbitrary code in that repository. Confirm? [yes/no]"`
    c. If user declines: abort setup and exit. Do NOT proceed.
    d. Record consent: set `trust_confirmed: true` in agent-settings.json.
-5. If goal not set → read `si-goal-clarifier.md` from this skill directory and run the 4-dimension Socratic interview directly in this context (Objective, Metric, Target, Scope). Write result to `.omc/self-improve/config/goal.md`.
+5. Persist `topic_slug` into `config/settings.json` when the resolved root is topic-scoped so future resumes stay on the same track.
+6. If goal not set → read `si-goal-clarifier.md` from this skill directory and run the 4-dimension Socratic interview directly in this context (Objective, Metric, Target, Scope). Write result to `<self-improve-root>/config/goal.md`.
 6. If benchmark not set → read `si-benchmark-builder.md` from this skill directory, spawn a custom Agent(model=opus) with its content as prompt. The agent surveys the repo, creates or wraps a benchmark, validates 3x, and records baseline.
    After benchmark is set, confirm the benchmark command with user:
-   `"Benchmark command: {benchmark_command}. This will be run repeatedly during the loop. Confirm? [yes/no]"`
+      `"Benchmark command: {benchmark_command}. This will be run repeatedly during the loop. Confirm? [yes/no]"`
    If user declines: abort setup and exit.
 7. If harness not set → confirm default harness rules (H001/H002/H003) with user or customize.
 8. **Gate**: All of `si_setting_goal`, `si_setting_benchmark`, `si_setting_harness`, `trust_confirmed` must be true.
@@ -167,7 +175,7 @@ Update `state_write(mode='self-improve', active=true, status="running")`.
 Read state via `state_read(mode='self-improve')`.
 
 If state is cleared (cancel was invoked) OR status is `user_stopped`:
-  a. Set `status: "user_stopped"` in `.omc/self-improve/state/agent-settings.json`
+  a. Set `status: "user_stopped"` in `<self-improve-root>/state/agent-settings.json`
   b. Update `iteration_state.json`: set `status: "interrupted"`, record `current_step`
   c. Clean up any active worktrees for the current round (Step 0 logic)
   d. Log: `"Self-improve stopped by user at iteration {N}, step {current_step}"`
@@ -175,7 +183,7 @@ If state is cleared (cancel was invoked) OR status is `user_stopped`:
 
 ### Step 3 — Check User Ideas
 
-Read `.omc/self-improve/config/idea.md`. If non-empty, snapshot contents for planners. Clear after planners consume.
+Read `<self-improve-root>/config/idea.md`. If non-empty, snapshot contents for planners. Clear after planners consume.
 
 ### Step 4 — Research
 
@@ -184,12 +192,12 @@ Spawn 1 general-purpose Agent(model=opus) with the content of `si-researcher.md`
 Pass in the prompt:
 - Current iteration number
 - Path to target repo
-- Path to `.omc/self-improve/config/goal.md`
-- Path to `.omc/self-improve/state/iteration_history/` (all prior records)
-- Path to `.omc/self-improve/state/research_briefs/` (prior briefs)
+- Path to `<self-improve-root>/config/goal.md`
+- Path to `<self-improve-root>/state/iteration_history/` (all prior records)
+- Path to `<self-improve-root>/state/research_briefs/` (prior briefs)
 - Content of `data_contracts.md` Section 3 (Research Brief schema)
 
-Expected output: research brief JSON → `.omc/self-improve/state/research_briefs/round_{n}.json`
+Expected output: research brief JSON → `<self-improve-root>/state/research_briefs/round_{n}.json`
 
 If researcher fails, proceed with history only.
 
@@ -201,12 +209,12 @@ Pass in each planner's prompt:
 - Planner identity (planner_a, planner_b, planner_c...)
 - Research brief path
 - Iteration history path
-- Harness rules from `.omc/self-improve/config/harness.md`
+- Harness rules from `<self-improve-root>/config/harness.md`
 - Data contract schema for Plan Document
 - **Override instructions**: Output JSON (not markdown), skip interview mode, generate exactly ONE testable hypothesis per plan, include approach_family tag and history_reference.
 - User ideas (if any, planner_a gets priority)
 
-Expected output: Plan Document JSON → `.omc/self-improve/plans/round_{n}/plan_planner_{id}.json`
+Expected output: Plan Document JSON → `<self-improve-root>/plans/round_{n}/plan_planner_{id}.json`
 
 ### Step 6 — Review
 
@@ -271,18 +279,18 @@ SKILL.md does this directly (not delegated):
    If `auto_push` is `false` (default): skip push. Log: `"Push skipped (auto_push: false). Run manually: git -C {repo_path} push origin improve/{goal_slug}"`
 6. **Archive** all non-winner branches via git-master: tag + delete
 7. If no candidate survived the loop: no merge this round. Improvement branch stays at prior state.
-8. **Write Merge Report** JSON to `.omc/self-improve/state/merge_reports/round_{n}.json` (schema: data_contracts.md Section 9).
+8. **Write Merge Report** JSON to `<self-improve-root>/state/merge_reports/round_{n}.json` (schema: data_contracts.md Section 9).
 
 ### Step 9 — Record & Visualize
 
-1. Write iteration history to `.omc/self-improve/state/iteration_history/round_{n}.json`
-2. Update `.omc/self-improve/state/agent-settings.json`:
+1. Write iteration history to `<self-improve-root>/state/iteration_history/round_{n}.json`
+2. Update `<self-improve-root>/state/agent-settings.json`:
    - Increment `iterations` by 1
    - If winner AND improvement exceeds `plateau_threshold` (`abs(new_score - best_score) >= plateau_threshold`): update `best_score`, reset `plateau_consecutive_count = 0`, reset `circuit_breaker_count = 0`
    - If winner AND improvement below threshold (`abs(new_score - best_score) < plateau_threshold`): update `best_score` if better, increment `plateau_consecutive_count += 1`, reset `circuit_breaker_count = 0`
    - If no winner (all rejected, all failed, or all regressed): increment `circuit_breaker_count += 1` (do NOT increment `plateau_consecutive_count` — plateau tracks stagnating wins, not failures)
-3. Append to `.omc/self-improve/tracking/raw_data.json` (one entry per candidate)
-4. Run `python3 {skill_dir}/scripts/plot_progress.py` for visualization
+3. Append to `<self-improve-root>/tracking/raw_data.json` (one entry per candidate)
+4. Run `python3 {skill_dir}/scripts/plot_progress.py --tracking-dir <self-improve-root>/tracking` for visualization
 5. Archive plans: copy current round plans to `state/plan_archive/round_{n}/`
 
 ### Step 10 — Cleanup
@@ -318,12 +326,12 @@ If NO stop condition: immediately go back to Step 1.
 On invocation, before entering the loop:
 
 1. **Always run Step 0** (stale worktree cleanup) — even on fresh start
-2. Read `.omc/self-improve/state/agent-settings.json`:
+2. Read `<self-improve-root>/state/agent-settings.json`:
    - If `status: "user_stopped"`: ask user `"Previous run was stopped at iteration {N}. Resume? [yes/no]"`. If no, exit. If yes, continue.
    - If `status: "running"`: session crashed — resume automatically (no user prompt)
    - If `status: "idle"`: fresh start
 3. Re-confirm trust gate only if `trust_confirmed` is `false` in agent-settings.json
-4. Read `.omc/self-improve/state/iteration_state.json`:
+4. Read `<self-improve-root>/state/iteration_state.json`:
    - `status: "in_progress"` → resume from `current_step`, skip completed sub-steps
    - `status: "completed"` → start next iteration
    - `status: "failed"` → complete recording step if needed, start next iteration

--- a/skills/self-improve/data_contracts.md
+++ b/skills/self-improve/data_contracts.md
@@ -126,7 +126,7 @@ Canonical JSON schemas for all messages exchanged between agents in the self-imp
 
 ## 5. Visualization Data
 
-**File:** `.omc/self-improve/tracking/raw_data.json` — top-level JSON array, append-only.
+**File:** `<self-improve-root>/tracking/raw_data.json` — top-level JSON array, append-only.
 
 ```json
 [
@@ -169,7 +169,7 @@ Custom families from harness.md are also valid.
 
 ## 8. Iteration State
 
-**File:** `.omc/self-improve/state/iteration_state.json` — tracks within-iteration progress.
+**File:** `<self-improve-root>/state/iteration_state.json` — tracks within-iteration progress.
 
 ```json
 {
@@ -235,13 +235,13 @@ Custom families from harness.md are also valid.
 
 ## 10. Plan Archive
 
-**Location:** `.omc/self-improve/state/plan_archive/round_{n}/`
+**Location:** `<self-improve-root>/state/plan_archive/round_{n}/`
 
 Exact copies of all plan JSON files, including critic and architect reviews. Permanent retention.
 
 ## 11. Event Log
 
-**File:** `.omc/self-improve/tracking/events.json` — append-only array.
+**File:** `<self-improve-root>/tracking/events.json` — append-only array.
 
 ```json
 [

--- a/skills/self-improve/scripts/plot_progress.py
+++ b/skills/self-improve/scripts/plot_progress.py
@@ -5,7 +5,7 @@ Reads raw_data.json and generates progress.png.
 
 Usage:
     python3 plot_progress.py --data /path/to/raw_data.json --output /path/to/progress.png
-    python3 plot_progress.py --tracking-dir /path/to/.omc/self-improve/tracking/
+    python3 plot_progress.py --tracking-dir /path/to/<self-improve-root>/tracking/
 """
 
 import argparse

--- a/skills/self-improve/scripts/resolve-paths.mjs
+++ b/skills/self-improve/scripts/resolve-paths.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const DEFAULT_TOPIC_SLUG = 'default';
+const TOPICS_DIR = 'topics';
+
+function slugify(value) {
+  const normalized = String(value ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Za-z0-9\s_-]/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || DEFAULT_TOPIC_SLUG;
+}
+
+function parseArgs(argv) {
+  const result = {
+    projectRoot: process.cwd(),
+    topic: '',
+    slug: '',
+    format: 'json',
+    ensureDirs: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--project-root' && next) {
+      result.projectRoot = next;
+      index += 1;
+    } else if (arg.startsWith('--project-root=')) {
+      result.projectRoot = arg.slice('--project-root='.length);
+    } else if (arg === '--topic' && next) {
+      result.topic = next;
+      index += 1;
+    } else if (arg.startsWith('--topic=')) {
+      result.topic = arg.slice('--topic='.length);
+    } else if (arg === '--slug' && next) {
+      result.slug = next;
+      index += 1;
+    } else if (arg.startsWith('--slug=')) {
+      result.slug = arg.slice('--slug='.length);
+    } else if (arg === '--format' && next) {
+      result.format = next;
+      index += 1;
+    } else if (arg.startsWith('--format=')) {
+      result.format = arg.slice('--format='.length);
+    } else if (arg === '--ensure-dirs') {
+      result.ensureDirs = true;
+    } else if (arg === '--help' || arg === '-h') {
+      result.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!['json', 'shell'].includes(result.format)) {
+    throw new Error(`Unsupported format: ${result.format}`);
+  }
+
+  return result;
+}
+
+function hasLegacyLayout(baseRoot) {
+  return existsSync(join(baseRoot, 'config', 'settings.json'))
+    || existsSync(join(baseRoot, 'state', 'agent-settings.json'));
+}
+
+function buildPaths(root, projectRoot, topicSlug, scopeMode) {
+  const configDir = join(root, 'config');
+  const stateDir = join(root, 'state');
+  const trackingDir = join(root, 'tracking');
+  const paths = {
+    project_root: projectRoot,
+    base_root: join(projectRoot, '.omc', 'self-improve'),
+    topic_slug: topicSlug,
+    scope_mode: scopeMode,
+    root,
+    config_dir: configDir,
+    state_dir: stateDir,
+    plans_dir: join(root, 'plans'),
+    tracking_dir: trackingDir,
+    settings_path: join(configDir, 'settings.json'),
+    goal_path: join(configDir, 'goal.md'),
+    harness_path: join(configDir, 'harness.md'),
+    idea_path: join(configDir, 'idea.md'),
+    agent_settings_path: join(stateDir, 'agent-settings.json'),
+    iteration_state_path: join(stateDir, 'iteration_state.json'),
+    research_briefs_dir: join(stateDir, 'research_briefs'),
+    iteration_history_dir: join(stateDir, 'iteration_history'),
+    merge_reports_dir: join(stateDir, 'merge_reports'),
+    plan_archive_dir: join(stateDir, 'plan_archive'),
+    raw_data_path: join(trackingDir, 'raw_data.json'),
+    baseline_path: join(trackingDir, 'baseline.json'),
+    events_path: join(trackingDir, 'events.json'),
+    progress_path: join(trackingDir, 'progress.png'),
+  };
+  return paths;
+}
+
+function ensureDirs(paths) {
+  for (const dirPath of [
+    paths.config_dir,
+    paths.state_dir,
+    paths.plans_dir,
+    paths.tracking_dir,
+    paths.research_briefs_dir,
+    paths.iteration_history_dir,
+    paths.merge_reports_dir,
+    paths.plan_archive_dir,
+  ]) {
+    mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+export function resolveSelfImprovePaths({ projectRoot = process.cwd(), topic = '', slug = '' } = {}) {
+  const resolvedProjectRoot = resolve(projectRoot);
+  const baseRoot = join(resolvedProjectRoot, '.omc', 'self-improve');
+  const explicitSlug = slugify(slug || topic);
+  const legacyLayout = hasLegacyLayout(baseRoot);
+  const shouldUseLegacyRoot = !slug && !topic && legacyLayout;
+  const topicSlug = shouldUseLegacyRoot ? DEFAULT_TOPIC_SLUG : explicitSlug;
+  const root = shouldUseLegacyRoot
+    ? baseRoot
+    : join(baseRoot, TOPICS_DIR, topicSlug);
+  const scopeMode = shouldUseLegacyRoot
+    ? 'legacy-flat-root'
+    : (slug || topic ? 'topic-scoped' : 'default-scoped');
+
+  return buildPaths(root, resolvedProjectRoot, topicSlug, scopeMode);
+}
+
+function renderShell(paths) {
+  return Object.entries(paths)
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join('\n');
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: node resolve-paths.mjs [--project-root PATH] [--topic TEXT | --slug SLUG] [--ensure-dirs] [--format json|shell]',
+      '',
+      'Resolves self-improve artifact paths.',
+      '- New runs default to .omc/self-improve/topics/<topic-slug>/',
+      '- Legacy flat .omc/self-improve/ is preserved only when no topic/slug is supplied and a flat layout already exists',
+      '',
+    ].join('\n'),
+  );
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const paths = resolveSelfImprovePaths({
+    projectRoot: args.projectRoot,
+    topic: args.topic,
+    slug: args.slug,
+  });
+
+  if (args.ensureDirs) {
+    ensureDirs(paths);
+  }
+
+  if (args.format === 'shell') {
+    process.stdout.write(`${renderShell(paths)}\n`);
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(paths, null, 2)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  }
+}

--- a/skills/self-improve/scripts/validate.sh
+++ b/skills/self-improve/scripts/validate.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 # validate.sh — Sealed file enforcement + plan schema validation for self-improvement loop.
 # Usage:
-#   ./validate.sh --worktree /path plan.json    # worktree mode + plan validation
-#   ./validate.sh plan.json                     # plan schema validation only
-#   ./validate.sh                               # sealed file check only
+#   ./validate.sh --worktree /path --settings /path/to/settings.json plan.json
+#   ./validate.sh --project-root /path/to/omc/project --topic "Improve tests" plan.json
+#   ./validate.sh plan.json
+#   ./validate.sh
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-# Settings path must be provided or discovered from .omc/self-improve/config/
+# Settings path may be provided directly or resolved from the scoped self-improve root.
 SETTINGS=""
+PROJECT_ROOT=""
+TOPIC_NAME=""
+TOPIC_SLUG=""
 
 # Parse arguments
 WORKTREE_PATH=""
@@ -26,6 +30,18 @@ while [[ $# -gt 0 ]]; do
             SETTINGS="$2"
             shift 2
             ;;
+        --project-root)
+            PROJECT_ROOT="$2"
+            shift 2
+            ;;
+        --topic)
+            TOPIC_NAME="$2"
+            shift 2
+            ;;
+        --slug)
+            TOPIC_SLUG="$2"
+            shift 2
+            ;;
         *)
             POSITIONAL_ARGS+=("$1")
             shift
@@ -33,19 +49,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 set -- "${POSITIONAL_ARGS[@]+"${POSITIONAL_ARGS[@]}"}"
-
-# Auto-discover settings if not provided
-if [[ -z "${SETTINGS}" ]]; then
-    # Walk up from worktree or CWD to find .omc/self-improve/config/settings.json
-    SEARCH_DIR="${WORKTREE_PATH:-$(pwd)}"
-    while [[ "${SEARCH_DIR}" != "/" ]]; do
-        if [[ -f "${SEARCH_DIR}/.omc/self-improve/config/settings.json" ]]; then
-            SETTINGS="${SEARCH_DIR}/.omc/self-improve/config/settings.json"
-            break
-        fi
-        SEARCH_DIR="$(dirname "${SEARCH_DIR}")"
-    done
-fi
 
 GIT_DIR="${WORKTREE_PATH:-$(pwd)}"
 
@@ -59,8 +62,90 @@ require_jq() {
     fi
 }
 
-check_sealed_files() {
+resolve_settings_from_project_root() {
+    local project_root="$1"
+    local resolver="${SCRIPT_DIR}/resolve-paths.mjs"
+    local args=( "${resolver}" --project-root "${project_root}" )
+
+    if [[ -n "${TOPIC_SLUG}" ]]; then
+        args+=( --slug "${TOPIC_SLUG}" )
+    elif [[ -n "${TOPIC_NAME}" ]]; then
+        args+=( --topic "${TOPIC_NAME}" )
+    fi
+
+    local resolved
+    resolved=$(node "${args[@]}" 2>/dev/null || true)
+    if [[ -z "${resolved}" ]]; then
+        return 1
+    fi
+
+    local candidate
+    candidate=$(printf '%s' "${resolved}" | jq -r '.settings_path // ""' 2>/dev/null || true)
+    if [[ -n "${candidate}" ]]; then
+        SETTINGS="${candidate}"
+        return 0
+    fi
+
+    return 1
+}
+
+discover_settings_from_search_root() {
+    local search_dir="$1"
+    while [[ "${search_dir}" != "/" ]]; do
+        if [[ -f "${search_dir}/.omc/self-improve/config/settings.json" ]]; then
+            SETTINGS="${search_dir}/.omc/self-improve/config/settings.json"
+            return 0
+        fi
+
+        shopt -s nullglob
+        local scoped_candidates=( "${search_dir}"/.omc/self-improve/topics/*/config/settings.json )
+        shopt -u nullglob
+        if [[ "${#scoped_candidates[@]}" -eq 1 ]]; then
+            SETTINGS="${scoped_candidates[0]}"
+            return 0
+        fi
+        if [[ "${#scoped_candidates[@]}" -gt 1 ]]; then
+            err "Multiple self-improve topics exist under ${search_dir}/.omc/self-improve/topics/. Pass --settings, --project-root with --topic/--slug, or set SELF_IMPROVE_SETTINGS_PATH."
+            exit 1
+        fi
+
+        search_dir="$(dirname "${search_dir}")"
+    done
+    return 1
+}
+
+resolve_settings_path() {
+    [[ -n "${SETTINGS}" ]] && return 0
+
+    if [[ -n "${SELF_IMPROVE_SETTINGS_PATH:-}" ]]; then
+        SETTINGS="${SELF_IMPROVE_SETTINGS_PATH}"
+        return 0
+    fi
+
     require_jq
+
+    if [[ -n "${PROJECT_ROOT}" ]]; then
+        if [[ -n "${TOPIC_SLUG}" || -n "${TOPIC_NAME}" ]]; then
+            if resolve_settings_from_project_root "${PROJECT_ROOT}"; then
+                return 0
+            fi
+        fi
+
+        if discover_settings_from_search_root "${PROJECT_ROOT}"; then
+            return 0
+        fi
+    fi
+
+    local search_dir="${WORKTREE_PATH:-$(pwd)}"
+    if discover_settings_from_search_root "${search_dir}"; then
+        return 0
+    fi
+
+    return 1
+}
+
+check_sealed_files() {
+    resolve_settings_path || true
 
     if [[ -z "${SETTINGS}" || ! -f "${SETTINGS}" ]]; then
         ok "No settings file found — skipping sealed file check."
@@ -298,7 +383,11 @@ check_result_schema() {
 }
 
 main() {
+    resolve_settings_path || true
     echo "=== self-improve validate.sh ==="
+    if [[ -n "${SETTINGS}" ]]; then
+        echo "Settings: ${SETTINGS}"
+    fi
     check_sealed_files
 
     if [[ ${#POSITIONAL_ARGS[@]} -ge 1 ]]; then

--- a/skills/self-improve/si-goal-clarifier.md
+++ b/skills/self-improve/si-goal-clarifier.md
@@ -4,8 +4,9 @@
 
 Arguments passed via context:
 - `repo_path`: Absolute path to the target repository
-- `config_path`: Path to .omc/self-improve/config/
+- `config_path`: Path to `<self-improve-root>/config/`
 - `agent_settings_path`: Path to agent-settings.json
+- `topic_slug`: Resolved self-improve topic slug
 
 ## Role
 
@@ -56,7 +57,7 @@ Each round:
 **Soft cap: 8 rounds**. **Hard cap: 12 rounds**.
 
 ### Phase 4 — Write Goal
-Write `.omc/self-improve/config/goal.md`:
+Write `<self-improve-root>/config/goal.md`:
 ```markdown
 # Improvement Goal
 

--- a/skills/self-improve/templates/settings.json
+++ b/skills/self-improve/templates/settings.json
@@ -5,6 +5,7 @@
   "current_repo_url": "",
   "fork_url": "",
   "upstream_url": "",
+  "topic_slug": "default",
   "target_branch": "main",
   "benchmark_command": "",
   "benchmark_format": "json",

--- a/src/cli/__tests__/self-improve-paths.test.ts
+++ b/src/cli/__tests__/self-improve-paths.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const RESOLVER = join(process.cwd(), 'skills', 'self-improve', 'scripts', 'resolve-paths.mjs');
+const VALIDATE = join(process.cwd(), 'skills', 'self-improve', 'scripts', 'validate.sh');
+
+function readJson(command: string, args: string[]) {
+  return JSON.parse(execFileSync(command, args, { encoding: 'utf-8' }));
+}
+
+describe('self-improve path scoping helpers', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'omc-self-improve-paths-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('defaults new runs to a scoped default topic root', () => {
+    const result = readJson('node', [RESOLVER, '--project-root', root]);
+    expect(result.topic_slug).toBe('default');
+    expect(result.scope_mode).toBe('default-scoped');
+    expect(result.root).toBe(join(root, '.omc', 'self-improve', 'topics', 'default'));
+  });
+
+  it('uses a slugified topic-specific root when topic text is provided', () => {
+    const result = readJson('node', [RESOLVER, '--project-root', root, '--topic', 'Latency & Throughput']);
+    expect(result.topic_slug).toBe('latency-throughput');
+    expect(result.scope_mode).toBe('topic-scoped');
+    expect(result.root).toBe(join(root, '.omc', 'self-improve', 'topics', 'latency-throughput'));
+  });
+
+  it('falls back to the legacy flat root when legacy state already exists and no topic is provided', () => {
+    const legacyConfigDir = join(root, '.omc', 'self-improve', 'config');
+    mkdirSync(legacyConfigDir, { recursive: true });
+    writeFileSync(join(legacyConfigDir, 'settings.json'), '{}\n', 'utf-8');
+
+    const result = readJson('node', [RESOLVER, '--project-root', root]);
+    expect(result.topic_slug).toBe('default');
+    expect(result.scope_mode).toBe('legacy-flat-root');
+    expect(result.root).toBe(join(root, '.omc', 'self-improve'));
+  });
+
+  it('creates the resolved scoped directories when asked', () => {
+    const result = readJson('node', [RESOLVER, '--project-root', root, '--slug', 'perf-track', '--ensure-dirs']);
+    expect(existsSync(result.config_dir)).toBe(true);
+    expect(existsSync(result.state_dir)).toBe(true);
+    expect(existsSync(result.tracking_dir)).toBe(true);
+  });
+
+  it('validate.sh auto-discovers a single scoped settings file', () => {
+    const scopedConfigDir = join(root, '.omc', 'self-improve', 'topics', 'perf-track', 'config');
+    mkdirSync(scopedConfigDir, { recursive: true });
+    writeFileSync(join(scopedConfigDir, 'settings.json'), JSON.stringify({ sealed_files: [] }), 'utf-8');
+
+    const output = execFileSync('bash', [VALIDATE], {
+      cwd: root,
+      encoding: 'utf-8',
+    });
+
+    expect(output).toContain(`Settings: ${join(scopedConfigDir, 'settings.json')}`);
+    expect(output).toContain('All checks passed');
+  });
+
+  it('validate.sh errors when multiple scoped topics exist without an explicit selector', () => {
+    const configA = join(root, '.omc', 'self-improve', 'topics', 'alpha', 'config');
+    const configB = join(root, '.omc', 'self-improve', 'topics', 'beta', 'config');
+    mkdirSync(configA, { recursive: true });
+    mkdirSync(configB, { recursive: true });
+    writeFileSync(join(configA, 'settings.json'), JSON.stringify({ sealed_files: [] }), 'utf-8');
+    writeFileSync(join(configB, 'settings.json'), JSON.stringify({ sealed_files: [] }), 'utf-8');
+
+    expect(() => execFileSync('bash', [VALIDATE], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })).toThrow(/Multiple self-improve topics exist/);
+  });
+
+  it('validate.sh resolves a selected topic via project root and slug', () => {
+    const selected = readJson('node', [RESOLVER, '--project-root', root, '--slug', 'alpha', '--ensure-dirs']);
+    writeFileSync(selected.settings_path, JSON.stringify({ sealed_files: [] }), 'utf-8');
+
+    const output = execFileSync('bash', [VALIDATE, '--project-root', root, '--slug', 'alpha'], {
+      cwd: root,
+      encoding: 'utf-8',
+    });
+
+    expect(output).toContain(`Settings: ${selected.settings_path}`);
+  });
+
+  it('templates/settings.json includes the persisted topic slug field', () => {
+    const templatePath = join(process.cwd(), 'skills', 'self-improve', 'templates', 'settings.json');
+    const template = JSON.parse(readFileSync(templatePath, 'utf-8')) as { topic_slug?: string };
+    expect(template.topic_slug).toBe('default');
+  });
+});


### PR DESCRIPTION
## Summary
- add a scoped self-improve path resolver that defaults new runs to topic-specific roots while preserving legacy flat-root fallback
- teach self-improve validation and docs/templates to resolve topic-scoped settings paths consistently
- add targeted regression coverage for default, explicit-topic, and legacy self-improve path resolution

## Verification
- npm run test:run -- src/cli/__tests__/self-improve-paths.test.ts
- npm run build
- npm run lint -- src/cli/__tests__/self-improve-paths.test.ts

Closes #2731