### PR TITLE
Fix HUD Max overage used credits classification

### DIFF
--- a/src/__tests__/hud/extra-usage.test.ts
+++ b/src/__tests__/hud/extra-usage.test.ts
@@ -101,6 +101,52 @@ describe('parseUsageResponse — extra_usage', () => {
     expect(result!.extraUsageSpentUsd).toBe(0);
     expect(result!.extraUsagePercent).toBe(0);
   });
+
+  it('parses Max organization overage used_credits as extra usage without enterprise fields', () => {
+    const result = parseUsageResponse({
+      five_hour: { utilization: 3 },
+      seven_day: { utilization: 16 },
+      seven_day_sonnet: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 2726,
+        monthly_limit: 5000,
+        currency: 'USD',
+      },
+    }, {
+      subscriptionType: 'max',
+      rateLimitTier: 'default_claude_max_20x',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.fiveHourPercent).toBe(3);
+    expect(result!.weeklyPercent).toBe(16);
+    expect(result!.sonnetWeeklyPercent).toBe(0);
+    expect(result!.extraUsageSpentUsd).toBeCloseTo(27.26, 2);
+    expect(result!.extraUsageLimitUsd).toBeCloseTo(50, 2);
+    expect(result!.extraUsagePercent).toBeCloseTo(54.52, 2);
+    expect(result!.enterpriseSpentUsd).toBeUndefined();
+    expect(result!.enterpriseLimitUsd).toBeUndefined();
+    expect(result!.enterpriseUtilization).toBeUndefined();
+  });
+
+  it('uses API utilization for non-enterprise used_credits overage when present', () => {
+    const result = parseUsageResponse({
+      five_hour: { utilization: 10 },
+      extra_usage: {
+        used_credits: 1000,
+        monthly_limit: 5000,
+        utilization: 30,
+        currency: 'USD',
+      },
+    }, { subscriptionType: 'pro', rateLimitTier: 'default' });
+
+    expect(result).not.toBeNull();
+    expect(result!.extraUsagePercent).toBe(30);
+    expect(result!.extraUsageSpentUsd).toBeCloseTo(10, 2);
+    expect(result!.extraUsageLimitUsd).toBeCloseTo(50, 2);
+    expect(result!.enterpriseSpentUsd).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -670,6 +670,64 @@ describe('getUsage routing', () => {
     expect(result!.sonnetWeeklyResetsAt).toBeInstanceOf(Date);
   });
 
+  it('passes OAuth subscription metadata so Max used_credits overage stays extra usage', async () => {
+    const mockedExistsSync = vi.mocked(fs.existsSync);
+    const mockedReadFileSync = vi.mocked(fs.readFileSync);
+
+    mockedExistsSync.mockImplementation((path) => String(path).endsWith('.credentials.json'));
+    mockedReadFileSync.mockImplementation((path) => {
+      if (String(path).endsWith('.credentials.json')) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'valid-token',
+            refreshToken: 'refresh-token',
+            expiresAt: Date.now() + 60_000,
+            subscriptionType: 'max',
+            rateLimitTier: 'default_claude_max_20x',
+          },
+        });
+      }
+      return '{}';
+    });
+
+    httpsModule.default.request.mockImplementationOnce((_options, callback) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void; on: typeof EventEmitter.prototype.on };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          five_hour: { utilization: 3 },
+          seven_day: { utilization: 16 },
+          seven_day_sonnet: { utilization: 0 },
+          extra_usage: {
+            is_enabled: true,
+            used_credits: 2726,
+            monthly_limit: 5000,
+            currency: 'USD',
+          },
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimits).toMatchObject({
+      fiveHourPercent: 3,
+      weeklyPercent: 16,
+      sonnetWeeklyPercent: 0,
+      extraUsageSpentUsd: 27.26,
+      extraUsageLimitUsd: 50,
+      extraUsagePercent: 54.52,
+    });
+    expect(result.rateLimits!.enterpriseSpentUsd).toBeUndefined();
+    expect(result.rateLimits!.enterpriseLimitUsd).toBeUndefined();
+  });
+
   it('returns getUsage rateLimits when OAuth credentials lack subscription metadata', async () => {
     const mockedExistsSync = vi.mocked(fs.existsSync);
     const mockedReadFileSync = vi.mocked(fs.readFileSync);

--- a/src/hud/__tests__/usage-api-enterprise.test.ts
+++ b/src/hud/__tests__/usage-api-enterprise.test.ts
@@ -29,6 +29,52 @@ describe('parseUsageResponse - enterprise extra_usage', () => {
     expect(result!.enterpriseSpentUsd).toBeCloseTo(3333.91, 2);
   });
 
+  it('keeps used_credits as enterprise cost when subscription metadata is unknown', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 333391,
+        monthly_limit: null,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response, {
+      subscriptionType: null,
+      rateLimitTier: null,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.enterpriseSpentUsd).toBeCloseTo(3333.91, 2);
+    expect(result!.enterpriseLimitUsd).toBeNull();
+    expect(result!.extraUsageSpentUsd).toBeUndefined();
+  });
+
+  it('keeps used_credits as enterprise cost for explicit enterprise subscriptions', () => {
+    const response = {
+      ...baseResponse,
+      five_hour: { utilization: 0 },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 333391,
+        monthly_limit: 500000,
+        currency: 'USD',
+      },
+    };
+    const result = parseUsageResponse(response, {
+      subscriptionType: 'enterprise',
+      rateLimitTier: 'default_claude_zero',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.enterpriseSpentUsd).toBeCloseTo(3333.91, 2);
+    expect(result!.enterpriseLimitUsd).toBeCloseTo(5000, 2);
+    expect(result!.enterpriseUtilization).toBeCloseTo(66.6782, 4);
+    expect(result!.extraUsageSpentUsd).toBeUndefined();
+    expect(result!.extraUsageLimitUsd).toBeUndefined();
+  });
+
   it('sets enterpriseLimitUsd to null when monthly_limit is null', () => {
     const response = {
       ...baseResponse,

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -95,6 +95,23 @@ interface UsageApiResponse {
   };
 }
 
+interface ParseUsageResponseOptions {
+  /** Subscription type from OAuth credentials (for distinguishing Max/Pro overage from Enterprise billing) */
+  subscriptionType?: string | null;
+  /** Rate limit tier from OAuth credentials; claude_zero tiers behave like Enterprise billing */
+  rateLimitTier?: string | null;
+}
+
+function isEnterpriseUsageContext(options?: ParseUsageResponseOptions): boolean {
+  if (!options) return true;
+
+  const subscriptionType = options.subscriptionType?.toLowerCase() ?? null;
+  const rateLimitTier = options.rateLimitTier ?? null;
+  if (subscriptionType == null && rateLimitTier == null) return true;
+
+  return subscriptionType === 'enterprise' || /claude_zero/i.test(rateLimitTier ?? '');
+}
+
 interface ZaiQuotaResponse {
   data?: {
     limits?: Array<{
@@ -816,18 +833,22 @@ function clamp(v: number | undefined): number {
 /**
  * Parse API response into RateLimits
  */
-export function parseUsageResponse(response: UsageApiResponse): RateLimits | null {
+export function parseUsageResponse(response: UsageApiResponse, options?: ParseUsageResponseOptions): RateLimits | null {
   const fiveHour = response.five_hour?.utilization;
   const sevenDay = response.seven_day?.utilization;
   const sonnetSevenDay = response.seven_day_sonnet?.utilization;
   const opusSevenDay = response.seven_day_opus?.utilization;
   const extra = response.extra_usage;
-  const enterpriseCredits = extra?.used_credits;
-  const enterpriseCurrency = (extra?.currency ?? 'USD').toUpperCase();
-  // Enterprise credits are only usable when we know how to interpret the minor-unit digits;
-  // see the USD guard in the extra_usage branch below for rationale.
-  const hasUsableEnterprise = enterpriseCredits != null && enterpriseCurrency === 'USD';
-  const hasUsableExtraUsage = extra?.limit_usd != null && extra.limit_usd > 0;
+  const usedCredits = extra?.used_credits;
+  const extraCurrency = (extra?.currency ?? 'USD').toUpperCase();
+  const isEnterpriseContext = isEnterpriseUsageContext(options);
+  // used_credits are only usable when we know how to interpret the minor-unit digits;
+  // see the USD guards in the extra_usage branch below for rationale.
+  const hasUsableUsedCredits = usedCredits != null && extraCurrency === 'USD';
+  const hasUsableEnterprise = isEnterpriseContext && hasUsableUsedCredits;
+  const hasUsableUsdExtraUsage = extra?.limit_usd != null && extra.limit_usd > 0;
+  const hasUsableCreditExtraUsage = !isEnterpriseContext && hasUsableUsedCredits && extra?.monthly_limit != null && extra.monthly_limit > 0;
+  const hasUsableExtraUsage = hasUsableUsdExtraUsage || hasUsableCreditExtraUsage;
 
   // Need at least one valid value. Model-specific weekly buckets are valid usage data
   // even when generic subscription/window metadata is absent or nullish.
@@ -886,7 +907,7 @@ export function parseUsageResponse(response: UsageApiResponse): RateLimits | nul
     // 0-digit, TND/BHD are 3-digit per ISO 4217) and skip the enterprise fields — the
     // renderer will then return null rather than display a wrong figure.
     const currency = (extra.currency ?? 'USD').toUpperCase();
-    if (extra.used_credits != null && currency === 'USD') {
+    if (extra.used_credits != null && currency === 'USD' && isEnterpriseContext) {
       result.enterpriseSpentUsd = extra.used_credits / 100;
       result.enterpriseLimitUsd = extra.monthly_limit == null ? null : extra.monthly_limit / 100;
       result.enterpriseCurrency = currency;
@@ -895,6 +916,17 @@ export function parseUsageResponse(response: UsageApiResponse): RateLimits | nul
         result.enterpriseUtilization = clamp((extra.used_credits / extra.monthly_limit) * 100);
       }
       // resets_at not provided in enterprise response — leave enterpriseResetsAt unset
+    } else if (extra.used_credits != null && currency === 'USD' && !isEnterpriseContext && extra.monthly_limit != null && extra.monthly_limit > 0) {
+      // Max/Pro organization overage path: the API can use the enterprise-shaped
+      // used_credits/monthly_limit fields even though the account should still render
+      // normal token-window limits. Treat those minor-unit values as extra usage.
+      const spentUsd = extra.used_credits / 100;
+      result.extraUsageSpentUsd = spentUsd;
+      result.extraUsageLimitUsd = extra.monthly_limit / 100;
+      result.extraUsagePercent = extra.utilization != null
+        ? clamp(extra.utilization)
+        : clamp((extra.used_credits / extra.monthly_limit) * 100);
+      result.extraUsageResetsAt = parseDate(extra.resets_at);
     } else if (extra.limit_usd != null && extra.limit_usd > 0) {
       // Pro metered path
       const spentUsd = extra.spent_usd ?? 0;
@@ -1245,10 +1277,15 @@ export async function getUsage(): Promise<UsageResult> {
         }
 
         const accessToken = creds.accessToken;
+        const subscriptionType = creds.subscriptionType;
+        const rateLimitTier = creds.rateLimitTier;
         return fetchAndCacheUsage({
           source: 'anthropic',
           fetchFn: () => fetchUsageFromApi(accessToken),
-          parseFn: parseUsageResponse,
+          parseFn: (data) => parseUsageResponse(data, {
+            subscriptionType,
+            rateLimitTier,
+          }),
           cache,
           pollIntervalMs,
         });


### PR DESCRIPTION
## Summary\n- Pass OAuth subscription/rate-limit-tier context into Anthropic usage parsing.\n- Keep Enterprise/claude_zero used_credits mapped to enterprise cost, including unknown metadata for legacy compatibility.\n- Map explicit non-enterprise used_credits/monthly_limit overage payloads to extraUsage* so 5h/weekly/Sonnet limits and extra spend can render together.\n\n## Tests\n- npm test -- --run src/__tests__/hud/extra-usage.test.ts src/__tests__/hud/usage-api.test.ts src/hud/__tests__/usage-api-enterprise.test.ts src/__tests__/hud/render-rate-limits-priority.test.ts\n- npx tsc --noEmit\n- npm run lint (0 errors, 8 existing warnings)\n- npm run build\n\nCloses #2835