### PR TITLE
fix(shell): portable shebangs + POSIX /bin/sh fallback

### DIFF
--- a/benchmark/entrypoint.sh
+++ b/benchmark/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "=== SWE-bench Evaluation Environment ==="

--- a/benchmark/quick_test.sh
+++ b/benchmark/quick_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Colors for output

--- a/benchmark/run_full_comparison.sh
+++ b/benchmark/run_full_comparison.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Colors for output

--- a/benchmark/run_omc.sh
+++ b/benchmark/run_omc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Colors for output

--- a/benchmark/run_vanilla.sh
+++ b/benchmark/run_vanilla.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Colors for output

--- a/benchmark/setup.sh
+++ b/benchmark/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Colors for output

--- a/scripts/test-pr25.sh
+++ b/scripts/test-pr25.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # PR #25 Test Suite: qa-tester agent with tmux support
 #

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Oh-My-ClaudeCode Uninstaller
 # Completely removes all OMC-installed files and configurations
 

--- a/skills/project-session-manager/lib/config.sh
+++ b/skills/project-session-manager/lib/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Configuration Management
 
 PSM_ROOT="${HOME}/.psm"

--- a/skills/project-session-manager/lib/parse.sh
+++ b/skills/project-session-manager/lib/parse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Reference Parser
 
 # Parse a reference string into components

