### PR TITLE
Centralize ultrawork protocol routing

### DIFF
--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -6,7 +6,7 @@ level: 4
 ---
 
 <Purpose>
-Ultrawork is a parallel execution engine that runs multiple agents simultaneously for independent tasks. It is a component, not a standalone persistence mode -- it provides parallelism and smart model routing but not persistence, verification loops, or state management.
+Ultrawork is a parallel execution engine and execution protocol for independent work. It emphasizes intent grounding, parallel context gathering, dependency-aware task graphs for non-trivial work, and concise evidence-backed execution summaries. It is a component, not a standalone persistence mode -- it provides parallelism and routing guidance, but not persistence, verification loops, or long-lived state management.
 </Purpose>
 
 <Use_When>
@@ -33,21 +33,34 @@ Sequential task execution wastes time when tasks are independent. Ultrawork enab
 - Read `docs/shared/agent-tiers.md` before first delegation for agent selection guidance
 - Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests)
 - Run quick commands (git status, file reads, simple checks) in the foreground
+- Resolve intent and uncertainty before implementation; explore first, ask only when still blocked
+- For non-trivial tasks, produce a dependency-aware plan with parallel waves before execution
+- Keep delegated-task reports concise: short summary, files touched, verification status, blockers
+- Manual QA is required for implemented behavior, not just diagnostics
 </Execution_Policy>
 
 <Steps>
 1. **Read agent reference**: Load `docs/shared/agent-tiers.md` for tier selection
-2. **Classify tasks by independence**: Identify which tasks can run in parallel vs which have dependencies
-3. **Route to correct tiers**:
+2. **Ground intent first**: Confirm whether the request is implementation, investigation, evaluation, or research; do not code before that is clear
+3. **Gather context in parallel**:
+   - direct tools for quick reads/searches
+   - exploration/docs agents for broad context
+4. **Classify tasks by independence**: Identify which tasks can run in parallel vs which have dependencies
+5. **Create a task graph for non-trivial work**:
+   - Parallel Execution Waves
+   - Dependency Matrix
+   - acceptance criteria and verification steps per task
+6. **Route to correct tiers**:
    - Simple lookups/definitions: LOW tier (Haiku)
    - Standard implementation: MEDIUM tier (Sonnet)
    - Complex analysis/refactoring: HIGH tier (Opus)
-4. **Fire independent tasks simultaneously**: Launch all parallel-safe tasks at once
-5. **Run dependent tasks sequentially**: Wait for prerequisites before launching dependent work
-6. **Background long operations**: Builds, installs, and test suites use `run_in_background: true`
-7. **Verify when all tasks complete** (lightweight):
+7. **Fire independent tasks simultaneously**: Launch all parallel-safe tasks at once
+8. **Run dependent tasks sequentially**: Wait for prerequisites before launching dependent work
+9. **Background long operations**: Builds, installs, and test suites use `run_in_background: true`
+10. **Verify when all tasks complete** (lightweight):
    - Build/typecheck passes
    - Affected tests pass
+   - Manual QA completed for implemented behavior
    - No new errors introduced
 </Steps>
 

