### PR TITLE
Fix post-tool verifier object response false positives

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -718,6 +718,40 @@ export function isClaudeCodeWriteSuccess(output) {
   return successPatterns.some(pattern => pattern.test(cleaned));
 }
 
+function extractTextFromKnownToolResponseField(value, depth = 0) {
+  if (typeof value === 'string') return [value];
+  if (!value || depth > 4) return [];
+
+  if (Array.isArray(value)) {
+    return value.flatMap(item => extractTextFromKnownToolResponseField(item, depth + 1));
+  }
+
+  if (typeof value !== 'object') return [];
+
+  const textFields = ['text', 'message', 'result', 'output', 'stdout'];
+  const texts = [];
+  for (const field of textFields) {
+    if (typeof value[field] === 'string') {
+      texts.push(value[field]);
+    }
+  }
+
+  if (
+    'content' in value &&
+    value.content &&
+    (Array.isArray(value.content) || typeof value.content === 'object')
+  ) {
+    texts.push(...extractTextFromKnownToolResponseField(value.content, depth + 1));
+  }
+
+  return texts;
+}
+
+function hasStructuredWriteSuccess(rawResponse) {
+  if (!rawResponse || typeof rawResponse === 'string') return false;
+  return extractTextFromKnownToolResponseField(rawResponse).some(isClaudeCodeWriteSuccess);
+}
+
 // Get agent completion summary from tracking state
 function getAgentCompletionSummary(directory, quietLevel = QUIET_LEVEL) {
   const trackingFile = join(directory, '.omc', 'state', 'subagent-tracking.json');
@@ -746,7 +780,7 @@ function getAgentCompletionSummary(directory, quietLevel = QUIET_LEVEL) {
 
 // Generate contextual message
 function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, options = {}) {
-  const { wasTruncated = false, rawLength = 0 } = options;
+  const { wasTruncated = false, rawLength = 0, structuredWriteSuccess = false } = options;
   let message = '';
 
   switch (toolName) {
@@ -797,7 +831,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
     }
 
     case 'Edit':
-      if (!isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput)) {
+      if (!structuredWriteSuccess && !isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput)) {
         message = 'Edit operation failed. Verify file exists and content matches exactly.';
       } else if (QUIET_LEVEL === 0) {
         message = 'Code modified. Verify changes work as expected before marking complete.';
@@ -805,7 +839,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
       break;
 
     case 'Write':
-      if (!isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput)) {
+      if (!structuredWriteSuccess && !isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput)) {
         message = 'Write operation failed. Check file permissions and directory existence.';
       } else if (QUIET_LEVEL === 0) {
         message = 'File written. Test the changes to ensure they work correctly.';
@@ -862,6 +896,8 @@ async function main() {
 
     const toolName = data.tool_name || data.toolName || '';
     const rawResponse = data.tool_response || data.toolOutput || '';
+    const structuredWriteSuccess =
+      (toolName === 'Write' || toolName === 'Edit') && hasStructuredWriteSuccess(rawResponse);
     const toolOutput = typeof rawResponse === 'string' ? rawResponse : JSON.stringify(rawResponse);
     const { clipped: clippedToolOutput, wasTruncated } = clipToolOutputForAnalysis(toolName, toolOutput);
     const sessionId = data.session_id || data.sessionId || 'unknown';
@@ -907,6 +943,7 @@ async function main() {
       generateMessage(toolName, clippedToolOutput, sessionId, toolCount, directory, {
         wasTruncated,
         rawLength: toolOutput.length,
+        structuredWriteSuccess,
       }),
       maybeBuildPreemptiveCompactionMessage(toolName, data, directory),
     );

--- a/src/__tests__/preemptive-compaction-hook.test.ts
+++ b/src/__tests__/preemptive-compaction-hook.test.ts
@@ -322,3 +322,87 @@ describe('post-tool-verifier preemptive compaction warnings', () => {
     });
   });
 });
+
+describe('post-tool-verifier Write/Edit response envelopes', () => {
+  const longFailureProse = [
+    'The following fixture text documents prior failures and must not be treated as the tool status.',
+    'x'.repeat(430),
+    'error: fixture prose only',
+    'no such file: fixture prose only',
+    'permission denied: fixture prose only',
+  ].join('\n');
+
+  it('trusts Write success markers extracted from object response fields before JSON stringify analysis', () => {
+    const result = runPostToolVerifier(
+      {
+        cwd: makeTempDir(),
+        tool_name: 'Write',
+        session_id: 'write-object-success-envelope-test',
+        tool_response: {
+          result: 'File written successfully at: /tmp/example.txt',
+          content: longFailureProse,
+        },
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    expect(result).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('trusts Edit success markers extracted from object response message before JSON stringify analysis', () => {
+    const result = runPostToolVerifier(
+      {
+        cwd: makeTempDir(),
+        tool_name: 'Edit',
+        session_id: 'edit-object-success-envelope-test',
+        tool_response: {
+          message: 'The file /tmp/example.txt has been updated successfully.',
+          content: longFailureProse,
+        },
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    expect(result).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('keeps real plain string Write failures failing', () => {
+    const result = runPostToolVerifier(
+      {
+        cwd: makeTempDir(),
+        tool_name: 'Write',
+        session_id: 'write-string-failure-test',
+        tool_response: 'Error: failed to write file',
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    expect(result).toEqual({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: 'Write operation failed. Check file permissions and directory existence.',
+      },
+    });
+  });
+
+  it('keeps real plain string Edit failures failing', () => {
+    const result = runPostToolVerifier(
+      {
+        cwd: makeTempDir(),
+        tool_name: 'Edit',
+        session_id: 'edit-string-failure-test',
+        tool_response: 'Error: failed to edit file',
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    expect(result).toEqual({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: 'Edit operation failed. Verify file exists and content matches exactly.',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract Write/Edit success markers from known object `tool_response` fields before JSON stringifying the envelope.
- Keep generic string failure detection intact for real plain-string Write/Edit failures.
- Add regression coverage for long object-envelope content containing failure prose while success is reported in structured fields.

Closes #2825.

## Verification

- `npm test -- --run src/__tests__/preemptive-compaction-hook.test.ts`
- `npm run lint` (warnings only; no errors)
- `npm run build`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*