### PR TITLE
feat(persistent-mode): deep-interview stop-hook so AskUserQuestion doesn't end the loop turn

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -38,6 +38,7 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 <Execution_Policy>
 - Ask ONE question at a time -- never batch multiple questions
+- Do NOT yield the turn after `AskUserQuestion` returns the user's answer. Continue the same turn through scoring (2c), reporting (2d), `state_write` (2e), and the next question (2a/2b). Yield only when ambiguity ≤ threshold, the user requests early exit, or a hard cap triggers.
 - Target the WEAKEST clarity dimension with each question
 - Make weakest-dimension targeting explicit every round: name the weakest dimension, state its score/gap, and explain why the next question is aimed there
 - Gather codebase facts via `explore` agent BEFORE asking the user about them
@@ -142,6 +143,8 @@ Round {n} | Targeting: {weakest_dimension} | Why now: {one_sentence_targeting_ra
 ```
 
 Options should include contextually relevant choices plus free-text.
+
+**Do not stop here.** When `AskUserQuestion` returns the user's answer, immediately proceed to Step 2c in the same turn — do not treat the answer as a turn boundary.
 
 ### Step 2c: Score Ambiguity
 

--- a/src/hooks/persistent-mode/__tests__/deep-interview.test.ts
+++ b/src/hooks/persistent-mode/__tests__/deep-interview.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { checkPersistentModes } from '../index.js';
+
+function makeTempProject(): string {
+  const tempDir = mkdtempSync(join(tmpdir(), 'di-stop-'));
+  execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+  return tempDir;
+}
+
+function writeDeepInterviewState(
+  tempDir: string,
+  sessionId: string,
+  overrides: Record<string, unknown> = {},
+  innerOverrides: Record<string, unknown> = {},
+): string {
+  const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  const path = join(sessionDir, 'deep-interview-state.json');
+  const now = new Date().toISOString();
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        active: true,
+        current_phase: 'deep-interview',
+        session_id: sessionId,
+        started_at: now,
+        last_checked_at: now,
+        ...overrides,
+        state: {
+          interview_id: 'test-uuid',
+          type: 'greenfield',
+          initial_idea: 'test idea',
+          rounds: [{ q: 'Q1', a: 'A1' }],
+          current_ambiguity: 0.6,
+          threshold: 0.2,
+          codebase_context: null,
+          challenge_modes_used: [],
+          ontology_snapshots: [],
+          ...innerOverrides,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  return path;
+}
+
+describe('deep-interview stop hook', () => {
+  let tempDir: string;
+  let savedCwd: string;
+  let savedDisableOmc: string | undefined;
+  let savedSkipHooks: string | undefined;
+  let savedTeamWorker: string | undefined;
+
+  beforeEach(() => {
+    tempDir = makeTempProject();
+    savedCwd = process.cwd();
+    process.chdir(tempDir);
+    // Scrub OMC kill switches that would short-circuit checkPersistentModes.
+    // The OMC plugin itself sets OMC_SKIP_HOOKS=persistent-mode in some shells
+    // for the user's own session — we don't want that bleeding into test runs.
+    savedDisableOmc = process.env.DISABLE_OMC;
+    savedSkipHooks = process.env.OMC_SKIP_HOOKS;
+    savedTeamWorker = process.env.OMC_TEAM_WORKER;
+    delete process.env.DISABLE_OMC;
+    delete process.env.OMC_SKIP_HOOKS;
+    delete process.env.OMC_TEAM_WORKER;
+  });
+
+  afterEach(() => {
+    process.chdir(savedCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+    if (savedDisableOmc === undefined) delete process.env.DISABLE_OMC;
+    else process.env.DISABLE_OMC = savedDisableOmc;
+    if (savedSkipHooks === undefined) delete process.env.OMC_SKIP_HOOKS;
+    else process.env.OMC_SKIP_HOOKS = savedSkipHooks;
+    if (savedTeamWorker === undefined) delete process.env.OMC_TEAM_WORKER;
+    else process.env.OMC_TEAM_WORKER = savedTeamWorker;
+  });
+
+  it('returns no-block when no deep-interview state exists', async () => {
+    const result = await checkPersistentModes('di-empty', tempDir);
+    expect(result.shouldBlock).toBe(false);
+    expect(result.mode).toBe('none');
+  });
+
+  it('returns no-block when active=false', async () => {
+    const sessionId = 'di-inactive';
+    writeDeepInterviewState(tempDir, sessionId, { active: false });
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(false);
+  });
+
+  it('blocks when active and ambiguity above threshold', async () => {
+    const sessionId = 'di-mid-loop';
+    writeDeepInterviewState(tempDir, sessionId, {}, {
+      current_ambiguity: 0.55,
+      threshold: 0.2,
+    });
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(true);
+    expect(result.mode).toBe('deep-interview');
+    expect(result.message).toContain('DEEP-INTERVIEW LOOP');
+    expect(result.message).toContain('Round 1');
+    expect(result.message).toContain('55%');
+    expect(result.message).toContain('20%');
+  });
+
+  it('passes through (no-block) when ambiguity has dropped to threshold', async () => {
+    const sessionId = 'di-terminal';
+    writeDeepInterviewState(tempDir, sessionId, {}, {
+      current_ambiguity: 0.2,
+      threshold: 0.2,
+    });
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(false);
+    expect(result.mode).toBe('deep-interview');
+  });
+
+  it('passes through (no-block) when ambiguity has dropped below threshold', async () => {
+    const sessionId = 'di-terminal-below';
+    writeDeepInterviewState(tempDir, sessionId, {}, {
+      current_ambiguity: 0.15,
+      threshold: 0.2,
+    });
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(false);
+  });
+
+  it('honors top-level user_exit_requested', async () => {
+    const sessionId = 'di-exit-top';
+    writeDeepInterviewState(tempDir, sessionId, { user_exit_requested: true }, {
+      current_ambiguity: 0.55,
+    });
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(false);
+  });
+
+  it('honors nested state.user_exit_requested', async () => {
+    const sessionId = 'di-exit-nested';
+    writeDeepInterviewState(tempDir, sessionId, {}, {
+      current_ambiguity: 0.55,
+      user_exit_requested: true,
+    });
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(false);
+  });
+
+  it('does not block while awaiting_confirmation is set', async () => {
+    const sessionId = 'di-awaiting';
+    writeDeepInterviewState(tempDir, sessionId, {
+      awaiting_confirmation: true,
+      awaiting_confirmation_set_at: new Date().toISOString(),
+    });
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(false);
+  });
+
+  it('isolates by session_id (other-session state is ignored)', async () => {
+    writeDeepInterviewState(tempDir, 'session-A');
+    const result = await checkPersistentModes('session-B', tempDir);
+    expect(result.shouldBlock).toBe(false);
+    expect(result.mode).toBe('none');
+  });
+
+  it('exhausts the circuit breaker after MAX reinforcements and deactivates', async () => {
+    const sessionId = 'di-breaker';
+    const statePath = writeDeepInterviewState(tempDir, sessionId, {}, {
+      current_ambiguity: 0.55,
+      threshold: 0.2,
+    });
+
+    let lastResult;
+    // First call increments breaker to 1, second to 2, ... 30th still blocks,
+    // 31st trips (count > MAX === 30) and deactivates.
+    for (let i = 0; i < 31; i += 1) {
+      lastResult = await checkPersistentModes(sessionId, tempDir);
+    }
+
+    expect(lastResult).toBeDefined();
+    expect(lastResult!.shouldBlock).toBe(false);
+    expect(lastResult!.mode).toBe('deep-interview');
+    expect(lastResult!.message).toContain('CIRCUIT BREAKER');
+
+    // State file should now be deactivated with a reason.
+    const persisted = JSON.parse(readFileSync(statePath, 'utf-8')) as Record<string, unknown>;
+    expect(persisted.active).toBe(false);
+    expect(persisted.deactivated_reason).toBe('stop_breaker_exhausted');
+  });
+
+  it('respects DISABLE_OMC kill switch', async () => {
+    process.env.DISABLE_OMC = '1';
+    const sessionId = 'di-kill-switch';
+    writeDeepInterviewState(tempDir, sessionId);
+    const result = await checkPersistentModes(sessionId, tempDir);
+    expect(result.shouldBlock).toBe(false);
+    expect(result.mode).toBe('none');
+    // afterEach restores DISABLE_OMC.
+  });
+});

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -72,7 +72,7 @@ export interface PersistentModeResult {
   /** Message to inject into context */
   message: string;
   /** Which mode triggered the block */
-  mode: 'ralph' | 'ultrawork' | 'todo-continuation' | 'autopilot' | 'autoresearch' | 'team' | 'ralplan' | 'none';
+  mode: 'ralph' | 'ultrawork' | 'todo-continuation' | 'autopilot' | 'autoresearch' | 'team' | 'ralplan' | 'deep-interview' | 'none';
   /** Additional metadata */
   metadata?: {
     todoCount?: number;
@@ -1268,6 +1268,37 @@ interface RalplanState {
   status?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Deep Interview enforcement (standalone Socratic loop)
+//
+// Deep Interview is a per-question loop: the skill calls AskUserQuestion,
+// receives the answer, then is supposed to keep working in the SAME turn
+// (score → state_write → ask the next question) until ambiguity drops below
+// the threshold. Without a stop-hook, Claude defaults to yielding the turn
+// after AskUserQuestion returns, forcing the user to re-prompt every round.
+// This block re-enforces the "do not yield mid-loop" rule from SKILL.md.
+// ---------------------------------------------------------------------------
+
+const DEEP_INTERVIEW_STOP_BLOCKER_MAX = 30;
+const DEEP_INTERVIEW_STOP_BLOCKER_TTL_MS = 45 * 60 * 1000; // 45 min
+
+interface DeepInterviewState {
+  active: boolean;
+  session_id?: string;
+  current_phase?: string;
+  awaiting_confirmation?: boolean;
+  user_exit_requested?: boolean;
+  last_checked_at?: string;
+  updated_at?: string;
+  started_at?: string;
+  state?: {
+    current_ambiguity?: number;
+    threshold?: number;
+    rounds?: unknown[];
+    user_exit_requested?: boolean;
+  };
+}
+
 interface AutoresearchStopState {
   active: boolean;
   session_id?: string;
@@ -1535,6 +1566,118 @@ When done, run \`/oh-my-claudecode:cancel\` to cleanly exit.
 
 `,
     mode: 'ralplan',
+  };
+}
+
+/**
+ * Check Deep Interview state and determine if it should reinforce.
+ *
+ * Blocks the stop event when an interview is mid-loop so the agent continues
+ * scoring (2c), reporting (2d), state_write (2e), and asking the next
+ * question (2a/2b) in the same turn instead of yielding after AskUserQuestion.
+ * Allows the stop when ambiguity has dropped to the threshold, the user
+ * requested early exit, or the circuit breaker fires.
+ */
+async function checkDeepInterview(
+  sessionId?: string,
+  directory?: string,
+  cancelInProgress?: boolean
+): Promise<PersistentModeResult | null> {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readModeState<DeepInterviewState>('deep-interview', workingDir, sessionId);
+  const stateRecord = state as any;
+  const hasTimestampFields = Boolean(
+    stateRecord &&
+    ['last_checked_at', 'updated_at', 'started_at'].some((key) =>
+      typeof stateRecord[key] === 'string' && String(stateRecord[key]).length > 0,
+    ),
+  );
+
+  if (!state || !state.active || (hasTimestampFields && isStaleState(state))) {
+    return null;
+  }
+
+  // Session isolation
+  if (sessionId && state.session_id && state.session_id !== sessionId) {
+    return null;
+  }
+
+  if (isAwaitingConfirmation(state)) {
+    return null;
+  }
+
+  // Honor user-requested early exit (top-level or nested under state).
+  if (state.user_exit_requested === true || state.state?.user_exit_requested === true) {
+    writeStopBreaker(workingDir, 'deep-interview', 0, sessionId);
+    return { shouldBlock: false, message: '', mode: 'deep-interview' };
+  }
+
+  // Terminal: ambiguity dropped to or below threshold — interview is complete,
+  // skill is now writing the spec / handing off. Allow the stop so the
+  // pipeline (deep-interview → omc-plan → autopilot) can proceed.
+  const ambiguity = state.state?.current_ambiguity;
+  const threshold = state.state?.threshold;
+  if (
+    typeof ambiguity === 'number' &&
+    typeof threshold === 'number' &&
+    ambiguity <= threshold
+  ) {
+    writeStopBreaker(workingDir, 'deep-interview', 0, sessionId);
+    return { shouldBlock: false, message: '', mode: 'deep-interview' };
+  }
+
+  // Cancel-in-progress bypass
+  if (cancelInProgress) {
+    return { shouldBlock: false, message: '', mode: 'deep-interview' };
+  }
+
+  // Circuit breaker: never reinforce more than DEEP_INTERVIEW_STOP_BLOCKER_MAX
+  // times for the same stuck loop. After that, allow stop and deactivate so a
+  // future invocation can start cleanly.
+  const breakerCount =
+    readStopBreaker(workingDir, 'deep-interview', sessionId, DEEP_INTERVIEW_STOP_BLOCKER_TTL_MS) + 1;
+  if (breakerCount > DEEP_INTERVIEW_STOP_BLOCKER_MAX) {
+    writeStopBreaker(workingDir, 'deep-interview', 0, sessionId);
+
+    (state as unknown as Record<string, unknown>).active = false;
+    (state as unknown as Record<string, unknown>).deactivated_reason = 'stop_breaker_exhausted';
+    (state as unknown as Record<string, unknown>).completed_at = new Date().toISOString();
+    writeModeState('deep-interview', state as unknown as Record<string, unknown>, workingDir, sessionId);
+
+    return {
+      shouldBlock: false,
+      message: `[DEEP-INTERVIEW CIRCUIT BREAKER] Stop enforcement exceeded ${DEEP_INTERVIEW_STOP_BLOCKER_MAX} reinforcements. Allowing stop and deactivating stale interview state to prevent infinite restart loops.`,
+      mode: 'deep-interview',
+    };
+  }
+  writeStopBreaker(workingDir, 'deep-interview', breakerCount, sessionId);
+
+  const roundCount = Array.isArray(state.state?.rounds) ? state.state!.rounds!.length : 0;
+  const ambiguityPctText =
+    typeof ambiguity === 'number' ? `${Math.round(ambiguity * 100)}%` : 'unknown';
+  const thresholdPctText =
+    typeof threshold === 'number' ? `${Math.round(threshold * 100)}%` : 'unknown';
+
+  return {
+    shouldBlock: true,
+    message: `<deep-interview-continuation>
+
+[DEEP-INTERVIEW LOOP - Round ${roundCount} | Ambiguity ${ambiguityPctText} (target ≤ ${thresholdPctText}) | Reinforcement ${breakerCount}/${DEEP_INTERVIEW_STOP_BLOCKER_MAX}]
+
+The Socratic interview loop is active. The user just answered AskUserQuestion — do NOT yield the turn. In this same turn:
+  1. Score ambiguity across all clarity dimensions (Step 2c)
+  2. Show the user the round summary + new ambiguity score (Step 2d)
+  3. Persist state via \`state_write\` (Step 2e)
+  4. Ask the next question targeting the weakest dimension (Steps 2a/2b)
+
+Yield only when ambiguity drops to or below the threshold, the user requests early exit, or the hard cap fires. To exit early at this score, the user must say "stop" / "exit" / "I'm done" — otherwise continue.
+
+</deep-interview-continuation>
+
+---
+
+`,
+    mode: 'deep-interview',
   };
 }
 
