### PR TITLE
fix(scientist): allow Write tool for stage report persistence

### DIFF
--- a/agents/scientist.md
+++ b/agents/scientist.md
@@ -3,7 +3,7 @@ name: scientist
 description: Data analysis and research execution specialist
 model: sonnet
 level: 3
-disallowedTools: Write, Edit
+disallowedTools: Edit
 ---
 
 <Agent_Prompt>


### PR DESCRIPTION
Scientist agent had `disallowedTools: Write, Edit` in frontmatter, which blocked the agent from persisting research output. The /sciomc skill orchestration explicitly requires scientists to write stage-N.md reports — without Write tool access, all 5 parallel scientist agents in a sciomc session would stall searching for unavailable Write schema via ToolSearch, never producing final deliverables.

Root cause: frontmatter was over-restrictive. Design intent (no arbitrary code modification) is preserved by keeping `Edit` disallowed. Write is needed for legitimate research output: stage reports, final synthesis, figures.

Empirical evidence (session 2447e8eb 2026-04-10): 5 scientist agents spawned via /sciomc accumulated 700KB of jsonl progress traces but zero stage-N.md files were ever written. All 5 stuck on ToolSearch loops trying to locate Write tool that frontmatter explicitly blocked.

Fix: Remove `Write` from disallowedTools list. Keep `Edit` blocked to preserve "no source code modification" design intent.

### Re-targeted against `dev`
This PR replaces #2446, which was closed by the bot because it targeted `main` instead of `dev`. Same single-commit fix, cherry-picked cleanly onto `origin/dev` (a5452913 → 07c4e69c).

Constraint: Scientist must persist findings via Write per /sciomc skill
Rejected: python_repl file write workaround | requires every scientist prompt to know workaround
Confidence: high
Scope-risk: narrow
Directive: When auditing OMC agent disallowedTools — apply minimum-restrictive principle. Use prompt/Process sections for behavioral restrictions, not frontmatter hard denies, since the latter blocks legitimate downstream skill workflows.

Co-Authored-By: LLM+TUI-IDE-based agent Reid

Directive: code produced under human supervisory control signal (ТСАУ / Control Engineering and Systems). Telegram @nemerowmikhailr · lawrenncecharlotte@gmail.com