### PR TITLE
feat(team): add mistral worker type via vibe CLI

### DIFF
--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: omc-teams
-description: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution
+description: CLI-team runtime for claude, codex, gemini, or mistral (vibe) workers in tmux panes when you need process-based parallel execution
 aliases: []
 level: 4
 ---
 
 # OMC Teams Skill
 
-Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Supports `claude`, `codex`, and `gemini` agent types.
+Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Supports `claude`, `codex`, `gemini`, and `mistral` agent types.
 
 `/omc-teams` is a legacy compatibility skill for the CLI-first runtime: use `omc team ...` commands (not deprecated MCP runtime tools).
 
@@ -17,12 +17,13 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 /oh-my-claudecode:omc-teams N:claude "task description"
 /oh-my-claudecode:omc-teams N:codex "task description"
 /oh-my-claudecode:omc-teams N:gemini "task description"
+/oh-my-claudecode:omc-teams N:mistral "task description"
 ```
 
 ### Parameters
 
 - **N** - Number of CLI workers (1-10)
-- **agent-type** - `claude` (Claude CLI), `codex` (OpenAI Codex CLI), or `gemini` (Google Gemini CLI)
+- **agent-type** - `claude` (Claude CLI), `codex` (OpenAI Codex CLI), `gemini` (Google Gemini CLI), or `mistral` (Mistral Vibe CLI)
 - **task** - Task description to distribute across all workers
 
 ### Examples
@@ -31,6 +32,7 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 /omc-teams 2:claude "implement auth module with tests"
 /omc-teams 2:codex "review the auth module for security issues"
 /omc-teams 3:gemini "redesign UI components for accessibility"
+/omc-teams 2:mistral "refactor logging to structured JSON across the data layer"
 ```
 
 ## Requirements
@@ -40,6 +42,7 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 - **claude** CLI: `npm install -g @anthropic-ai/claude-code`
 - **codex** CLI: `npm install -g @openai/codex`
 - **gemini** CLI: `npm install -g @google/gemini-cli`
+- **mistral** CLI (`vibe`): `uv tool install mistral-vibe` (or `pipx install mistral-vibe`), then `vibe --setup` to configure the API key. The team runtime invokes vibe's built-in `auto-approve` agent for unattended work; model selection lives in `~/.vibe/agents/*.toml`.
 
 ## Workflow
 
@@ -66,12 +69,12 @@ tmux display-message -p '#S'
 Extract:
 
 - `N` — worker count (1–10)
-- `agent-type` — `claude|codex|gemini`
+- `agent-type` — `claude|codex|gemini|mistral`
 - `task` — task description
 
 Validate before decomposing or running anything:
 
-- Reject unsupported agent types up front. `/omc-teams` only supports **`claude`**, **`codex`**, and **`gemini`**.
+- Reject unsupported agent types up front. `/omc-teams` only supports **`claude`**, **`codex`**, **`gemini`**, and **`mistral`**.
 - If the user asks for an unsupported type such as `expert`, explain that `/omc-teams` launches external CLI workers only.
 - For native Claude Code team agents/roles, direct them to **`/oh-my-claudecode:team`** instead.
 
@@ -96,6 +99,7 @@ working directory before launch:
 - Do not anchor the launch cwd to only the repo containing `.omc/plans/...` when
   target repos are siblings; that strands `codex`, `claude`, and `gemini` workers in
   the plan repo instead of the implementation workspace.
+- The same applies to `mistral` (vibe) workers — they share the single launch cwd.
 - If no safe shared workspace root can be identified, do not launch `/omc-teams`.
   Report the single-cwd constraint and ask for, or derive from evidence, the intended
   workspace root.
@@ -111,7 +115,7 @@ state_write(mode="team", current_phase="team-exec", active=true)
 Start workers via CLI:
 
 ```bash
-omc team <N>:<claude|codex|gemini> "<task>"
+omc team <N>:<claude|codex|gemini|mistral> "<task>"
 ```
 
 For the multi-repo case resolved in Phase 2.5, launch from the shared workspace root
@@ -175,9 +179,10 @@ If encountered, switch to `omc team ...` CLI commands.
 | ---------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
 | `not inside tmux`            | Requested in-place pane topology from a non-tmux surface | Start tmux and rerun, or let `omc team` use its detached-session fallback           |
 | `cmux surface detected`      | Running inside cmux without `$TMUX` | Use the normal `omc team ...` flow; OMC will launch a detached tmux session         |
-| `Unsupported agent type`     | Requested agent is not claude/codex/gemini | Use `claude`, `codex`, or `gemini`; for native Claude Code agents use `/oh-my-claudecode:team` |
+| `Unsupported agent type`     | Requested agent is not claude/codex/gemini/mistral | Use `claude`, `codex`, `gemini`, or `mistral`; for native Claude Code agents use `/oh-my-claudecode:team` |
 | `codex: command not found`   | Codex CLI not installed             | `npm install -g @openai/codex`                                                      |
 | `gemini: command not found`  | Gemini CLI not installed            | `npm install -g @google/gemini-cli`                                                 |
+| `vibe: command not found`    | Mistral Vibe CLI not installed      | `uv tool install mistral-vibe` (or `pipx install mistral-vibe`), then `vibe --setup` to log in |
 | `Team <name> is not running` | stale or missing runtime state      | `omc team status <team-name>` then `omc team shutdown <team-name> --force` if stale |
 | `status: failed`             | Workers exited with incomplete work | inspect runtime output, narrow scope, rerun                                         |
 
@@ -185,7 +190,7 @@ If encountered, switch to `omc team ...` CLI commands.
 
 | Aspect       | `/team`                                   | `/omc-teams`                                         |
 | ------------ | ----------------------------------------- | ---------------------------------------------------- |
-| Worker type  | Claude Code native team agents            | claude / codex / gemini CLI processes in tmux        |
+| Worker type  | Claude Code native team agents            | claude / codex / gemini / mistral CLI processes in tmux |
 | Invocation   | `TeamCreate` / `Task` / `SendMessage`     | `omc team [N:agent]` + `status` + `shutdown` + `api` |
 | Coordination | Native team messaging and staged pipeline | tmux worker runtime + CLI API state files            |
 | Use when     | You want Claude-native team orchestration | You want external CLI worker execution               |

