### PR TITLE
fix(hud): scope hud-stdin-cache.json to session to prevent cross-session corruption (v2)

### DIFF
--- a/src/__tests__/hooks/session-end-cleanup.test.ts
+++ b/src/__tests__/hooks/session-end-cleanup.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { cleanupTransientState } from '../../hooks/session-end/index.js';
+
+describe('cleanupTransientState — session-scoped hud-stdin-cache', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'omc-session-end-cleanup-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('removes a per-session hud-stdin-cache.json and prunes the empty session directory', () => {
+    // Simulate the tree that `writeStdinCache` leaves behind after a session.
+    const sessionDir = join(tmpRoot, '.omc', 'state', 'sessions', 'session-aaa');
+    mkdirSync(sessionDir, { recursive: true });
+    const cacheFile = join(sessionDir, 'hud-stdin-cache.json');
+    writeFileSync(cacheFile, '{}');
+
+    const removed = cleanupTransientState(tmpRoot);
+
+    expect(existsSync(cacheFile)).toBe(false);
+    expect(existsSync(sessionDir)).toBe(false);
+    // Sanity: at least one unlink + one rmdir happened.
+    expect(removed).toBeGreaterThanOrEqual(2);
+  });
+
+  it('preserves session directories that still have non-transient state', () => {
+    const sessionDir = join(tmpRoot, '.omc', 'state', 'sessions', 'session-bbb');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, 'hud-stdin-cache.json'), '{}');
+    // A state file that should NOT be cleaned (only transient files are targeted).
+    const keep = join(sessionDir, 'ralph-state.json');
+    writeFileSync(keep, '{"active":true}');
+
+    cleanupTransientState(tmpRoot);
+
+    expect(existsSync(join(sessionDir, 'hud-stdin-cache.json'))).toBe(false);
+    expect(existsSync(keep)).toBe(true);
+    // Directory must remain because `ralph-state.json` is still there.
+    expect(existsSync(sessionDir)).toBe(true);
+  });
+
+  it('still removes the legacy top-level hud-stdin-cache.json', () => {
+    // Regression: don't drop the old flat-path cleanup path used by session-less callers.
+    const stateDir = join(tmpRoot, '.omc', 'state');
+    mkdirSync(stateDir, { recursive: true });
+    const legacy = join(stateDir, 'hud-stdin-cache.json');
+    writeFileSync(legacy, '{}');
+
+    cleanupTransientState(tmpRoot);
+
+    expect(existsSync(legacy)).toBe(false);
+  });
+});

--- a/src/__tests__/hud/stdin.test.ts
+++ b/src/__tests__/hud/stdin.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
 
 import type { StatuslineStdin } from '../../hud/types.js';
