### PR TITLE
Fix Codex MCP config duplicate table sync

### DIFF
--- a/src/installer/__tests__/mcp-registry.test.ts
+++ b/src/installer/__tests__/mcp-registry.test.ts
@@ -314,6 +314,65 @@ describe('unified MCP registry sync', () => {
     expect(second.content).toBe(first.content);
   });
 
+  it('does not append managed duplicates for existing user-owned mcp_servers tables', () => {
+    const existingToml = [
+      'model = "gpt-5"',
+      '',
+      '[mcp_servers.atlassian]',
+      'command = "uvx"',
+      'args = ["mcp-atlassian"]',
+      '',
+    ].join('\n');
+
+    const registry = {
+      atlassian: {
+        command: 'uvx',
+        args: ['mcp-atlassian'],
+      },
+      storybook_local: {
+        command: 'npx',
+        args: ['-y', '@storybook/mcp'],
+        timeout: 15,
+      },
+    };
+
+    const result = syncCodexConfigToml(existingToml, registry);
+
+    expect(result.changed).toBe(true);
+    expect(result.content.match(/\[mcp_servers\.atlassian\]/g)).toHaveLength(1);
+    expect(result.content).toContain('[mcp_servers.storybook_local]');
+    expect(result.content).toContain('# BEGIN OMC MANAGED MCP REGISTRY');
+    expect(result.content).toContain('# END OMC MANAGED MCP REGISTRY');
+
+    const second = syncCodexConfigToml(result.content, registry);
+    expect(second.changed).toBe(false);
+    expect(second.content).toBe(result.content);
+  });
+
+  it('preserves an existing user-owned codex table when setup sync runs repeatedly', () => {
+    writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({
+      atlassian: { command: 'uvx', args: ['mcp-atlassian'] },
+      storybook_local: { command: 'npx', args: ['-y', '@storybook/mcp'], timeout: 15 },
+    }, null, 2));
+    writeFileSync(getCodexConfigPath(), [
+      'model = "gpt-5"',
+      '',
+      '[mcp_servers.atlassian]',
+      'command = "uvx"',
+      'args = ["mcp-atlassian"]',
+      '',
+    ].join('\n'));
+
+    const first = syncUnifiedMcpRegistryTargets({ theme: 'dark' });
+    const second = syncUnifiedMcpRegistryTargets({ theme: 'dark' });
+    const codexConfig = readFileSync(getCodexConfigPath(), 'utf-8');
+
+    expect(first.result.codexChanged).toBe(true);
+    expect(second.result.codexChanged).toBe(false);
+    expect(codexConfig.match(/\[mcp_servers\.atlassian\]/g)).toHaveLength(1);
+    expect(codexConfig).toContain('[mcp_servers.storybook_local]');
+  });
+
   it('removes previously managed Claude and Codex MCP entries when the registry becomes empty', () => {
     writeFileSync(join(omcDir, 'mcp-registry-state.json'), JSON.stringify({ managedServers: ['gitnexus'] }, null, 2));
     writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({}, null, 2));

--- a/src/installer/mcp-registry.ts
+++ b/src/installer/mcp-registry.ts
@@ -433,6 +433,27 @@ function stripManagedCodexBlock(content: string): string {
   return content.replace(managedBlockPattern, '').trimEnd();
 }
 
+function parseCodexMcpServerNames(content: string): Set<string> {
+  const names = new Set<string>();
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const sectionMatch = line.match(/^\[mcp_servers\.([^\]]+)\]$/);
+    if (sectionMatch) {
+      const name = sectionMatch[1].trim();
+      if (name) {
+        names.add(name);
+      }
+    }
+  }
+
+  return names;
+}
+
 export function renderManagedCodexMcpBlock(registry: UnifiedMcpRegistry): string {
   const names = Object.keys(registry);
   if (names.length === 0) {
@@ -445,7 +466,11 @@ export function renderManagedCodexMcpBlock(registry: UnifiedMcpRegistry): string
 
 export function syncCodexConfigToml(existingContent: string, registry: UnifiedMcpRegistry): { content: string; changed: boolean } {
   const base = stripManagedCodexBlock(existingContent);
-  const managedBlock = renderManagedCodexMcpBlock(registry);
+  const existingServerNames = parseCodexMcpServerNames(base);
+  const managedRegistry = Object.fromEntries(
+    Object.entries(registry).filter(([name]) => !existingServerNames.has(name))
+  );
+  const managedBlock = renderManagedCodexMcpBlock(managedRegistry);
   const nextContent = managedBlock
     ? `${base ? `${base}\n\n` : ''}${managedBlock}\n`
     : (base ? `${base}\n` : '');


### PR DESCRIPTION
## Summary
- Skip rendering managed Codex MCP entries when the same `[mcp_servers.*]` table already exists outside the OMC managed block
- Preserve user-owned Codex MCP tables while still adding missing registry entries to the managed block
- Add regression coverage for direct TOML sync and repeated setup sync runs with pre-existing Codex config entries

Closes #2748

## Verification
- `npm run test:run -- src/installer/__tests__/mcp-registry.test.ts`
- `npm run test:run -- src/__tests__/installer-mcp-config.test.ts src/__tests__/doctor-conflicts.test.ts`
- `npx tsc --noEmit --pretty false --project tsconfig.json`
- `npx eslint src/installer/mcp-registry.ts src/installer/__tests__/mcp-registry.test.ts`