@@ -1919,6 +2062,17 @@ export async function checkPersistentModes(
     const teamResult = await checkTeamPipeline(sessionId, workingDir, cancelInProgress);
     if (teamResult) {
       return teamResult;
+    }
+  }
+
+  // Priority 1.9: Deep Interview (standalone Socratic loop)
+  // The skill calls AskUserQuestion every round and is supposed to keep going
+  // through 2c/2d/2e/next-question in the same turn. Without this hook, Claude
+  // yields after AskUserQuestion and the user has to re-prompt every round.
+  if (!tombstonedWorkflowModes.has('deep-interview')) {
+    const deepInterviewResult = await checkDeepInterview(sessionId, workingDir, cancelInProgress);
+    if (deepInterviewResult) {
+      return deepInterviewResult;
     }
   }
 


### PR DESCRIPTION
## Summary

The `deep-interview` skill is built around a per-question loop:
`AskUserQuestion` → score (2c) → state_write (2e) → next question (2a/2b),
repeat until ambiguity ≤ threshold. SKILL.md tells Claude not to yield
mid-loop, but in practice Claude defaults to treating the
`AskUserQuestion` answer as a turn boundary, so the loop stalls and the
user has to re-prompt every round.

Every other persistent OMC mode (ralph, autopilot, ultrawork, ultraqa,
ralplan, team-pipeline, autoresearch) has a stop-hook that re-enforces
"don't yield." Deep-interview was the one persistent mode without one —
this PR adds it.