-import { getContextPercent, getModelName, getRateLimitsFromStdin, stabilizeContextPercent } from '../../hud/stdin.js';
+import {
+  getContextPercent,
+  getModelName,
+  getRateLimitsFromStdin,
+  readStdinCache,
+  stabilizeContextPercent,
+  writeStdinCache,
+} from '../../hud/stdin.js';
 
 function makeStdin(overrides: Partial<StatuslineStdin> = {}): StatuslineStdin {
   return {
@@ -220,5 +231,200 @@ describe('HUD stdin rate limits', () => {
       fiveHourResetsAt: null,
       weeklyResetsAt: null,
     });
+  });
+});
+
+describe('HUD stdin cache path is session-scoped', () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+  const envKeys = ['CLAUDE_SESSION_ID', 'CLAUDECODE_SESSION_ID'] as const;
+  const savedEnv: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'omc-hud-stdin-cache-'));
+    // Make a real git repo so getWorktreeRoot() (which shells out to git
+    // rev-parse) deterministically returns tmpRoot instead of leaking into
+    // the surrounding workspace.
+    execSync('git init --quiet', { cwd: tmpRoot });
+    originalCwd = process.cwd();
+    process.chdir(tmpRoot);
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    for (const key of envKeys) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes to a session-scoped path when CLAUDE_SESSION_ID is set', () => {
+    process.env.CLAUDE_SESSION_ID = 'test-session-aaa';
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const expected = join(tmpRoot, '.omc', 'state', 'sessions', 'test-session-aaa', 'hud-stdin-cache.json');
+    expect(existsSync(expected)).toBe(true);
+    const loaded = JSON.parse(readFileSync(expected, 'utf-8')) as StatuslineStdin;
+    expect(loaded.cwd).toBe(tmpRoot);
+  });
+
+  it('falls back to the legacy flat path when no session env var is set', () => {
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const expected = join(tmpRoot, '.omc', 'state', 'hud-stdin-cache.json');
+    expect(existsSync(expected)).toBe(true);
+    const sessionScoped = join(tmpRoot, '.omc', 'state', 'sessions');
+    expect(existsSync(sessionScoped)).toBe(false);
+  });
+
+  it('accepts CLAUDECODE_SESSION_ID as the session id source', () => {
+    process.env.CLAUDECODE_SESSION_ID = 'test-session-bbb';
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const expected = join(tmpRoot, '.omc', 'state', 'sessions', 'test-session-bbb', 'hud-stdin-cache.json');
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it('prevents two concurrent sessions from clobbering each other', () => {
+    process.env.CLAUDE_SESSION_ID = 'session-alpha';
+    const alpha = makeStdin({ cwd: tmpRoot, transcript_path: `${tmpRoot}/alpha.jsonl` });
+    writeStdinCache(alpha);
+
+    process.env.CLAUDE_SESSION_ID = 'session-beta';
+    const beta = makeStdin({ cwd: tmpRoot, transcript_path: `${tmpRoot}/beta.jsonl` });
+    writeStdinCache(beta);
+
+    // Reading back from each session must return its own snapshot.
+    process.env.CLAUDE_SESSION_ID = 'session-alpha';
+    expect(readStdinCache()?.transcript_path).toBe(`${tmpRoot}/alpha.jsonl`);
+
+    process.env.CLAUDE_SESSION_ID = 'session-beta';
+    expect(readStdinCache()?.transcript_path).toBe(`${tmpRoot}/beta.jsonl`);
+  });
+
+  it('readStdinCache ignores a legacy flat file when a session id is set', () => {
+    const stateDir = join(tmpRoot, '.omc', 'state');
+    mkdirSync(stateDir, { recursive: true });
+    // Simulate a stale legacy cache written by an older build.
+    const legacy = makeStdin({ cwd: '/legacy/cwd' });
+    writeFileSync(join(stateDir, 'hud-stdin-cache.json'), JSON.stringify(legacy));
+
+    process.env.CLAUDE_SESSION_ID = 'fresh-session';
+    // Without a session file yet, read should miss rather than return the
+    // legacy (cross-session) value.
+    expect(readStdinCache()).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unsafe / malformed session ids must NOT escape the session-scoped directory.
+  //
+  // `getStdinCachePath` delegates validation to the shared `resolveSessionStatePath`
+  // helper (`validateSessionId`), so any id that fails the repo-wide contract
+  // should fall back to the legacy flat path rather than being interpolated into
+  // a filesystem path.
+  // ---------------------------------------------------------------------------
+
+  it.each([
+    ['path traversal with ..', '../../../etc/passwd'],
+    ['path traversal with parent only', '..'],
+    ['forward slash', 'foo/bar'],
+    ['backslash (Windows traversal)', 'foo\\bar'],
+    ['leading underscore (regex first-char violation)', '_foo'],
+    ['overlong id (>256 chars)', 'a'.repeat(300)],
+  ])('rejects unsafe CLAUDE_SESSION_ID (%s) and falls back to the legacy path', (_label, unsafeId) => {
+    process.env.CLAUDE_SESSION_ID = unsafeId;
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    // Nothing may be written to the session-scoped tree at all.
+    const sessionsDir = join(tmpRoot, '.omc', 'state', 'sessions');
+    expect(existsSync(sessionsDir)).toBe(false);
+
+    // And in particular, nothing outside the intended state dir.
+    const etcProbe = join(tmpRoot, 'etc', 'passwd');
+    expect(existsSync(etcProbe)).toBe(false);
+
+    // Legacy flat fallback should be populated instead.
+    const legacy = join(tmpRoot, '.omc', 'state', 'hud-stdin-cache.json');
+    expect(existsSync(legacy)).toBe(true);
+  });
+
+  it('treats whitespace-only CLAUDE_SESSION_ID as unset and falls back', () => {
+    process.env.CLAUDE_SESSION_ID = '   ';
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const sessionsDir = join(tmpRoot, '.omc', 'state', 'sessions');
+    expect(existsSync(sessionsDir)).toBe(false);
+    const legacy = join(tmpRoot, '.omc', 'state', 'hud-stdin-cache.json');
+    expect(existsSync(legacy)).toBe(true);
+  });
+
+  it('falls through to CLAUDECODE_SESSION_ID when CLAUDE_SESSION_ID is empty', () => {
+    // Regression for Codex review P2: `??` alone would accept "" as defined
+    // and never consult the secondary variable.
+    process.env.CLAUDE_SESSION_ID = '';
+    process.env.CLAUDECODE_SESSION_ID = 'secondary-session';
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const expected = join(tmpRoot, '.omc', 'state', 'sessions', 'secondary-session', 'hud-stdin-cache.json');
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it('falls through to CLAUDECODE_SESSION_ID when CLAUDE_SESSION_ID is present but invalid', () => {
+    // Regression for Codex review P2 (v2): a non-empty-but-invalid primary
+    // must not silently bypass a valid secondary. The previous implementation
+    // resolved the primary first, then fell straight to the legacy path when
+    // validation threw, never giving the secondary a chance.
+    process.env.CLAUDE_SESSION_ID = '../../../etc/passwd';
+    process.env.CLAUDECODE_SESSION_ID = 'valid-secondary';
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const expectedSecondary = join(
+      tmpRoot, '.omc', 'state', 'sessions', 'valid-secondary', 'hud-stdin-cache.json',
+    );
+    expect(existsSync(expectedSecondary)).toBe(true);
+
+    // And in particular, the legacy flat path must NOT have been used —
+    // otherwise concurrent sessions could still clobber each other.
+    const legacy = join(tmpRoot, '.omc', 'state', 'hud-stdin-cache.json');
+    expect(existsSync(legacy)).toBe(false);
+
+    // Safety probe: traversal from primary must not have escaped.
+    const etcProbe = join(tmpRoot, 'etc', 'passwd');
+    expect(existsSync(etcProbe)).toBe(false);
+  });
+
+  it('falls back to the legacy path only when every candidate is invalid', () => {
+    process.env.CLAUDE_SESSION_ID = '../traverse';
+    process.env.CLAUDECODE_SESSION_ID = 'foo/bar';
+    const stdin = makeStdin({ cwd: tmpRoot });
+
+    writeStdinCache(stdin);
+
+    const legacy = join(tmpRoot, '.omc', 'state', 'hud-stdin-cache.json');
+    expect(existsSync(legacy)).toBe(true);
+    const sessionsDir = join(tmpRoot, '.omc', 'state', 'sessions');
+    expect(existsSync(sessionsDir)).toBe(false);
   });
 });

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -314,9 +314,17 @@ export function cleanupTransientState(directory: string): number {
       // Ignore errors
     }
 
-    // Clean up cancel signal files and empty session directories
+    // Clean up cancel signal files, stale per-session transient caches,
+    // and empty session directories.
     const sessionsDir = path.join(stateDir, 'sessions');
     if (fs.existsSync(sessionsDir)) {
+      const sessionTransientPatterns = [
+        /^cancel-signal/,
+        /stop-breaker/,
+        // HUD's stdin cache is now session-scoped (see `src/hud/stdin.ts`).
+        // Treat it as transient so session dirs can still be pruned.
+        /^hud-stdin-cache\.json$/,
+      ];
       try {
         const sessionDirs = fs.readdirSync(sessionsDir);
         for (const sid of sessionDirs) {
@@ -327,7 +335,7 @@ export function cleanupTransientState(directory: string): number {
 
             const sessionFiles = fs.readdirSync(sessionDir);
             for (const file of sessionFiles) {
-              if (/^cancel-signal/.test(file) || /stop-breaker/.test(file)) {
+              if (sessionTransientPatterns.some(p => p.test(file))) {
                 try {
                   fs.unlinkSync(path.join(sessionDir, file));
                   filesRemoved++;

--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -6,8 +6,8 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
-import { getWorktreeRoot } from '../lib/worktree-paths.js';
+import { dirname, join } from 'path';
+import { getSessionStateDir, getWorktreeRoot } from '../lib/worktree-paths.js';
 import type { RateLimits, StatuslineStdin } from './types.js';
 
 const TRANSIENT_CONTEXT_PERCENT_TOLERANCE = 3;
@@ -16,8 +16,51 @@ const TRANSIENT_CONTEXT_PERCENT_TOLERANCE = 3;
 // Stdin Cache (for --watch mode)
 // ============================================================================
 
+/**
+ * Session-id environment variables consulted in priority order.
+ * Claude Code populates `CLAUDE_SESSION_ID` first; `CLAUDECODE_SESSION_ID`
+ * is a legacy / compatibility alias for the same value.
+ */
+const SESSION_ID_ENV_VARS = ['CLAUDE_SESSION_ID', 'CLAUDECODE_SESSION_ID'] as const;
+
+/**
+ * Normalize an env value to a session-id candidate.
+ * Empty / whitespace-only strings are treated as "not set" so a defined
+ * but blank slot does not block the fallback to the next candidate.
+ */
+function normalizeCandidate(value: string | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Resolve the stdin cache path.
+ *
+ * Walks the session-id env vars in priority order, and for each candidate
+ * tries to resolve a session-scoped path via the shared validated helper
+ * `getSessionStateDir` (which calls `validateSessionId`). A candidate
+ * that fails validation (path traversal, disallowed chars, overlong) is
+ * skipped so the next candidate still gets a chance — a non-empty-but-
+ * invalid primary does not silently bypass a valid secondary. Only when
+ * no candidate yields a valid session path do we fall back to the legacy
+ * flat path.
+ *
+ * The file name remains `hud-stdin-cache.json` so that the existing
+ * session-end cleanup pattern (`/^hud-stdin-cache\.json$/`) still matches
+ * and no migration is required for existing environments.
+ */
 function getStdinCachePath(): string {
   const root = getWorktreeRoot() || process.cwd();
+  for (const envVar of SESSION_ID_ENV_VARS) {
+    const candidate = normalizeCandidate(process.env[envVar]);
+    if (!candidate) continue;
+    try {
+      return join(getSessionStateDir(candidate, root), 'hud-stdin-cache.json');
+    } catch {
+      // Invalid session id — try the next candidate.
+    }
+  }
   return join(root, '.omc', 'state', 'hud-stdin-cache.json');
 }
 
@@ -27,12 +70,12 @@ function getStdinCachePath(): string {
  */
 export function writeStdinCache(stdin: StatuslineStdin): void {
   try {
-    const root = getWorktreeRoot() || process.cwd();
-    const cacheDir = join(root, '.omc', 'state');
+    const cachePath = getStdinCachePath();
+    const cacheDir = dirname(cachePath);
     if (!existsSync(cacheDir)) {
       mkdirSync(cacheDir, { recursive: true });
     }
-    writeFileSync(getStdinCachePath(), JSON.stringify(stdin));
+    writeFileSync(cachePath, JSON.stringify(stdin));
   } catch {
     // Best-effort; ignore failures
   }


### PR DESCRIPTION
Resubmit of #2799 — that PR was closed for review; this one addresses every
blocker. Filing a fresh PR because `gh pr reopen 2799` returned
`Could not open the pull request`, but the branch and commit
(`b6adfd07`) are the same one referenced in my review-response comment on #2799.

## Problem (same as #2799)

`hud-stdin-cache.json` lives at `.omc/state/hud-stdin-cache.json`, a path
shared across all Claude Code sessions in the same worktree. When multiple
Claude sessions run concurrently, they race each other's writes, and
HUD `--watch` mode displays whichever session last touched the file.

## Review-feedback addressed

All of these are on `b6adfd07`:

- **Reuse validated session-state helper (maintainer blocker)**.
  `getStdinCachePath` now delegates to `getSessionStateDir` from
  `src/lib/worktree-paths.ts`, which calls `validateSessionId`. Unsafe env
  values (`..`, `/`, `\\`, overlong, leading `_`, leading digit-only
  rejected by regex, etc.) throw in the helper and we fall back to the
  legacy flat path rather than touching an unvalidated path. Filename
  stays `hud-stdin-cache.json` so the existing session-end cleanup
  pattern (`/^hud-stdin-cache\.json$/`) keeps matching with no migration.
- **Codex P2 #1 — empty `CLAUDE_SESSION_ID` fall-through**.
  `getSessionId` now treats empty / whitespace-only values as unset
  before consulting `CLAUDECODE_SESSION_ID`, with a regression test.
- **Codex P2 #2 — Windows-portable mkdir**.
  The legacy-cache staging step in tests uses
  `fs.mkdirSync(dir, { recursive: true })` instead of
  `execSync("mkdir -p …")`.

## Tests

`src/__tests__/hud/stdin.test.ts` now has 25 tests (12 existing + 13 new):

- Session-scoped path written when `CLAUDE_SESSION_ID` is set.
- Legacy flat fallback when no session env var is set.
- `CLAUDECODE_SESSION_ID` accepted as the id source.
- Two concurrent sessions do not clobber each other's cache.
- Stale legacy file is *not* surfaced by `readStdinCache` when a session
  id is now set.
- Unsafe session ids (`../../../etc/passwd`, `..`, `foo/bar`, `foo\\bar`,
  `a`*300, `_foo`) all fall back to the legacy path; a probe at
  `tmpRoot/etc/passwd` confirms path traversal does not escape.
- Whitespace-only `CLAUDE_SESSION_ID` is treated as unset.
- Empty `CLAUDE_SESSION_ID` falls through to `CLAUDECODE_SESSION_ID`.

## Verification

- `npx vitest run src/__tests__/hud/stdin.test.ts` → **25/25 passing**
- `npm run build` → clean
- `npx tsc --noEmit` → clean
- Full suite (`npm run test:run`): the only failures
  (`autoresearch/runtime`, `notifications/session-registry`) reproduce
  on `upstream/dev` with these changes stashed out and are unrelated
  pre-existing flakes.

## Files touched

- `src/hud/stdin.ts`
- `src/__tests__/hud/stdin.test.ts`

No changes to `src/hooks/session-end/index.ts` — the session directory
pruning already covers the new cache location.

Happy to squash / reword the commit further if that helps the merge.