### PR TITLE
Clarify bundled agent effort inheritance

### DIFF
--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -48,7 +48,8 @@ disallowedTools: Write, Edit
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: high (thorough gap analysis).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: high (thorough gap analysis).
     - Stop when all requirement categories have been evaluated and findings are prioritized.
   </Execution_Policy>
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -61,7 +61,8 @@ disallowedTools: Write, Edit
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: high (thorough analysis with evidence).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: high (thorough analysis with evidence).
     - Stop when diagnosis is complete and all recommendations have file:line references.
     - For obvious bugs (typo, missing import): skip to recommendation with verification.
   </Execution_Policy>

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -69,7 +69,8 @@ disallowedTools: Write, Edit
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: high (thorough two-stage review).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: high (thorough two-stage review).
     - For trivial changes: brief quality check only.
     - Stop when verdict is clear and all issues are documented with severity and fix suggestions.
   </Execution_Policy>

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -171,7 +171,8 @@ disallowedTools: Write, Edit
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: maximum. This is thorough review. Leave no stone unturned.
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: maximum. This is thorough review. Leave no stone unturned.
     - Do NOT stop at the first few findings. Work typically has layered issues — surface problems mask deeper structural ones.
     - Time-box per-finding verification but DO NOT skip verification entirely.
     - If the work is genuinely excellent and you cannot find significant issues after thorough investigation, say so clearly — a clean bill of health from you carries real signal.

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -71,7 +71,8 @@ level: 3
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: medium (systematic investigation).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: medium (systematic investigation).
     - Stop when root cause is identified with evidence and minimal fix is recommended.
     - For build errors: stop when build command exits 0 and no new errors exist.
     - Escalate after 3 failed hypotheses (do not keep trying variations of the same approach).

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -55,7 +55,8 @@ level: 2
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: high (visual quality is non-negotiable).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: high (visual quality is non-negotiable).
     - Match implementation complexity to aesthetic vision: maximalist = elaborate code, minimalist = precise restraint.
     - Stop when the UI is functional, visually intentional, and verified.
   </Execution_Policy>

--- a/agents/document-specialist.md
+++ b/agents/document-specialist.md
@@ -38,7 +38,7 @@ Implementing against outdated or incorrect API documentation causes bugs that ar
 <Tool_Usage> - Use Read to inspect local documentation files first when they are likely to answer the question (README, docs/, migration/reference guides). - Use Bash for read-only Context Hub checks when appropriate (for example: `command -v chub`, `chub search <topic>`, `chub get <doc-id>`). Do not install or mutate the environment unless explicitly asked. - If Context Hub (`chub`) or Context7 MCP tools are available, use them for curated external SDK/framework/API documentation before generic web search. - Use WebSearch for finding official documentation, papers, manuals, and reference databases when `chub`/curated docs are unavailable or incomplete. - Use WebFetch for extracting details from specific documentation pages. - Do not turn local-doc inspection into broad codebase exploration; hand implementation search back to explore when needed.
 </Tool_Usage>
 
-<Execution_Policy> - Default effort: medium (find the answer, cite the source). - Quick lookups (haiku tier): 1-2 searches, direct answer with one source URL. - Comprehensive research (sonnet tier): multiple sources, synthesis, conflict resolution. - Stop when the question is answered with cited sources.
+<Execution_Policy> - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override. - Behavioral effort guidance: medium (find the answer, cite the source). - Quick lookups (haiku tier): 1-2 searches, direct answer with one source URL. - Comprehensive research (sonnet tier): multiple sources, synthesis, conflict resolution. - Stop when the question is answered with cited sources.
 </Execution_Policy>
 
 <Output_Format> ## Research: [Query]

--- a/agents/executor.md
+++ b/agents/executor.md
@@ -70,7 +70,8 @@ level: 2
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: match complexity to task classification.
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: match complexity to task classification.
     - Trivial tasks: skip extensive exploration, verify only modified file.
     - Scoped tasks: targeted exploration, verify modified files + run relevant tests.
     - Complex tasks: full exploration, full verification suite, document decisions in remember tags.

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -64,7 +64,8 @@ disallowedTools: Write, Edit
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: medium (3-5 parallel searches from different angles).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: medium (3-5 parallel searches from different angles).
     - Quick lookups: 1-2 targeted searches.
     - Thorough investigations: 5-10 searches including alternative naming conventions and related files.
     - Stop when you have enough information for the caller to proceed without follow-up questions.

