### PR TITLE
Fix Max HUD rate limits with enterprise spend cache data

### DIFF
--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -140,6 +140,35 @@ describe('render: rate limits display priority', () => {
     expect(plain).not.toContain('spent:');
   });
 
+  it('renders Max 20x 5h/wk/sn limits when enterprise spent exists but enterprise limit is null', async () => {
+    const context = makeContext({
+      subscriptionType: 'max',
+      rateLimitTier: 'default_claude_max_20x',
+      rateLimitsResult: {
+        rateLimits: {
+          fiveHourPercent: 36,
+          weeklyPercent: 32,
+          sonnetWeeklyPercent: 8,
+          enterpriseSpentUsd: 12.34,
+          enterpriseLimitUsd: null,
+          enterpriseCurrency: 'USD',
+        },
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    const plain = stripAnsi(output);
+
+    expect(plain.trim()).not.toBe('');
+    expect(plain).toContain('5h:');
+    expect(plain).toContain('36%');
+    expect(plain).toContain('wk:');
+    expect(plain).toContain('32%');
+    expect(plain).toContain('sn:');
+    expect(plain).toContain('8%');
+    expect(plain).not.toContain('spent:');
+  });
+
   it.each([
     ['zero', 0],
     ['negative', -1],


### PR DESCRIPTION
## Summary
- Add a focused HUD regression for Max 20x accounts whose cached rate-limit payload includes `enterpriseSpentUsd` while `enterpriseLimitUsd` is null.
- Assert normal 5h/week/Sonnet rate limits remain visible and enterprise `spent:` cost is not rendered.
- Preserve true enterprise behavior through existing enterprise render coverage.

Closes #2849.

## Verification
- `npm test -- --run src/__tests__/hud/render-rate-limits-priority.test.ts src/__tests__/hud/render-enterprise.test.ts src/hud/__tests__/enterprise-cost.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `npm test -- --run`

## Notes
- `npm run build` generated broad dist/bridge churn from stale generated artifacts; those unrelated generated changes were intentionally not committed to keep this PR narrow.