--- a/src/__tests__/issue-2652-runtime-wiring-and-output-contract.test.ts
+++ b/src/__tests__/issue-2652-runtime-wiring-and-output-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ULTRAWORK_MESSAGE } from '../installer/hooks.js';
+import { getUltraworkMessage } from '../hooks/keyword-detector/ultrawork/index.js';
 
 describe('issue #2652 runtime wiring and output contract', () => {
   it('ships the Stop hook through persistent-mode.mjs', () => {
@@ -19,6 +20,7 @@ describe('issue #2652 runtime wiring and output contract', () => {
   });
 
   it('ultrawork mode instructs spawned agents to keep outputs concise', () => {
+    expect(ULTRAWORK_MESSAGE).toBe(getUltraworkMessage());
     expect(ULTRAWORK_MESSAGE).toContain('CONCISE OUTPUTS');
     expect(ULTRAWORK_MESSAGE).toContain('under 100 words');
     expect(ULTRAWORK_MESSAGE).toContain('files touched');

--- a/src/features/__tests__/magic-keywords.test.ts
+++ b/src/features/__tests__/magic-keywords.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMagicKeywordProcessor } from '../magic-keywords.js';
+
+describe('magic-keywords ultrawork integration', () => {
+  it('uses the centralized default ultrawork generator', () => {
+    const processPrompt = createMagicKeywordProcessor();
+    const result = processPrompt('ultrawork fix this task');
+
+    expect(result).toContain('ULTRAWORK MODE ENABLED!');
+    expect(result).toContain('CONCISE OUTPUTS');
+    expect(result).toContain('fix this task');
+  });
+
+  it('routes planner context before model context', () => {
+    const processPrompt = createMagicKeywordProcessor();
+    const result = processPrompt('ultrawork plan this change', 'planner', 'gpt-5.4');
+
+    expect(result).toContain('CRITICAL: YOU ARE A PLANNER, NOT AN IMPLEMENTER');
+    expect(result).toContain('Parallel Execution Waves');
+    expect(result).not.toContain('<output_verbosity_spec>');
+  });
+});

--- a/src/features/magic-keywords.ts
+++ b/src/features/magic-keywords.ts
@@ -6,6 +6,7 @@
  */
 
 import type { MagicKeyword, PluginConfig } from '../shared/types.js';
+import { getUltraworkMessage } from '../hooks/keyword-detector/ultrawork/index.js';
 
 /**
  * Code block pattern for stripping from detection
@@ -61,208 +62,16 @@ function hasActionableTrigger(text: string, trigger: string): boolean {
 }
 
 /**
- * Ultrawork Planner Section - for planner-type agents
- */
-const ULTRAWORK_PLANNER_SECTION = `## CRITICAL: YOU ARE A PLANNER, NOT AN IMPLEMENTER
-
-**IDENTITY CONSTRAINT (NON-NEGOTIABLE):**
-You ARE the planner. You ARE NOT an implementer. You DO NOT write code. You DO NOT execute tasks.
-
-**TOOL RESTRICTIONS (SYSTEM-ENFORCED):**
-| Tool | Allowed | Blocked |
-|------|---------|---------|
-| Write/Edit | \`.omc/**/*.md\` ONLY | Everything else |
-| Read | All files | - |
-| Bash | Research commands only | Implementation commands |
-| Task | explore, document-specialist | - |
-
-**IF YOU TRY TO WRITE/EDIT OUTSIDE \`.omc/\`:**
-- System will BLOCK your action
-- You will receive an error
-- DO NOT retry - you are not supposed to implement
-
-**YOUR ONLY WRITABLE PATHS:**
-- \`.omc/plans/*.md\` - Final work plans
-- \`.omc/drafts/*.md\` - Working drafts during interview
-
-**WHEN USER ASKS YOU TO IMPLEMENT:**
-REFUSE. Say: "I'm a planner. I create work plans, not implementations. Start implementing after I finish planning."
-
----
-
-## CONTEXT GATHERING (MANDATORY BEFORE PLANNING)
-
-You ARE the planner. Your job: create bulletproof work plans.
-**Before drafting ANY plan, gather context via explore/document-specialist agents.**
-
-### Research Protocol
-1. **Fire parallel background agents** for comprehensive context:
-   \`\`\`
-   Task(subagent_type="explore", prompt="Find existing patterns for [topic] in codebase", run_in_background=true)
-   Task(subagent_type="explore", prompt="Find test infrastructure and conventions", run_in_background=true)
-   Task(subagent_type="document-specialist", prompt="Find official docs and best practices for [technology]", run_in_background=true)
-   \`\`\`
-2. **Wait for results** before planning - rushed plans fail
-3. **Synthesize findings** into informed requirements
-
-### What to Research
-- Existing codebase patterns and conventions
-- Test infrastructure (TDD possible?)
-- External library APIs and constraints
-- Similar implementations in OSS (via document-specialist)
-
-**NEVER plan blind. Context first, plan second.**`;
-
-/**
- * Determines if the agent is a planner-type agent.
- * Planner agents should NOT be told to call plan agent (they ARE the planner).
- */
-function isPlannerAgent(agentName?: string): boolean {
-  if (!agentName) return false;
-  const lowerName = agentName.toLowerCase();
-  return lowerName.includes('planner') || lowerName.includes('planning') || lowerName === 'plan';
-}
-
-/**
- * Generates the ultrawork message based on agent context.
- * Planner agents get context-gathering focused instructions.
- * Other agents get the original strong agent utilization instructions.
- */
-function getUltraworkMessage(agentName?: string): string {
-  const isPlanner = isPlannerAgent(agentName);
-
-  if (isPlanner) {
-    return `<ultrawork-mode>
-
-**MANDATORY**: You MUST say "ULTRAWORK MODE ENABLED!" to the user as your first response when this mode activates. This is non-negotiable.
-
-${ULTRAWORK_PLANNER_SECTION}
-
-</ultrawork-mode>
-
----
-
-`;
-  }
-
-  return `<ultrawork-mode>
-
-**MANDATORY**: You MUST say "ULTRAWORK MODE ENABLED!" to the user as your first response when this mode activates. This is non-negotiable.
-
-[CODE RED] Maximum precision required. Ultrathink before acting.
-
-YOU MUST LEVERAGE ALL AVAILABLE AGENTS TO THEIR FULLEST POTENTIAL.
-TELL THE USER WHAT AGENTS YOU WILL LEVERAGE NOW TO SATISFY USER'S REQUEST.
-
-## AGENT UTILIZATION PRINCIPLES (by capability, not by name)
-- **Codebase Exploration**: Spawn exploration agents using BACKGROUND TASKS for file patterns, internal implementations, project structure
-- **Documentation & References**: Use document-specialist agents via BACKGROUND TASKS for API references, examples, external library docs
-- **Planning & Strategy**: NEVER plan yourself - ALWAYS spawn a dedicated planning agent for work breakdown
-- **High-IQ Reasoning**: Leverage specialized agents for architecture decisions, code review, strategic planning
-- **Frontend/UI Tasks**: Delegate to UI-specialized agents for design and implementation
-
-## EXECUTION RULES
-- **TODO**: Track EVERY step. Mark complete IMMEDIATELY after each.
-- **PARALLEL**: Fire independent agent calls simultaneously via Task(run_in_background=true) - NEVER wait sequentially.
-- **BACKGROUND FIRST**: Use Task for exploration/document-specialist agents (10+ concurrent if needed).
-- **VERIFY**: Re-read request after completion. Check ALL requirements met before reporting done.
-- **DELEGATE**: Don't do everything yourself - orchestrate specialized agents for their strengths.
-
-## WORKFLOW
-1. Analyze the request and identify required capabilities
-2. Spawn exploration/document-specialist agents via Task(run_in_background=true) in PARALLEL (10+ if needed)
-3. Always Use Plan agent with gathered context to create detailed work breakdown
-4. Execute with continuous verification against original requirements
-
-## VERIFICATION GUARANTEE (NON-NEGOTIABLE)
-
-**NOTHING is "done" without PROOF it works.**
-
-### Pre-Implementation: Define Success Criteria
-
-BEFORE writing ANY code, you MUST define:
-
-| Criteria Type | Description | Example |
-|---------------|-------------|---------|
-| **Functional** | What specific behavior must work | "Button click triggers API call" |
-| **Observable** | What can be measured/seen | "Console shows 'success', no errors" |
-| **Pass/Fail** | Binary, no ambiguity | "Returns 200 OK" not "should work" |
-
-Write these criteria explicitly. Share with user if scope is non-trivial.
-
-### Test Plan Template (MANDATORY for non-trivial tasks)
-
-\`\`\`
-## Test Plan
-### Objective: [What we're verifying]
-### Prerequisites: [Setup needed]
-### Test Cases:
-1. [Test Name]: [Input] → [Expected Output] → [How to verify]
-2. ...
-### Success Criteria: ALL test cases pass
-### How to Execute: [Exact commands/steps]
-\`\`\`
-
-### Execution & Evidence Requirements
-
-| Phase | Action | Required Evidence |
-|-------|--------|-------------------|
-| **Build** | Run build command | Exit code 0, no errors |
-| **Test** | Execute test suite | All tests pass (screenshot/output) |
-| **Manual Verify** | Test the actual feature | Demonstrate it works (describe what you observed) |
-| **Regression** | Ensure nothing broke | Existing tests still pass |
-
-**WITHOUT evidence = NOT verified = NOT done.**
-
-### TDD Workflow (when test infrastructure exists)
-
-1. **SPEC**: Define what "working" means (success criteria above)
-2. **RED**: Write failing test → Run it → Confirm it FAILS
-3. **GREEN**: Write minimal code → Run test → Confirm it PASSES
-4. **REFACTOR**: Clean up → Tests MUST stay green
-5. **VERIFY**: Run full test suite, confirm no regressions
-6. **EVIDENCE**: Report what you ran and what output you saw
-
-### Verification Anti-Patterns (BLOCKING)
-
-| Violation | Why It Fails |
-|-----------|--------------|
-| "It should work now" | No evidence. Run it. |
-| "I added the tests" | Did they pass? Show output. |
-| "Fixed the bug" | How do you know? What did you test? |
-| "Implementation complete" | Did you verify against success criteria? |
-| Skipping test execution | Tests exist to be RUN, not just written |
-
-**CLAIM NOTHING WITHOUT PROOF. EXECUTE. VERIFY. SHOW EVIDENCE.**
-
-## ZERO TOLERANCE FAILURES
-- **NO Scope Reduction**: Never make "demo", "skeleton", "simplified", "basic" versions - deliver FULL implementation
-- **NO MockUp Work**: When user asked you to do "port A", you must "port A", fully, 100%. No Extra feature, No reduced feature, no mock data, fully working 100% port.
-- **NO Partial Completion**: Never stop at 60-80% saying "you can extend this..." - finish 100%
-- **NO Assumed Shortcuts**: Never skip requirements you deem "optional" or "can be added later"
-- **NO Premature Stopping**: Never declare done until ALL TODOs are completed and verified
-- **NO TEST DELETION**: Never delete or skip failing tests to make the build pass. Fix the code, not the tests.
-
-THE USER ASKED FOR X. DELIVER EXACTLY X. NOT A SUBSET. NOT A DEMO. NOT A STARTING POINT.
-
-</ultrawork-mode>
-
----
-
-`;
-}
-
-/**
  * Ultrawork mode enhancement
  * Activates maximum performance with parallel agent orchestration
  */
 const ultraworkEnhancement: MagicKeyword = {
   triggers: ['ultrawork', 'ulw', 'uw'],
   description: 'Activates maximum performance mode with parallel agent orchestration',
-  action: (prompt: string, agentName?: string) => {
+  action: (prompt: string, agentName?: string, modelId?: string) => {
     // Remove the trigger word and add enhancement instructions
     const cleanPrompt = removeTriggerWords(prompt, ['ultrawork', 'ulw', 'uw']);
-    return getUltraworkMessage(agentName) + cleanPrompt;
+    return getUltraworkMessage(agentName, modelId) + cleanPrompt;
   }
 };
 
@@ -389,7 +198,7 @@ export const builtInMagicKeywords: MagicKeyword[] = [
 /**
  * Create a magic keyword processor with custom triggers
  */
-export function createMagicKeywordProcessor(config?: PluginConfig['magicKeywords']): (prompt: string, agentName?: string) => string {
+export function createMagicKeywordProcessor(config?: PluginConfig['magicKeywords']): (prompt: string, agentName?: string, modelId?: string) => string {
   const keywords = builtInMagicKeywords.map(k => ({ ...k, triggers: [...k.triggers] }));
 
   // Override triggers from config
@@ -420,7 +229,7 @@ export function createMagicKeywordProcessor(config?: PluginConfig['magicKeywords
     }
   }
 
-  return (prompt: string, agentName?: string): string => {
+  return (prompt: string, agentName?: string, modelId?: string): string => {
     let result = prompt;
 
     for (const keyword of keywords) {
@@ -429,7 +238,7 @@ export function createMagicKeywordProcessor(config?: PluginConfig['magicKeywords
       });
 
       if (hasKeyword) {
-        result = keyword.action(result, agentName);
+        result = keyword.action(result, agentName, modelId);
       }
     }
 

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -128,6 +128,33 @@ describe('processHook - Routing Matrix', () => {
       expect(typeof result.message).toBe('string');
     });
 
+    it('routes ultrawork planner context ahead of model routing', async () => {
+      const result = await processHook('keyword-detector', {
+        sessionId: 'test-session',
+        prompt: '/ultrawork fix the complex multi-step regression in src/hooks/bridge.ts function processKeywordDetector by preserving keyword routing, state activation behavior, verification messaging, prompt enhancement flow, bridge wiring, runtime output guarantees, prompt-context propagation, and related test coverage, installer constants, generated bridge artifacts, keyword false-positive behavior, session isolation assumptions, and developer-facing documentation without changing unrelated orchestration behavior elsewhere in this worktree',
+        directory: '/tmp/test-routing',
+        agent_name: 'planner',
+        model: 'gpt-5.4',
+      } as HookInput & { agent_name: string; model: string });
+
+      expect(result.continue).toBe(true);
+      expect(result.message).toContain('CRITICAL: YOU ARE A PLANNER, NOT AN IMPLEMENTER');
+      expect(result.message).toContain('Parallel Execution Waves');
+    });
+
+    it('routes ultrawork gpt models to the GPT-oriented protocol', async () => {
+      const result = await processHook('keyword-detector', {
+        sessionId: 'test-session',
+        prompt: '/ultrawork fix the complex multi-step regression in src/hooks/bridge.ts function processKeywordDetector by preserving keyword routing, state activation behavior, verification messaging, prompt enhancement flow, bridge wiring, runtime output guarantees, prompt-context propagation, and related test coverage, installer constants, generated bridge artifacts, keyword false-positive behavior, session isolation assumptions, and developer-facing documentation without changing unrelated orchestration behavior elsewhere in this worktree',
+        directory: '/tmp/test-routing',
+        model: 'gpt-5.4',
+      } as HookInput & { model: string });
+
+      expect(result.continue).toBe(true);
+      expect(result.message).toContain('<output_verbosity_spec>');
+      expect(result.message).toContain('DECISION FRAMEWORK: Self vs Delegate');
+    });
+
     it('should route code review keyword to the review mode message', async () => {
       const input: HookInput = {
         sessionId: 'test-session',

--- a/src/hooks/bridge-normalize.ts
+++ b/src/hooks/bridge-normalize.ts
@@ -39,6 +39,11 @@ const HookInputSchema = z.object({
   prompt: z.string().optional(),
   message: z.object({ content: z.string().optional() }).optional(),
   parts: z.array(z.object({ type: z.string(), text: z.string().optional() })).optional(),
+  model: z.string().optional(),
+  model_id: z.string().optional(),
+  modelId: z.string().optional(),
+  agent_name: z.string().optional(),
+  agentName: z.string().optional(),
 
   // Stop hook fields
   stop_reason: z.string().optional(),
@@ -72,6 +77,11 @@ interface RawHookInput {
   prompt?: string;
   message?: { content?: string };
   parts?: Array<{ type: string; text?: string }>;
+  model?: string;
+  model_id?: string;
+  modelId?: string;
+  agent_name?: string;
+  agentName?: string;
 
   // Allow other fields to pass through
   [key: string]: unknown;
@@ -98,6 +108,7 @@ const KNOWN_FIELDS = new Set([
   'permission_mode', 'tool_use_id', 'transcript_path',
   // Subagent fields
   'agent_id', 'agent_name', 'agent_type', 'parent_session_id',
+  'agentName', 'model', 'model_id', 'modelId',
   // Common extra fields from Claude Code
   'input', 'output', 'result', 'error', 'status',
   // Session-end fields

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -81,7 +81,6 @@ import {
 } from "./skill-state/index.js";
 import { parseExplicitWorkflowSlashInvocation } from "./keyword-detector/index.js";
 import {
-  ULTRAWORK_MESSAGE,
   ULTRATHINK_MESSAGE,
   SEARCH_MESSAGE,
   ANALYZE_MESSAGE,
@@ -91,6 +90,7 @@ import {
   RALPH_MESSAGE,
   PROMPT_TRANSLATION_MESSAGE,
 } from "../installer/hooks.js";
+import { getUltraworkMessage } from "./keyword-detector/ultrawork/index.js";
 // Agent dashboard is used in pre/post-tool-use hot path
 import { getAgentDashboard } from "./subagent-tracker/index.js";
 // Session replay recordFileTouch is used in pre-tool-use hot path
@@ -168,6 +168,16 @@ function getExtraField(input: HookInput, key: string): unknown {
 function getHookToolUseId(input: HookInput): string | undefined {
   const value = getExtraField(input, "tool_use_id");
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function getHookContextString(input: HookInput, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = getExtraField(input, key);
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
 }
 
 function extractAsyncAgentId(toolOutput: unknown): string | undefined {
@@ -738,6 +748,10 @@ function validateHookInput<T>(
 export interface HookInput {
   /** Session identifier */
   sessionId?: string;
+  /** Optional agent name context for routing prompt variants */
+  agentName?: string;
+  /** Optional model identifier context for routing prompt variants */
+  model?: string;
   /** User prompt text */
   prompt?: string;
   /** Message content (alternative to prompt) */
@@ -1280,7 +1294,12 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
         if (activated) {
           markModeAwaitingConfirmation(directory, sessionId, 'ultrawork');
         }
-        messages.push(ULTRAWORK_MESSAGE);
+        messages.push(
+          getUltraworkMessage(
+            getHookContextString(input, "agentName", "agent_name"),
+            getHookContextString(input, "model", "modelId", "model_id"),
+          ),
+        );
         break;
       }
 

--- a/src/hooks/keyword-detector/ultrawork/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/ultrawork/__tests__/index.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getUltraworkMessage,
+  getUltraworkSource,
+  isGeminiModel,
+  isGptModel,
+  isPlannerAgent,
+} from '../index.js';
+
+describe('ultrawork message routing', () => {
+  it('routes planner before model family', () => {
+    expect(isPlannerAgent('planner')).toBe(true);
+    expect(getUltraworkSource('planner', 'gpt-5.4')).toBe('planner');
+
+    const message = getUltraworkMessage('planner', 'gpt-5.4');
+    expect(message).toContain('CRITICAL: YOU ARE A PLANNER, NOT AN IMPLEMENTER');
+    expect(message).toContain('Parallel Execution Waves');
+    expect(message).toContain('Dependency Matrix');
+  });
+
+  it('routes GPT and Codex-family models to the GPT variant', () => {
+    expect(isGptModel('gpt-5.4')).toBe(true);
+    expect(isGptModel('codex-mini')).toBe(true);
+    expect(getUltraworkSource(undefined, 'gpt-5.4')).toBe('gpt');
+
+    const message = getUltraworkMessage(undefined, 'gpt-5.4');
+    expect(message).toContain('<output_verbosity_spec>');
+    expect(message).toContain('DECISION FRAMEWORK: Self vs Delegate');
+    expect(message).toContain('MANUAL QA IS MANDATORY');
+  });
+
+  it('routes Gemini-family models to the Gemini variant', () => {
+    expect(isGeminiModel('gemini-2.5-pro')).toBe(true);
+    expect(getUltraworkSource(undefined, 'gemini-2.5-pro')).toBe('gemini');
+
+    const message = getUltraworkMessage(undefined, 'gemini-2.5-pro');
+    expect(message).toContain('STEP 0: CLASSIFY INTENT');
+    expect(message).toContain('ANTI-SKIP RULES');
+  });
+
+  it('falls back to the default variant and preserves concise-output guarantees', () => {
+    expect(getUltraworkSource(undefined, 'claude-sonnet-4')).toBe('default');
+
+    const message = getUltraworkMessage(undefined, 'claude-sonnet-4');
+    expect(message).toContain('CONCISE OUTPUTS');
+    expect(message).toContain('under 100 words');
+    expect(message).toContain('files touched');
+    expect(message).toContain('verification status');
+  });
+});

--- a/src/hooks/keyword-detector/ultrawork/default.ts
+++ b/src/hooks/keyword-detector/ultrawork/default.ts
@@ -1,0 +1,67 @@
+export const ULTRAWORK_DEFAULT_MESSAGE = `<ultrawork-mode>
+
+**MANDATORY**: You MUST say "ULTRAWORK MODE ENABLED!" to the user as your first response when this mode activates. This is non-negotiable.
+
+[CODE RED] Maximum precision required. Ultrathink before acting.
+
+## CERTAINTY PROTOCOL
+
+Do not implement until you understand:
+- the user's exact intent
+- the existing codebase pattern to follow
+- which files own the behavior
+- how you will verify the result
+
+If uncertainty remains:
+1. Explore the codebase in parallel
+2. Gather external docs only when needed
+3. Use a planner for non-trivial dependency graphs
+4. Ask the user only if ambiguity still blocks safe execution
+
+## AGENT UTILIZATION PRINCIPLES
+
+- **Explore first**: spawn exploration work for code paths, patterns, and tests
+- **Research when needed**: use document-specialist / researcher agents for external APIs and official docs
+- **Plan non-trivial work**: create a dependency-aware task graph before multi-file implementation
+- **Delegate by specialty**: use executor, test-engineer, writer, verifier, architect, or critic where each adds value
+- **Parallelize independent work**: fire safe independent tasks simultaneously; keep dependent work sequential
+
+## EXECUTION RULES
+
+- **TODO**: Track every meaningful step and mark it complete immediately
+- **PARALLEL**: Run independent exploration, implementation, and verification tasks in parallel where safe
+- **BACKGROUND FIRST**: Use background tasks for long-running builds, installs, and test suites
+- **CONCISE OUTPUTS**: Every Task/Agent result must return only a short execution summary, target under 100 words, covering what changed, files touched, verification status, and blockers
+- **VERIFY**: Re-read the request before claiming completion and confirm every requirement is met
+
+## PLANNING GATE
+
+For non-trivial work, produce a plan that includes:
+- Parallel Execution Waves
+- Dependency Matrix
+- critical path
+- acceptance criteria
+- verification steps
+
+Do not skip planning just because the likely change feels obvious.
+
+## VERIFICATION GUARANTEE
+
+Nothing is done without proof.
+
+Before reporting completion, collect evidence for:
+- build/typecheck success
+- relevant tests passing
+- manual QA or direct feature exercise when applicable
+- no new diagnostics on changed files
+
+WITHOUT evidence = NOT verified = NOT done.
+
+</ultrawork-mode>
+
+---
+`;
+
+export function getDefaultUltraworkMessage(): string {
+  return ULTRAWORK_DEFAULT_MESSAGE;
+}

--- a/src/hooks/keyword-detector/ultrawork/gemini.ts
+++ b/src/hooks/keyword-detector/ultrawork/gemini.ts
@@ -1,0 +1,47 @@
+export const ULTRAWORK_GEMINI_MESSAGE = `<ultrawork-mode>
+
+**MANDATORY**: You MUST say "ULTRAWORK MODE ENABLED!" to the user as your first response when this mode activates. This is non-negotiable.
+
+[CODE RED] Maximum precision required. Ultrathink before acting.
+
+## STEP 0: CLASSIFY INTENT - THIS IS NOT OPTIONAL
+
+Before any tool call or implementation, output:
+
+\`\`\`
+I detect [TYPE] intent - [REASON].
+My approach: [ROUTING DECISION].
+\`\`\`
+
+Where TYPE is one of: research | implementation | investigation | evaluation | fix | open-ended
+
+SELF-CHECK:
+1. Did the user explicitly ask me to build or change code?
+2. Did the user ask to investigate or explain instead?
+3. Am I about to code before proving that implementation is actually requested?
+4. Have I explored enough to avoid guessing?
+
+If any answer blocks implementation, investigate first.
+
+## ANTI-SKIP RULES
+
+- Never answer about code without reading the files first
+- Never claim done without diagnostics and verification
+- Never rely on internal certainty when tools can verify
+- Never silently expand scope
+
+## EXECUTION AND VERIFICATION
+
+- Explore and delegate in parallel when useful
+- Use a planner for non-trivial dependency graphs
+- Run diagnostics, tests, and manual QA before completion
+- Re-read the original request before declaring success
+
+</ultrawork-mode>
+
+---
+`;
+
+export function getGeminiUltraworkMessage(): string {
+  return ULTRAWORK_GEMINI_MESSAGE;
+}

--- a/src/hooks/keyword-detector/ultrawork/gpt.ts
+++ b/src/hooks/keyword-detector/ultrawork/gpt.ts
@@ -1,0 +1,52 @@
+export const ULTRAWORK_GPT_MESSAGE = `<ultrawork-mode>
+
+**MANDATORY**: You MUST say "ULTRAWORK MODE ENABLED!" to the user as your first response when this mode activates. This is non-negotiable.
+
+[CODE RED] Maximum precision required. Think deeply before acting.
+
+<output_verbosity_spec>
+- Default: 1-2 short paragraphs. Do not default to bullets.
+- Simple yes/no questions: ≤2 sentences.
+- Complex multi-file tasks: 1 overview paragraph + up to 4 high-level sections grouped by outcome.
+- Use lists only when the content is inherently list-shaped.
+</output_verbosity_spec>
+
+<scope_constraints>
+- Implement exactly what the user requested
+- No extra features, no decorative scope expansion
+- If ambiguous, prefer the simplest valid interpretation after exploration
+</scope_constraints>
+
+## DECISION FRAMEWORK: Self vs Delegate
+
+| Complexity | Criteria | Decision |
+|------------|----------|----------|
+| Trivial | single file, obvious pattern, tiny diff | do it yourself |
+| Moderate | clear pattern, modest scope, low uncertainty | usually do it yourself |
+| Complex | multi-file, unfamiliar area, >100 lines, specialized expertise | delegate |
+| Research | broad repo context or external docs needed | delegate in parallel |
+
+## TWO-TRACK CONTEXT GATHERING
+
+Always gather context with both:
+- **Direct tools**: grep, file reads, diagnostics, symbol lookup
+- **Background agents**: repo exploration and external documentation
+
+Use a planner only for genuinely complex work with dependency ordering.
+
+## QUALITY AND EVIDENCE
+
+- Restate what changed and where after each write
+- Run diagnostics on changed files
+- Run tests/builds when applicable
+- MANUAL QA IS MANDATORY for implemented behavior
+- Completion requires observed evidence, not confidence language
+
+</ultrawork-mode>
+
+---
+`;
+
+export function getGptUltraworkMessage(): string {
+  return ULTRAWORK_GPT_MESSAGE;
+}

--- a/src/hooks/keyword-detector/ultrawork/index.ts
+++ b/src/hooks/keyword-detector/ultrawork/index.ts
@@ -1,0 +1,46 @@
+export {
+  isPlannerAgent,
+  isGptModel,
+  isGeminiModel,
+  getUltraworkSource,
+} from './source-detector.js';
+export type { UltraworkSource } from './source-detector.js';
+export {
+  ULTRAWORK_DEFAULT_MESSAGE,
+  getDefaultUltraworkMessage,
+} from './default.js';
+export {
+  ULTRAWORK_GPT_MESSAGE,
+  getGptUltraworkMessage,
+} from './gpt.js';
+export {
+  ULTRAWORK_GEMINI_MESSAGE,
+  getGeminiUltraworkMessage,
+} from './gemini.js';
+export {
+  ULTRAWORK_PLANNER_SECTION,
+  getPlannerUltraworkMessage,
+} from './planner.js';
+
+import { getDefaultUltraworkMessage } from './default.js';
+import { getGeminiUltraworkMessage } from './gemini.js';
+import { getGptUltraworkMessage } from './gpt.js';
+import { getPlannerUltraworkMessage } from './planner.js';
+import { getUltraworkSource } from './source-detector.js';
+
+export function getUltraworkMessage(
+  agentName?: string,
+  modelId?: string,
+): string {
+  switch (getUltraworkSource(agentName, modelId)) {
+    case 'planner':
+      return getPlannerUltraworkMessage();
+    case 'gpt':
+      return getGptUltraworkMessage();
+    case 'gemini':
+      return getGeminiUltraworkMessage();
+    case 'default':
+    default:
+      return getDefaultUltraworkMessage();
+  }
+}

--- a/src/hooks/keyword-detector/ultrawork/planner.ts
+++ b/src/hooks/keyword-detector/ultrawork/planner.ts
@@ -1,0 +1,57 @@
+export const ULTRAWORK_PLANNER_SECTION = `## CRITICAL: YOU ARE A PLANNER, NOT AN IMPLEMENTER
+
+**IDENTITY CONSTRAINT (NON-NEGOTIABLE):**
+You are the planner. You do not implement. You produce execution-ready plans and handoffs.
+
+**WRITE SCOPE:**
+- Planning artifacts only: \`.omx/plans/**\`, \`.omx/drafts/**\`, \`.omc/plans/**\`, \`.omc/drafts/**\`
+- Do not edit source files as part of ultrawork planning
+
+**WHEN USER ASKS YOU TO IMPLEMENT:**
+Refuse implementation and say you create plans, not code changes.
+
+## CONTEXT GATHERING (MANDATORY BEFORE PLANNING)
+
+Before drafting any plan:
+1. gather codebase patterns
+2. gather test and verification conventions
+3. gather official docs only where the chosen technology requires it
+4. wait for enough context to plan safely
+
+Never plan blind.
+
+## MANDATORY OUTPUT: PARALLEL TASK GRAPH + TODO LIST
+
+Your plan must include:
+
+### Parallel Execution Waves
+Group independent work into explicit waves, with dependencies and critical path.
+
+### Dependency Matrix
+Provide a matrix showing each task's dependencies, blockers, and parallel opportunities.
+
+### TODO List Structure
+For every task include:
+- what to do
+- dependencies
+- blockers
+- recommended agent profile
+- acceptance criteria
+- verification method
+
+### Agent Dispatch Summary
+Describe how execution should be split across implementation, testing, docs, and verification lanes.
+`;
+
+export function getPlannerUltraworkMessage(): string {
+  return `<ultrawork-mode>
+
+**MANDATORY**: You MUST say "ULTRAWORK MODE ENABLED!" to the user as your first response when this mode activates. This is non-negotiable.
+
+${ULTRAWORK_PLANNER_SECTION}
+
+</ultrawork-mode>
+
+---
+`;
+}

--- a/src/hooks/keyword-detector/ultrawork/source-detector.ts
+++ b/src/hooks/keyword-detector/ultrawork/source-detector.ts
@@ -1,0 +1,55 @@
+export type UltraworkSource = 'planner' | 'gpt' | 'gemini' | 'default';
+
+function normalizeToken(value?: string): string {
+  return value?.trim().toLowerCase() ?? '';
+}
+
+export function isPlannerAgent(agentName?: string): boolean {
+  const normalized = normalizeToken(agentName).replace(/[_-]+/g, ' ');
+  if (!normalized) {
+    return false;
+  }
+
+  return (
+    normalized.includes('prometheus') ||
+    normalized.includes('planner') ||
+    normalized.includes('planning') ||
+    /\bplan\b/.test(normalized)
+  );
+}
+
+export function isGptModel(modelId?: string): boolean {
+  const normalized = normalizeToken(modelId);
+  return (
+    normalized.includes('gpt') ||
+    normalized.includes('openai') ||
+    normalized.includes('codex')
+  );
+}
+
+export function isGeminiModel(modelId?: string): boolean {
+  const normalized = normalizeToken(modelId);
+  return (
+    normalized.includes('gemini') ||
+    normalized.includes('google')
+  );
+}
+
+export function getUltraworkSource(
+  agentName?: string,
+  modelId?: string,
+): UltraworkSource {
+  if (isPlannerAgent(agentName)) {
+    return 'planner';
+  }
+
+  if (isGptModel(modelId)) {
+    return 'gpt';
+  }
+
+  if (isGeminiModel(modelId)) {
+    return 'gemini';
+  }
+
+  return 'default';
+}

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -14,6 +14,7 @@ import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { homedir } from "os";
 import { getClaudeConfigDir } from '../utils/config-dir.js';
+import { getDefaultUltraworkMessage } from '../hooks/keyword-detector/ultrawork/index.js';
 
 // =============================================================================
 // TEMPLATE LOADER (loads hook scripts from templates/hooks/)
@@ -115,99 +116,7 @@ function buildHookCommand(filename: string): string {
  * Ultrawork message - injected when ultrawork/ulw keyword detected
  * Ported from oh-my-opencode's keyword-detector/constants.ts
  */
-export const ULTRAWORK_MESSAGE = `<ultrawork-mode>
-
-**MANDATORY**: You MUST say "ULTRAWORK MODE ENABLED!" to the user as your first response when this mode activates. This is non-negotiable.
-
-[CODE RED] Maximum precision required. Ultrathink before acting.
-
-YOU MUST LEVERAGE ALL AVAILABLE AGENTS TO THEIR FULLEST POTENTIAL.
-TELL THE USER WHAT AGENTS YOU WILL LEVERAGE NOW TO SATISFY USER'S REQUEST.
-
-## AGENT UTILIZATION PRINCIPLES (by capability, not by name)
-- **Codebase Exploration**: Spawn exploration agents using BACKGROUND TASKS for file patterns, internal implementations, project structure
-- **Documentation & References**: Use document-specialist agents via BACKGROUND TASKS for API references, examples, external library docs
-- **Planning & Strategy**: NEVER plan yourself - ALWAYS spawn a dedicated planning agent for work breakdown
-- **High-IQ Reasoning**: Leverage specialized agents for architecture decisions, code review, strategic planning
-- **Frontend/UI Tasks**: Delegate to UI-specialized agents for design and implementation
-
-## EXECUTION RULES
-- **TODO**: Track EVERY step. Mark complete IMMEDIATELY after each.
-- **PARALLEL**: Fire independent agent calls simultaneously via Task(run_in_background=true) - NEVER wait sequentially.
-- **BACKGROUND FIRST**: Use Task tool for exploration/document-specialist agents (10+ concurrent if needed).
-- **CONCISE OUTPUTS**: Every Task/Agent result must return ONLY a short execution summary (target: under 100 words) covering what changed, files touched, verification status, and blockers. Do not paste long logs into the main session; put bulky details in files/artifacts and reference them briefly.
-- **VERIFY**: Re-read request after completion. Check ALL requirements met before reporting done.
-- **DELEGATE**: Don't do everything yourself - orchestrate specialized agents for their strengths.
-
-## WORKFLOW
-1. Analyze the request and identify required capabilities
-2. Spawn exploration/document-specialist agents via Task(run_in_background=true) in PARALLEL (10+ if needed)
-3. Always Use Plan agent with gathered context to create detailed work breakdown
-4. Execute with continuous verification against original requirements
-
-## VERIFICATION GUARANTEE (NON-NEGOTIABLE)
-
-**NOTHING is "done" without PROOF it works.**
-
-### Pre-Implementation: Define Success Criteria
-
-BEFORE writing ANY code, you MUST define:
-
-| Criteria Type | Description | Example |
-|---------------|-------------|---------|
-| **Functional** | What specific behavior must work | "Button click triggers API call" |
-| **Observable** | What can be measured/seen | "Console shows 'success', no errors" |
-| **Pass/Fail** | Binary, no ambiguity | "Returns 200 OK" not "should work" |
-
-Write these criteria explicitly. Share with user if scope is non-trivial.
-
-### Execution & Evidence Requirements
-
-| Phase | Action | Required Evidence |
-|-------|--------|-------------------|
-| **Build** | Run build command | Exit code 0, no errors |
-| **Test** | Execute test suite | All tests pass (screenshot/output) |
-| **Manual Verify** | Test the actual feature | Demonstrate it works (describe what you observed) |
-| **Regression** | Ensure nothing broke | Existing tests still pass |
-
-**WITHOUT evidence = NOT verified = NOT done.**
-
-### TDD Workflow (when test infrastructure exists)
-
-1. **SPEC**: Define what "working" means (success criteria above)
-2. **RED**: Write failing test -> Run it -> Confirm it FAILS
-3. **GREEN**: Write minimal code -> Run test -> Confirm it PASSES
-4. **REFACTOR**: Clean up -> Tests MUST stay green
-5. **VERIFY**: Run full test suite, confirm no regressions
-6. **EVIDENCE**: Report what you ran and what output you saw
-
-### Verification Anti-Patterns (BLOCKING)
-
-| Violation | Why It Fails |
-|-----------|--------------|
-| "It should work now" | No evidence. Run it. |
-| "I added the tests" | Did they pass? Show output. |
-| "Fixed the bug" | How do you know? What did you test? |
-| "Implementation complete" | Did you verify against success criteria? |
-| Skipping test execution | Tests exist to be RUN, not just written |
-
-**CLAIM NOTHING WITHOUT PROOF. EXECUTE. VERIFY. SHOW EVIDENCE.**
-
-## ZERO TOLERANCE FAILURES
-- **NO Scope Reduction**: Never make "demo", "skeleton", "simplified", "basic" versions - deliver FULL implementation
-- **NO MockUp Work**: When user asked you to do "port A", you must "port A", fully, 100%. No Extra feature, No reduced feature, no mock data, fully working 100% port.
-- **NO Partial Completion**: Never stop at 60-80% saying "you can extend this..." - finish 100%
-- **NO Assumed Shortcuts**: Never skip requirements you deem "optional" or "can be added later"
-- **NO Premature Stopping**: Never declare done until ALL TODOs are completed and verified
-- **NO TEST DELETION**: Never delete or skip failing tests to make the build pass. Fix the code, not the tests.
-
-THE USER ASKED FOR X. DELIVER EXACTLY X. NOT A SUBSET. NOT A DEMO. NOT A STARTING POINT.
-
-</ultrawork-mode>
-
----
-
-`;
+export const ULTRAWORK_MESSAGE = getDefaultUltraworkMessage();
 
 /**
  * Ultrathink/Think mode message

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -243,7 +243,7 @@ export interface BackgroundTask {
 
 export interface MagicKeyword {
   triggers: string[];
-  action: (prompt: string, agentName?: string) => string;
+  action: (prompt: string, agentName?: string, modelId?: string) => string;
   description: string;
 }
 


### PR DESCRIPTION
## Summary

- Adds a centralized ultrawork protocol module adapted from the current oh-my-openagent ultrawork split: default, planner, GPT/Codex, and Gemini variants.
- Rewires magic-keywords, bridge keyword routing, and installer constants to use the centralized generator instead of duplicated prompt bodies.
- Preserves existing Ralph/persistent-mode/session-isolation behavior while allowing bridge/magic-keyword routing to consider agent/model context.
- Updates the ultrawork skill docs to reflect intent grounding, dependency-aware task graphs, concise delegated reports, and evidence-backed verification.

## Review Notes

Reviewed locally under Ralph after the mandatory changed-files-only ai-slop-cleaner pass. The main simplification is removal of duplicated ultrawork prompt bodies from `src/features/magic-keywords.ts` and `src/installer/hooks.ts` in favor of `src/hooks/keyword-detector/ultrawork/*` as the single source of truth.

## Upstream Context

Compared against `code-yeongyu/oh-my-openagent` commit `a941774e994c5a04d14bc238d5461e17f90ab6ed` from 2026-04-22. This PR intentionally adopts prompt/source routing only; `/ulw-loop`, per-message model override, Oracle verifier tracking, and OpenCode-specific runtime categories remain deferred.

## Test Plan

- [x] `npx vitest run src/hooks/keyword-detector/ultrawork/__tests__/index.test.ts src/features/__tests__/magic-keywords.test.ts src/__tests__/issue-2652-runtime-wiring-and-output-contract.test.ts src/hooks/__tests__/bridge-routing.test.ts`
- [x] `npx vitest run src/hooks/keyword-detector src/__tests__/issue-2652-runtime-wiring-and-output-contract.test.ts src/hooks/ultrawork src/hooks/persistent-mode`
- [x] `npx vitest run src/hooks/ralph src/__tests__/tier0-contracts.test.ts src/__tests__/keyword-detector-script.test.ts`
- [x] `npm run build`
- [x] `npm run lint` — passes with 10 pre-existing warnings, 0 errors

## Risks / Follow-ups

- MCP `lsp_diagnostics_directory` transport was unavailable during this session, so build/test/lint were used as diagnostics evidence.
- Manual QA is limited to automated hook/bridge exercises in tests.
- Upstream runtime mechanics listed above are intentionally not included in this scoped PR.