--- a/src/__tests__/runtime-guidance-plan-ralph.test.ts
+++ b/src/__tests__/runtime-guidance-plan-ralph.test.ts
@@ -6,6 +6,7 @@ const availability = vi.hoisted(() => ({
   codex: false,
   gemini: false,
   cursor: false,
+  mistral: false,
 }));
 
 vi.mock('../team/model-contract.js', () => ({
@@ -23,6 +24,7 @@ describe('runtime-guidance: ralplan/plan/ralph Codex availability', () => {
     availability.codex = false;
     availability.gemini = false;
     availability.cursor = false;
+    availability.mistral = false;
   });
 
   describe('renderSkillRuntimeGuidance for plan-family skills', () => {

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,15 @@ import { fileURLToPath } from 'url';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
 export const ASK_USAGE = [
-  'Usage: omc ask <claude|codex|gemini> <question or task>',
-  '   or: omc ask <claude|codex|gemini> -p "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --print "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --prompt "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --agent-prompt <role> "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --agent-prompt=<role> --prompt "<prompt>"',
+  'Usage: omc ask <claude|codex|gemini|mistral> <question or task>',
+  '   or: omc ask <claude|codex|gemini|mistral> -p "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|mistral> --print "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|mistral> --prompt "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|mistral> --agent-prompt <role> "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|mistral> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'codex', 'gemini'] as const;
+const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'mistral'] as const;
 export type AskProvider = (typeof ASK_PROVIDERS)[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 

--- a/src/cli/commands/doctor-team-routing.ts
+++ b/src/cli/commands/doctor-team-routing.ts
@@ -24,6 +24,7 @@ const PROVIDER_BINARY: Record<TeamRoleProvider, string> = {
   claude: 'claude',
   codex: 'codex',
   gemini: 'gemini',
+  mistral: 'vibe',
 };
 
 function probeProvider(provider: TeamRoleProvider): ProviderProbe {
@@ -61,7 +62,7 @@ function collectConfiguredProviders(): Set<TeamRoleProvider> {
   const roleRouting = cfg.team?.roleRouting ?? {};
   for (const spec of Object.values(roleRouting)) {
     const provider = spec?.provider as TeamRoleProvider | undefined;
-    if (provider === 'claude' || provider === 'codex' || provider === 'gemini') {
+    if (provider === 'claude' || provider === 'codex' || provider === 'gemini' || provider === 'mistral') {
       providers.add(provider);
     }
   }

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -20,7 +20,7 @@ import { loadConfig } from '../../config/loader.js';
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
-const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini']);
+const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'mistral']);
 const DEFAULT_TEAM_CLI_AGENT_TYPE: CliAgentType = 'claude';
 
 const TEAM_HELP = `

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -14,7 +14,7 @@ import { isProcessAlive } from '../platform/index.js';
 import { getGlobalOmcStatePath } from '../utils/paths.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
-const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor']);
+const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor', 'mistral']);
 const SUBCOMMANDS = new Set(['start', 'status', 'wait', 'cleanup', 'resume', 'shutdown', 'api', 'help', '--help', '-h']);
 
 const SUPPORTED_API_OPERATIONS = new Set([
@@ -784,7 +784,7 @@ export async function teamCleanupCommand(
 
 export const TEAM_USAGE = `
 Usage:
-  omc team start --agent <claude|codex|gemini|cursor>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--new-window] [--json]
+  omc team start --agent <claude|codex|gemini|mistral|cursor>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--new-window] [--json]
   omc team status <job_id|team_name> [--json] [--cwd DIR]
   omc team wait <job_id> [--timeout-ms MS] [--json]
   omc team cleanup <job_id> [--grace-ms MS] [--json]

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -416,10 +416,10 @@ export function loadEnvConfig(): Partial<PluginConfig> {
 
   if (process.env.OMC_DELEGATION_ROUTING_DEFAULT_PROVIDER) {
     const provider = process.env.OMC_DELEGATION_ROUTING_DEFAULT_PROVIDER;
-    if (["claude", "codex", "gemini"].includes(provider)) {
+    if (["claude", "codex", "gemini", "mistral"].includes(provider)) {
       config.delegationRouting = {
         ...config.delegationRouting,
-        defaultProvider: provider as "claude" | "codex" | "gemini",
+        defaultProvider: provider as "claude" | "codex" | "gemini" | "mistral",
       };
     }
   }
@@ -475,7 +475,7 @@ function warnOnDeprecatedDelegationRouting(config: PluginConfig): void {
  */
 const CANONICAL_TEAM_ROLE_SET = new Set<string>(CANONICAL_TEAM_ROLES);
 const KNOWN_AGENT_NAME_SET = new Set<string>(KNOWN_AGENT_NAMES);
-const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini"]);
+const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini", "mistral"]);
 const TEAM_ROLE_TIERS = new Set(["HIGH", "MEDIUM", "LOW"]);
 
 export function validateTeamConfig(config: PluginConfig): void {
@@ -1057,7 +1057,7 @@ export function generateConfigSchema(): object {
           },
           defaultProvider: {
             type: "string",
-            enum: ["claude", "codex", "gemini"],
+            enum: ["claude", "codex", "gemini", "mistral"],
             default: "claude",
             description:
               "Default provider for delegation routing when no specific role mapping exists",
@@ -1070,7 +1070,7 @@ export function generateConfigSchema(): object {
               properties: {
                 provider: {
                   type: "string",
-                  enum: ["claude", "codex", "gemini"],
+                  enum: ["claude", "codex", "gemini", "mistral"],
                 },
                 tool: { type: "string", enum: ["Task"] },
                 model: { type: "string" },
@@ -1092,7 +1092,7 @@ export function generateConfigSchema(): object {
               maxAgents: { type: "integer", minimum: 1 },
               defaultAgentType: {
                 type: "string",
-                enum: ["claude", "codex", "gemini"],
+                enum: ["claude", "codex", "gemini", "mistral"],
                 default: "claude",
               },
               monitorIntervalMs: { type: "integer", minimum: 1 },
@@ -1106,7 +1106,7 @@ export function generateConfigSchema(): object {
             additionalProperties: {
               type: "object",
               properties: {
-                provider: { type: "string", enum: ["claude", "codex", "gemini"] },
+                provider: { type: "string", enum: ["claude", "codex", "gemini", "mistral"] },
                 model: { type: "string" },
                 agent: { type: "string" },
               },

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -245,7 +245,7 @@ function makeJobResponse(jobId: string, job: OmcTeamJob, extra: Record<string, u
 
 const startSchema = z.object({
   teamName: z.string().describe('Slug name for the team (e.g. "auth-review")'),
-  agentTypes: z.array(z.string()).describe('Agent type per worker: "claude", "codex", or "gemini"'),
+  agentTypes: z.array(z.string()).describe('Agent type per worker: "claude", "codex", "gemini", or "mistral"'),
   tasks: z.array(z.object({
     subject: z.string().describe('Brief task title'),
     description: z.string().describe('Full task description'),
@@ -552,7 +552,7 @@ const TOOLS = [
       type: 'object' as const,
       properties: {
         teamName: { type: 'string', description: 'Slug name for the team' },
-        agentTypes: { type: 'array', items: { type: 'string' }, description: '"claude", "codex", or "gemini" per worker' },
+        agentTypes: { type: 'array', items: { type: 'string' }, description: '"claude", "codex", "gemini", or "mistral" per worker' },
         tasks: {
           type: 'array',
           items: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -341,7 +341,9 @@ export type DelegationProvider =
   /** Use /team to coordinate Codex CLI workers in tmux panes. */
   | "codex"
   /** Use /team to coordinate Gemini CLI workers in tmux panes. */
-  | "gemini";
+  | "gemini"
+  /** Use /team to coordinate Mistral (vibe) CLI workers in tmux panes. */
+  | "mistral";
 
 /** Tool type for delegation routing — only Claude Task is supported. */
 export type DelegationTool = "Task";
@@ -414,7 +416,7 @@ export const CANONICAL_TEAM_ROLES = [
 export type CanonicalTeamRole = typeof CANONICAL_TEAM_ROLES[number];
 
 /** Provider for /team role routing. */
-export type TeamRoleProvider = 'claude' | 'codex' | 'gemini';
+export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'mistral';
 
 /** Tier name accepted in role-assignment `model` field. */
 export type TeamRoleTier = 'HIGH' | 'MEDIUM' | 'LOW';

--- a/src/team/__tests__/bridge-entry.test.ts
+++ b/src/team/__tests__/bridge-entry.test.ts
@@ -46,6 +46,10 @@ describe('bridge-entry security', () => {
     expect(source).toContain("config.provider !== 'gemini'");
   });
 
+  it('validates provider includes mistral', () => {
+    expect(source).toContain("config.provider !== 'mistral'");
+  });
+
   it('has signal handlers for graceful cleanup', () => {
     expect(source).toContain('SIGINT');
     expect(source).toContain('SIGTERM');

--- a/src/team/__tests__/capabilities.test.ts
+++ b/src/team/__tests__/capabilities.test.ts
@@ -9,7 +9,7 @@ import type { WorkerCapability } from '../types.js';
 
 function makeMember(
   name: string,
-  backend: 'claude-native' | 'mcp-codex' | 'mcp-gemini',
+  backend: 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'mcp-mistral',
   capabilities: WorkerCapability[],
   status: 'active' | 'idle' | 'dead' = 'active'
 ): UnifiedTeamMember {
@@ -46,6 +46,13 @@ describe('capabilities', () => {
       expect(caps).toContain('ui-design');
       expect(caps).toContain('documentation');
       expect(caps).toContain('research');
+    });
+
+    it('returns capabilities for mcp-mistral', () => {
+      const caps = getDefaultCapabilities('mcp-mistral');
+      expect(caps).toContain('code-review');
+      expect(caps).toContain('security-review');
+      expect(caps).toContain('architecture');
     });
 
     it('returns a copy, not a reference', () => {
@@ -97,6 +104,14 @@ describe('capabilities', () => {
       const ranked = rankWorkersForTask([w1, w2, w3], ['code-review', 'security-review']);
       expect(ranked[0].name).toBe('codex'); // perfect match
       expect(ranked.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('ranks mistral worker for code-review task', () => {
+      const w1 = makeMember('mistral', 'mcp-mistral', ['code-review', 'security-review', 'architecture', 'refactoring']);
+      const w2 = makeMember('gemini', 'mcp-gemini', ['ui-design', 'documentation']);
+
+      const ranked = rankWorkersForTask([w1, w2], ['code-review']);
+      expect(ranked[0].name).toBe('mistral');
     });
 
     it('excludes workers with score 0', () => {

--- a/src/team/__tests__/cli-worker-contract.test.ts
+++ b/src/team/__tests__/cli-worker-contract.test.ts
@@ -21,6 +21,11 @@ describe('cli-worker-contract', () => {
       expect(shouldInjectContract('code-reviewer', 'gemini')).toBe(true);
     });
 
+    it('returns true for reviewer roles on mistral', () => {
+      expect(shouldInjectContract('critic', 'mistral')).toBe(true);
+      expect(shouldInjectContract('code-reviewer', 'mistral')).toBe(true);
+    });
+
     it('returns false for claude workers regardless of role', () => {
       expect(shouldInjectContract('critic', 'claude')).toBe(false);
       expect(shouldInjectContract('code-reviewer', 'claude')).toBe(false);
@@ -30,6 +35,7 @@ describe('cli-worker-contract', () => {
       expect(shouldInjectContract('executor', 'codex')).toBe(false);
       expect(shouldInjectContract('architect', 'gemini')).toBe(false);
       expect(shouldInjectContract('planner', 'codex')).toBe(false);
+      expect(shouldInjectContract('architect', 'mistral')).toBe(false);
     });
 
     it('returns false for null/undefined inputs', () => {

--- a/src/team/__tests__/edge-cases.test.ts
+++ b/src/team/__tests__/edge-cases.test.ts
@@ -809,6 +809,21 @@ describe('team-registration edge cases', () => {
       expect(config.members).toHaveLength(1);
       expect(config.members[0].agentType).toBe('mcp-gemini');
     });
+
+    it('replaces existing entry with same name for mistral', () => {
+      const configPath = join(CONFIG_DIR, 'config.json');
+      writeFileSync(configPath, JSON.stringify({
+        teamName: REG_TEAM,
+        members: [{ name: 'myworker', backendType: 'tmux', agentType: 'mcp-codex' }],
+      }));
+
+      writeProbeResult(REG_DIR, { probeResult: 'pass', probedAt: '', version: '' });
+      registerMcpWorker(REG_TEAM, 'myworker', 'mistral', 'codestral-2-latest', 'sess-x', '/cwd', REG_DIR);
+
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+      expect(config.members).toHaveLength(1);
+      expect(config.members[0].agentType).toBe('mcp-mistral');
+    });
   });
 
   describe('unregisterMcpWorker with corrupt config.json', () => {

--- a/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
+++ b/src/team/__tests__/mcp-team-bridge.spawn-args.test.ts
@@ -17,4 +17,20 @@ describe('mcp-team-bridge spawn args', () => {
     expect(source).not.toContain('"-i"');
     expect(source).toMatch(/cmd = "gemini";/);
   });
+
+  it('spawns vibe with -p prompt + streaming output + auto-approve agent for mistral', () => {
+    expect(source).toMatch(/cmd = "vibe";/);
+    expect(source).toContain('"-p"');
+    expect(source).toContain('"streaming"');
+    expect(source).toContain('"auto-approve"');
+  });
+
+  it('does not push --model for mistral (vibe selects model via agent profile)', () => {
+    // Locate the mistral branch in spawnCliProcess and verify it does not push --model.
+    // Vibe rejects --model as an unknown flag — model selection happens via --agent
+    // mapping to ~/.vibe/agents/<name>.toml.
+    const mistralBranch = source.match(/provider === "mistral"\) \{[\s\S]*?\} else \{/);
+    expect(mistralBranch).not.toBeNull();
+    expect(mistralBranch![0]).not.toMatch(/args\.push\("--model"/);
+  });
 });

--- a/src/team/__tests__/message-router.test.ts
+++ b/src/team/__tests__/message-router.test.ts
@@ -25,7 +25,7 @@ describe('message-router', () => {
   });
 
   function registerWorker(name: string, agentType: string = 'mcp-codex') {
-    const provider = agentType === 'mcp-gemini' ? 'gemini' : 'codex' as const;
+    const provider = agentType === 'mcp-gemini' ? 'gemini' : agentType === 'mcp-mistral' ? 'mistral' : 'codex' as const;
     registerMcpWorker(teamName, name, provider, 'gpt-5.3-codex', `${teamName}-${name}`, testDir, testDir);
     // Write heartbeat so worker shows up as alive
     writeHeartbeat(testDir, {

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -106,6 +106,13 @@ describe('model-contract', () => {
       expect(c.agentType).toBe('gemini');
       expect(c.binary).toBe('gemini');
     });
+    it('returns contract for mistral with vibe binary and prompt-mode support', () => {
+      const c = getContract('mistral');
+      expect(c.agentType).toBe('mistral');
+      expect(c.binary).toBe('vibe');
+      expect(c.supportsPromptMode).toBe(true);
+      expect(c.promptModeFlag).toBe('-p');
+    });
     it('throws for unknown agent type', () => {
       expect(() => getContract('unknown' as any)).toThrow('Unknown agent type');
     });
@@ -135,6 +142,24 @@ describe('model-contract', () => {
         const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
         clearSecurityConfigCache();
         expect(() => getContract('gemini')).toThrow('blocked by security policy');
+      } finally {
+        if (origSecurity === undefined) {
+          delete process.env.OMC_SECURITY;
+        } else {
+          process.env.OMC_SECURITY = origSecurity;
+        }
+        const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
+        clearSecurityConfigCache();
+      }
+    });
+
+    it('blocks mistral when external LLM is disabled', async () => {
+      const origSecurity = process.env.OMC_SECURITY;
+      process.env.OMC_SECURITY = 'strict';
+      try {
+        const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
+        clearSecurityConfigCache();
+        expect(() => getContract('mistral')).toThrow('blocked by security policy');
       } finally {
         if (origSecurity === undefined) {
           delete process.env.OMC_SECURITY;

--- a/src/team/__tests__/resolved-routing-snapshot.test.ts
+++ b/src/team/__tests__/resolved-routing-snapshot.test.ts
@@ -139,4 +139,18 @@ describe('buildResolvedRoutingSnapshot', () => {
     expect(snap['code-reviewer'].primary.provider).toBe('gemini');
     expect(snap['code-reviewer'].fallback.provider).toBe('claude');
   });
+
+  it('routes critic to mistral primary with claude fallback', () => {
+    const cfg: PluginConfig = {
+      team: {
+        roleRouting: {
+          critic: { provider: 'mistral', model: 'codestral-2-latest' },
+        },
+      },
+    };
+    const snap = buildResolvedRoutingSnapshot(cfg);
+    expect(snap.critic.primary.provider).toBe('mistral');
+    expect(snap.critic.primary.model).toBe('codestral-2-latest');
+    expect(snap.critic.fallback.provider).toBe('claude');
+  });
 });

--- a/src/team/__tests__/runtime-prompt-mode.test.ts
+++ b/src/team/__tests__/runtime-prompt-mode.test.ts
@@ -87,7 +87,7 @@ vi.mock('child_process', async (importOriginal) => {
 
 import { spawnWorkerForTask, type TeamRuntime } from '../runtime.js';
 
-function makeRuntime(cwd: string, agentType: 'gemini' | 'codex' | 'claude'): TeamRuntime {
+function makeRuntime(cwd: string, agentType: 'gemini' | 'codex' | 'claude' | 'mistral'): TeamRuntime {
   return {
     teamName: 'test-team',
     sessionName: 'test-session:0',
@@ -176,6 +176,52 @@ describe('spawnWorkerForTask – prompt mode and interactive worker launch', () 
 
   it('gemini worker writes inbox before spawn', async () => {
     const runtime = makeRuntime(cwd, 'gemini');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const inboxPath = join(cwd, '.omc/state/team/test-team/workers/worker-1/inbox.md');
+    const content = readFileSync(inboxPath, 'utf-8');
+    expect(content).toContain('Initial Task Assignment');
+    expect(content).toContain('Test task');
+    expect(content).toContain('Do something');
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('mistral worker launch args include -p flag with inbox path', async () => {
+    const runtime = makeRuntime(cwd, 'mistral');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    expect(launchCmd).toContain("'-p'");
+    expect(launchCmd).toContain('.omc/state/team/test-team/workers/worker-1/inbox.md');
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('mistral worker skips trust-confirm (no "1" sent via send-keys)', async () => {
+    const runtime = makeRuntime(cwd, 'mistral');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const literalMessages = tmuxCalls.args
+      .filter(args => args[0] === 'send-keys' && args.includes('-l'))
+      .map(args => args[args.length - 1]);
+
+    const trustConfirmSent = literalMessages.some(msg => msg === '1');
+    expect(trustConfirmSent).toBe(false);
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('mistral worker writes inbox before spawn', async () => {
+    const runtime = makeRuntime(cwd, 'mistral');
 
     await spawnWorkerForTask(runtime, 'worker-1', 0);
 

--- a/src/team/__tests__/runtime-v2-role-routing.test.ts
+++ b/src/team/__tests__/runtime-v2-role-routing.test.ts
@@ -65,7 +65,7 @@ describe('runtime-v2 role routing — processCliWorkerVerdicts (AC-7)', () => {
   async function bootstrap(opts: {
     verdict: 'approve' | 'revise' | 'reject';
     paneAlive?: boolean;
-    workerCli?: 'codex' | 'gemini' | 'claude';
+    workerCli?: 'codex' | 'gemini' | 'claude' | 'mistral';
     omitVerdictFile?: boolean;
     invalidVerdictJson?: boolean;
   }): Promise<{ teamRoot: string; outputFile: string; taskPath: string }> {

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -556,6 +556,56 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(mocks.sendToWorker).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps mistral (vibe) prompt-mode launch args to a short inbox pointer and waits for claim evidence', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-mistral-prompt-'));
+
+    modelContractMocks.isPromptModeAgent.mockImplementation((agentType?: string) => agentType === 'mistral');
+    mocks.spawnWorkerInPane.mockImplementation(async () => {
+      const taskDir = join(cwd, '.omc', 'state', 'team', 'dispatch-team', 'tasks');
+      const canonicalTaskPath = join(taskDir, 'task-1.json');
+      const legacyTaskPath = join(taskDir, '1.json');
+      const taskPath = await readFile(canonicalTaskPath, 'utf-8')
+        .then(() => canonicalTaskPath)
+        .catch(async () => {
+          await readFile(legacyTaskPath, 'utf-8');
+          return legacyTaskPath;
+        });
+      const existing = JSON.parse(await readFile(taskPath, 'utf-8'));
+      await writeFile(taskPath, JSON.stringify({
+        ...existing,
+        status: 'in_progress',
+        owner: 'worker-1',
+      }, null, 2), 'utf-8');
+    });
+
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'dispatch-team',
+      workerCount: 1,
+      agentTypes: ['mistral'],
+      tasks: [{
+        subject: 'Dispatch test',
+        description: 'Verify mistral prompt-mode inbox pointer.',
+      }],
+      cwd,
+    });
+
+    expect(modelContractMocks.getPromptModeArgs).toHaveBeenCalledWith(
+      'mistral',
+      expect.stringContaining('.omc/state/team/dispatch-team/workers/worker-1/inbox.md'),
+    );
+    expect(mocks.spawnWorkerInPane).toHaveBeenCalledWith(
+      'dispatch-session',
+      '%2',
+      expect.objectContaining({
+        launchBinary: '/usr/bin/mistral',
+      }),
+    );
+    expect(runtime.config.workers[0]?.assigned_tasks).toEqual(['1']);
+    expect(mocks.sendToWorker).not.toHaveBeenCalled();
+  });
+
   it('keeps gemini prompt-mode launch args to a short inbox pointer and waits for claim evidence', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-gemini-prompt-'));
 

--- a/src/team/__tests__/runtime-v2.vibe-preflight.test.ts
+++ b/src/team/__tests__/runtime-v2.vibe-preflight.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const mocks = vi.hoisted(() => ({
+  createTeamSession: vi.fn(),
+  spawnWorkerInPane: vi.fn(),
+  sendToWorker: vi.fn(),
+  waitForPaneReady: vi.fn(),
+  applyMainVerticalLayout: vi.fn(),
+  tmuxExecAsync: vi.fn(),
+  queueInboxInstruction: vi.fn(),
+}));
+
+const modelContractMocks = vi.hoisted(() => ({
+  buildWorkerArgv: vi.fn((agentType?: string, config?: { resolvedBinaryPath?: string }) => [config?.resolvedBinaryPath ?? agentType ?? 'vibe']),
+  resolveValidatedBinaryPath: vi.fn((agentType?: string) => {
+    if (agentType === 'mistral') throw new Error("Resolved CLI binary 'vibe' to untrusted location: /tmp/vibe");
+    return `/usr/bin/${agentType ?? 'claude'}`;
+  }),
+  getContract: vi.fn((agentType?: string) => ({ binary: agentType === 'mistral' ? 'vibe' : agentType ?? 'claude' })),
+  getWorkerEnv: vi.fn(() => ({ OMC_TEAM_WORKER: 'vibe-preflight-team/worker-1' })),
+  isPromptModeAgent: vi.fn(() => false),
+  getPromptModeArgs: vi.fn(() => []),
+  resolveClaudeWorkerModel: vi.fn(() => undefined),
+}));
+
+vi.mock('../../cli/tmux-utils.js', () => ({
+  tmuxExecAsync: mocks.tmuxExecAsync,
+}));
+
+vi.mock('../tmux-session.js', () => ({
+  createTeamSession: mocks.createTeamSession,
+  spawnWorkerInPane: mocks.spawnWorkerInPane,
+  sendToWorker: mocks.sendToWorker,
+  waitForPaneReady: mocks.waitForPaneReady,
+  paneHasActiveTask: vi.fn(() => false),
+  paneLooksReady: vi.fn(() => true),
+  applyMainVerticalLayout: mocks.applyMainVerticalLayout,
+}));
+
+vi.mock('../model-contract.js', () => ({
+  buildWorkerArgv: modelContractMocks.buildWorkerArgv,
+  resolveValidatedBinaryPath: modelContractMocks.resolveValidatedBinaryPath,
+  getContract: modelContractMocks.getContract,
+  getWorkerEnv: modelContractMocks.getWorkerEnv,
+  isPromptModeAgent: modelContractMocks.isPromptModeAgent,
+  getPromptModeArgs: modelContractMocks.getPromptModeArgs,
+  resolveClaudeWorkerModel: modelContractMocks.resolveClaudeWorkerModel,
+}));
+
+vi.mock('../mcp-comm.js', () => ({
+  queueInboxInstruction: mocks.queueInboxInstruction,
+}));
+
+describe('runtime-v2 vibe (mistral) preflight routing', () => {
+  let cwd = '';
+
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.createTeamSession.mockResolvedValue({
+      sessionName: 'vibe-preflight-session',
+      leaderPaneId: '%1',
+      workerPaneIds: [],
+      sessionMode: 'split-pane',
+    });
+    mocks.spawnWorkerInPane.mockResolvedValue(undefined);
+    mocks.waitForPaneReady.mockResolvedValue(true);
+    mocks.applyMainVerticalLayout.mockResolvedValue(undefined);
+    mocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'split-window') {
+        return { stdout: '%2\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+    mocks.queueInboxInstruction.mockResolvedValue({ ok: true, reason: 'transport_direct', transport: 'transport_direct' });
+  });
+
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('keeps an explicitly routed mistral lane on mistral when strict preflight path probing false-negatives', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'vibe-preflight-repro-'));
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'vibe-preflight-team',
+      workerCount: 1,
+      agentTypes: ['mistral'],
+      tasks: [{ subject: 'Review code', description: 'Review code', role: 'executor' }],
+      cwd,
+      pluginConfig: {
+        team: { roleRouting: { executor: { provider: 'mistral' } } },
+      } as any,
+    });
+
+    expect(runtime.config.workers[0]?.worker_cli).toBe('mistral');
+    expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(
+      'mistral',
+      expect.objectContaining({
+        teamName: 'vibe-preflight-team',
+        workerName: 'worker-1',
+      }),
+    );
+  });
+});

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -10,7 +10,7 @@ describe('runtime types', () => {
     const config: TeamConfig = {
       teamName: 'test',
       workerCount: 2,
-      agentTypes: ['codex', 'gemini'],
+      agentTypes: ['codex', 'gemini', 'mistral'],
       tasks: [{ subject: 'Task 1', description: 'Do something' }],
       cwd: '/tmp',
     };

--- a/src/team/__tests__/scaling-launch-config.test.ts
+++ b/src/team/__tests__/scaling-launch-config.test.ts
@@ -152,6 +152,7 @@ describe('scaleUp launch config', () => {
   it.each([
     ['codex', ['/usr/bin/codex', 'exec', '--dangerously-bypass-approvals-and-sandbox']],
     ['gemini', ['/usr/bin/gemini', '--approval-mode', 'yolo']],
+    ['mistral', ['/usr/bin/vibe', '--agent', 'auto-approve', '-p', 'streaming']],
   ] as const)('uses model-contract launch argv for %s scale-up workers', async (
     agentType: CliAgentType,
     workerArgv: readonly string[],

--- a/src/team/__tests__/stage-router.test.ts
+++ b/src/team/__tests__/stage-router.test.ts
@@ -90,6 +90,16 @@ describe('stage-router resolveRoleAssignment', () => {
       expect(out.agent).toBe('codeReviewer');
     });
 
+    it('respects provider=mistral with explicit model passthrough', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { critic: { provider: 'mistral', model: 'codestral-2-latest' } } },
+      };
+      const out = resolveRoleAssignment('critic', cfg);
+      expect(out.provider).toBe('mistral');
+      expect(out.model).toBe('codestral-2-latest');
+      expect(out.agent).toBe('critic');
+    });
+
     it('resolves tier name (HIGH) into Claude opus model for claude provider', () => {
       const cfg: PluginConfig = {
         team: { roleRouting: { executor: { provider: 'claude', model: 'HIGH' } } },
@@ -162,6 +172,17 @@ describe('stage-router resolveRoleAssignment', () => {
       };
       const snap = buildResolvedRoutingSnapshot(cfg);
       expect(snap['code-reviewer'].primary.provider).toBe('codex');
+    });
+  });
+
+  describe('mistral routing', () => {
+    it('routes executor to mistral provider with explicit model', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { executor: { provider: 'mistral', model: 'codestral-2-latest' } } },
+      };
+      const out = resolveRoleAssignment('executor', cfg);
+      expect(out.provider).toBe('mistral');
+      expect(out.model).toBe('codestral-2-latest');
     });
   });
 });

--- a/src/team/__tests__/task-router.test.ts
+++ b/src/team/__tests__/task-router.test.ts
@@ -19,8 +19,9 @@ describe('task-router', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  function registerWorker(name: string, provider: 'codex' | 'gemini' = 'codex', status: 'polling' | 'executing' | 'quarantined' = 'polling') {
-    registerMcpWorker(teamName, name, provider, provider === 'codex' ? 'gpt-5.3-codex' : 'gemini-3-pro', `${teamName}-${name}`, testDir, testDir);
+  function registerWorker(name: string, provider: 'codex' | 'gemini' | 'mistral' = 'codex', status: 'polling' | 'executing' | 'quarantined' = 'polling') {
+    const model = provider === 'codex' ? 'gpt-5.3-codex' : provider === 'gemini' ? 'gemini-3-pro' : 'codestral-2-latest';
+    registerMcpWorker(teamName, name, provider, model, `${teamName}-${name}`, testDir, testDir);
     writeHeartbeat(testDir, {
       workerName: name,
       teamName,
@@ -138,6 +139,18 @@ describe('task-router', () => {
       expect(decisions[0].reason).toBeTruthy();
       expect(decisions[0].confidence).toBeGreaterThan(0);
       expect(decisions[0].confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('routes to mistral worker for code review capabilities', () => {
+      registerWorker('mistral-1', 'mistral');
+
+      const tasks = [makeTask('t1', 'Review code')];
+      const decisions = routeTasks(teamName, testDir, tasks, {
+        t1: ['code-review'],
+      });
+
+      expect(decisions).toHaveLength(1);
+      expect(decisions[0].assignedTo).toBe('mistral-1');
     });
   });
 });

--- a/src/team/__tests__/team-registration.test.ts
+++ b/src/team/__tests__/team-registration.test.ts
@@ -74,6 +74,15 @@ describe('registerMcpWorker / unregisterMcpWorker', () => {
     expect(workers[0].agentType).toBe('mcp-gemini');
   });
 
+  it('registers mistral worker and deduplicates on re-register', () => {
+    registerMcpWorker(TEST_TEAM, 'myworker', 'mistral', 'codestral-2-latest', 'sess-x', '/cwd', TEST_DIR);
+    registerMcpWorker(TEST_TEAM, 'myworker', 'mistral', 'codestral-2-latest', 'sess-y', '/cwd2', TEST_DIR);
+    const workers = listMcpWorkers(TEST_TEAM, TEST_DIR);
+    expect(workers).toHaveLength(1);
+    expect(workers[0].agentType).toBe('mcp-mistral');
+    expect(workers[0].name).toBe('myworker');
+  });
+
   it('registers multiple workers', () => {
     registerMcpWorker(TEST_TEAM, 'w1', 'codex', 'gpt-5', 'sess1', '/cwd', TEST_DIR);
     registerMcpWorker(TEST_TEAM, 'w2', 'gemini', 'gemini-pro', 'sess2', '/cwd', TEST_DIR);

--- a/src/team/__tests__/team-status.test.ts
+++ b/src/team/__tests__/team-status.test.ts
@@ -42,7 +42,7 @@ function writeHeartbeatFile(data: HeartbeatData): void {
   atomicWriteJson(hbPath, data);
 }
 
-function makeWorker(name: string, provider: 'codex' | 'gemini' = 'codex'): McpWorkerMember {
+function makeWorker(name: string, provider: 'codex' | 'gemini' | 'mistral' = 'codex'): McpWorkerMember {
   return {
     agentId: `${name}@${TEST_TEAM}`,
     name,
@@ -56,7 +56,7 @@ function makeWorker(name: string, provider: 'codex' | 'gemini' = 'codex'): McpWo
   };
 }
 
-function makeHeartbeat(workerName: string, provider: 'codex' | 'gemini' = 'codex', ageMs: number = 0): HeartbeatData {
+function makeHeartbeat(workerName: string, provider: 'codex' | 'gemini' | 'mistral' = 'codex', ageMs: number = 0): HeartbeatData {
   return {
     workerName,
     teamName: TEST_TEAM,
@@ -129,6 +129,24 @@ describe('getTeamStatus', () => {
     expect(status.taskSummary.pending).toBe(1);
     expect(status.usage.taskCount).toBe(0);
     expect(status.performance.totalMs).toBeGreaterThanOrEqual(status.performance.taskScanMs);
+  });
+
+  it('aggregates mistral worker status with heartbeats', () => {
+    const w1 = makeWorker('m1', 'mistral');
+    writeWorkerRegistry([w1]);
+
+    writeHeartbeatFile(makeHeartbeat('m1', 'mistral', 1000));
+
+    writeTask(makeTask('1', 'm1', 'in_progress'));
+
+    const status = getTeamStatus(TEST_TEAM, WORK_DIR);
+
+    expect(status.workers).toHaveLength(1);
+
+    const sw1 = status.workers.find(w => w.workerName === 'm1')!;
+    expect(sw1.provider).toBe('mistral');
+    expect(sw1.isAlive).toBe(true);
+    expect(sw1.taskStats.inProgress).toBe(1);
   });
 
   it('detects dead workers via heartbeat age', () => {

--- a/src/team/__tests__/unified-team.test.ts
+++ b/src/team/__tests__/unified-team.test.ts
@@ -19,11 +19,13 @@ describe('unified-team', () => {
   });
 
   function registerWorker(name: string, agentType: string = 'mcp-codex') {
+    const provider = agentType === 'mcp-codex' ? 'codex' : agentType === 'mcp-mistral' ? 'mistral' : 'gemini';
+    const model = agentType === 'mcp-codex' ? 'gpt-5.3-codex' : agentType === 'mcp-mistral' ? 'codestral-2-latest' : 'gemini-3.1-pro-preview';
     registerMcpWorker(
       teamName,
       name,
-      agentType === 'mcp-codex' ? 'codex' : 'gemini',
-      agentType === 'mcp-codex' ? 'gpt-5.3-codex' : 'gemini-3.1-pro-preview',
+      provider,
+      model,
       `tmux-${name}`,
       testDir,
       testDir
@@ -94,6 +96,16 @@ describe('unified-team', () => {
       const members = getTeamMembers(teamName, testDir);
       expect(members).toHaveLength(1);
       expect(members[0].backend).toBe('mcp-codex');
+    });
+
+    it('includes mcp-mistral workers from shadow registry', () => {
+      registerWorker('mistral-1', 'mcp-mistral');
+
+      const members = getTeamMembers(teamName, testDir);
+      expect(members).toHaveLength(1);
+
+      const mistral = members.find(m => m.name === 'mistral-1');
+      expect(mistral).toBeDefined();
     });
   });
 });

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -156,6 +156,9 @@ describe('worker-bootstrap', () => {
       const geminiOverlay = generateWorkerOverlay({ ...baseParams, agentType: 'gemini' });
       expect(geminiOverlay).toContain('Agent-Type Guidance (gemini)');
       expect(geminiOverlay).toContain('milestone');
+
+      const mistralOverlay = generateWorkerOverlay({ ...baseParams, agentType: 'mistral' });
+      expect(mistralOverlay).toContain('Agent-Type Guidance (mistral / vibe)');
     });
     it('documents CLI lifecycle examples that match the active team api contract', () => {
       const overlay = generateWorkerOverlay(baseParams);
@@ -186,6 +189,13 @@ describe('worker-bootstrap', () => {
       expect(env.OMC_TEAM_WORKER).toBe('my-team/worker-2');
       expect(env.OMC_TEAM_NAME).toBe('my-team');
       expect(env.OMC_WORKER_AGENT_TYPE).toBe('gemini');
+    });
+
+    it('returns correct env vars for mistral', () => {
+      const env = getWorkerEnv('my-team', 'worker-3', 'mistral');
+      expect(env.OMC_TEAM_WORKER).toBe('my-team/worker-3');
+      expect(env.OMC_TEAM_NAME).toBe('my-team');
+      expect(env.OMC_WORKER_AGENT_TYPE).toBe('mistral');
     });
   });
 });

--- a/src/team/__tests__/worker-cli-roundtrip.test.ts
+++ b/src/team/__tests__/worker-cli-roundtrip.test.ts
@@ -48,6 +48,18 @@ describe('WorkerInfo.worker_cli round-trip', () => {
     expect(out.worker_cli).toBe('gemini');
   });
 
+  it('preserves worker_cli=mistral through JSON serialization', () => {
+    const w: WorkerInfo = {
+      name: 'worker-5',
+      index: 5,
+      role: 'executor',
+      worker_cli: 'mistral',
+      assigned_tasks: [],
+    };
+    const out = roundtrip(w);
+    expect(out.worker_cli).toBe('mistral');
+  });
+
   it('omits worker_cli when undefined (legacy entries)', () => {
     const w: WorkerInfo = {
       name: 'worker-legacy',

--- a/src/team/__tests__/worker-restart.test.ts
+++ b/src/team/__tests__/worker-restart.test.ts
@@ -143,5 +143,23 @@ describe('worker-restart', () => {
       expect(config.provider).toBe('gemini');
       expect(config.model).toBe('gemini-3-pro-preview');
     });
+
+    it('preserves provider=mistral after restart synthesis', () => {
+      const worker: McpWorkerMember = {
+        agentId: 'agent-3',
+        name: 'mistral-worker',
+        agentType: 'mcp-mistral',
+        model: 'codestral-2-latest',
+        joinedAt: Date.now(),
+        tmuxPaneId: 'omc-team-test-mistral-worker',
+        cwd: '/home/user/project',
+        backendType: 'tmux',
+        subscriptions: [],
+      };
+
+      const config = synthesizeBridgeConfig(worker, 'my-team');
+      expect(config.provider).toBe('mistral');
+      expect(config.model).toBe('codestral-2-latest');
+    });
   });
 });

--- a/src/team/bridge-entry.ts
+++ b/src/team/bridge-entry.ts
@@ -129,8 +129,8 @@ function main(): void {
   config.workerName = sanitizeName(config.workerName);
 
   // Validate provider
-  if (config.provider !== 'codex' && config.provider !== 'gemini') {
-    console.error(`Invalid provider: ${config.provider}. Must be 'codex' or 'gemini'.`);
+  if (config.provider !== 'codex' && config.provider !== 'gemini' && config.provider !== 'mistral') {
+    console.error(`Invalid provider: ${config.provider}. Must be 'codex', 'gemini', or 'mistral'.`);
     process.exit(1);
   }
 

--- a/src/team/capabilities.ts
+++ b/src/team/capabilities.ts
@@ -19,6 +19,8 @@ const DEFAULT_CAPABILITIES: Record<WorkerBackend, WorkerCapability[]> = {
   'tmux-codex': ['code-review', 'security-review', 'architecture', 'refactoring'],
   'tmux-gemini': ['ui-design', 'documentation', 'research', 'code-edit'],
   'tmux-cursor': ['code-edit', 'refactoring', 'general'],
+  'mcp-mistral': ['code-review', 'security-review', 'architecture', 'refactoring'],
+  'tmux-mistral': ['code-review', 'security-review', 'architecture', 'refactoring'],
 };
 
 /**

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -36,5 +36,6 @@ export function detectAllClis(): Record<string, CliInfo> {
     codex: detectCli('codex'),
     gemini: detectCli('gemini'),
     cursor: detectCli('cursor-agent'),
+    mistral: detectCli('vibe'),
   };
 }

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -166,9 +166,9 @@ function validateModelName(model: string | undefined): void {
 
 /** Validate provider is one of allowed values */
 function validateProvider(provider: string): void {
-  if (provider !== "codex" && provider !== "gemini") {
+  if (provider !== "codex" && provider !== "gemini" && provider !== "mistral") {
     throw new Error(
-      `Invalid provider: ${provider}. Must be 'codex' or 'gemini'`,
+      `Invalid provider: ${provider}. Must be 'codex', 'gemini', or 'mistral'`,
     );
   }
 }
@@ -368,7 +368,7 @@ export function recordTaskCompletionUsage(args: {
   taskId: string;
   promptFile: string;
   outputFile: string;
-  provider: "codex" | "gemini";
+  provider: "codex" | "gemini" | "mistral";
   startedAt: number;
   startedAtIso: string;
 }): void {
@@ -443,12 +443,47 @@ function parseCodexOutput(output: string): string {
   return messages.join("\n") || output;
 }
 
+/** Maximum accumulated size for parseVibeStreamingOutput (1MB) */
+const MAX_VIBE_OUTPUT_SIZE = 1024 * 1024;
+
+/**
+ * Parse vibe --output streaming JSONL to extract assistant text responses.
+ * Each line is a JSON object with a "role" field. Lines where role === "assistant"
+ * contain the assistant's reply in the "content" field.
+ */
+function parseVibeStreamingOutput(output: string): string {
+  const lines = output
+    .trim()
+    .split("\n")
+    .filter((l) => l.trim());
+  const messages: string[] = [];
+  let totalSize = 0;
+
+  for (const line of lines) {
+    if (totalSize >= MAX_VIBE_OUTPUT_SIZE) {
+      messages.push("[output truncated]");
+      break;
+    }
+    try {
+      const event = JSON.parse(line);
+      if (event.role === "assistant" && typeof event.content === "string") {
+        messages.push(event.content);
+        totalSize += event.content.length;
+      }
+    } catch {
+      /* skip non-JSON lines */
+    }
+  }
+
+  return messages.join("\n") || output.trim();
+}
+
 /**
  * Spawn a CLI process and return both the child handle and a result promise.
  * This allows the bridge to kill the child on shutdown while still awaiting the result.
  */
 function spawnCliProcess(
-  provider: "codex" | "gemini",
+  provider: "codex" | "gemini" | "mistral",
   prompt: string,
   model: string | undefined,
   cwd: string,
@@ -471,6 +506,14 @@ function spawnCliProcess(
       "--dangerously-bypass-approvals-and-sandbox",
       "--skip-git-repo-check",
     ];
+  } else if (provider === "mistral") {
+    cmd = "vibe";
+    // -p requires the prompt as its value (vibe does not read prompt from stdin).
+    // --output streaming emits newline-delimited JSON; parsed by parseVibeStreamingOutput.
+    // Verified: `vibe -p "..." --output streaming` works; stdin-only mode errors with
+    // "No prompt provided for programmatic mode".
+    args = ["-p", prompt, "--output", "streaming", "--agent", "auto-approve"];
+    // vibe ignores model param — selection is via --agent / TOML profile
   } else {
     cmd = "gemini";
     args = ["--approval-mode", "yolo"];
@@ -508,8 +551,14 @@ function spawnCliProcess(
         settled = true;
         clearTimeout(timeoutHandle);
         if (code === 0) {
-          const response =
-            provider === "codex" ? parseCodexOutput(stdout) : stdout.trim();
+          let response: string;
+          if (provider === "codex") {
+            response = parseCodexOutput(stdout);
+          } else if (provider === "mistral") {
+            response = parseVibeStreamingOutput(stdout);
+          } else {
+            response = stdout.trim();
+          }
           resolve(response);
         } else {
           const detail = stderr || stdout.trim() || "No output";
@@ -526,17 +575,22 @@ function spawnCliProcess(
       }
     });
 
-    // Write prompt via stdin
-    child.stdin?.on("error", (err) => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timeoutHandle);
-        child.kill("SIGTERM");
-        reject(new Error(`Stdin write error: ${err.message}`));
-      }
-    });
-    child.stdin?.write(prompt);
-    child.stdin?.end();
+    // Write prompt via stdin for codex and gemini.
+    // mistral (vibe) receives the prompt as the -p flag value; no stdin write needed.
+    if (provider !== "mistral") {
+      child.stdin?.on("error", (err) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeoutHandle);
+          child.kill("SIGTERM");
+          reject(new Error(`Stdin write error: ${err.message}`));
+        }
+      });
+      child.stdin?.write(prompt);
+      child.stdin?.end();
+    } else {
+      child.stdin?.end();
+    }
   });
 
   return { child, result };

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -5,7 +5,7 @@ import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
-export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor';
+export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor' | 'mistral';
 
 export interface CliAgentContract {
   agentType: CliAgentType;
@@ -238,6 +238,27 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
       // Minimal flags — cursor-agent owns its own session/auth state.
       // The model is selected interactively inside cursor-agent itself.
       return [...extraFlags];
+    },
+    parseOutput(rawOutput: string): string {
+      return rawOutput.trim();
+    },
+  },
+  mistral: {
+    agentType: 'mistral',
+    binary: 'vibe',
+    installInstructions: 'Install Mistral Vibe CLI: see https://docs.mistral.ai/',
+    // Vibe has both an interactive REPL (default) and programmatic mode (-p),
+    // mirroring gemini. Team workers launch as persistent panes; reviewer-style
+    // roles use the verdict-output contract via prompt mode.
+    supportsPromptMode: true,
+    promptModeFlag: '-p',
+    buildLaunchArgs(_model?: string, extraFlags: string[] = []): string[] {
+      // 'auto-approve' is vibe's built-in unattended agent, analogous to
+      // claude's --dangerously-skip-permissions and gemini's --approval-mode yolo.
+      // Model selection happens via the vibe agent profile (~/.vibe/agents/*.toml),
+      // so the model parameter is intentionally ignored. Override the agent by
+      // passing ['--agent', '<name>'] through extraFlags upstream.
+      return ['--agent', 'auto-approve', ...extraFlags];
     },
     parseOutput(rawOutput: string): string {
       return rawOutput.trim();

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -925,7 +925,7 @@ export async function shutdownTeam(
   // Polling for ACK files on CLI worker teams wastes the full timeoutMs on every shutdown.
   // Detect CLI worker teams by checking if all agent types are known CLI types, and skip
   // ACK polling — the tmux kill below handles process cleanup instead.
-  const CLI_AGENT_TYPES = new Set<string>(['claude', 'codex', 'gemini']);
+  const CLI_AGENT_TYPES = new Set<string>(['claude', 'codex', 'gemini', 'mistral']);
   const agentTypes: string[] = configData?.agentTypes ?? [];
   const isCliWorkerTeam = agentTypes.length > 0 && agentTypes.every(t => CLI_AGENT_TYPES.has(t));
 

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -54,7 +54,7 @@ import {
 // ── Environment gate ──────────────────────────────────────────────────────────
 
 const OMC_TEAM_SCALING_ENABLED_ENV = 'OMC_TEAM_SCALING_ENABLED';
-const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini']);
+const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini', 'mistral']);
 
 export function isScalingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[OMC_TEAM_SCALING_ENABLED_ENV];

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -127,12 +127,17 @@ function resolveClaudeModel(
 /**
  * Resolve a user-supplied `model` value for an external provider worker.
  *
- * Tier names are Claude-centric and not meaningful for codex/gemini, so tier
- * input (or absent input) maps to the provider's builtin default. Only an
- * explicit non-tier model ID is passed through.
+ * Tier names are Claude-centric and not meaningful for codex/gemini/mistral,
+ * so tier input (or absent input) maps to the provider's builtin default.
+ * Only an explicit non-tier model ID is passed through.
+ *
+ * Mistral (vibe) selects its model via the agent profile in
+ * ~/.vibe/agents/*.toml, not a CLI flag — the resolved value is therefore
+ * discarded by the mistral contract's buildLaunchArgs. An empty string is
+ * returned when no explicit model is provided.
  */
 function resolveExternalModel(
-  provider: 'codex' | 'gemini',
+  provider: 'codex' | 'gemini' | 'mistral',
   raw: string | undefined,
   cfg: PluginConfig,
 ): string {
@@ -143,7 +148,10 @@ function resolveExternalModel(
   if (provider === 'codex') {
     return defaults?.codexModel ?? BUILTIN_EXTERNAL_MODEL_DEFAULTS.codexModel;
   }
-  return defaults?.geminiModel ?? BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel;
+  if (provider === 'gemini') {
+    return defaults?.geminiModel ?? BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel;
+  }
+  return '';
 }
 
 /**

--- a/src/team/team-registration.ts
+++ b/src/team/team-registration.ts
@@ -77,7 +77,7 @@ export function getRegistrationStrategy(workingDirectory: string): 'config' | 's
 export function registerMcpWorker(
   teamName: string,
   workerName: string,
-  provider: 'codex' | 'gemini' | 'claude',
+  provider: 'codex' | 'gemini' | 'claude' | 'mistral',
   model: string,
   tmuxTarget: string,
   cwd: string,

--- a/src/team/team-status.ts
+++ b/src/team/team-status.ts
@@ -59,7 +59,7 @@ function peekRecentOutboxMessages(
 
 export interface WorkerStatus {
   workerName: string;
-  provider: 'claude' | 'codex' | 'gemini';
+  provider: 'claude' | 'codex' | 'gemini' | 'mistral';
   heartbeat: HeartbeatData | null;
   isAlive: boolean;
   currentTask: TaskFile | null;
@@ -133,7 +133,7 @@ export function getTeamStatus(
     };
 
     const currentTask = workerTasks.find(t => t.status === 'in_progress') || null;
-    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini';
+    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini' | 'mistral';
 
     return {
       workerName: w.name,

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -15,7 +15,7 @@ import type { CanonicalTeamRole, RoleAssignment } from '../shared/types.js';
 export interface BridgeConfig {
   teamName: string;
   workerName: string;
-  provider: 'codex' | 'gemini';
+  provider: 'codex' | 'gemini' | 'mistral';
   model?: string;
   workingDirectory: string;
   pollIntervalMs: number;       // default: 3000
@@ -90,7 +90,7 @@ export interface DrainSignal {
 export interface McpWorkerMember {
   agentId: string;          // "{workerName}@{teamName}"
   name: string;             // workerName
-  agentType: string;        // "mcp-codex" | "mcp-gemini"
+  agentType: string;        // e.g. "mcp-codex", "tmux-mistral", etc. — see WorkerBackend type
   model: string;
   joinedAt: number;         // Date.now()
   tmuxPaneId: string;       // tmux session name
@@ -103,7 +103,7 @@ export interface McpWorkerMember {
 export interface HeartbeatData {
   workerName: string;
   teamName: string;
-  provider: 'codex' | 'gemini' | 'claude';
+  provider: 'codex' | 'gemini' | 'claude' | 'mistral';
   pid: number;
   lastPollAt: string;       // ISO timestamp of last poll cycle
   currentTaskId?: string;   // task being executed, if any
@@ -126,7 +126,7 @@ export interface ConfigProbeResult {
 /** Sidecar mapping task IDs to execution modes */
 export interface TaskModeMap {
   teamName: string;
-  taskModes: Record<string, 'mcp_codex' | 'mcp_gemini' | 'claude_worker'>;
+  taskModes: Record<string, 'mcp_codex' | 'mcp_gemini' | 'mcp_mistral' | 'claude_worker'>;
 }
 
 /** Failure sidecar for a task */
@@ -138,7 +138,7 @@ export interface TaskFailureSidecar {
 }
 
 /** Worker backend type */
-export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini' | 'tmux-cursor';
+export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'mcp-mistral' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini' | 'tmux-mistral' | 'tmux-cursor';
 
 /** Worker capability tag */
 export type WorkerCapability =
@@ -254,7 +254,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor';
+  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor' | 'mistral';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/usage-tracker.ts
+++ b/src/team/usage-tracker.ts
@@ -4,7 +4,7 @@
  * Usage tracker for team sessions.
  *
  * Tracks wall-clock time and prompt/response character counts per task.
- * NOTE: Token counts are not available from Codex/Gemini CLI output.
+ * NOTE: Token counts are not available from Codex/Gemini/Mistral CLI output.
  * Character counts serve as a rough proxy for usage estimation.
  *
  * Storage: append-only JSONL at .omc/logs/team-usage-{team}.jsonl
@@ -17,7 +17,7 @@ import { appendFileWithMode, ensureDirWithMode, validateResolvedPath } from './f
 export interface TaskUsageRecord {
   taskId: string;
   workerName: string;
-  provider: 'codex' | 'gemini';
+  provider: 'codex' | 'gemini' | 'mistral';
   model: string;
   startedAt: string;
   completedAt: string;
@@ -28,7 +28,7 @@ export interface TaskUsageRecord {
 
 export interface WorkerUsageSummary {
   workerName: string;
-  provider: 'codex' | 'gemini';
+  provider: 'codex' | 'gemini' | 'mistral';
   model: string;
   taskCount: number;
   totalWallClockMs: number;

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -100,6 +100,13 @@ function agentTypeGuidance(agentType: CliAgentType): string {
         `- You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done. Then keep waiting for the next mailbox message; do NOT type \`/exit\` unless the leader sends an explicit shutdown.`,
         '- Reviewer/critic/security-review roles are NOT supported for cursor workers — those require a verdict-file write-and-exit which the REPL does not perform. Take only executor-style tasks.',
       ].join('\n');
+    case 'mistral':
+      return [
+        '### Agent-Type Guidance (mistral / vibe)',
+        '- Execute task work in small, verifiable increments and report each milestone to leader-fixed.',
+        '- Keep commit-sized changes scoped to assigned files only; no broad refactors.',
+        `- CRITICAL: You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done. Do not exit without transitioning the task status.`,
+      ].join('\n');
     case 'claude':
     default:
       return [

--- a/src/team/worker-restart.ts
+++ b/src/team/worker-restart.ts
@@ -144,7 +144,7 @@ export function synthesizeBridgeConfig(
     workerName: worker.name,
     teamName,
     workingDirectory: worker.cwd,
-    provider: worker.agentType.replace('mcp-', '') as 'codex' | 'gemini',
+    provider: worker.agentType.replace('mcp-', '') as 'codex' | 'gemini' | 'mistral',
     model: worker.model,
     pollIntervalMs: 3000,
     taskTimeoutMs: 600000,


### PR DESCRIPTION
## Summary
- Adds `mistral` as the 4th tmux worker type alongside `claude`, `codex`, `gemini`, and the recently merged `cursor-agent`
- Wires Mistral's [`vibe`](https://docs.mistral.ai/agents/) agentic CLI through both team runtimes (CLI-pane via `omc team N:mistral` and MCP-bridge spawn path)
- Brings test coverage for mistral to feature parity with `gemini` (22 test files, including a new `runtime-v2.vibe-preflight.test.ts`)

## Why mistral / vibe
Mistral's `vibe` CLI matches the agentic-CLI contract OMC already uses for claude/codex/gemini: persistent worker process, prompt-mode entry, autonomous tool execution under an `--agent` profile. Codestral 2 (the default model behind `vibe`) is competitive with Sonnet for code transforms, and Mistral Pro subscribers can use it without per-token cost concerns — making it a useful fan-out option for teams that want extra parallelism without burning Anthropic quota.

## What's wired
- **Type plumbing**: `CliAgentType` extended; `vibeContract` added to `model-contract.ts` (binary `vibe`, `-p` prompt mode, `--agent auto-approve`, no `--model` flag)
- **Both runtimes**: CLI-pane spawn via `runtime.ts`/`runtime-v2.ts` and MCP-bridge spawn via `mcp-team-bridge.ts`
- **Capabilities/scaling/status**: capability ranking, scaleUp/scaleDown launch argv, status display, stage router, worker bootstrap/restart all aware of mistral
- **Validation**: bridge-entry, ask CLI provider matrix, doctor team-routing, config loader provider validation
- **Worker overlay**: `### Agent-Type Guidance (mistral / vibe)` block emitted in worker overlay
- **Skill docs**: `skills/omc-teams/SKILL.md` updated to list mistral as a worker option

## Test parity
- 21 existing test files extended (drop-in mistral rows / parallel `it(...)` blocks mirroring the gemini pattern)
- 1 new file: `src/team/__tests__/runtime-v2.vibe-preflight.test.ts` mirroring the existing gemini-preflight test

Test surface includes: launch argv, prompt-mode flow, role routing, status dedup, registration, restart preservation, capability ranking, MCP bridge spawn args.

## Field validation
End-to-end smoke tested against a real `vibe` install:

```
omc team 1:mistral "say hello in one line, then transition the task and exit"
```

Vibe spawned with `--agent auto-approve -p '<inbox-pointer>'`, read the worker inbox, called `omc team api claim-task`, did the work, called `omc team api transition-task-status`, exited cleanly. Total elapsed: 18s.

## One known gotcha (not blocking)
The leader's prompt-mode startup-evidence wait at `runtime-v2.ts:705-718` is `3 attempts × 250ms = 750ms`, which is shorter than vibe's boot-to-first-API-call latency. The worker still completes successfully, but the leader emits a one-time `startup_manual_intervention_required:<worker>:mistral_startup_evidence_missing` event on each start. Functional impact: zero (worker keeps running and finishes). Suggested follow-up: bump the wait window for prompt-mode agents, or add per-agent overrides. Happy to land that in a follow-up PR.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/team/__tests__/` — 887 / 891 pass; 3 pre-existing failures in `git-worktree.test.ts` unchanged from baseline (zero mistral content)
- [x] End-to-end smoke test on real vibe install (1-worker team, basic transition flow)
- [ ] Reviewer to confirm: build artifacts (`bridge/`, `dist/`) deliberately omitted from this PR per the cursor-agent precedent (#2736); maintainer's release pipeline regenerates them