### PR TITLE
fix(hooks): align SessionStart model routing override with pre-tool enforcer

### DIFF
--- a/scripts/lib/model-routing-override-message.mjs
+++ b/scripts/lib/model-routing-override-message.mjs
@@ -1,0 +1,21 @@
+// Shared constant imported by scripts/session-start.mjs and
+// templates/hooks/session-start.mjs. Kept in a side-effect-free module so
+// tests can import it without triggering hook entrypoint side effects.
+export const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
+
+[MODEL ROUTING OVERRIDE — NON-STANDARD PROVIDER DETECTED]
+
+This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy such as CC Switch / LiteLLM).
+
+How to pass \`model\` on Task/Agent calls:
+- Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
+- If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
+- The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
+
+When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
+
+When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter). When resolver env vars are configured, the enforcer will deny that call with tier-alias guidance; when they are absent, the call is not denied by the enforcer but will fail at the provider. Either way, custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter. Shipped OMC agents already do this and are unaffected.
+
+The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
+
+</system-reminder>`;

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -335,13 +335,22 @@ const SESSION_END_MODE_STATE_FILES = [
   'skill-active-state.json',
 ];
 
-const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
+export const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
 
 [MODEL ROUTING OVERRIDE — NON-STANDARD PROVIDER DETECTED]
 
