### PR TITLE
Fix structured Write/Edit success envelopes

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -747,11 +747,31 @@ function extractTextFromKnownToolResponseField(value, depth = 0) {
   return texts;
 }
 
-function hasExplicitStructuredFailureIndicator(value, depth = 0) {
+function isStructuredEnvelopePayloadField(fieldName) {
+  return new Set([
+    'content',
+    'oldstring',
+    'newstring',
+    'originalfile',
+    'structuredpatch',
+    'patch',
+    'diff',
+    'lines',
+    'line',
+    'text',
+    'message',
+    'output',
+    'stdout',
+    'stderr',
+  ]).has(fieldName.toLowerCase());
+}
+
+function hasExplicitStructuredFailureIndicator(value, depth = 0, fieldName = '') {
   if (!value || typeof value === 'string' || depth > 4) return false;
+  if (fieldName && isStructuredEnvelopePayloadField(fieldName)) return false;
 
   if (Array.isArray(value)) {
-    return value.some(item => hasExplicitStructuredFailureIndicator(item, depth + 1));
+    return value.some(item => hasExplicitStructuredFailureIndicator(item, depth + 1, fieldName));
   }
 
   if (typeof value !== 'object') return false;
@@ -770,7 +790,7 @@ function hasExplicitStructuredFailureIndicator(value, depth = 0) {
       return true;
     }
 
-    if (hasExplicitStructuredFailureIndicator(fieldValue, depth + 1)) {
+    if (hasExplicitStructuredFailureIndicator(fieldValue, depth + 1, key)) {
       return true;
     }
   }

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -747,6 +747,37 @@ function extractTextFromKnownToolResponseField(value, depth = 0) {
   return texts;
 }
 
+function hasExplicitStructuredFailureIndicator(value, depth = 0) {
+  if (!value || typeof value === 'string' || depth > 4) return false;
+
+  if (Array.isArray(value)) {
+    return value.some(item => hasExplicitStructuredFailureIndicator(item, depth + 1));
+  }
+
+  if (typeof value !== 'object') return false;
+
+  for (const [key, fieldValue] of Object.entries(value)) {
+    const normalizedKey = key.toLowerCase();
+    if (
+      (normalizedKey.includes('error') || normalizedKey.includes('fail')) &&
+      fieldValue !== false &&
+      fieldValue !== 0 &&
+      fieldValue !== null &&
+      fieldValue !== undefined &&
+      !(typeof fieldValue === 'string' && fieldValue.trim() === '') &&
+      !(Array.isArray(fieldValue) && fieldValue.length === 0)
+    ) {
+      return true;
+    }
+
+    if (hasExplicitStructuredFailureIndicator(fieldValue, depth + 1)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function hasEditEnvelopeSuccess(value, depth = 0) {
   if (!value || typeof value === 'string' || depth > 4) return false;
 
@@ -755,6 +786,8 @@ function hasEditEnvelopeSuccess(value, depth = 0) {
   }
 
   if (typeof value !== 'object') return false;
+
+  if (hasExplicitStructuredFailureIndicator(value, depth)) return false;
 
   if (typeof value.filePath === 'string' && Array.isArray(value.structuredPatch)) {
     return true;
@@ -772,6 +805,8 @@ function hasWriteEnvelopeSuccess(value, depth = 0) {
 
   if (typeof value !== 'object') return false;
 
+  if (hasExplicitStructuredFailureIndicator(value, depth)) return false;
+
   if (
     typeof value.filePath === 'string' &&
     (value.type === 'create' || value.type === 'update')
@@ -787,6 +822,11 @@ function hasStructuredWriteSuccess(rawResponse, toolName = '') {
   if (toolName === 'Edit' && hasEditEnvelopeSuccess(rawResponse)) return true;
   if (toolName === 'Write' && hasWriteEnvelopeSuccess(rawResponse)) return true;
   return extractTextFromKnownToolResponseField(rawResponse).some(isClaudeCodeWriteSuccess);
+}
+
+function hasStructuredWriteFailure(rawResponse) {
+  if (!rawResponse || typeof rawResponse === 'string') return false;
+  return hasExplicitStructuredFailureIndicator(rawResponse);
 }
 
 // Get agent completion summary from tracking state
@@ -817,7 +857,12 @@ function getAgentCompletionSummary(directory, quietLevel = QUIET_LEVEL) {
 
 // Generate contextual message
 function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, options = {}) {
-  const { wasTruncated = false, rawLength = 0, structuredWriteSuccess = false } = options;
+  const {
+    wasTruncated = false,
+    rawLength = 0,
+    structuredWriteSuccess = false,
+    structuredWriteFailure = false,
+  } = options;
   let message = '';
 
   switch (toolName) {
@@ -868,7 +913,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
     }
 
     case 'Edit':
-      if (!structuredWriteSuccess && !isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput)) {
+      if (structuredWriteFailure || (!structuredWriteSuccess && !isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput))) {
         message = 'Edit operation failed. Verify file exists and content matches exactly.';
       } else if (QUIET_LEVEL === 0) {
         message = 'Code modified. Verify changes work as expected before marking complete.';
@@ -876,7 +921,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
       break;
 
     case 'Write':
-      if (!structuredWriteSuccess && !isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput)) {
+      if (structuredWriteFailure || (!structuredWriteSuccess && !isClaudeCodeWriteSuccess(toolOutput) && detectWriteFailure(toolOutput))) {
         message = 'Write operation failed. Check file permissions and directory existence.';
       } else if (QUIET_LEVEL === 0) {
         message = 'File written. Test the changes to ensure they work correctly.';
@@ -935,6 +980,8 @@ async function main() {
     const rawResponse = data.tool_response || data.toolOutput || '';
     const structuredWriteSuccess =
       (toolName === 'Write' || toolName === 'Edit') && hasStructuredWriteSuccess(rawResponse, toolName);
+    const structuredWriteFailure =
+      (toolName === 'Write' || toolName === 'Edit') && hasStructuredWriteFailure(rawResponse);
     const toolOutput = typeof rawResponse === 'string' ? rawResponse : JSON.stringify(rawResponse);
     const { clipped: clippedToolOutput, wasTruncated } = clipToolOutputForAnalysis(toolName, toolOutput);
     const sessionId = data.session_id || data.sessionId || 'unknown';
@@ -981,6 +1028,7 @@ async function main() {
         wasTruncated,
         rawLength: toolOutput.length,
         structuredWriteSuccess,
+        structuredWriteFailure,
       }),
       maybeBuildPreemptiveCompactionMessage(toolName, data, directory),
     );

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -758,12 +758,12 @@ function isStructuredEnvelopePayloadField(fieldName) {
     'diff',
     'lines',
     'line',
-    'text',
-    'message',
-    'output',
-    'stdout',
-    'stderr',
   ]).has(fieldName.toLowerCase());
+}
+
+function isStructuredEnvelopeStatusTextField(fieldName) {
+  return new Set(['message', 'output', 'stdout', 'stderr', 'text', 'result'])
+    .has(fieldName.toLowerCase());
 }
 
 function hasExplicitStructuredFailureIndicator(value, depth = 0, fieldName = '') {
@@ -778,6 +778,14 @@ function hasExplicitStructuredFailureIndicator(value, depth = 0, fieldName = '')
 
   for (const [key, fieldValue] of Object.entries(value)) {
     const normalizedKey = key.toLowerCase();
+    if (
+      typeof fieldValue === 'string' &&
+      isStructuredEnvelopeStatusTextField(key) &&
+      detectWriteFailure(fieldValue)
+    ) {
+      return true;
+    }
+
     if (
       (normalizedKey.includes('error') || normalizedKey.includes('fail')) &&
       fieldValue !== false &&

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -747,8 +747,45 @@ function extractTextFromKnownToolResponseField(value, depth = 0) {
   return texts;
 }
 
-function hasStructuredWriteSuccess(rawResponse) {
+function hasEditEnvelopeSuccess(value, depth = 0) {
+  if (!value || typeof value === 'string' || depth > 4) return false;
+
+  if (Array.isArray(value)) {
+    return value.some(item => hasEditEnvelopeSuccess(item, depth + 1));
+  }
+
+  if (typeof value !== 'object') return false;
+
+  if (typeof value.filePath === 'string' && Array.isArray(value.structuredPatch)) {
+    return true;
+  }
+
+  return Object.values(value).some(item => hasEditEnvelopeSuccess(item, depth + 1));
+}
+
+function hasWriteEnvelopeSuccess(value, depth = 0) {
+  if (!value || typeof value === 'string' || depth > 4) return false;
+
+  if (Array.isArray(value)) {
+    return value.some(item => hasWriteEnvelopeSuccess(item, depth + 1));
+  }
+
+  if (typeof value !== 'object') return false;
+
+  if (
+    typeof value.filePath === 'string' &&
+    (value.type === 'create' || value.type === 'update')
+  ) {
+    return true;
+  }
+
+  return Object.values(value).some(item => hasWriteEnvelopeSuccess(item, depth + 1));
+}
+
+function hasStructuredWriteSuccess(rawResponse, toolName = '') {
   if (!rawResponse || typeof rawResponse === 'string') return false;
+  if (toolName === 'Edit' && hasEditEnvelopeSuccess(rawResponse)) return true;
+  if (toolName === 'Write' && hasWriteEnvelopeSuccess(rawResponse)) return true;
   return extractTextFromKnownToolResponseField(rawResponse).some(isClaudeCodeWriteSuccess);
 }
 
@@ -897,7 +934,7 @@ async function main() {
     const toolName = data.tool_name || data.toolName || '';
     const rawResponse = data.tool_response || data.toolOutput || '';
     const structuredWriteSuccess =
-      (toolName === 'Write' || toolName === 'Edit') && hasStructuredWriteSuccess(rawResponse);
+      (toolName === 'Write' || toolName === 'Edit') && hasStructuredWriteSuccess(rawResponse, toolName);
     const toolOutput = typeof rawResponse === 'string' ? rawResponse : JSON.stringify(rawResponse);
     const { clipped: clippedToolOutput, wasTruncated } = clipToolOutputForAnalysis(toolName, toolOutput);
     const sessionId = data.session_id || data.sessionId || 'unknown';

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -612,6 +612,57 @@ describe('post-tool hook structured Write/Edit envelopes (issue #2840)', () => {
     expect(out.hookSpecificOutput?.additionalContext).not.toContain('Write operation failed');
   });
 
+  it('trusts Write success envelopes with payload JSON containing error and failure keys', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Write',
+      tool_response: {
+        type: 'create',
+        filePath: '/tmp/issue-2841-write-payload.ts',
+        content: {
+          error: 'payload fixture key, not tool status',
+          failure: 'payload fixture key, not tool status',
+          nested: {
+            failedReason: 'payload fixture key, not tool status',
+          },
+        },
+      },
+      session_id: 'issue-2841-write-payload-keys-success',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('File written.');
+    expect(out.hookSpecificOutput?.additionalContext).not.toContain('Write operation failed');
+  });
+
+  it('trusts Edit success envelopes with payload fields containing error and failure keys', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Edit',
+      tool_response: {
+        filePath: '/tmp/issue-2841-edit-payload.ts',
+        oldString: '{"error":"old payload fixture","failure":"old payload fixture"}',
+        newString: '{"error":"new payload fixture","failure":"new payload fixture"}',
+        originalFile: '{"error":"original payload fixture","failure":"original payload fixture"}',
+        structuredPatch: [
+          {
+            oldStart: 1,
+            oldLines: 1,
+            newStart: 1,
+            newLines: 1,
+            lines: [
+              { error: '-payload fixture key, not tool status' },
+              { failure: '+payload fixture key, not tool status' },
+            ],
+          },
+        ],
+      },
+      session_id: 'issue-2841-edit-payload-keys-success',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Code modified.');
+    expect(out.hookSpecificOutput?.additionalContext).not.toContain('Edit operation failed');
+  });
+
   it('does not trust Write-shaped envelopes with explicit failure fields', () => {
     const out = runPostToolVerifier({
       tool_name: 'Write',

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -663,6 +663,57 @@ describe('post-tool hook structured Write/Edit envelopes (issue #2840)', () => {
     expect(out.hookSpecificOutput?.additionalContext).not.toContain('Edit operation failed');
   });
 
+  it.each(['message', 'output', 'stdout', 'stderr'])(
+    'does not trust Write-shaped envelopes with %s failure status text',
+    field => {
+      const out = runPostToolVerifier({
+        tool_name: 'Write',
+        tool_response: {
+          type: 'create',
+          filePath: `/tmp/issue-2841-write-${field}.ts`,
+          [field]: 'error: failed to write',
+          content: { error: 'payload key remains ignored' },
+        },
+        session_id: `issue-2841-write-${field}-status-failure`,
+        cwd: process.cwd(),
+      });
+
+      expect(out.hookSpecificOutput?.additionalContext).toContain('Write operation failed');
+    },
+  );
+
+  it.each(['message', 'output', 'stdout', 'stderr'])(
+    'does not trust Edit-shaped envelopes with %s failure status text',
+    field => {
+      const out = runPostToolVerifier({
+        tool_name: 'Edit',
+        tool_response: {
+          filePath: `/tmp/issue-2841-edit-${field}.ts`,
+          [field]: 'error: failed to edit',
+          oldString: '{"error":"payload fixture"}',
+          newString: '{"failure":"payload fixture"}',
+          originalFile: '{"error":"payload fixture","failure":"payload fixture"}',
+          structuredPatch: [
+            {
+              oldStart: 1,
+              oldLines: 1,
+              newStart: 1,
+              newLines: 1,
+              lines: [
+                { error: '-payload fixture key, not tool status' },
+                { failure: '+payload fixture key, not tool status' },
+              ],
+            },
+          ],
+        },
+        session_id: `issue-2841-edit-${field}-status-failure`,
+        cwd: process.cwd(),
+      });
+
+      expect(out.hookSpecificOutput?.additionalContext).toContain('Edit operation failed');
+    },
+  );
+
   it('does not trust Write-shaped envelopes with explicit failure fields', () => {
     const out = runPostToolVerifier({
       tool_name: 'Write',

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -612,6 +612,92 @@ describe('post-tool hook structured Write/Edit envelopes (issue #2840)', () => {
     expect(out.hookSpecificOutput?.additionalContext).not.toContain('Write operation failed');
   });
 
+  it('does not trust Write-shaped envelopes with explicit failure fields', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Write',
+      tool_response: {
+        type: 'create',
+        filePath: '/tmp/issue-2841-write.ts',
+        error: 'failed to write',
+        content: 'File content that would otherwise be valid.',
+      },
+      session_id: 'issue-2841-write-envelope-error',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Write operation failed');
+  });
+
+  it('does not trust nested Write-shaped envelopes with explicit failure fields', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Write',
+      tool_response: {
+        result: {
+          type: 'update',
+          filePath: '/tmp/issue-2841-nested-write.ts',
+          failure: 'operation failed',
+          content: 'File content that would otherwise be valid.',
+        },
+      },
+      session_id: 'issue-2841-nested-write-envelope-failure',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Write operation failed');
+  });
+
+  it('does not trust Edit-shaped envelopes with explicit error fields', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Edit',
+      tool_response: {
+        filePath: '/tmp/issue-2841-edit.ts',
+        error: 'failed to edit',
+        oldString: 'const before = true;',
+        newString: 'const after = true;',
+        structuredPatch: [
+          {
+            oldStart: 1,
+            oldLines: 1,
+            newStart: 1,
+            newLines: 1,
+            lines: ['-const before = true;', '+const after = true;'],
+          },
+        ],
+      },
+      session_id: 'issue-2841-edit-envelope-error',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Edit operation failed');
+  });
+
+  it('does not trust nested Edit-shaped envelopes with explicit failure fields', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Edit',
+      tool_response: {
+        data: {
+          filePath: '/tmp/issue-2841-nested-edit.ts',
+          failure: 'operation failed',
+          oldString: 'const before = true;',
+          newString: 'const after = true;',
+          structuredPatch: [
+            {
+              oldStart: 1,
+              oldLines: 1,
+              newStart: 1,
+              newLines: 1,
+              lines: ['-const before = true;', '+const after = true;'],
+            },
+          ],
+        },
+      },
+      session_id: 'issue-2841-nested-edit-envelope-failure',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Edit operation failed');
+  });
+
   it('keeps plain string Write failure detection unchanged', () => {
     const out = runPostToolVerifier({
       tool_name: 'Write',

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -569,6 +569,61 @@ describe('post-tool hook regression coverage (issue #2615)', () => {
   });
 });
 
+describe('post-tool hook structured Write/Edit envelopes (issue #2840)', () => {
+  it('trusts real Edit success envelopes before scanning embedded source fields', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Edit',
+      tool_response: {
+        filePath: '/tmp/issue-2840-edit.ts',
+        oldString: 'throw new Error("old fixture")',
+        newString: 'expect(output).toContain("error: boom")',
+        originalFile: 'error: fixture prose\nfailed to write fixture',
+        structuredPatch: [
+          {
+            oldStart: 1,
+            oldLines: 1,
+            newStart: 1,
+            newLines: 1,
+            lines: ['-throw new Error("old fixture")', '+expect(output).toContain("error: boom")'],
+          },
+        ],
+      },
+      session_id: 'issue-2840-edit-envelope',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Code modified.');
+    expect(out.hookSpecificOutput?.additionalContext).not.toContain('Edit operation failed');
+  });
+
+  it.each(['create', 'update'])('trusts real Write %s success envelopes before scanning content', type => {
+    const out = runPostToolVerifier({
+      tool_name: 'Write',
+      tool_response: {
+        type,
+        filePath: `/tmp/issue-2840-${type}.ts`,
+        content: 'const message = "error: fixture only";\n// failed to write appears in content',
+      },
+      session_id: `issue-2840-write-${type}-envelope`,
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('File written.');
+    expect(out.hookSpecificOutput?.additionalContext).not.toContain('Write operation failed');
+  });
+
+  it('keeps plain string Write failure detection unchanged', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Write',
+      tool_response: 'error: failed to write file',
+      session_id: 'issue-2840-string-write-failure',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Write operation failed');
+  });
+});
+
 describe('OMC_QUIET hook message suppression (issue #1646)', () => {
   it('suppresses routine success/advice messages at OMC_QUIET=1 while keeping failures', () => {
     const edit = runPostToolVerifier(


### PR DESCRIPTION
## Summary
- Recognize real Claude Code structured Edit success envelopes (`filePath` + `structuredPatch`) before scanning embedded source fields.
- Recognize real structured Write success envelopes (`filePath` + `type: create|update`) before scanning file content.
- Preserve existing plain string failure detection and prose success-marker behavior.

Fixes #2840.

## Verification
- `npx vitest run src/__tests__/post-tool-verifier.test.mjs --reporter=json`
- `npx vitest run src/__tests__/post-tool-verifier.test.mjs src/__tests__/preemptive-compaction-hook.test.ts --reporter=json`
- `npm run test:run -- --reporter=json`
- `npm run lint -- --format json`

🤖 Generated with [Codex](https://openai.com/codex)
