### PR TITLE
feat(hud): show billing-period spend for Enterprise subscriptions

### DIFF
--- a/src/__tests__/hud/render-enterprise.test.ts
+++ b/src/__tests__/hud/render-enterprise.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for enterprise cost rendering in render.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '../../hud/render.js';
+import { DEFAULT_HUD_CONFIG, type HudRenderContext, type HudConfig } from '../../hud/types.js';
+
+// Mock git elements
+vi.mock('../../hud/elements/git.js', () => ({
+  renderGitRepo: vi.fn(() => null),
+  renderGitBranch: vi.fn(() => null),
+  renderGitStatus: vi.fn(() => null),
+}));
+
+vi.mock('../../hud/elements/cwd.js', () => ({
+  renderCwd: vi.fn(() => null),
+}));
+
+// Strip ANSI codes for readable assertions
+function strip(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+}
+
+function createContext(overrides: Partial<HudRenderContext> = {}): HudRenderContext {
+  return {
+    contextPercent: 30,
+    modelName: 'claude-sonnet-4-5',
+    ralph: null,
+    ultrawork: null,
+    prd: null,
+    autopilot: null,
+    activeAgents: [],
+    todos: [],
+    backgroundTasks: [],
+    cwd: '/home/user/project',
+    lastSkill: null,
+    rateLimitsResult: null,
+    customBuckets: null,
+    pendingPermission: null,
+    thinkingState: null,
+    sessionHealth: null,
+    omcVersion: null,
+    updateAvailable: null,
+    toolCallCount: 0,
+    agentCallCount: 0,
+    skillCallCount: 0,
+    promptTime: null,
+    apiKeySource: null,
+    profileName: null,
+    sessionSummary: null,
+    ...overrides,
+  };
+}
+
+function createConfig(overrides: Partial<HudConfig['elements']> = {}): HudConfig {
+  return {
+    ...DEFAULT_HUD_CONFIG,
+    elements: {
+      ...DEFAULT_HUD_CONFIG.elements,
+      omcLabel: false,
+      rateLimits: false,
+      ralph: false,
+      autopilot: false,
+      prdStory: false,
+      activeSkills: false,
+      contextBar: false,
+      agents: false,
+      backgroundTasks: false,
+      todos: false,
+      promptTime: false,
+      sessionHealth: false,
+      showCallCounts: false,
+      thinking: false,
+      ...overrides,
+    },
+  };
+}
+
+describe('render - enterprise cost branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders spent:$ when subscriptionType is enterprise and enterpriseSpentUsd is set', async () => {
+    const context = createContext({
+      subscriptionType: 'enterprise',
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 0,
+          enterpriseSpentUsd: 3323.93,
+          enterpriseLimitUsd: null,
+          enterpriseCurrency: 'USD',
+        },
+        stale: false,
+      },
+    });
+    const config = createConfig({ showEnterpriseCost: true });
+    const output = await render(context, config);
+    const plain = strip(output);
+    expect(plain).toContain('spent:$3,323.93');
+  });
+
+  it('does NOT render tok: when enterprise cost renders successfully', async () => {
+    const context = createContext({
+      subscriptionType: 'enterprise',
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 0,
+          enterpriseSpentUsd: 100,
+          enterpriseLimitUsd: null,
+          enterpriseCurrency: 'USD',
+        },
+      },
+      lastRequestTokenUsage: { inputTokens: 1200, outputTokens: 340 },
+    });
+    const config = createConfig({ showTokens: true, showEnterpriseCost: true });
+    const output = await render(context, config);
+    const plain = strip(output);
+    expect(plain).not.toContain('tok:');
+    expect(plain).toContain('spent:');
+  });
+
+  it('detects enterprise via rateLimitTier containing claude_zero', async () => {
+    const context = createContext({
+      rateLimitTier: 'default_claude_zero',
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 0,
+          enterpriseSpentUsd: 50,
+          enterpriseLimitUsd: null,
+          enterpriseCurrency: 'USD',
+        },
+      },
+    });
+    const config = createConfig({ showEnterpriseCost: true });
+    const output = await render(context, config);
+    const plain = strip(output);
+    expect(plain).toContain('spent:$50.00');
+  });
+
+  it('falls back to token rendering when enterprise but no cost data (API error)', async () => {
+    const context = createContext({
+      subscriptionType: 'enterprise',
+      rateLimitsResult: {
+        rateLimits: null,
+        error: 'network',
+      },
+      lastRequestTokenUsage: { inputTokens: 1200, outputTokens: 340 },
+    });
+    const config = createConfig({ showTokens: true, showEnterpriseCost: true });
+    const output = await render(context, config);
+    const plain = strip(output);
+    // No cost data available → fall back to tokens
+    expect(plain).toContain('tok:');
+  });
+
+  it('does not render enterprise cost when showEnterpriseCost is false', async () => {
+    const context = createContext({
+      subscriptionType: 'enterprise',
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 0,
+          enterpriseSpentUsd: 100,
+          enterpriseLimitUsd: null,
+          enterpriseCurrency: 'USD',
+        },
+      },
+    });
+    const config = createConfig({ showEnterpriseCost: false });
+    const output = await render(context, config);
+    const plain = strip(output);
+    expect(plain).not.toContain('spent:');
+  });
+
+  it('does not render enterprise cost when enterpriseMode is forced false', async () => {
+    const context = createContext({
+      subscriptionType: 'enterprise',
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 0,
+          enterpriseSpentUsd: 100,
+          enterpriseLimitUsd: null,
+          enterpriseCurrency: 'USD',
+        },
+      },
+    });
+    const config = createConfig({ enterpriseMode: false });
+    const output = await render(context, config);
+    const plain = strip(output);
+    expect(plain).not.toContain('spent:');
+  });
+
+  it('suppresses 5h/wk rate-limit display when enterprise cost data is present', async () => {
+    // Regression: enterprise API returns five_hour: null, so clamp(null) produced
+    // fiveHourPercent: 0 which rendered a misleading "5h:0% wk:0%" alongside the cost.
+    const context = createContext({
+      subscriptionType: 'enterprise',
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 0,
+          weeklyPercent: 0,
+          enterpriseSpentUsd: 3323.93,
+          enterpriseLimitUsd: null,
+          enterpriseCurrency: 'USD',
+        },
+      },
+    });
+    const config = createConfig({
+      rateLimits: true,
+      showEnterpriseCost: true,
+    });
+    const output = await render(context, config);
+    const plain = strip(output);
+    expect(plain).toContain('spent:$3,323.93');
+    expect(plain).not.toMatch(/5h:\s*0%/);
+    expect(plain).not.toMatch(/wk:\s*0%/);
+  });
+
+  it('still renders 5h/wk for non-enterprise users (no regression on Pro/Max)', async () => {
+    const context = createContext({
+      subscriptionType: 'pro',
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 45,
+          weeklyPercent: 12,
+        },
+      },
+    });
+    const config = createConfig({ rateLimits: true });
+    const output = await render(context, config);
+    const plain = strip(output);
+    expect(plain).toMatch(/5h:\s*45%/);
+  });
+
+  it('renders token usage for non-enterprise user even with showEnterpriseCost: true', async () => {
+    const context = createContext({
+      subscriptionType: 'pro',
+      lastRequestTokenUsage: { inputTokens: 1200, outputTokens: 340 },
+    });
+    const config = createConfig({ showTokens: true, showEnterpriseCost: true });
+    const output = await render(context, config);
+    const plain = strip(output);
+    expect(plain).toContain('tok:');
+    expect(plain).not.toContain('spent:');
+  });
+});

