### PR TITLE
Fix stale Ralph stop hook after cancel

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -572,6 +572,32 @@ function readStateFileWithSession(stateDir, filename, sessionId) {
   return readStateFile(stateDir, filename);
 }
 
+const WORKFLOW_SLOT_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function isWorkflowSlotTombstonedForMode(stateDir, mode, sessionId) {
+  const safeSessionId = sessionId && /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId) ? sessionId : "";
+  const ledgerPath = safeSessionId
+    ? join(stateDir, "sessions", safeSessionId, "skill-active-state.json")
+    : join(stateDir, "skill-active-state.json");
+  const ledger = readJsonFile(ledgerPath);
+  const slot = ledger?.active_skills?.[mode];
+  if (!slot || typeof slot !== "object") return false;
+  if (typeof slot.completed_at !== "string" || !slot.completed_at) return false;
+  const completedAt = new Date(slot.completed_at).getTime();
+  if (!Number.isFinite(completedAt)) return true;
+  return Date.now() - completedAt < WORKFLOW_SLOT_TOMBSTONE_TTL_MS;
+}
+
+function isAuthoritativeModeActive(stateDir, mode, loaded, sessionId) {
+  const state = loaded?.state;
+  if (!state?.active) return false;
+  if (isWorkflowSlotTombstonedForMode(stateDir, mode, sessionId)) return false;
+  const safeSessionId = sessionId && /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId) ? sessionId : "";
+  if (safeSessionId && state.session_id && state.session_id !== safeSessionId) return false;
+  return true;
+}
+
+
 function getActiveSubagentCount(stateDir) {
   try {
     const tracking = readJsonFile(join(stateDir, "subagent-tracking.json"));
@@ -891,7 +917,7 @@ async function main() {
 
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions
-    if (ralph.state?.active && !isAwaitingConfirmation(ralph.state) && !isStaleState(ralph.state) && isSessionMatch(ralph.state, sessionId)) {
+    if (isAuthoritativeModeActive(stateDir, "ralph", ralph, sessionId) && !isAwaitingConfirmation(ralph.state) && !isStaleState(ralph.state) && isSessionMatch(ralph.state, sessionId)) {
       const iteration = ralph.state.iteration || 1;
       const maxIter = ralph.state.max_iterations || 100;
 
@@ -1212,7 +1238,7 @@ async function main() {
     // Session isolation: only block if state belongs to this session (issue #311)
     // Project isolation: only block if state belongs to this project
     if (
-      ultrawork.state?.active && !isAwaitingConfirmation(ultrawork.state) &&
+      isAuthoritativeModeActive(stateDir, "ultrawork", ultrawork, sessionId) && !isAwaitingConfirmation(ultrawork.state) &&
       !isStaleState(ultrawork.state) &&
       isSessionMatch(ultrawork.state, sessionId) &&
       isStateForCurrentProject(ultrawork.state, directory, ultrawork.isGlobal)

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -370,6 +370,32 @@ function readStateFileWithSession(stateDir, globalStateDir, filename, sessionId)
   return readStateFile(stateDir, globalStateDir, filename);
 }
 
+const WORKFLOW_SLOT_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function isWorkflowSlotTombstonedForMode(stateDir, mode, sessionId) {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const ledgerPath = safeSessionId
+    ? join(stateDir, "sessions", safeSessionId, "skill-active-state.json")
+    : join(stateDir, "skill-active-state.json");
+  const ledger = readJsonFile(ledgerPath);
+  const slot = ledger?.active_skills?.[mode];
+  if (!slot || typeof slot !== "object") return false;
+  if (typeof slot.completed_at !== "string" || !slot.completed_at) return false;
+  const completedAt = new Date(slot.completed_at).getTime();
+  if (!Number.isFinite(completedAt)) return true;
+  return Date.now() - completedAt < WORKFLOW_SLOT_TOMBSTONE_TTL_MS;
+}
+
+function isAuthoritativeModeActive(stateDir, mode, loaded, sessionId) {
+  const state = loaded?.state;
+  if (!state?.active) return false;
+  if (isWorkflowSlotTombstonedForMode(stateDir, mode, sessionId)) return false;
+  const safeSessionId = sanitizeSessionId(sessionId);
+  if (safeSessionId && state.session_id && state.session_id !== safeSessionId) return false;
+  return true;
+}
+
+
 function isSessionCancelInProgress(stateDir, sessionId) {
   const isActiveSignal = (signalPath) => {
     const signal = readJsonFile(signalPath);
@@ -762,7 +788,7 @@ async function main() {
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions
     if (
-      ralph.state?.active && !isAwaitingConfirmation(ralph.state) &&
+      isAuthoritativeModeActive(stateDir, "ralph", ralph, sessionId) && !isAwaitingConfirmation(ralph.state) &&
       !isStaleState(ralph.state) &&
       isStateForCurrentProject(ralph.state, directory, ralph.isGlobal)
     ) {
@@ -1102,7 +1128,7 @@ async function main() {
     // If state has session_id, it must match. If no session_id (legacy), allow.
     // Project isolation: only block if state belongs to this project
     if (
-      ultrawork.state?.active && !isAwaitingConfirmation(ultrawork.state) &&
+      isAuthoritativeModeActive(stateDir, "ultrawork", ultrawork, sessionId) && !isAwaitingConfirmation(ultrawork.state) &&
       !isStaleState(ultrawork.state) &&
       (hasValidSessionId
         ? ultrawork.state.session_id === sessionId

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -48,6 +48,30 @@ function readJsonFile(path) {
   }
 }
 
+
+const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+const WORKFLOW_SLOT_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function isWorkflowSlotTombstonedForMode(omcRoot, mode, sessionId) {
+  const safeSessionId = typeof sessionId === 'string' && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  const ledgerPath = safeSessionId
+    ? join(omcRoot, 'state', 'sessions', safeSessionId, 'skill-active-state.json')
+    : join(omcRoot, 'state', 'skill-active-state.json');
+  const ledger = readJsonFile(ledgerPath);
+  const slot = ledger?.active_skills?.[mode];
+  if (!slot || typeof slot !== 'object') return false;
+  if (typeof slot.completed_at !== 'string' || !slot.completed_at) return false;
+  const completedAt = new Date(slot.completed_at).getTime();
+  if (!Number.isFinite(completedAt)) return true;
+  return Date.now() - completedAt < WORKFLOW_SLOT_TOMBSTONE_TTL_MS;
+}
+
+function shouldRestoreModeState(omcRoot, mode, state, sessionId) {
+  if (!state?.active) return false;
+  if (isWorkflowSlotTombstonedForMode(omcRoot, mode, sessionId)) return false;
+  return true;
+}
+
 function getRuntimeBaseDir() {
   return process.env.CLAUDE_PLUGIN_ROOT || join(__dirname, '..');
 }
@@ -563,7 +587,7 @@ async function main() {
       ultraworkState = readJsonFile(join(omcRoot, 'state', 'ultrawork-state.json'));
     }
 
-    if (ultraworkState?.active) {
+    if (shouldRestoreModeState(omcRoot, 'ultrawork', ultraworkState, sessionId)) {
       messages.push(`<session-restore>
 
 [ULTRAWORK MODE RESTORED]
@@ -596,7 +620,7 @@ Treat this as prior-session context only. Prioritize the user's newest request, 
         ralphState = readJsonFile(join(omcRoot, 'ralph-state.json'));
       }
     }
-    if (ralphState?.active) {
+    if (shouldRestoreModeState(omcRoot, 'ralph', ralphState, sessionId)) {
       messages.push(`<session-restore>
 
 [RALPH LOOP RESTORED]

--- a/src/__tests__/state-root-resolution.test.ts
+++ b/src/__tests__/state-root-resolution.test.ts
@@ -66,6 +66,33 @@ function getCentralizedOmcRoot(projectDir: string, stateDir: string): string {
   }
 }
 
+function writeWorkflowTombstone(
+  omcRoot: string,
+  sessionId: string,
+  mode: 'ralph' | 'ultrawork',
+): void {
+  const sessionDir = join(omcRoot, 'state', 'sessions', sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, 'skill-active-state.json'),
+    JSON.stringify({
+      version: 2,
+      active_skills: {
+        [mode]: {
+          skill_name: mode,
+          started_at: '2026-04-26T00:00:00.000Z',
+          completed_at: new Date().toISOString(),
+          session_id: sessionId,
+          mode_state_path: `${mode}-state.json`,
+          initialized_mode: mode,
+          initialized_state_path: join(omcRoot, 'state', `${mode}-state.json`),
+          initialized_session_state_path: join(sessionDir, `${mode}-state.json`),
+        },
+      },
+    }, null, 2),
+  );
+}
+
 describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
   let tempDir: string;
   let fakeProject: string;
@@ -115,6 +142,63 @@ describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
     const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
       .hookSpecificOutput?.additionalContext ?? '';
     expect(context).toContain('[RALPH LOOP RESTORED]');
+  });
+
+  it('session-start ignores tombstoned stale ralph restore state after cancel', () => {
+    const sessionId = 'test-session-tombstoned-ralph';
+    const omcRoot = join(fakeProject, '.omc');
+    const stateDir = join(omcRoot, 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ralph-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        prompt: 'Tombstoned task must not restore',
+        iteration: 12,
+        max_iterations: 100,
+      }),
+    );
+    writeWorkflowTombstone(omcRoot, sessionId, 'ralph');
+
+    const output = runHook(SESSION_START, {
+      hook_event_name: 'SessionStart',
+      session_id: sessionId,
+      cwd: fakeProject,
+    });
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).not.toContain('[RALPH LOOP RESTORED]');
+    expect(context).not.toContain('Tombstoned task must not restore');
+  });
+
+  it('session-start ignores tombstoned stale ultrawork restore state after cancel', () => {
+    const sessionId = 'test-session-tombstoned-ultrawork';
+    const omcRoot = join(fakeProject, '.omc');
+    const stateDir = join(omcRoot, 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ultrawork-state.json'),
+      JSON.stringify({
+        active: true,
+        session_id: sessionId,
+        started_at: '2026-04-26T00:00:00.000Z',
+        original_prompt: 'Tombstoned ultrawork must not restore',
+      }),
+    );
+    writeWorkflowTombstone(omcRoot, sessionId, 'ultrawork');
+
+    const output = runHook(SESSION_START, {
+      hook_event_name: 'SessionStart',
+      session_id: sessionId,
+      cwd: fakeProject,
+    });
+
+    const context = (output as { hookSpecificOutput?: { additionalContext?: string } })
+      .hookSpecificOutput?.additionalContext ?? '';
+    expect(context).not.toContain('[ULTRAWORK MODE RESTORED]');
+    expect(context).not.toContain('Tombstoned ultrawork must not restore');
   });
 
   // ────────────────────────────────────────────────────────────────────────────

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -57,6 +57,7 @@ import type { TeamPipelinePhase } from '../team-pipeline/types.js';
 import { getActiveAgentSnapshot } from '../subagent-tracker/index.js';
 import type { IdleNotificationRepoState } from './idle-repo-state.js';
 import { truncatePromptForEcho } from '../../lib/truncate-prompt.js';
+import { isModeActive } from '../mode-registry/index.js';
 
 export interface ToolErrorState {
   tool_name: string;
@@ -1874,9 +1875,11 @@ export async function checkPersistentModes(
   };
 
   const runRalphPriority = async (): Promise<PersistentModeResult | null> => {
-    // Skip when the ralph workflow slot is tombstoned — a stale `ralph-state.json`
-    // from a crashed session must not block a fresh invocation.
-    if (tombstonedWorkflowModes.has('ralph')) return null;
+    // Skip when the authoritative registry says Ralph is inactive. This keeps
+    // Stop enforcement aligned with state_list_active and ignores stale
+    // restored/cache artifacts (including tombstoned workflow slots) after
+    // cancel/state_clear has made the registry empty.
+    if (tombstonedWorkflowModes.has('ralph') || !isModeActive('ralph', workingDir, sessionId)) return null;
     return checkRalphLoop(sessionId, workingDir, cancelInProgress);
   };
 
@@ -1923,7 +1926,7 @@ export async function checkPersistentModes(
   }
 
   // Priority 2: Ultrawork Mode (performance mode with persistence)
-  if (!tombstonedWorkflowModes.has('ultrawork')) {
+  if (!tombstonedWorkflowModes.has('ultrawork') && isModeActive('ultrawork', workingDir, sessionId)) {
     const ultraworkResult = await checkUltrawork(sessionId, workingDir, hasIncompleteTodos, cancelInProgress);
     if (ultraworkResult) {
       return ultraworkResult;

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -70,6 +70,33 @@ function writeLegacyModeState(
   writeFileSync(join(stateDir, fileName), JSON.stringify(state, null, 2));
 }
 
+function writeWorkflowTombstone(
+  tempDir: string,
+  sessionId: string,
+  mode: 'ralph' | 'ultrawork',
+): void {
+  const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, "skill-active-state.json"),
+    JSON.stringify({
+      version: 2,
+      active_skills: {
+        [mode]: {
+          skill_name: mode,
+          started_at: new Date(Date.now() - 60_000).toISOString(),
+          completed_at: new Date().toISOString(),
+          session_id: sessionId,
+          mode_state_path: `${mode}-state.json`,
+          initialized_mode: mode,
+          initialized_state_path: join(tempDir, ".omc", "state", `${mode}-state.json`),
+          initialized_session_state_path: join(sessionDir, `${mode}-state.json`),
+        },
+      },
+    }, null, 2),
+  );
+}
+
 function resolveCentralizedStateDir(directory: string, customStateDir: string): string {
   const previous = process.env.OMC_STATE_DIR;
   process.env.OMC_STATE_DIR = customStateDir;
@@ -451,6 +478,85 @@ describe("Stop Hook Blocking Contract", () => {
       expect(output.continue).toBe(true);
     });
 
+    it("does not fire ralph stop reinforcement when authoritative registry is empty after cancel tombstone", async () => {
+      const sessionId = "ralph-stale-restored-after-cancel";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          iteration: 7,
+          max_iterations: 100,
+          session_id: sessionId,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          prompt: "stale restored task",
+        }, null, 2),
+      );
+      writeWorkflowTombstone(tempDir, sessionId, "ralph");
+
+      const { getActiveModes } = await import("../mode-registry/index.js");
+      expect(getActiveModes(tempDir, sessionId)).not.toContain("ralph");
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe("none");
+      expect(result.message).not.toContain("[RALPH LOOP");
+    });
+
+    it("does not fire ultrawork stop reinforcement when authoritative registry is empty after cancel tombstone", async () => {
+      const sessionId = "ultrawork-stale-restored-after-cancel";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writePendingTodo(tempDir, "pending work should not revive stale ultrawork");
+      writeFileSync(
+        join(sessionDir, "ultrawork-state.json"),
+        JSON.stringify({
+          active: true,
+          started_at: new Date().toISOString(),
+          original_prompt: "stale restored ultrawork",
+          session_id: sessionId,
+          reinforcement_count: 3,
+          last_checked_at: new Date().toISOString(),
+        }, null, 2),
+      );
+      writeWorkflowTombstone(tempDir, sessionId, "ultrawork");
+
+      const { getActiveModes } = await import("../mode-registry/index.js");
+      expect(getActiveModes(tempDir, sessionId)).not.toContain("ultrawork");
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.mode).not.toBe("ultrawork");
+      expect(result.message).not.toContain("[ULTRAWORK");
+    });
+
+    it("still fires ralph stop reinforcement when authoritative registry reports active ralph", async () => {
+      const sessionId = "ralph-active-registry";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          iteration: 1,
+          max_iterations: 100,
+          session_id: sessionId,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          prompt: "active task",
+        }, null, 2),
+      );
+
+      const { getActiveModes } = await import("../mode-registry/index.js");
+      expect(getActiveModes(tempDir, sessionId)).toContain("ralph");
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(true);
+      expect(result.mode).toBe("ralph");
+      expect(result.message).toContain("[RALPH - ITERATION");
+    });
+
     it("allows stop after broad clear removes leftover session-scoped state", async () => {
       const sessionA = "test-broad-clear-a";
       const sessionB = "test-broad-clear-b";
@@ -748,6 +854,30 @@ describe("Stop Hook Blocking Contract", () => {
       expect(output.decision).toBe("block");
     });
 
+    it("returns continue: true for tombstoned stale ralph state", () => {
+      const sessionId = "ralph-mjs-tombstoned";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          iteration: 9,
+          max_iterations: 100,
+          session_id: sessionId,
+          started_at: new Date().toISOString(),
+          last_checked_at: new Date().toISOString(),
+          prompt: "stale restored ralph",
+        })
+      );
+      writeWorkflowTombstone(tempDir, sessionId, "ralph");
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+      expect(String(output.reason || "")).not.toContain("[RALPH LOOP");
+    });
+
     it("returns decision: block when ultrawork is active", () => {
       const sessionId = "ultrawork-mjs-test";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
@@ -766,6 +896,29 @@ describe("Stop Hook Blocking Contract", () => {
 
       const output = runScript({ directory: tempDir, sessionId });
       expect(output.decision).toBe("block");
+    });
+
+    it("returns continue: true for tombstoned stale ultrawork state", () => {
+      const sessionId = "ultrawork-mjs-tombstoned";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ultrawork-state.json"),
+        JSON.stringify({
+          active: true,
+          started_at: new Date().toISOString(),
+          original_prompt: "stale restored ultrawork",
+          session_id: sessionId,
+          reinforcement_count: 0,
+          last_checked_at: new Date().toISOString(),
+        })
+      );
+      writeWorkflowTombstone(tempDir, sessionId, "ultrawork");
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+      expect(String(output.reason || "")).not.toContain("[ULTRAWORK");
     });
 
     it("returns continue: true for stale legacy ultrawork state without a session", () => {

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -417,6 +417,32 @@ function readStateFileWithSession(stateDir, globalStateDir, filename, sessionId)
   return readStateFile(stateDir, globalStateDir, filename);
 }
 
+const WORKFLOW_SLOT_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function isWorkflowSlotTombstonedForMode(stateDir, mode, sessionId) {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const ledgerPath = safeSessionId
+    ? join(stateDir, "sessions", safeSessionId, "skill-active-state.json")
+    : join(stateDir, "skill-active-state.json");
+  const ledger = readJsonFile(ledgerPath);
+  const slot = ledger?.active_skills?.[mode];
+  if (!slot || typeof slot !== "object") return false;
+  if (typeof slot.completed_at !== "string" || !slot.completed_at) return false;
+  const completedAt = new Date(slot.completed_at).getTime();
+  if (!Number.isFinite(completedAt)) return true;
+  return Date.now() - completedAt < WORKFLOW_SLOT_TOMBSTONE_TTL_MS;
+}
+
+function isAuthoritativeModeActive(stateDir, mode, loaded, sessionId) {
+  const state = loaded?.state;
+  if (!state?.active) return false;
+  if (isWorkflowSlotTombstonedForMode(stateDir, mode, sessionId)) return false;
+  const safeSessionId = sanitizeSessionId(sessionId);
+  if (safeSessionId && state.session_id && state.session_id !== safeSessionId) return false;
+  return true;
+}
+
+
 function getActiveSubagentCount(stateDir) {
   try {
     const tracking = readJsonFile(join(stateDir, "subagent-tracking.json"));
@@ -741,7 +767,7 @@ async function main() {
     // Priority 1: Ralph Loop (explicit persistence mode)
     // Skip if state is stale (older than 2 hours) - prevents blocking new sessions
     if (
-      ralph.state?.active && !isAwaitingConfirmation(ralph.state) &&
+      isAuthoritativeModeActive(stateDir, "ralph", ralph, sessionId) && !isAwaitingConfirmation(ralph.state) &&
       !isStaleState(ralph.state) &&
       isStateForCurrentProject(ralph.state, directory, ralph.isGlobal)
     ) {
@@ -1036,7 +1062,7 @@ async function main() {
     // Session isolation: only block if state belongs to this session (issue #311)
     // If state has session_id, it must match. If no session_id (legacy), allow.
     if (
-      ultrawork.state?.active && !isAwaitingConfirmation(ultrawork.state) &&
+      isAuthoritativeModeActive(stateDir, "ultrawork", ultrawork, sessionId) && !isAwaitingConfirmation(ultrawork.state) &&
       !isStaleState(ultrawork.state) &&
       (hasValidSessionId
         ? ultrawork.state.session_id === sessionId

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -55,6 +55,30 @@ function writeJsonFile(path, data) {
   }
 }
 
+
+const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+const WORKFLOW_SLOT_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function isWorkflowSlotTombstonedForMode(directory, mode, sessionId) {
+  const safeSessionId = typeof sessionId === 'string' && SESSION_ID_ALLOWLIST.test(sessionId) ? sessionId : '';
+  const ledgerPath = safeSessionId
+    ? join(directory, '.omc', 'state', 'sessions', safeSessionId, 'skill-active-state.json')
+    : join(directory, '.omc', 'state', 'skill-active-state.json');
+  const ledger = readJsonFile(ledgerPath);
+  const slot = ledger?.active_skills?.[mode];
+  if (!slot || typeof slot !== 'object') return false;
+  if (typeof slot.completed_at !== 'string' || !slot.completed_at) return false;
+  const completedAt = new Date(slot.completed_at).getTime();
+  if (!Number.isFinite(completedAt)) return true;
+  return Date.now() - completedAt < WORKFLOW_SLOT_TOMBSTONE_TTL_MS;
+}
+
+function shouldRestoreModeState(directory, mode, state, sessionId) {
+  if (!state?.active) return false;
+  if (isWorkflowSlotTombstonedForMode(directory, mode, sessionId)) return false;
+  return true;
+}
+
 async function checkForUpdates(currentVersion) {
   const cacheFile = join(homedir(), '.omc', 'update-check.json');
   const now = Date.now();
@@ -515,7 +539,7 @@ To update, run: omc update
           ultraworkCandidate.collision.state,
         ),
       );
-    } else if (ultraworkCandidate.restore) {
+    } else if (shouldRestoreModeState(directory, 'ultrawork', ultraworkCandidate.restore, sessionId)) {
       const ultraworkState = ultraworkCandidate.restore;
       messages.push(`<session-restore>
 


### PR DESCRIPTION
Fixes #2832.

## Summary
- Align Ralph/Ultrawork Stop hook enforcement with the authoritative active-mode registry semantics.
- Ignore tombstoned stale Ralph/Ultrawork restore artifacts after cancel/state_clear so stale restored state cannot re-fire stop reinforcement.
- Suppress SessionStart restore context for tombstoned Ralph/Ultrawork state while preserving active-mode behavior.
- Add regressions for stale tombstoned Ralph/Ultrawork and active Ralph reinforcement.

## Verification
- npm test -- --run src/hooks/persistent-mode/stop-hook-blocking.test.ts src/__tests__/state-root-resolution.test.ts src/installer/__tests__/session-start-template.test.ts
- npm run build -- --pretty false
- npm run lint (passes with existing warnings only)
- node --check scripts/persistent-mode.mjs scripts/persistent-mode.cjs scripts/session-start.mjs templates/hooks/persistent-mode.mjs templates/hooks/session-start.mjs
- npx tsc --noEmit
