### PR TITLE
Fix /ccg routing when PATH omc is stale

### DIFF
--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -299,7 +299,7 @@ Deep interview body`
       .toContain('Skill("oh-my-claudecode:autoresearch")');
   });
 
-  it('keeps /ccg advisor asks on omc ask inside an active Claude session', async () => {
+  it('routes /ccg advisor asks through the plugin bridge inside an active Claude session when CLAUDE_PLUGIN_ROOT is set', async () => {
     process.env.CLAUDE_PLUGIN_ROOT = '/plugin-root';
     process.env.PATH = '';
     process.env.CLAUDECODE = '1';
@@ -313,9 +313,9 @@ Deep interview body`
     });
 
     expect(result.success).toBe(true);
-    expect(result.replacementText).toContain('`omc ask codex "<codex prompt>"`');
-    expect(result.replacementText).toContain('`omc ask gemini "<gemini prompt>"`');
-    expect(result.replacementText).not.toContain('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask codex');
-    expect(result.replacementText).not.toContain('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask gemini');
+    expect(result.replacementText).toContain('`node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask codex "<codex prompt>"`');
+    expect(result.replacementText).toContain('`node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask gemini "<gemini prompt>"`');
+    expect(result.replacementText).not.toContain('`omc ask codex "<codex prompt>"`');
+    expect(result.replacementText).not.toContain('`omc ask gemini "<gemini prompt>"`');
   });
 });

--- a/src/__tests__/omc-cli-rendering.test.ts
+++ b/src/__tests__/omc-cli-rendering.test.ts
@@ -35,23 +35,25 @@ describe('omc CLI rendering', () => {
     expect(output).toContain('> node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask codex --agent-prompt critic "check"');
   });
 
-  it('keeps omc ask invocations inside an active Claude session to avoid nested bridge launches', () => {
+  it('routes ask invocations through the plugin bridge inside an active Claude session when CLAUDE_PLUGIN_ROOT is set', () => {
     const env = {
       CLAUDE_PLUGIN_ROOT: '/tmp/plugin-root',
       CLAUDECODE: '1',
       CLAUDE_SESSION_ID: 'session-123',
     } as NodeJS.ProcessEnv;
 
-    expect(resolveOmcCliPrefix({ omcAvailable: true, env })).toBe('omc');
-    expect(formatOmcCliInvocation('ask codex --prompt "check"', { omcAvailable: true, env }))
-      .toBe('omc ask codex --prompt "check"');
+    expect(resolveOmcCliPrefix({ omcAvailable: false, env })).toBe('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs');
+    expect(formatOmcCliInvocation('ask codex --prompt "check"', { omcAvailable: false, env }))
+      .toBe('node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask codex --prompt "check"');
 
     const input = [
       'Run `omc ask codex "review"`.',
       '> omc ask gemini --prompt "improve docs"',
     ].join('\n');
 
-    expect(rewriteOmcCliInvocations(input, { omcAvailable: true, env })).toBe(input);
+    const output = rewriteOmcCliInvocations(input, { omcAvailable: false, env });
+    expect(output).toContain('`node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask codex "review"`');
+    expect(output).toContain('> node "$CLAUDE_PLUGIN_ROOT"/bridge/cli.cjs ask gemini --prompt "improve docs"');
   });
 
   it('leaves text unchanged when omc remains the selected prefix', () => {

--- a/src/utils/omc-cli-rendering.ts
+++ b/src/utils/omc-cli-rendering.ts
@@ -17,14 +17,6 @@ function commandExists(command: string, env: NodeJS.ProcessEnv): boolean {
   return result.status === 0;
 }
 
-function isClaudeSession(env: NodeJS.ProcessEnv): boolean {
-  return Boolean(
-    env.CLAUDECODE?.trim()
-    || env.CLAUDE_SESSION_ID?.trim()
-    || env.CLAUDECODE_SESSION_ID?.trim(),
-  );
-}
-
 export function resolveOmcCliPrefix(options: OmcCliRenderOptions = {}): string {
   const env = options.env ?? process.env;
   const omcAvailable = options.omcAvailable ?? commandExists(OMC_CLI_BINARY, env);
@@ -44,15 +36,7 @@ function resolveInvocationPrefix(
   commandSuffix: string,
   options: OmcCliRenderOptions = {},
 ): string {
-  const env = options.env ?? process.env;
-  const normalizedSuffix = commandSuffix.trim();
-
-  // Ask flows are intentionally safe inside Claude Code and must not be
-  // rewritten to the bridge binary, which can re-enter the launch guard.
-  if (/^ask(?:\s|$)/.test(normalizedSuffix) && isClaudeSession(env)) {
-    return OMC_CLI_BINARY;
-  }
-
+  void commandSuffix;
   return resolveOmcCliPrefix(options);
 }
 


### PR DESCRIPTION
## Summary
- route /ccg advisor asks through the plugin bridge when `CLAUDE_PLUGIN_ROOT` is set so stale PATH `omc` cannot hijack ask flows
- remove the Claude-session special case that preserved bare `omc ask` rendering
- lock the regression with targeted CLI rendering and auto-slash alias tests

## Verification
- `npx vitest run src/__tests__/omc-cli-rendering.test.ts src/__tests__/auto-slash-aliases.test.ts`

Closes #2757
