### PR TITLE
Fix HUD statusLine cold-start flicker

### DIFF
--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -33,13 +33,21 @@ extract_json_string() {
 }
 
 SESSION_KEY=$(extract_json_string session_id)
+if [ -z "$SESSION_KEY" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+  SESSION_KEY=$CLAUDE_SESSION_ID
+fi
 TRANSCRIPT_PATH=$(extract_json_string transcript_path)
-if [ -z "$SESSION_KEY" ]; then
+if [ -z "$SESSION_KEY" ] && [ -n "$TRANSCRIPT_PATH" ]; then
   SESSION_KEY=$(printf '%s\n' "$TRANSCRIPT_PATH" | sed -n 's/.*\([0-9a-fA-F][0-9a-fA-F-]\{35\}\).*/\1/p' | head -1)
+  if [ -z "$SESSION_KEY" ]; then
+    SESSION_KEY=$(printf '%s\n' "$TRANSCRIPT_PATH" | cksum 2>/dev/null | awk '{print "transcript-" $1}')
+  fi
 fi
 if [ -z "$SESSION_KEY" ]; then
   CWD_VALUE=$(extract_json_string cwd)
-  SESSION_KEY=$(printf '%s|%s\n' "$TRANSCRIPT_PATH" "$CWD_VALUE" | cksum 2>/dev/null | awk '{print $1}')
+  if [ -n "$CWD_VALUE" ]; then
+    SESSION_KEY=$(printf '%s\n' "$CWD_VALUE" | cksum 2>/dev/null | awk '{print "cwd-" $1}')
+  fi
 fi
 if [ -z "$SESSION_KEY" ]; then
   SESSION_KEY=default

--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# OMC HUD cached statusLine launcher.
+#
+# Claude Code invokes statusLine commands for every render. Starting Node and
+# importing the HUD bundle each time can take hundreds of milliseconds, which
+# makes the first frame blank/flickery. This POSIX wrapper keeps the statusLine
+# protocol unchanged (stdin JSON in, one line out) while making the hot path a
+# shell read + cat of the last rendered line. A single background Node refresh
+# updates the session-scoped cache for the next frame.
+
+case "$0" in
+  */*) SCRIPT_DIR=${0%/*} ;;
+  *) SCRIPT_DIR=. ;;
+esac
+SCRIPT_DIR=$(cd "$SCRIPT_DIR" 2>/dev/null && pwd -P) || SCRIPT_DIR=.
+CONFIG_DIR=${CLAUDE_CONFIG_DIR:-$(cd "$SCRIPT_DIR/.." 2>/dev/null && pwd -P)}
+CACHE_DIR=${OMC_HUD_CACHE_DIR:-"$CONFIG_DIR/hud/cache"}
+HUD_SCRIPT=${1:-"$SCRIPT_DIR/omc-hud.mjs"}
+INPUT_TMP="$CACHE_DIR/stdin.$$.tmp"
+
+mkdir -p "$CACHE_DIR" 2>/dev/null || {
+  printf '[OMC] Starting...\n'
+  exit 0
+}
+
+# Capture Claude's current statusLine stdin first so rendered output can be
+# scoped per session/worktree instead of leaking across concurrent sessions.
+cat > "$INPUT_TMP" 2>/dev/null || :
+
+extract_json_string() {
+  key=$1
+  sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$INPUT_TMP" 2>/dev/null | head -1
+}
+
+SESSION_KEY=$(extract_json_string session_id)
+TRANSCRIPT_PATH=$(extract_json_string transcript_path)
+if [ -z "$SESSION_KEY" ]; then
+  SESSION_KEY=$(printf '%s\n' "$TRANSCRIPT_PATH" | sed -n 's/.*\([0-9a-fA-F][0-9a-fA-F-]\{35\}\).*/\1/p' | head -1)
+fi
+if [ -z "$SESSION_KEY" ]; then
+  CWD_VALUE=$(extract_json_string cwd)
+  SESSION_KEY=$(printf '%s|%s\n' "$TRANSCRIPT_PATH" "$CWD_VALUE" | cksum 2>/dev/null | awk '{print $1}')
+fi
+if [ -z "$SESSION_KEY" ]; then
+  SESSION_KEY=default
+fi
+SESSION_KEY=$(printf '%s' "$SESSION_KEY" | sed 's/[^A-Za-z0-9_.-]/_/g')
+
+INPUT_FILE="$CACHE_DIR/stdin.$SESSION_KEY.json"
+OUTPUT_FILE="$CACHE_DIR/statusline.$SESSION_KEY.txt"
+LOCK_DIR="$CACHE_DIR/render.$SESSION_KEY.lock"
+NODE_STDOUT_TMP="$CACHE_DIR/statusline.$SESSION_KEY.$$.tmp"
+NODE_STDERR_TMP="$CACHE_DIR/statusline.$SESSION_KEY.$$.err"
+
+if [ -s "$INPUT_TMP" ]; then
+  mv "$INPUT_TMP" "$INPUT_FILE" 2>/dev/null || cp "$INPUT_TMP" "$INPUT_FILE" 2>/dev/null || :
+fi
+rm -f "$INPUT_TMP" 2>/dev/null || :
+
+# Hot path: return immediately from the last successful render for this session.
+if [ -s "$OUTPUT_FILE" ]; then
+  cat "$OUTPUT_FILE" 2>/dev/null || printf '[OMC] Starting...\n'
+else
+  printf '[OMC] Starting...\n'
+fi
+
+# Avoid spawning a Node renderer on every statusLine render. mkdir is atomic.
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  # Recover from stale locks left by crashes.
+  if [ -d "$LOCK_DIR" ]; then
+    now=$(date +%s 2>/dev/null || printf '0')
+    lock_mtime=$( (stat -c %Y "$LOCK_DIR" 2>/dev/null || stat -f %m "$LOCK_DIR" 2>/dev/null) | head -1 )
+    if [ -n "$lock_mtime" ] && [ "$now" -gt 0 ] && [ $((now - lock_mtime)) -gt 10 ]; then
+      rm -rf "$LOCK_DIR" 2>/dev/null || :
+      mkdir "$LOCK_DIR" 2>/dev/null || exit 0
+    else
+      exit 0
+    fi
+  else
+    exit 0
+  fi
+fi
+
+refresh_cache() {
+  if [ ! -s "$INPUT_FILE" ]; then
+    rm -rf "$LOCK_DIR" 2>/dev/null || :
+    return
+  fi
+
+  if [ -x "$SCRIPT_DIR/find-node.sh" ]; then
+    sh "$SCRIPT_DIR/find-node.sh" "$HUD_SCRIPT" < "$INPUT_FILE" > "$NODE_STDOUT_TMP" 2> "$NODE_STDERR_TMP"
+  else
+    node "$HUD_SCRIPT" < "$INPUT_FILE" > "$NODE_STDOUT_TMP" 2> "$NODE_STDERR_TMP"
+  fi
+
+  # Keep the last good line if rendering fails or returns empty output.
+  if [ -s "$NODE_STDOUT_TMP" ]; then
+    mv "$NODE_STDOUT_TMP" "$OUTPUT_FILE" 2>/dev/null || cp "$NODE_STDOUT_TMP" "$OUTPUT_FILE" 2>/dev/null || :
+  fi
+
+  rm -f "$NODE_STDOUT_TMP" "$NODE_STDERR_TMP" 2>/dev/null || :
+  rm -rf "$LOCK_DIR" 2>/dev/null || :
+}
+
+if [ "${OMC_HUD_SYNC_REFRESH:-0}" = "1" ]; then
+  refresh_cache
+else
+  ( refresh_cache ) >/dev/null 2>&1 &
+fi
+
+exit 0

--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -36,6 +36,9 @@ SESSION_KEY=$(extract_json_string session_id)
 if [ -z "$SESSION_KEY" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
   SESSION_KEY=$CLAUDE_SESSION_ID
 fi
+if [ -z "$SESSION_KEY" ] && [ -n "${CLAUDECODE_SESSION_ID:-}" ]; then
+  SESSION_KEY=$CLAUDECODE_SESSION_ID
+fi
 TRANSCRIPT_PATH=$(extract_json_string transcript_path)
 if [ -z "$SESSION_KEY" ] && [ -n "$TRANSCRIPT_PATH" ]; then
   SESSION_KEY=$(printf '%s\n' "$TRANSCRIPT_PATH" | sed -n 's/.*\([0-9a-fA-F][0-9a-fA-F-]\{35\}\).*/\1/p' | head -1)

--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -36,6 +36,11 @@ if (!existsSync(HUD_LIB_DIR)) {
   mkdirSync(HUD_LIB_DIR, { recursive: true });
 }
 copyFileSync(join(__dirname, 'lib', 'config-dir.mjs'), join(HUD_LIB_DIR, 'config-dir.mjs'));
+copyFileSync(join(__dirname, 'lib', 'config-dir.sh'), join(HUD_LIB_DIR, 'config-dir.sh'));
+copyFileSync(join(__dirname, 'find-node.sh'), join(HUD_DIR, 'find-node.sh'));
+copyFileSync(join(__dirname, 'lib', 'hud-cache-wrapper.sh'), join(HUD_DIR, 'omc-hud-cache.sh'));
+try { chmodSync(join(HUD_DIR, 'find-node.sh'), 0o755); } catch { /* Windows doesn't need this */ }
+try { chmodSync(join(HUD_DIR, 'omc-hud-cache.sh'), 0o755); } catch { /* Windows doesn't need this */ }
 
 // 2. Create HUD wrapper script
 const hudScriptPath = join(HUD_DIR, 'omc-hud.mjs').replace(/\\/g, '/');
@@ -54,9 +59,13 @@ try {
     settings = JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8'));
   }
 
+  const statusLineCommand = process.platform === 'win32'
+    ? `"${nodeBin}" "${hudScriptPath.replace(/\\/g, "/")}"`
+    : `sh "${join(HUD_DIR, 'omc-hud-cache.sh').replace(/\\/g, "/")}" "${hudScriptPath.replace(/\\/g, "/")}"`;
+
   settings.statusLine = {
     type: 'command',
-    command: `"${nodeBin}" "${hudScriptPath.replace(/\\/g, "/")}"`
+    command: statusLineCommand
   };
   writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2));
   console.log('[OMC] Configured HUD statusLine in settings.json');