--- a/src/__tests__/hud/watch-mode-init.test.ts
+++ b/src/__tests__/hud/watch-mode-init.test.ts
@@ -124,7 +124,10 @@ describe('HUD watch mode initialization', () => {
       readAutopilotStateForHud,
     }));
 
-    vi.doMock('../../hud/usage-api.js', () => ({ getUsage }));
+    vi.doMock('../../hud/usage-api.js', () => ({
+      getUsage,
+      getSubscriptionInfo: vi.fn(() => ({ subscriptionType: null, rateLimitTier: null })),
+    }));
     vi.doMock('../../hud/custom-rate-provider.js', () => ({ executeCustomProvider: vi.fn(async () => null) }));
     vi.doMock('../../hud/render.js', () => ({ render }));
     vi.doMock('../../hud/elements/api-key-source.js', () => ({ detectApiKeySource: vi.fn(() => null) }));

--- a/src/hud/__tests__/enterprise-cost.test.ts
+++ b/src/hud/__tests__/enterprise-cost.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for renderEnterpriseCost element
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderEnterpriseCost } from '../elements/enterprise-cost.js';
+import type { RateLimits } from '../types.js';
+
+// Strip ANSI codes for readable assertions
+function strip(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+}
+
+function base(overrides: Partial<RateLimits> = {}): RateLimits {
+  return {
+    fiveHourPercent: 0,
+    ...overrides,
+  };
+}
+
+describe('renderEnterpriseCost', () => {
+  it('returns null when limits is null', () => {
+    expect(renderEnterpriseCost(null)).toBeNull();
+  });
+
+  it('returns null when limits is undefined', () => {
+    expect(renderEnterpriseCost(undefined)).toBeNull();
+  });
+
+  it('returns null when enterpriseSpentUsd is undefined (no data)', () => {
+    const limits = base();
+    expect(renderEnterpriseCost(limits)).toBeNull();
+  });
+
+  it('renders unlimited format when enterpriseLimitUsd is null', () => {
+    const limits = base({
+      enterpriseSpentUsd: 3323.93,
+      enterpriseLimitUsd: null,
+      enterpriseCurrency: 'USD',
+    });
+    const result = renderEnterpriseCost(limits);
+    expect(result).not.toBeNull();
+    const plain = strip(result!);
+    expect(plain).toBe('spent:$3,323.93');
+  });
+
+  it('renders unlimited format with no denominator or percent', () => {
+    const limits = base({
+      enterpriseSpentUsd: 100,
+      enterpriseLimitUsd: null,
+      enterpriseCurrency: 'USD',
+    });
+    const plain = strip(renderEnterpriseCost(limits)!);
+    expect(plain).not.toContain('/');
+    expect(plain).not.toContain('%');
+    expect(plain).toBe('spent:$100.00');
+  });
+
+  it('renders zero spend correctly for unlimited', () => {
+    const limits = base({
+      enterpriseSpentUsd: 0,
+      enterpriseLimitUsd: null,
+      enterpriseCurrency: 'USD',
+    });
+    const plain = strip(renderEnterpriseCost(limits)!);
+    expect(plain).toBe('spent:$0.00');
+  });
+
+  it('renders capped format with percent when limit exists', () => {
+    const limits = base({
+      enterpriseSpentUsd: 35.21,
+      enterpriseLimitUsd: 500,
+      enterpriseUtilization: 7.042,
+      enterpriseCurrency: 'USD',
+    });
+    const result = renderEnterpriseCost(limits);
+    expect(result).not.toBeNull();
+    const plain = strip(result!);
+    expect(plain).toBe('spent:$35.21/$500.00 (7%)');
+  });
+
+  it('applies green color below 70% utilization', () => {
+    const limits = base({
+      enterpriseSpentUsd: 10,
+      enterpriseLimitUsd: 100,
+      enterpriseUtilization: 50,
+      enterpriseCurrency: 'USD',
+    });
+    const result = renderEnterpriseCost(limits)!;
+    // Green ANSI code is \x1b[32m
+    expect(result).toContain('\x1b[32m');
+  });
+
+  it('applies yellow color at 70% utilization', () => {
+    const limits = base({
+      enterpriseSpentUsd: 70,
+      enterpriseLimitUsd: 100,
+      enterpriseUtilization: 70,
+      enterpriseCurrency: 'USD',
+    });
+    const result = renderEnterpriseCost(limits)!;
+    // Yellow ANSI code is \x1b[33m
+    expect(result).toContain('\x1b[33m');
+  });
+
+  it('applies red color at 90% utilization', () => {
+    const limits = base({
+      enterpriseSpentUsd: 90,
+      enterpriseLimitUsd: 100,
+      enterpriseUtilization: 90,
+      enterpriseCurrency: 'USD',
+    });
+    const result = renderEnterpriseCost(limits)!;
+    // Red ANSI code is \x1b[31m
+    expect(result).toContain('\x1b[31m');
+  });
+
+  it('defaults currency to USD when enterpriseCurrency is absent', () => {
+    const limits = base({
+      enterpriseSpentUsd: 50,
+      enterpriseLimitUsd: null,
+      // no enterpriseCurrency
+    });
+    const plain = strip(renderEnterpriseCost(limits)!);
+    expect(plain).toContain('$50.00');
+  });
+
+  it('uses ISO code prefix for non-USD currency', () => {
+    const limits = base({
+      enterpriseSpentUsd: 4500000,
+      enterpriseLimitUsd: null,
+      enterpriseCurrency: 'KRW',
+    });
+    const plain = strip(renderEnterpriseCost(limits)!);
+    expect(plain).toBe('spent:KRW 4,500,000.00');
+  });
+
+  it('appends stale marker when stale=true', () => {
+    const limits = base({
+      enterpriseSpentUsd: 100,
+      enterpriseLimitUsd: null,
+      enterpriseCurrency: 'USD',
+    });
+    const result = renderEnterpriseCost(limits, true)!;
+    const plain = strip(result);
+    expect(plain).toContain('*');
+  });
+
+  it('does not append stale marker when stale=false', () => {
+    const limits = base({
+      enterpriseSpentUsd: 100,
+      enterpriseLimitUsd: null,
+      enterpriseCurrency: 'USD',
+    });
+    const result = renderEnterpriseCost(limits, false)!;
+    const plain = strip(result);
+    expect(plain).not.toContain('*');
+  });
+
+  it('formats large numbers with comma separators', () => {
+    const limits = base({
+      enterpriseSpentUsd: 1234567.89,
+      enterpriseLimitUsd: null,
+      enterpriseCurrency: 'USD',
+    });
+    const plain = strip(renderEnterpriseCost(limits)!);
+    expect(plain).toBe('spent:$1,234,567.89');
+  });
+});

