### PR TITLE
Fix Max HUD rate limits with enterprise spend

### DIFF
--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -110,6 +110,41 @@ describe('render: rate limits display priority', () => {
     expect(output).toContain('8%');
   });
 
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['null', null],
+    ['undefined', undefined],
+  ] as const)(
+    'renders normal rate limits for Max-like responses with %s enterprise limit',
+    async (_caseName, enterpriseLimitUsd) => {
+      const context = makeContext({
+        subscriptionType: 'max',
+        rateLimitTier: null,
+        rateLimitsResult: {
+          rateLimits: {
+            fiveHourPercent: 36,
+            weeklyPercent: 32,
+            sonnetWeeklyPercent: 8,
+            enterpriseSpentUsd: 12.34,
+            enterpriseLimitUsd,
+            enterpriseCurrency: 'USD',
+          },
+        },
+      });
+
+      const output = await render(context, makeConfig());
+
+      expect(output).toContain('5h:');
+      expect(output).toContain('36%');
+      expect(output).toContain('wk:');
+      expect(output).toContain('32%');
+      expect(output).toContain('sn:');
+      expect(output).toContain('8%');
+      expect(output).not.toContain('spent:');
+    },
+  );
+
   it('shows [API 429] when error=rate_limited and rateLimits is null', async () => {
     const context = makeContext({
       rateLimitsResult: {

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -297,10 +297,20 @@ export async function render(
     }
   }
 
+  // Determine effective enterprise mode before rendering limits: only real
+  // enterprise accounts replace token-window limits with enterprise cost.
+  const isEnterprise = enabledElements.enterpriseMode !== undefined
+    ? enabledElements.enterpriseMode
+    : (
+        (context.subscriptionType ?? '').toLowerCase() === 'enterprise' ||
+        /claude_zero/i.test(context.rateLimitTier ?? '')
+      );
+
   // Rate limits (5h and weekly) - data takes priority over error indicator.
   // Skip for enterprise responses where token-window limits aren't applicable
   // (the enterpriseCost element replaces this slot for those accounts).
   const hasEnterpriseData =
+    isEnterprise &&
     context.rateLimitsResult?.rateLimits?.enterpriseSpentUsd !== undefined;
   if (enabledElements.rateLimits && context.rateLimitsResult && !hasEnterpriseData) {
     if (context.rateLimitsResult.rateLimits) {
@@ -351,14 +361,6 @@ export async function render(
       if (session) rendered.set("session", session);
     }
   }
-
-  // Determine effective enterprise mode
-  const isEnterprise = enabledElements.enterpriseMode !== undefined
-    ? enabledElements.enterpriseMode
-    : (
-        (context.subscriptionType ?? '').toLowerCase() === 'enterprise' ||
-        /claude_zero/i.test(context.rateLimitTier ?? '')
-      );
 
   if (isEnterprise && enabledElements.showEnterpriseCost !== false) {
     const stale = context.rateLimitsResult?.stale;


### PR DESCRIPTION
## Summary
- Fix HUD rate-limit suppression so non-enterprise/Max usage responses that include `enterpriseSpentUsd` still render normal 5h/weekly/Sonnet bars.
- Preserve genuine enterprise behavior by keeping enterprise cost suppression tied to the existing enterprise-mode decision.
- Add regression coverage for Max-like responses with `enterpriseLimitUsd` set to `0`, negative, `null`, or `undefined`.

Fixes #2813

## Tests
- `npm run test:run -- src/__tests__/hud/render-rate-limits-priority.test.ts src/__tests__/hud/render-enterprise.test.ts src/__tests__/hud/usage-api.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `git diff --check`

## Verification
- Ralph architect verification: APPROVED.