--- a/skills/project-session-manager/lib/providers/azure-devops.sh
+++ b/skills/project-session-manager/lib/providers/azure-devops.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Azure DevOps Provider
 
 provider_azure_available() {

--- a/skills/project-session-manager/lib/providers/bitbucket.sh
+++ b/skills/project-session-manager/lib/providers/bitbucket.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Bitbucket Provider
 
 provider_bitbucket_available() {

--- a/skills/project-session-manager/lib/providers/gitea.sh
+++ b/skills/project-session-manager/lib/providers/gitea.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Gitea Provider
 
 provider_gitea_available() {

--- a/skills/project-session-manager/lib/providers/github.sh
+++ b/skills/project-session-manager/lib/providers/github.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM GitHub Provider
 
 provider_github_available() {

--- a/skills/project-session-manager/lib/providers/gitlab.sh
+++ b/skills/project-session-manager/lib/providers/gitlab.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM GitLab Provider
 
 provider_gitlab_available() {

--- a/skills/project-session-manager/lib/providers/interface.sh
+++ b/skills/project-session-manager/lib/providers/interface.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Provider Interface
 # Each provider implements: _available, _detect_ref, _fetch_issue, _issue_closed,
 #                          _fetch_pr (optional), _pr_merged (optional), _clone_url

--- a/skills/project-session-manager/lib/providers/jira.sh
+++ b/skills/project-session-manager/lib/providers/jira.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Jira Provider
 # Uses `jira` CLI (https://github.com/ankitpokhrel/jira-cli)
 

--- a/skills/project-session-manager/lib/session.sh
+++ b/skills/project-session-manager/lib/session.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Session Registry Management
 
 # Lock file for atomic registry operations

--- a/skills/project-session-manager/lib/tmux.sh
+++ b/skills/project-session-manager/lib/tmux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Tmux Session Management
 
 # Check if tmux is available

--- a/skills/project-session-manager/lib/worktree.sh
+++ b/skills/project-session-manager/lib/worktree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PSM Worktree Management
 
 # Validate worktree path is under PSM worktree root before deletion

--- a/skills/project-session-manager/psm.sh
+++ b/skills/project-session-manager/psm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Project Session Manager (PSM) - Main Script
 # Usage: psm.sh <command> [args...]
 

--- a/skills/project-session-manager/tests/test-psm-prompt-injection.sh
+++ b/skills/project-session-manager/tests/test-psm-prompt-injection.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Regression tests for PSM prompt injection (issue #2506)
 # Root cause: psm_launch_claude only sent "claude Enter" with no task context injected.
 # Fix: psm_render_template + psm_inject_prompt + context file written to worktree.

--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -309,10 +309,10 @@ describe('wrapWithLoginShell', () => {
     expect(result).toMatch(/^exec /);
   });
 
-  it('defaults to /bin/bash when $SHELL is not set', () => {
+  it('defaults to /bin/sh when $SHELL is not set', () => {
     vi.stubEnv('SHELL', '');
     const result = wrapWithLoginShell('codex');
-    expect(result).toContain('/bin/bash');
+    expect(result).toContain('/bin/sh');
     expect(result).toContain('-lc');
   });
 

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -333,7 +333,7 @@ export function wrapWithLoginShell(command: string): string {
     return `${quoteForCmd(comspec)} /d /s /c ${quoteForCmd(command)}`;
   }
 
-  const shell = process.env.SHELL || '/bin/bash';
+  const shell = process.env.SHELL || '/bin/sh';
   const shellName = basename(shell).replace(/\.(exe|cmd|bat)$/i, '');
   const rcFile = process.env.HOME ? `${process.env.HOME}/.${shellName}rc` : '';
   const sourcePrefix = rcFile

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -89,7 +89,7 @@ export function getDefaultShell(): string {
   if (process.platform === 'win32' && !isUnixLikeOnWindows()) {
     return process.env.COMSPEC || 'cmd.exe';
   }
-  const shell = process.env.SHELL || '/bin/bash';
+  const shell = process.env.SHELL || '/bin/sh';
   // Validate that the shell supports our launch script syntax.
   // Unsupported shells (tcsh, csh, etc.) fall back to /bin/sh.
   const name = basename(shell.replace(/\\/g, '/')).replace(/\.(exe|cmd|bat)$/i, '');


### PR DESCRIPTION
  
  ## Problem                                                                                                                                                                                              
                                                                                                                                                 
  On NixOS, `/bin/bash` does not exist — only `/bin/sh` is provided as a                                                                                                                                  
  FHS-compatible path. Any script with `#!/bin/bash` shebang or code that
  hardcodes `/bin/bash` will fail with:                                                                                                                                                                   
                                                                                                                                                 
      /bin/sh: line 1: /bin/bash: No such file or directory                                                                                                                                               
   
  Other distros (Alpine, some hardened containers, BSDs under Linuxulator)                                                                                                                                
  have similar gaps. See Wikipedia on shebang portability for the                                                                     
  canonical reference on why `#!/usr/bin/env <interpreter>` is the                                                                                                                                        
  portable form:                                                                                                                                                                                          
  https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability                                                                                                                                                
                                                                                                                                                                                                          
  ## Changes                                                                                                                          
                                                                                                                                                                                                          
  Three categories of fixes, all minimal:                                                                                             

  1. **22 shell scripts** — change shebang `#!/bin/bash` → `#!/usr/bin/env bash`.
     `/usr/bin/env` is POSIX-guaranteed to exist on every Unix including NixOS,                                                                                                                           
     and resolves `bash` via `$PATH`. No behavior change on systems where
     `/bin/bash` does exist.                                                                                                                                                                              
                                                                                                                                      
  2. **`src/team/tmux-session.ts` + `src/cli/tmux-utils.ts`** — change the                                                                                                                                
     fallback when `$SHELL` is unset from `'/bin/bash'` → `'/bin/sh'`.                                                                                                                                    
     `/bin/sh` is the POSIX-required path and exists on every Unix. This
     fallback only triggers when `$SHELL` is empty (rare), but when it does                                                                                                                               
     it was guaranteed to fail on NixOS.                                                                                              
                                                                                                                                                                                                          
  3. **`src/cli/__tests__/tmux-utils.test.ts`** — update the "defaults to                                                             
     … when $SHELL is not set" test assertion to match the new fallback.                                                                                                                                  
                     
  ## What's intentionally NOT changed                                                                                                                                                                     
                                                                                                                                      
  - `BASH_CANDIDATES = ['/bin/bash', '/usr/bin/bash']` — this list already
    has a `resolveShellFromPath()` fallback that walks `$PATH`, which finds                                                                                                                               
    the NixOS bash (e.g. `/run/current-system/sw/bin/bash`) via the user's                                                                                                                                
    profile. No change needed here.                                                                                                                                                                       
  - Test files that intentionally stub `$SHELL='/bin/bash'` as input to                                                                                                                                   
    test specific behavior — those remain as-is.                                                                                                                                                          
                            
  ## Testing                                                                                                                                                                                              
                                                                                                                                      
  - All 82 tests across the touched files (`tmux-utils`, `tmux-session`,
    `shell-affinity`) pass.                                                                                                                                                                               
  - Full suite: 8585 passed / 1 skipped / 1 unrelated pre-existing
    `config-dir.test.ts` failure (that test hardcodes `PATH=/bin:/usr/bin`                                                                                                                                
    which has no `node` on NixOS — separate NixOS issue, not introduced here).   