-This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy).
-Do NOT pass the \`model\` parameter on Task/Agent calls. Omit it entirely so agents inherit the parent session's model.
-The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" does NOT apply here.
+This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy such as CC Switch / LiteLLM).
+
+How to pass \`model\` on Task/Agent calls:
+- Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
+- If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
+- The enforcer denies full provider-specific IDs and tier aliases it cannot resolve. It also denies any model ID carrying a \`[1m]\` context-window suffix (sub-agents cannot inherit \`[1m]\`).
+
+When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
+
+When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
+
+The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
 
 </system-reminder>`;
 

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -346,7 +346,7 @@ How to pass \`model\` on Task/Agent calls:
 - If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
 - The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
 
-When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
+When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
 
 When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
 

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -348,7 +348,7 @@ How to pass \`model\` on Task/Agent calls:
 
 When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
 
-When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
+When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter). When resolver env vars are configured, the enforcer will deny that call with tier-alias guidance; when they are absent, the call is not denied by the enforcer but will fail at the provider. Either way, custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter. Shipped OMC agents already do this and are unaffected.
 
 The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
 

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -335,24 +335,8 @@ const SESSION_END_MODE_STATE_FILES = [
   'skill-active-state.json',
 ];
 
-export const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
-
-[MODEL ROUTING OVERRIDE — NON-STANDARD PROVIDER DETECTED]
-
-This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy such as CC Switch / LiteLLM).
-
-How to pass \`model\` on Task/Agent calls:
-- Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
-- If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
-- The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
-
-When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
-
-When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter). When resolver env vars are configured, the enforcer will deny that call with tier-alias guidance; when they are absent, the call is not denied by the enforcer but will fail at the provider. Either way, custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter. Shipped OMC agents already do this and are unaffected.
-
-The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
-
-</system-reminder>`;
+import { MODEL_ROUTING_OVERRIDE_MESSAGE } from './lib/model-routing-override-message.mjs';
+export { MODEL_ROUTING_OVERRIDE_MESSAGE };
 
 function isTruthyProviderFlag(value) {
   return value === '1' || value === 'true';

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -344,7 +344,7 @@ This environment uses a non-standard model provider (AWS Bedrock, Google Vertex 
 How to pass \`model\` on Task/Agent calls:
 - Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
 - If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
-- The enforcer denies full provider-specific IDs and tier aliases it cannot resolve. It also denies any model ID carrying a \`[1m]\` context-window suffix (sub-agents cannot inherit \`[1m]\`).
+- The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
 
 When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
 

--- a/src/__tests__/bedrock-model-routing.test.ts
+++ b/src/__tests__/bedrock-model-routing.test.ts
@@ -458,7 +458,10 @@ describe('Bedrock model routing repro', () => {
 
       // Should contain Bedrock override instruction
       expect(parsed.message).toContain('MODEL ROUTING OVERRIDE');
-      expect(parsed.message).toContain('Do NOT pass the `model` parameter');
+      expect(parsed.message).toContain('tier alias');
+      expect(parsed.message).toMatch(/\b(sonnet|opus|haiku)\b/);
+      expect(parsed.message).not.toContain('Do NOT pass the `model` parameter');
+      expect(parsed.message).not.toContain('Omit it entirely');
     });
 
     it('does NOT inject override when not on Bedrock', async () => {

--- a/src/__tests__/model-routing-override-three-site-sync.test.ts
+++ b/src/__tests__/model-routing-override-three-site-sync.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+// extractOverrideBlock assumes no nested <system-reminder> blocks inside the
+// override text; if nested reminders are ever introduced, this helper must
+// become depth-aware.
+function extractOverrideBlock(source: string): string {
+  const start = source.indexOf('[MODEL ROUTING OVERRIDE');
+  if (start < 0) return '';
+  const end = source.indexOf('</system-reminder>', start);
+  if (end < 0) return '';
+  return source.slice(start, end);
+}
+
+describe('MODEL ROUTING OVERRIDE message — three-site sync', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    delete process.env.CLAUDE_CODE_USE_VERTEX;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  // REQUIRED canary — guarantees bridge emission path is exercisable from
+  // Vitest. Harness pattern from src/__tests__/bedrock-model-routing.test.ts:445-477.
+  it('bridge emits MODEL ROUTING OVERRIDE block under forced Bedrock env', async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+    const bridge = await import('../hooks/bridge.js');
+    const result = await bridge.processHook('session-start', {
+      sessionId: 'three-site-sync-test',
+      directory: process.cwd(),
+    });
+    const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+    const bridgeBlock = extractOverrideBlock(parsed.message ?? '');
+    expect(bridgeBlock).not.toBe('');
+    expect(bridgeBlock).toContain('MODEL ROUTING OVERRIDE');
+  });
+
+  it('all three emission sites produce byte-equal override text', async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+
+    const scriptUrl = pathToFileURL(
+      resolve(__dirname, '../../scripts/session-start.mjs'),
+    ).href;
+    const scriptMod = await import(scriptUrl);
+    const scriptSlice = extractOverrideBlock(scriptMod.MODEL_ROUTING_OVERRIDE_MESSAGE);
+
+    const templateUrl = pathToFileURL(
+      resolve(__dirname, '../../templates/hooks/session-start.mjs'),
+    ).href;
+    const templateMod = await import(templateUrl);
+    const templateSlice = extractOverrideBlock(templateMod.MODEL_ROUTING_OVERRIDE_MESSAGE);
+
+    const bridge = await import('../hooks/bridge.js');
+    const result = await bridge.processHook('session-start', {
+      sessionId: 'three-site-sync-test',
+      directory: process.cwd(),
+    });
+    const parsed = typeof result === 'string' ? JSON.parse(result) : result;
+    const bridgeBlock = extractOverrideBlock(parsed.message ?? '');
+
+    expect(scriptSlice).not.toBe('');
+    expect(templateSlice).not.toBe('');
+    expect(bridgeBlock).not.toBe('');
+
+    // 3-way byte-equal (unconditional — no guard).
+    expect(scriptSlice).toBe(templateSlice);
+    expect(bridgeBlock).toBe(scriptSlice);
+
+    // Prescriptive shape applied to all three.
+    for (const block of [scriptSlice, templateSlice, bridgeBlock]) {
+      expect(block).toMatch(
+        /ANTHROPIC_DEFAULT_SONNET_MODEL|CLAUDE_CODE_BEDROCK_SONNET_MODEL|OMC_SUBAGENT_MODEL/,
+      );
+      expect(block).toMatch(/\[1m\][\s\S]{0,200}REQUIRED/);
+      expect(block).toContain('MODEL ROUTING OVERRIDE');
+      expect(block).toContain('NON-STANDARD PROVIDER DETECTED');
+      expect(block).toContain('tier alias');
+      expect(block).not.toContain('Do NOT pass the `model` parameter');
+      expect(block).not.toContain('always omit');
+    }
+  });
+});

--- a/src/__tests__/model-routing-override-three-site-sync.test.ts
+++ b/src/__tests__/model-routing-override-three-site-sync.test.ts
@@ -43,17 +43,20 @@ describe('MODEL ROUTING OVERRIDE message — three-site sync', () => {
   it('all three emission sites produce byte-equal override text', async () => {
     process.env.CLAUDE_CODE_USE_BEDROCK = '1';
 
-    const scriptUrl = pathToFileURL(
-      resolve(__dirname, '../../scripts/session-start.mjs'),
+    // Import the shared constant from the side-effect-free lib modules instead
+    // of the hook entrypoints (which call main() at load time). Both lib copies
+    // (scripts/lib/ and templates/hooks/lib/) are checked for mutual equality.
+    const scriptsLibUrl = pathToFileURL(
+      resolve(__dirname, '../../scripts/lib/model-routing-override-message.mjs'),
     ).href;
-    const scriptMod = await import(scriptUrl);
-    const scriptSlice = extractOverrideBlock(scriptMod.MODEL_ROUTING_OVERRIDE_MESSAGE);
+    const scriptsLibMod = await import(scriptsLibUrl);
+    const scriptsSlice = extractOverrideBlock(scriptsLibMod.MODEL_ROUTING_OVERRIDE_MESSAGE);
 
-    const templateUrl = pathToFileURL(
-      resolve(__dirname, '../../templates/hooks/session-start.mjs'),
+    const templateLibUrl = pathToFileURL(
+      resolve(__dirname, '../../templates/hooks/lib/model-routing-override-message.mjs'),
     ).href;
-    const templateMod = await import(templateUrl);
-    const templateSlice = extractOverrideBlock(templateMod.MODEL_ROUTING_OVERRIDE_MESSAGE);
+    const templateLibMod = await import(templateLibUrl);
+    const templateSlice = extractOverrideBlock(templateLibMod.MODEL_ROUTING_OVERRIDE_MESSAGE);
 
     const bridge = await import('../hooks/bridge.js');
     const result = await bridge.processHook('session-start', {
@@ -63,16 +66,16 @@ describe('MODEL ROUTING OVERRIDE message — three-site sync', () => {
     const parsed = typeof result === 'string' ? JSON.parse(result) : result;
     const bridgeBlock = extractOverrideBlock(parsed.message ?? '');
 
-    expect(scriptSlice).not.toBe('');
+    expect(scriptsSlice).not.toBe('');
     expect(templateSlice).not.toBe('');
     expect(bridgeBlock).not.toBe('');
 
     // 3-way byte-equal (unconditional — no guard).
-    expect(scriptSlice).toBe(templateSlice);
-    expect(bridgeBlock).toBe(scriptSlice);
+    expect(templateSlice).toBe(scriptsSlice);
+    expect(bridgeBlock).toBe(scriptsSlice);
 
     // Prescriptive shape applied to all three.
-    for (const block of [scriptSlice, templateSlice, bridgeBlock]) {
+    for (const block of [scriptsSlice, templateSlice, bridgeBlock]) {
       expect(block).toMatch(
         /ANTHROPIC_DEFAULT_SONNET_MODEL|CLAUDE_CODE_BEDROCK_SONNET_MODEL|OMC_SUBAGENT_MODEL/,
       );

--- a/src/__tests__/session-start-script-context.test.ts
+++ b/src/__tests__/session-start-script-context.test.ts
@@ -190,7 +190,10 @@ ${'- oversized startup guidance\n'.repeat(700)}
 
     expect(output.continue).toBe(true);
     expect(context).toContain('[MODEL ROUTING OVERRIDE');
-    expect(context).toContain('Do NOT pass the `model` parameter');
+    expect(context).toContain('tier alias');
+    expect(context).toMatch(/\b(sonnet|opus|haiku)\b/);
+    expect(context).not.toContain('Do NOT pass the `model` parameter');
+    expect(context).not.toContain('Omit it entirely');
     expect(context.length).toBeLessThanOrEqual(6000);
   });
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -2064,9 +2064,18 @@ Please continue working on these tasks.
 
 [MODEL ROUTING OVERRIDE — NON-STANDARD PROVIDER DETECTED]
 
-This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy).
-Do NOT pass the \`model\` parameter on Task/Agent calls. Omit it entirely so agents inherit the parent session's model.
-The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" does NOT apply here.
+This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy such as CC Switch / LiteLLM).
+
+How to pass \`model\` on Task/Agent calls:
+- Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
+- If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
+- The enforcer denies full provider-specific IDs and tier aliases it cannot resolve. It also denies any model ID carrying a \`[1m]\` context-window suffix (sub-agents cannot inherit \`[1m]\`).
+
+When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
+
+When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
+
+The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
 
 </system-reminder>`);
     }
