### PR TITLE
fix: align .omc/skills persistence contract across ignore rules, setup, and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 node_modules/
 *.log
 .DS_Store
-.omc/
-.omc/
+!.omc/
+.omc/*
+!.omc/skills/
+!.omc/skills/**
 .idea/
 .claude/
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Learn once, reuse forever. OMC extracts hard-won debugging knowledge into portab
 | | Project Scope | User Scope |
 |---|---|---|
 | **Path** | `.omc/skills/` | `~/.omc/skills/` |
-| **Shared with** | Team (version-controlled) | All your projects |
+| **Shared with** | Team (commit the skill file to keep it across worktrees) | All your projects |
 | **Priority** | Higher (overrides user) | Lower (fallback) |
 
 ```yaml
@@ -287,6 +287,8 @@ Wrap handler at server.py:42 in try/except ClientDisconnectedError...
 **Manage skills:** `/skill list | add | remove | edit | search`
 **Auto-learn:** `/learner` extracts reusable patterns with strict quality gates
 **Auto-inject:** Matching skills load into context automatically — no manual recall needed
+
+Project-scoped skills are stored in `.omc/skills/` and are intended to be committed when you want them shared. If you create them inside a linked git worktree and do not commit them, they disappear when that worktree is removed.
 
 [Full feature list →](docs/REFERENCE.md)
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -472,7 +472,7 @@ Next time keywords match → Solution auto-injects
 
 Storage:
 
-- **Project-level**: `.omc/skills/` (version-controlled)
+- **Project-level**: `.omc/skills/` (intended to be committed with the repo; uncommitted worktree-local skills disappear when that worktree is removed)
 - **User-level**: `~/.claude/skills/omc-learned/` (portable)
 
 #### 4. HUD Statusline (Real-Time Orchestration)

--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -115,6 +115,7 @@ ensure_local_omc_git_exclude() {
 
   cat >> "$exclude_path" <<'EOF'
 # BEGIN OMC local artifacts
+!.omc/
 .omc/*
 !.omc/skills/
 !.omc/skills/**

--- a/skills/learner/SKILL.md
+++ b/skills/learner/SKILL.md
@@ -110,7 +110,7 @@ This classification ensures expertise can be updated independently without desta
 ### Step 4: Save Location
 
 - **User-level**: `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/<skill-name>.md` - Rare. Only for truly portable insights.
-- **Project-level**: `.omc/skills/<skill-name>.md` - Default. Version-controlled with repo.
+- **Project-level**: `.omc/skills/<skill-name>.md` - Default. Intended to be committed with the repo when you want the team to keep the skill. In linked worktrees, uncommitted skills are still worktree-local and disappear if that worktree is deleted.
 
 ### Required File Format
 

--- a/skills/omc-setup/phases/01-install-claude-md.md
+++ b/skills/omc-setup/phases/01-install-claude-md.md
@@ -42,7 +42,7 @@ partially reconstruct CLAUDE.md.
 After running the script, verify the target file contains both markers. If marker validation
 fails, stop and report the failure instead of writing CLAUDE.md manually.
 
-For `local` installs inside a git repository, the script also seeds `.git/info/exclude` with an OMC block that ignores local `.omc/*` artifacts by default while preserving `.omc/skills/` for version-controlled project skills.
+For `local` installs inside a git repository, the script also seeds `.git/info/exclude` with an OMC block that re-includes `.omc/`, ignores local `.omc/*` artifacts by default, and preserves `.omc/skills/` for project skills you intend to commit.
 
 **FALLBACK** if curl fails:
 Tell user to manually download from:
@@ -58,7 +58,7 @@ If `CONFIG_TARGET` is `local`:
 ```
 OMC Project Configuration Complete
 - CLAUDE.md: Updated with latest configuration from GitHub at ./.claude/CLAUDE.md
-- Git excludes: Added local `.omc/*` ignore rules to `.git/info/exclude` (keeps `.omc/skills/` trackable)
+- Git excludes: Added local `.omc/*` ignore rules to `.git/info/exclude` (keeps `.omc/skills/` trackable for committed project skills)
 - Backup: Previous CLAUDE.md backed up (if existed)
 - Scope: PROJECT - applies only to this project
 - Hooks: Provided by plugin (no manual installation needed)

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -725,7 +725,7 @@ When invoked without arguments, run the full guided wizard.
 
 **Automatic Application**: Claude detects triggers and applies skills automatically - no need to remember or search for solutions.
 
-**Version Control**: Project-level skills (.omc/skills/) are committed with your code, so the whole team benefits.
+**Version Control**: Project-level skills (`.omc/skills/`) are intended to be committed with your code so the whole team benefits. In linked worktrees, uncommitted skills remain local to that worktree and disappear if it is removed.
 
 **Evolving Knowledge**: Skills improve over time as you discover better approaches and refine triggers.
 

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -152,10 +152,116 @@ Use the real docs file.
 
     const excludeContents = readFileSync(excludePath, 'utf-8');
     expect(excludeContents).toContain('# BEGIN OMC local artifacts');
+    expect(excludeContents).toContain('!.omc/');
     expect(excludeContents).toContain('.omc/*');
     expect(excludeContents).toContain('!.omc/skills/');
     expect(excludeContents).toContain('!.omc/skills/**');
     expect(excludeContents).toContain('# END OMC local artifacts');
+  });
+
+  it('keeps the local git exclude block aligned with the tracked root .gitignore skill exceptions', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const repoGitignore = readFileSync(join(process.cwd(), '.gitignore'), 'utf-8');
+    expect(repoGitignore).toContain('!.omc/');
+    expect(repoGitignore).toContain('.omc/*');
+    expect(repoGitignore).toContain('!.omc/skills/');
+    expect(repoGitignore).toContain('!.omc/skills/**');
+
+    const gitInit = spawnSync('git', ['init'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+      },
+      encoding: 'utf-8',
+    });
+    expect(gitInit.status).toBe(0);
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'local'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+
+    const excludePath = join(fixture.projectRoot, '.git', 'info', 'exclude');
+    const excludeContents = readFileSync(excludePath, 'utf-8');
+    expect(excludeContents).toContain('!.omc/');
+    expect(excludeContents).toContain('.omc/*');
+    expect(excludeContents).toContain('!.omc/skills/');
+    expect(excludeContents).toContain('!.omc/skills/**');
+  });
+
+  it('local git exclude block keeps .omc/skills trackable while ignoring sibling .omc artifacts', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const gitInit = spawnSync('git', ['init'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+      },
+      encoding: 'utf-8',
+    });
+    expect(gitInit.status).toBe(0);
+
+    const seedExclude = join(fixture.projectRoot, '.git', 'info', 'exclude');
+    writeFileSync(seedExclude, '.omc/\n');
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'local'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+
+    const skillDir = join(fixture.projectRoot, '.omc', 'skills');
+    const stateDir = join(fixture.projectRoot, '.omc', 'state');
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(skillDir, 'example.md'), 'skill');
+    writeFileSync(join(stateDir, 'example.json'), '{}');
+
+    const skillIgnore = spawnSync('git', ['check-ignore', '-v', '.omc/skills/example.md'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+      },
+      encoding: 'utf-8',
+    });
+    expect(skillIgnore.status).toBe(0);
+    expect(skillIgnore.stdout).toContain('!.omc/skills/**');
+
+    const stateIgnore = spawnSync('git', ['check-ignore', '-v', '.omc/state/example.json'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+      },
+      encoding: 'utf-8',
+    });
+    expect(stateIgnore.status).toBe(0);
+    expect(stateIgnore.stdout).toContain('.omc/*');
   });
 
   it('does not duplicate the local git exclude block on repeated local setup runs', () => {

--- a/src/__tests__/skills-frontmatter-regression.test.ts
+++ b/src/__tests__/skills-frontmatter-regression.test.ts
@@ -26,6 +26,7 @@ describe('builtin skill drafting contracts for learned skills (issue #2425)', ()
     expect(learner!.template).toContain('Do **not** write plain markdown without frontmatter.');
     expect(learner!.template).toContain('.omc/skills/<skill-name>.md');
     expect(learner!.template).toContain('skills/omc-learned/<skill-name>.md');
+    expect(learner!.template).toContain('uncommitted skills are still worktree-local');
   });
 
   it('skillify skill instructs drafting flat file-backed skills with YAML frontmatter', () => {


### PR DESCRIPTION
## Summary
- preserve `.omc/skills/**` as the only tracked `.omc` subtree in the repo root ignore rules
- align `setup-claude-md.sh` local excludes with the same `.omc/skills/**` exception shape
- clarify learner/docs wording that project skills should be committed and uncommitted linked-worktree skills disappear when the worktree is removed
- add targeted regression coverage for ignore-rule and template contract alignment

## Verification
- `npm test -- src/__tests__/setup-claude-md-script.test.ts src/__tests__/skills-frontmatter-regression.test.ts`
