### PR TITLE
fix(hud): scope hud-stdin-cache.json to session to prevent cross-session corruption

### DIFF
--- a/src/__tests__/hud/stdin.test.ts
+++ b/src/__tests__/hud/stdin.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
 
 import type { StatuslineStdin } from '../../hud/types.js';
-import { getContextPercent, getModelName, getRateLimitsFromStdin, stabilizeContextPercent } from '../../hud/stdin.js';
+import {
+  getContextPercent,
+  getModelName,
+  getRateLimitsFromStdin,
+  readStdinCache,
+  stabilizeContextPercent,
+  writeStdinCache,
+} from '../../hud/stdin.js';
 
 function makeStdin(overrides: Partial<StatuslineStdin> = {}): StatuslineStdin {
   return {
@@ -220,5 +231,101 @@ describe('HUD stdin rate limits', () => {
       fiveHourResetsAt: null,
       weeklyResetsAt: null,
     });
+  });
+});
+
+describe('HUD stdin cache path is session-scoped', () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+  const envKeys = ['CLAUDE_SESSION_ID', 'CLAUDECODE_SESSION_ID'] as const;
+  const savedEnv: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'omc-hud-stdin-cache-'));
+    // Make a real git repo so getWorktreeRoot() (which shells out to git
+    // rev-parse) deterministically returns tmpRoot instead of leaking into
+    // the surrounding workspace.
+    execSync('git init --quiet', { cwd: tmpRoot });
+    originalCwd = process.cwd();
+    process.chdir(tmpRoot);
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    for (const key of envKeys) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes to a session-scoped path when CLAUDE_SESSION_ID is set', () => {
+    process.env.CLAUDE_SESSION_ID = 'test-session-aaa';
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const expected = join(tmpRoot, '.omc', 'state', 'sessions', 'test-session-aaa', 'hud-stdin-cache.json');
+    expect(existsSync(expected)).toBe(true);
+    const loaded = JSON.parse(readFileSync(expected, 'utf-8')) as StatuslineStdin;
+    expect(loaded.cwd).toBe(tmpRoot);
+  });
+
+  it('falls back to the legacy flat path when no session env var is set', () => {
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const expected = join(tmpRoot, '.omc', 'state', 'hud-stdin-cache.json');
+    expect(existsSync(expected)).toBe(true);
+    const sessionScoped = join(tmpRoot, '.omc', 'state', 'sessions');
+    expect(existsSync(sessionScoped)).toBe(false);
+  });
+
+  it('accepts CLAUDECODE_SESSION_ID as the session id source', () => {
+    process.env.CLAUDECODE_SESSION_ID = 'test-session-bbb';
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const expected = join(tmpRoot, '.omc', 'state', 'sessions', 'test-session-bbb', 'hud-stdin-cache.json');
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it('prevents two concurrent sessions from clobbering each other', () => {
+    process.env.CLAUDE_SESSION_ID = 'session-alpha';
+    const alpha = makeStdin({ cwd: tmpRoot, transcript_path: `${tmpRoot}/alpha.jsonl` });
+    writeStdinCache(alpha);
+
+    process.env.CLAUDE_SESSION_ID = 'session-beta';
+    const beta = makeStdin({ cwd: tmpRoot, transcript_path: `${tmpRoot}/beta.jsonl` });
+    writeStdinCache(beta);
+
+    // Reading back from each session must return its own snapshot.
+    process.env.CLAUDE_SESSION_ID = 'session-alpha';
+    expect(readStdinCache()?.transcript_path).toBe(`${tmpRoot}/alpha.jsonl`);
+
+    process.env.CLAUDE_SESSION_ID = 'session-beta';
+    expect(readStdinCache()?.transcript_path).toBe(`${tmpRoot}/beta.jsonl`);
+  });
+
+  it('readStdinCache ignores a legacy flat file when a session id is set', () => {
+    const stateDir = join(tmpRoot, '.omc', 'state');
+    execSync(`mkdir -p "${stateDir}"`);
+    // Simulate a stale legacy cache written by an older build.
+    const legacy = makeStdin({ cwd: '/legacy/cwd' });
+    writeFileSync(join(stateDir, 'hud-stdin-cache.json'), JSON.stringify(legacy));
+
+    process.env.CLAUDE_SESSION_ID = 'fresh-session';
+    // Without a session file yet, read should miss rather than return the
+    // legacy (cross-session) value.
+    expect(readStdinCache()).toBeNull();
   });
 });

--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { getWorktreeRoot } from '../lib/worktree-paths.js';
 import type { RateLimits, StatuslineStdin } from './types.js';
 
