### PR TITLE
Guard write/edit success envelopes in post-tool verifier

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -703,6 +703,21 @@ export function detectWriteFailure(output) {
   return errorPatterns.some(pattern => pattern.test(cleaned));
 }
 
+// Detect Claude Code's deterministic write/edit success markers so docs or
+// serialized tool output containing diagnostic prose do not override success.
+export function isClaudeCodeWriteSuccess(output) {
+  if (!output) return false;
+
+  const cleaned = stripClaudeTempCwdErrors(output);
+  const successPatterns = [
+    /(^|\n)The file .+ has been updated successfully\.?(\n|$)/i,
+    /(^|\n)File (?:created|written|updated) successfully(?:\s+at:\s*.+)?\.?(\n|$)/i,
+    /(^|\n).*file state is current in your context\b.*(\n|$)/i,
+  ];
+
+  return successPatterns.some(pattern => pattern.test(cleaned));
+}
+
 // Get agent completion summary from tracking state
 function getAgentCompletionSummary(directory, quietLevel = QUIET_LEVEL) {
   const trackingFile = join(directory, '.omc', 'state', 'subagent-tracking.json');
@@ -782,7 +797,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
     }
 
     case 'Edit':
-      if (detectWriteFailure(toolOutput)) {
+      if (!isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput)) {
         message = 'Edit operation failed. Verify file exists and content matches exactly.';
       } else if (QUIET_LEVEL === 0) {
         message = 'Code modified. Verify changes work as expected before marking complete.';
@@ -790,7 +805,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
       break;
 
     case 'Write':
-      if (detectWriteFailure(toolOutput)) {
+      if (!isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput)) {
         message = 'Write operation failed. Check file permissions and directory existence.';
       } else if (QUIET_LEVEL === 0) {
         message = 'File written. Test the changes to ensure they work correctly.';

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -9,7 +9,7 @@ import { join } from 'path';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import process from 'process';
-import { detectBashFailure, detectWriteFailure, isNonZeroExitWithOutput, summarizeAgentResult } from '../../scripts/post-tool-verifier.mjs';
+import { detectBashFailure, detectWriteFailure, isClaudeCodeWriteSuccess, isNonZeroExitWithOutput, summarizeAgentResult } from '../../scripts/post-tool-verifier.mjs';
 
 const SCRIPT_PATH = join(process.cwd(), 'scripts', 'post-tool-verifier.mjs');
 const TEMPLATE_HOOK_PATH = join(process.cwd(), 'templates', 'hooks', 'post-tool-use.mjs');
@@ -328,6 +328,30 @@ describe('isNonZeroExitWithOutput (issue #960)', () => {
   });
 });
 
+describe('isClaudeCodeWriteSuccess', () => {
+  it('detects canonical edit success output', () => {
+    expect(isClaudeCodeWriteSuccess('The file /tmp/doc.md has been updated successfully.')).toBe(true);
+  });
+
+  it('detects canonical write success output with location suffix', () => {
+    expect(isClaudeCodeWriteSuccess('File created successfully at: /tmp/doc.md')).toBe(true);
+  });
+
+  it('detects file-state confirmation output', () => {
+    expect(isClaudeCodeWriteSuccess('The file state is current in your context window.')).toBe(true);
+  });
+
+  it('ignores arbitrary markdown diagnostic prose without a success marker', () => {
+    const content = [
+      '## Example',
+      '',
+      '$ ls graphify-out',
+      'No such file or directory',
+    ].join('\n');
+    expect(isClaudeCodeWriteSuccess(content)).toBe(false);
+  });
+});
+
 describe('detectWriteFailure', () => {
   describe('Claude Code temp CWD false positives (issue #696)', () => {
     it('should not flag macOS temp CWD permission error as a write failure', () => {
@@ -382,6 +406,16 @@ describe('detectWriteFailure', () => {
 
     it('should return false for clean output', () => {
       expect(detectWriteFailure('File written successfully')).toBe(false);
+    });
+
+    it('should still report diagnostic-looking markdown as a raw failure signal without a tool success guard', () => {
+      const content = [
+        '## Example',
+        '',
+        '$ ls graphify-out',
+        'No such file or directory',
+      ].join('\n');
+      expect(detectWriteFailure(content)).toBe(true);
     });
   });
 
@@ -477,6 +511,40 @@ describe('agent output summarization / truncation (issue #1373)', () => {
 });
 
 describe('post-tool hook regression coverage (issue #2615)', () => {
+  it('prefers canonical edit success output over embedded markdown diagnostics', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Edit',
+      tool_response: [
+        'The file /tmp/doc.md has been updated successfully.',
+        '',
+        '## Example',
+        '',
+        '$ ls graphify-out',
+        'No such file or directory',
+      ].join('\n'),
+      session_id: 'issue-2792-edit',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Code modified.');
+    expect(out.hookSpecificOutput?.additionalContext).not.toContain('Edit operation failed');
+  });
+
+  it('prefers canonical write success output over serialized tool output with diagnostics', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Write',
+      tool_response: [
+        'File created successfully at: /tmp/doc.md',
+        '{"stdout":"No such file or directory","exitCode":1}',
+      ].join('\n'),
+      session_id: 'issue-2792-write',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('File written.');
+    expect(out.hookSpecificOutput?.additionalContext).not.toContain('Write operation failed');
+  });
+
   it('does not treat inline error-like strings in Edit output as an edit failure', () => {
     const out = runPostToolVerifier({
       tool_name: 'Edit',


### PR DESCRIPTION
## Summary
- add a narrow structural success-signal guard for canonical Edit/Write success responses
- prefer explicit success envelopes over embedded markdown or serialized diagnostic payload text
- add focused regressions for issue #2792 without weakening raw detector semantics

## Validation
- npx vitest run src/__tests__/post-tool-verifier.test.mjs
- npx tsc --noEmit --pretty false

Closes #2792