### PR TITLE
Fix HUD rate limits with missing subscription metadata

### DIFF
--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -88,6 +88,28 @@ describe('render: rate limits display priority', () => {
     expect(output).not.toContain('[API 429]');
   });
 
+  it('renders 5h/wk/sn rate limits when subscription info is unavailable', async () => {
+    const context = makeContext({
+      subscriptionType: null,
+      rateLimitTier: null,
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 36,
+          weeklyPercent: 32,
+          sonnetWeeklyPercent: 8,
+        },
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).toContain('5h:');
+    expect(output).toContain('36%');
+    expect(output).toContain('wk:');
+    expect(output).toContain('32%');
+    expect(output).toContain('sn:');
+    expect(output).toContain('8%');
+  });
+
   it('shows [API 429] when error=rate_limited and rateLimits is null', async () => {
     const context = makeContext({
       rateLimitsResult: {

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as childProcess from 'child_process';
 import * as os from 'os';
 import { EventEmitter } from 'events';
-import { isZaiHost, parseZaiResponse, isMinimaxHost, parseMinimaxResponse, getUsage } from '../../hud/usage-api.js';
+import { isZaiHost, parseZaiResponse, isMinimaxHost, parseMinimaxResponse, getUsage, parseUsageResponse } from '../../hud/usage-api.js';
 
 // Mock file-lock so withFileLock always executes the callback (tests focus on routing, not locking)
 vi.mock('../../lib/file-lock.js', () => ({
@@ -654,6 +654,70 @@ describe('getUsage routing', () => {
     expect(execFileMock).toHaveBeenCalledTimes(2);
     expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
     expect(httpsModule.default.request.mock.calls[0][0].headers.Authorization).toBe('Bearer fresh-legacy-token');
+  });
+
+  it('preserves model-specific rate limits when generic subscription windows are nullish', () => {
+    const result = parseUsageResponse({
+      five_hour: { utilization: 36, resets_at: '2026-04-24T13:00:00Z' },
+      seven_day: null,
+      seven_day_sonnet: { utilization: 8, resets_at: '2026-04-25T13:00:00Z' },
+    } as unknown as Parameters<typeof parseUsageResponse>[0]);
+
+    expect(result).not.toBeNull();
+    expect(result!.fiveHourPercent).toBe(36);
+    expect(result!.weeklyPercent).toBeUndefined();
+    expect(result!.sonnetWeeklyPercent).toBe(8);
+    expect(result!.sonnetWeeklyResetsAt).toBeInstanceOf(Date);
+  });
+
+  it('returns getUsage rateLimits when OAuth credentials lack subscription metadata', async () => {
+    const mockedExistsSync = vi.mocked(fs.existsSync);
+    const mockedReadFileSync = vi.mocked(fs.readFileSync);
+
+    mockedExistsSync.mockImplementation((path) => String(path).endsWith('.credentials.json'));
+    mockedReadFileSync.mockImplementation((path) => {
+      if (String(path).endsWith('.credentials.json')) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'valid-token',
+            refreshToken: 'refresh-token',
+            expiresAt: Date.now() + 60_000,
+            subscriptionType: null,
+            rateLimitTier: null,
+          },
+        });
+      }
+      return '{}';
+    });
+
+    httpsModule.default.request.mockImplementationOnce((_options, callback) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void; on: typeof EventEmitter.prototype.on };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          five_hour: { utilization: 36, resets_at: '2026-04-24T13:00:00Z' },
+          seven_day: { utilization: 32, resets_at: '2026-04-25T13:00:00Z' },
+          seven_day_sonnet: { utilization: 8, resets_at: '2026-04-25T13:00:00Z' },
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimits).toMatchObject({
+      fiveHourPercent: 36,
+      weeklyPercent: 32,
+      sonnetWeeklyPercent: 8,
+    });
+    expect(result.rateLimits!.fiveHourResetsAt).toBeInstanceOf(Date);
+    expect(result.rateLimits!.weeklyResetsAt).toBeInstanceOf(Date);
+    expect(result.rateLimits!.sonnetWeeklyResetsAt).toBeInstanceOf(Date);
   });
 
   it('routes to z.ai when ANTHROPIC_BASE_URL is z.ai host', async () => {

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -443,8 +443,15 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       : null;
     const contextPercent = getContextPercent(stdin);
 
-    // Read subscription info for enterprise detection (best-effort, never throws)
-    const subscriptionInfo = getSubscriptionInfo();
+    // Read subscription info for enterprise detection (best-effort).
+    // Rate-limit rendering must not depend on this metadata being present.
+    const subscriptionInfo = (() => {
+      try {
+        return getSubscriptionInfo() ?? { subscriptionType: null, rateLimitTier: null };
+      } catch {
+        return { subscriptionType: null, rateLimitTier: null };
+      }
+    })();
 
     // Build render context
     const context: HudRenderContext = {

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -819,14 +819,26 @@ function clamp(v: number | undefined): number {
 export function parseUsageResponse(response: UsageApiResponse): RateLimits | null {
   const fiveHour = response.five_hour?.utilization;
   const sevenDay = response.seven_day?.utilization;
-  const enterpriseCredits = response.extra_usage?.used_credits;
-  const enterpriseCurrency = (response.extra_usage?.currency ?? 'USD').toUpperCase();
+  const sonnetSevenDay = response.seven_day_sonnet?.utilization;
+  const opusSevenDay = response.seven_day_opus?.utilization;
+  const extra = response.extra_usage;
+  const enterpriseCredits = extra?.used_credits;
+  const enterpriseCurrency = (extra?.currency ?? 'USD').toUpperCase();
   // Enterprise credits are only usable when we know how to interpret the minor-unit digits;
   // see the USD guard in the extra_usage branch below for rationale.
   const hasUsableEnterprise = enterpriseCredits != null && enterpriseCurrency === 'USD';
+  const hasUsableExtraUsage = extra?.limit_usd != null && extra.limit_usd > 0;
 
-  // Need at least one valid value (5h/7d for Pro/Max, or usable enterprise credits)
-  if (fiveHour == null && sevenDay == null && !hasUsableEnterprise) return null;
+  // Need at least one valid value. Model-specific weekly buckets are valid usage data
+  // even when generic subscription/window metadata is absent or nullish.
+  if (
+    fiveHour == null &&
+    sevenDay == null &&
+    sonnetSevenDay == null &&
+    opusSevenDay == null &&
+    !hasUsableEnterprise &&
+    !hasUsableExtraUsage
+  ) return null;
 
   // Parse ISO 8601 date strings to Date objects
   const parseDate = (dateStr: string | undefined): Date | null => {
@@ -841,15 +853,17 @@ export function parseUsageResponse(response: UsageApiResponse): RateLimits | nul
 
   // Per-model quotas are at the top level (flat structure)
   // e.g., response.seven_day_sonnet, response.seven_day_opus
-  const sonnetSevenDay = response.seven_day_sonnet?.utilization;
   const sonnetResetsAt = response.seven_day_sonnet?.resets_at;
 
   const result: RateLimits = {
     fiveHourPercent: clamp(fiveHour),
-    weeklyPercent: clamp(sevenDay),
     fiveHourResetsAt: parseDate(response.five_hour?.resets_at),
-    weeklyResetsAt: parseDate(response.seven_day?.resets_at),
   };
+
+  if (sevenDay != null) {
+    result.weeklyPercent = clamp(sevenDay);
+    result.weeklyResetsAt = parseDate(response.seven_day?.resets_at);
+  }
 
   // Add Sonnet-specific quota if available from API
   if (sonnetSevenDay != null) {
@@ -858,7 +872,6 @@ export function parseUsageResponse(response: UsageApiResponse): RateLimits | nul
   }
 
   // Add Opus-specific quota if available from API
-  const opusSevenDay = response.seven_day_opus?.utilization;
   const opusResetsAt = response.seven_day_opus?.resets_at;
   if (opusSevenDay != null) {
     result.opusWeeklyPercent = clamp(opusSevenDay);
@@ -866,7 +879,6 @@ export function parseUsageResponse(response: UsageApiResponse): RateLimits | nul
   }
 
   // Add extra (metered) usage if available (Pro subscribers with extra usage allocation)
-  const extra = response.extra_usage;
   if (extra != null) {
     // Enterprise path: used_credits (minor units) is present instead of spent_usd/limit_usd.
     // Only USD is observed in practice; the /100 divisor below assumes 2-digit minor units.


### PR DESCRIPTION
## Summary\n- Fixes #2809\n- Keeps subscription metadata lookup best-effort so missing/nullish metadata cannot prevent HUD rendering\n- Preserves parsed usage buckets when generic weekly data is nullish but model-specific buckets like Sonnet are present\n- Adds regression coverage for 5h/wk/sn rendering with unavailable subscription info and getUsage with null subscription metadata\n\n## Verification\n- npm run test:run -- src/__tests__/hud/usage-api.test.ts src/__tests__/hud/render-rate-limits-priority.test.ts\n- npx tsc --noEmit\n- npm run lint (passes with existing warnings only)\n- npm run build\n- git diff --check