--- a/src/hud/__tests__/usage-api-enterprise.test.ts
+++ b/src/hud/__tests__/usage-api-enterprise.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for parseUsageResponse with enterprise extra_usage payload
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseUsageResponse } from '../usage-api.js';
+
+describe('parseUsageResponse - enterprise extra_usage', () => {
+  const baseResponse = {
+    five_hour: null as unknown as undefined,
+    seven_day: null as unknown as undefined,
+    seven_day_opus: null as unknown as undefined,
+    seven_day_sonnet: null as unknown as undefined,
+  };
+
+  it('parses used_credits as enterpriseSpentUsd (÷100)', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 333391,
+        monthly_limit: null,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result).not.toBeNull();
+    expect(result!.enterpriseSpentUsd).toBeCloseTo(3333.91, 2);
+  });
+
+  it('sets enterpriseLimitUsd to null when monthly_limit is null', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 333391,
+        monthly_limit: null,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result!.enterpriseLimitUsd).toBeNull();
+  });
+
+  it('does NOT set extraUsageSpentUsd from enterprise payload', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 333391,
+        monthly_limit: null,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result!.extraUsageSpentUsd).toBeUndefined();
+    expect(result!.extraUsageLimitUsd).toBeUndefined();
+  });
+
+  it('sets enterpriseCurrency from API response', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 50000,
+        monthly_limit: null,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result!.enterpriseCurrency).toBe('USD');
+  });
+
+  it('defaults enterpriseCurrency to USD when currency is absent', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 50000,
+        monthly_limit: null,
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result!.enterpriseCurrency).toBe('USD');
+  });
+
+  it('computes enterpriseUtilization when monthly_limit is positive', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 5000,
+        monthly_limit: 10000,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result!.enterpriseSpentUsd).toBeCloseTo(50, 2);
+    expect(result!.enterpriseLimitUsd).toBeCloseTo(100, 2);
+    expect(result!.enterpriseUtilization).toBeCloseTo(50, 1);
+  });
+
+  it('does NOT set enterpriseUtilization when monthly_limit is null', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 333391,
+        monthly_limit: null,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result!.enterpriseUtilization).toBeUndefined();
+  });
+
+  it('returns non-null when only used_credits is present (five_hour/seven_day both null)', () => {
+    // Regression: early-return at parseUsageResponse used to reject this payload,
+    // dropping enterprise data entirely. This is the actual Enterprise API response shape.
+    const response = {
+      five_hour: null as unknown as undefined,
+      seven_day: null as unknown as undefined,
+      seven_day_opus: null as unknown as undefined,
+      seven_day_sonnet: null as unknown as undefined,
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 333391,
+        monthly_limit: null,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result).not.toBeNull();
+    expect(result!.enterpriseSpentUsd).toBeCloseTo(3333.91, 2);
+  });
+
+  it('returns null when neither rate-limit buckets nor enterprise credits are present', () => {
+    const response = {
+      five_hour: null as unknown as undefined,
+      seven_day: null as unknown as undefined,
+    };
+    expect(parseUsageResponse(response)).toBeNull();
+  });
+
+  it('still parses Pro metered path (spent_usd/limit_usd) without interference', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 45 },
+      extra_usage: {
+        spent_usd: 3.21,
+        limit_usd: 50,
+        utilization: 6.42,
+      },
+    };
+    const result = parseUsageResponse(response);
+    expect(result!.extraUsageSpentUsd).toBeCloseTo(3.21, 2);
+    expect(result!.extraUsageLimitUsd).toBeCloseTo(50, 2);
+    expect(result!.enterpriseSpentUsd).toBeUndefined();
+  });
+});

