### PR TITLE
fix(cleanup-orphans): unref SIGKILL escalation timer to avoid 5s CLI hang

### DIFF
--- a/scripts/cleanup-orphans.mjs
+++ b/scripts/cleanup-orphans.mjs
@@ -130,7 +130,21 @@ function teamConfigExists(name) {
 }
 
 /**
- * Kill a process: SIGTERM first, SIGKILL after 5s if still alive.
+ * Kill a process.
+ *
+ * On Windows: `taskkill /F` terminates synchronously.
+ *
+ * On Unix: issue SIGTERM for graceful exit. A best-effort SIGKILL escalation
+ * is scheduled 5s later, but the timer is `.unref()`ed so it does not block
+ * the Node event loop — main() exits promptly after SIGTERM and does not
+ * hang waiting for the escalation window to elapse. In practice, OMC agent
+ * processes (claude/codex/gemini/omc) respect SIGTERM and exit within
+ * milliseconds; the SIGKILL path is a safety net that only fires if the
+ * caller's event loop stays alive long enough (e.g., another timer or I/O
+ * keeps the process running past 5s). Callers that need guaranteed
+ * escalation should poll `process.kill(pid, 0)` themselves or re-run this
+ * script. See commit message for the rationale behind removing the implicit
+ * 5s hang this function previously caused.
  */
 function killProcess(pid) {
   // Validate PID is a positive integer (prevent command injection)
@@ -143,7 +157,10 @@ function killProcess(pid) {
       // Send SIGTERM
       process.kill(pid, 'SIGTERM');
 
-      // Wait 5s, then SIGKILL if still alive
+      // Schedule a best-effort SIGKILL escalation after 5s.
+      // .unref() ensures this pending timer does not keep the Node event
+      // loop alive — without it, main() would appear to "hang" for 5s per
+      // orphan after printing the JSON result.
       setTimeout(() => {
         try {
           process.kill(pid, 0); // Check if still running
@@ -151,7 +168,7 @@ function killProcess(pid) {
         } catch {
           // Process already exited
         }
-      }, 5000);
+      }, 5000).unref();
     }
     return true;
   } catch {
@@ -204,6 +221,13 @@ function main() {
       ? `Found ${orphans.length} orphan(s). Re-run without --dry-run to clean up.`
       : `Cleaned up ${results.filter(r => r.action === 'killed').length}/${orphans.length} orphan(s).`,
   }));
+
+  // Exit explicitly so we don't depend on timer/handle lifetime to end the
+  // process. The SIGKILL escalation timers scheduled in killProcess() are
+  // .unref()ed and therefore do not block exit; this line makes the intent
+  // symmetric with the earlier no-orphan return paths (which already call
+  // process.exit(0)).
+  process.exit(0);
 }
 
 main();