--- a/src/__tests__/hud-marketplace-resolution.test.ts
+++ b/src/__tests__/hud-marketplace-resolution.test.ts
@@ -68,6 +68,11 @@ describe('HUD marketplace resolution', () => {
       statusLine?: { command?: string };
     };
     expect(settings.statusLine?.command).toContain(`${join(configDir, 'hud', 'omc-hud.mjs').replace(/\\/g, '/')}`);
+    if (process.platform !== 'win32') {
+      expect(settings.statusLine?.command).toContain('omc-hud-cache.sh');
+      expect(existsSync(join(configDir, 'hud', 'omc-hud-cache.sh'))).toBe(true);
+      expect(existsSync(join(configDir, 'hud', 'find-node.sh'))).toBe(true);
+    }
     expect(existsSync(join(configDir, '.omc-config.json'))).toBe(true);
 
     const content = readFileSync(hudScriptPath, 'utf-8');

--- a/src/__tests__/installer-hud-skip.test.ts
+++ b/src/__tests__/installer-hud-skip.test.ts
@@ -168,4 +168,12 @@ describe('isOmcStatusLine', () => {
       command: 'sh ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/find-node.sh ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs'
     })).toBe(true);
   });
+
+
+  it('should recognize cached HUD statusLine as OMC', () => {
+    expect(isOmcStatusLine({
+      type: 'command',
+      command: 'sh ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud-cache.sh ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs'
+    })).toBe(true);
+  });
 });