--- a/src/hud/elements/enterprise-cost.ts
+++ b/src/hud/elements/enterprise-cost.ts
@@ -1,0 +1,74 @@
+/**
+ * OMC HUD - Enterprise Cost Element
+ *
+ * Renders billing-period cumulative spend for Claude Enterprise subscribers.
+ * Shows spent:$X,XXX.XX when unlimited, or spent:$X.XX/$Y.YY (Z%) when capped.
+ */
+
+import type { RateLimits } from '../types.js';
+import { RESET } from '../colors.js';
+
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const DIM = '\x1b[2m';
+
+// Thresholds matching limits.ts for consistency
+const WARNING_THRESHOLD = 70;
+const CRITICAL_THRESHOLD = 90;
+
+function getColor(percent: number): string {
+  if (percent >= CRITICAL_THRESHOLD) return RED;
+  if (percent >= WARNING_THRESHOLD) return YELLOW;
+  return GREEN;
+}
+
+/**
+ * Format a monetary amount with thousands-separator commas and 2 decimal places.
+ * e.g. 3323.93 → "3,323.93"
+ */
+function formatMoney(amount: number): string {
+  const [intPart, decPart] = amount.toFixed(2).split('.');
+  const withCommas = (intPart ?? '0').replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return `${withCommas}.${decPart ?? '00'}`;
+}
+
+/**
+ * Get currency prefix string.
+ * USD → "$", anything else → "KRW " (ISO code + space)
+ */
+function currencyPrefix(currency: string): string {
+  return currency.toUpperCase() === 'USD' ? '$' : `${currency.toUpperCase()} `;
+}
+
+/**
+ * Render enterprise billing-period cost display.
+ *
+ * Format (unlimited): spent:$3,323.93
+ * Format (capped):    spent:$3.21/$50.00 (7%)   with color on percent
+ * Returns null when enterpriseSpentUsd is undefined (API error / no data).
+ */
+export function renderEnterpriseCost(
+  limits: RateLimits | null | undefined,
+  stale?: boolean,
+): string | null {
+  if (!limits || limits.enterpriseSpentUsd === undefined) return null;
+
+  const staleMarker = stale ? `${DIM}*${RESET}` : '';
+  const currency = limits.enterpriseCurrency ?? 'USD';
+  const prefix = currencyPrefix(currency);
+  const spentStr = formatMoney(limits.enterpriseSpentUsd);
+
+  if (limits.enterpriseLimitUsd == null) {
+    // Unlimited plan — show spent amount only
+    return `${DIM}spent:${RESET}${prefix}${spentStr}${staleMarker}`;
+  }
+
+  // Capped plan — show spent/limit (utilization%)
+  const limitStr = formatMoney(limits.enterpriseLimitUsd);
+  const utilization = limits.enterpriseUtilization ?? 0;
+  const rounded = Math.min(100, Math.max(0, Math.round(utilization)));
+  const color = getColor(rounded);
+
+  return `${DIM}spent:${RESET}${prefix}${spentStr}/${prefix}${limitStr} ${color}(${rounded}%)${RESET}${staleMarker}`;
+}

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -29,7 +29,7 @@ import {
   readPrdStateForHud,
   readAutopilotStateForHud,
 } from "./omc-state.js";
