### PR TITLE
fix: add YAML frontmatter to implementation-template.md

### DIFF
--- a/src/agents/templates/implementation-template.md
+++ b/src/agents/templates/implementation-template.md
@@ -1,3 +1,9 @@
+---
+name: implementation-template
+description: Template for delegating code implementation, refactoring, or modification tasks to specialized agents
+model: sonnet
+---
+
 # Implementation Task Template
 
 Use this template when delegating code implementation, refactoring, or modification tasks.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`src/agents/templates/implementation-template.md` has no YAML frontmatter — no `name`, `description`, or `model` fields. This is the same issue as the companion `exploration-template.md`. Because the file lives inside an agent-discoverable path (`src/agents/templates/`), NLPM's scanner treats it as an agent definition and applies two -25 penalties for missing required fields, dropping the score to 45/100 and causing a registration failure warning.

## Why it matters

Agent scanners walk `agents/` subtrees expecting files to be valid agent definitions. A file without `name` and `description` cannot be registered and emits confusing errors in diagnostic output. Users running `/nlpm:ls` or similar tooling will see the template reported as a broken agent.

## Fix

Add minimal YAML frontmatter (`name`, `description`, `model: sonnet`) matching the format used by all other agents in the catalog. The content of the file is unchanged — it remains a human-readable template showing how to structure implementation delegation prompts.