### PR TITLE
docs: sync .github/CLAUDE.md OMC version marker to 4.13.2

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.8.2 -->
+<!-- OMC:VERSION:4.13.2 -->
 
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`.github/CLAUDE.md` declares `<!-- OMC:VERSION:4.8.2 -->` while `docs/CLAUDE.md` and `.claude-plugin/plugin.json` both declare version `4.13.2` — a drift of 5 minor versions.

## Why it matters

`.github/CLAUDE.md` is loaded as runtime context for CI and PR agents. When those agents read version `4.8.2`, they may make incorrect assumptions about available features, tool names, or skill signatures that were added or changed in the intervening releases. The drift also causes NLPM's cross-component consistency checker to flag a version mismatch on every audit.

## Fix

Update the `OMC:VERSION` comment from `4.8.2` to `4.13.2` to match `docs/CLAUDE.md` and `plugin.json`.

A note to the release checklist to keep `.github/CLAUDE.md` in sync with `plugin.json` on every release would prevent this from drifting again.