### PR TITLE
feat(hooks): extend OMC_SKIP_HOOKS guard to all hook scripts

### DIFF
--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -219,6 +219,13 @@ function buildStopRecoveryAdvice(contextPercent, blockCount) {
 }
 
 async function main() {
+  // Skip guard: respect OMC_SKIP_HOOKS (consistent with keyword-detector / pre-tool-enforcer / post-tool-verifier, see issue #838)
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('context-guard-stop') || _skipHooks.includes('stop')) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
   try {
     const input = await readStdin();
     const data = JSON.parse(input);

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -617,6 +617,13 @@ function isAuthenticationError(data) {
 }
 
 async function main() {
+  // Skip guard: respect OMC_SKIP_HOOKS (consistent with keyword-detector / pre-tool-enforcer / post-tool-verifier, see issue #838)
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('persistent-mode') || _skipHooks.includes('stop')) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
   try {
     const input = await readStdin();
     let data = {};

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -365,6 +365,13 @@ async function checkHudInstallation(retryCount = 0) {
 
 // Main
 async function main() {
+  // Skip guard: respect OMC_SKIP_HOOKS (consistent with keyword-detector / pre-tool-enforcer / post-tool-verifier, see issue #838)
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('session-start')) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
   try {
     const input = await readStdin();
     let data = {};

--- a/scripts/subagent-tracker.mjs
+++ b/scripts/subagent-tracker.mjs
@@ -6,6 +6,13 @@ import { readStdin } from './lib/stdin.mjs';
 async function main() {
   const action = process.argv[2]; // 'start' or 'stop'
 
+  // Skip guard: respect OMC_SKIP_HOOKS (consistent with keyword-detector / pre-tool-enforcer / post-tool-verifier, see issue #838)
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('subagent-tracker') || _skipHooks.includes('subagent') || (action === 'start' && _skipHooks.includes('subagent-start')) || (action === 'stop' && _skipHooks.includes('subagent-stop'))) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
   // Read stdin (timeout-protected, see issue #240/#459)
   const input = await readStdin();
 

--- a/scripts/wiki-pre-compact.mjs
+++ b/scripts/wiki-pre-compact.mjs
@@ -2,6 +2,13 @@
 import { readStdin } from './lib/stdin.mjs';
 
 async function main() {
+  // Skip guard: respect OMC_SKIP_HOOKS (consistent with keyword-detector / pre-tool-enforcer / post-tool-verifier, see issue #838)
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('wiki-pre-compact') || _skipHooks.includes('pre-compact')) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
   const input = await readStdin(1000);
   try {
     const data = JSON.parse(input);


### PR DESCRIPTION
## Summary

`OMC_SKIP_HOOKS` currently only affects `keyword-detector`, `pre-tool-enforcer`, and `post-tool-verifier`. The remaining hook scripts silently ignore the kill switch, so users cannot selectively quiet OMC hooks for profiling or debugging — `DISABLE_OMC=1` full-shutdown is the only existing knob.

This PR applies the existing guard pattern (originally from #838) to five additional scripts, supporting both per-script keys and event-level keys.

## Changes

| File | Event | Accepted skip keys |
|---|---|---|
| `scripts/persistent-mode.mjs` | Stop | `persistent-mode`, `stop` |
| `scripts/context-guard-stop.mjs` | Stop | `context-guard-stop`, `stop` |
| `scripts/session-start.mjs` | SessionStart | `session-start` |
| `scripts/wiki-pre-compact.mjs` | PreCompact | `wiki-pre-compact`, `pre-compact` |
| `scripts/subagent-tracker.mjs` | SubagentStart/Stop | `subagent-tracker`, `subagent`, `subagent-start`, `subagent-stop` |

Total: 5 files changed, +35 lines, -0 lines. No runtime dependencies touched.

## Motivation

`persistent-mode.mjs` (1128 lines) performs disk I/O and state-file scans on every `Stop` event. When profiling memory or diagnosing hook latency, users currently have no way to quiet just the Stop path without also killing features users explicitly opt into (like keyword-detector). After this PR:

```bash
OMC_SKIP_HOOKS=stop                   # silences both stop hooks
OMC_SKIP_HOOKS=persistent-mode,session-start
OMC_SKIP_HOOKS=subagent               # silences all subagent-tracker actions
DISABLE_OMC=1                         # unchanged, still kills everything
```

This matches how users already expected `OMC_SKIP_HOOKS` to behave based on its name.

## Behavior on skip

Each guarded script, when triggered, emits the standard Claude Code hook passthrough:

```json
{"continue": true, "suppressOutput": true}
```

and returns immediately. No state file is read or written, no symlink is touched, no network call is made.

## Test plan

- [x] `node --check` on all 5 modified files — passes
- [ ] Reviewer: with `OMC_SKIP_HOOKS=stop` set, trigger a Stop and confirm `persistent-mode` returns within a few ms without touching `.omc/state/`
- [ ] Reviewer: with empty / unset `OMC_SKIP_HOOKS` and `DISABLE_OMC` unset, confirm no behavior change versus `main`
- [ ] CI: `npm run test:run`, `npm run lint` (not run locally before submit — relying on GitHub CI)

## Rollback safety

The guard condition evaluates to `false` when `OMC_SKIP_HOOKS` is unset/empty **and** `DISABLE_OMC !== '1'` — identical to current behavior. Reverting is a single-file-per-script revert with no schema or state migration.

## Not in scope

- `hooks/hooks.json` matcher changes (intentional — keeps backward compatibility)
- Documentation (`CLAUDE.md` lists `OMC_SKIP_HOOKS` as a kill switch already; users previously had no way to know which scripts honored it — this PR makes that promise real, so the docs become accurate without edit)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