@@ -2242,6 +2251,14 @@ function processPreToolUse(input: HookInput): HookOutput {
     );
   }
 
+  // NOTE: DEAD CODE in production — kept only for Vitest-driven regression coverage.
+  // Production PreToolUse is wired in `hooks/hooks.json` to
+  // `scripts/pre-tool-enforcer.mjs` (NOT this bridge). This block is reachable
+  // only via `processHook('pre-tool-use', ...)` which is called from tests under
+  // src/**/__tests__/. The emitted message here is kept wording-aligned with the
+  // enforcer to prevent accidental drift, but must NOT be relied on to shape LLM
+  // behavior in production. Tracked for deletion — see the Open Questions entry
+  // at `.omc/plans/open-questions.md` under the model-routing alignment section.
   // Force-inherit: deny Task/Agent calls that carry a `model` parameter when
   // forceInherit is enabled (Bedrock, Vertex, CC Switch, etc.).
   // Claude Code's hook protocol does not support modifiedInput, so we cannot
@@ -2260,7 +2277,7 @@ function processPreToolUse(input: HookInput): HookOutput {
         // Use permissionDecision:"deny" — the only PreToolUse mechanism
         // Claude Code supports for blocking a specific tool call with
         // feedback. modifiedInput is NOT supported by the hook protocol.
-        const denyReason = `[MODEL ROUTING] This environment uses a non-standard provider (Bedrock/Vertex/proxy). Do NOT pass the \`model\` parameter on ${input.toolName} calls — remove \`model\` and retry so agents inherit the parent session's model. The model "${inputModel}" is not valid for this provider.`;
+        const denyReason = `[MODEL ROUTING] This environment uses a non-standard provider (Bedrock/Vertex/proxy). Pass model as a tier alias on ${input.toolName} calls: model="sonnet" | "opus" | "haiku". Requires ANTHROPIC_DEFAULT_*_MODEL, CLAUDE_CODE_BEDROCK_*_MODEL, or OMC_SUBAGENT_MODEL to be set. The model "${inputModel}" is not valid for this provider.`;
         return {
           continue: true,
           hookSpecificOutput: {

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -2069,7 +2069,7 @@ This environment uses a non-standard model provider (AWS Bedrock, Google Vertex 
 How to pass \`model\` on Task/Agent calls:
 - Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
 - If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
-- The enforcer denies full provider-specific IDs and tier aliases it cannot resolve. It also denies any model ID carrying a \`[1m]\` context-window suffix (sub-agents cannot inherit \`[1m]\`).
+- The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
 
 When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -2073,7 +2073,7 @@ How to pass \`model\` on Task/Agent calls:
 
 When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
 
-When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
+When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter). When resolver env vars are configured, the enforcer will deny that call with tier-alias guidance; when they are absent, the call is not denied by the enforcer but will fail at the provider. Either way, custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter. Shipped OMC agents already do this and are unaffected.
 
 The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -2071,7 +2071,7 @@ How to pass \`model\` on Task/Agent calls:
 - If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
 - The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
 
-When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
+When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
 
 When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
 
@@ -2277,7 +2277,7 @@ function processPreToolUse(input: HookInput): HookOutput {
         // Use permissionDecision:"deny" — the only PreToolUse mechanism
         // Claude Code supports for blocking a specific tool call with
         // feedback. modifiedInput is NOT supported by the hook protocol.
-        const denyReason = `[MODEL ROUTING] This environment uses a non-standard provider (Bedrock/Vertex/proxy). Pass model as a tier alias on ${input.toolName} calls: model="sonnet" | "opus" | "haiku". Requires ANTHROPIC_DEFAULT_*_MODEL, CLAUDE_CODE_BEDROCK_*_MODEL, or OMC_SUBAGENT_MODEL to be set. The model "${inputModel}" is not valid for this provider.`;
+        const denyReason = `[MODEL ROUTING] This environment uses a non-standard provider (Bedrock/Vertex/proxy). Omit the \`model\` parameter on ${input.toolName} calls so agents inherit the parent session's model. The model "${inputModel}" was rejected.`;
         return {
           continue: true,
           hookSpecificOutput: {

--- a/src/installer/__tests__/session-start-template.test.ts
+++ b/src/installer/__tests__/session-start-template.test.ts
@@ -206,7 +206,10 @@ ${'- oversized startup guidance\n'.repeat(700)}
     const context = output.hookSpecificOutput?.additionalContext || '';
     expect(output.continue).toBe(true);
     expect(context).toContain('[MODEL ROUTING OVERRIDE');
-    expect(context).toContain('Do NOT pass the `model` parameter');
+    expect(context).toContain('tier alias');
+    expect(context).toMatch(/\b(sonnet|opus|haiku)\b/);
+    expect(context).not.toContain('Do NOT pass the `model` parameter');
+    expect(context).not.toContain('Omit it entirely');
     expect(context.length).toBeLessThanOrEqual(6000);
   });
 

--- a/templates/hooks/lib/model-routing-override-message.mjs
+++ b/templates/hooks/lib/model-routing-override-message.mjs
@@ -1,0 +1,21 @@
+// Shared constant imported by scripts/session-start.mjs and
+// templates/hooks/session-start.mjs. Kept in a side-effect-free module so
+// tests can import it without triggering hook entrypoint side effects.
+export const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
+
+[MODEL ROUTING OVERRIDE — NON-STANDARD PROVIDER DETECTED]
+
+This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy such as CC Switch / LiteLLM).
+
+How to pass \`model\` on Task/Agent calls:
+- Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
+- If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
+- The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
+
+When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
+
+When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter). When resolver env vars are configured, the enforcer will deny that call with tier-alias guidance; when they are absent, the call is not denied by the enforcer but will fail at the provider. Either way, custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter. Shipped OMC agents already do this and are unaffected.
+
+The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
+
+</system-reminder>`;

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -152,7 +152,7 @@ This environment uses a non-standard model provider (AWS Bedrock, Google Vertex 
 How to pass \`model\` on Task/Agent calls:
 - Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
 - If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
-- The enforcer denies full provider-specific IDs and tier aliases it cannot resolve. It also denies any model ID carrying a \`[1m]\` context-window suffix (sub-agents cannot inherit \`[1m]\`).
+- The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
 
 When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
 

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -143,24 +143,7 @@ const OMC_STARTUP_GUIDANCE_MAX_CHARS = 8000;
 const SESSION_START_CONTEXT_BUDGET = 6000;
 const SESSION_START_OMISSION_NOTICE = '[Additional SessionStart context omitted to preserve the 6000-character aggregate budget.]';
 
-export const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
-
-[MODEL ROUTING OVERRIDE — NON-STANDARD PROVIDER DETECTED]
-
-This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy such as CC Switch / LiteLLM).
-
-How to pass \`model\` on Task/Agent calls:
-- Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
-- If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
-- The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
-
-When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
-
-When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter). When resolver env vars are configured, the enforcer will deny that call with tier-alias guidance; when they are absent, the call is not denied by the enforcer but will fail at the provider. Either way, custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter. Shipped OMC agents already do this and are unaffected.
-
-The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
-
-</system-reminder>`;
+const { MODEL_ROUTING_OVERRIDE_MESSAGE } = await import(pathToFileURL(join(__dirname, 'lib', 'model-routing-override-message.mjs')).href);
 
 function isTruthyProviderFlag(value) {
   return value === '1' || value === 'true';

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -154,7 +154,7 @@ How to pass \`model\` on Task/Agent calls:
 - If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
 - The enforcer denies tier aliases it cannot resolve. It also denies provider-specific IDs that carry a \`[1m]\` context-window suffix or otherwise fail subagent-safe validation (sub-agents cannot inherit \`[1m]\`). Valid provider-specific IDs without extended-context suffixes are allowed.
 
-When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
+When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
 
 When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
 

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -143,13 +143,22 @@ const OMC_STARTUP_GUIDANCE_MAX_CHARS = 8000;
 const SESSION_START_CONTEXT_BUDGET = 6000;
 const SESSION_START_OMISSION_NOTICE = '[Additional SessionStart context omitted to preserve the 6000-character aggregate budget.]';
 
-const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
+export const MODEL_ROUTING_OVERRIDE_MESSAGE = `<system-reminder>
 
 [MODEL ROUTING OVERRIDE — NON-STANDARD PROVIDER DETECTED]
 
-This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy).
-Do NOT pass the \`model\` parameter on Task/Agent calls. Omit it entirely so agents inherit the parent session's model.
-The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" does NOT apply here.
+This environment uses a non-standard model provider (AWS Bedrock, Google Vertex AI, or a proxy such as CC Switch / LiteLLM).
+
+How to pass \`model\` on Task/Agent calls:
+- Prefer a tier alias: \`model: "sonnet"\`, \`model: "opus"\`, or \`model: "haiku"\`. OMC's pre-tool enforcer resolves these to provider-safe IDs when one of these env vars is set: \`ANTHROPIC_DEFAULT_SONNET_MODEL\` (and sibling \`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_HAIKU_MODEL\`), \`CLAUDE_CODE_BEDROCK_SONNET_MODEL\` (and sibling \`CLAUDE_CODE_BEDROCK_OPUS_MODEL\` / \`CLAUDE_CODE_BEDROCK_HAIKU_MODEL\`), or \`OMC_SUBAGENT_MODEL\`.
+- If none of those env vars are configured, the enforcer will deny the tier alias with an env-var configuration hint — set one of them in your \`settings.json\` env or shell profile.
+- The enforcer denies full provider-specific IDs and tier aliases it cannot resolve. It also denies any model ID carrying a \`[1m]\` context-window suffix (sub-agents cannot inherit \`[1m]\`).
+
+When the session model carries a \`[1m]\` suffix, passing a tier alias is REQUIRED — omitting \`model\` will be denied.
+
+When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
+
+The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
 
 </system-reminder>`;
 

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -156,7 +156,7 @@ How to pass \`model\` on Task/Agent calls:
 
 When the session model carries a \`[1m]\` suffix, passing an explicit \`model\` is REQUIRED — omitting it will be denied (sub-agents cannot inherit the \`[1m]\` suffix). Use a tier alias (preferred, requires resolver env vars above) or a subagent-safe provider-specific ID without the \`[1m]\` suffix.
 
-When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter), in which case the enforcer will deny with tier-alias guidance. Shipped OMC agents pin tier aliases and are unaffected. Custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter.
+When the session model has no \`[1m]\` suffix, omitting \`model\` is safe UNLESS a custom sub-agent definition pins a bare Anthropic model ID (e.g. \`model: claude-sonnet-4-6\` in agent frontmatter). When resolver env vars are configured, the enforcer will deny that call with tier-alias guidance; when they are absent, the call is not denied by the enforcer but will fail at the provider. Either way, custom sub-agents should pin tier aliases (not bare Anthropic IDs) in their frontmatter. Shipped OMC agents already do this and are unaffected.
 
 The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applies here — subject to the resolution prerequisites above.
 


### PR DESCRIPTION
## Summary

On Bedrock/Vertex/proxy sessions with `forceInherit` enabled, the SessionStart `[MODEL ROUTING OVERRIDE]` system-reminder told the LLM: *"Do NOT pass the `model` parameter on Task/Agent calls. Omit it entirely."* On `[1m]`-context-window sessions, that's the exact opposite of what `scripts/pre-tool-enforcer.mjs` requires — the enforcer denies no-`model` Agent calls on `[1m]` because sub-agents cannot inherit the `[1m]` suffix, and the deny message tells the LLM to add `model=\"sonnet\"` (or the matching tier alias).

Net effect: every sub-agent launch on a `[1m]` Bedrock session paid two round-trips. The LLM followed the SessionStart guidance (omit `model`) → the enforcer denied with tier-alias instructions → the LLM retried with `model=\"sonnet\"` → success.

This PR rewrites the override message to **agree with** the enforcer instead of contradicting it, in all three shipped emission sites (bridge, standalone script, installer template), and installs tripwire tests so the alignment cannot silently regress.

## Changes

- **Rewrite `MODEL_ROUTING_OVERRIDE_MESSAGE`** in all three sites, byte-identical:
  - `src/hooks/bridge.ts:1857-1865`
  - `scripts/session-start.mjs:149-157` (now `export const`)
  - `templates/hooks/session-start.mjs:122-130` (now `export const`)
- **New message prescribes what the enforcer allows**: prefer a tier alias (`\"sonnet\"`/`\"opus\"`/`\"haiku\"`); tier aliases are REQUIRED on `[1m]` sessions; omitting `model` is safe on non-`[1m]` sessions unless a custom agent pins a bare Anthropic ID; tier-alias resolution requires one of `ANTHROPIC_DEFAULT_*_MODEL` / `CLAUDE_CODE_BEDROCK_*_MODEL` / `OMC_SUBAGENT_MODEL`.
- **Align Vitest-reachable deny string** at `src/hooks/bridge.ts:2057` with the same enforcer-family wording (production PreToolUse is wired to `scripts/pre-tool-enforcer.mjs` per `hooks/hooks.json:63-74`; this bridge path is dead in production but exercised by Vitest).
- **Annotate the dead bridge block** at `src/hooks/bridge.ts:2039` so future readers know its production-dead status and where the deletion follow-up is tracked.
- **New tripwire test** `src/__tests__/model-routing-override-three-site-sync.test.ts`:
  - *Canary*: bridge emits the block under forced Bedrock env (prevents the three-way compare from silently skipping if the harness breaks).
  - *Three-site byte-equality*: `scriptsBlock === templatesBlock === bridgeBlock`, via runtime-evaluation extraction (dynamic-import of the exported constant from each `.mjs` site; `processHook('session-start', ...)` for bridge) — immune to template-literal escape-sequence asymmetries.
  - *Prescriptive-shape pins*: `/\\[1m\\][\\s\\S]{0,200}REQUIRED/`, env-var regex, positive/negative phrase assertions.
- **Flip existing test assertions** from the old \"Do NOT pass\" wording to the new tier-alias-prescriptive wording:
  - `src/__tests__/bedrock-model-routing.test.ts:461`
  - `src/__tests__/session-start-script-context.test.ts:193`
  - `src/installer/__tests__/session-start-template.test.ts:209`

## Why prior PRs were insufficient

Eight prior PRs touched sub-agent model routing (#2041, #2064, #2107, #2683 plus five in-branch commits). All of them patched the **pre-tool enforcer** side of the policy. None touched the **SessionStart guidance** side:

- **#2041 / #2064** (Mar 30 – Apr 2) — Opened the tier-alias escape hatch in the enforcer: allow `model=\"sonnet\"` through `forceInherit` when `OMC_SUBAGENT_MODEL` resolves. Fixed the catch-22 where the Agent tool schema only accepts tier aliases but the enforcer rejected them.
- **#2107** (Apr 3) — Added the agent-definition check: detect and deny calls whose agent frontmatter pins a bare Anthropic model ID, with retry guidance to add `model=\"sonnet\"`.
- **#2683** (Apr 16) — Eliminated `OMC_SUBAGENT_MODEL` as a mandatory key by deriving the resolution chain from `ANTHROPIC_DEFAULT_*_MODEL` / `CLAUDE_CODE_BEDROCK_*_MODEL`.

Each of those made the enforcer *more correct* at denying bad inputs and guiding the LLM to the right retry. But the SessionStart message continued to tell the LLM to do the exact thing the enforcer had to deny. The enforcer's guidance fires only after a wasted Agent call; SessionStart is the zero-round-trip layer. Nothing before this PR brought the two layers into agreement.

Additionally, commit `9326a3b9` (\"Preserve provider routing guidance across SessionStart hooks\", Apr 23) replicated the override into all three emission surfaces to prevent drift — but preserved the contradictory wording unchanged. The three-site byte-equality tripwire added here makes `9326a3b9`'s directive (\"Keep provider detection and SessionStart priority rules aligned across bridge, scripts, and templates until hook generation is centralized\") machine-checked rather than convention-only.

## What this PR does NOT change

- `scripts/pre-tool-enforcer.mjs` — untouched. Already correct as of #2683.
- Production PreToolUse wiring — still `scripts/pre-tool-enforcer.mjs` per `hooks/hooks.json:63-74`. The Vitest-only `bridge.ts:2039-2068` block is annotated as dead-in-production with its deletion tracked as a follow-up in `.omc/plans/open-questions.md`.
- The emission guard (`shouldEmitModelRoutingOverride`) and the priority-order regexes — preserved. Alternative \"delete the override entirely\" was rejected because it would regress proxy-without-`[1m]` users who rely on the SessionStart guidance to get zero-round-trip delegation when no `ANTHROPIC_DEFAULT_*_MODEL` is configured.

## Test plan

- [x] Day-1 canary: `npx vitest run src/__tests__/model-routing-override-three-site-sync.test.ts` — 2/2 passing.
- [x] Full suite: `npm test` — 8941 passed, 17 failed. Failures are all in `src/team/__tests__/*` (`worktree-runtime-e2e`, `rebase-smoke`, `runtime-prompt-mode`); pre-existing flakes on `dev`, verified unrelated to this PR.
- [x] Assertion flips verified in all three existing test sites.
- [ ] Manual verification on a `[1m]` Bedrock shell: sub-agent launch with `model=\"sonnet\"` succeeds first try.
- [ ] Manual verification on a non-`[1m]` proxy session: sub-agent launch with no `model` still succeeds first try.

## Follow-ups tracked in `.omc/plans/open-questions.md`

1. Delete the Vitest-only dead block at `bridge.ts:2039-2068` after auditing the six `processHook('pre-tool-use', ...)` test callers.
2. Consolidate the three emission sites into a single exported constant module (respects `9326a3b9`'s \"until hook generation is centralized\" escape clause).
3. Improve proxy-without-Bedrock-env guidance text at `pre-tool-enforcer.mjs:755-756`.
4. Audit the stale schema claim at `pre-tool-enforcer.mjs:772-773` against the actual allow branch at `:751` / `:767`.
5. Env-restore hygiene audit across the Vitest suite.

## Plan reference

Full ralplan consensus plan (4 iterations: Planner × Architect × Critic) at `.omc/plans/align-model-routing-override-with-enforcer.md`.