--- a/src/installer/__tests__/hud-cache-wrapper.test.ts
+++ b/src/installer/__tests__/hud-cache-wrapper.test.ts
@@ -188,4 +188,73 @@ describe('HUD cached statusLine launcher', () => {
     }
   });
 
+
+  it('uses legacy CLAUDECODE_SESSION_ID when newer env and stdin session_id are absent', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.legacy-env-session-123.txt'), 'LEGACY ENV SESSION HUD\n');
+      mkdirSync(join(staged.cacheDir, 'render.legacy-env-session-123.lock'));
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nexit 0\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        CLAUDE_CONFIG_DIR: staged.dir,
+        CLAUDECODE_SESSION_ID: 'legacy-env-session-123',
+        OMC_HUD_CACHE_DIR: staged.cacheDir,
+      };
+      delete env.CLAUDE_SESSION_ID;
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: JSON.stringify({ cwd: '/tmp/same-worktree', model: { id: 'claude' } }),
+        encoding: 'utf8',
+        env,
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('LEGACY ENV SESSION HUD\n');
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers CLAUDE_SESSION_ID over legacy CLAUDECODE_SESSION_ID', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.new-env-session.txt'), 'NEW ENV SESSION HUD\n');
+      writeFileSync(join(staged.cacheDir, 'statusline.legacy-env-session.txt'), 'LEGACY ENV SESSION HUD\n');
+      mkdirSync(join(staged.cacheDir, 'render.new-env-session.lock'));
+      mkdirSync(join(staged.cacheDir, 'render.legacy-env-session.lock'));
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nexit 0\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: JSON.stringify({ cwd: '/tmp/same-worktree', model: { id: 'claude' } }),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          CLAUDE_SESSION_ID: 'new-env-session',
+          CLAUDECODE_SESSION_ID: 'legacy-env-session',
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('NEW ENV SESSION HUD\n');
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/installer/__tests__/hud-cache-wrapper.test.ts
+++ b/src/installer/__tests__/hud-cache-wrapper.test.ts
@@ -123,4 +123,69 @@ describe('HUD cached statusLine launcher', () => {
     }
   });
 
