### PR TITLE
fix: add YAML frontmatter to exploration-template.md

### DIFF
--- a/src/agents/templates/exploration-template.md
+++ b/src/agents/templates/exploration-template.md
@@ -1,3 +1,9 @@
+---
+name: exploration-template
+description: Template for delegating exploration, research, or search tasks to specialized agents
+model: haiku
+---
+
 # Exploration Task Template
 
 Use this template when delegating exploration, research, or search tasks.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`src/agents/templates/exploration-template.md` has no YAML frontmatter — no `name`, `description`, or `model` fields. Because the file lives inside an agent-discoverable path (`src/agents/templates/`), NLPM's scanner treats it as an agent definition and applies two -25 penalties for missing required fields, dropping the score to 45/100 and causing a registration failure warning.

## Why it matters

Agent scanners (including NLPM and Claude Code's own plugin loader) walk `agents/` subtrees expecting files to be valid agent definitions. A file without `name` and `description` cannot be registered and emits confusing errors in diagnostic output. Users who run `/nlpm:ls` or similar tooling on this repo will see the template reported as a broken agent rather than understood as documentation.

## Fix

Add minimal YAML frontmatter (`name`, `description`, `model: haiku`) that matches the format used by all other agents in the catalog (e.g., `agents/architect.md`). The content of the file is unchanged — it remains a human-readable template showing how to structure exploration delegation prompts.