-import { getUsage } from "./usage-api.js";
+import { getUsage, getSubscriptionInfo } from "./usage-api.js";
 import { executeCustomProvider } from "./custom-rate-provider.js";
 import { render } from "./render.js";
 import { detectApiKeySource } from "./elements/api-key-source.js";
@@ -443,6 +443,9 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       : null;
     const contextPercent = getContextPercent(stdin);
 
+    // Read subscription info for enterprise detection (best-effort, never throws)
+    const subscriptionInfo = getSubscriptionInfo();
+
     // Build render context
     const context: HudRenderContext = {
       contextPercent,
@@ -476,6 +479,8 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       apiKeySource: config.elements.apiKeySource
         ? detectApiKeySource(cwd)
         : null,
+      subscriptionType: subscriptionInfo.subscriptionType,
+      rateLimitTier: subscriptionInfo.rateLimitTier,
       profileName: process.env.CLAUDE_CONFIG_DIR
         ? basename(process.env.CLAUDE_CONFIG_DIR).replace(/^\./, "")
         : null,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -28,6 +28,7 @@ import { renderPermission } from "./elements/permission.js";
 import { renderThinking } from "./elements/thinking.js";
 import { renderSession } from "./elements/session.js";
 import { renderTokenUsage } from "./elements/token-usage.js";
+import { renderEnterpriseCost } from "./elements/enterprise-cost.js";
 import { renderPromptTime } from "./elements/prompt-time.js";
 import { renderAutopilot } from "./elements/autopilot.js";
 import { renderCwd } from "./elements/cwd.js";
@@ -296,8 +297,12 @@ export async function render(
     }
   }
 
