### PR TITLE
Protect HUD limits from enterprise-shaped Pro/Max spend

### DIFF
--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -146,6 +146,33 @@ describe('render: rate limits display priority', () => {
   );
 
   it.each(['pro', 'max'] as const)(
+    'renders normal 5h/wk limits for non-enterprise %s when enterprise spend is nonzero',
+    async (subscriptionType) => {
+      const context = makeContext({
+        subscriptionType,
+        rateLimitTier: null,
+        rateLimitsResult: {
+          rateLimits: {
+            fiveHourPercent: 36,
+            weeklyPercent: 32,
+            enterpriseSpentUsd: 12.34,
+            enterpriseLimitUsd: 50,
+            enterpriseCurrency: 'USD',
+          },
+        },
+      });
+
+      const output = await render(context, makeConfig());
+
+      expect(output).toContain('5h:');
+      expect(output).toContain('36%');
+      expect(output).toContain('wk:');
+      expect(output).toContain('32%');
+      expect(output).not.toContain('spent:');
+    },
+  );
+
+  it.each(['pro', 'max'] as const)(
     'renders normal 5h/wk limits for non-enterprise %s when enterprise spend is zero',
     async (subscriptionType) => {
       const context = makeContext({


### PR DESCRIPTION
Fixes #2829.

## Summary
- Add regression coverage for Pro/Max HUD usage results that include enterprise-shaped `enterpriseSpentUsd`/`enterpriseLimitUsd` while retaining 5h/weekly limits.
- Preserve intended enterprise behavior where actual enterprise accounts render `spent:` instead of duplicate 5h/wk limits.

## Verification
- `npm test -- --run src/__tests__/hud/render-rate-limits-priority.test.ts src/__tests__/hud/render-enterprise.test.ts src/hud/__tests__/usage-api-enterprise.test.ts`
- `npm run lint -- src/hud/render.ts src/__tests__/hud/render-rate-limits-priority.test.ts src/hud/usage-api.ts src/hud/__tests__/usage-api-enterprise.test.ts` (0 errors; existing repo warnings outside touched files)
- `npx tsc --noEmit`
