### PR TITLE
docs: fix broken /docs/concepts link in Getting Started

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -231,7 +231,7 @@ These keywords invoke a single appropriate agent directly, without running the f
 ### Next steps
 
 - [Configuration](#configuration) - Adjust agent models and features for your project
-- [Concepts](/docs/concepts) - Understand the relationship between agents, skills, and hooks
+- [Architecture](./ARCHITECTURE.md) - Understand the relationship between agents, skills, and hooks
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/GETTING-STARTED.md` has a "Next steps" bullet that links to `/docs/concepts`, but no such file or directory exists in the repo — the link 404s when the doc is rendered on GitHub (or any site that resolves it relative to the repo root).

This PR retargets the bullet to `./ARCHITECTURE.md`, which is a natural replacement: its overview paragraph already frames OMC around the four interlocking systems (Hooks, Skills, Agents, State) that the bullet promises to explain.

```diff
- [Concepts](/docs/concepts) - Understand the relationship between agents, skills, and hooks
+ [Architecture](./ARCHITECTURE.md) - Understand the relationship between agents, skills, and hooks
```

Relative path style matches the other doc links in the same file (`./LOCAL_PLUGIN_INSTALL.md`, `./REFERENCE.md`, `./company-context-interface.md`).

## Scope

- 1 file, 1 line. Docs only, no code.
- Base: `dev` per `CONTRIBUTING.md` §2.
- Deliberately not touching the dangling `ANALYTICS-SYSTEM.md` references in `docs/AGENTS.md:29` and `docs/PERFORMANCE-MONITORING.md:503` — the `cleanup/deprecated-analytics` branch looks like it may already cover those.

## Verification

- `grep -rn '/docs/concepts' . --include='*.md'` → 0 hits after the change.
- `docs/ARCHITECTURE.md` exists and covers "agents, skills, and hooks".
