### PR TITLE
fix(keyword-detector): stop false-positive autopilot on "autonomous"

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -860,7 +860,11 @@ async function main() {
     }
 
     // Autopilot keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(autopilot|auto pilot|auto-pilot|autonomous|full auto|fullsend)\b|(오토파일럿)/i) ||
+    // "autonomous" intentionally excluded — it is too common in technical and
+    // research prose (e.g. "autonomous driving", "autonomous agent") to be a
+    // reliable trigger. Aligns with src/hooks/keyword-detector/index.ts and
+    // templates/hooks/keyword-detector.mjs, which already exclude it.
+    if (hasActionableKeyword(cleanPrompt, /\b(autopilot|auto pilot|auto-pilot|full auto|fullsend)\b|(오토파일럿)/i) ||
         hasActionableKeyword(cleanPrompt, /\b(build|create|make)\s+me\s+(an?\s+)?(app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b/i) ||
         hasActionableKeyword(cleanPrompt, /\bi\s+want\s+a\s+/i) ||
         hasActionableKeyword(cleanPrompt, /\bi\s+want\s+an\s+/i) ||

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -356,4 +356,37 @@ diff --git a/a b/b
     expect(context).toContain('<code-review-mode>');
     expect(context).not.toContain('[MAGIC KEYWORD: CODE-REVIEW]');
   });
+
+  // Regression: "autonomous" appearing in technical / research prose must not
+  // trigger autopilot (false positive previously created spurious
+  // autopilot-state.json and a stop-hook loop). The TS source and the
+  // templates/hooks mjs already exclude the word; this test guards the
+  // deployed scripts/keyword-detector.mjs against drift.
+  it('does not activate autopilot when "autonomous" appears in technical prose', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-autonomous-'));
+    const sessionId = 'session-autonomous-regression';
+    const output = runKeywordDetector(
+      'DriveVLA-W0: World Models Amplify Data Scaling Law in Autonomous Driving — please summarize this paper.',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+    const autopilotStatePath = join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(existsSync(autopilotStatePath)).toBe(false);
+  });
+
+  it('still activates autopilot for an explicit autopilot invocation (positive control)', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-autopilot-positive-'));
+    const sessionId = 'session-autopilot-positive';
+    const output = runKeywordDetector('autopilot build a todo CLI', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+    const autopilotStatePath = join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(existsSync(autopilotStatePath)).toBe(true);
+  });
 });


### PR DESCRIPTION
> Retargeted from #2738 (closed — should land on `dev`, not `main`). Same patch, cherry-picked cleanly onto current `dev` (applies without conflicts; no other files touched).

## Summary

The deployed `scripts/keyword-detector.mjs` still lists `autonomous` in the autopilot trigger regex, while both the TypeScript source (`src/hooks/keyword-detector/index.ts`) and the new-install template (`templates/hooks/keyword-detector.mjs`) already removed it. This PR syncs the deployed script with the TS/template authority and adds regression tests against drift.

`autonomous` is extremely common in technical / research prose — *autonomous driving*, *autonomous agent*, *autonomous system*. Any prompt mentioning such a term silently created `autopilot-state.json`. The Stop hook (`persistent-mode.mjs`) then treated autopilot as active and produced an inescapable

> `[AUTOPILOT - Phase: unspecified] Autopilot not complete. Continue working.`

block loop. `state_clear` from the cancel skill could not target the per-project state path, and the Stop hook kept refreshing the file — a real-world session hit this while simply pasting a paper title (`DriveVLA-W0: World Models Amplify Data Scaling Law in Autonomous Driving`).

## Reproduction (before this patch)

```bash
echo '{"hook_event_name":"UserPromptSubmit","cwd":"'"$(pwd)"'",
  "session_id":"x","prompt":"DriveVLA-W0: World Models Amplify Data
  Scaling Law in Autonomous Driving"}' | node scripts/keyword-detector.mjs
```

→ emits `[MAGIC KEYWORD: AUTOPILOT]` and writes `.omc/state/sessions/x/autopilot-state.json`.

After this patch the same prompt returns `{"continue":true,"suppressOutput":true}` and writes no state, while `autopilot build a todo CLI` still triggers autopilot as expected.

## Why the TS source was already correct

`src/hooks/keyword-detector/index.ts` L47:

```ts
autopilot: /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b|(오토파일럿)/i,
```

and the colocated test (`src/hooks/keyword-detector/__tests__/index.test.ts`) already asserts *"should NOT detect autonomous keyword"*. The drift was isolated to the deployed `.mjs`, which also carries a handful of extra loose patterns (`i want a`, `build me X`, `end to end`, …) not present in the canonical TS. Those extras are orthogonal to this bug, so this PR keeps the fix minimal and only removes `autonomous`.

## Changes

- **`scripts/keyword-detector.mjs`** — drop `autonomous` from the autopilot regex. Add a comment explaining why and pointing at the already-aligned TS source and templates mjs so the deployed file does not drift again.
- **`src/__tests__/keyword-detector-script.test.ts`** — two new regression tests exercising the actual `.mjs` via `execFileSync`:
  - *negative*: `Autonomous Driving` paper-title prompt must not emit `[MAGIC KEYWORD: AUTOPILOT]` nor create `autopilot-state.json`.
  - *positive control*: explicit `autopilot build a todo CLI` must still emit the magic keyword and create the state.

## Test plan

- [x] `node scripts/keyword-detector.mjs` with autonomous-in-prose prompt → `{"continue":true,"suppressOutput":true}`, no state file.
- [x] `node scripts/keyword-detector.mjs` with explicit `autopilot ...` prompt → emits `[MAGIC KEYWORD: AUTOPILOT]`, state file written.
- [ ] `npm test -- keyword-detector-script` (maintainer to run; two new cases added).
- [x] Other English trigger variants (`auto pilot`, `auto-pilot`, `full auto`, `fullsend`) and the Korean `오토파일럿` are retained.

## Related

The underlying Stop-hook loop behaviour (block loop + per-project state not cleared by cancel) is a separate issue — the fix here prevents the false activation at its source so cancel is no longer required in normal use. A follow-up could align `scripts/keyword-detector.mjs` more broadly with `templates/hooks/keyword-detector.mjs` (remove the loose `i want a/an`, `build me`, `end to end` patterns), but that is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)