+
+  it('uses CLAUDE_SESSION_ID when stdin has no session_id', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.env-session-123.txt'), 'ENV SESSION HUD\n');
+      mkdirSync(join(staged.cacheDir, 'render.env-session-123.lock'));
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nexit 0\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: JSON.stringify({ cwd: '/tmp/same-worktree', model: { id: 'claude' } }),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          CLAUDE_SESSION_ID: 'env-session-123',
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('ENV SESSION HUD\n');
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not collide same-cwd sessions when transcript_path is missing but CLAUDE_SESSION_ID differs', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.env-session-a.txt'), 'ENV SESSION A\n');
+      writeFileSync(join(staged.cacheDir, 'statusline.env-session-b.txt'), 'ENV SESSION B\n');
+      mkdirSync(join(staged.cacheDir, 'render.env-session-a.lock'));
+      mkdirSync(join(staged.cacheDir, 'render.env-session-b.lock'));
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nexit 0\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const runForEnvSession = (sessionId: string) => spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: JSON.stringify({ cwd: '/tmp/same-worktree', model: { id: 'claude' } }),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          CLAUDE_SESSION_ID: sessionId,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(runForEnvSession('env-session-a').stdout).toBe('ENV SESSION A\n');
+      expect(runForEnvSession('env-session-b').stdout).toBe('ENV SESSION B\n');
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/installer/__tests__/hud-cache-wrapper.test.ts
+++ b/src/installer/__tests__/hud-cache-wrapper.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const root = resolve(__dirname, '..', '..', '..');
+const wrapperSource = join(root, 'scripts', 'lib', 'hud-cache-wrapper.sh');
+
+function stageWrapper() {
+  const dir = mkdtempSync(join(tmpdir(), 'omc-hud-cache-wrapper-'));
+  const hudDir = join(dir, 'hud');
+  const cacheDir = join(hudDir, 'cache');
+  mkdirSync(cacheDir, { recursive: true });
+  const wrapperPath = join(hudDir, 'omc-hud-cache.sh');
+  const hudPath = join(hudDir, 'omc-hud.mjs');
+  writeFileSync(wrapperPath, readFileSync(wrapperSource, 'utf8'), 'utf8');
+  chmodSync(wrapperPath, 0o755);
+  return { dir, hudDir, cacheDir, wrapperPath, hudPath };
+}
+
+const stdinPayload = JSON.stringify({ session_id: 'session-123', cwd: '/tmp', transcript_path: '/tmp/session.jsonl', model: { id: 'claude' } });
+
+describe('HUD cached statusLine launcher', () => {
+  it('cached hot path returns the previous render without invoking Node when refresh is locked', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'CACHED HUD LINE\n');
+      mkdirSync(join(staged.cacheDir, 'render.session-123.lock'));
+
+      const nodeMarker = join(staged.dir, 'node-invoked');
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), `#!/bin/sh\ntouch ${JSON.stringify(nodeMarker)}\nexit 0\n`, 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const start = Date.now();
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+      const elapsedMs = Date.now() - start;
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('CACHED HUD LINE\n');
+      expect(existsSync(nodeMarker)).toBe(false);
+      expect(elapsedMs).toBeLessThan(100);
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('first render prints a nonblank placeholder and refreshes the cache from Node', () => {
+    const staged = stageWrapper();
+    try {
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(
+        join(fakeBin, 'node'),
+        '#!/bin/sh\nprintf "FRESH HUD LINE\\n"\n',
+        'utf8',
+      );
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+          OMC_HUD_SYNC_REFRESH: '1',
+        },
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('[OMC] Starting...\n');
+      expect(readFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'utf8')).toBe('FRESH HUD LINE\n');
+      expect(readFileSync(join(staged.cacheDir, 'stdin.session-123.json'), 'utf8')).toBe(stdinPayload);
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('scopes cached output by session_id to avoid cross-session flicker', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.session-a.txt'), 'SESSION A\n');
+      writeFileSync(join(staged.cacheDir, 'statusline.session-b.txt'), 'SESSION B\n');
+      mkdirSync(join(staged.cacheDir, 'render.session-a.lock'));
+      mkdirSync(join(staged.cacheDir, 'render.session-b.lock'));
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nexit 0\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const runForSession = (sessionId: string) => spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: JSON.stringify({ session_id: sessionId, cwd: '/tmp', transcript_path: '/tmp/session.jsonl' }),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(runForSession('session-a').stdout).toBe('SESSION A\n');
+      expect(runForSession('session-b').stdout).toBe('SESSION B\n');
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+});

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -72,6 +72,8 @@ describe('install() standalone hook reconciliation', () => {
     expect((writtenSettings as { statusLine?: { command?: string } }).statusLine?.command).toContain(
       `${join(testClaudeDir, 'hud', 'omc-hud.mjs').replace(/\\/g, '/')}`,
     );
+    expect((writtenSettings as { statusLine?: { command?: string } }).statusLine?.command).toContain('omc-hud-cache.sh');
+    expect(readFileSync(join(testClaudeDir, 'hud', 'omc-hud-cache.sh'), 'utf-8')).toContain('HUD cached statusLine launcher');
     expect(readFileSync(join(testClaudeDir, 'hud', 'omc-hud.mjs'), 'utf-8')).toContain(
       'const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs")).href);',
     );

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -192,9 +192,24 @@ function quoteShellArg(value: string): string {
   return `"${value.replace(/"/g, '\\"')}"`;
 }
 
-function buildStatusLineCommand(nodeBin: string, hudScriptPath: string, findNodePath?: string): string {
+function buildStatusLineCommand(
+  nodeBin: string,
+  hudScriptPath: string,
+  findNodePath?: string,
+  cacheWrapperPath?: string,
+): string {
   if (isWindows()) {
     return `${quoteShellArg(nodeBin)} ${quoteShellArg(hudScriptPath)}`;
+  }
+
+  const normalizedHudScriptPath = hudScriptPath.replace(/\\/g, '/');
+
+  if (cacheWrapperPath) {
+    if (isDefaultClaudeConfigDirPath(CLAUDE_CONFIG_DIR)) {
+      return 'sh ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud-cache.sh ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs';
+    }
+
+    return `sh ${quoteShellArg(cacheWrapperPath.replace(/\\/g, '/'))} ${quoteShellArg(normalizedHudScriptPath)}`;
   }
 
   if (isDefaultClaudeConfigDirPath(CLAUDE_CONFIG_DIR)) {
@@ -205,7 +220,6 @@ function buildStatusLineCommand(nodeBin: string, hudScriptPath: string, findNode
     return 'node ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hud/omc-hud.mjs';
   }
 
-  const normalizedHudScriptPath = hudScriptPath.replace(/\\/g, '/');
   if (findNodePath) {
     return `sh ${quoteShellArg(findNodePath.replace(/\\/g, '/'))} ${quoteShellArg(normalizedHudScriptPath)}`;
   }
@@ -516,6 +530,8 @@ function configureInstallerSettings(
       try {
         const findNodeSrc = join(getPackageDir(), 'scripts', 'find-node.sh');
         const findNodeDest = join(HUD_DIR, 'find-node.sh');
+        const cacheWrapperSrc = join(getPackageDir(), 'scripts', 'lib', 'hud-cache-wrapper.sh');
+        const cacheWrapperDest = join(HUD_DIR, 'omc-hud-cache.sh');
         const configDirHelperSrc = join(getPackageDir(), 'scripts', 'lib', 'config-dir.sh');
         const hudLibDir = join(HUD_DIR, 'lib');
         const configDirHelperDest = join(hudLibDir, 'config-dir.sh');
@@ -523,10 +539,12 @@ function configureInstallerSettings(
           mkdirSync(hudLibDir, { recursive: true });
         }
         copyFileSync(findNodeSrc, findNodeDest);
+        copyFileSync(cacheWrapperSrc, cacheWrapperDest);
         copyFileSync(configDirHelperSrc, configDirHelperDest);
         chmodSync(findNodeDest, 0o755);
+        chmodSync(cacheWrapperDest, 0o755);
         chmodSync(configDirHelperDest, 0o755);
-        statusLineCommand = buildStatusLineCommand(nodeBin, context.hudScriptPath.replace(/\\/g, '/'), findNodeDest);
+        statusLineCommand = buildStatusLineCommand(nodeBin, context.hudScriptPath.replace(/\\/g, '/'), findNodeDest, cacheWrapperDest);
       } catch {
         statusLineCommand = buildStatusLineCommand(nodeBin, context.hudScriptPath.replace(/\\/g, '/'));
       }


### PR DESCRIPTION
## Summary
- install a POSIX `omc-hud-cache.sh` statusLine launcher that returns the last session-scoped HUD line immediately
- refresh the canonical `omc-hud.mjs` renderer in the background via existing `find-node.sh` Node discovery
- keep Windows on the direct Node statusLine path and preserve existing `omc-hud.mjs` wrapper/import behavior

Closes #2843

## Verification
- `git diff --check`
- `npx tsc --noEmit --pretty false`
- `npm test -- --run src/installer/__tests__/hud-cache-wrapper.test.ts src/__tests__/installer-hud-skip.test.ts src/installer/__tests__/standalone-hook-reconcile.test.ts src/__tests__/hud-marketplace-resolution.test.ts src/installer/__tests__/hud-wrapper-env.test.ts src/__tests__/hud-wrapper-template-sync.test.ts`
- `npm run lint` (0 errors; existing unrelated warnings)
- `npm run build`
