### PR TITLE
fix(keyword-detector): prevent re-entry from pasted system-echo blocks

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -355,43 +355,40 @@ const QUESTION_FOLLOWUP_PATTERNS = [
 // copies a "[RALPH LOOP - ITERATION N] ..." block into a new session to debug
 // it will unintentionally re-trigger ralph, and the pasted text ends up as
 // the new state.prompt — producing a recursive self-reinforcing loop.
-// NOTE: all patterns use the `gim` flags. Matching is case-insensitive because
-// hasActionableKeyword operates on a `.toLowerCase()`-ed cleanPrompt, and
-// multi-line because each pattern now consumes a SINGLE line of echoed hook
-// output at a time. Previously we matched the entire echo block up to a blank
-// line, but that swallowed a user's real follow-up request when they typed it
-// on the very next line without inserting a blank separator (reviewed and
-// flagged as P1 by Codex automated review). Single-line matches keep the
-// guard strong (every recognizable echo line is stripped) while preserving
-// any non-echo text that follows.
+// Continuation lines that hook output typically emits DIRECTLY after a
+// recognized block header. They must be stripped only in that context —
+// never standalone — because a user might legitimately start a prompt with
+// "Task: …" or similar (Codex automated review P1/P2 on #2795).
+const ECHO_CONTINUATION = '(?:\\r?\\n[ \\t]*(?:Task:\\s|When FULLY complete \\(after Architect verification\\)|run\\s+\\/oh-my-claudecode:cancel).*)*';
+
+// NOTE: each pattern is a SINGLE LOGICAL BLOCK: the block header line +
+// zero-or-more continuation lines that hooks emit right after it. The whole
+// match is stripped together. Both `i` (case-insensitive against the
+// lower-cased cleanPrompt upstream) and `m` (so `^`/`$` match line
+// boundaries) are required.
+function buildEchoBlockRegex(headerBody) {
+  return new RegExp(`^[ \\t]*${headerBody}.*${ECHO_CONTINUATION}$`, 'gim');
+}
+
 const SYSTEM_ECHO_BLOCK_PATTERNS = [
   // persistent-mode.mjs block headers
-  /^[ \t]*\[RALPH LOOP\s*-\s*ITERATION[^\]\n]*\].*$/gim,
-  /^[ \t]*\[RALPH LOOP\s*-\s*(?:HARD LIMIT|EXTENDED)\].*$/gim,
-  /^[ \t]*\[TEAM\s*-\s*Phase:[^\]\n]*\].*$/gim,
-  /^[ \t]*\[AUTOPILOT[^\]\n]*\].*$/gim,
-  /^[ \t]*\[ULTRAPILOT[^\]\n]*\].*$/gim,
-  /^[ \t]*\[ULTRAWORK[^\]\n]*\].*$/gim,
-  /^[ \t]*\[ULTRAQA[^\]\n]*\].*$/gim,
-  /^[ \t]*\[PIPELINE[^\]\n]*\].*$/gim,
-  /^[ \t]*\[SWARM[^\]\n]*\].*$/gim,
-  /^[ \t]*\[TOOL ERROR[^\]\n]*\].*$/gim,
+  buildEchoBlockRegex('\\[RALPH LOOP\\s*-\\s*ITERATION[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[RALPH LOOP\\s*-\\s*(?:HARD LIMIT|EXTENDED)\\]'),
+  buildEchoBlockRegex('\\[TEAM\\s*-\\s*Phase:[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[AUTOPILOT[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[ULTRAPILOT[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[ULTRAWORK[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[ULTRAQA[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[PIPELINE[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[SWARM[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[TOOL ERROR[^\\]\\n]*\\]'),
   // keyword-detector.mjs block headers
-  /^[ \t]*\[MAGIC KEYWORD:[^\]\n]*\].*$/gim,
-  /^[ \t]*\[MAGIC KEYWORDS DETECTED:[^\]\n]*\].*$/gim,
+  buildEchoBlockRegex('\\[MAGIC KEYWORD:[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[MAGIC KEYWORDS DETECTED:[^\\]\\n]*\\]'),
   // Stop-hook wrapping by the Claude Code harness
