### PR TITLE
Fix Ralph cross-session cancel state resurrection

### DIFF
--- a/src/hooks/persistent-mode/__tests__/cancel-race.test.ts
+++ b/src/hooks/persistent-mode/__tests__/cancel-race.test.ts
@@ -100,4 +100,47 @@ describe('persistent-mode cancel race guard (issue #921)', () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('should not re-enforce when a resumed session clears the owning session and writes a foreign cancel signal', async () => {
+    const ownerSessionId = 'session-2743-owner';
+    const resumedSessionId = 'session-2743-resumed';
+    const tempDir = mkdtempSync(join(tmpdir(), 'persistent-cross-session-cancel-'));
+
+    try {
+      execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+      const ownerDir = makeRalphSession(tempDir, ownerSessionId);
+      const resumedDir = join(tempDir, '.omc', 'state', 'sessions', resumedSessionId);
+      mkdirSync(resumedDir, { recursive: true });
+
+      writeFileSync(
+        join(ownerDir, 'cancel-signal-state.json'),
+        JSON.stringify(
+          {
+            active: true,
+            requested_at: new Date().toISOString(),
+            expires_at: new Date(Date.now() + 30_000).toISOString(),
+            mode: 'ralph',
+            source: 'state_clear'
+          },
+          null,
+          2
+        )
+      );
+
+      const result = await checkPersistentModes(resumedSessionId, tempDir, {
+        stop_reason: 'end_turn'
+      });
+
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe('none');
+      expect(existsSync(join(ownerDir, 'ultrawork-state.json'))).toBe(false);
+      const ralphState = JSON.parse(
+        readFileSync(join(ownerDir, 'ralph-state.json'), 'utf-8')
+      ) as { iteration: number; max_iterations: number };
+      expect(ralphState.iteration).toBe(10);
+      expect(ralphState.max_iterations).toBe(10);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/tools/__tests__/state-tools.test.ts
+++ b/src/tools/__tests__/state-tools.test.ts
@@ -749,6 +749,33 @@ describe('state-tools', () => {
       expect(result.content[0].text).toContain('recovered session file');
       expect(existsSync(join(strandedDir, 'ralph-state.json'))).toBe(false);
     });
+
+    it('should clear the owning session when the current session resumed ralph from a different conversation', async () => {
+      const currentSessionId = 'resume-session-b';
+      const ownerSessionId = 'resume-session-a';
+      const ownerDir = join(TEST_DIR, '.omc', 'state', 'sessions', ownerSessionId);
+      mkdirSync(ownerDir, { recursive: true });
+      writeFileSync(
+        join(ownerDir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          session_id: ownerSessionId,
+          iteration: 4,
+          linked_ultrawork: true,
+        }),
+      );
+
+      const result = await stateClearTool.handler({
+        mode: 'ralph',
+        session_id: currentSessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain(`cleared owning session: ${ownerSessionId}`);
+      expect(existsSync(join(ownerDir, 'ralph-state.json'))).toBe(false);
+      expect(existsSync(join(TEST_DIR, '.omc', 'state', 'sessions', currentSessionId, 'cancel-signal-state.json'))).toBe(true);
+      expect(existsSync(join(ownerDir, 'cancel-signal-state.json'))).toBe(true);
+    });
   });
 
   describe('session-scoped behavior', () => {

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -213,6 +213,56 @@ function clearSessionOwnedStateCandidates(
   return { cleared, hadFailure, paths };
 }
 
+function writeSessionCancelSignal(
+  root: string,
+  sessionId: string,
+  mode: StateToolMode,
+): void {
+  const now = Date.now();
+  const cancelSignalPath = resolveSessionStatePath('cancel-signal', sessionId, root);
+  atomicWriteJsonSync(cancelSignalPath, {
+    active: true,
+    requested_at: new Date(now).toISOString(),
+    expires_at: new Date(now + CANCEL_SIGNAL_TTL_MS).toISOString(),
+    mode,
+    source: 'state_clear'
+  });
+}
+
+function isSessionModeActive(
+  mode: StateToolMode,
+  root: string,
+  sessionId: string,
+): boolean {
+  if (MODE_CONFIGS[mode as ExecutionMode]) {
+    return isModeActive(mode as ExecutionMode, root, sessionId);
+  }
+
+  const statePath = resolveSessionStatePath(mode, sessionId, root);
+  if (!existsSync(statePath)) {
+    return false;
+  }
+
+  try {
+    const state = JSON.parse(readFileSync(statePath, 'utf-8')) as Record<string, unknown>;
+    return state.active === true;
+  } catch {
+    return false;
+  }
+}
+
+function findSingleOwningSessionForMode(
+  mode: StateToolMode,
+  root: string,
+  requesterSessionId: string,
+): string | undefined {
+  const owningSessions = listSessionIds(root).filter((sid) => (
+    sid !== requesterSessionId && isSessionModeActive(mode, root, sid)
+  ));
+
+  return owningSessions.length === 1 ? owningSessions[0] : undefined;
+}
+
 // ============================================================================
 // state_read - Read state for a mode
 // ============================================================================
@@ -514,23 +564,34 @@ export const stateClearTool: ToolDefinition<{
       // If session_id provided, clear only session-specific state
       if (sessionId) {
         validateSessionId(sessionId);
+        const requestedSessionOwnedPaths = findSessionOwnedStateFiles(mode, sessionId, root);
         for (const teamStatePath of findSessionOwnedStateFiles('team', sessionId, root)) {
           collectTeamNamesForCleanup(teamStatePath);
         }
-        const now = Date.now();
-        const cancelSignalPath = resolveSessionStatePath('cancel-signal', sessionId, root);
-        atomicWriteJsonSync(cancelSignalPath, {
-          active: true,
-          requested_at: new Date(now).toISOString(),
-          expires_at: new Date(now + CANCEL_SIGNAL_TTL_MS).toISOString(),
-          mode,
-          source: 'state_clear'
-        });
+        writeSessionCancelSignal(root, sessionId, mode);
 
         if (MODE_CONFIGS[mode as ExecutionMode]) {
           const success = clearModeState(mode as ExecutionMode, root, sessionId);
           const sessionCleanup = clearSessionOwnedStateCandidates(mode, root, sessionId);
           const legacyCleanup = clearLegacyStateCandidates(mode, root, sessionId);
+          let ownerSessionId: string | undefined;
+          let ownerSessionCleanup = { cleared: 0, hadFailure: false, paths: [] as string[] };
+          let ownerLegacyCleanup = { cleared: 0, hadFailure: false };
+
+          if (requestedSessionOwnedPaths.length === 0 && sessionCleanup.cleared === 0 && legacyCleanup.cleared === 0) {
+            ownerSessionId = findSingleOwningSessionForMode(mode, root, sessionId);
+            if (ownerSessionId) {
+              if (mode === 'team') {
+                for (const teamStatePath of findSessionOwnedStateFiles('team', ownerSessionId, root)) {
+                  collectTeamNamesForCleanup(teamStatePath);
+                }
+              }
+              writeSessionCancelSignal(root, ownerSessionId, mode);
+              clearModeState(mode as ExecutionMode, root, ownerSessionId);
+              ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root, ownerSessionId);
+              ownerLegacyCleanup = clearLegacyStateCandidates(mode, root, ownerSessionId);
+            }
+          }
 
           const ghostNoteParts: string[] = [];
           if (legacyCleanup.cleared > 0) {
@@ -538,6 +599,9 @@ export const stateClearTool: ToolDefinition<{
           }
           if (sessionCleanup.cleared > 0) {
             ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? '' : 's'}`);
+          }
+          if (ownerSessionId) {
+            ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
           }
           const ghostNote = ghostNoteParts.length > 0 ? ` (${ghostNoteParts.join(', ')})` : '';
           const runtimeCleanupNote = (() => {
@@ -550,7 +614,13 @@ export const stateClearTool: ToolDefinition<{
             if (prunedMissions > 0) details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
             return details.length > 0 ? ` (${details.join(', ')})` : '';
           })();
-          if (success && !legacyCleanup.hadFailure && !sessionCleanup.hadFailure) {
+          if (
+            success &&
+            !legacyCleanup.hadFailure &&
+            !sessionCleanup.hadFailure &&
+            !ownerSessionCleanup.hadFailure &&
+            !ownerLegacyCleanup.hadFailure
+          ) {
             return {
               content: [{
                 type: 'text' as const,
@@ -569,8 +639,24 @@ export const stateClearTool: ToolDefinition<{
 
         // Fallback for modes not in registry (e.g., ralplan)
         const sessionCleanup = clearSessionOwnedStateCandidates(mode, root, sessionId);
-
         const legacyCleanup = clearLegacyStateCandidates(mode, root, sessionId);
+        let ownerSessionId: string | undefined;
+        let ownerSessionCleanup = { cleared: 0, hadFailure: false, paths: [] as string[] };
+        let ownerLegacyCleanup = { cleared: 0, hadFailure: false };
+
+        if (requestedSessionOwnedPaths.length === 0 && sessionCleanup.cleared === 0 && legacyCleanup.cleared === 0) {
+          ownerSessionId = findSingleOwningSessionForMode(mode, root, sessionId);
+          if (ownerSessionId) {
+            if (mode === 'team') {
+              for (const teamStatePath of findSessionOwnedStateFiles('team', ownerSessionId, root)) {
+                collectTeamNamesForCleanup(teamStatePath);
+              }
+            }
+            writeSessionCancelSignal(root, ownerSessionId, mode);
+            ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root, ownerSessionId);
+            ownerLegacyCleanup = clearLegacyStateCandidates(mode, root, ownerSessionId);
+          }
+        }
 
         const ghostNoteParts: string[] = [];
         if (legacyCleanup.cleared > 0) {
@@ -578,6 +664,9 @@ export const stateClearTool: ToolDefinition<{
         }
         if (sessionCleanup.cleared > 0) {
           ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? '' : 's'}`);
+        }
+        if (ownerSessionId) {
+          ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
         }
         const ghostNote = ghostNoteParts.length > 0 ? ` (${ghostNoteParts.join(', ')})` : '';
         const runtimeCleanupNote = (() => {
@@ -593,7 +682,7 @@ export const stateClearTool: ToolDefinition<{
         return {
           content: [{
             type: 'text' as const,
-            text: `${legacyCleanup.hadFailure || sessionCleanup.hadFailure ? 'Warning: Some files could not be removed' : 'Successfully cleared state'} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
+            text: `${legacyCleanup.hadFailure || sessionCleanup.hadFailure || ownerSessionCleanup.hadFailure || ownerLegacyCleanup.hadFailure ? 'Warning: Some files could not be removed' : 'Successfully cleared state'} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
           }]
         };
       }


### PR DESCRIPTION
## Summary
- clear the single owning Ralph session when a resumed session cancels without any local state files
- write cancel signals for both the resumed session and the owning session so stop-hook enforcement stays down during teardown
- cover the owner-clear path and the foreign cancel-signal stop-hook guard with focused regression tests

## Testing
- npm test -- --run src/tools/__tests__/state-tools.test.ts src/hooks/persistent-mode/__tests__/cancel-race.test.ts
- npm test -- --run src/tools/__tests__/cancel-integration.test.ts src/hooks/persistent-mode/session-isolation.test.ts src/lib/__tests__/mode-state-io.test.ts src/hooks/mode-registry/__tests__/session-isolation.test.ts
- npx tsc --noEmit
- npx eslint src/tools/state-tools.ts src/tools/__tests__/state-tools.test.ts src/hooks/persistent-mode/__tests__/cancel-race.test.ts

Fixes #2743