### PR TITLE
Honor team maxAgents without dropping queued work

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -236,6 +236,89 @@ describe('team cli', () => {
     logSpy.mockRestore();
   });
 
+  it('teamCommand start caps active workers from --cwd maxAgents without dropping replicated tasks', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-max-agents-start-'));
+    mkdirSync(join(cwd, '.claude'), { recursive: true });
+    writeFileSync(join(cwd, '.claude', 'omc.jsonc'), JSON.stringify({
+      team: { ops: { maxAgents: 2 } },
+    }));
+
+    mocks.spawn.mockReturnValue({
+      pid: 8989,
+      stdin: { write, end },
+      unref,
+    });
+
+    try {
+      const { teamCommand } = await import('../team.js');
+      await teamCommand([
+        'start', '--agent', 'codex', '--count', '4',
+        '--task', 'lint all modules', '--cwd', cwd, '--json',
+      ]);
+
+      const stdinPayload = JSON.parse(write.mock.calls[0][0] as string) as {
+        workerCount?: number;
+        agentTypes: string[];
+        tasks: Array<{ subject: string; description: string }>;
+      };
+      expect(stdinPayload.workerCount).toBe(2);
+      expect(stdinPayload.agentTypes).toEqual(['codex', 'codex']);
+      expect(stdinPayload.tasks).toHaveLength(4);
+      expect(stdinPayload.tasks.every((t) => t.description === 'lint all modules')).toBe(true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      logSpy.mockRestore();
+    }
+  });
+
+  it('teamCommand start caps active workers from --cwd maxAgents without dropping explicit tasks', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-max-agents-explicit-'));
+    mkdirSync(join(cwd, '.claude'), { recursive: true });
+    writeFileSync(join(cwd, '.claude', 'omc.jsonc'), JSON.stringify({
+      team: { ops: { maxAgents: 2 } },
+    }));
+
+    mocks.spawn.mockReturnValue({
+      pid: 9090,
+      stdin: { write, end },
+      unref,
+    });
+
+    try {
+      const { teamCommand } = await import('../team.js');
+      await teamCommand([
+        'start', '--agent', 'codex', '--count', '4',
+        '--task', 'task one', '--task', 'task two', '--task', 'task three', '--task', 'task four',
+        '--cwd', cwd, '--json',
+      ]);
+
+      const stdinPayload = JSON.parse(write.mock.calls[0][0] as string) as {
+        workerCount?: number;
+        agentTypes: string[];
+        tasks: Array<{ subject: string; description: string }>;
+      };
+      expect(stdinPayload.workerCount).toBe(2);
+      expect(stdinPayload.agentTypes).toEqual(['codex', 'codex']);
+      expect(stdinPayload.tasks.map((task) => task.description)).toEqual([
+        'task one',
+        'task two',
+        'task three',
+        'task four',
+      ]);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      logSpy.mockRestore();
+    }
+  });
+
   it('teamCommand start without --json outputs non-JSON', async () => {
     const write = vi.fn();
     const end = vi.fn();
@@ -797,6 +880,42 @@ describe('team cli', () => {
     expect(out.pid).toBe(5151);
 
     logSpy.mockRestore();
+  });
+
+  it('legacy shorthand caps active workers from --cwd maxAgents without dropping backlog', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-max-agents-legacy-'));
+    mkdirSync(join(cwd, '.claude'), { recursive: true });
+    writeFileSync(join(cwd, '.claude', 'omc.jsonc'), JSON.stringify({
+      team: { ops: { maxAgents: 2 } },
+    }));
+
+    mocks.spawn.mockReturnValue({
+      pid: 5252,
+      stdin: { write, end },
+      unref,
+    });
+
+    try {
+      const { teamCommand } = await import('../team.js');
+      await teamCommand(['4:codex', 'ship', 'feature', '--cwd', cwd, '--json']);
+
+      const payload = JSON.parse(write.mock.calls[0][0] as string) as {
+        workerCount?: number;
+        agentTypes: string[];
+        tasks: Array<{ subject: string; description: string }>;
+      };
+      expect(payload.workerCount).toBe(2);
+      expect(payload.agentTypes).toEqual(['codex', 'codex']);
+      expect(payload.tasks).toHaveLength(4);
+      expect(payload.tasks.every((task) => task.description === 'ship feature')).toBe(true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      logSpy.mockRestore();
+    }
   });
 
 

--- a/src/cli/commands/__tests__/team-role-shorthand.test.ts
+++ b/src/cli/commands/__tests__/team-role-shorthand.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const runtimeV2Mocks = vi.hoisted(() => ({
   isRuntimeV2Enabled: vi.fn(() => true),
@@ -29,6 +32,7 @@ vi.mock('../../../agents/utils.js', () => ({
 describe('teamCommand role-only shorthand', () => {
   const originalCwd = process.cwd();
   let logSpy: ReturnType<typeof vi.spyOn>;
+  let tempDir: string | undefined;
 
   beforeEach(() => {
     runtimeV2Mocks.isRuntimeV2Enabled.mockReturnValue(true);
@@ -47,6 +51,8 @@ describe('teamCommand role-only shorthand', () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
     logSpy.mockRestore();
     vi.clearAllMocks();
   });
@@ -66,6 +72,54 @@ describe('teamCommand role-only shorthand', () => {
       tasks: [
         { subject: 'Worker 1: fix the bug', description: 'fix the bug', owner: 'worker-1' },
         { subject: 'Worker 2: fix the bug', description: 'fix the bug', owner: 'worker-2' },
+      ],
+    }));
+  });
+
+  it('caps active workers from existing team.ops.maxAgents without dropping atomic backlog', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'omc-team-max-agents-command-'));
+    mkdirSync(join(tempDir, '.claude'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'omc.jsonc'), JSON.stringify({
+      team: { ops: { maxAgents: 2 } },
+    }));
+    process.chdir(tempDir);
+
+    const { teamCommand } = await import('../team.js');
+
+    await teamCommand(['4:codex', 'review the system']);
+
+    expect(runtimeV2Mocks.startTeamV2).toHaveBeenCalledWith(expect.objectContaining({
+      workerCount: 2,
+      agentTypes: ['codex', 'codex'],
+      tasks: [
+        { subject: 'Worker 1: review the system', description: 'review the system', owner: 'worker-1' },
+        { subject: 'Worker 2: review the system', description: 'review the system', owner: 'worker-2' },
+        { subject: 'Worker 3: review the system', description: 'review the system', owner: 'worker-1' },
+        { subject: 'Worker 4: review the system', description: 'review the system', owner: 'worker-2' },
+      ],
+    }));
+  });
+
+  it('caps active workers from existing team.ops.maxAgents without dropping decomposed subtasks', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'omc-team-max-agents-decomposed-'));
+    mkdirSync(join(tempDir, '.claude'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'omc.jsonc'), JSON.stringify({
+      team: { ops: { maxAgents: 2 } },
+    }));
+    process.chdir(tempDir);
+
+    const { teamCommand } = await import('../team.js');
+
+    await teamCommand(['4:codex', 'fix auth and fix billing and fix search and fix docs']);
+
+    expect(runtimeV2Mocks.startTeamV2).toHaveBeenCalledWith(expect.objectContaining({
+      workerCount: 2,
+      agentTypes: ['codex', 'codex'],
+      tasks: [
+        { subject: 'fix auth', description: 'fix auth', owner: 'worker-1' },
+        { subject: 'fix billing', description: 'fix billing', owner: 'worker-2' },
+        { subject: 'fix search', description: 'fix search', owner: 'worker-1' },
+        { subject: 'fix docs', description: 'fix docs', owner: 'worker-2' },
       ],
     }));
   });

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -16,6 +16,7 @@ import {
 } from '../../team/api-interop.js';
 import type { CliAgentType } from '../../team/model-contract.js';
 import { loadConfig } from '../../config/loader.js';
+import { resolveTeamFanout } from '../../team/fanout-policy.js';
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
@@ -553,37 +554,40 @@ function parseTeamApiArgs(args: string[]): {
 
 async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<void> {
   await assertTeamSpawnAllowed(cwd);
+  const cfg = loadConfig();
 
   // Decompose the task string into subtasks when possible
   const decomposition = splitTaskString(parsed.task);
-  const effectiveWorkerCount = resolveTeamFanoutLimit(
+  const requestedBacklogCount = resolveTeamFanoutLimit(
     parsed.workerCount,
     parsed.agentTypes[0],
     parsed.workerCount,
     decomposition
   );
+  const fanout = resolveTeamFanout(requestedBacklogCount, cfg.team?.ops);
+  const effectiveWorkerCount = fanout.effective;
 
   // Build the task list from decomposition subtasks or fall back to atomic replication
   const tasks: Array<{ subject: string; description: string; owner?: string }> = [];
   if (decomposition.strategy !== 'atomic' && decomposition.subtasks.length > 1) {
-    // Use decomposed subtasks — one per subtask (up to effectiveWorkerCount)
-    const subtasks = decomposition.subtasks.slice(0, effectiveWorkerCount);
+    // Use decomposed subtasks — preserve requested backlog and round-robin over active workers.
+    const subtasks = decomposition.subtasks.slice(0, requestedBacklogCount);
     for (let i = 0; i < subtasks.length; i++) {
       tasks.push({
         subject: subtasks[i].subject,
         description: subtasks[i].description,
-        owner: `worker-${i + 1}`,
+        owner: `worker-${(i % effectiveWorkerCount) + 1}`,
       });
     }
   } else {
-    // Atomic task: replicate across all workers (backward compatible)
-    for (let i = 0; i < effectiveWorkerCount; i++) {
+    // Atomic task: preserve requested backlog and round-robin over active workers.
+    for (let i = 0; i < requestedBacklogCount; i++) {
       tasks.push({
-        subject: effectiveWorkerCount === 1
+        subject: requestedBacklogCount === 1
           ? parsed.task.slice(0, 80)
           : `Worker ${i + 1}: ${parsed.task}`.slice(0, 80),
         description: parsed.task,
-        owner: `worker-${i + 1}`,
+        owner: `worker-${(i % effectiveWorkerCount) + 1}`,
       });
     }
   }
@@ -606,7 +610,7 @@ async function handleTeamStart(parsed: ParsedTeamArgs, cwd: string): Promise<voi
       tasks,
       cwd,
       newWindow: parsed.newWindow,
-      workerRoles: parsed.workerSpecs.map((spec) => spec.role ?? spec.agentType),
+      workerRoles: parsed.workerSpecs.slice(0, effectiveWorkerCount).map((spec) => spec.role ?? spec.agentType),
       ...(rolePrompt ? { roleName: parsed.role, rolePrompt } : {}),
     });
 

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -8,8 +8,10 @@ import { executeTeamApiOperation as executeCanonicalTeamApiOperation, resolveTea
 import { cleanupTeamWorktrees } from '../team/git-worktree.js';
 import { killWorkerPanes, killTeamSession, getWorkerLiveness } from '../team/tmux-session.js';
 import { validateTeamName } from '../team/team-name.js';
+import { resolveTeamFanout } from '../team/fanout-policy.js';
 import { monitorTeam, resumeTeam, shutdownTeam } from '../team/runtime.js';
 import { readTeamConfig } from '../team/monitor.js';
+import { loadConfig } from '../config/loader.js';
 import { isProcessAlive } from '../platform/index.js';
 import { getGlobalOmcStatePath } from '../utils/paths.js';
 
@@ -365,6 +367,16 @@ function parseJsonInput(inputRaw: string | undefined): Record<string, unknown> {
     throw new Error('Invalid --input JSON payload');
   }
   return parsed;
+}
+
+function loadConfigForCwd(cwd: string): ReturnType<typeof loadConfig> {
+  const previousCwd = process.cwd();
+  try {
+    process.chdir(cwd);
+    return loadConfig();
+  } finally {
+    process.chdir(previousCwd);
+  }
 }
 
 export async function startTeamJob(input: TeamStartInput): Promise<TeamStartResult> {
@@ -948,7 +960,7 @@ function parseStartArgs(args: string[]): StartArgsParsed {
   if (agentValues.length === 0) throw new Error('Missing required --agent');
   if (taskValues.length === 0) throw new Error('Missing required --task');
 
-  const agentTypes = agentValues.length === 1
+  const requestedAgentTypes = agentValues.length === 1
     ? Array.from({ length: count }, () => agentValues[0])
     : [...agentValues];
 
@@ -957,13 +969,15 @@ function parseStartArgs(args: string[]): StartArgsParsed {
   }
 
   const taskDescriptions = taskValues.length === 1
-    ? Array.from({ length: agentTypes.length }, () => taskValues[0])
+    ? Array.from({ length: requestedAgentTypes.length }, () => taskValues[0])
     : [...taskValues];
 
-  if (taskDescriptions.length !== agentTypes.length) {
-    throw new Error(`Task count (${taskDescriptions.length}) must match worker count (${agentTypes.length}).`);
+  if (taskDescriptions.length !== requestedAgentTypes.length) {
+    throw new Error(`Task count (${taskDescriptions.length}) must match worker count (${requestedAgentTypes.length}).`);
   }
 
+  const fanout = resolveTeamFanout(requestedAgentTypes.length, loadConfigForCwd(cwd).team?.ops);
+  const agentTypes = requestedAgentTypes.slice(0, fanout.effective);
   const resolvedTeamName = (teamName && teamName.trim()) ? teamName.trim() : autoTeamName(taskDescriptions[0]);
   const tasks: TeamTaskInput[] = taskDescriptions.map((description, index) => ({
     subject: `${subjectPrefix} ${index + 1}`,
@@ -973,6 +987,7 @@ function parseStartArgs(args: string[]): StartArgsParsed {
   return {
     input: {
       teamName: resolvedTeamName,
+      workerCount: fanout.effective,
       agentTypes,
       tasks,
       cwd,
@@ -1328,6 +1343,7 @@ export async function teamCommand(argv: string[]): Promise<void> {
   if (!SUBCOMMANDS.has(command)) {
     const legacy = parseLegacyStartAlias(argv);
     if (legacy) {
+      const fanout = resolveTeamFanout(legacy.workerCount, loadConfigForCwd(legacy.cwd).team?.ops);
       const tasks = Array.from({ length: legacy.workerCount }, (_, idx) => ({
         subject: legacy.ralph ? `Ralph Task ${idx + 1}` : `Task ${idx + 1}`,
         description: legacy.task,
@@ -1335,8 +1351,8 @@ export async function teamCommand(argv: string[]): Promise<void> {
 
       const result = await startTeamJob({
         teamName: legacy.teamName,
-        workerCount: legacy.workerCount,
-        agentTypes: Array.from({ length: legacy.workerCount }, () => legacy.agentType),
+        workerCount: fanout.effective,
+        agentTypes: Array.from({ length: fanout.effective }, () => legacy.agentType),
         tasks,
         cwd: legacy.cwd,
         ...(legacy.newWindow ? { newWindow: true } : {}),

--- a/src/team/__tests__/fanout-policy.test.ts
+++ b/src/team/__tests__/fanout-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMaxWorkers, resolveTeamFanout } from '../fanout-policy.js';
+
+describe('resolveTeamFanout', () => {
+  it('caps active fanout using existing team.ops.maxAgents', () => {
+    expect(resolveTeamFanout(4, { maxAgents: 2 })).toEqual({
+      requested: 4,
+      effective: 2,
+      capped: true,
+    });
+  });
+
+  it('leaves fanout unchanged when maxAgents is absent', () => {
+    expect(resolveTeamFanout(3, undefined)).toEqual({
+      requested: 3,
+      effective: 3,
+      capped: false,
+    });
+  });
+});
+
+describe('normalizeMaxWorkers', () => {
+  it('accepts positive integer max worker counts', () => {
+    expect(normalizeMaxWorkers(2)).toBe(2);
+  });
+
+  it('ignores invalid persisted max worker counts', () => {
+    expect(normalizeMaxWorkers(0)).toBeUndefined();
+    expect(normalizeMaxWorkers(2.5)).toBeUndefined();
+    expect(normalizeMaxWorkers('2')).toBeUndefined();
+  });
+});

--- a/src/team/fanout-policy.ts
+++ b/src/team/fanout-policy.ts
@@ -1,0 +1,34 @@
+import type { TeamOpsConfig } from '../shared/types.js';
+
+export interface TeamFanoutDecision {
+  requested: number;
+  effective: number;
+  capped: boolean;
+}
+
+/**
+ * Cap active team worker fanout without changing the requested work/backlog.
+ *
+ * `team.ops.maxAgents` is an active-worker ceiling. Callers should keep task
+ * construction based on the original requested count and only use `effective`
+ * for spawned workers / agent fanout.
+ */
+export function resolveTeamFanout(
+  requestedWorkerCount: number,
+  ops: TeamOpsConfig | undefined,
+): TeamFanoutDecision {
+  const requested = Math.max(1, Math.trunc(requestedWorkerCount));
+  const configuredMax = ops?.maxAgents;
+  if (typeof configuredMax !== 'number' || !Number.isInteger(configuredMax) || configuredMax < 1) {
+    return { requested, effective: requested, capped: false };
+  }
+
+  const effective = Math.min(requested, configuredMax);
+  return { requested, effective, capped: effective < requested };
+}
+
+export function normalizeMaxWorkers(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1
+    ? value
+    : undefined;
+}

--- a/src/team/monitor.ts
+++ b/src/team/monitor.ts
@@ -29,6 +29,7 @@ import type {
 import type { TeamPhase } from './phase-controller.js';
 import { normalizeTeamManifest } from './governance.js';
 import { canonicalizeTeamConfigWorkers } from './worker-canonicalization.js';
+import { normalizeMaxWorkers } from './fanout-policy.js';
 
 // ---------------------------------------------------------------------------
 // State I/O helpers (self-contained, no external deps beyond fs)
@@ -66,7 +67,7 @@ function configFromManifest(manifest: TeamManifestV2): TeamConfig {
     governance: manifest.governance,
     worker_launch_mode: manifest.policy.worker_launch_mode,
     worker_count: manifest.worker_count,
-    max_workers: 20,
+    max_workers: normalizeMaxWorkers(manifest.max_workers) ?? 20,
     workers: manifest.workers,
     created_at: manifest.created_at,
     tmux_session: manifest.tmux_session,
@@ -97,7 +98,9 @@ export async function readTeamConfig(teamName: string, cwd: string): Promise<Tea
     workers: [...(config.workers ?? []), ...(manifest.workers ?? [])],
     worker_count: Math.max(config.worker_count ?? 0, manifest.worker_count ?? 0),
     next_task_id: Math.max(config.next_task_id ?? 1, manifest.next_task_id ?? 1),
-    max_workers: Math.max(config.max_workers ?? 0, 20),
+    max_workers: normalizeMaxWorkers(config.max_workers)
+      ?? normalizeMaxWorkers(manifest.max_workers)
+      ?? 20,
   });
 }
 

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -85,6 +85,7 @@ import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 import type { CanonicalTeamRole, PluginConfig, RoleAssignment, TeamRoleAssignmentSpec } from '../shared/types.js';
 import { CANONICAL_TEAM_ROLES } from '../shared/types.js';
 import { loadConfig } from '../config/loader.js';
+import { normalizeMaxWorkers } from './fanout-policy.js';
 import { buildResolvedRoutingSnapshot, getRoleRoutingSpec } from './stage-router.js';
 import { routeTaskToRole } from './role-router.js';
 import { normalizeDelegationRole } from '../features/delegation-routing/types.js';
@@ -185,6 +186,16 @@ interface ShutdownGateCounts {
 }
 
 const MONITOR_SIGNAL_STALE_MS = 30_000;
+
+function loadConfigForCwd(cwd: string): PluginConfig {
+  const previousCwd = process.cwd();
+  try {
+    process.chdir(cwd);
+    return loadConfig();
+  } finally {
+    process.chdir(previousCwd);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helper: sanitize team name
@@ -800,7 +811,8 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
   // for the team's lifetime (stickiness per plan AC-10): spawn/scaleUp/restart
   // all read this snapshot and never re-resolve. Config edits mid-lifetime
   // do NOT change routing — user must recreate the team to pick up changes.
-  const pluginCfg: PluginConfig = config.pluginConfig ?? loadConfig();
+  const pluginCfg: PluginConfig = config.pluginConfig ?? loadConfigForCwd(leaderCwd);
+  const maxWorkers = Math.max(normalizeMaxWorkers(pluginCfg.team?.ops?.maxAgents) ?? 20, config.workerCount);
   const resolvedRouting = buildResolvedRoutingSnapshot(pluginCfg);
   const worktreeMode: TeamWorktreeMode = normalizeTeamWorktreeMode(
     process.env.OMC_TEAM_WORKTREE_MODE ?? pluginCfg.team?.ops?.worktreeMode,
@@ -1004,7 +1016,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     policy: DEFAULT_TEAM_TRANSPORT_POLICY,
     governance: DEFAULT_TEAM_GOVERNANCE,
     worker_count: config.workerCount,
-    max_workers: 20,
+    max_workers: maxWorkers,
     workers: workersInfo,
     created_at: new Date().toISOString(),
     tmux_session: sessionName,
@@ -1053,6 +1065,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     permissions_snapshot: permissionsSnapshot,
     tmux_session: sessionName,
     worker_count: teamConfig.worker_count,
+    max_workers: teamConfig.max_workers,
     workers: workersInfo,
     next_task_id: teamConfig.next_task_id,
     created_at: teamConfig.created_at,

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -52,6 +52,7 @@ import {
   listTasks as listTasksImpl,
 } from './state/tasks.js';
 import { canonicalizeTeamConfigWorkers } from './worker-canonicalization.js';
+import { normalizeMaxWorkers } from './fanout-policy.js';
 
 // Re-export types for consumers
 export type {
@@ -200,7 +201,7 @@ function configFromManifest(manifest: TeamManifestV2): TeamConfig {
     governance: manifest.governance,
     worker_launch_mode: manifest.policy.worker_launch_mode,
     worker_count: manifest.worker_count,
-    max_workers: 20,
+    max_workers: normalizeMaxWorkers(manifest.max_workers) ?? 20,
     workers: manifest.workers,
     created_at: manifest.created_at,
     tmux_session: manifest.tmux_session,
@@ -228,7 +229,9 @@ function mergeTeamConfigSources(config: TeamConfig | null, manifest: TeamManifes
     workers: [...(config.workers ?? []), ...(manifest.workers ?? [])],
     worker_count: Math.max(config.worker_count ?? 0, manifest.worker_count ?? 0),
     next_task_id: Math.max(config.next_task_id ?? 1, manifest.next_task_id ?? 1),
-    max_workers: Math.max(config.max_workers ?? 0, 20),
+    max_workers: normalizeMaxWorkers(config.max_workers)
+      ?? normalizeMaxWorkers(manifest.max_workers)
+      ?? 20,
   });
 }
 

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -234,6 +234,7 @@ export interface TeamManifestV2 {
   permissions_snapshot: PermissionsSnapshot;
   tmux_session: string;
   worker_count: number;
+  max_workers?: number;
   workers: WorkerInfo[];
   next_task_id: number;
   created_at: string;


### PR DESCRIPTION
## Summary

Narrow follow-up to the closed adaptive fanout PRs.

This PR does **not** add adaptive resource policy, CPU/RAM/load checks, or new `OMC_TEAM_*` environment variables. It only makes the existing `team.ops.maxAgents` option act as an active-worker fanout cap while preserving all requested task backlog.

## Behavior

- Requested work/backlog remains based on the original request.
- Active worker fanout is capped by `team.ops.maxAgents`.
- Overflow tasks are assigned round-robin over the capped worker set.
- Both team command paths preserve backlog:
  - `src/cli/commands/team.ts`
  - `src/cli/team.ts` job/legacy start path

Example with `team.ops.maxAgents = 2`:

```txt
omc team 4:codex "review auth"

workers launched: 2
tasks queued: 4
owners: worker-1, worker-2, worker-1, worker-2
```

## Notes

The manifest/config `max_workers` preservation is internal runtime bookkeeping so later reads/scale-up paths do not lose the active-worker ceiling after team creation.

## Verification

- `npm run test:run -- src/team/__tests__/fanout-policy.test.ts src/cli/__tests__/team.test.ts src/cli/commands/__tests__/team-role-shorthand.test.ts src/cli/commands/__tests__/team.test.ts`
- `npx tsc --noEmit`
- `npm run lint` — existing warnings only, 0 errors
- `npm run build`
- `git diff --check upstream/dev...HEAD`