-  // Rate limits (5h and weekly) - data takes priority over error indicator
-  if (enabledElements.rateLimits && context.rateLimitsResult) {
+  // Rate limits (5h and weekly) - data takes priority over error indicator.
+  // Skip for enterprise responses where token-window limits aren't applicable
+  // (the enterpriseCost element replaces this slot for those accounts).
+  const hasEnterpriseData =
+    context.rateLimitsResult?.rateLimits?.enterpriseSpentUsd !== undefined;
+  if (enabledElements.rateLimits && context.rateLimitsResult && !hasEnterpriseData) {
     if (context.rateLimitsResult.rateLimits) {
       const stale = context.rateLimitsResult.stale;
       const limits = enabledElements.useBars
@@ -347,7 +352,31 @@ export async function render(
     }
   }
 
-  if (enabledElements.showTokens === true) {
+  // Determine effective enterprise mode
+  const isEnterprise = enabledElements.enterpriseMode !== undefined
+    ? enabledElements.enterpriseMode
+    : (
+        (context.subscriptionType ?? '').toLowerCase() === 'enterprise' ||
+        /claude_zero/i.test(context.rateLimitTier ?? '')
+      );
+
+  if (isEnterprise && enabledElements.showEnterpriseCost !== false) {
+    const stale = context.rateLimitsResult?.stale;
+    const cost = renderEnterpriseCost(
+      context.rateLimitsResult?.rateLimits,
+      stale,
+    );
+    if (cost) {
+      rendered.set("enterpriseCost", cost);
+    } else if (enabledElements.showTokens === true) {
+      // Enterprise but no cost data — fall back to token usage
+      const tokenUsage = renderTokenUsage(
+        context.lastRequestTokenUsage,
+        context.sessionTotalTokens,
+      );
+      if (tokenUsage) rendered.set("tokens", tokenUsage);
+    }
+  } else if (enabledElements.showTokens === true) {
     const tokenUsage = renderTokenUsage(
       context.lastRequestTokenUsage,
       context.sessionTotalTokens,

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -206,6 +206,17 @@ export interface RateLimits {
   extraUsageLimitUsd?: number;
   /** When the extra usage period resets (null if unavailable) */
   extraUsageResetsAt?: Date | null;
+
+  /** Enterprise billing-period cumulative spend in USD */
+  enterpriseSpentUsd?: number;
+  /** Enterprise monthly limit in USD (null = unlimited) */
+  enterpriseLimitUsd?: number | null;
+  /** Enterprise billing utilization (0-100), only set when monthly_limit is a positive number */
+  enterpriseUtilization?: number;
+  /** Enterprise billing currency (e.g. 'USD') */
+  enterpriseCurrency?: string;
+  /** When the enterprise billing period resets (null if unavailable or not returned by API) */
+  enterpriseResetsAt?: Date | null;
 }
 
 /**
@@ -383,6 +394,12 @@ export interface HudRenderContext {
   /** API key source: 'project', 'global', or 'env' */
   apiKeySource: ApiKeySource | null;
 
+  /** OAuth subscription type (e.g. 'enterprise'), null when unavailable */
+  subscriptionType?: string | null;
+
+  /** OAuth rate limit tier (e.g. 'default_claude_zero'), null when unavailable */
+  rateLimitTier?: string | null;
+
   /** Active profile name (derived from CLAUDE_CONFIG_DIR), null if default */
   profileName: string | null;
 
@@ -473,6 +490,8 @@ export interface HudElementConfig {
   showSessionDuration?: boolean;  // Show session:19m duration display (default: true if sessionHealth is true)
   showHealthIndicator?: boolean;  // Show 🟢/🟡/🔴 health indicator (default: true if sessionHealth is true)
   showTokens?: boolean;           // Show last-request token usage when enabled (tok:i1.2k/o340)
+  enterpriseMode?: boolean;       // Explicit override for enterprise mode (undefined = auto-detect)
+  showEnterpriseCost?: boolean;   // Whether to render enterprise billing cost (default: true when enterprise)
   useBars: boolean;           // Show visual progress bars instead of/alongside percentages
   showCallCounts?: boolean;   // Show tool/agent/skill call counts on the right of the status line (default: true)
   callCountsFormat?: CallCountsFormat; // Controls call count icon rendering: auto (platform default), emoji, or ascii
@@ -528,7 +547,7 @@ export interface LayoutConfig {
 export const DEFAULT_ELEMENT_ORDER: Required<LayoutConfig> = {
   line1: ['hostname', 'cwd', 'gitRepo', 'gitBranch', 'gitStatus', 'model', 'apiKeySource', 'profile'],
   main: [
-    'omcLabel', 'rateLimits', 'customBuckets', 'permission', 'thinking',
+    'omcLabel', 'enterpriseCost', 'rateLimits', 'customBuckets', 'permission', 'thinking',
     'promptTime', 'session', 'tokens', 'ralph', 'autopilot', 'prd',
     'skills', 'lastSkill', 'contextBar', 'agents', 'background',
     'callCounts', 'lastTool', 'sessionSummary',

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -69,6 +69,10 @@ interface OAuthCredentials {
   refreshToken?: string;
   /** Where the credentials were read from, needed for write-back */
   source?: 'keychain' | 'file';
+  /** Subscription type from OAuth credentials (e.g. 'enterprise') */
+  subscriptionType?: string;
+  /** Rate limit tier from OAuth credentials (e.g. 'default_claude_zero') */
+  rateLimitTier?: string;
 }
 
 interface UsageApiResponse {
@@ -83,6 +87,11 @@ interface UsageApiResponse {
     spent_usd?: number;
     limit_usd?: number;
     resets_at?: string;
+    // Enterprise-specific fields
+    is_enabled?: boolean;
+    used_credits?: number;
+    monthly_limit?: number | null;
+    currency?: string;
   };
 }
 
@@ -440,6 +449,8 @@ function readKeychainCredential(serviceName: string, account?: string): OAuthCre
       expiresAt: creds.expiresAt,
       refreshToken: creds.refreshToken,
       source: 'keychain' as const,
+      subscriptionType: creds.subscriptionType,
+      rateLimitTier: creds.rateLimitTier,
     };
   } catch {
     return null;
@@ -502,6 +513,8 @@ function readFileCredentials(): OAuthCredentials | null {
         expiresAt: creds.expiresAt,
         refreshToken: creds.refreshToken,
         source: 'file' as const,
+        subscriptionType: creds.subscriptionType,
+        rateLimitTier: creds.rateLimitTier,
       };
     }
   } catch {
@@ -521,6 +534,22 @@ function getCredentials(): OAuthCredentials | null {
 
   // Fall back to file
   return readFileCredentials();
+}
+
+/**
+ * Get subscription info from OAuth credentials.
+ * Returns subscriptionType and rateLimitTier (null when unavailable; never throws).
+ */
+export function getSubscriptionInfo(): { subscriptionType: string | null; rateLimitTier: string | null } {
+  try {
+    const creds = getCredentials();
+    return {
+      subscriptionType: creds?.subscriptionType ?? null,
+      rateLimitTier: creds?.rateLimitTier ?? null,
+    };
+  } catch {
+    return { subscriptionType: null, rateLimitTier: null };
+  }
 }
 
 /**
@@ -790,9 +819,10 @@ function clamp(v: number | undefined): number {
 export function parseUsageResponse(response: UsageApiResponse): RateLimits | null {
   const fiveHour = response.five_hour?.utilization;
   const sevenDay = response.seven_day?.utilization;
+  const enterpriseCredits = response.extra_usage?.used_credits;
 
-  // Need at least one valid value
-  if (fiveHour == null && sevenDay == null) return null;
+  // Need at least one valid value (5h/7d for Pro/Max, or used_credits for Enterprise)
+  if (fiveHour == null && sevenDay == null && enterpriseCredits == null) return null;
 
   // Parse ISO 8601 date strings to Date objects
   const parseDate = (dateStr: string | undefined): Date | null => {
@@ -833,15 +863,28 @@ export function parseUsageResponse(response: UsageApiResponse): RateLimits | nul
 
   // Add extra (metered) usage if available (Pro subscribers with extra usage allocation)
   const extra = response.extra_usage;
-  if (extra != null && extra.limit_usd != null && extra.limit_usd > 0) {
-    const spentUsd = extra.spent_usd ?? 0;
-    result.extraUsageSpentUsd = spentUsd;
-    result.extraUsageLimitUsd = extra.limit_usd;
-    // Use API-provided utilization when available; fall back to spent/limit ratio
-    result.extraUsagePercent = extra.utilization != null
-      ? clamp(extra.utilization)
-      : clamp((spentUsd / extra.limit_usd) * 100);
-    result.extraUsageResetsAt = parseDate(extra.resets_at);
+  if (extra != null) {
+    // Enterprise path: used_credits (cents) is present instead of spent_usd/limit_usd
+    if (extra.used_credits != null) {
+      result.enterpriseSpentUsd = extra.used_credits / 100;
+      result.enterpriseLimitUsd = extra.monthly_limit == null ? null : extra.monthly_limit / 100;
+      result.enterpriseCurrency = extra.currency ?? 'USD';
+      // Only compute utilization when there is a positive cap
+      if (extra.monthly_limit != null && extra.monthly_limit > 0) {
+        result.enterpriseUtilization = clamp((extra.used_credits / extra.monthly_limit) * 100);
+      }
+      // resets_at not provided in enterprise response — leave enterpriseResetsAt unset
+    } else if (extra.limit_usd != null && extra.limit_usd > 0) {
+      // Pro metered path
+      const spentUsd = extra.spent_usd ?? 0;
+      result.extraUsageSpentUsd = spentUsd;
+      result.extraUsageLimitUsd = extra.limit_usd;
+      // Use API-provided utilization when available; fall back to spent/limit ratio
+      result.extraUsagePercent = extra.utilization != null
+        ? clamp(extra.utilization)
+        : clamp((spentUsd / extra.limit_usd) * 100);
+      result.extraUsageResetsAt = parseDate(extra.resets_at);
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary

Token rate-limit buckets (`five_hour`, `seven_day`) are always `null` for Claude Enterprise accounts, so the HUD's usage display was effectively empty for Enterprise users. This PR adds a new `enterpriseCost` element that renders cumulative billing-period spend in the slot where rate-limit usage normally lives.

**Before** (Enterprise user): rate-limit slot empty, no usage feedback
**After** (Enterprise user): `[OMC] | spent:$3,323.93 | session:... | ctx:...`

## How it works

1. **Detection** — OAuth credentials include `subscriptionType` (e.g. `"enterprise"`) and `rateLimitTier` (e.g. `"default_claude_zero"`). `getSubscriptionInfo()` extracts these from keychain/file credentials; the render path treats the user as enterprise when either signal matches.
2. **Data source** — The existing `/api/oauth/usage` endpoint already returns enterprise-shaped data:
   ```json
   {
     "five_hour": null, "seven_day": null, ...,
     "extra_usage": {
       "is_enabled": true,
       "used_credits": 333391,      // cents → $3,333.91
       "monthly_limit": null,        // null = unlimited
       "currency": "USD"
     }
   }
   ```
   `parseUsageResponse` now branches on `used_credits` to populate new `enterprise*` fields on `RateLimits` without affecting the Pro metered-usage path.
3. **Rendering** — `renderEnterpriseCost()` formats `spent:$3,323.93` (unlimited) or `spent:$X/$Y (Z%)` (capped), with utilization-based coloring matching the rest of the HUD. For non-USD currencies it uses the ISO code prefix (e.g. `spent:KRW 4,500,000`).
4. **Display slot** — `enterpriseCost` sits in `DEFAULT_ELEMENT_ORDER.main` at the position rate limits normally occupy. Rate-limit rendering is suppressed when enterprise data is present to avoid a confusing `5h:0% wk:0%` alongside the cost.

## Bugs fixed along the way

- `parseUsageResponse` used to early-return when both `five_hour` and `seven_day` were null, silently discarding the enterprise `extra_usage` payload. Now checks for `used_credits` before bailing.
- Enterprise payloads producing `fiveHourPercent: 0` (via `clamp(null)`) were surfacing a meaningless `5h:0% wk:0%` display; `render.ts` now suppresses the rate-limits element when enterprise data is the source.

## Configuration

- `omcHud.enterpriseMode: true | false` — explicit override (auto-detected when absent)
- `omcHud.showEnterpriseCost: false` — opt out of the cost display even for enterprise users

## Test plan

- [x] `npm test -- src/__tests__/hud src/hud/__tests__` — 683/683 pass
- [x] 34 new/updated tests covering:
  - `parseUsageResponse` enterprise branch, including the all-null-buckets regression
  - `renderEnterpriseCost` unlimited/capped/stale/non-USD paths
  - `render.ts` enterprise branch, fallback to tokens on error, rateLimits suppression, Pro path unchanged
- [x] `npm run lint` — 0 new errors
- [x] `npm run build` — clean
- [x] Live smoke test against production `/api/oauth/usage` (Enterprise subscription) — real numbers render as expected

## Notes

No pricing table needed: Anthropic's API returns the canonical figure. Session-scoped `stdin.cost.total_cost_usd` was explicitly not used — users want billing-period cumulative, not per-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)