### PR TITLE
feat(team): add cursor-agent as 4th tmux worker type (executor-only)

### DIFF
--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -14,7 +14,7 @@ import { isProcessAlive } from '../platform/index.js';
 import { getGlobalOmcStatePath } from '../utils/paths.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
-const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini']);
+const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor']);
 const SUBCOMMANDS = new Set(['start', 'status', 'wait', 'cleanup', 'resume', 'shutdown', 'api', 'help', '--help', '-h']);
 
 const SUPPORTED_API_OPERATIONS = new Set([
@@ -685,7 +685,7 @@ export async function teamCleanupCommand(
 
 export const TEAM_USAGE = `
 Usage:
-  omc team start --agent <claude|codex|gemini>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--new-window] [--json]
+  omc team start --agent <claude|codex|gemini|cursor>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--new-window] [--json]
   omc team status <job_id|team_name> [--json] [--cwd DIR]
   omc team wait <job_id> [--timeout-ms MS] [--json]
   omc team cleanup <job_id> [--grace-ms MS] [--json]

--- a/src/team/capabilities.ts
+++ b/src/team/capabilities.ts
@@ -18,6 +18,7 @@ const DEFAULT_CAPABILITIES: Record<WorkerBackend, WorkerCapability[]> = {
   'tmux-claude': ['code-edit', 'testing', 'general'],
   'tmux-codex': ['code-review', 'security-review', 'architecture', 'refactoring'],
   'tmux-gemini': ['ui-design', 'documentation', 'research', 'code-edit'],
+  'tmux-cursor': ['code-edit', 'refactoring', 'general'],
 };
 
 /**

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -35,5 +35,6 @@ export function detectAllClis(): Record<string, CliInfo> {
     claude: detectCli('claude'),
     codex: detectCli('codex'),
     gemini: detectCli('gemini'),
+    cursor: detectCli('cursor-agent'),
   };
 }

--- a/src/team/cli-worker-contract.ts
+++ b/src/team/cli-worker-contract.ts
@@ -57,7 +57,14 @@ export function shouldInjectContract(
   provider: CliAgentType | null | undefined,
 ): boolean {
   if (!role || !provider) return false;
-  if (provider === 'claude') return false;
+  // Claude workers speak through the team messaging API directly.
+  // Cursor workers run as interactive REPLs — they cannot perform the
+  // write-verdict-and-exit dance the contract requires, so reviewer
+  // roles must not be assigned to cursor in the first place. The
+  // role-router and worker-bootstrap guidance both flag this; here we
+  // simply skip contract injection if a cursor worker somehow lands on
+  // a CONTRACT_ROLES role rather than emit instructions it cannot follow.
+  if (provider === 'claude' || provider === 'cursor') return false;
   return CONTRACT_ROLES.has(role);
 }
 

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -5,7 +5,7 @@ import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
-export type CliAgentType = 'claude' | 'codex' | 'gemini';
+export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor';
 
 export interface CliAgentContract {
   agentType: CliAgentType;
@@ -219,6 +219,24 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
       const args = ['--approval-mode', 'yolo'];
       if (model) args.push('--model', model);
       return [...args, ...extraFlags];
+    },
+    parseOutput(rawOutput: string): string {
+      return rawOutput.trim();
+    },
+  },
+  cursor: {
+    agentType: 'cursor',
+    binary: 'cursor-agent',
+    installInstructions: 'Install Cursor Agent CLI: see https://docs.cursor.com/cli',
+    // cursor-agent runs as an interactive REPL — no exit-on-complete prompt mode.
+    // Keep supportsPromptMode false so the verdict-file contract path
+    // (CONTRACT_ROLES + shouldInjectContract) skips this provider; cursor
+    // workers participate as executors only.
+    supportsPromptMode: false,
+    buildLaunchArgs(_model?: string, extraFlags: string[] = []): string[] {
+      // Minimal flags — cursor-agent owns its own session/auth state.
+      // The model is selected interactively inside cursor-agent itself.
+      return [...extraFlags];
     },
     parseOutput(rawOutput: string): string {
       return rawOutput.trim();

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -138,7 +138,7 @@ export interface TaskFailureSidecar {
 }
 
 /** Worker backend type */
-export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini';
+export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini' | 'tmux-cursor';
 
 /** Worker capability tag */
 export type WorkerCapability =
@@ -253,7 +253,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude' | 'gemini';
+  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -73,6 +73,13 @@ function agentTypeGuidance(agentType: CliAgentType): string {
         '- Keep commit-sized changes scoped to assigned files only; no broad refactors.',
         `- CRITICAL: You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done. Do not exit without transitioning the task status.`,
       ].join('\n');
+    case 'cursor':
+      return [
+        '### Agent-Type Guidance (cursor)',
+        '- You are an interactive REPL (cursor-agent), not a one-shot CLI. Stay in the session; the leader will continue to send prompts via mailbox.',
+        `- You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done. Then keep waiting for the next mailbox message; do NOT type \`/exit\` unless the leader sends an explicit shutdown.`,
+        '- Reviewer/critic/security-review roles are NOT supported for cursor workers — those require a verdict-file write-and-exit which the REPL does not perform. Take only executor-style tasks.',
+      ].join('\n');
     case 'claude':
     default:
       return [


### PR DESCRIPTION
Adds **cursor-agent** (Cursor's Composer 2 REPL) as a first-class \`omc team\` worker provider alongside claude/codex/gemini.

## Why

cursor-agent is a very capable interactive coding agent that many users (including myself) already keep a running Cursor Pro/Max plan for. Making it a native OMC worker lets those users burn Cursor credits for throughput work while the Claude orchestrator retains the plan/verify role — without leaving the \`omc team\` mental model.

The user also gets the full cmux-pane visibility: they can watch the cursor-agent REPL live, interrupt by typing directly into the split, and the orchestrator continues to coordinate via the standard filesystem A2A at \`.omc/state/team/<team>/\`.

## Changes

| File | Change |
|---|---|
| \`src/team/model-contract.ts\` | Extend \`CliAgentType\` with \`'cursor'\`; add \`CONTRACTS.cursor\` (binary \`cursor-agent\`, \`supportsPromptMode: false\`, minimal launch args) |
| \`src/team/types.ts\` | Extend \`WorkerBackend\` with \`'tmux-cursor'\`; widen \`WorkerInfo.worker_cli\` to include \`'cursor'\` |
| \`src/team/capabilities.ts\` | Map \`tmux-cursor\` to \`['code-edit', 'refactoring', 'general']\` |
| \`src/team/cli-detection.ts\` | Detect \`cursor-agent\` in \`detectAllClis()\` |
| \`src/team/worker-bootstrap.ts\` | Add \`case 'cursor':\` to \`agentTypeGuidance\` with REPL-aware instructions (stay in session, claim/transition tasks via team-api, do not auto-exit) |
| \`src/team/cli-worker-contract.ts\` | Skip \`shouldInjectContract\` for cursor, matching the claude carve-out |
| \`src/cli/team.ts\` | Add \`'cursor'\` to \`VALID_CLI_AGENT_TYPES\`; update help text |

## Executor-only: why

Codex and Gemini use \`supportsPromptMode: true\` because they're one-shot CLIs (run a prompt → exit). The CLI-worker output contract (\`CONTRACT_ROLES\` = critic/code-reviewer/security-reviewer/test-engineer) depends on exit-on-complete so the verdict JSON can be read by the leader's worker-completion handler.

cursor-agent is an **interactive REPL** — it does not exit after answering. Routing a reviewer role to a cursor worker would hang the team because the verdict file would never be written. This patch:

1. Sets \`supportsPromptMode: false\` on the cursor contract.
2. Extends \`shouldInjectContract\` to skip cursor (alongside claude).
3. Documents the constraint in the in-prompt \`agentTypeGuidance\`.

Mailbox / inbox / sentinel / heartbeat flow is unchanged — cursor workers participate in the standard filesystem A2A the same way claude workers do.

## Verification

\`\`\`
\$ npx tsc --noEmit
# all production sources pass
\$ cursor-agent --version   # confirms binary detection
# → version output
\`\`\`

End-to-end test (pending once this PR lands):

\`\`\`
\$ omc team 1:cursor:executor \"implement hello.py and ack on leader-fixed\"
# cursor pane spawns in cmux split, receives trigger message,
# claims task, edits file, transitions task status, waits.
\`\`\`

## Known follow-up (flagged honestly)

One residual TS error remains in \`src/__tests__/runtime-guidance-plan-ralph.test.ts\` at line 87 — it uses a hard-coded literal-union helper signature \`(agentType: \"claude\" | \"codex\" | \"gemini\") => agentType is \"claude\"\` that should be widened to \`(agentType: CliAgentType) => agentType is \"claude\"\` to accept the new provider. My local agent harness currently guards \`*.test.ts\` edits (it's a generic \"don't silence tests\" hook that mis-fires on type-widening), so rather than bypass it I'm surfacing this for a one-line amendment in-PR. Happy to paste the exact diff in a comment — it's simply replacing the literal union with the existing \`CliAgentType\` import.

## Compatibility

- Existing claude/codex/gemini worker types and behaviors are unchanged.
- No bridge/MCP changes — cursor uses the existing tmux-pane path.
- The \`BridgeConfig.provider\` literal \`'codex' | 'gemini'\` is intentionally NOT widened: cursor does not go through the bridge runtime, so that narrower type correctly excludes it.

## Relationship to cmux

This PR pairs well with two upstream cmux fixes I just opened to make \`omc team\` work inside cmux at all:
- manaflow-ai/cmux#3031 — \`__tmux-compat display-message\` short-form format expansion
- manaflow-ai/cmux#3032 — \`surface.send_text/read_text/send_key\` RPC accepts \`surface_ref\`/\`surface\` aliases

Once all three land, \`cmux omc team 1:cursor,1:codex,1:gemini \"...\"\` works end-to-end with each agent in its own cmux split, driveable both by the user (direct keyboard input) and the orchestrator (via the filesystem mailbox).