### PR TITLE
fix(installer): validate MCP server names before rendering Codex TOML

### DIFF
--- a/src/installer/__tests__/mcp-registry.test.ts
+++ b/src/installer/__tests__/mcp-registry.test.ts
@@ -373,6 +373,49 @@ describe('unified MCP registry sync', () => {
     expect(codexConfig).toContain('[mcp_servers.storybook_local]');
   });
 
+  it('skips invalid registry server names when rendering managed Codex TOML blocks', () => {
+    const maliciousName = 'evil]\nmodel = "pwned"\n[mcp_servers.injected';
+    const result = syncCodexConfigToml('model = "gpt-5"\n', {
+      [maliciousName]: {
+        command: 'uvx',
+        args: ['demo-server'],
+      },
+      safe_name: {
+        command: 'custom-mcp',
+        args: ['serve'],
+      },
+    });
+
+    expect(result.content).toContain('model = "gpt-5"');
+    expect(result.content).toContain('[mcp_servers.safe_name]');
+    expect(result.content).not.toContain('[mcp_servers.evil]');
+    expect(result.content).not.toContain('[mcp_servers.injected]');
+    expect(result.content).not.toContain('model = "pwned"');
+  });
+
+  it('does not let malformed registry names inject extra Codex MCP tables during setup sync', () => {
+    const maliciousName = 'evil]\nmodel = "pwned"\n[mcp_servers.injected';
+    writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({
+      [maliciousName]: {
+        command: 'uvx',
+        args: ['demo-server'],
+      },
+      safe_name: {
+        command: 'custom-mcp',
+        args: ['serve'],
+      },
+    }, null, 2));
+
+    const { result } = syncUnifiedMcpRegistryTargets({ theme: 'dark' });
+    const codexConfig = readFileSync(getCodexConfigPath(), 'utf-8');
+
+    expect(result.codexChanged).toBe(true);
+    expect(codexConfig).toContain('[mcp_servers.safe_name]');
+    expect(codexConfig).not.toContain('[mcp_servers.evil]');
+    expect(codexConfig).not.toContain('[mcp_servers.injected]');
+    expect(codexConfig).not.toContain('model = "pwned"');
+  });
+
   it('removes previously managed Claude and Codex MCP entries when the registry becomes empty', () => {
     writeFileSync(join(omcDir, 'mcp-registry-state.json'), JSON.stringify({ managedServers: ['gitnexus'] }, null, 2));
     writeFileSync(getUnifiedMcpRegistryPath(), JSON.stringify({}, null, 2));

--- a/src/installer/mcp-registry.ts
+++ b/src/installer/mcp-registry.ts
@@ -47,6 +47,7 @@ export interface UnifiedMcpRegistryStatus {
 const MANAGED_START = '# BEGIN OMC MANAGED MCP REGISTRY';
 const MANAGED_END = '# END OMC MANAGED MCP REGISTRY';
 const DEFAULT_LAUNCHER_MCP_STARTUP_TIMEOUT_SEC = 15;
+const CODEX_MCP_SERVER_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 export function getUnifiedMcpRegistryPath(): string {
   return process.env.OMC_MCP_REGISTRY_PATH?.trim() || getGlobalOmcConfigPath('mcp-registry.json');
@@ -445,7 +446,7 @@ function parseCodexMcpServerNames(content: string): Set<string> {
     const sectionMatch = line.match(/^\[mcp_servers\.([^\]]+)\]$/);
     if (sectionMatch) {
       const name = sectionMatch[1].trim();
-      if (name) {
+      if (name && CODEX_MCP_SERVER_NAME_PATTERN.test(name)) {
         names.add(name);
       }
     }
@@ -468,7 +469,9 @@ export function syncCodexConfigToml(existingContent: string, registry: UnifiedMc
   const base = stripManagedCodexBlock(existingContent);
   const existingServerNames = parseCodexMcpServerNames(base);
   const managedRegistry = Object.fromEntries(
-    Object.entries(registry).filter(([name]) => !existingServerNames.has(name))
+    Object.entries(registry).filter(([name]) => (
+      CODEX_MCP_SERVER_NAME_PATTERN.test(name) && !existingServerNames.has(name)
+    ))
   );
   const managedBlock = renderManagedCodexMcpBlock(managedRegistry);
   const nextContent = managedBlock


### PR DESCRIPTION
## Summary
- reject managed Codex MCP entries whose names are not safe bare TOML table suffixes before rendering `[mcp_servers.<name>]`
- keep the change narrowly scoped to the Codex TOML sync path so existing Claude JSON registry behavior stays unchanged
- add regression coverage for both direct TOML sync and setup-driven sync with malformed registry names

## Root cause verified
The current Codex sync path trims registry entry names but still renders them as raw bare TOML table names.

In a local repro against current `dev`, a registry key like:

```text
evil]
model = "pwned"
[mcp_servers.injected
```

produced a managed block that parsed as two real MCP tables in `config.toml` instead of one server entry.

This patch keeps the fix small by validating names at the Codex render/filter boundary instead of broadening registry behavior elsewhere.

## Changed files
- `src/installer/mcp-registry.ts`
- `src/installer/__tests__/mcp-registry.test.ts`

## Verification
- `npm run test:run -- src/installer/__tests__/mcp-registry.test.ts`
- `npx tsc --noEmit --pretty false --project tsconfig.json`
- `npx eslint src/installer/mcp-registry.ts src/installer/__tests__/mcp-registry.test.ts`
- isolated temp `HOME` / `CODEX_HOME` / `CLAUDE_CONFIG_DIR` repro showing malformed registry names no longer inject extra Codex MCP tables

Closes #2763
