### PR TITLE
Fix deep-dive ambiguity threshold settings

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -90,8 +90,10 @@ jobs:
           # Capture exit code of omc update itself (PIPESTATUS[0])
           # npm install may emit deprecation warnings to stderr — those are not
           # omc errors. Filter those out and fail on everything else.
+          set +e
           omc update 1>"$RUNNER_TEMP/omc-update.stdout.log" 2>"$RUNNER_TEMP/omc-update.stderr.log"
           UPDATE_EXIT=$?
+          set -e
 
           # Check for non-npm stderr (omc warnings/errors/exceptions)
           # Exclude npm deprecation warnings: "npm deprecated ..." or lines not starting with npm/
@@ -106,7 +108,10 @@ jobs:
 
           if [ "$UPDATE_EXIT" -ne 0 ]; then
             echo "FAIL: omc update exited with code $UPDATE_EXIT"
+            echo "Full stdout:"
             cat "$RUNNER_TEMP/omc-update.stdout.log"
+            echo "Full stderr:"
+            cat "$RUNNER_TEMP/omc-update.stderr.log"
             exit 1
           fi
 

--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -83868,7 +83868,7 @@ function applyDeepInterviewRuntimeSettings(template) {
 }
 function renderBundledSkillBody(skillName, body) {
   const rewrittenBody = rewriteOmcCliInvocations(body.trim());
-  return skillName === "deep-interview" ? applyDeepInterviewRuntimeSettings(rewrittenBody) : rewrittenBody;
+  return skillName === "deep-interview" || skillName === "deep-dive" ? applyDeepInterviewRuntimeSettings(rewrittenBody) : rewrittenBody;
 }
 function loadSkillFromFile(skillPath, skillName) {
   try {

--- a/dist/features/builtin-skills/skills.js
+++ b/dist/features/builtin-skills/skills.js
@@ -134,7 +134,7 @@ function applyDeepInterviewRuntimeSettings(template) {
 }
 export function renderBundledSkillBody(skillName, body) {
     const rewrittenBody = rewriteOmcCliInvocations(body.trim());
-    return skillName === 'deep-interview'
+    return skillName === 'deep-interview' || skillName === 'deep-dive'
         ? applyDeepInterviewRuntimeSettings(rewrittenBody)
         : rewrittenBody;
 }

--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -67,6 +67,10 @@ The name "deep dive" naturally implies this flow: first dig deep into the proble
      2. **Config / environment / orchestration cause**
      3. **Measurement / artifact / assumption mismatch cause**
    - For brownfield: run `explore` agent to identify relevant codebase areas, store as `codebase_context` for later injection
+4.5. **Load runtime settings**:
+   - Read `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` and `./.claude/settings.json` (project overrides user)
+   - Resolve `omc.deepInterview.ambiguityThreshold` into `<resolvedThreshold>`; if it is undefined, use `0.2`
+   - Derive `<resolvedThresholdPercent>` from `<resolvedThreshold>` and substitute both placeholders throughout the remaining instructions before continuing
 5. **Initialize state** via `state_write(mode="deep-interview")`:
 
 ```json
@@ -85,7 +89,7 @@ The name "deep dive" naturally implies this flow: first dig deep into the proble
     "spec_path": null,
     "rounds": [],
     "current_ambiguity": 1.0,
-    "threshold": 0.2,
+    "threshold": <resolvedThreshold>,
     "codebase_context": null,
     "challenge_modes_used": [],
     "ontology_snapshots": []
@@ -253,7 +257,7 @@ No overrides to the interview mechanics themselves — only the 3 initialization
 
 ### Spec Generation
 
-When ambiguity ≤ threshold (default 0.2), generate the spec in **standard deep-interview format** with one addition:
+When ambiguity ≤ the resolved threshold for this run, generate the spec in **standard deep-interview format** with one addition:
 
 - All standard sections: Goal, Constraints, Non-Goals, Acceptance Criteria, Assumptions Exposed, Technical Context, Ontology, Ontology Convergence, Interview Transcript
 - **Additional section: "Trace Findings"** — summarizes the trace results (most likely explanation, per-lane critical unknowns resolved, evidence that shaped the interview)
@@ -303,7 +307,7 @@ Stage 1: Deep Dive               Stage 2: Ralplan                Stage 3: Autopi
 │ Interview (Socratic)│───>│ Architect reviews         │───>│ Phase 3: QA cycling  │
 │ 3-point injection   │    │ Critic validates          │    │ Phase 4: Validation  │
 │ Spec crystallization│    │ Loop until consensus      │    │ Phase 5: Cleanup     │
-│ Gate: ≤20% ambiguity│    │ ADR + RALPLAN-DR summary  │    │                      │
+│ Gate: ≤<resolvedThresholdPercent> ambiguity│    │ ADR + RALPLAN-DR summary  │    │                      │
 └─────────────────────┘    └───────────────────────────┘    └──────────────────────┘
 Output: spec.md            Output: consensus-plan.md        Output: working code
 ```
@@ -347,7 +351,7 @@ User: /deep-dive "Production DAG fails intermittently on the transformation step
     Q1: "What's the expected data volume range and is there a peak period?"
     Q2: "Does the DAG have memory limits configured in its resource pool?"
     Q3: "How does the retry behavior interact with the scheduler?"
-  → Interview continues until ambiguity ≤ 20%
+  → Interview continues until ambiguity ≤ <resolvedThresholdPercent>
 
 [Phase 5] Spec ready. User selects ralplan → autopilot.
   → omc-plan --consensus --direct runs on the spec
@@ -433,8 +437,10 @@ Optional settings in `.claude/settings.json`:
 ```json
 {
   "omc": {
+    "deepInterview": {
+      "ambiguityThreshold": <resolvedThreshold>
+    },
     "deepDive": {
-      "ambiguityThreshold": 0.2,
       "defaultTraceLanes": 3,
       "enableTeamMode": true,
       "sequentialFallback": true

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -433,6 +433,61 @@ describe('Builtin Skills', () => {
       expect(raw).not.toContain('ambiguity ≤ 20%');
     });
 
+    it('loads deep-dive ambiguityThreshold from deep-interview settings before state init and updates threshold copy', () => {
+      const profileDir = mkdtempSync(join(tmpdir(), 'omc-deep-dive-profile-'));
+      const projectDir = mkdtempSync(join(tmpdir(), 'omc-deep-dive-project-'));
+      tempDirs.push(profileDir, projectDir);
+
+      process.env.CLAUDE_CONFIG_DIR = profileDir;
+      writeFileSync(
+        join(profileDir, 'settings.json'),
+        JSON.stringify({ omc: { deepInterview: { ambiguityThreshold: 0.18 } } }),
+      );
+
+      mkdirSync(join(projectDir, '.claude'), { recursive: true });
+      writeFileSync(
+        join(projectDir, '.claude', 'settings.json'),
+        JSON.stringify({ omc: { deepInterview: { ambiguityThreshold: 0.11 } } }),
+      );
+
+      process.chdir(projectDir);
+      clearSkillsCache();
+
+      const skill = getBuiltinSkill('deep-dive');
+      expect(skill).toBeDefined();
+      const t = skill!.template;
+
+      expect(t).toContain('Load runtime settings');
+      expect(t).toContain('Resolve `omc.deepInterview.ambiguityThreshold` into `0.11`');
+      expect(t).toContain('"threshold": 0.11,');
+      expect(t).toContain('When ambiguity ≤ the resolved threshold for this run');
+      expect(t).toContain('Gate: ≤11% ambiguity');
+      expect(t).toContain('Interview continues until ambiguity ≤ 11%');
+      expect(t.indexOf('Load runtime settings')).toBeLessThan(
+        t.indexOf('Initialize state') ?? Number.POSITIVE_INFINITY,
+      );
+      expect(t).not.toContain('"threshold": 0.2,');
+      expect(t).not.toContain('omc.deepDive.ambiguityThreshold');
+    });
+
+    it('ships config-aware deep-dive SKILL.md using the deep-interview threshold namespace', () => {
+      const raw = readFileSync(join(originalCwd, 'skills', 'deep-dive', 'SKILL.md'), 'utf-8');
+
+      expect(raw).toContain('Load runtime settings');
+      expect(raw).toContain('Read `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` and `./.claude/settings.json`');
+      expect(raw).toContain('Resolve `omc.deepInterview.ambiguityThreshold` into `<resolvedThreshold>`');
+      expect(raw).toContain('"threshold": <resolvedThreshold>,');
+      expect(raw).toContain('Gate: ≤<resolvedThresholdPercent> ambiguity');
+      expect(raw).toContain('Interview continues until ambiguity ≤ <resolvedThresholdPercent>');
+      expect(raw).toContain('"deepInterview":');
+      expect(raw).toContain('"ambiguityThreshold": <resolvedThreshold>');
+
+      expect(raw).not.toContain('omc.deepDive.ambiguityThreshold');
+      expect(raw).not.toContain('"threshold": 0.2,');
+      expect(raw).not.toContain('Gate: ≤20% ambiguity');
+      expect(raw).not.toContain('ambiguity ≤ 20%');
+    });
+
     it('renders deep-interview summary-gate hardening while preserving AskUserQuestion transport', () => {
       const skill = getBuiltinSkill('deep-interview');
       expect(skill).toBeDefined();

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -163,7 +163,7 @@ function applyDeepInterviewRuntimeSettings(template: string): string {
 
 export function renderBundledSkillBody(skillName: string, body: string): string {
   const rewrittenBody = rewriteOmcCliInvocations(body.trim());
-  return skillName === 'deep-interview'
+  return skillName === 'deep-interview' || skillName === 'deep-dive'
     ? applyDeepInterviewRuntimeSettings(rewrittenBody)
     : rewrittenBody;
 }


### PR DESCRIPTION
## Summary\n- Load the shared deep-interview ambiguity threshold during deep-dive Phase 1 before state initialization\n- Render deep-dive state, gate wording, examples, and docs with the resolved threshold instead of hardcoded 20%/0.2\n- Remove the misleading deepDive ambiguityThreshold docs and add regression coverage for the shared namespace\n\nCloses #2851\n\n## Verification\n- npm test -- --run src/__tests__/auto-slash-aliases.test.ts src/__tests__/skills.test.ts\n- npx tsc --noEmit\n- npm run lint (0 errors; existing warnings only)\n- npm run build\n- npm test -- --run\n