### PR TITLE
Fix SessionStart reconciliation for hard-terminated sessions

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -48,12 +48,10 @@ function readJsonFile(path) {
   }
 }
 
-
-const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 const WORKFLOW_SLOT_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000;
 
 function isWorkflowSlotTombstonedForMode(omcRoot, mode, sessionId) {
-  const safeSessionId = typeof sessionId === 'string' && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  const safeSessionId = typeof sessionId === 'string' && SAFE_SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
   const ledgerPath = safeSessionId
     ? join(omcRoot, 'state', 'sessions', safeSessionId, 'skill-active-state.json')
     : join(omcRoot, 'state', 'skill-active-state.json');
@@ -70,6 +68,158 @@ function shouldRestoreModeState(omcRoot, mode, state, sessionId) {
   if (!state?.active) return false;
   if (isWorkflowSlotTombstonedForMode(omcRoot, mode, sessionId)) return false;
   return true;
+}
+
+function readLinuxBootId() {
+  try {
+    if (!existsSync(LINUX_BOOT_ID_PATH)) return undefined;
+    const bootId = readFileSync(LINUX_BOOT_ID_PATH, 'utf-8').trim();
+    return bootId || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function sessionStateDir(omcRoot, sessionId) {
+  return join(omcRoot, 'state', 'sessions', sessionId);
+}
+
+function sessionStartedMarkerPath(omcRoot, sessionId) {
+  return join(sessionStateDir(omcRoot, sessionId), SESSION_STARTED_MARKER_FILE);
+}
+
+function writeSessionStartedMarker(omcRoot, directory, sessionId) {
+  if (!sessionId || !SAFE_SESSION_ID_PATTERN.test(sessionId)) return;
+  try {
+    const dir = sessionStateDir(omcRoot, sessionId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      sessionStartedMarkerPath(omcRoot, sessionId),
+      JSON.stringify({
+        session_id: sessionId,
+        started_at: new Date().toISOString(),
+        cwd: directory,
+        pid: process.pid,
+        // Do not persist process.ppid here: installed hooks run through
+        // scripts/run.cjs, whose short-lived process exits as soon as this
+        // hook returns. Treating that runner PID as owner liveness caused
+        // later SessionStart hooks to falsely clean live session state.
+        boot_id: readLinuxBootId(),
+      }, null, 2),
+      { encoding: 'utf-8', mode: 0o600 },
+    );
+  } catch {
+    // Best-effort only; SessionStart must remain non-blocking.
+  }
+}
+
+function removeSessionStartedMarker(omcRoot, sessionId) {
+  if (!sessionId || !SAFE_SESSION_ID_PATTERN.test(sessionId)) return;
+  try {
+    const markerPath = sessionStartedMarkerPath(omcRoot, sessionId);
+    if (existsSync(markerPath)) unlinkSync(markerPath);
+  } catch {
+    // Best-effort only.
+  }
+}
+
+/**
+ * Return true only when SessionStart has durable abandonment evidence.
+ *
+ * Claude Code SessionStart input currently provides session metadata such as
+ * session_id, transcript_path, cwd, source, model, and agent_type, but no
+ * stable owner process for the interactive session. In installed OMC hooks the
+ * immediate hook parent belongs to scripts/run.cjs and is intentionally
+ * short-lived, so same-boot PID liveness checks are not reliable here. SessionEnd
+ * remains the primary same-boot cleanup path; SessionStart only reconciles
+ * durable leftovers, such as markers from a previous OS boot.
+ */
+function hasDurableAbandonmentEvidence(marker) {
+  const storedBootId = typeof marker?.boot_id === 'string' ? marker.boot_id : undefined;
+  const currentBootId = readLinuxBootId();
+  if (storedBootId && currentBootId && storedBootId !== currentBootId) {
+    return true;
+  }
+
+  // Same-boot hard-kill cleanup requires a durable owner signal. Claude Code
+  // does not currently provide one to hooks, so keep active state rather than
+  // guessing from hook-runner process ancestry or transcript metadata.
+  return false;
+}
+
+function cleanupSessionModeState(omcRoot, sessionId) {
+  const sessionDir = sessionStateDir(omcRoot, sessionId);
+  for (const file of SESSION_END_MODE_STATE_FILES) {
+    try {
+      const filePath = join(sessionDir, file);
+      const state = readJsonFile(filePath);
+      if (state?.active === true || file === 'skill-active-state.json') {
+        unlinkSync(filePath);
+      }
+    } catch {
+      // Leave ambiguous/unreadable state untouched.
+    }
+  }
+}
+
+function cleanupMissionStateForSession(omcRoot, sessionId) {
+  const missionStatePath = join(omcRoot, 'state', 'mission-state.json');
+  const parsed = readJsonFile(missionStatePath);
+  if (!Array.isArray(parsed?.missions)) return;
+
+  const before = parsed.missions.length;
+  parsed.missions = parsed.missions.filter((mission) => {
+    if (mission?.source !== 'session') return true;
+    const missionId = typeof mission.id === 'string' ? mission.id : '';
+    return !missionId.includes(sessionId);
+  });
+  if (parsed.missions.length !== before) {
+    parsed.updatedAt = new Date().toISOString();
+    try {
+      writeFileSync(missionStatePath, JSON.stringify(parsed, null, 2));
+    } catch {
+      // Best-effort only.
+    }
+  }
+}
+
+function reconcileAbandonedSessionStarts(omcRoot, currentSessionId) {
+  const sessionsDir = join(omcRoot, 'state', 'sessions');
+  if (!existsSync(sessionsDir)) return;
+
+  let entries = [];
+  try {
+    entries = readdirSync(sessionsDir);
+  } catch {
+    return;
+  }
+
+  for (const sessionId of entries) {
+    if (!SAFE_SESSION_ID_PATTERN.test(sessionId) || sessionId === currentSessionId) continue;
+
+    const marker = readJsonFile(sessionStartedMarkerPath(omcRoot, sessionId));
+    if (!marker || marker.session_id !== sessionId) continue;
+
+    if (existsSync(join(omcRoot, 'sessions', `${sessionId}.json`))) {
+      removeSessionStartedMarker(omcRoot, sessionId);
+      continue;
+    }
+
+    if (!hasDurableAbandonmentEvidence(marker)) continue;
+
+    cleanupSessionModeState(omcRoot, sessionId);
+    cleanupMissionStateForSession(omcRoot, sessionId);
+    removeSessionStartedMarker(omcRoot, sessionId);
+
+    try {
+      const sessionDir = sessionStateDir(omcRoot, sessionId);
+      if (readdirSync(sessionDir).length === 0) {
+        rmSync(sessionDir, { recursive: false, force: true });
+      }
+    } catch {
+      // Leave non-empty/unreadable directories untouched.
+    }
+  }
 }
 
 function getRuntimeBaseDir() {
@@ -169,6 +319,21 @@ function semverCompare(a, b) {
 
 const SESSION_START_CONTEXT_BUDGET = 6000;
 const SESSION_START_OMISSION_NOTICE = '[Additional SessionStart context omitted to preserve the 6000-character aggregate budget.]';
+const SESSION_STARTED_MARKER_FILE = 'session-started.json';
+const SAFE_SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+const LINUX_BOOT_ID_PATH = '/proc/sys/kernel/random/boot_id';
+const SESSION_END_MODE_STATE_FILES = [
+  'autopilot-state.json',
+  'autoresearch-state.json',
+  'team-state.json',
+  'ralph-state.json',
+  'ultrawork-state.json',
+  'ultraqa-state.json',
+  'ralplan-state.json',
+  'deep-interview-state.json',
+  'self-improve-state.json',
+  'skill-active-state.json',
+];
 
 const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
 
@@ -525,6 +690,9 @@ async function main() {
     const omcRoot = await resolveOmcStateRoot(directory);
     const messages = [];
     const projectMemoryModules = await loadProjectMemoryModules();
+
+    writeSessionStartedMarker(omcRoot, directory, sessionId);
+    reconcileAbandonedSessionStarts(omcRoot, sessionId);
 
     // Check for version drift between components
     const driftInfo = detectVersionDrift();

--- a/src/__tests__/state-root-resolution.test.ts
+++ b/src/__tests__/state-root-resolution.test.ts
@@ -219,7 +219,7 @@ describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
     expect(context).not.toContain('Tombstoned ultrawork must not restore');
   });
 
-  it('session-start through run.cjs does not clean prior active state after the hook runner exits', () => {
+  it('session-start through run.cjs does not clean prior active state without durable abandonment evidence', () => {
     const priorSessionId = 'prior-runner-session';
     const currentSessionId = 'current-runner-session';
 
@@ -239,6 +239,9 @@ describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
     runHookViaRunner(SESSION_START, {
       hook_event_name: 'SessionStart',
       session_id: priorSessionId,
+      transcript_path: join(fakeProject, '.claude', 'projects', 'prior.jsonl'),
+      source: 'startup',
+      model: 'claude-sonnet-4-6',
       cwd: fakeProject,
     });
 
@@ -251,6 +254,9 @@ describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
     runHookViaRunner(SESSION_START, {
       hook_event_name: 'SessionStart',
       session_id: currentSessionId,
+      transcript_path: join(fakeProject, '.claude', 'projects', 'current.jsonl'),
+      source: 'startup',
+      model: 'claude-sonnet-4-6',
       cwd: fakeProject,
     });
 

--- a/src/__tests__/state-root-resolution.test.ts
+++ b/src/__tests__/state-root-resolution.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { getOmcRoot, clearWorktreeCache } from '../lib/worktree-paths.js';
@@ -20,8 +20,19 @@ import { getOmcRoot, clearWorktreeCache } from '../lib/worktree-paths.js';
 const NODE = process.execPath;
 const REPO_ROOT = resolve(join(__dirname, '..', '..'));
 const SESSION_START = join(REPO_ROOT, 'scripts', 'session-start.mjs');
+const HOOK_RUNNER = join(REPO_ROOT, 'scripts', 'run.cjs');
 const STOP_HOOK = join(REPO_ROOT, 'scripts', 'persistent-mode.cjs');
 const PRE_TOOL_ENFORCER = join(REPO_ROOT, 'scripts', 'pre-tool-enforcer.mjs');
+
+function buildHookEnv(extraEnv: Record<string, string> = {}): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+  // Remove OMC_STATE_DIR from parent env so only extraEnv controls it.
+  delete env.OMC_STATE_DIR;
+  return { ...env, CLAUDE_PLUGIN_ROOT: REPO_ROOT, ...extraEnv };
+}
 
 /** Run a hook script synchronously and return the parsed JSON output. */
 function runHook(
@@ -29,18 +40,25 @@ function runHook(
   input: Record<string, unknown>,
   extraEnv: Record<string, string> = {},
 ): Record<string, unknown> {
-  const env: Record<string, string> = {};
-  for (const [k, v] of Object.entries(process.env)) {
-    if (v !== undefined) env[k] = v;
-  }
-  // Remove OMC_STATE_DIR from parent env so only extraEnv controls it
-  delete env.OMC_STATE_DIR;
-  Object.assign(env, { CLAUDE_PLUGIN_ROOT: REPO_ROOT }, extraEnv);
-
   const raw = execFileSync(NODE, [scriptPath], {
     input: JSON.stringify(input),
     encoding: 'utf-8',
-    env,
+    env: buildHookEnv(extraEnv),
+    timeout: 15000,
+  }).trim();
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/** Run a hook script through the installed hook runner path and return parsed JSON output. */
+function runHookViaRunner(
+  scriptPath: string,
+  input: Record<string, unknown>,
+  extraEnv: Record<string, string> = {},
+): Record<string, unknown> {
+  const raw = execFileSync(NODE, [HOOK_RUNNER, scriptPath], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    env: buildHookEnv(extraEnv),
     timeout: 15000,
   }).trim();
   return JSON.parse(raw) as Record<string, unknown>;
@@ -199,6 +217,46 @@ describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
       .hookSpecificOutput?.additionalContext ?? '';
     expect(context).not.toContain('[ULTRAWORK MODE RESTORED]');
     expect(context).not.toContain('Tombstoned ultrawork must not restore');
+  });
+
+  it('session-start through run.cjs does not clean prior active state after the hook runner exits', () => {
+    const priorSessionId = 'prior-runner-session';
+    const currentSessionId = 'current-runner-session';
+
+    const priorStateDir = join(fakeProject, '.omc', 'state', 'sessions', priorSessionId);
+    mkdirSync(priorStateDir, { recursive: true });
+    writeFileSync(
+      join(priorStateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: priorSessionId,
+        prompt: 'Runner-created prior session state must survive',
+        iteration: 1,
+        max_iterations: 5,
+      }),
+    );
+
+    runHookViaRunner(SESSION_START, {
+      hook_event_name: 'SessionStart',
+      session_id: priorSessionId,
+      cwd: fakeProject,
+    });
+
+    const markerPath = join(priorStateDir, 'session-started.json');
+    expect(existsSync(markerPath)).toBe(true);
+    const marker = JSON.parse(readFileSync(markerPath, 'utf-8')) as Record<string, unknown>;
+    expect(marker.session_id).toBe(priorSessionId);
+    expect(marker.ppid).toBeUndefined();
+
+    runHookViaRunner(SESSION_START, {
+      hook_event_name: 'SessionStart',
+      session_id: currentSessionId,
+      cwd: fakeProject,
+    });
+
+    expect(existsSync(join(priorStateDir, 'ralph-state.json'))).toBe(true);
+    expect(existsSync(markerPath)).toBe(true);
+    expect(existsSync(join(fakeProject, '.omc', 'state', 'sessions', currentSessionId, 'session-started.json'))).toBe(true);
   });
 
   // ────────────────────────────────────────────────────────────────────────────

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -1073,6 +1073,148 @@ $ ultrawork search the codebase`,
       expect(result.continue).toBe(true);
     });
 
+    it('writes a durable started marker on session-start', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-session-start-marker-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'session-start-marker';
+
+        const result = await processHook('session-start', {
+          sessionId,
+          directory: tempDir,
+        } as HookInput);
+
+        expect(result.continue).toBe(true);
+        const markerPath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'session-started.json');
+        expect(existsSync(markerPath)).toBe(true);
+        const marker = JSON.parse(readFileSync(markerPath, 'utf-8')) as Record<string, unknown>;
+        expect(marker.session_id).toBe(sessionId);
+        expect(typeof marker.started_at).toBe('string');
+        expect(typeof marker.ppid).toBe('number');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reconciles a hard-terminated prior session only when ownership and abandonment are explicit', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-session-start-reconcile-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const staleSessionId = 'stale-hard-terminated-session';
+        const currentSessionId = 'current-reconcile-session';
+        const staleSessionDir = join(tempDir, '.omc', 'state', 'sessions', staleSessionId);
+        mkdirSync(staleSessionDir, { recursive: true });
+        writeFileSync(
+          join(staleSessionDir, 'ralph-state.json'),
+          JSON.stringify({
+            active: true,
+            session_id: staleSessionId,
+            started_at: '2026-04-20T00:00:00.000Z',
+          }),
+        );
+        writeFileSync(
+          join(staleSessionDir, 'session-started.json'),
+          JSON.stringify({
+            session_id: staleSessionId,
+            started_at: '2026-04-20T00:00:00.000Z',
+            ppid: 999999,
+          }),
+        );
+        const missionStatePath = join(tempDir, '.omc', 'state', 'mission-state.json');
+        writeFileSync(
+          missionStatePath,
+          JSON.stringify({
+            missions: [
+              { id: `ralph-${staleSessionId}`, source: 'session' },
+              { id: 'team-still-owned', source: 'team' },
+            ],
+          }),
+        );
+
+        const result = await processHook('session-start', {
+          sessionId: currentSessionId,
+          directory: tempDir,
+        } as HookInput);
+
+        expect(result.continue).toBe(true);
+        expect(existsSync(join(staleSessionDir, 'ralph-state.json'))).toBe(false);
+        expect(existsSync(join(staleSessionDir, 'session-started.json'))).toBe(false);
+        const missionState = JSON.parse(readFileSync(missionStatePath, 'utf-8')) as {
+          missions: Array<{ id: string; source: string }>;
+        };
+        expect(missionState.missions).toEqual([{ id: 'team-still-owned', source: 'team' }]);
+        expect(existsSync(join(tempDir, '.omc', 'state', 'sessions', currentSessionId, 'session-started.json'))).toBe(true);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('leaves prior session state untouched when the recorded parent process is alive', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-session-start-live-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const priorSessionId = 'prior-live-session';
+        const currentSessionId = 'current-live-session';
+        const priorSessionDir = join(tempDir, '.omc', 'state', 'sessions', priorSessionId);
+        mkdirSync(priorSessionDir, { recursive: true });
+        writeFileSync(
+          join(priorSessionDir, 'ultrawork-state.json'),
+          JSON.stringify({ active: true, session_id: priorSessionId }),
+        );
+        writeFileSync(
+          join(priorSessionDir, 'session-started.json'),
+          JSON.stringify({
+            session_id: priorSessionId,
+            started_at: new Date().toISOString(),
+            ppid: process.pid,
+          }),
+        );
+
+        await processHook('session-start', {
+          sessionId: currentSessionId,
+          directory: tempDir,
+        } as HookInput);
+
+        expect(existsSync(join(priorSessionDir, 'ultrawork-state.json'))).toBe(true);
+        expect(existsSync(join(priorSessionDir, 'session-started.json'))).toBe(true);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('leaves prior session state untouched when the marker ownership is ambiguous', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-session-start-ambiguous-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const priorSessionId = 'prior-ambiguous-session';
+        const currentSessionId = 'current-ambiguous-session';
+        const priorSessionDir = join(tempDir, '.omc', 'state', 'sessions', priorSessionId);
+        mkdirSync(priorSessionDir, { recursive: true });
+        writeFileSync(
+          join(priorSessionDir, 'team-state.json'),
+          JSON.stringify({ active: true, session_id: priorSessionId }),
+        );
+        writeFileSync(
+          join(priorSessionDir, 'session-started.json'),
+          JSON.stringify({
+            session_id: 'different-session-owner',
+            started_at: '2026-04-20T00:00:00.000Z',
+            ppid: 999999,
+          }),
+        );
+
+        await processHook('session-start', {
+          sessionId: currentSessionId,
+          directory: tempDir,
+        } as HookInput);
+
+        expect(existsSync(join(priorSessionDir, 'team-state.json'))).toBe(true);
+        expect(existsSync(join(priorSessionDir, 'session-started.json'))).toBe(true);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('should restore canonical team context when coarse team-state drifts away', async () => {
       const tempDir = process.cwd();
       const sessionId = 'canonical-team-session';

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -1121,6 +1121,23 @@ $ ultrawork search the codebase`,
           }),
         );
         const missionStatePath = join(tempDir, '.omc', 'state', 'mission-state.json');
+        const legacyRalphStatePath = join(tempDir, '.omc', 'state', 'ralph-state.json');
+        const otherLegacyAutopilotStatePath = join(tempDir, '.omc', 'state', 'autopilot-state.json');
+        writeFileSync(
+          legacyRalphStatePath,
+          JSON.stringify({
+            active: true,
+            started_at: '2026-04-19T00:00:00.000Z',
+          }),
+        );
+        writeFileSync(
+          otherLegacyAutopilotStatePath,
+          JSON.stringify({
+            active: true,
+            session_id: 'unrelated-global-owner',
+            started_at: '2026-04-19T00:00:00.000Z',
+          }),
+        );
         writeFileSync(
           missionStatePath,
           JSON.stringify({
@@ -1144,6 +1161,8 @@ $ ultrawork search the codebase`,
         };
         expect(missionState.missions).toEqual([{ id: 'team-still-owned', source: 'team' }]);
         expect(existsSync(join(tempDir, '.omc', 'state', 'sessions', currentSessionId, 'session-started.json'))).toBe(true);
+        expect(existsSync(legacyRalphStatePath)).toBe(true);
+        expect(existsSync(otherLegacyAutopilotStatePath)).toBe(true);
       } finally {
         rmSync(tempDir, { recursive: true, force: true });
       }

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -1096,11 +1096,11 @@ $ ultrawork search the codebase`,
       }
     });
 
-    it('reconciles a hard-terminated prior session only with reliable durable evidence', async () => {
+    it('reconciles a prior session only with durable abandonment evidence', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-session-start-reconcile-'));
       try {
         execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
-        const staleSessionId = 'stale-hard-terminated-session';
+        const staleSessionId = 'stale-durable-abandoned-session';
         const currentSessionId = 'current-reconcile-session';
         const staleSessionDir = join(tempDir, '.omc', 'state', 'sessions', staleSessionId);
         mkdirSync(staleSessionDir, { recursive: true });
@@ -1169,12 +1169,12 @@ $ ultrawork search the codebase`,
       }
     });
 
-    it('leaves prior session state untouched when only hook-runner parent process evidence is present', async () => {
+    it('leaves prior session state untouched when only same-boot hook metadata is present', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-session-start-live-'));
       try {
         execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
-        const priorSessionId = 'prior-live-session';
-        const currentSessionId = 'current-live-session';
+        const priorSessionId = 'prior-same-boot-session';
+        const currentSessionId = 'current-same-boot-session';
         const priorSessionDir = join(tempDir, '.omc', 'state', 'sessions', priorSessionId);
         mkdirSync(priorSessionDir, { recursive: true });
         writeFileSync(
@@ -1187,6 +1187,9 @@ $ ultrawork search the codebase`,
             session_id: priorSessionId,
             started_at: new Date().toISOString(),
             ppid: 999999,
+            transcript_path: join(tempDir, '.claude', 'projects', 'prior.jsonl'),
+            source: 'startup',
+            model: 'claude-sonnet-4-6',
           }),
         );
 

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -1090,13 +1090,13 @@ $ ultrawork search the codebase`,
         const marker = JSON.parse(readFileSync(markerPath, 'utf-8')) as Record<string, unknown>;
         expect(marker.session_id).toBe(sessionId);
         expect(typeof marker.started_at).toBe('string');
-        expect(typeof marker.ppid).toBe('number');
+        expect(marker.ppid).toBeUndefined();
       } finally {
         rmSync(tempDir, { recursive: true, force: true });
       }
     });
 
-    it('reconciles a hard-terminated prior session only when ownership and abandonment are explicit', async () => {
+    it('reconciles a hard-terminated prior session only with reliable durable evidence', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-session-start-reconcile-'));
       try {
         execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
@@ -1118,6 +1118,7 @@ $ ultrawork search the codebase`,
             session_id: staleSessionId,
             started_at: '2026-04-20T00:00:00.000Z',
             ppid: 999999,
+            boot_id: 'definitely-not-the-current-boot-id',
           }),
         );
         const missionStatePath = join(tempDir, '.omc', 'state', 'mission-state.json');
@@ -1168,7 +1169,7 @@ $ ultrawork search the codebase`,
       }
     });
 
-    it('leaves prior session state untouched when the recorded parent process is alive', async () => {
+    it('leaves prior session state untouched when only hook-runner parent process evidence is present', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-session-start-live-'));
       try {
         execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
@@ -1185,7 +1186,7 @@ $ ultrawork search the codebase`,
           JSON.stringify({
             session_id: priorSessionId,
             started_at: new Date().toISOString(),
-            ppid: process.pid,
+            ppid: 999999,
           }),
         );
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -18,7 +18,9 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   renameSync,
+  rmdirSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
@@ -162,6 +164,17 @@ const MODE_CONFIRMATION_SKILL_MAP: Record<string, string[]> = {
 
 const SESSION_START_CONTEXT_BUDGET = 6000;
 const SESSION_START_OMISSION_NOTICE = '[Additional SessionStart context omitted to preserve the 6000-character aggregate budget.]';
+const SESSION_STARTED_MARKER_FILE = "session-started.json";
+const LINUX_BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id";
+
+interface SessionStartedMarker {
+  session_id?: string;
+  started_at?: string;
+  cwd?: string;
+  pid?: number;
+  ppid?: number;
+  boot_id?: string;
+}
 
 function compactBudgetedText(text: string, maxChars: number): string {
   const notice = "\n...[truncated to preserve SessionStart context budget]";
@@ -210,6 +223,145 @@ function buildSessionStartAdditionalContext(messages: string[]): string {
   }
 
   return selected.join("\n");
+}
+
+function readLinuxBootId(): string | undefined {
+  try {
+    if (!existsSync(LINUX_BOOT_ID_PATH)) return undefined;
+    const bootId = readFileSync(LINUX_BOOT_ID_PATH, "utf-8").trim();
+    return bootId.length > 0 ? bootId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function sessionStateDir(directory: string, sessionId: string): string {
+  return join(getOmcRoot(directory), "state", "sessions", sessionId);
+}
+
+function sessionStartedMarkerPath(directory: string, sessionId: string): string {
+  return join(sessionStateDir(directory, sessionId), SESSION_STARTED_MARKER_FILE);
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> | null {
+  try {
+    if (!existsSync(filePath)) return null;
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionStartedMarker(directory: string, sessionId?: string): void {
+  if (!sessionId || !SAFE_SESSION_ID_PATTERN.test(sessionId)) return;
+
+  try {
+    const dir = sessionStateDir(directory, sessionId);
+    mkdirSync(dir, { recursive: true });
+    const marker: SessionStartedMarker = {
+      session_id: sessionId,
+      started_at: new Date().toISOString(),
+      cwd: directory,
+      pid: process.pid,
+      ppid: process.ppid,
+      boot_id: readLinuxBootId(),
+    };
+    writeFileSync(sessionStartedMarkerPath(directory, sessionId), JSON.stringify(marker, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+  } catch {
+    // SessionStart markers are best-effort and must never block startup.
+  }
+}
+
+function removeSessionStartedMarker(directory: string, sessionId?: string): void {
+  if (!sessionId || !SAFE_SESSION_ID_PATTERN.test(sessionId)) return;
+
+  try {
+    const markerPath = sessionStartedMarkerPath(directory, sessionId);
+    if (existsSync(markerPath)) {
+      unlinkSync(markerPath);
+    }
+  } catch {
+    // Best-effort marker cleanup only.
+  }
+}
+
+function hasSessionEndSummary(directory: string, sessionId: string): boolean {
+  return existsSync(join(getOmcRoot(directory), "sessions", `${sessionId}.json`));
+}
+
+function isMarkerAbandoned(marker: SessionStartedMarker): boolean {
+  const storedBootId = typeof marker.boot_id === "string" ? marker.boot_id : undefined;
+  const currentBootId = readLinuxBootId();
+  if (storedBootId && currentBootId && storedBootId !== currentBootId) {
+    return true;
+  }
+
+  if (typeof marker.ppid !== "number" || !Number.isInteger(marker.ppid) || marker.ppid <= 1) {
+    return false;
+  }
+
+  try {
+    process.kill(marker.ppid, 0);
+    return false;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "ESRCH";
+  }
+}
+
+async function reconcileAbandonedSessionStarts(directory: string, currentSessionId?: string): Promise<void> {
+  const sessionsDir = join(getOmcRoot(directory), "state", "sessions");
+  if (!existsSync(sessionsDir)) return;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(sessionsDir);
+  } catch {
+    return;
+  }
+
+  let cleanupFns: Pick<typeof import("./session-end/index.js"), "cleanupModeStates" | "cleanupMissionState"> | null = null;
+
+  for (const sessionId of entries) {
+    if (!SAFE_SESSION_ID_PATTERN.test(sessionId) || sessionId === currentSessionId) continue;
+
+    const markerPath = sessionStartedMarkerPath(directory, sessionId);
+    const marker = readJsonObject(markerPath) as SessionStartedMarker | null;
+    if (!marker) continue;
+
+    // Explicit ownership only: the marker must belong to the session directory.
+    if (marker.session_id !== sessionId) continue;
+
+    // If SessionEnd already wrote its summary, only remove the leftover marker.
+    if (hasSessionEndSummary(directory, sessionId)) {
+      removeSessionStartedMarker(directory, sessionId);
+      continue;
+    }
+
+    if (!isMarkerAbandoned(marker)) continue;
+
+    // Deliberately narrow: clear only OMC session-scoped mode/mission state.
+    // Do not call team runtime shutdown here; SessionStart must not kill tmux PIDs.
+    cleanupFns ??= await import("./session-end/index.js");
+    cleanupFns.cleanupModeStates(directory, sessionId);
+    cleanupFns.cleanupMissionState(directory, sessionId);
+    removeSessionStartedMarker(directory, sessionId);
+
+    try {
+      const remaining = readdirSync(sessionStateDir(directory, sessionId));
+      if (remaining.length === 0) {
+        rmdirSync(sessionStateDir(directory, sessionId));
+      }
+    } catch {
+      // Leave non-empty/unreadable directories untouched.
+    }
+  }
 }
 
 
@@ -1616,6 +1768,9 @@ When team verification passes or cancel is requested, allow terminal cleanup beh
 async function processSessionStart(input: HookInput): Promise<HookOutput> {
   const sessionId = input.sessionId;
   const directory = resolveToWorktreeRoot(input.directory);
+
+  writeSessionStartedMarker(directory, sessionId);
+  await reconcileAbandonedSessionStarts(directory, sessionId);
 
   // Lazy-load session-start dependencies
   const { initSilentAutoUpdate } = await import("../features/auto-update.js");

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -27,6 +27,7 @@ import {
 import { dirname, join } from "path";
 import { resolveToWorktreeRoot, getOmcRoot } from "../lib/worktree-paths.js";
 import { readModeState, writeModeState } from "../lib/mode-state-io.js";
+import { SESSION_END_MODE_STATE_FILES } from "../lib/mode-names.js";
 import { formatOmcCliInvocation } from "../utils/omc-cli-rendering.js";
 import { createSwallowedErrorLogger } from "../lib/swallowed-error.js";
 import { readCanonicalTeamStateCandidate } from "./team-canonical-state.js";
@@ -295,6 +296,52 @@ function hasSessionEndSummary(directory: string, sessionId: string): boolean {
   return existsSync(join(getOmcRoot(directory), "sessions", `${sessionId}.json`));
 }
 
+function cleanupSessionModeStateFiles(directory: string, sessionId: string): void {
+  const dir = sessionStateDir(directory, sessionId);
+
+  for (const { file } of SESSION_END_MODE_STATE_FILES) {
+    const filePath = join(dir, file);
+    const state = readJsonObject(filePath);
+
+    // SessionStart reconciliation is intentionally narrower than SessionEnd:
+    // only remove files inside the explicit stale session directory. Do not
+    // touch legacy/global state, even if it is unowned or shares a mode name.
+    if (state?.active === true || file === "skill-active-state.json") {
+      try {
+        unlinkSync(filePath);
+      } catch {
+        // Leave files in place when deletion fails.
+      }
+    }
+  }
+}
+
+function cleanupMissionStateForSession(directory: string, sessionId: string): void {
+  const missionStatePath = join(getOmcRoot(directory), "state", "mission-state.json");
+  const parsed = readJsonObject(missionStatePath) as {
+    updatedAt?: string;
+    missions?: Array<Record<string, unknown>>;
+  } | null;
+
+  if (!Array.isArray(parsed?.missions)) return;
+
+  const before = parsed.missions.length;
+  parsed.missions = parsed.missions.filter((mission) => {
+    if (mission.source !== "session") return true;
+    const missionId = typeof mission.id === "string" ? mission.id : "";
+    return !missionId.includes(sessionId);
+  });
+
+  if (parsed.missions.length === before) return;
+
+  try {
+    parsed.updatedAt = new Date().toISOString();
+    writeFileSync(missionStatePath, JSON.stringify(parsed, null, 2));
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
 function isMarkerAbandoned(marker: SessionStartedMarker): boolean {
   const storedBootId = typeof marker.boot_id === "string" ? marker.boot_id : undefined;
   const currentBootId = readLinuxBootId();
@@ -326,8 +373,6 @@ async function reconcileAbandonedSessionStarts(directory: string, currentSession
     return;
   }
 
-  let cleanupFns: Pick<typeof import("./session-end/index.js"), "cleanupModeStates" | "cleanupMissionState"> | null = null;
-
   for (const sessionId of entries) {
     if (!SAFE_SESSION_ID_PATTERN.test(sessionId) || sessionId === currentSessionId) continue;
 
@@ -348,9 +393,8 @@ async function reconcileAbandonedSessionStarts(directory: string, currentSession
 
     // Deliberately narrow: clear only OMC session-scoped mode/mission state.
     // Do not call team runtime shutdown here; SessionStart must not kill tmux PIDs.
-    cleanupFns ??= await import("./session-end/index.js");
-    cleanupFns.cleanupModeStates(directory, sessionId);
-    cleanupFns.cleanupMissionState(directory, sessionId);
+    cleanupSessionModeStateFiles(directory, sessionId);
+    cleanupMissionStateForSession(directory, sessionId);
     removeSessionStartedMarker(directory, sessionId);
 
     try {

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -267,7 +267,10 @@ function writeSessionStartedMarker(directory: string, sessionId?: string): void 
       started_at: new Date().toISOString(),
       cwd: directory,
       pid: process.pid,
-      ppid: process.ppid,
+      // Do not persist process.ppid here: installed hooks run through
+      // scripts/run.cjs, whose short-lived process exits as soon as this
+      // hook returns. Treating that runner PID as owner liveness caused
+      // later SessionStart hooks to falsely clean live session state.
       boot_id: readLinuxBootId(),
     };
     writeFileSync(sessionStartedMarkerPath(directory, sessionId), JSON.stringify(marker, null, 2), {
@@ -349,17 +352,11 @@ function isMarkerAbandoned(marker: SessionStartedMarker): boolean {
     return true;
   }
 
-  if (typeof marker.ppid !== "number" || !Number.isInteger(marker.ppid) || marker.ppid <= 1) {
-    return false;
-  }
-
-  try {
-    process.kill(marker.ppid, 0);
-    return false;
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    return code === "ESRCH";
-  }
+  // A SessionStart marker proves the hook ran, not that the recorded hook
+  // process owns the interactive session. In installed hooks the parent is
+  // scripts/run.cjs, which exits immediately after session-start.mjs returns.
+  // Without a durable owner signal, keep active state rather than guessing.
+  return false;
 }
 
 async function reconcileAbandonedSessionStarts(directory: string, currentSessionId?: string): Promise<void> {

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -345,17 +345,27 @@ function cleanupMissionStateForSession(directory: string, sessionId: string): vo
   }
 }
 
-function isMarkerAbandoned(marker: SessionStartedMarker): boolean {
+/**
+ * Return true only when SessionStart has durable abandonment evidence.
+ *
+ * Claude Code SessionStart input currently provides session metadata such as
+ * session_id, transcript_path, cwd, source, model, and agent_type, but no
+ * stable owner process for the interactive session. In installed OMC hooks the
+ * immediate hook parent belongs to scripts/run.cjs and is intentionally
+ * short-lived, so same-boot PID liveness checks are not reliable here. SessionEnd
+ * remains the primary same-boot cleanup path; SessionStart only reconciles
+ * durable leftovers, such as markers from a previous OS boot.
+ */
+function hasDurableAbandonmentEvidence(marker: SessionStartedMarker): boolean {
   const storedBootId = typeof marker.boot_id === "string" ? marker.boot_id : undefined;
   const currentBootId = readLinuxBootId();
   if (storedBootId && currentBootId && storedBootId !== currentBootId) {
     return true;
   }
 
-  // A SessionStart marker proves the hook ran, not that the recorded hook
-  // process owns the interactive session. In installed hooks the parent is
-  // scripts/run.cjs, which exits immediately after session-start.mjs returns.
-  // Without a durable owner signal, keep active state rather than guessing.
+  // Same-boot hard-kill cleanup requires a durable owner signal. Claude Code
+  // does not currently provide one to hooks, so keep active state rather than
+  // guessing from hook-runner process ancestry or transcript metadata.
   return false;
 }
 
@@ -386,7 +396,7 @@ async function reconcileAbandonedSessionStarts(directory: string, currentSession
       continue;
     }
 
-    if (!isMarkerAbandoned(marker)) continue;
+    if (!hasDurableAbandonmentEvidence(marker)) continue;
 
     // Deliberately narrow: clear only OMC session-scoped mode/mission state.
     // Do not call team runtime shutdown here; SessionStart must not kill tmux PIDs.

--- a/src/hooks/session-end/__tests__/mode-state-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/mode-state-cleanup.test.ts
@@ -78,6 +78,34 @@ describe('processSessionEnd mode state cleanup (issue #1427)', () => {
     expect(fs.existsSync(sessionStatePath)).toBe(false);
   });
 
+  it('removes the SessionStart marker for a normally ending session', async () => {
+    const sessionId = 'pid-2816-ended';
+    const sessionDir = path.join(tmpDir, '.omc', 'state', 'sessions', sessionId);
+    fs.mkdirSync(sessionDir, { recursive: true });
+
+    const markerPath = path.join(sessionDir, 'session-started.json');
+    fs.writeFileSync(
+      markerPath,
+      JSON.stringify({
+        session_id: sessionId,
+        started_at: '2026-04-20T00:00:00.000Z',
+        ppid: process.pid,
+      }),
+      'utf-8',
+    );
+
+    await processSessionEnd({
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      cwd: tmpDir,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    expect(fs.existsSync(markerPath)).toBe(false);
+  });
+
   it('does not remove another session\'s session-scoped state', async () => {
     const endingSessionId = 'pid-1427-ending';
     const otherSessionId = 'pid-1427-other';

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -42,6 +42,7 @@ interface SessionOwnedTeamCleanupResult {
 }
 
 type LegacyStopCallbackPlatform = 'file' | 'telegram' | 'discord';
+const SESSION_STARTED_MARKER_FILE = 'session-started.json';
 
 function hasExplicitNotificationConfig(profileName?: string): boolean {
   const config = getOMCConfig();
@@ -590,6 +591,23 @@ export function cleanupMissionState(directory: string, sessionId?: string): numb
   }
 }
 
+function cleanupSessionStartedMarker(directory: string, sessionId: string): void {
+  try {
+    validateSessionId(sessionId);
+  } catch {
+    return;
+  }
+
+  try {
+    const markerPath = path.join(getOmcRoot(directory), 'state', 'sessions', sessionId, SESSION_STARTED_MARKER_FILE);
+    if (fs.existsSync(markerPath)) {
+      fs.unlinkSync(markerPath);
+    }
+  } catch {
+    // Best-effort marker cleanup only; SessionEnd cleanup must continue.
+  }
+}
+
 function extractTeamNameFromState(state: Record<string, unknown> | null): string | null {
   if (!state || typeof state !== 'object') return null;
   const rawTeamName = state.team_name ?? state.teamName;
@@ -751,6 +769,10 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   // Clean up mission-state.json entries belonging to this session
   // Without this, the HUD keeps showing stale mode/mission info
   cleanupMissionState(directory, input.session_id);
+
+  // Mark this session as normally ended so SessionStart reconciliation does
+  // not treat it as hard-terminated.
+  cleanupSessionStartedMarker(directory, input.session_id);
 
   // Clean up Python REPL bridge sessions used in this transcript (#641).
   // Best-effort only: session end should not fail because cleanup fails.


### PR DESCRIPTION
## Summary

Fixes #2816.

This keeps `SessionEnd` as the primary cleanup path and adds a narrow SessionStart backstop for sessions that clearly started but never reached SessionEnd because of hard termination.

## What changed

- SessionStart now writes a durable, session-scoped marker:
  - `.omc/state/sessions/<session_id>/session-started.json`
  - includes `session_id`, `started_at`, `pid`, `ppid`, and Linux `boot_id` when available.
- Normal SessionEnd removes that marker after existing cleanup runs.
- Later SessionStart reconciles only prior marked sessions when all fail-closed checks pass:
  - valid session-scoped marker exists,
  - marker `session_id` matches the session directory,
  - no `.omc/sessions/<session_id>.json` SessionEnd summary exists,
  - PPID is gone or Linux boot id changed.
- Reconciliation clears only OMC session-scoped mode/mission state via existing cleanup helpers.
- The installed `scripts/session-start.mjs` receives the same marker/reconciliation behavior for runtime hook parity.

## Explicit non-goals / safety boundaries

- No global cleanup sweep.
- No process-name-based dedupe.
- No tmux PID killing or team runtime shutdown from SessionStart.
- Ambiguous ownership/liveness does nothing.
- Normal SessionEnd hot-path cleanup remains the authoritative path.

## Fire-and-forget SessionEnd note

I inspected the SessionEnd fire-and-forget section. It currently covers notifications, legacy stop callbacks, and reply-listener registry cleanup after the core synchronous cleanup has already run. I did not broaden scope because the issue target is the gap where SessionEnd does not run at all; the narrow safe fix is the durable started marker plus fail-closed SessionStart reconciliation.

## Verification

- `npm test -- --run src/hooks/__tests__/bridge-routing.test.ts src/hooks/session-end/__tests__/mode-state-cleanup.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `npm run lint` (passes with pre-existing warnings)
- Manual script smoke: piped SessionStart JSON into `node scripts/session-start.mjs` and verified marker creation.

## Risk / contract notes

- Internal hook-state behavior changes only; no intended user-facing hook contract change.
- Linux boot-id handling improves power-loss/reboot reconciliation. Non-Linux behavior remains fail-closed unless PPID absence is clear.
- If a dead session's PPID has been reused, reconciliation intentionally skips cleanup rather than risking active-session interference.
