### PR TITLE
feat(paths): document the cross-plugin shared-content contract at .omc/

### DIFF
--- a/src/lib/__tests__/worktree-paths.test.ts
+++ b/src/lib/__tests__/worktree-paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, rmSync, existsSync, mkdtempSync } from 'fs';
+import { mkdirSync, rmSync, existsSync, mkdtempSync, writeFileSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
 import { join, basename } from 'path';
 import {
@@ -25,6 +25,9 @@ import {
   getWorktreeRoot,
   getProjectIdentifier,
   clearDualDirWarnings,
+  getSharedOmcRoot,
+  migrateOmcpContentToOmc,
+  clearOmcpContentWarnings,
 } from '../worktree-paths.js';
 
 const TEST_DIR = '/tmp/worktree-paths-test';
@@ -676,6 +679,145 @@ describe('worktree-paths', () => {
       const projectId = getProjectIdentifier(TEST_DIR);
       expect(result).toBe(join(stateDir, projectId, 'state'));
       expect(existsSync(result)).toBe(true);
+    });
+  });
+
+  describe('getSharedOmcRoot', () => {
+    beforeEach(() => {
+      clearOmcpContentWarnings();
+    });
+
+    it('returns the same path as getOmcRoot in the local case', () => {
+      expect(getSharedOmcRoot(TEST_DIR)).toBe(getOmcRoot(TEST_DIR));
+      expect(getSharedOmcRoot(TEST_DIR)).toBe(join(TEST_DIR, '.omc'));
+    });
+
+    it('returns the same path as getOmcRoot when OMC_STATE_DIR is set', () => {
+      const stateDir = mkdtempSync('/tmp/shared-root-state-');
+      try {
+        process.env.OMC_STATE_DIR = stateDir;
+        expect(getSharedOmcRoot(TEST_DIR)).toBe(getOmcRoot(TEST_DIR));
+      } finally {
+        delete process.env.OMC_STATE_DIR;
+        rmSync(stateDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('migrateOmcpContentToOmc (reverse migration)', () => {
+    beforeEach(() => {
+      clearOmcpContentWarnings();
+    });
+
+    it('moves notepad.md and project-memory.json from .omcp/ into .omc/', () => {
+      const omcp = join(TEST_DIR, '.omcp');
+      mkdirSync(omcp, { recursive: true });
+      writeFileSync(join(omcp, 'notepad.md'), 'note', 'utf-8');
+      writeFileSync(join(omcp, 'project-memory.json'), '{}', 'utf-8');
+
+      const moved = migrateOmcpContentToOmc(TEST_DIR);
+
+      expect(moved).toBe(true);
+      expect(existsSync(join(TEST_DIR, '.omc', 'notepad.md'))).toBe(true);
+      expect(existsSync(join(TEST_DIR, '.omc', 'project-memory.json'))).toBe(true);
+      expect(existsSync(join(omcp, 'notepad.md'))).toBe(false);
+      expect(existsSync(join(omcp, 'project-memory.json'))).toBe(false);
+      expect(readFileSync(join(TEST_DIR, '.omc', 'notepad.md'), 'utf-8')).toBe('note');
+    });
+
+    it('merges plans/, research/, notepads/ into .omc/', () => {
+      const omcp = join(TEST_DIR, '.omcp');
+      mkdirSync(join(omcp, 'plans'), { recursive: true });
+      mkdirSync(join(omcp, 'research', 'spike-a'), { recursive: true });
+      mkdirSync(join(omcp, 'notepads', 'plan-x'), { recursive: true });
+      writeFileSync(join(omcp, 'plans', 'feature.md'), 'plan', 'utf-8');
+      writeFileSync(join(omcp, 'research', 'spike-a', 'notes.md'), 'r', 'utf-8');
+      writeFileSync(join(omcp, 'notepads', 'plan-x', 'wisdom.md'), 'w', 'utf-8');
+
+      const moved = migrateOmcpContentToOmc(TEST_DIR);
+
+      expect(moved).toBe(true);
+      expect(existsSync(join(TEST_DIR, '.omc', 'plans', 'feature.md'))).toBe(true);
+      expect(existsSync(join(TEST_DIR, '.omc', 'research', 'spike-a', 'notes.md'))).toBe(true);
+      expect(existsSync(join(TEST_DIR, '.omc', 'notepads', 'plan-x', 'wisdom.md'))).toBe(true);
+    });
+
+    it('keeps the .omc/ copy and warns once when both exist', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        const omcp = join(TEST_DIR, '.omcp');
+        const omc = join(TEST_DIR, '.omc');
+        mkdirSync(omcp, { recursive: true });
+        mkdirSync(omc, { recursive: true });
+        writeFileSync(join(omcp, 'notepad.md'), 'old', 'utf-8');
+        writeFileSync(join(omc, 'notepad.md'), 'new', 'utf-8');
+
+        migrateOmcpContentToOmc(TEST_DIR);
+        migrateOmcpContentToOmc(TEST_DIR);
+
+        expect(readFileSync(join(omc, 'notepad.md'), 'utf-8')).toBe('new');
+        expect(existsSync(join(omcp, 'notepad.md'))).toBe(true);
+        const conflictWarns = warnSpy.mock.calls.filter(c =>
+          typeof c[0] === 'string' && c[0].includes('omc-share') && c[0].includes('Both')
+        );
+        expect(conflictWarns.length).toBe(1);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('is idempotent (no-op on second call after migration)', () => {
+      const omcp = join(TEST_DIR, '.omcp');
+      mkdirSync(omcp, { recursive: true });
+      writeFileSync(join(omcp, 'notepad.md'), 'note', 'utf-8');
+
+      expect(migrateOmcpContentToOmc(TEST_DIR)).toBe(true);
+      expect(migrateOmcpContentToOmc(TEST_DIR)).toBe(false);
+    });
+
+    it('is a no-op when .omcp/ does not exist', () => {
+      expect(migrateOmcpContentToOmc(TEST_DIR)).toBe(false);
+      expect(existsSync(join(TEST_DIR, '.omc'))).toBe(false);
+    });
+
+    it('is skipped when OMC_STATE_DIR is set', () => {
+      const stateDir = mkdtempSync('/tmp/omcp-content-mig-');
+      try {
+        process.env.OMC_STATE_DIR = stateDir;
+        const omcp = join(TEST_DIR, '.omcp');
+        mkdirSync(omcp, { recursive: true });
+        writeFileSync(join(omcp, 'notepad.md'), 'note', 'utf-8');
+
+        expect(migrateOmcpContentToOmc(TEST_DIR)).toBe(false);
+        expect(existsSync(join(omcp, 'notepad.md'))).toBe(true);
+      } finally {
+        delete process.env.OMC_STATE_DIR;
+        rmSync(stateDir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not move plugin-private state under .omcp/state/', () => {
+      const omcp = join(TEST_DIR, '.omcp');
+      mkdirSync(join(omcp, 'state', 'sessions', 'pid-123'), { recursive: true });
+      writeFileSync(join(omcp, 'state', 'ralph-state.json'), '{}', 'utf-8');
+
+      migrateOmcpContentToOmc(TEST_DIR);
+
+      // State stays in .omcp/, never moves to .omc/
+      expect(existsSync(join(omcp, 'state', 'ralph-state.json'))).toBe(true);
+      expect(existsSync(join(TEST_DIR, '.omc', 'state'))).toBe(false);
+    });
+
+    it('runs automatically on getOmcRoot in the local case', () => {
+      const omcp = join(TEST_DIR, '.omcp');
+      mkdirSync(omcp, { recursive: true });
+      writeFileSync(join(omcp, 'notepad.md'), 'auto', 'utf-8');
+
+      // Calling getOmcRoot triggers the migration
+      getOmcRoot(TEST_DIR);
+
+      expect(existsSync(join(TEST_DIR, '.omc', 'notepad.md'))).toBe(true);
+      expect(readFileSync(join(TEST_DIR, '.omc', 'notepad.md'), 'utf-8')).toBe('auto');
     });
   });
 });

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -11,14 +11,36 @@
 
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, realpathSync, readdirSync } from 'fs';
+import { existsSync, mkdirSync, realpathSync, readdirSync, renameSync } from 'fs';
 import { homedir } from 'os';
 import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
 
-/** Standard .omc subdirectories */
+/**
+ * Standard .omc subdirectories.
+ *
+ * Two roots are exposed:
+ * - ROOT (`.omc`): everything oh-my-claudecode owns. State, sessions,
+ *   plans, research, notepad — historically all under `.omc/`.
+ * - SHARED_ROOT (`.omc`): the same directory, named explicitly to
+ *   document the cross-plugin contract with oh-my-copilot. Notepad,
+ *   project memory, plans, research, and plan-scoped notepads under
+ *   this root are intentionally readable by either plugin so a plan
+ *   written by one CLI is visible to the other in the same worktree.
+ *
+ * In oh-my-copilot ROOT is `.omcp/` (plugin-private state) while
+ * SHARED_ROOT remains `.omc/`. Keeping the constants symmetric here
+ * makes the convention explicit and lets shared-content callers use
+ * SHARED_ROOT to signal "this resource is meant to cross plugin
+ * boundaries" without changing behavior in this repo.
+ *
+ * See migrateOmcpContentToOmc() for one-time relocation of shared
+ * content authored by an older oh-my-copilot version that wrote to
+ * `.omcp/`.
+ */
 export const OmcPaths = {
   ROOT: '.omc',
+  SHARED_ROOT: '.omc',
   STATE: '.omc/state',
   SESSIONS: '.omc/state/sessions',
   PLANS: '.omc/plans',
@@ -211,7 +233,151 @@ export function getOmcRoot(worktreeRoot?: string): string {
     return centralizedPath;
   }
   const root = worktreeRoot || getWorktreeRoot() || process.cwd();
+  // Auto-relocate shared content that an older oh-my-copilot left under
+  // `.omcp/` so a returning user does not lose their notepad/plans/etc.
+  // when they switch CLIs. Idempotent and skipped under OMC_STATE_DIR.
+  migrateOmcpContentToOmc(root);
   return join(root, OmcPaths.ROOT);
+}
+
+/**
+ * Get the cross-plugin shared content root.
+ *
+ * Semantically equivalent to getOmcRoot() in oh-my-claudecode (both
+ * resolve to `.omc/`), but exposed as a distinct symbol to document
+ * the cross-plugin contract with oh-my-copilot. Callers that author
+ * resources meant to be visible to either CLI — notepad, project
+ * memory, plans, research, plan-scoped notepads — should use this
+ * function rather than getOmcRoot() so the intent is explicit and the
+ * symmetric oh-my-copilot helper can swap in `.omc/` instead of
+ * `.omcp/` without further refactoring.
+ *
+ * @param worktreeRoot - Optional worktree root
+ * @returns Absolute path to the shared content root (same as getOmcRoot)
+ */
+export function getSharedOmcRoot(worktreeRoot?: string): string {
+  return getOmcRoot(worktreeRoot);
+}
+
+/** Track which omcp→omc reverse-migration warnings have been logged */
+const omcpContentWarnings = new Set<string>();
+
+/**
+ * Clear the omcp→omc reverse-migration warning cache (testing only).
+ * @internal
+ */
+export function clearOmcpContentWarnings(): void {
+  omcpContentWarnings.clear();
+}
+
+/**
+ * One-time reverse relocation of shared content from `.omcp/` to `.omc/`.
+ *
+ * In oh-my-copilot, shared content (notepad, project memory, plans,
+ * research, plan-scoped notepads) used to live under `.omcp/` and is
+ * now relocated to `.omc/` by the symmetric forward migration. This
+ * function handles the case where a returning user's prior writes
+ * happened entirely in oh-my-copilot before the relocation shipped:
+ * Claude Code spots `.omcp/notepad.md` and moves it to `.omc/notepad.md`
+ * so the content is not orphaned when the user switches CLIs.
+ *
+ * Behavior:
+ * - For notepad.md and project-memory.json: rename if the `.omc/` target
+ *   does not exist; if both exist, keep `.omc/` and warn once.
+ * - For plans/, research/, notepads/: merge entries individually with
+ *   the same conflict semantics, leaving runtime-private state under
+ *   `.omcp/state/` untouched.
+ * - Idempotent. Repeated calls after migration are no-ops.
+ * - Skipped when OMC_STATE_DIR is set (centralized layout has no
+ *   `.omcp/` segment in this repo).
+ *
+ * @param worktreeRoot - The worktree root directory
+ * @returns true if any item was moved, false otherwise
+ */
+export function migrateOmcpContentToOmc(worktreeRoot: string): boolean {
+  if (process.env.OMC_STATE_DIR) return false;
+
+  const omcpRoot = join(worktreeRoot, '.omcp');
+  const omcRoot = join(worktreeRoot, OmcPaths.SHARED_ROOT);
+  if (!existsSync(omcpRoot)) return false;
+
+  let moved = false;
+
+  const fileMoves: Array<[string, string]> = [
+    [join(omcpRoot, 'notepad.md'), join(omcRoot, 'notepad.md')],
+    [join(omcpRoot, 'project-memory.json'), join(omcRoot, 'project-memory.json')],
+  ];
+
+  for (const [src, dst] of fileMoves) {
+    if (!existsSync(src)) continue;
+    if (existsSync(dst)) {
+      const warningKey = `omcp-content:${src}`;
+      if (!omcpContentWarnings.has(warningKey)) {
+        omcpContentWarnings.add(warningKey);
+        console.warn(
+          `[omc-share] Both ${src} and ${dst} exist. Using ${dst}; remove the ` +
+          `legacy file manually after verifying no data loss.`
+        );
+      }
+      continue;
+    }
+    try {
+      mkdirSync(dirname(dst), { recursive: true });
+      renameSync(src, dst);
+      moved = true;
+    } catch (err) {
+      console.warn(
+        `[omc-share] Failed to relocate ${src} → ${dst}: ` +
+        `${err instanceof Error ? err.message : err}`
+      );
+    }
+  }
+
+  for (const sub of ['plans', 'research', 'notepads']) {
+    const srcDir = join(omcpRoot, sub);
+    if (!existsSync(srcDir)) continue;
+    const dstDir = join(omcRoot, sub);
+    try {
+      mkdirSync(dstDir, { recursive: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
+        console.warn(`[omc-share] Could not create ${dstDir}: ${err}`);
+        continue;
+      }
+    }
+    let entries: string[];
+    try {
+      entries = readdirSync(srcDir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const s = join(srcDir, entry);
+      const d = join(dstDir, entry);
+      if (existsSync(d)) {
+        const warningKey = `omcp-content:${s}`;
+        if (!omcpContentWarnings.has(warningKey)) {
+          omcpContentWarnings.add(warningKey);
+          console.warn(
+            `[omc-share] Both ${s} and ${d} exist. Using ${d}; remove the ` +
+            `legacy entry manually after verifying no data loss.`
+          );
+        }
+        continue;
+      }
+      try {
+        renameSync(s, d);
+        moved = true;
+      } catch (err) {
+        console.warn(
+          `[omc-share] Failed to relocate ${s} → ${d}: ` +
+          `${err instanceof Error ? err.message : err}`
+        );
+      }
+    }
+  }
+
+  return moved;
 }
 
 /**


### PR DESCRIPTION
## Summary

Documents the cross-plugin shared-content convention with [oh-my-copilot](https://github.com/RobinNorberg/oh-my-copilot/pull/89) (downstream Copilot CLI fork). In this repo the behavior change is intentionally minimal — `.omc/` already holds everything this plugin owns. The PR adds:

- `OmcPaths.SHARED_ROOT` alongside `ROOT` (both `.omc`) to make the contract explicit
- `getSharedOmcRoot()` — semantically equivalent to `getOmcRoot()` here, but exposed as a distinct symbol so shared-content callers signal intent and so the symmetric oh-my-copilot helper has a counterpart with the same name
- `migrateOmcpContentToOmc()` — one-time reverse migration that relocates `notepad.md`, `project-memory.json`, and the contents of `plans/`, `research/`, `notepads/` from `.omcp/` to `.omc/` when the targets are absent. Wired into `getOmcRoot()` so a returning oh-my-copilot user who never updated their other CLI doesn't lose content when they open Claude Code

## Why

oh-my-copilot historically wrote *all* state and content under `.omcp/`. The downstream PR splits private state (`.omcp/state/`, `.omcp/sessions/`, autoresearch, logs) from cross-plugin content (`.omc/notepad.md`, `.omc/project-memory.json`, `.omc/plans/`, etc.) so a plan written in Claude Code is visible in Copilot CLI and vice-versa within the same worktree. With both PRs landed:

| Resource | oh-my-claudecode | oh-my-copilot |
|---|---|---|
| Shared content (notepad, project memory, plans, research, plan-notepads) | `<worktree>/.omc/` | `<worktree>/.omc/` |
| Plugin-private state, sessions, logs, autoresearch | `<worktree>/.omc/state/` etc. | `<worktree>/.omcp/state/` etc. |

State sharing is intentionally **out of scope** — schemas are version-coupled to each plugin's runtime and concurrent writers would corrupt each other.

## Migration safety

The reverse migration is conservative:

- Skipped under `OMC_STATE_DIR` (centralized layout has no `.omcp/` segment in this repo)
- Per-file: `rename` only when target doesn't exist; otherwise keep `.omc/` and warn once
- Per-directory (`plans/`, `research/`, `notepads/`): merge entries individually with the same conflict semantics
- Plugin-private state under `.omcp/state/` is **never** touched
- Idempotent — repeated calls after migration are no-ops

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/lib/__tests__/worktree-paths.test.ts` — 56 passed, 12 failed
  - The 12 fails are the same ones present on `dev` baseline (existing tests use Linux-style `/tmp/...` literals that resolve as `C:\tmp\...` on Windows). My new tests follow the same pattern; on Linux CI all 22 should pass
  - **+10 new passing tests** for `getSharedOmcRoot` (local case, OMC_STATE_DIR equivalence) and `migrateOmcpContentToOmc` (file move, dir merge, conflict-keeps-omc + single-warning, idempotency, no-op when `.omcp/` absent, skip when centralized, state-stays-private, auto-trigger via `getOmcRoot`)
- [x] Full Windows run reproduces existing baseline failure count outside the targeted file; my change is too localized to ripple
- [ ] **Reviewer: please run CI on Linux for the full-suite signal.** I can only validate the targeted file under Windows due to existing Linux-only test fixtures

## New tests added

| Block | Coverage |
|---|---|
| `getSharedOmcRoot` | local equivalence with `getOmcRoot`, OMC_STATE_DIR equivalence |
| `migrateOmcpContentToOmc` (reverse migration) | file move, dir merge, conflict-keeps-omc + single-warning, idempotency, no-op when `.omcp/` absent, skip when centralized, state stays under `.omcp/state/`, auto-trigger via `getOmcRoot` |

## Companion PR

- Downstream: https://github.com/RobinNorberg/oh-my-copilot/pull/89 (forward migration `.omcp/` → `.omc/`, identical migration semantics)