--- a/agents/git-master.md
+++ b/agents/git-master.md
@@ -50,7 +50,8 @@ level: 3
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: medium (atomic commits with style matching).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: medium (atomic commits with style matching).
     - Stop when all commits are created and verified with git log output.
   </Execution_Policy>
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -69,7 +69,8 @@ level: 4
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: medium (focused interview, concise plan).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: medium (focused interview, concise plan).
     - Stop when the plan is actionable and user-confirmed.
     - Interview phase is the default state. Plan generation only on explicit request.
   </Execution_Policy>

--- a/agents/qa-tester.md
+++ b/agents/qa-tester.md
@@ -48,7 +48,8 @@ level: 3
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: medium (happy path + key error paths).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: medium (happy path + key error paths).
     - Comprehensive (opus tier): happy path + edge cases + security + performance + concurrent access.
     - Stop when all test cases are executed and results are documented.
   </Execution_Policy>

--- a/agents/scientist.md
+++ b/agents/scientist.md
@@ -50,7 +50,8 @@ disallowedTools: Write, Edit
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: medium (thorough analysis proportional to data complexity).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: medium (thorough analysis proportional to data complexity).
     - Quick inspections (haiku tier): .head(), .describe(), value_counts. Speed over depth.
     - Deep analysis (sonnet tier): multi-step analysis, statistical testing, visualization, full report.
     - Stop when findings answer the objective and evidence is documented.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -63,7 +63,8 @@ disallowedTools: Write, Edit
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: high (thorough OWASP analysis).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: high (thorough OWASP analysis).
     - Stop when all applicable OWASP categories are evaluated and findings are prioritized.
     - Always review when: new API endpoints, auth code changes, user input handling, DB queries, file uploads, payment code, dependency updates.
   </Execution_Policy>

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -78,7 +78,8 @@ level: 3
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: medium (practical tests that cover important paths).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: medium (practical tests that cover important paths).
     - Stop when tests pass, cover the requested scope, and fresh test output is shown.
   </Execution_Policy>
 

--- a/agents/tracer.md
+++ b/agents/tracer.md
@@ -87,7 +87,8 @@ level: 3
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: medium-high
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: medium-high
     - Prefer evidence density over breadth, but do not stop at the first plausible explanation when alternatives remain viable
     - When ambiguity remains high, preserve a ranked shortlist instead of forcing a single verdict
     - If the trace is blocked by missing evidence, end with the best current ranking plus the critical unknown and discriminating probe

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -48,7 +48,8 @@ level: 3
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: high (thorough evidence-based verification).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: high (thorough evidence-based verification).
     - Stop when verdict is clear with evidence for every acceptance criterion.
   </Execution_Policy>
 

--- a/agents/writer.md
+++ b/agents/writer.md
@@ -51,7 +51,8 @@ level: 2
   </Tool_Usage>
 
   <Execution_Policy>
-    - Default effort: low (concise, accurate documentation).
+    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
+    - Behavioral effort guidance: low (concise, accurate documentation).
     - Stop when documentation is complete, accurate, and verified.
   </Execution_Policy>
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -180,7 +180,7 @@ tags: tag1, tag2
 Skill documentation here...
 ```
 
-**Agents** are discovered from `.md` files in the agents directory with similar frontmatter structure.
+**Agents** are discovered from `.md` files in the agents directory with similar frontmatter structure. Supported runtime fields depend on Claude Code; OMC's bundled agent files currently rely on `name`, `description`, `model`, optional tool restrictions, and prompt body guidance. They do not currently ship an `effort:` frontmatter override, so effort inherits from the parent Claude Code session unless a custom agent explicitly adds one.
 
 ## MCP Server Discovery
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -192,9 +192,13 @@ name: architect
 description: Your custom description
 tools: Read, Grep, Glob, Bash, Edit
 model: opus # or sonnet, haiku
+# Optional: effort inherits from the parent Claude Code session unless you add an explicit override.
+# effort: high
 ---
 Your custom system prompt here...
 ```
+
+Bundled OMC agent prompts currently do **not** ship an `effort:` frontmatter field. Any effort language inside `agents/*.md` is behavioral guidance for the prompt body, while runtime effort inherits from the parent Claude Code session unless the agent markdown explicitly declares an override.
 
 ### Project-Level Config
 


### PR DESCRIPTION
## Summary
- clarify bundled agent effort wording as behavioral prompt guidance rather than runtime frontmatter
- document that bundled OMC agents inherit parent-session effort unless custom agent markdown explicitly adds an `effort:` override
- keep executor effort guidance dynamic by task complexity without changing runtime behavior

## Verification
- `npm test -- --run src/__tests__/installer.test.ts src/__tests__/agent-registry.test.ts src/__tests__/load-agent-prompt.test.ts`
- `git diff --check`
- `rg -n '^effort\\s*:' agents docs` returned no bundled/docs `effort:` frontmatter additions

Closes #2786
