### PR TITLE
Fix Windows Claude CLI .cmd launch detection

### DIFF
--- a/src/cli/__tests__/autoresearch-setup-session.test.ts
+++ b/src/cli/__tests__/autoresearch-setup-session.test.ts
@@ -87,4 +87,27 @@ describe('runAutoresearchSetupSession', () => {
 
     expect(() => runAutoresearchSetupSession({ repoRoot: '/repo', missionText: 'Improve launch flow' })).toThrow(/claude_autoresearch_setup_failed:2/);
   });
+
+  it('uses shell:true on win32 so claude.cmd can run in print mode', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 0,
+      stdout: '{"missionText":"Improve launch flow","evaluatorCommand":"npm run test:run -- launch","evaluatorSource":"inferred","confidence":0.86,"slug":"launch-flow","readyToLaunch":true}',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+    } as ReturnType<typeof spawnSync>);
+
+    runAutoresearchSetupSession({ repoRoot: '/repo', missionText: 'Improve launch flow' });
+
+    expect(vi.mocked(spawnSync)).toHaveBeenCalledWith('claude', ['-p', expect.any(String)], expect.objectContaining({
+      cwd: '/repo',
+      encoding: 'utf-8',
+      shell: true,
+    }));
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
 });

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -193,6 +193,22 @@ describe('runClaude — exit code propagation', () => {
 
       expect(processExitSpy).not.toHaveBeenCalled();
     });
+
+    it('uses shell:true on win32 so claude.cmd can launch', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
+
+      runClaude('/tmp', ['--resume'], 'sid');
+
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledWith('claude', ['--resume'], {
+        cwd: '/tmp',
+        stdio: 'inherit',
+        shell: true,
+      });
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    });
   });
 
   describe('inside-tmux policy', () => {
@@ -221,6 +237,22 @@ describe('runClaude — exit code propagation', () => {
       runClaude('/tmp', [], 'sid');
 
       expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('uses shell:true on win32 so claude.cmd can launch inside tmux', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
+
+      runClaude('/tmp', ['--continue'], 'sid');
+
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledWith('claude', ['--continue'], {
+        cwd: '/tmp',
+        stdio: 'inherit',
+        shell: true,
+      });
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     });
 
     it('exits with code 1 on ENOENT', () => {

--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -24,6 +24,7 @@ import {
   buildTmuxShellCommand,
   buildTmuxShellCommandWithEnv,
   createHudWatchPane,
+  isClaudeAvailable,
   killTmuxPane,
   listHudWatchPaneIdsInCurrentWindow,
   resolveLaunchPolicy,
@@ -128,6 +129,22 @@ describe('resolveLaunchPolicy', () => {
       ['/d', '/s', '/c', '"C:\\Program Files\\psmux\\tmux.cmd" -V'],
       { timeout: 5000 }
     );
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+});
+
+describe('isClaudeAvailable', () => {
+  it('uses shell:true on win32 so npm .cmd wrappers resolve', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    mockedExecFileSync.mockReturnValue(Buffer.from('2.1.116'));
+
+    expect(isClaudeAvailable()).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith('claude', ['--version'], {
+      stdio: 'ignore',
+      shell: true,
+    });
 
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   });

--- a/src/cli/autoresearch-setup-session.ts
+++ b/src/cli/autoresearch-setup-session.ts
@@ -145,6 +145,7 @@ export function runAutoresearchSetupSession(input: AutoresearchSetupSessionInput
   const result = spawnSync('claude', ['-p', prompt], {
     cwd: input.repoRoot,
     encoding: 'utf-8',
+    shell: process.platform === 'win32',
     env: {
       ...process.env,
       CLAUDE_CODE_ENTRYPOINT: AUTORESEARCH_SETUP_ENTRYPOINT,

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -412,7 +412,11 @@ function runClaudeInsideTmux(cwd: string, args: string[]): void {
 
   // Launch Claude in current pane
   try {
-    execFileSync('claude', args, { cwd, stdio: 'inherit' });
+    execFileSync('claude', args, {
+      cwd,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
   } catch (error) {
     const err = error as NodeJS.ErrnoException & { status?: number | null };
     if (err.code === 'ENOENT') {
@@ -516,7 +520,11 @@ function runClaudeOutsideTmux(cwd: string, args: string[], _sessionId: string): 
  */
 function runClaudeDirect(cwd: string, args: string[]): void {
   try {
-    execFileSync('claude', args, { cwd, stdio: 'inherit' });
+    execFileSync('claude', args, {
+      cwd,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
   } catch (error) {
     const err = error as NodeJS.ErrnoException & { status?: number | null };
     if (err.code === 'ENOENT') {

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -200,7 +200,10 @@ export function isTmuxAvailable(): boolean {
  */
 export function isClaudeAvailable(): boolean {
   try {
-    execFileSync('claude', ['--version'], { stdio: 'ignore' });
+    execFileSync('claude', ['--version'], {
+      stdio: 'ignore',
+      shell: process.platform === 'win32',
+    });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- Add Windows-only shell execution to real source Claude CLI detection and launch paths so npm-installed claude.cmd wrappers resolve.
- Cover direct launch, inside-tmux launch, availability probing, and autoresearch print-mode setup.
- Keep Unix behavior unchanged by guarding shell execution with process.platform === 'win32'.

Fixes #2752.

## Verification
- npm test -- --run src/cli/__tests__/tmux-utils.test.ts src/cli/__tests__/launch.test.ts src/cli/__tests__/autoresearch-setup-session.test.ts
- npx eslint src/cli/tmux-utils.ts src/cli/launch.ts src/cli/autoresearch-setup-session.ts src/cli/__tests__/tmux-utils.test.ts src/cli/__tests__/launch.test.ts src/cli/__tests__/autoresearch-setup-session.test.ts
- npx tsc --noEmit

## Notes
- Not tested on a real Windows host; regression coverage stubs win32 and asserts shell:true is passed.