### PR TITLE
fix(hud): preserve Pro/Max rate limits with zero enterprise spend

### DIFF
--- a/dist/hud/render.js
+++ b/dist/hud/render.js
@@ -237,11 +237,20 @@ export async function render(context, config) {
             rendered.set("omcLabel", bold(`[OMC${versionTag}]`));
         }
     }
+    // Determine effective enterprise mode before rendering limits: only real
+    // enterprise accounts replace token-window limits with enterprise cost.
+    const isEnterprise = enabledElements.enterpriseMode !== undefined
+        ? enabledElements.enterpriseMode
+        : ((context.subscriptionType ?? '').toLowerCase() === 'enterprise' ||
+            /claude_zero/i.test(context.rateLimitTier ?? ''));
     // Rate limits (5h and weekly) - data takes priority over error indicator.
-    // Skip for enterprise responses where token-window limits aren't applicable
-    // (the enterpriseCost element replaces this slot for those accounts).
-    const hasEnterpriseData = context.rateLimitsResult?.rateLimits?.enterpriseSpentUsd !== undefined;
-    if (enabledElements.rateLimits && context.rateLimitsResult && !hasEnterpriseData) {
+    // Enterprise cost data only replaces token-window limits for accounts that
+    // are actually enterprise/claude_zero. Anthropic may include zero-dollar
+    // enterprise fields for non-enterprise paid plans; those must still show
+    // normal 5h/wk limits.
+    const enterpriseCostReplacesRateLimits = isEnterprise &&
+        context.rateLimitsResult?.rateLimits?.enterpriseSpentUsd !== undefined;
+    if (enabledElements.rateLimits && context.rateLimitsResult && !enterpriseCostReplacesRateLimits) {
         if (context.rateLimitsResult.rateLimits) {
             const stale = context.rateLimitsResult.stale;
             const limits = enabledElements.useBars
@@ -285,11 +294,6 @@ export async function render(context, config) {
                 rendered.set("session", session);
         }
     }
-    // Determine effective enterprise mode
-    const isEnterprise = enabledElements.enterpriseMode !== undefined
-        ? enabledElements.enterpriseMode
-        : ((context.subscriptionType ?? '').toLowerCase() === 'enterprise' ||
-            /claude_zero/i.test(context.rateLimitTier ?? ''));
     if (isEnterprise && enabledElements.showEnterpriseCost !== false) {
         const stale = context.rateLimitsResult?.stale;
         const cost = renderEnterpriseCost(context.rateLimitsResult?.rateLimits, stale);

--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -145,6 +145,56 @@ describe('render: rate limits display priority', () => {
     },
   );
 
+  it.each(['pro', 'max'] as const)(
+    'renders normal 5h/wk limits for non-enterprise %s when enterprise spend is zero',
+    async (subscriptionType) => {
+      const context = makeContext({
+        subscriptionType,
+        rateLimitTier: null,
+        rateLimitsResult: {
+          rateLimits: {
+            fiveHourPercent: 10,
+            weeklyPercent: 2,
+            enterpriseSpentUsd: 0,
+            enterpriseLimitUsd: 50,
+            enterpriseCurrency: 'USD',
+          },
+        },
+      });
+
+      const output = await render(context, makeConfig());
+
+      expect(output).toContain('5h:');
+      expect(output).toContain('10%');
+      expect(output).toContain('wk:');
+      expect(output).toContain('2%');
+      expect(output).not.toContain('spent:');
+    },
+  );
+
+  it('uses enterprise cost instead of double-rendering 5h/wk for actual enterprise zero spend', async () => {
+    const context = makeContext({
+      subscriptionType: 'enterprise',
+      rateLimitTier: null,
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 10,
+          weeklyPercent: 2,
+          enterpriseSpentUsd: 0,
+          enterpriseLimitUsd: 50,
+          enterpriseCurrency: 'USD',
+        },
+      },
+    });
+
+    const output = await render(context, makeConfig());
+
+    expect(output).toContain('spent:');
+    expect(output).toContain('$0.00/$50.00');
+    expect(output).not.toContain('5h:');
+    expect(output).not.toContain('wk:');
+  });
+
   it('shows [API 429] when error=rate_limited and rateLimits is null', async () => {
     const context = makeContext({
       rateLimitsResult: {

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -307,12 +307,14 @@ export async function render(
       );
 
   // Rate limits (5h and weekly) - data takes priority over error indicator.
-  // Skip for enterprise responses where token-window limits aren't applicable
-  // (the enterpriseCost element replaces this slot for those accounts).
-  const hasEnterpriseData =
+  // Enterprise cost data only replaces token-window limits for accounts that
+  // are actually enterprise/claude_zero. Anthropic may include zero-dollar
+  // enterprise fields for non-enterprise paid plans; those must still show
+  // normal 5h/wk limits.
+  const enterpriseCostReplacesRateLimits =
     isEnterprise &&
     context.rateLimitsResult?.rateLimits?.enterpriseSpentUsd !== undefined;
-  if (enabledElements.rateLimits && context.rateLimitsResult && !hasEnterpriseData) {
+  if (enabledElements.rateLimits && context.rateLimitsResult && !enterpriseCostReplacesRateLimits) {
     if (context.rateLimitsResult.rateLimits) {
       const stale = context.rateLimitsResult.stale;
       const limits = enabledElements.useBars


### PR DESCRIPTION
## Summary
- Fix the HUD rate-limit render gate so enterprise cost only replaces normal `5h:`/`wk:` limits for actual enterprise/`claude_zero` accounts.
- Preserve normal Pro/Max rate-limit rendering when Anthropic usage data includes `enterpriseSpentUsd: 0` and `enterpriseLimitUsd`.
- Add regression coverage for both non-enterprise zero enterprise spend and actual enterprise zero spend without double-rendering.

Closes #2822.

## Verification
- `npm test -- --run src/__tests__/hud/render-rate-limits-priority.test.ts src/__tests__/hud/render-enterprise.test.ts src/hud/__tests__/enterprise-cost.test.ts`
- `npx eslint src/hud/render.ts src/__tests__/hud/render-rate-limits-priority.test.ts`
- `npm run build`
- Architect review: APPROVED

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
