### PR TITLE
Add cap-only adaptive team fanout policy

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -68,8 +68,10 @@ vi.mock('../../team/git-worktree.js', async (importOriginal) => {
 
 describe('team cli', () => {
   let jobsDir: string;
+  let originalCwd: string;
 
   beforeEach(() => {
+    originalCwd = process.cwd();
     jobsDir = mkdtempSync(join(tmpdir(), 'omc-team-cli-jobs-'));
     process.env.OMC_JOBS_DIR = jobsDir;
     process.env.OMC_RUNTIME_CLI_PATH = '/tmp/runtime-cli.cjs';
@@ -92,6 +94,7 @@ describe('team cli', () => {
   });
 
   afterEach(() => {
+    process.chdir(originalCwd);
     delete process.env.OMC_JOBS_DIR;
     delete process.env.OMC_RUNTIME_CLI_PATH;
     delete process.env.OMC_TEAM_MAX_AGENTS;
@@ -267,6 +270,80 @@ describe('team cli', () => {
     expect(stdinPayload.agentTypes).toEqual(['gemini', 'gemini']);
     expect(stdinPayload.tasks).toHaveLength(4);
     expect(stdinPayload.tasks.every((t) => t.description === 'lint all modules')).toBe(true);
+
+    logSpy.mockRestore();
+  });
+
+  it('teamCommand start loads resource policy from --cwd project config', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const rootDir = mkdtempSync(join(tmpdir(), 'omc-team-root-cwd-'));
+    const projectDir = join(rootDir, 'project');
+
+    mkdirSync(join(rootDir, '.claude'), { recursive: true });
+    mkdirSync(join(projectDir, '.claude'), { recursive: true });
+    writeFileSync(join(rootDir, '.claude', 'omc.jsonc'), JSON.stringify({
+      team: { ops: { maxAgents: 4 } },
+    }));
+    writeFileSync(join(projectDir, '.claude', 'omc.jsonc'), JSON.stringify({
+      team: { ops: { maxAgents: 2 } },
+    }));
+    process.chdir(rootDir);
+
+    mocks.spawn.mockReturnValue({
+      pid: 8991,
+      stdin: { write, end },
+      unref,
+    });
+
+    const { teamCommand } = await import('../team.js');
+    await teamCommand([
+      'start', '--agent', 'gemini', '--count', '4',
+      '--task', 'lint all modules', '--cwd', projectDir, '--name', 'lint-team', '--json',
+    ]);
+
+    const stdinPayload = JSON.parse(write.mock.calls[0][0] as string) as {
+      workerCount?: number;
+      agentTypes: string[];
+      tasks: Array<{ subject: string; description: string }>;
+      cwd: string;
+    };
+    expect(stdinPayload.cwd).toBe(projectDir);
+    expect(stdinPayload.workerCount).toBe(2);
+    expect(stdinPayload.agentTypes).toEqual(['gemini', 'gemini']);
+    expect(stdinPayload.tasks).toHaveLength(4);
+
+    logSpy.mockRestore();
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('legacy team shorthand caps workers but preserves requested backlog', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    process.env.OMC_TEAM_MAX_AGENTS = '2';
+    mocks.spawn.mockReturnValue({
+      pid: 8992,
+      stdin: { write, end },
+      unref,
+    });
+
+    const { teamCommand } = await import('../team.js');
+    await teamCommand(['4:codex', 'review auth flow', '--json']);
+
+    const stdinPayload = JSON.parse(write.mock.calls[0][0] as string) as {
+      workerCount?: number;
+      agentTypes: string[];
+      tasks: Array<{ subject: string; description: string }>;
+    };
+    expect(stdinPayload.workerCount).toBe(2);
+    expect(stdinPayload.agentTypes).toEqual(['codex', 'codex']);
+    expect(stdinPayload.tasks).toHaveLength(4);
+    expect(stdinPayload.tasks.every((task) => task.description === 'review auth flow')).toBe(true);
 
     logSpy.mockRestore();
   });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -94,6 +94,9 @@ describe('team cli', () => {
   afterEach(() => {
     delete process.env.OMC_JOBS_DIR;
     delete process.env.OMC_RUNTIME_CLI_PATH;
+    delete process.env.OMC_TEAM_MAX_AGENTS;
+    delete process.env.OMC_TEAM_ADAPTIVE_AGENTS;
+    delete process.env.OMC_TEAM_RESOURCE_PROFILE;
     rmSync(jobsDir, { recursive: true, force: true });
   });
 
@@ -232,6 +235,37 @@ describe('team cli', () => {
 
     const output = JSON.parse(logSpy.mock.calls[0][0] as string) as { status: string };
     expect(output.status).toBe('running');
+
+    logSpy.mockRestore();
+  });
+
+  it('teamCommand start caps initial workers with team resource policy', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    process.env.OMC_TEAM_MAX_AGENTS = '2';
+    mocks.spawn.mockReturnValue({
+      pid: 8989,
+      stdin: { write, end },
+      unref,
+    });
+
+    const { teamCommand } = await import('../team.js');
+    await teamCommand([
+      'start', '--agent', 'gemini', '--count', '4',
+      '--task', 'lint all modules', '--name', 'lint-team', '--json',
+    ]);
+
+    const stdinPayload = JSON.parse(write.mock.calls[0][0] as string) as {
+      workerCount?: number;
+      agentTypes: string[];
+      tasks: Array<{ subject: string; description: string }>;
+    };
+    expect(stdinPayload.workerCount).toBe(2);
+    expect(stdinPayload.agentTypes).toEqual(['gemini', 'gemini']);
+    expect(stdinPayload.tasks).toHaveLength(2);
 
     logSpy.mockRestore();
   });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -265,7 +265,48 @@ describe('team cli', () => {
     };
     expect(stdinPayload.workerCount).toBe(2);
     expect(stdinPayload.agentTypes).toEqual(['gemini', 'gemini']);
-    expect(stdinPayload.tasks).toHaveLength(2);
+    expect(stdinPayload.tasks).toHaveLength(4);
+    expect(stdinPayload.tasks.every((t) => t.description === 'lint all modules')).toBe(true);
+
+    logSpy.mockRestore();
+  });
+
+  it('teamCommand start preserves explicit tasks when resource policy caps workers', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    process.env.OMC_TEAM_MAX_AGENTS = '2';
+    mocks.spawn.mockReturnValue({
+      pid: 8990,
+      stdin: { write, end },
+      unref,
+    });
+
+    const { teamCommand } = await import('../team.js');
+    await teamCommand([
+      'start',
+      '--agent', 'gemini,codex,claude',
+      '--task', 'lint all modules',
+      '--task', 'typecheck the cli',
+      '--task', 'review resource policy',
+      '--name', 'lint-team',
+      '--json',
+    ]);
+
+    const stdinPayload = JSON.parse(write.mock.calls[0][0] as string) as {
+      workerCount?: number;
+      agentTypes: string[];
+      tasks: Array<{ subject: string; description: string }>;
+    };
+    expect(stdinPayload.workerCount).toBe(2);
+    expect(stdinPayload.agentTypes).toEqual(['gemini', 'codex']);
+    expect(stdinPayload.tasks.map((task) => task.description)).toEqual([
+      'lint all modules',
+      'typecheck the cli',
+      'review resource policy',
+    ]);
 
     logSpy.mockRestore();
   });

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -16,6 +16,8 @@ import {
 } from '../../team/api-interop.js';
 import type { CliAgentType } from '../../team/model-contract.js';
 import { loadConfig } from '../../config/loader.js';
+import type { PluginConfig } from '../../shared/types.js';
+import { resolveTeamWorkerCount } from '../../team/resource-policy.js';
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
@@ -551,28 +553,36 @@ function parseTeamApiArgs(args: string[]): {
 // Team start (spawns tmux workers)
 // ---------------------------------------------------------------------------
 
-async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<void> {
+async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string, pluginConfig: PluginConfig): Promise<void> {
   await assertTeamSpawnAllowed(cwd);
 
   // Decompose the task string into subtasks when possible
   const decomposition = splitTaskString(parsed.task);
-  const effectiveWorkerCount = resolveTeamFanoutLimit(
+  const fanoutWorkerCount = resolveTeamFanoutLimit(
     parsed.workerCount,
     parsed.agentTypes[0],
     parsed.workerCount,
     decomposition
   );
+  const workerCountDecision = resolveTeamWorkerCount(fanoutWorkerCount, pluginConfig.team?.ops);
+  const effectiveWorkerCount = workerCountDecision.effective;
+  const effectiveAgentTypes = parsed.agentTypes.slice(0, effectiveWorkerCount);
+  const effectiveWorkerRoles = parsed.workerSpecs
+    .slice(0, effectiveWorkerCount)
+    .map((spec) => spec.role ?? spec.agentType);
 
   // Build the task list from decomposition subtasks or fall back to atomic replication
   const tasks: Array<{ subject: string; description: string; owner?: string }> = [];
   if (decomposition.strategy !== 'atomic' && decomposition.subtasks.length > 1) {
-    // Use decomposed subtasks — one per subtask (up to effectiveWorkerCount)
-    const subtasks = decomposition.subtasks.slice(0, effectiveWorkerCount);
+    // Use decomposed subtasks — keep the pre-resource fanout so capping workers
+    // does not silently drop work; overflow subtasks are distributed across the
+    // smaller active worker pool.
+    const subtasks = decomposition.subtasks.slice(0, fanoutWorkerCount);
     for (let i = 0; i < subtasks.length; i++) {
       tasks.push({
         subject: subtasks[i].subject,
         description: subtasks[i].description,
-        owner: `worker-${i + 1}`,
+        owner: `worker-${(i % effectiveWorkerCount) + 1}`,
       });
     }
   } else {
@@ -602,15 +612,16 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
     const runtime = await startTeamV2({
       teamName: parsed.teamName,
       workerCount: effectiveWorkerCount,
-      agentTypes: parsed.agentTypes.slice(0, effectiveWorkerCount),
+      agentTypes: effectiveAgentTypes,
       tasks,
       cwd,
       newWindow: parsed.newWindow,
-      workerRoles: parsed.workerSpecs.map((spec) => spec.role ?? spec.agentType),
+      workerRoles: effectiveWorkerRoles,
       ...(rolePrompt ? { roleName: parsed.role, rolePrompt } : {}),
+      pluginConfig,
     });
 
-    const uniqueTypes = [...new Set(parsed.agentTypes)].join(',');
+    const uniqueTypes = [...new Set(effectiveAgentTypes)].join(',');
 
     if (parsed.json) {
       const snapshot = await monitorTeamV2(runtime.teamName, cwd);
@@ -619,6 +630,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
         sessionName: runtime.sessionName,
         workerCount: runtime.config.worker_count,
         agentType: uniqueTypes,
+        resourcePolicy: workerCountDecision.capped ? workerCountDecision : undefined,
         tasks: snapshot ? snapshot.tasks : null,
       }));
       return;
@@ -628,6 +640,9 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
     console.log(`tmux session: ${runtime.sessionName}`);
     console.log(`workers: ${runtime.config.worker_count}`);
     console.log(`agent_type: ${uniqueTypes}`);
+    if (workerCountDecision.capped) {
+      console.log(`resource_policy: workers ${workerCountDecision.requested} -> ${workerCountDecision.effective} (${workerCountDecision.reason})`);
+    }
 
     const snapshot = await monitorTeamV2(runtime.teamName, cwd);
     if (snapshot) {
@@ -641,13 +656,13 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
   const runtime = await startTeam({
     teamName: parsed.teamName,
     workerCount: effectiveWorkerCount,
-    agentTypes: parsed.agentTypes.slice(0, effectiveWorkerCount) as CliAgentType[],
+    agentTypes: effectiveAgentTypes as CliAgentType[],
     tasks,
     cwd,
     newWindow: parsed.newWindow,
   });
 
-  const uniqueTypesV1 = [...new Set(parsed.agentTypes)].join(',');
+  const uniqueTypesV1 = [...new Set(effectiveAgentTypes)].join(',');
 
   if (parsed.json) {
     const snapshot = await monitorTeam(runtime.teamName, cwd, runtime.workerPaneIds);
@@ -656,6 +671,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
       sessionName: runtime.sessionName,
       workerCount: runtime.workerNames.length,
       agentType: uniqueTypesV1,
+      resourcePolicy: workerCountDecision.capped ? workerCountDecision : undefined,
       tasks: snapshot ? {
         total: snapshot.taskCounts.pending + snapshot.taskCounts.inProgress + snapshot.taskCounts.completed + snapshot.taskCounts.failed,
         pending: snapshot.taskCounts.pending,
@@ -671,6 +687,9 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
   console.log(`tmux session: ${runtime.sessionName}`);
   console.log(`workers: ${runtime.workerNames.length}`);
   console.log(`agent_type: ${uniqueTypesV1}`);
+  if (workerCountDecision.capped) {
+    console.log(`resource_policy: workers ${workerCountDecision.requested} -> ${workerCountDecision.effective} (${workerCountDecision.reason})`);
+  }
 
   const snapshot = await monitorTeam(runtime.teamName, cwd, runtime.workerPaneIds);
   if (snapshot) {
@@ -884,7 +903,7 @@ export async function teamCommand(args: string[]): Promise<void> {
     const cfg = loadConfig();
     const defaultAgentType = cfg.team?.ops?.defaultAgentType ?? DEFAULT_TEAM_CLI_AGENT_TYPE;
     const parsed = parseTeamArgs(args, defaultAgentType);
-    await handleTeamStart(parsed, cwd);
+    await handleTeamStart(parsed, cwd, cfg);
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     console.log(TEAM_HELP.trim());

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -969,10 +969,9 @@ function parseStartArgs(args: string[]): StartArgsParsed {
   const cfg = loadConfig();
   const workerCountDecision = resolveTeamWorkerCount(agentTypes.length, cfg.team?.ops);
   const effectiveAgentTypes = agentTypes.slice(0, workerCountDecision.effective);
-  const effectiveTaskDescriptions = taskDescriptions.slice(0, workerCountDecision.effective);
 
-  const resolvedTeamName = (teamName && teamName.trim()) ? teamName.trim() : autoTeamName(effectiveTaskDescriptions[0]);
-  const tasks: TeamTaskInput[] = effectiveTaskDescriptions.map((description, index) => ({
+  const resolvedTeamName = (teamName && teamName.trim()) ? teamName.trim() : autoTeamName(taskDescriptions[0]);
+  const tasks: TeamTaskInput[] = taskDescriptions.map((description, index) => ({
     subject: `${subjectPrefix} ${index + 1}`,
     description,
   }));

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -12,6 +12,8 @@ import { monitorTeam, resumeTeam, shutdownTeam } from '../team/runtime.js';
 import { readTeamConfig } from '../team/monitor.js';
 import { isProcessAlive } from '../platform/index.js';
 import { getGlobalOmcStatePath } from '../utils/paths.js';
+import { loadConfig } from '../config/loader.js';
+import { resolveTeamWorkerCount } from '../team/resource-policy.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
 const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor']);
@@ -964,8 +966,13 @@ function parseStartArgs(args: string[]): StartArgsParsed {
     throw new Error(`Task count (${taskDescriptions.length}) must match worker count (${agentTypes.length}).`);
   }
 
-  const resolvedTeamName = (teamName && teamName.trim()) ? teamName.trim() : autoTeamName(taskDescriptions[0]);
-  const tasks: TeamTaskInput[] = taskDescriptions.map((description, index) => ({
+  const cfg = loadConfig();
+  const workerCountDecision = resolveTeamWorkerCount(agentTypes.length, cfg.team?.ops);
+  const effectiveAgentTypes = agentTypes.slice(0, workerCountDecision.effective);
+  const effectiveTaskDescriptions = taskDescriptions.slice(0, workerCountDecision.effective);
+
+  const resolvedTeamName = (teamName && teamName.trim()) ? teamName.trim() : autoTeamName(effectiveTaskDescriptions[0]);
+  const tasks: TeamTaskInput[] = effectiveTaskDescriptions.map((description, index) => ({
     subject: `${subjectPrefix} ${index + 1}`,
     description,
   }));
@@ -973,9 +980,10 @@ function parseStartArgs(args: string[]): StartArgsParsed {
   return {
     input: {
       teamName: resolvedTeamName,
-      agentTypes,
+      agentTypes: effectiveAgentTypes,
       tasks,
       cwd,
+      workerCount: effectiveAgentTypes.length,
       ...(newWindow ? { newWindow: true } : {}),
       ...(pollIntervalMs != null ? { pollIntervalMs } : {}),
       ...(sentinelGateTimeoutMs != null ? { sentinelGateTimeoutMs } : {}),
@@ -1328,15 +1336,18 @@ export async function teamCommand(argv: string[]): Promise<void> {
   if (!SUBCOMMANDS.has(command)) {
     const legacy = parseLegacyStartAlias(argv);
     if (legacy) {
-      const tasks = Array.from({ length: legacy.workerCount }, (_, idx) => ({
+      const cfg = loadConfig();
+      const workerCountDecision = resolveTeamWorkerCount(legacy.workerCount, cfg.team?.ops);
+      const workerCount = workerCountDecision.effective;
+      const tasks = Array.from({ length: workerCount }, (_, idx) => ({
         subject: legacy.ralph ? `Ralph Task ${idx + 1}` : `Task ${idx + 1}`,
         description: legacy.task,
       }));
 
       const result = await startTeamJob({
         teamName: legacy.teamName,
-        workerCount: legacy.workerCount,
-        agentTypes: Array.from({ length: legacy.workerCount }, () => legacy.agentType),
+        workerCount,
+        agentTypes: Array.from({ length: workerCount }, () => legacy.agentType),
         tasks,
         cwd: legacy.cwd,
         ...(legacy.newWindow ? { newWindow: true } : {}),

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -13,6 +13,7 @@ import { readTeamConfig } from '../team/monitor.js';
 import { isProcessAlive } from '../platform/index.js';
 import { getGlobalOmcStatePath } from '../utils/paths.js';
 import { loadConfig } from '../config/loader.js';
+import type { PluginConfig } from '../shared/types.js';
 import { resolveTeamWorkerCount } from '../team/resource-policy.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
@@ -367,6 +368,20 @@ function parseJsonInput(inputRaw: string | undefined): Record<string, unknown> {
     throw new Error('Invalid --input JSON payload');
   }
   return parsed;
+}
+
+function loadConfigForCwd(cwd: string): PluginConfig {
+  const previousCwd = process.cwd();
+  try {
+    if (cwd && cwd !== previousCwd) {
+      process.chdir(cwd);
+    }
+    return loadConfig();
+  } finally {
+    if (process.cwd() !== previousCwd) {
+      process.chdir(previousCwd);
+    }
+  }
 }
 
 export async function startTeamJob(input: TeamStartInput): Promise<TeamStartResult> {
@@ -966,7 +981,7 @@ function parseStartArgs(args: string[]): StartArgsParsed {
     throw new Error(`Task count (${taskDescriptions.length}) must match worker count (${agentTypes.length}).`);
   }
 
-  const cfg = loadConfig();
+  const cfg = loadConfigForCwd(cwd);
   const workerCountDecision = resolveTeamWorkerCount(agentTypes.length, cfg.team?.ops);
   const effectiveAgentTypes = agentTypes.slice(0, workerCountDecision.effective);
 
@@ -1335,10 +1350,10 @@ export async function teamCommand(argv: string[]): Promise<void> {
   if (!SUBCOMMANDS.has(command)) {
     const legacy = parseLegacyStartAlias(argv);
     if (legacy) {
-      const cfg = loadConfig();
+      const cfg = loadConfigForCwd(legacy.cwd);
       const workerCountDecision = resolveTeamWorkerCount(legacy.workerCount, cfg.team?.ops);
       const workerCount = workerCountDecision.effective;
-      const tasks = Array.from({ length: workerCount }, (_, idx) => ({
+      const tasks = Array.from({ length: legacy.workerCount }, (_, idx) => ({
         subject: legacy.ralph ? `Ralph Task ${idx + 1}` : `Task ${idx + 1}`,
         description: legacy.task,
       }));

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -576,6 +576,38 @@ describe("team.roleRouting (Option E)", () => {
     expect(config.team?.ops?.resourceProfile).toBe("conservative");
   });
 
+  it("ignores malformed adaptive team ops env values without overriding file config", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omc-team-malformed-resource-env-"));
+    try {
+      const claudeDir = join(tempDir, ".claude");
+      require("node:fs").mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(
+        join(claudeDir, "omc.jsonc"),
+        JSON.stringify({
+          team: {
+            ops: {
+              maxAgents: 5,
+              adaptiveAgents: true,
+              resourceProfile: "balanced",
+            },
+          },
+        }),
+      );
+      process.env.OMC_TEAM_MAX_AGENTS = "2abc";
+      process.env.OMC_TEAM_ADAPTIVE_AGENTS = "maybe";
+      process.env.OMC_TEAM_RESOURCE_PROFILE = "turbo";
+      process.chdir(tempDir);
+
+      const config = loadConfig();
+
+      expect(config.team?.ops?.maxAgents).toBe(5);
+      expect(config.team?.ops?.adaptiveAgents).toBe(true);
+      expect(config.team?.ops?.resourceProfile).toBe("balanced");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects invalid team.ops.resourceProfile values", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "omc-team-bad-resource-profile-"));
     try {

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -28,6 +28,9 @@ const ALL_KEYS = [
   "ANTHROPIC_DEFAULT_HAIKU_MODEL",
   "OMC_DELEGATION_ROUTING_ENABLED",
   "OMC_DELEGATION_ROUTING_DEFAULT_PROVIDER",
+  "OMC_TEAM_MAX_AGENTS",
+  "OMC_TEAM_ADAPTIVE_AGENTS",
+  "OMC_TEAM_RESOURCE_PROFILE",
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -556,6 +559,36 @@ describe("team.roleRouting (Option E)", () => {
       );
       process.chdir(tempDir);
       expect(() => loadConfig()).toThrow(/team\.ops\.defaultAgentType/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges adaptive team ops from env", () => {
+    process.env.OMC_TEAM_MAX_AGENTS = "4";
+    process.env.OMC_TEAM_ADAPTIVE_AGENTS = "true";
+    process.env.OMC_TEAM_RESOURCE_PROFILE = "conservative";
+
+    const config = loadConfig();
+
+    expect(config.team?.ops?.maxAgents).toBe(4);
+    expect(config.team?.ops?.adaptiveAgents).toBe(true);
+    expect(config.team?.ops?.resourceProfile).toBe("conservative");
+  });
+
+  it("rejects invalid team.ops.resourceProfile values", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omc-team-bad-resource-profile-"));
+    try {
+      const claudeDir = join(tempDir, ".claude");
+      require("node:fs").mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(
+        join(claudeDir, "omc.jsonc"),
+        JSON.stringify({
+          team: { ops: { resourceProfile: "turbo" } },
+        }),
+      );
+      process.chdir(tempDir);
+      expect(() => loadConfig()).toThrow(/team\.ops\.resourceProfile/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -437,6 +437,33 @@ export function loadEnvConfig(): Partial<PluginConfig> {
     };
   }
 
+  const teamOps: NonNullable<NonNullable<PluginConfig["team"]>["ops"]> = {};
+  if (process.env.OMC_TEAM_MAX_AGENTS) {
+    const maxAgents = parseInt(process.env.OMC_TEAM_MAX_AGENTS, 10);
+    if (!isNaN(maxAgents) && maxAgents >= 1) {
+      teamOps.maxAgents = maxAgents;
+    }
+  }
+  if (process.env.OMC_TEAM_ADAPTIVE_AGENTS !== undefined) {
+    const normalized = process.env.OMC_TEAM_ADAPTIVE_AGENTS.trim().toLowerCase();
+    teamOps.adaptiveAgents = ["1", "true", "yes", "on", "enabled"].includes(normalized);
+  }
+  if (process.env.OMC_TEAM_RESOURCE_PROFILE) {
+    const profile = process.env.OMC_TEAM_RESOURCE_PROFILE.trim().toLowerCase();
+    if (TEAM_RESOURCE_PROFILES.has(profile)) {
+      teamOps.resourceProfile = profile as NonNullable<typeof teamOps.resourceProfile>;
+    }
+  }
+  if (Object.keys(teamOps).length > 0) {
+    config.team = {
+      ...config.team,
+      ops: {
+        ...config.team?.ops,
+        ...teamOps,
+      },
+    };
+  }
+
   return config;
 }
 
@@ -477,6 +504,7 @@ const CANONICAL_TEAM_ROLE_SET = new Set<string>(CANONICAL_TEAM_ROLES);
 const KNOWN_AGENT_NAME_SET = new Set<string>(KNOWN_AGENT_NAMES);
 const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini"]);
 const TEAM_ROLE_TIERS = new Set(["HIGH", "MEDIUM", "LOW"]);
+const TEAM_RESOURCE_PROFILES = new Set(["conservative", "balanced", "aggressive"]);
 
 export function validateTeamConfig(config: PluginConfig): void {
   const team = (config as Record<string, unknown>).team as
@@ -486,6 +514,17 @@ export function validateTeamConfig(config: PluginConfig): void {
 
   const ops = team.ops as Record<string, unknown> | undefined;
   if (ops && typeof ops === "object") {
+    if (ops.maxAgents !== undefined) {
+      if (
+        typeof ops.maxAgents !== "number" ||
+        !Number.isInteger(ops.maxAgents) ||
+        ops.maxAgents < 1
+      ) {
+        throw new Error(
+          `[OMC] team.ops.maxAgents: invalid value "${String(ops.maxAgents)}". Expected integer >= 1.`,
+        );
+      }
+    }
     if (ops.defaultAgentType !== undefined) {
       if (
         typeof ops.defaultAgentType !== "string" ||
@@ -501,6 +540,18 @@ export function validateTeamConfig(config: PluginConfig): void {
       if (typeof ops.worktreeMode !== "string" || !allowed.has(ops.worktreeMode)) {
         throw new Error(
           `[OMC] team.ops.worktreeMode: invalid value "${String(ops.worktreeMode)}". Allowed: ${[...allowed].join(", ")}`,
+        );
+      }
+    }
+    if (ops.adaptiveAgents !== undefined && typeof ops.adaptiveAgents !== "boolean") {
+      throw new Error(
+        `[OMC] team.ops.adaptiveAgents: invalid value "${String(ops.adaptiveAgents)}". Expected boolean.`,
+      );
+    }
+    if (ops.resourceProfile !== undefined) {
+      if (typeof ops.resourceProfile !== "string" || !TEAM_RESOURCE_PROFILES.has(ops.resourceProfile)) {
+        throw new Error(
+          `[OMC] team.ops.resourceProfile: invalid value "${String(ops.resourceProfile)}". Allowed: ${[...TEAM_RESOURCE_PROFILES].join(", ")}`,
         );
       }
     }
@@ -1098,6 +1149,17 @@ export function generateConfigSchema(): object {
               monitorIntervalMs: { type: "integer", minimum: 1 },
               shutdownTimeoutMs: { type: "integer", minimum: 1 },
               costMode: { type: "string", enum: ["normal", "downgrade"] },
+              adaptiveAgents: {
+                type: "boolean",
+                description:
+                  "When true, cap requested /team workers to fit local CPU and memory.",
+              },
+              resourceProfile: {
+                type: "string",
+                enum: ["conservative", "balanced", "aggressive"],
+                default: "balanced",
+                description: "Local resource posture used by adaptiveAgents.",
+              },
             },
           },
           roleRouting: {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -439,14 +439,19 @@ export function loadEnvConfig(): Partial<PluginConfig> {
 
   const teamOps: NonNullable<NonNullable<PluginConfig["team"]>["ops"]> = {};
   if (process.env.OMC_TEAM_MAX_AGENTS) {
-    const maxAgents = parseInt(process.env.OMC_TEAM_MAX_AGENTS, 10);
-    if (!isNaN(maxAgents) && maxAgents >= 1) {
+    const rawMaxAgents = process.env.OMC_TEAM_MAX_AGENTS.trim();
+    if (/^[1-9]\d*$/.test(rawMaxAgents)) {
+      const maxAgents = parseInt(rawMaxAgents, 10);
       teamOps.maxAgents = maxAgents;
     }
   }
   if (process.env.OMC_TEAM_ADAPTIVE_AGENTS !== undefined) {
     const normalized = process.env.OMC_TEAM_ADAPTIVE_AGENTS.trim().toLowerCase();
-    teamOps.adaptiveAgents = ["1", "true", "yes", "on", "enabled"].includes(normalized);
+    if (["1", "true", "yes", "on", "enabled"].includes(normalized)) {
+      teamOps.adaptiveAgents = true;
+    } else if (["0", "false", "no", "off", "disabled"].includes(normalized)) {
+      teamOps.adaptiveAgents = false;
+    }
   }
   if (process.env.OMC_TEAM_RESOURCE_PROFILE) {
     const profile = process.env.OMC_TEAM_RESOURCE_PROFILE.trim().toLowerCase();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -459,6 +459,9 @@ export type OrchestratorSpec = Pick<TeamRoleAssignmentSpec, 'model'>;
 /** Cost mode reserved for future downgrade behavior (no implementation yet). */
 export type TeamCostMode = 'normal' | 'downgrade';
 
+/** Local resource posture used when adaptive team sizing is enabled. */
+export type TeamResourceProfile = 'conservative' | 'balanced' | 'aggressive';
+
 /** Ops-level knobs for `/team`. */
 export interface TeamOpsConfig {
   maxAgents?: number;
@@ -466,6 +469,14 @@ export interface TeamOpsConfig {
   monitorIntervalMs?: number;
   shutdownTimeoutMs?: number;
   costMode?: TeamCostMode;
+  /**
+   * Opt-in cap that shrinks requested /team fanout to fit local CPU and memory.
+   * It never increases the user-requested worker count and always respects
+   * `maxAgents` when set.
+   */
+  adaptiveAgents?: boolean;
+  /** Resource posture for adaptiveAgents. Defaults to balanced. */
+  resourceProfile?: TeamResourceProfile;
   /** Opt-in native team worker worktrees. Disabled unless explicitly set. */
   worktreeMode?: 'disabled' | 'off' | 'detached' | 'branch' | 'named';
 }

--- a/src/team/__tests__/max-workers-config.test.ts
+++ b/src/team/__tests__/max-workers-config.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readTeamConfig } from '../monitor.js';
+import { teamReadConfig } from '../team-ops.js';
+import type { TeamConfig, TeamManifestV2 } from '../types.js';
+
+describe('team max_workers config readers', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-team-max-workers-'));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  async function writeTeamState(maxWorkers: number): Promise<void> {
+    const root = join(cwd, '.omc', 'state', 'team', 'max-team');
+    await mkdir(root, { recursive: true });
+    const common = {
+      name: 'max-team',
+      task: 'demo',
+      worker_count: 2,
+      workers: [
+        { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        { name: 'worker-2', index: 2, role: 'executor', assigned_tasks: [] },
+      ],
+      next_task_id: 2,
+      created_at: new Date().toISOString(),
+      leader_cwd: cwd,
+      team_state_root: root,
+      leader_pane_id: '%0',
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+    };
+    const config: TeamConfig = {
+      ...common,
+      agent_type: 'claude',
+      worker_launch_mode: 'interactive',
+      max_workers: maxWorkers,
+      tmux_session: 'max-team:0',
+    };
+    const manifest: TeamManifestV2 = {
+      ...common,
+      schema_version: 2,
+      leader: { session_id: 'max-team:0', worker_id: 'leader-fixed', role: 'leader' },
+      policy: {
+        display_mode: 'split_pane',
+        worker_launch_mode: 'interactive',
+        dispatch_mode: 'hook_preferred_with_fallback',
+        dispatch_ack_timeout_ms: 15_000,
+      },
+      governance: {
+        delegation_only: false,
+        plan_approval_required: false,
+        nested_teams_allowed: false,
+        one_team_per_leader_session: true,
+        cleanup_requires_all_workers_inactive: true,
+      },
+      permissions_snapshot: {
+        approval_mode: 'default',
+        sandbox_mode: 'workspace-write',
+        network_access: false,
+      },
+      tmux_session: 'max-team:0',
+      max_workers: maxWorkers,
+    };
+
+    await writeFile(join(root, 'config.json'), JSON.stringify(config, null, 2));
+    await writeFile(join(root, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  }
+
+  it('preserves configured max_workers below the legacy default in monitor reads', async () => {
+    await writeTeamState(2);
+
+    await expect(readTeamConfig('max-team', cwd)).resolves.toMatchObject({
+      max_workers: 2,
+      worker_count: 2,
+    });
+  });
+
+  it('preserves configured max_workers below the legacy default in team ops reads', async () => {
+    await writeTeamState(2);
+
+    await expect(teamReadConfig('max-team', cwd)).resolves.toMatchObject({
+      max_workers: 2,
+      worker_count: 2,
+    });
+  });
+});
+

--- a/src/team/__tests__/max-workers-config.test.ts
+++ b/src/team/__tests__/max-workers-config.test.ts
@@ -92,4 +92,3 @@ describe('team max_workers config readers', () => {
     });
   });
 });
-

--- a/src/team/__tests__/resource-policy.test.ts
+++ b/src/team/__tests__/resource-policy.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { estimateResourceWorkerCap, resolveTeamWorkerCount } from '../resource-policy.js';
+import type { LocalResourceSnapshot } from '../resource-policy.js';
+
+const baseSnapshot: LocalResourceSnapshot = {
+  cpuCount: 8,
+  totalMemoryBytes: 16 * 1024 ** 3,
+  freeMemoryBytes: 8 * 1024 ** 3,
+  loadAverage1m: 2,
+  platform: 'darwin',
+};
+
+describe('team resource policy', () => {
+  it('does not change requested workers when adaptiveAgents and maxAgents are unset', () => {
+    const decision = resolveTeamWorkerCount(6, {}, {}, baseSnapshot);
+
+    expect(decision.effective).toBe(6);
+    expect(decision.capped).toBe(false);
+    expect(decision.adaptiveEnabled).toBe(false);
+    expect(decision.reason).toBe('requested');
+  });
+
+  it('honors maxAgents as a static cap even without adaptiveAgents', () => {
+    const decision = resolveTeamWorkerCount(6, { maxAgents: 3 }, {}, baseSnapshot);
+
+    expect(decision.effective).toBe(3);
+    expect(decision.capped).toBe(true);
+    expect(decision.reason).toContain('maxAgents=3');
+  });
+
+  it('caps requested workers by local CPU and memory when adaptiveAgents is enabled', () => {
+    const constrained: LocalResourceSnapshot = {
+      cpuCount: 4,
+      totalMemoryBytes: 8 * 1024 ** 3,
+      freeMemoryBytes: 3 * 1024 ** 3,
+      loadAverage1m: 1,
+      platform: 'darwin',
+    };
+
+    const decision = resolveTeamWorkerCount(
+      8,
+      { adaptiveAgents: true, resourceProfile: 'balanced' },
+      {},
+      constrained,
+    );
+
+    expect(decision.effective).toBe(1);
+    expect(decision.resourceCap).toBe(1);
+    expect(decision.capped).toBe(true);
+    expect(decision.snapshot).toEqual(constrained);
+  });
+
+  it('never increases worker count above the user request', () => {
+    const roomy: LocalResourceSnapshot = {
+      cpuCount: 32,
+      totalMemoryBytes: 128 * 1024 ** 3,
+      freeMemoryBytes: 96 * 1024 ** 3,
+      loadAverage1m: 1,
+      platform: 'linux',
+    };
+
+    const decision = resolveTeamWorkerCount(
+      2,
+      { adaptiveAgents: true, resourceProfile: 'aggressive' },
+      {},
+      roomy,
+    );
+
+    expect(decision.effective).toBe(2);
+    expect(decision.capped).toBe(false);
+  });
+
+  it('treats high load average as resource pressure on Unix-like platforms', () => {
+    const cap = estimateResourceWorkerCap({
+      cpuCount: 8,
+      totalMemoryBytes: 32 * 1024 ** 3,
+      freeMemoryBytes: 24 * 1024 ** 3,
+      loadAverage1m: 12,
+      platform: 'linux',
+    }, 'balanced');
+
+    expect(cap).toBe(4);
+  });
+
+  it('lets environment overrides win over config', () => {
+    const decision = resolveTeamWorkerCount(
+      5,
+      { maxAgents: 5, adaptiveAgents: false, resourceProfile: 'aggressive' },
+      {
+        OMC_TEAM_MAX_AGENTS: '2',
+        OMC_TEAM_ADAPTIVE_AGENTS: '1',
+        OMC_TEAM_RESOURCE_PROFILE: 'conservative',
+      } as NodeJS.ProcessEnv,
+      baseSnapshot,
+    );
+
+    expect(decision.maxAgents).toBe(2);
+    expect(decision.adaptiveEnabled).toBe(true);
+    expect(decision.resourceProfile).toBe('conservative');
+    expect(decision.effective).toBe(2);
+  });
+});
+

--- a/src/team/__tests__/resource-policy.test.ts
+++ b/src/team/__tests__/resource-policy.test.ts
@@ -99,5 +99,22 @@ describe('team resource policy', () => {
     expect(decision.resourceProfile).toBe('conservative');
     expect(decision.effective).toBe(2);
   });
-});
 
+  it('ignores malformed environment overrides instead of partially parsing them', () => {
+    const decision = resolveTeamWorkerCount(
+      5,
+      { maxAgents: 4, adaptiveAgents: true, resourceProfile: 'balanced' },
+      {
+        OMC_TEAM_MAX_AGENTS: '2abc',
+        OMC_TEAM_ADAPTIVE_AGENTS: 'maybe',
+        OMC_TEAM_RESOURCE_PROFILE: 'turbo',
+      } as NodeJS.ProcessEnv,
+      baseSnapshot,
+    );
+
+    expect(decision.maxAgents).toBe(4);
+    expect(decision.adaptiveEnabled).toBe(true);
+    expect(decision.resourceProfile).toBe('balanced');
+    expect(decision.effective).toBe(4);
+  });
+});

--- a/src/team/monitor.ts
+++ b/src/team/monitor.ts
@@ -66,7 +66,7 @@ function configFromManifest(manifest: TeamManifestV2): TeamConfig {
     governance: manifest.governance,
     worker_launch_mode: manifest.policy.worker_launch_mode,
     worker_count: manifest.worker_count,
-    max_workers: 20,
+    max_workers: manifest.max_workers ?? 20,
     workers: manifest.workers,
     created_at: manifest.created_at,
     tmux_session: manifest.tmux_session,
@@ -97,7 +97,7 @@ export async function readTeamConfig(teamName: string, cwd: string): Promise<Tea
     workers: [...(config.workers ?? []), ...(manifest.workers ?? [])],
     worker_count: Math.max(config.worker_count ?? 0, manifest.worker_count ?? 0),
     next_task_id: Math.max(config.next_task_id ?? 1, manifest.next_task_id ?? 1),
-    max_workers: Math.max(config.max_workers ?? 0, 20),
+    max_workers: config.max_workers ?? manifest.max_workers ?? 20,
   });
 }
 

--- a/src/team/resource-policy.ts
+++ b/src/team/resource-policy.ts
@@ -1,0 +1,189 @@
+import { cpus, freemem, loadavg, platform, totalmem } from 'os';
+import type { TeamOpsConfig, TeamResourceProfile } from '../shared/types.js';
+
+const BYTES_PER_GIB = 1024 ** 3;
+
+export interface LocalResourceSnapshot {
+  cpuCount: number;
+  totalMemoryBytes: number;
+  freeMemoryBytes: number;
+  loadAverage1m?: number;
+  platform: NodeJS.Platform | string;
+}
+
+export interface TeamWorkerCountDecision {
+  requested: number;
+  effective: number;
+  capped: boolean;
+  adaptiveEnabled: boolean;
+  maxAgents?: number;
+  resourceCap?: number;
+  resourceProfile: TeamResourceProfile;
+  reason: string;
+  snapshot?: LocalResourceSnapshot;
+}
+
+interface ResourceProfilePolicy {
+  cpuReserve: number;
+  memoryPerWorkerBytes: number;
+  minimumFreeMemoryBytes: number;
+  loadPressureRatio: number;
+}
+
+const RESOURCE_PROFILE_POLICIES: Record<TeamResourceProfile, ResourceProfilePolicy> = {
+  conservative: {
+    cpuReserve: 2,
+    memoryPerWorkerBytes: 2 * BYTES_PER_GIB,
+    minimumFreeMemoryBytes: 1 * BYTES_PER_GIB,
+    loadPressureRatio: 0.75,
+  },
+  balanced: {
+    cpuReserve: 1,
+    memoryPerWorkerBytes: 1.5 * BYTES_PER_GIB,
+    minimumFreeMemoryBytes: 1 * BYTES_PER_GIB,
+    loadPressureRatio: 1.0,
+  },
+  aggressive: {
+    cpuReserve: 0,
+    memoryPerWorkerBytes: 1 * BYTES_PER_GIB,
+    minimumFreeMemoryBytes: 0.5 * BYTES_PER_GIB,
+    loadPressureRatio: 1.25,
+  },
+};
+
+const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on', 'enabled']);
+const FALSY_ENV_VALUES = new Set(['0', 'false', 'no', 'off', 'disabled']);
+
+function parseBooleanEnv(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (TRUTHY_ENV_VALUES.has(normalized)) return true;
+  if (FALSY_ENV_VALUES.has(normalized)) return false;
+  return undefined;
+}
+
+function parsePositiveIntEnv(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : undefined;
+}
+
+function clampWorkerCount(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(1, Math.floor(value));
+}
+
+function resolveResourceProfile(
+  ops: TeamOpsConfig | undefined,
+  env: NodeJS.ProcessEnv,
+): TeamResourceProfile {
+  const envProfile = env.OMC_TEAM_RESOURCE_PROFILE?.trim().toLowerCase();
+  if (envProfile === 'conservative' || envProfile === 'balanced' || envProfile === 'aggressive') {
+    return envProfile;
+  }
+  return ops?.resourceProfile ?? 'balanced';
+}
+
+function resolveMaxAgents(
+  ops: TeamOpsConfig | undefined,
+  env: NodeJS.ProcessEnv,
+): number | undefined {
+  return parsePositiveIntEnv(env.OMC_TEAM_MAX_AGENTS) ?? ops?.maxAgents;
+}
+
+function isAdaptiveAgentsEnabled(
+  ops: TeamOpsConfig | undefined,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return parseBooleanEnv(env.OMC_TEAM_ADAPTIVE_AGENTS) ?? (ops?.adaptiveAgents === true);
+}
+
+export function readLocalResourceSnapshot(): LocalResourceSnapshot {
+  const cpuCount = Math.max(1, cpus().length);
+  const currentPlatform = platform();
+  const loadAverage = loadavg();
+  return {
+    cpuCount,
+    totalMemoryBytes: totalmem(),
+    freeMemoryBytes: freemem(),
+    ...(currentPlatform === 'win32' ? {} : { loadAverage1m: loadAverage[0] }),
+    platform: currentPlatform,
+  };
+}
+
+export function estimateResourceWorkerCap(
+  snapshot: LocalResourceSnapshot,
+  profile: TeamResourceProfile,
+): number {
+  const policy = RESOURCE_PROFILE_POLICIES[profile];
+  const cpuCap = Math.max(1, snapshot.cpuCount - policy.cpuReserve);
+  const memoryAvailableForWorkers = Math.max(
+    0,
+    snapshot.freeMemoryBytes - policy.minimumFreeMemoryBytes,
+  );
+  const memoryCap = Math.max(
+    1,
+    Math.floor(memoryAvailableForWorkers / policy.memoryPerWorkerBytes),
+  );
+  let cap = Math.max(1, Math.min(cpuCap, memoryCap));
+
+  if (
+    typeof snapshot.loadAverage1m === 'number' &&
+    Number.isFinite(snapshot.loadAverage1m) &&
+    snapshot.loadAverage1m > snapshot.cpuCount * policy.loadPressureRatio
+  ) {
+    cap = Math.max(1, Math.min(cap, Math.floor(snapshot.cpuCount / 2)));
+  }
+
+  return cap;
+}
+
+/**
+ * Resolve initial /team fanout from user request + configured caps.
+ *
+ * This function is intentionally cap-only: it never increases the requested
+ * worker count. That keeps the feature safe for existing team workflows while
+ * allowing opt-in resource protection on constrained machines.
+ */
+export function resolveTeamWorkerCount(
+  requestedWorkerCount: number,
+  ops: TeamOpsConfig | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+  snapshot: LocalResourceSnapshot = readLocalResourceSnapshot(),
+): TeamWorkerCountDecision {
+  const requested = clampWorkerCount(requestedWorkerCount);
+  const profile = resolveResourceProfile(ops, env);
+  const maxAgents = resolveMaxAgents(ops, env);
+  const adaptiveEnabled = isAdaptiveAgentsEnabled(ops, env);
+
+  let effective = requested;
+  const reasons: string[] = [];
+
+  if (maxAgents !== undefined && maxAgents < effective) {
+    effective = maxAgents;
+    reasons.push(`maxAgents=${maxAgents}`);
+  }
+
+  let resourceCap: number | undefined;
+  if (adaptiveEnabled) {
+    resourceCap = estimateResourceWorkerCap(snapshot, profile);
+    if (resourceCap < effective) {
+      effective = resourceCap;
+      reasons.push(`resourceCap=${resourceCap}`);
+    }
+  }
+
+  effective = clampWorkerCount(effective);
+
+  return {
+    requested,
+    effective,
+    capped: effective < requested,
+    adaptiveEnabled,
+    ...(maxAgents !== undefined ? { maxAgents } : {}),
+    ...(resourceCap !== undefined ? { resourceCap } : {}),
+    resourceProfile: profile,
+    reason: reasons.length > 0 ? reasons.join(', ') : 'requested',
+    ...(adaptiveEnabled ? { snapshot } : {}),
+  };
+}

--- a/src/team/resource-policy.ts
+++ b/src/team/resource-policy.ts
@@ -64,7 +64,9 @@ function parseBooleanEnv(raw: string | undefined): boolean | undefined {
 
 function parsePositiveIntEnv(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
-  const parsed = Number.parseInt(raw, 10);
+  const normalized = raw.trim();
+  if (!/^[1-9]\d*$/.test(normalized)) return undefined;
+  const parsed = Number.parseInt(normalized, 10);
   return Number.isInteger(parsed) && parsed >= 1 ? parsed : undefined;
 }
 

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -1004,7 +1004,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     policy: DEFAULT_TEAM_TRANSPORT_POLICY,
     governance: DEFAULT_TEAM_GOVERNANCE,
     worker_count: config.workerCount,
-    max_workers: 20,
+    max_workers: pluginCfg.team?.ops?.maxAgents ?? 20,
     workers: workersInfo,
     created_at: new Date().toISOString(),
     tmux_session: sessionName,

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -1053,6 +1053,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     permissions_snapshot: permissionsSnapshot,
     tmux_session: sessionName,
     worker_count: teamConfig.worker_count,
+    max_workers: teamConfig.max_workers,
     workers: workersInfo,
     next_task_id: teamConfig.next_task_id,
     created_at: teamConfig.created_at,

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -200,7 +200,7 @@ function configFromManifest(manifest: TeamManifestV2): TeamConfig {
     governance: manifest.governance,
     worker_launch_mode: manifest.policy.worker_launch_mode,
     worker_count: manifest.worker_count,
-    max_workers: 20,
+    max_workers: manifest.max_workers ?? 20,
     workers: manifest.workers,
     created_at: manifest.created_at,
     tmux_session: manifest.tmux_session,
@@ -228,7 +228,7 @@ function mergeTeamConfigSources(config: TeamConfig | null, manifest: TeamManifes
     workers: [...(config.workers ?? []), ...(manifest.workers ?? [])],
     worker_count: Math.max(config.worker_count ?? 0, manifest.worker_count ?? 0),
     next_task_id: Math.max(config.next_task_id ?? 1, manifest.next_task_id ?? 1),
-    max_workers: Math.max(config.max_workers ?? 0, 20),
+    max_workers: config.max_workers ?? manifest.max_workers ?? 20,
   });
 }
 

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -234,6 +234,7 @@ export interface TeamManifestV2 {
   permissions_snapshot: PermissionsSnapshot;
   tmux_session: string;
   worker_count: number;
+  max_workers?: number;
   workers: WorkerInfo[];
   next_task_id: number;
   created_at: string;


### PR DESCRIPTION
## Summary

Revised proposal after #2808 was closed. This version addresses the OMX review blockers from #2808 and requests maintainer confirmation for the new user-facing config/env contract.

Adds an opt-in local resource policy for `/team` startup so requested worker fanout can be capped based on configured max agents and local CPU/memory/load pressure.

This is intentionally cap-only:
- never increases the requested worker count
- applies `team.ops.maxAgents` as a static cap
- applies CPU/RAM/load-derived caps only when `team.ops.adaptiveAgents` is enabled
- preserves requested tasks/backlog when fanout is capped
- preserves existing runtime-v2 routing snapshot behavior

## Review feedback addressed from #2808

- `git diff --check upstream/dev...HEAD` passes.
- Capped worker fanout preserves all explicit user tasks/backlog instead of truncating `--task` values.
- `max_workers` below the legacy default is preserved through config/manifest readers so later `scaleUp` honors `maxAgents`.
- Malformed env overrides are ignored instead of silently coercing or overriding valid file config:
  - `OMC_TEAM_MAX_AGENTS=2abc` is not accepted as `2`
  - `OMC_TEAM_ADAPTIVE_AGENTS=maybe` does not become `false`
  - invalid `OMC_TEAM_RESOURCE_PROFILE` does not override file config

## New config contract for maintainer confirmation

```jsonc
{
  "team": {
    "ops": {
      "maxAgents": 4,
      "adaptiveAgents": true,
      "resourceProfile": "balanced"
    }
  }
}
```

Env overrides:
- `OMC_TEAM_MAX_AGENTS`
- `OMC_TEAM_ADAPTIVE_AGENTS`
- `OMC_TEAM_RESOURCE_PROFILE`

This PR intentionally asks for maintainer/owner confirmation on these names and the contract shape before merge.

## Why cap-only?

Runtime scale up/down already exists, but monitor-driven automatic scaling has higher race/drain/worktree risk. This PR keeps the contribution small and safe by only adjusting initial team fanout.

## Tests

- `npm run test:run -- src/team/__tests__/resource-policy.test.ts src/team/__tests__/max-workers-config.test.ts src/config/__tests__/loader.test.ts src/cli/__tests__/team.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --check upstream/dev...HEAD`

Lint passes with existing warnings only.