-  /^[ \t]*Stop hook (?:blocking error|feedback|stopped continuation).*$/gim,
-  /^[ \t]*PreToolUse:[^\n]*hook additional context:.*$/gim,
-  /^[ \t]*PostToolUse:[^\n]*hook additional context:.*$/gim,
-  // Continuation lines that the hooks above almost always emit directly after
-  // the block header. These are stripped separately so that only genuine hook
-  // echoes disappear — a line like "Task: 사용자가 직접 쓴 내용" that a user
-  // authors on their own (outside any recognized echo block) would lack the
-  // surrounding signatures, and while the line itself would still match, the
-  // user rarely starts a real request with these exact tokens.
-  /^[ \t]*When FULLY complete \(after Architect verification\).*$/gim,
-  /^[ \t]*run\s+\/oh-my-claudecode:cancel.*$/gim,
-  /^[ \t]*Task:\s.*$/gim,
+  buildEchoBlockRegex('Stop hook (?:blocking error|feedback|stopped continuation)'),
+  buildEchoBlockRegex('PreToolUse:[^\\n]*hook additional context:'),
+  buildEchoBlockRegex('PostToolUse:[^\\n]*hook additional context:'),
 ];
 
 // Signature lines indicating the text is predominantly a system echo. Even

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -355,28 +355,43 @@ const QUESTION_FOLLOWUP_PATTERNS = [
 // copies a "[RALPH LOOP - ITERATION N] ..." block into a new session to debug
 // it will unintentionally re-trigger ralph, and the pasted text ends up as
 // the new state.prompt — producing a recursive self-reinforcing loop.
-// NOTE: all patterns use the `i` flag. hasActionableKeyword operates on
-// cleanPrompt which is `.toLowerCase()`-ed, so these patterns must match
-// case-insensitively to catch pasted echoes.
+// NOTE: all patterns use the `gim` flags. Matching is case-insensitive because
+// hasActionableKeyword operates on a `.toLowerCase()`-ed cleanPrompt, and
+// multi-line because each pattern now consumes a SINGLE line of echoed hook
+// output at a time. Previously we matched the entire echo block up to a blank
+// line, but that swallowed a user's real follow-up request when they typed it
+// on the very next line without inserting a blank separator (reviewed and
+// flagged as P1 by Codex automated review). Single-line matches keep the
+// guard strong (every recognizable echo line is stripped) while preserving
+// any non-echo text that follows.
 const SYSTEM_ECHO_BLOCK_PATTERNS = [
-  // persistent-mode.mjs outputs
-  /\[RALPH LOOP\s*-\s*ITERATION[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[RALPH LOOP\s*-\s*(?:HARD LIMIT|EXTENDED)\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[TEAM\s*-\s*Phase:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[AUTOPILOT[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[ULTRAPILOT[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[ULTRAWORK[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[ULTRAQA[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[PIPELINE[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[SWARM[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[TOOL ERROR[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  // keyword-detector.mjs outputs
-  /\[MAGIC KEYWORD:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[MAGIC KEYWORDS DETECTED:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  // persistent-mode.mjs block headers
+  /^[ \t]*\[RALPH LOOP\s*-\s*ITERATION[^\]\n]*\].*$/gim,
+  /^[ \t]*\[RALPH LOOP\s*-\s*(?:HARD LIMIT|EXTENDED)\].*$/gim,
+  /^[ \t]*\[TEAM\s*-\s*Phase:[^\]\n]*\].*$/gim,
+  /^[ \t]*\[AUTOPILOT[^\]\n]*\].*$/gim,
+  /^[ \t]*\[ULTRAPILOT[^\]\n]*\].*$/gim,
+  /^[ \t]*\[ULTRAWORK[^\]\n]*\].*$/gim,
+  /^[ \t]*\[ULTRAQA[^\]\n]*\].*$/gim,
+  /^[ \t]*\[PIPELINE[^\]\n]*\].*$/gim,
+  /^[ \t]*\[SWARM[^\]\n]*\].*$/gim,
+  /^[ \t]*\[TOOL ERROR[^\]\n]*\].*$/gim,
+  // keyword-detector.mjs block headers
+  /^[ \t]*\[MAGIC KEYWORD:[^\]\n]*\].*$/gim,
+  /^[ \t]*\[MAGIC KEYWORDS DETECTED:[^\]\n]*\].*$/gim,
   // Stop-hook wrapping by the Claude Code harness
-  /Stop hook (?:blocking error|feedback|stopped continuation)[\s\S]*?(?=\n\n|\n?$)/gi,
-  /PreToolUse:[^\n]*hook additional context:[\s\S]*?(?=\n\n|\n?$)/gi,
-  /PostToolUse:[^\n]*hook additional context:[\s\S]*?(?=\n\n|\n?$)/gi,
+  /^[ \t]*Stop hook (?:blocking error|feedback|stopped continuation).*$/gim,
+  /^[ \t]*PreToolUse:[^\n]*hook additional context:.*$/gim,
+  /^[ \t]*PostToolUse:[^\n]*hook additional context:.*$/gim,
+  // Continuation lines that the hooks above almost always emit directly after
+  // the block header. These are stripped separately so that only genuine hook
+  // echoes disappear — a line like "Task: 사용자가 직접 쓴 내용" that a user
+  // authors on their own (outside any recognized echo block) would lack the
+  // surrounding signatures, and while the line itself would still match, the
+  // user rarely starts a real request with these exact tokens.
+  /^[ \t]*When FULLY complete \(after Architect verification\).*$/gim,
+  /^[ \t]*run\s+\/oh-my-claudecode:cancel.*$/gim,
+  /^[ \t]*Task:\s.*$/gim,
 ];
 
 // Signature lines indicating the text is predominantly a system echo. Even

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -347,6 +347,107 @@ const QUESTION_FOLLOWUP_PATTERNS = [
   /\b(?:how\s+many|how\s+much|why|what\s+happened|what\s+went\s+wrong|token\s+budget|cost|pricing)\b/i,
   /(?:왜|얼마|몇\s*번|몇번|토큰|가격|비용|질문)/u,
 ];
+
+// Patterns that identify system-generated echoes (hook outputs) which can be
+// pasted back into the prompt verbatim. If a mode keyword only appears inside
+// such an echo block we MUST NOT re-activate the mode: otherwise a user who
+// copies a "[RALPH LOOP - ITERATION N] ..." block into a new session to debug
+// it will unintentionally re-trigger ralph, and the pasted text ends up as
+// the new state.prompt — producing a recursive self-reinforcing loop.
+// NOTE: all patterns use the `i` flag. hasActionableKeyword operates on
+// cleanPrompt which is `.toLowerCase()`-ed, so these patterns must match
+// case-insensitively to catch pasted echoes.
+const SYSTEM_ECHO_BLOCK_PATTERNS = [
+  // persistent-mode.mjs outputs
+  /\[RALPH LOOP\s*-\s*ITERATION[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[RALPH LOOP\s*-\s*(?:HARD LIMIT|EXTENDED)\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[TEAM\s*-\s*Phase:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[AUTOPILOT[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[ULTRAPILOT[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[ULTRAWORK[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[ULTRAQA[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[PIPELINE[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[SWARM[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[TOOL ERROR[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  // keyword-detector.mjs outputs
+  /\[MAGIC KEYWORD:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[MAGIC KEYWORDS DETECTED:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  // Stop-hook wrapping by the Claude Code harness
+  /Stop hook (?:blocking error|feedback|stopped continuation)[\s\S]*?(?=\n\n|\n?$)/gi,
+  /PreToolUse:[^\n]*hook additional context:[\s\S]*?(?=\n\n|\n?$)/gi,
+  /PostToolUse:[^\n]*hook additional context:[\s\S]*?(?=\n\n|\n?$)/gi,
+];
+
+// Signature lines indicating the text is predominantly a system echo. Even
+// when the block patterns above fail to delimit cleanly (e.g. truncation),
+// presence of these sentinels should make us treat the prompt as an echo.
+// All patterns use `i` because hasActionableKeyword sees a lowercased prompt.
+const SYSTEM_ECHO_SIGNATURES = [
+  /\bWhen FULLY complete \(after Architect verification\)\b/i,
+  /\brun\s+\/oh-my-claudecode:cancel\b/i,
+  /\[RALPH LOOP\s*-\s*ITERATION\b/i,
+];
+
+const MAX_STATE_PROMPT_LEN = 500;
+
+function stripSystemEchoes(text) {
+  if (typeof text !== 'string' || text.length === 0) return '';
+  let cleaned = text;
+  for (const pattern of SYSTEM_ECHO_BLOCK_PATTERNS) {
+    cleaned = cleaned.replace(pattern, ' ');
+  }
+  return cleaned;
+}
+
+function looksLikeSystemEcho(text) {
+  if (typeof text !== 'string' || text.length === 0) return false;
+  if (SYSTEM_ECHO_SIGNATURES.some((pattern) => pattern.test(text))) return true;
+  // Also treat the presence of ANY echo block pattern as an echo, so that
+  // mode-specific paste blocks (AUTOPILOT, ULTRAWORK, TEAM, etc.) are
+  // recognized without needing a dedicated signature line.
+  for (const pattern of SYSTEM_ECHO_BLOCK_PATTERNS) {
+    const probe = new RegExp(pattern.source, pattern.flags.replace('g', ''));
+    if (probe.test(text)) return true;
+  }
+  return false;
+}
+
+/**
+ * Sanitize a prompt before persisting it to a *-state.json file.
+ * Returning the raw prompt risks storing large system echoes or pasted
+ * hook output, which persistent-mode.mjs would then blast back into the
+ * next Stop-hook block reason on every iteration.
+ *
+ * Strategy:
+ * 1. Strip echoes first. If non-empty content remains AND that remainder no
+ *    longer looks like an echo, keep it (preserves the real user request in
+ *    an "echo + blank line + real request" paste).
+ * 2. Otherwise, if the raw prompt looks like a pure echo, substitute the
+ *    placeholder sentinel.
+ * 3. Finally, hard-truncate to MAX_STATE_PROMPT_LEN chars.
+ */
+function sanitizePromptForState(prompt) {
+  if (typeof prompt !== 'string') return '';
+  const trimmed = prompt.trim();
+  if (!trimmed) return '';
+
+  const stripped = stripSystemEchoes(trimmed).trim();
+  if (stripped.length > 0 && !looksLikeSystemEcho(stripped)) {
+    return stripped.length > MAX_STATE_PROMPT_LEN
+      ? `${stripped.slice(0, MAX_STATE_PROMPT_LEN - 3)}...`
+      : stripped;
+  }
+
+  if (looksLikeSystemEcho(trimmed)) {
+    return '(prompt omitted: pasted system echo)';
+  }
+
+  // Fallback (stripping left nothing but original isn't recognizably an echo)
+  const base = stripped.length > 0 ? stripped : trimmed;
+  return base.length > MAX_STATE_PROMPT_LEN
+    ? `${base.slice(0, MAX_STATE_PROMPT_LEN - 3)}...`
+    : base;
+}
 const MODE_REFERENCE_PATTERN =
   /\b(?:ralph|autopilot|auto[\s-]?pilot|ultrawork|ulw|ralplan|ultrathink|deepsearch|deep[\s-]?analyze|deepanalyze|deep[\s-]interview|ouroboros|ccg|claude-codex-gemini|deerflow)\b/gi;
 
@@ -477,15 +578,25 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
 }
 
 function hasActionableKeyword(text, pattern) {
+  // Strip system-generated echo blocks (persistent-mode/keyword-detector
+  // outputs, Stop-hook wrappers) BEFORE searching for keywords. Otherwise
+  // pasting a previous "[RALPH LOOP - ITERATION N] ..." block into a prompt
+  // would re-activate ralph mode and the echo itself would be saved as
+  // state.prompt, which persistent-mode.mjs then blasts back on every
+  // iteration — a self-reinforcing loop that is hard to cancel.
+  const searchText = looksLikeSystemEcho(text)
+    ? stripSystemEchoes(text)
+    : text;
+
   const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
   const globalPattern = new RegExp(pattern.source, flags);
 
-  for (const match of text.matchAll(globalPattern)) {
+  for (const match of searchText.matchAll(globalPattern)) {
     if (match.index === undefined) {
       continue;
     }
 
-    if (isInformationalKeywordContext(text, match.index, match[0].length, match[0])) {
+    if (isInformationalKeywordContext(searchText, match.index, match[0].length, match[0])) {
       continue;
     }
 
@@ -496,19 +607,26 @@ function hasActionableKeyword(text, pattern) {
 }
 
 function hasActionableRalplanKeyword(text, pattern) {
+  // Same echo guard as hasActionableKeyword.
+  const searchText = looksLikeSystemEcho(text)
+    ? stripSystemEchoes(text)
+    : text;
+
   const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
   const globalPattern = new RegExp(pattern.source, flags);
 
-  for (const match of text.matchAll(globalPattern)) {
+  for (const match of searchText.matchAll(globalPattern)) {
     if (match.index === undefined) {
       continue;
     }
 
-    if (isInformationalKeywordContext(text, match.index, match[0].length, match[0])) {
+    // match.index is relative to searchText — use searchText for all
+    // downstream context lookups to keep indices aligned.
+    if (isInformationalKeywordContext(searchText, match.index, match[0].length, match[0])) {
       continue;
     }
 
-    if (!hasExplicitInvocationContext(text, match.index, match[0].length, match[0])) {
+    if (!hasExplicitInvocationContext(searchText, match.index, match[0].length, match[0])) {
       continue;
     }
 
@@ -520,6 +638,10 @@ function hasActionableRalplanKeyword(text, pattern) {
 
 // Create state file for a mode
 function activateState(directory, prompt, stateName, sessionId) {
+  const now = new Date().toISOString();
+  // Sanitize prompt BEFORE writing to state: prevents pasted system echoes
+  // and oversized blobs from being persisted and re-emitted by Stop hook.
+  const safePrompt = sanitizePromptForState(prompt);
   let state;
 
   if (stateName === 'ralph') {
@@ -528,35 +650,38 @@ function activateState(directory, prompt, stateName, sessionId) {
       active: true,
       iteration: 1,
       max_iterations: 100,
-      started_at: new Date().toISOString(),
-      prompt: prompt,
+      started_at: now,
+      prompt: safePrompt,
       session_id: sessionId || undefined,
       project_path: directory,
       linked_ultrawork: true,
       awaiting_confirmation: true,
-      last_checked_at: new Date().toISOString()
+      awaiting_confirmation_set_at: now,
+      last_checked_at: now
     };
   } else if (stateName === 'ralplan') {
     // Ralplan needs active + session_id for stop-hook enforcement
     state = {
       active: true,
-      started_at: new Date().toISOString(),
+      started_at: now,
       session_id: sessionId || undefined,
       project_path: directory,
       awaiting_confirmation: true,
-      last_checked_at: new Date().toISOString()
+      awaiting_confirmation_set_at: now,
+      last_checked_at: now
     };
   } else {
     // Generic state for ultrawork, autopilot, etc.
     state = {
       active: true,
-      started_at: new Date().toISOString(),
-      original_prompt: prompt,
+      started_at: now,
+      original_prompt: safePrompt,
       session_id: sessionId || undefined,
       project_path: directory,
       reinforcement_count: 0,
       awaiting_confirmation: true,
-      last_checked_at: new Date().toISOString()
+      awaiting_confirmation_set_at: now,
+      last_checked_at: now
     };
   }
 
@@ -584,7 +709,7 @@ function activateRalplanStartupState(directory, prompt, sessionId) {
     active: true,
     started_at: now,
     current_phase: 'ralplan',
-    original_prompt: prompt,
+    original_prompt: sanitizePromptForState(prompt),
     session_id: sessionId || undefined,
     project_path: directory,
     awaiting_confirmation: true,

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -28,6 +28,7 @@ import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
+import { atomicWriteFileSync } from './lib/atomic-write.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
 // Resolve OMC package root: CLAUDE_PLUGIN_ROOT (plugin system) or derive from this script's location
@@ -685,13 +686,16 @@ function activateState(directory, prompt, stateName, sessionId) {
     };
   }
 
-  // Write to session-scoped path if sessionId available
+  // Write to session-scoped path if sessionId available. Use atomic writes
+  // so that concurrent hook processes cannot expose half-written JSON to
+  // persistent-mode.mjs's readJsonFile (which would otherwise return null
+  // and temporarily drop mode enforcement).
   if (sessionId && /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) {
     const sessionDir = join(directory, '.omc', 'state', 'sessions', sessionId);
     if (!existsSync(sessionDir)) {
       try { mkdirSync(sessionDir, { recursive: true }); } catch {}
     }
-    try { writeFileSync(join(sessionDir, `${stateName}-state.json`), JSON.stringify(state, null, 2), { mode: 0o600 }); } catch {}
+    try { atomicWriteFileSync(join(sessionDir, `${stateName}-state.json`), JSON.stringify(state, null, 2)); } catch {}
     return;
   }
 
@@ -700,7 +704,7 @@ function activateState(directory, prompt, stateName, sessionId) {
   if (!existsSync(localDir)) {
     try { mkdirSync(localDir, { recursive: true }); } catch {}
   }
-  try { writeFileSync(join(localDir, `${stateName}-state.json`), JSON.stringify(state, null, 2), { mode: 0o600 }); } catch {}
+  try { atomicWriteFileSync(join(localDir, `${stateName}-state.json`), JSON.stringify(state, null, 2)); } catch {}
 }
 
 function activateRalplanStartupState(directory, prompt, sessionId) {
@@ -722,7 +726,7 @@ function activateRalplanStartupState(directory, prompt, sessionId) {
     if (!existsSync(sessionDir)) {
       try { mkdirSync(sessionDir, { recursive: true }); } catch {}
     }
-    try { writeFileSync(join(sessionDir, 'ralplan-state.json'), JSON.stringify(state, null, 2), { mode: 0o600 }); } catch {}
+    try { atomicWriteFileSync(join(sessionDir, 'ralplan-state.json'), JSON.stringify(state, null, 2)); } catch {}
     return;
   }
 
@@ -730,7 +734,7 @@ function activateRalplanStartupState(directory, prompt, sessionId) {
   if (!existsSync(localDir)) {
     try { mkdirSync(localDir, { recursive: true }); } catch {}
   }
-  try { writeFileSync(join(localDir, 'ralplan-state.json'), JSON.stringify(state, null, 2), { mode: 0o600 }); } catch {}
+  try { atomicWriteFileSync(join(localDir, 'ralplan-state.json'), JSON.stringify(state, null, 2)); } catch {}
 }
 
 /**
@@ -969,7 +973,14 @@ async function main() {
       return;
     }
 
-    const cleanPrompt = sanitizeForKeywordDetection(prompt).toLowerCase();
+    // Strip pasted system-echo blocks BEFORE any mode-keyword dispatch runs.
+    // This covers both the hasActionableKeyword() call sites AND alternative
+    // matchers (e.g. isAntiSlopCleanupRequest) that bypass it. The helper
+    // inside hasActionableKeyword also strips defensively, which stays as
+    // belt-and-suspenders.
+    const cleanPrompt = stripSystemEchoes(
+      sanitizeForKeywordDetection(prompt).toLowerCase(),
+    );
 
     // Collect all matching keywords
     const matches = [];

--- a/src/__tests__/keyword-detector-echo-guard.test.ts
+++ b/src/__tests__/keyword-detector-echo-guard.test.ts
@@ -144,6 +144,28 @@ describe('keyword-detector.mjs — pasted system-echo re-entry guard', () => {
     expect(existsSync(stateFile(cwd, sid, 'ralph'))).toBe(true);
   });
 
+  // Regression for Codex automated review P1/P2 (third round): the previous
+  // revision added standalone single-line strippers for `Task:\s`,
+  // `When FULLY complete`, and `run /oh-my-claudecode:cancel`, which meant
+  // a user's legitimate "Task: ralph로 이거 해줘" prompt would have its
+  // only line removed before keyword dispatch. Continuation stripping must
+  // happen ONLY in the context of an echo block header.
+  it('STILL activates ralph for a user prompt that starts with "Task:" (no echo header)', () => {
+    const cwd = makeCwd('kd-task-standalone-');
+    const sid = 'sess-task-standalone';
+
+    const output = runKeywordDetector('Task: ralph로 이 문제 계속 고쳐주세요', cwd, sid);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(stateFile(cwd, sid, 'ralph'))).toBe(true);
+
+    const state = JSON.parse(readFileSync(stateFile(cwd, sid, 'ralph'), 'utf-8'));
+    // The user's `Task:` line is NOT treated as echo continuation here, so
+    // its content is preserved in state.prompt (up to the 500-char cap).
+    expect(state.prompt).toContain('이 문제 계속 고쳐주세요');
+  });
+
   // Regression for Codex automated review P1: echo-block body was being
   // consumed all the way to EOF when no blank line separated it from the
   // user's follow-up request. Users commonly type the real request on the

--- a/src/__tests__/keyword-detector-echo-guard.test.ts
+++ b/src/__tests__/keyword-detector-echo-guard.test.ts
@@ -144,6 +144,32 @@ describe('keyword-detector.mjs — pasted system-echo re-entry guard', () => {
     expect(existsSync(stateFile(cwd, sid, 'ralph'))).toBe(true);
   });
 
+  // Regression for Codex automated review P1: echo-block body was being
+  // consumed all the way to EOF when no blank line separated it from the
+  // user's follow-up request. Users commonly type the real request on the
+  // immediate next line. Must STILL activate ralph in that shape.
+  it('activates ralph when an echo block is DIRECTLY followed (no blank line) by a real ralph request', () => {
+    const cwd = makeCwd('kd-echo-no-blank-');
+    const sid = 'sess-echo-no-blank';
+
+    const prompt = [
+      '[RALPH LOOP - ITERATION 2/100] Work is NOT done.',
+      'Task: previous task',
+      'ralph로 새 작업 계속 진행',
+    ].join('\n');
+
+    const output = runKeywordDetector(prompt, cwd, sid);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(stateFile(cwd, sid, 'ralph'))).toBe(true);
+
+    const state = JSON.parse(readFileSync(stateFile(cwd, sid, 'ralph'), 'utf-8'));
+    expect(state.prompt).toContain('새 작업 계속 진행');
+    expect(state.prompt).not.toContain('[RALPH LOOP');
+    expect(state.prompt).not.toContain('Task: previous task');
+  });
+
   // Regression for hasActionableKeyword searchText-index alignment:
   // user quotes a previous RALPH LOOP block AND issues a fresh explicit ralph
   // request after a blank line. Stripping the echo must NOT prevent the

--- a/src/__tests__/keyword-detector-echo-guard.test.ts
+++ b/src/__tests__/keyword-detector-echo-guard.test.ts
@@ -1,0 +1,201 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT_PATH = join(process.cwd(), 'scripts', 'keyword-detector.mjs');
+const NODE = process.execPath;
+
+const tempDirs: string[] = [];
+
+function makeCwd(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  }
+});
+
+function runKeywordDetector(prompt: string, cwd: string, sessionId: string) {
+  const raw = execFileSync(NODE, [SCRIPT_PATH], {
+    input: JSON.stringify({
+      hook_event_name: 'UserPromptSubmit',
+      cwd,
+      session_id: sessionId,
+      prompt,
+    }),
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      OMC_SKIP_HOOKS: '',
+    },
+    timeout: 15000,
+  }).trim();
+
+  return JSON.parse(raw) as {
+    continue: boolean;
+    suppressOutput?: boolean;
+    hookSpecificOutput?: {
+      hookEventName?: string;
+      additionalContext?: string;
+    };
+  };
+}
+
+function stateFile(cwd: string, sessionId: string, name: string) {
+  return join(cwd, '.omc', 'state', 'sessions', sessionId, `${name}-state.json`);
+}
+
+describe('keyword-detector.mjs — pasted system-echo re-entry guard', () => {
+  // Primary regression: user pastes a bare [RALPH LOOP - ITERATION N] block
+  // (no other user request). Must NOT re-activate ralph.
+  it('does NOT re-activate ralph for a bare [RALPH LOOP - ITERATION] paste', () => {
+    const cwd = makeCwd('kd-echo-bare-ralph-');
+    const sid = 'sess-bare-ralph';
+    const prompt = [
+      '[RALPH LOOP - ITERATION 3/100] Work is NOT done. Continue working.',
+      'When FULLY complete (after Architect verification), run /oh-my-claudecode:cancel to cleanly exit ralph mode and clean up all state files. If cancel fails, retry with /oh-my-claudecode:cancel --force.',
+      'Task: keep iterating on ralph until tests pass',
+    ].join('\n');
+
+    const output = runKeywordDetector(prompt, cwd, sid);
+
+    expect(output.continue).toBe(true);
+    expect(existsSync(stateFile(cwd, sid, 'ralph'))).toBe(false);
+    expect(existsSync(stateFile(cwd, sid, 'ultrawork'))).toBe(false);
+  });
+
+  // Other modes' paste blocks must also not re-activate.
+  it('does NOT re-activate autopilot from [AUTOPILOT #N/M] paste', () => {
+    const cwd = makeCwd('kd-echo-autopilot-');
+    const sid = 'sess-autopilot';
+    const prompt = '[AUTOPILOT #2/20] Continue working.\nTask: foo';
+
+    runKeywordDetector(prompt, cwd, sid);
+
+    expect(existsSync(stateFile(cwd, sid, 'autopilot'))).toBe(false);
+  });
+
+  it('does NOT re-activate ultrawork from [ULTRAWORK #N/M] paste', () => {
+    const cwd = makeCwd('kd-echo-ultrawork-');
+    const sid = 'sess-ultrawork';
+    const prompt = '[ULTRAWORK #3/50] Continue working.\nTask: bar';
+
+    runKeywordDetector(prompt, cwd, sid);
+
+    expect(existsSync(stateFile(cwd, sid, 'ultrawork'))).toBe(false);
+  });
+
+  // A "Stop hook feedback:" wrapper must also be recognized as echo.
+  it('does NOT re-activate ralph when the prompt is a Stop hook feedback block', () => {
+    const cwd = makeCwd('kd-echo-stop-hook-');
+    const sid = 'sess-stop-hook';
+    const prompt = [
+      'Stop hook feedback:',
+      '[RALPH LOOP - ITERATION 5/100] Work is NOT done.',
+      'When FULLY complete (after Architect verification), run /oh-my-claudecode:cancel ...',
+      'Task: previous ralph task prompt',
+    ].join('\n');
+
+    runKeywordDetector(prompt, cwd, sid);
+
+    expect(existsSync(stateFile(cwd, sid, 'ralph'))).toBe(false);
+  });
+
+  // Sanity check: legitimate explicit invocation still works.
+  it('STILL activates ralph for an explicit user request', () => {
+    const cwd = makeCwd('kd-echo-real-invocation-');
+    const sid = 'sess-real-ralph';
+
+    const output = runKeywordDetector('ralph로 이 문제 계속 고쳐주세요', cwd, sid);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(stateFile(cwd, sid, 'ralph'))).toBe(true);
+  });
+
+  // Regression for hasActionableKeyword searchText-index alignment:
+  // user quotes a previous RALPH LOOP block AND issues a fresh explicit ralph
+  // request after a blank line. Stripping the echo must NOT prevent the
+  // trailing real request from matching, because isInformationalKeywordContext
+  // / hasExplicitInvocationContext need match.index to align with the
+  // text they're inspecting (the stripped searchText).
+  it('activates ralph when an echo block is followed by a blank line and a real ralph request', () => {
+    const cwd = makeCwd('kd-echo-plus-real-ralph-');
+    const sid = 'sess-echo-plus-real-ralph';
+
+    const prompt = [
+      '[RALPH LOOP - ITERATION 4/100] Work is NOT done.',
+      'Task: previous task',
+      '',
+      'ralph로 새 작업 계속해줘',
+    ].join('\n');
+
+    const output = runKeywordDetector(prompt, cwd, sid);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(stateFile(cwd, sid, 'ralph'))).toBe(true);
+
+    // state.prompt should capture the REAL request, not the echo sentinel,
+    // when stripping leaves meaningful non-echo content.
+    const state = JSON.parse(readFileSync(stateFile(cwd, sid, 'ralph'), 'utf-8'));
+    expect(state.prompt).toContain('새 작업 계속해줘');
+    expect(state.prompt).not.toContain('[RALPH LOOP');
+    expect(state.prompt).not.toBe('(prompt omitted: pasted system echo)');
+  });
+});
+
+describe('keyword-detector.mjs — state.prompt sanitization', () => {
+  it('truncates oversized prompts when writing ralph state', () => {
+    const cwd = makeCwd('kd-prompt-len-');
+    const sid = 'sess-prompt-len';
+    const longTail = 'x'.repeat(2000);
+    const prompt = `ralph로 다음 긴 지시사항을 수행해주세요:\n${longTail}`;
+
+    runKeywordDetector(prompt, cwd, sid);
+    const path = stateFile(cwd, sid, 'ralph');
+    expect(existsSync(path)).toBe(true);
+
+    const state = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(typeof state.prompt).toBe('string');
+    expect(state.prompt.length).toBeLessThanOrEqual(500);
+  });
+
+  it('records awaiting_confirmation_set_at on ralph state (enables 2-min TTL)', () => {
+    const cwd = makeCwd('kd-setat-ralph-');
+    const sid = 'sess-setat-ralph';
+
+    runKeywordDetector('ralph로 시작해주세요', cwd, sid);
+    const path = stateFile(cwd, sid, 'ralph');
+    expect(existsSync(path)).toBe(true);
+
+    const state = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(state.awaiting_confirmation).toBe(true);
+    expect(typeof state.awaiting_confirmation_set_at).toBe('string');
+    expect(Number.isFinite(new Date(state.awaiting_confirmation_set_at).getTime())).toBe(true);
+  });
+
+  it('records awaiting_confirmation_set_at on ultrawork state', () => {
+    const cwd = makeCwd('kd-setat-ultrawork-');
+    const sid = 'sess-setat-uw';
+
+    runKeywordDetector('ulw로 시작해주세요', cwd, sid);
+    const path = stateFile(cwd, sid, 'ultrawork');
+    expect(existsSync(path)).toBe(true);
+
+    const state = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(state.awaiting_confirmation).toBe(true);
+    expect(typeof state.awaiting_confirmation_set_at).toBe('string');
+  });
+});

--- a/src/__tests__/keyword-detector-echo-guard.test.ts
+++ b/src/__tests__/keyword-detector-echo-guard.test.ts
@@ -96,6 +96,26 @@ describe('keyword-detector.mjs — pasted system-echo re-entry guard', () => {
   });
 
   // A "Stop hook feedback:" wrapper must also be recognized as echo.
+  // Regression for Major #1 (GPT-5.5): isAntiSlopCleanupRequest bypasses
+  // hasActionableKeyword. Stripping must happen upstream in the main dispatch
+  // so all matchers benefit, not only the hasActionableKeyword ones.
+  it('does NOT re-activate ai-slop-cleaner from a pasted echo whose Task line contains cleanup/deslop terms', () => {
+    const cwd = makeCwd('kd-echo-anti-slop-');
+    const sid = 'sess-anti-slop';
+    const prompt = [
+      '[RALPH LOOP - ITERATION 7/100] Work is NOT done.',
+      'Task: please run ai-slop-cleaner and deslop the duplicated functions',
+    ].join('\n');
+
+    const output = runKeywordDetector(prompt, cwd, sid);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AI-SLOP-CLEANER]');
+    expect(context).not.toContain('<ai-slop-cleaner-mode>');
+    expect(existsSync(stateFile(cwd, sid, 'ai-slop-cleaner'))).toBe(false);
+  });
+
   it('does NOT re-activate ralph when the prompt is a Stop hook feedback block', () => {
     const cwd = makeCwd('kd-echo-stop-hook-');
     const sid = 'sess-stop-hook';

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -330,25 +330,35 @@ const QUESTION_FOLLOWUP_PATTERNS = [
 // copying a "[RALPH LOOP - ITERATION N] ..." block to ask "why does this keep
 // firing?" silently re-triggers ralph and the echo itself becomes state.prompt
 // — a self-reinforcing loop that is hard to cancel.
-// NOTE: all patterns use the `i` flag. hasActionableKeyword operates on
-// cleanPrompt which is `.toLowerCase()`-ed, so these patterns must match
-// case-insensitively to catch pasted echoes.
+// NOTE: all patterns use the `gim` flags. Matching is case-insensitive because
+// hasActionableKeyword operates on a `.toLowerCase()`-ed cleanPrompt, and
+// multi-line because each pattern now consumes a SINGLE line of echoed hook
+// output at a time. A previous version used a multi-line `[\s\S]*?(?=\n\n|\n?$)`
+// body that swallowed a user's real follow-up request when they typed it on
+// the very next line without inserting a blank separator (P1 flagged by
+// Codex automated review). Single-line matches keep the guard strong while
+// preserving any non-echo text that follows.
 const SYSTEM_ECHO_BLOCK_PATTERNS = [
-  /\[RALPH LOOP\s*-\s*ITERATION[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[RALPH LOOP\s*-\s*(?:HARD LIMIT|EXTENDED)\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[TEAM\s*-\s*Phase:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[AUTOPILOT[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[ULTRAPILOT[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[ULTRAWORK[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[ULTRAQA[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[PIPELINE[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[SWARM[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[TOOL ERROR[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[MAGIC KEYWORD:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /\[MAGIC KEYWORDS DETECTED:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
-  /Stop hook (?:blocking error|feedback|stopped continuation)[\s\S]*?(?=\n\n|\n?$)/gi,
-  /PreToolUse:[^\n]*hook additional context:[\s\S]*?(?=\n\n|\n?$)/gi,
-  /PostToolUse:[^\n]*hook additional context:[\s\S]*?(?=\n\n|\n?$)/gi,
+  /^[ \t]*\[RALPH LOOP\s*-\s*ITERATION[^\]\n]*\].*$/gim,
+  /^[ \t]*\[RALPH LOOP\s*-\s*(?:HARD LIMIT|EXTENDED)\].*$/gim,
+  /^[ \t]*\[TEAM\s*-\s*Phase:[^\]\n]*\].*$/gim,
+  /^[ \t]*\[AUTOPILOT[^\]\n]*\].*$/gim,
+  /^[ \t]*\[ULTRAPILOT[^\]\n]*\].*$/gim,
+  /^[ \t]*\[ULTRAWORK[^\]\n]*\].*$/gim,
+  /^[ \t]*\[ULTRAQA[^\]\n]*\].*$/gim,
+  /^[ \t]*\[PIPELINE[^\]\n]*\].*$/gim,
+  /^[ \t]*\[SWARM[^\]\n]*\].*$/gim,
+  /^[ \t]*\[TOOL ERROR[^\]\n]*\].*$/gim,
+  /^[ \t]*\[MAGIC KEYWORD:[^\]\n]*\].*$/gim,
+  /^[ \t]*\[MAGIC KEYWORDS DETECTED:[^\]\n]*\].*$/gim,
+  /^[ \t]*Stop hook (?:blocking error|feedback|stopped continuation).*$/gim,
+  /^[ \t]*PreToolUse:[^\n]*hook additional context:.*$/gim,
+  /^[ \t]*PostToolUse:[^\n]*hook additional context:.*$/gim,
+  // Continuation lines (single-line too) — signatures that hooks emit right
+  // after the block header.
+  /^[ \t]*When FULLY complete \(after Architect verification\).*$/gim,
+  /^[ \t]*run\s+\/oh-my-claudecode:cancel.*$/gim,
+  /^[ \t]*Task:\s.*$/gim,
 ];
 
 const SYSTEM_ECHO_SIGNATURES = [

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -330,35 +330,35 @@ const QUESTION_FOLLOWUP_PATTERNS = [
 // copying a "[RALPH LOOP - ITERATION N] ..." block to ask "why does this keep
 // firing?" silently re-triggers ralph and the echo itself becomes state.prompt
 // — a self-reinforcing loop that is hard to cancel.
-// NOTE: all patterns use the `gim` flags. Matching is case-insensitive because
-// hasActionableKeyword operates on a `.toLowerCase()`-ed cleanPrompt, and
-// multi-line because each pattern now consumes a SINGLE line of echoed hook
-// output at a time. A previous version used a multi-line `[\s\S]*?(?=\n\n|\n?$)`
-// body that swallowed a user's real follow-up request when they typed it on
-// the very next line without inserting a blank separator (P1 flagged by
-// Codex automated review). Single-line matches keep the guard strong while
-// preserving any non-echo text that follows.
+// Continuation lines that hook output typically emits DIRECTLY after a
+// recognized block header. They must be stripped only in that context —
+// never standalone — because a user might legitimately start a prompt with
+// "Task: …" or similar (Codex automated review P1/P2 on #2795).
+const ECHO_CONTINUATION = '(?:\\r?\\n[ \\t]*(?:Task:\\s|When FULLY complete \\(after Architect verification\\)|run\\s+\\/oh-my-claudecode:cancel).*)*';
+
+// Each pattern is a single logical block: the block header line + zero or
+// more continuation lines emitted right after it. The whole match is
+// stripped together.
+function buildEchoBlockRegex(headerBody) {
+  return new RegExp(`^[ \\t]*${headerBody}.*${ECHO_CONTINUATION}$`, 'gim');
+}
+
 const SYSTEM_ECHO_BLOCK_PATTERNS = [
-  /^[ \t]*\[RALPH LOOP\s*-\s*ITERATION[^\]\n]*\].*$/gim,
-  /^[ \t]*\[RALPH LOOP\s*-\s*(?:HARD LIMIT|EXTENDED)\].*$/gim,
-  /^[ \t]*\[TEAM\s*-\s*Phase:[^\]\n]*\].*$/gim,
-  /^[ \t]*\[AUTOPILOT[^\]\n]*\].*$/gim,
-  /^[ \t]*\[ULTRAPILOT[^\]\n]*\].*$/gim,
-  /^[ \t]*\[ULTRAWORK[^\]\n]*\].*$/gim,
-  /^[ \t]*\[ULTRAQA[^\]\n]*\].*$/gim,
-  /^[ \t]*\[PIPELINE[^\]\n]*\].*$/gim,
-  /^[ \t]*\[SWARM[^\]\n]*\].*$/gim,
-  /^[ \t]*\[TOOL ERROR[^\]\n]*\].*$/gim,
-  /^[ \t]*\[MAGIC KEYWORD:[^\]\n]*\].*$/gim,
-  /^[ \t]*\[MAGIC KEYWORDS DETECTED:[^\]\n]*\].*$/gim,
-  /^[ \t]*Stop hook (?:blocking error|feedback|stopped continuation).*$/gim,
-  /^[ \t]*PreToolUse:[^\n]*hook additional context:.*$/gim,
-  /^[ \t]*PostToolUse:[^\n]*hook additional context:.*$/gim,
-  // Continuation lines (single-line too) — signatures that hooks emit right
-  // after the block header.
-  /^[ \t]*When FULLY complete \(after Architect verification\).*$/gim,
-  /^[ \t]*run\s+\/oh-my-claudecode:cancel.*$/gim,
-  /^[ \t]*Task:\s.*$/gim,
+  buildEchoBlockRegex('\\[RALPH LOOP\\s*-\\s*ITERATION[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[RALPH LOOP\\s*-\\s*(?:HARD LIMIT|EXTENDED)\\]'),
+  buildEchoBlockRegex('\\[TEAM\\s*-\\s*Phase:[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[AUTOPILOT[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[ULTRAPILOT[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[ULTRAWORK[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[ULTRAQA[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[PIPELINE[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[SWARM[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[TOOL ERROR[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[MAGIC KEYWORD:[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('\\[MAGIC KEYWORDS DETECTED:[^\\]\\n]*\\]'),
+  buildEchoBlockRegex('Stop hook (?:blocking error|feedback|stopped continuation)'),
+  buildEchoBlockRegex('PreToolUse:[^\\n]*hook additional context:'),
+  buildEchoBlockRegex('PostToolUse:[^\\n]*hook additional context:'),
 ];
 
 const SYSTEM_ECHO_SIGNATURES = [

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -323,6 +323,95 @@ const QUESTION_FOLLOWUP_PATTERNS = [
   /\b(?:how\s+many|how\s+much|why|what\s+happened|what\s+went\s+wrong|token\s+budget|cost|pricing)\b/i,
   /(?:왜|얼마|몇\s*번|몇번|토큰|가격|비용|질문)/u,
 ];
+
+// Patterns that identify system-generated echoes (hook outputs) which users may
+// paste back into a prompt while debugging. If a mode keyword only appears
+// inside such an echo block we must NOT re-activate the mode: otherwise
+// copying a "[RALPH LOOP - ITERATION N] ..." block to ask "why does this keep
+// firing?" silently re-triggers ralph and the echo itself becomes state.prompt
+// — a self-reinforcing loop that is hard to cancel.
+// NOTE: all patterns use the `i` flag. hasActionableKeyword operates on
+// cleanPrompt which is `.toLowerCase()`-ed, so these patterns must match
+// case-insensitively to catch pasted echoes.
+const SYSTEM_ECHO_BLOCK_PATTERNS = [
+  /\[RALPH LOOP\s*-\s*ITERATION[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[RALPH LOOP\s*-\s*(?:HARD LIMIT|EXTENDED)\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[TEAM\s*-\s*Phase:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[AUTOPILOT[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[ULTRAPILOT[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[ULTRAWORK[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[ULTRAQA[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[PIPELINE[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[SWARM[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[TOOL ERROR[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[MAGIC KEYWORD:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /\[MAGIC KEYWORDS DETECTED:[^\]]*\][\s\S]*?(?=\n\n|\n?$)/gi,
+  /Stop hook (?:blocking error|feedback|stopped continuation)[\s\S]*?(?=\n\n|\n?$)/gi,
+  /PreToolUse:[^\n]*hook additional context:[\s\S]*?(?=\n\n|\n?$)/gi,
+  /PostToolUse:[^\n]*hook additional context:[\s\S]*?(?=\n\n|\n?$)/gi,
+];
+
+const SYSTEM_ECHO_SIGNATURES = [
+  /\bWhen FULLY complete \(after Architect verification\)\b/i,
+  /\brun\s+\/oh-my-claudecode:cancel\b/i,
+  /\[RALPH LOOP\s*-\s*ITERATION\b/i,
+];
+
+const MAX_STATE_PROMPT_LEN = 500;
+
+function stripSystemEchoes(text) {
+  if (typeof text !== 'string' || text.length === 0) return '';
+  let cleaned = text;
+  for (const pattern of SYSTEM_ECHO_BLOCK_PATTERNS) {
+    cleaned = cleaned.replace(pattern, ' ');
+  }
+  return cleaned;
+}
+
+function looksLikeSystemEcho(text) {
+  if (typeof text !== 'string' || text.length === 0) return false;
+  if (SYSTEM_ECHO_SIGNATURES.some((pattern) => pattern.test(text))) return true;
+  // Also treat the presence of ANY echo block pattern as an echo.
+  for (const pattern of SYSTEM_ECHO_BLOCK_PATTERNS) {
+    const probe = new RegExp(pattern.source, pattern.flags.replace('g', ''));
+    if (probe.test(text)) return true;
+  }
+  return false;
+}
+
+/**
+ * Sanitize a prompt before persisting it to a *-state.json file.
+ *
+ * Strategy:
+ * 1. Strip echoes first. If non-empty content remains AND that remainder no
+ *    longer looks like an echo, keep it (preserves the real user request in
+ *    an "echo + blank line + real request" paste).
+ * 2. Otherwise, if the raw prompt looks like a pure echo, substitute the
+ *    placeholder sentinel.
+ * 3. Finally, hard-truncate to MAX_STATE_PROMPT_LEN chars.
+ */
+function sanitizePromptForState(prompt) {
+  if (typeof prompt !== 'string') return '';
+  const trimmed = prompt.trim();
+  if (!trimmed) return '';
+
+  const stripped = stripSystemEchoes(trimmed).trim();
+  if (stripped.length > 0 && !looksLikeSystemEcho(stripped)) {
+    return stripped.length > MAX_STATE_PROMPT_LEN
+      ? `${stripped.slice(0, MAX_STATE_PROMPT_LEN - 3)}...`
+      : stripped;
+  }
+
+  if (looksLikeSystemEcho(trimmed)) {
+    return '(prompt omitted: pasted system echo)';
+  }
+
+  const base = stripped.length > 0 ? stripped : trimmed;
+  return base.length > MAX_STATE_PROMPT_LEN
+    ? `${base.slice(0, MAX_STATE_PROMPT_LEN - 3)}...`
+    : base;
+}
+
 const MODE_REFERENCE_PATTERN =
   /\b(?:ralph|autopilot|auto[\s-]?pilot|ultrawork|ulw|ralplan|ultrathink|deepsearch|deep[\s-]?analyze|deepanalyze|deep[\s-]interview|ouroboros|ccg|claude-codex-gemini|deerflow)\b/gi;
 
@@ -453,15 +542,23 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
 }
 
 function hasActionableKeyword(text, pattern) {
+  // Strip system-generated echo blocks (hook outputs, Stop-hook wrappers)
+  // before searching for keywords. Otherwise pasting a previous
+  // "[RALPH LOOP - ITERATION N] ..." block into a prompt would re-activate
+  // the mode and the echo itself would become the new state.prompt.
+  const searchText = looksLikeSystemEcho(text)
+    ? stripSystemEchoes(text)
+    : text;
+
   const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
   const globalPattern = new RegExp(pattern.source, flags);
 
-  for (const match of text.matchAll(globalPattern)) {
+  for (const match of searchText.matchAll(globalPattern)) {
     if (match.index === undefined) {
       continue;
     }
 
-    if (isInformationalKeywordContext(text, match.index, match[0].length, match[0])) {
+    if (isInformationalKeywordContext(searchText, match.index, match[0].length, match[0])) {
       continue;
     }
 
@@ -472,19 +569,24 @@ function hasActionableKeyword(text, pattern) {
 }
 
 function hasActionableRalplanKeyword(text, pattern) {
+  // Same echo guard as hasActionableKeyword.
+  const searchText = looksLikeSystemEcho(text)
+    ? stripSystemEchoes(text)
+    : text;
+
   const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
   const globalPattern = new RegExp(pattern.source, flags);
 
-  for (const match of text.matchAll(globalPattern)) {
+  for (const match of searchText.matchAll(globalPattern)) {
     if (match.index === undefined) {
       continue;
     }
 
-    if (isInformationalKeywordContext(text, match.index, match[0].length, match[0])) {
+    if (isInformationalKeywordContext(searchText, match.index, match[0].length, match[0])) {
       continue;
     }
 
-    if (!hasExplicitInvocationContext(text, match.index, match[0].length, match[0])) {
+    if (!hasExplicitInvocationContext(searchText, match.index, match[0].length, match[0])) {
       continue;
     }
 
@@ -498,6 +600,10 @@ function hasActionableRalplanKeyword(text, pattern) {
 const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 
 function activateState(directory, prompt, stateName, sessionId) {
+  const now = new Date().toISOString();
+  // Sanitize prompt BEFORE writing to state: prevents pasted system echoes
+  // and oversized blobs from being persisted and re-emitted by Stop hook.
+  const safePrompt = sanitizePromptForState(prompt);
   let state;
 
   if (stateName === 'ralph') {
@@ -506,24 +612,26 @@ function activateState(directory, prompt, stateName, sessionId) {
       active: true,
       iteration: 1,
       max_iterations: 100,
-      started_at: new Date().toISOString(),
-      prompt: prompt,
+      started_at: now,
+      prompt: safePrompt,
       session_id: sessionId || undefined,
       project_path: directory,
       reinforcement_count: 0,
       awaiting_confirmation: true,
-      last_checked_at: new Date().toISOString()
+      awaiting_confirmation_set_at: now,
+      last_checked_at: now
     };
   } else {
     state = {
       active: true,
-      started_at: new Date().toISOString(),
-      original_prompt: prompt,
+      started_at: now,
+      original_prompt: safePrompt,
       session_id: sessionId || undefined,
       project_path: directory,
       reinforcement_count: 0,
       awaiting_confirmation: true,
-      last_checked_at: new Date().toISOString()
+      awaiting_confirmation_set_at: now,
+      last_checked_at: now
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #2794.

Prevents `keyword-detector.mjs` from re-activating a mode when the user pastes a previous Stop-hook block (e.g. `[RALPH LOOP - ITERATION N/100] ... Task: previous task`) back into a new prompt. Three linked defects combined to make this a self-reinforcing loop that users could not escape without manually deleting state files.

## Root causes (3 linked defects)

**B1 — hasActionableKeyword searches the prompt verbatim.** No guard for echoed hook output. Pasting `[RALPH LOOP - ITERATION …]` blocks re-triggers ralph on the embedded "ralph" word.

**B2 — activateState persists the raw prompt.** Whatever paste contained the keyword gets stored in `state.prompt` verbatim, and `persistent-mode.mjs` re-emits it as the `Task:` line of every subsequent block reason — often hundreds of bytes of hook echo.

**B3 — `awaiting_confirmation_set_at` was missing from ralph/autopilot/generic state.** `persistent-mode.mjs::isAwaitingConfirmation` reads `awaiting_confirmation_set_at`, falling back to `started_at` for the 2-minute TTL. `activateRalplanStartupState` set the field; `activateState` (which writes ralph / ralplan / generic state) did not. Result: once the user is idle for >2 minutes, the Stop hook flips from "waiting for user confirmation" to "continue Ralph loop" and the block reason starts firing — frequently the very moment the user is typing a debug question about the previous firing.

## Fix

1. **`SYSTEM_ECHO_BLOCK_PATTERNS`** (15 patterns) and **`SYSTEM_ECHO_SIGNATURES`** (3 sentinels) — recognize the known hook-output shapes: `[RALPH LOOP - ITERATION/HARD LIMIT/EXTENDED]`, `[TEAM - Phase:]`, `[AUTOPILOT / ULTRAPILOT / ULTRAWORK / ULTRAQA / PIPELINE / SWARM / TOOL ERROR]`, `[MAGIC KEYWORD(S)]`, `Stop hook (blocking error|feedback|stopped continuation)`, and `Pre/PostToolUse: ... hook additional context:` wrappers. All `gi` — critical, because `cleanPrompt` is `.toLowerCase()`-ed upstream and `/g`-only patterns silently no-op.
2. **`stripSystemEchoes` / `looksLikeSystemEcho`** — helper to detect and remove echo blocks.
3. **`hasActionableKeyword` / `hasActionableRalplanKeyword`** — when the prompt looks like an echo, search `stripSystemEchoes(text)` instead. All downstream context checks (`isInformationalKeywordContext`, `hasExplicitInvocationContext`) are fed the same cleaned text so `match.index` stays aligned.
4. **`sanitizePromptForState`** — strip echoes first, and if real content remains keep it (preserves a real request placed after `echo + blank line`); otherwise store the placeholder sentinel `"(prompt omitted: pasted system echo)"`. Hard truncate at 500 chars.
5. **`activateState` + `activateRalplanStartupState`** — always record `awaiting_confirmation_set_at: now` and pass the prompt through `sanitizePromptForState` before persisting.
6. **Mirrored in `templates/hooks/keyword-detector.mjs`** so fresh `omc setup` installs carry the guard. The existing structural divergence between `scripts/` and `templates/` is preserved; only the echo-guard + state-format invariants needed to sync.

## Test plan

### New regression file — `src/__tests__/keyword-detector-echo-guard.test.ts` (9 tests, all pass)

- [x] bare `[RALPH LOOP - ITERATION N/100]` paste → **no ralph/ultrawork state written**
- [x] `[AUTOPILOT #N/M]` paste → **no autopilot state**
- [x] `[ULTRAWORK #N/M]` paste → **no ultrawork state**
- [x] `Stop hook feedback: [RALPH LOOP ...]` wrapper paste → **no ralph state**
- [x] explicit `ralph로 …` invocation → **still activates ralph**
- [x] echo block + blank line + explicit request (`[RALPH LOOP ...]\n\nralph로 새 작업 계속해줘`) → **activates ralph AND state.prompt contains the real request, not the sentinel**
- [x] 2000-char `ralph로 …` prompt → **`state.prompt.length ≤ 500`**
- [x] ralph activation → **`awaiting_confirmation_set_at` is a parseable ISO string**
- [x] ultrawork activation → same

### Adjacent suites — no regression

- [x] `keyword-detector-script.test.ts` — 24 pass
- [x] `ralph-prd.test.ts` — 33 pass
- [x] `ralph-prd-mandatory.test.ts` — 37 pass
- [x] `ralph-progress.test.ts` — pass
- [x] `runtime-guidance-plan-ralph.test.ts` — pass
- **144 related tests, all pass.**

### Manual reproduction

Before the fix, on a clean temp dir:

```bash
TMP=$(mktemp -d)
echo '{"hook_event_name":"UserPromptSubmit","cwd":"'$TMP'","session_id":"s","prompt":"[AUTOPILOT #2/20] Continue working.\nTask: foo"}' \
  | node scripts/keyword-detector.mjs
ls $TMP/.omc/state/sessions/s/  # autopilot-state.json present ← bug
```

After the fix:

```bash
# Same input
ls $TMP/.omc/state/sessions/s/  # empty ← fixed
```

## Review notes

Two rounds of review with GPT-5 codex (architect + code-reviewer). Round 1 issued `REQUEST_CHANGES` with one **major** (index-alignment in `hasActionableRalplanKeyword`) and several minor/nits. All blocking/major/minor items addressed; nits deferred with justification. Round 2 verdict: **APPROVE, no blocking findings**.

## Backward compatibility

- Existing `*-state.json` files lacking `awaiting_confirmation_set_at` continue to work via the existing `started_at` fallback in `persistent-mode.mjs::isAwaitingConfirmation`. No migration needed.
- `state.prompt` format unchanged; only newly-activated states pass through `sanitizePromptForState`.
- Users currently stuck in the loop can escape by deleting the offending `ralph-state.json` / `ultrawork-state.json` (pre-existing workaround, unchanged by this PR).

## Out of scope (deliberate)

- Unifying `templates/hooks/keyword-detector.mjs` with `scripts/keyword-detector.mjs` (pre-existing divergence).
- Changing the 2-minute `AWAITING_CONFIRMATION_TTL_MS` — this PR only fixes the missing timestamp, not the TTL length itself.
- Reviewing other state files that may have similar issues (`autopilot-state.json` is covered via `activateState`'s generic branch; others should be audited separately if needed).

## Co-author

Fix designed and authored collaboratively with Claude Opus 4.7 (1M context); reviewed by GPT-5 codex.