### PR TITLE
fix: preserve weekly HUD quotas when stdin rate limits are present

### DIFF
--- a/src/__tests__/hud/watch-mode-init.test.ts
+++ b/src/__tests__/hud/watch-mode-init.test.ts
@@ -213,15 +213,63 @@ describe('HUD watch mode initialization', () => {
     expect(readAutopilotStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
   });
 
-  it('prefers stdin rate limits over the usage API when available', async () => {
+  it('merges stdin generic rate limits over usage API data when available', async () => {
     const hud = await importHudModule({
       config: makeConfig(true),
       stdin: makeStdin(true),
+      getUsageResult: {
+        rateLimits: {
+          fiveHourPercent: 55,
+          weeklyPercent: 10,
+          fiveHourResetsAt: new Date(1777000000 * 1000),
+          weeklyResetsAt: new Date(1777100000 * 1000),
+          sonnetWeeklyPercent: 44,
+          sonnetWeeklyResetsAt: new Date(1777200000 * 1000),
+          opusWeeklyPercent: 7,
+          opusWeeklyResetsAt: new Date(1777300000 * 1000),
+          extraUsagePercent: 3,
+          extraUsageSpentUsd: 1.25,
+          extraUsageLimitUsd: 10,
+        },
+        error: 'network',
+        stale: true,
+      },
     });
 
     await hud.main(true, false);
 
-    expect(getUsage).not.toHaveBeenCalled();
+    expect(getUsage).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledWith(expect.objectContaining({
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 11,
+          weeklyPercent: 2,
+          fiveHourResetsAt: new Date(1776348000 * 1000),
+          weeklyResetsAt: new Date(1776916800 * 1000),
+          sonnetWeeklyPercent: 44,
+          sonnetWeeklyResetsAt: new Date(1777200000 * 1000),
+          opusWeeklyPercent: 7,
+          opusWeeklyResetsAt: new Date(1777300000 * 1000),
+          extraUsagePercent: 3,
+          extraUsageSpentUsd: 1.25,
+          extraUsageLimitUsd: 10,
+        },
+        error: 'network',
+        stale: true,
+      },
+    }), expect.anything());
+  });
+
+  it('falls back to stdin rate limits when usage API returns no rate limits', async () => {
+    const hud = await importHudModule({
+      config: makeConfig(true),
+      stdin: makeStdin(true),
+      getUsageResult: { rateLimits: null, error: 'no_credentials' },
+    });
+
+    await hud.main(true, false);
+
+    expect(getUsage).toHaveBeenCalledTimes(1);
     expect(render).toHaveBeenCalledWith(expect.objectContaining({
       rateLimitsResult: {
         rateLimits: {
@@ -230,6 +278,7 @@ describe('HUD watch mode initialization', () => {
           fiveHourResetsAt: new Date(1776348000 * 1000),
           weeklyResetsAt: new Date(1776916800 * 1000),
         },
+        error: 'no_credentials',
       },
     }), expect.anything());
   });

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -37,8 +37,10 @@ import { refreshMissionBoardState } from "./mission-board.js";
 import { sanitizeOutput } from "./sanitize.js";
 import type {
   HudRenderContext,
+  RateLimits,
   SessionHealth,
   SessionSummaryState,
+  UsageResult,
 } from "./types.js";
 import { getRuntimePackageVersion } from "../lib/version.js";
 import { compareVersions } from "../features/auto-update.js";
@@ -62,6 +64,23 @@ function extractSessionIdFromPath(transcriptPath: string): string | null {
   if (!transcriptPath) return null;
   const match = transcriptPath.match(/([0-9a-f-]{36})(?:\.jsonl)?$/i);
   return match ? match[1] : null;
+}
+
+function mergeStdinRateLimits(
+  stdinRateLimits: RateLimits | null,
+  usageResult: UsageResult | null,
+): UsageResult | null {
+  if (!stdinRateLimits) {
+    return usageResult;
+  }
+
+  return {
+    ...(usageResult ?? {}),
+    rateLimits: {
+      ...(usageResult?.rateLimits ?? {}),
+      ...stdinRateLimits,
+    },
+  };
 }
 
 /**
@@ -340,14 +359,15 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       writeHudState(stateToWrite, cwd, currentSessionId ?? undefined);
     }
 
-    // Prefer Claude Code stdin rate limits when available to avoid cold-start API fetches.
+    // Merge Claude Code stdin generic buckets with API/cache-specific fields.
+    // Stdin owns fresher five-hour/seven-day values, while getUsage() may provide
+    // Sonnet/Opus weekly, monthly, extra, stale, and error metadata.
     const stdinRateLimits = getRateLimitsFromStdin(stdin);
+    const usageResult = config.elements.rateLimits === false ? null : await getUsage();
     const rateLimitsResult =
       config.elements.rateLimits === false
         ? null
-        : stdinRateLimits
-          ? { rateLimits: stdinRateLimits }
-          : await getUsage();
+        : mergeStdinRateLimits(stdinRateLimits, usageResult);
 
     // Fetch custom rate limit buckets (if configured)
     const customBuckets =


### PR DESCRIPTION
## Summary
- preserve Sonnet/Opus weekly HUD values even when Claude Code stdin already provides generic rate limit buckets
- merge stdin generic buckets over usage API data instead of short-circuiting weekly quota data
- add focused HUD regression coverage for the stdin + weekly quota path

## Testing
- npx eslint src/hud/index.ts src/__tests__/hud/watch-mode-init.test.ts
- npm test -- --run src/__tests__/hud/watch-mode-init.test.ts src/__tests__/hud/stdin.test.ts src/__tests__/hud/render-rate-limits-priority.test.ts
- npm run build

Closes #2750