- Adds `<Execution_Policy>` "Do NOT yield" bullet + Step 2b "Do not stop
  here" reminder to `skills/deep-interview/SKILL.md` (the instruction
  side)
- Adds `checkDeepInterview` to `src/hooks/persistent-mode/index.ts`,
  mirroring `checkRalplan`'s shape (the enforcement side):
  - state-file driven (reads `deep-interview-state.json` already
    initialized by SKILL.md Phase 1)
  - circuit breaker (30 reinforcements / 45 min TTL) auto-deactivates
    stuck loops
  - terminal pass-through when ambiguity ≤ threshold, on
    `user_exit_requested`, on `awaiting_confirmation`, on
    `cancelInProgress`, on breaker exhaustion
  - reinforcement message names round number + ambiguity % + threshold
    + the 4 loop steps (concrete continuation prompt, not vague
    "keep going")
- Adds `'deep-interview'` to `PersistentModeResult.mode` union
- Wires the new check as Priority 1.9 (after team-pipeline, before
  ultrawork) in `checkPersistentModes`

## Test plan

- [x] New file `src/hooks/persistent-mode/__tests__/deep-interview.test.ts` — 11 tests
  - empty state → pass-through
  - `active=false` → pass-through
  - active + ambiguity above threshold → blocks with shaped reminder
  - terminal ambiguity (`<= threshold`) → pass-through
  - top-level `user_exit_requested` → pass-through
  - nested `state.user_exit_requested` → pass-through
  - `awaiting_confirmation` → pass-through
  - session isolation (other-session state ignored)
  - circuit-breaker exhaustion (30 calls) → pass-through + state deactivated
  - `DISABLE_OMC=1` kill switch → pass-through
- [x] Full `src/hooks/persistent-mode/` regression: 296/296 tests pass (19 files)
- [x] tsc clean (no errors in the patched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)