### PR TITLE
security: add diff preview and confirmation before CLAUDE.md overwrite in omc-doctor

### DIFF
--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -180,10 +180,28 @@ node -e "const p=require('path'),f=require('fs'),h=require('os').homedir(),d=pro
 ```
 
 ### Fix: Missing/Outdated CLAUDE.md
-Fetch latest from GitHub and write to `${CLAUDE_CONFIG_DIR:-~/.claude}/CLAUDE.md`:
+Fetch latest from GitHub, show a diff, and ask for confirmation before writing:
+
+1. Fetch the content:
 ```
 WebFetch(url: "https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md", prompt: "Return the complete raw markdown content exactly as-is")
 ```
+
+2. If a local `${CLAUDE_CONFIG_DIR:-~/.claude}/CLAUDE.md` exists, read it and display a short summary of what will change (e.g., lines added/removed, version marker difference).
+
+3. Ask the user for confirmation before writing:
+```
+I fetched the latest CLAUDE.md from GitHub (OMC:VERSION:<fetched-version>).
+Your current file is at <local-version> (or missing).
+
+Shall I overwrite ${CLAUDE_CONFIG_DIR:-~/.claude}/CLAUDE.md with the fetched content?
+This will replace any local customizations outside the OMC:START/OMC:END block.
+```
+
+4. Only write the fetched content if the user explicitly confirms.
+
+> **Note:** The fetch targets the `main` branch tip and is unauthenticated. If you need a specific version, you can pin the URL to a commit SHA:
+> `https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/<SHA>/docs/CLAUDE.md`
 
 ### Fix: Legacy Curl-Installed Content
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium)

`skills/omc-doctor/SKILL.md` line 185: the "Fix: Missing/Outdated CLAUDE.md" auto-fix fetches `https://raw.githubusercontent.com/Yeachan-Heo/oh-my-claudecode/main/docs/CLAUDE.md` via an unauthenticated `WebFetch` and silently overwrites the user's `~/.claude/CLAUDE.md` without showing a diff or asking for confirmation.

Two risks:

1. **Supply-chain / branch compromise**: The fetch targets `main` branch tip. If the upstream repository is compromised (or the user's DNS/TLS is manipulated), the fetched content could contain malicious instructions that are injected into their CLAUDE.md and silently executed on the next Claude session.

2. **Local customization loss**: Users who have made customizations to `~/.claude/CLAUDE.md` outside the `OMC:START/OMC:END` block will lose them without warning.

## Fix

Add three steps before writing:
1. Fetch the content (as before)
2. Read the current local file and summarize what will change (version marker, line delta)
3. Show a confirmation prompt explaining what will be overwritten

Also add a note that the URL can be pinned to a specific commit SHA for stronger supply-chain guarantees — this is optional but gives security-conscious users a clear path.

The fetch URL itself is unchanged; the only behavioral change is that the write now requires explicit user confirmation.