--- a/src/__tests__/cleanup-orphans-unref.test.ts
+++ b/src/__tests__/cleanup-orphans-unref.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Guardrail: scripts/cleanup-orphans.mjs must not keep the Node event loop
+ * alive with a refed 5s SIGKILL escalation timer, and main() must exit
+ * explicitly.
+ *
+ * Rationale (see commit message): the script is invoked as a synchronous
+ * subprocess from `/cancel` and `/team` skills — the invoker waits for it
+ * to exit. If the SIGKILL escalation setTimeout is not .unref()ed and
+ * main() does not call process.exit(0), every orphan that receives SIGTERM
+ * causes the script to hang until the 5s timer fires, delaying the parent
+ * skill UX.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const SCRIPT_PATH = join(REPO_ROOT, 'scripts', 'cleanup-orphans.mjs');
+
+describe('scripts/cleanup-orphans.mjs — SIGKILL escalation timer must not block event loop', () => {
+  it('script file exists', () => {
+    expect(existsSync(SCRIPT_PATH)).toBe(true);
+  });
+
+  const src = existsSync(SCRIPT_PATH) ? readFileSync(SCRIPT_PATH, 'utf8') : '';
+
+  it('schedules a 5000ms setTimeout (existing SIGKILL escalation path)', () => {
+    // Tolerant match across whitespace/newlines: setTimeout( ... , 5000 ) ...
+    expect(src).toMatch(/setTimeout\s*\(/);
+    expect(src).toMatch(/\b5000\s*\)/);
+  });
+
+  it('calls .unref() on the 5000ms SIGKILL escalation timer', () => {
+    // Match the full setTimeout(...) call ending at `}, 5000)` followed by .unref()
+    // (single-line; the `[\s\S]*?` allows the arrow body to span multiple lines).
+    const pattern = /setTimeout\(\s*\(\)\s*=>\s*\{[\s\S]*?\},\s*5000\)\.unref\(\)/;
+    expect(src).toMatch(pattern);
+  });
+
+  it('main() ends with an explicit process.exit(0)', () => {
+    // The last line of main() before the closing brace must be process.exit(0);
+    // We check that the success-path JSON print is followed by process.exit(0)
+    // before the next top-level `main();` invocation.
+    const mainEndPattern = /Cleaned up[^]*?process\.exit\(0\);\s*\}\s*main\(\);/;
+    expect(src).toMatch(mainEndPattern);
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/cleanup-orphans.mjs` is invoked as a synchronous subprocess from `/cancel` and `/team` skills (see [`skills/cancel/SKILL.md:249`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/dev/skills/cancel/SKILL.md) and [`skills/team/SKILL.md:579`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/dev/skills/team/SKILL.md)). After SIGTERM'ing each orphan agent, `killProcess` scheduled a `setTimeout(..., 5000)` to escalate to SIGKILL but never called `.unref()` on it, and `main()` returned without `process.exit(0)` on the success path. Node therefore kept the event loop alive for the full 5 s **per invocation**, even after the result JSON was already printed. Users experienced this as the cleanup script hanging for five seconds, delaying the parent skill UX.

## Root cause

[`scripts/cleanup-orphans.mjs:147`](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/dev/scripts/cleanup-orphans.mjs#L147) before this PR:

```js
// Wait 5s, then SIGKILL if still alive
setTimeout(() => {
  try {
    process.kill(pid, 0); // Check if still running
    process.kill(pid, 'SIGKILL');
  } catch {
    // Process already exited
  }
}, 5000);
```

- `setTimeout()` returns a refed `Timeout` object. Node's event loop will stay alive until every refed handle settles.
- `main()` (line 207 before this PR) did not call `process.exit(0)` on the success path. The two earlier no-orphan branches (lines 172 and 183) already did, so the success path was asymmetric.
- Net effect: after printing the result JSON, the script blocked on the 5 s timer before the Node process could exit. With multiple orphans the timers run concurrently so the total stay is still ~5 s, but the user perceives the hang every time at least one orphan is killed.

## Change

1. **Call `.unref()` on the escalation timer.** The timer is still scheduled and will fire if the event loop stays alive for another reason, but it no longer pins the loop on its own.

2. **Add an explicit `process.exit(0)` at the end of `main()`** for symmetry with the two earlier no-orphan exit paths. The intent — "we are done, tear the process down" — is now explicit in code rather than being an emergent property of Node's event-loop heuristics.

3. **Update the `killProcess` header comment** to describe the new best-effort SIGKILL semantics and why the `.unref()` is intentional.

4. **Add a source-level guardrail test** at `src/__tests__/cleanup-orphans-unref.test.ts` modeled on the existing `src/__tests__/paths-consistency.test.ts` pattern. It reads the script file and asserts that
   - a 5000 ms `setTimeout` is still present (regression guard for the escalation intent),
   - `.unref()` is applied to that timer,
   - `main()` ends with `process.exit(0)` before the top-level `main()` call.

## Intentional behavior change (please read)

The previous code relied on the refed timer to implicitly keep the process alive for 5 s, giving the SIGKILL a chance to fire. That guarantee is now weakened — if the caller's event loop drains before 5 s, the SIGKILL escalation may not run and an orphan that ignores SIGTERM will persist.

In practice all OMC agent targets (claude / codex / gemini / omc Node processes) respect SIGTERM and exit within milliseconds, so the trade-off is favourable: users stop paying a 5 s tax on every cleanup, and the rare rogue orphan can always be addressed by re-running the script.

If strict escalation is required here, I'm happy to follow up (or update this PR in review) with an async restructure that:

- returns a `Promise<boolean>` from `killProcess`,
- has `main()` become `async` and `await Promise.all(...)` of the kills before calling `process.exit(0)`,
- keeps the timers `.unref()`'d as belt-and-suspenders.

That variant preserves strict SIGKILL escalation but necessarily re-introduces the 5 s wait on every invocation, which is the symptom this PR is fixing. I went with the lighter change and am raising the tradeoff here so you can steer.

## Testing

```
npm run build                                                     # green
npm run lint                                                      # green
npm run test:run                                                  # green (full suite)
npx vitest run src/__tests__/cleanup-orphans-unref.test.ts        # 4 tests pass
```

**Manual sanity check.** The script was run before and after the patch from the repo root:

- Before: process stayed alive for ~5 s after printing the result JSON when at least one orphan was SIGTERM'd.
- After: process exits immediately after printing the result JSON.

(The guardrail test is intentionally source-level — a behavioral end-to-end test would need a fake long-lived process to SIGTERM, which is out of scope for this minimal fix.)

## Scope

- `scripts/cleanup-orphans.mjs` — `killProcess` timer gets `.unref()`, `main()` gets explicit `process.exit(0)`, comment is updated. No logic changes beyond the timer and exit.
- `src/__tests__/cleanup-orphans-unref.test.ts` — new guardrail test file.
- No `dist/` or `bridge/` output committed — those are generated artifacts and based on the recent history on `dev` it looks like maintainers regenerate them in dedicated build commits. Happy to include a build-regen commit here if that's preferred.

## Checklist

- [x] Targets `dev` (per `CONTRIBUTING.md`)
- [x] `npm run build`, `npm run lint`, `npm run test:run` all green
- [x] New test added and passing
- [x] No unrelated files touched
- [x] Tradeoff called out in PR body for maintainer steering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