@@ -16,8 +16,25 @@ const TRANSIENT_CONTEXT_PERCENT_TOLERANCE = 3;
 // Stdin Cache (for --watch mode)
 // ============================================================================
 
+/**
+ * Return the current session id, if present in the environment.
+ *
+ * Claude Code populates `CLAUDE_SESSION_ID` / `CLAUDECODE_SESSION_ID` for
+ * tools it invokes. The cache path uses this to keep concurrent sessions
+ * from clobbering each other's last-stdin snapshots.
+ */
+function getSessionId(): string | null {
+  const id = process.env.CLAUDE_SESSION_ID ?? process.env.CLAUDECODE_SESSION_ID;
+  return id && id.length > 0 ? id : null;
+}
+
 function getStdinCachePath(): string {
   const root = getWorktreeRoot() || process.cwd();
+  const sessionId = getSessionId();
+  if (sessionId) {
+    return join(root, '.omc', 'state', 'sessions', sessionId, 'hud-stdin-cache.json');
+  }
+  // Fallback when no session id is available (e.g. bare CLI invocations).
   return join(root, '.omc', 'state', 'hud-stdin-cache.json');
 }
 
@@ -27,12 +44,12 @@ function getStdinCachePath(): string {
  */
 export function writeStdinCache(stdin: StatuslineStdin): void {
   try {
-    const root = getWorktreeRoot() || process.cwd();
-    const cacheDir = join(root, '.omc', 'state');
+    const cachePath = getStdinCachePath();
+    const cacheDir = dirname(cachePath);
     if (!existsSync(cacheDir)) {
       mkdirSync(cacheDir, { recursive: true });
     }
-    writeFileSync(getStdinCachePath(), JSON.stringify(stdin));
+    writeFileSync(cachePath, JSON.stringify(stdin));
   } catch {
     // Best-effort; ignore failures
   }


### PR DESCRIPTION
## Problem

`hud-stdin-cache.json` lives at `.omc/state/hud-stdin-cache.json`, a path
shared across all Claude Code sessions in the same worktree. When multiple
Claude sessions run concurrently (different terminals, split workspaces,
`--resume` alongside new sessions), they race each other's writes.

Repro:
1. Start 2 Claude sessions in the same repo (different `cwd`/tab).
2. After a few turns, read `.omc/state/hud-stdin-cache.json`.
3. The `cwd`, `session_id`, and token stats reflect whichever session
   last touched the cache — not the reader's own session.

Impact: HUD `--watch` mode displays incorrect statusline values (session
id, cwd, model, token/cost numbers) when stdin is a TTY and the cache
falls back to the shared file.

## Root cause

`src/hud/stdin.ts#getStdinCachePath()` returns a single flat path without
incorporating session identity. Other session state (e.g.
`state/sessions/{id}/hud-state.json`) is already session-scoped, so this
is an outlier rather than a new convention.

## Fix

Route the stdin cache through the session-scoped path
`state/sessions/{sessionId}/hud-stdin-cache.json` when
`CLAUDE_SESSION_ID` / `CLAUDECODE_SESSION_ID` is available. Keep the
original flat path as a fallback for contexts that lack session env
vars (preserves behavior for existing call sites).

No migration needed: the legacy file is transient (`writeStdinCache` is
best-effort, `readStdinCache` tolerates missing files) and
`session-end` already cleans it up.

## Testing

- New unit tests in ``src/__tests__/hud/stdin.test.ts``:
  - Session-scoped path when ``CLAUDE_SESSION_ID`` is set
  - Legacy flat path fallback when no session env var is set
  - ``CLAUDECODE_SESSION_ID`` also accepted
  - Concurrent writes from two sessions do not overwrite each other
  - ``readStdinCache`` ignores stale legacy file when a session id is set
- Targeted run: ``npx vitest run src/__tests__/hud/stdin.test.ts`` — 17/17 passing (12 existing + 5 new).
- Full suite (``npm run test:run``) unchanged relative to ``upstream/dev``
  baseline: the only failures (``autoresearch/runtime``,
  ``notifications/session-registry``) reproduce on ``upstream/dev`` HEAD
  with these changes stashed out, so they are pre-existing flakes, not
  regressions from this PR.
- ``npm run build`` passes end-to-end.

## Related

- Files touched: ``src/hud/stdin.ts``, ``src/__tests__/hud/stdin.test.ts``
- ``src/hooks/session-end/index.ts`` left untouched; session directory
  pruning already covers the new cache location.