### PR TITLE
fix(deep-interview): forbid yielding turn between rounds

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -38,6 +38,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 <Execution_Policy>
 - Ask ONE question at a time -- never batch multiple questions
+- Do NOT yield the turn after `AskUserQuestion` returns the user's answer. Continue the same turn through scoring (2c), reporting (2d), `state_write` (2e), and the next question (2a/2b). Yield only when ambiguity ≤ threshold, the user requests early exit, or a hard cap triggers.
 - Target the WEAKEST clarity dimension with each question
 - Make weakest-dimension targeting explicit every round: name the weakest dimension, state its score/gap, and explain why the next question is aimed there
 - Gather codebase facts via `explore` agent BEFORE asking the user about them
@@ -152,6 +153,8 @@ Round {n} | Targeting: {weakest_dimension} | Why now: {one_sentence_targeting_ra
 ```
 
 Options should include contextually relevant choices plus free-text.
+
+**Do not stop here.** When `AskUserQuestion` returns the user's answer, immediately proceed to Step 2c in the same turn — do not treat the answer as a turn boundary.
 
 ### Step 2c: Score Ambiguity
 


### PR DESCRIPTION
## Summary
- Two-line clarification to `skills/deep-interview/SKILL.md` so the Phase 2 interview loop doesn't break across turns.
- The skill describes the round flow (2a → 2f) as continuous, but never explicitly forbids ending the turn after `AskUserQuestion` returns. Agents default to treating user responses as turn boundaries and stall there.

## Repro
1. Run `/deep-interview <vague idea>` and answer the first question.
2. Observe `.omc/state/deep-interview-state.json` — `round` stays at `0`, `current_ambiguity` doesn't change, `updated_at` goes stale.
3. Send any "still there?" nudge — the agent then runs 2c–2f and asks the next question.

In the affected session this manifested as ~8 minutes of silence per round on a greenfield interview at threshold 0.2.

## Fix
- `<Execution_Policy>`: add a bullet right after the "ONE question at a time" rule explicitly stating the loop must not yield the turn between 2c (score), 2d (report), 2e (`state_write`), and 2a/2b (next question). Yielding is only allowed when ambiguity ≤ threshold, the user requests early exit, or a hard cap triggers.
- `### Step 2b`: append a "Do not stop here" sentence so the rule appears at the natural failure point as well as in the policy block.

## Why two edits, not one
The policy block is the canonical rule list, but agents drafting their next action read locally — they're at Step 2b when the failure happens, not scrolling back to `<Execution_Policy>`. The inline reminder catches them at the decision point.

## Test plan
- [ ] Run a fresh `/deep-interview` after applying the patch and confirm `round` increments + the next question fires without a nudge.
- [ ] Confirm `state.current_ambiguity` updates after each answer.
- [ ] Spot-check that early-exit ("just build it") still works at round 3+.
- [ ] No code paths touched, only `SKILL.md`; no build / TS / test changes required.