### PR TITLE
fix(hud): context percent fallback for non-Anthropic providers

### DIFF
--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -241,13 +241,15 @@ function parseResetDate(value: number | string | undefined): Date | null {
 }
 
 /**
- * Get total tokens from stdin context_window.current_usage
+ * Get total tokens from stdin context_window.current_usage.
+ * Includes cache_read_input_tokens for accurate totals with cached contexts.
  */
 function getTotalTokens(stdin: StatuslineStdin): number {
   const usage = getCurrentUsage(stdin);
   return (
     (usage?.input_tokens ?? 0) +
-    (usage?.cache_creation_input_tokens ?? 0)
+    (usage?.cache_creation_input_tokens ?? 0) +
+    (usage?.cache_read_input_tokens ?? 0)
   );
 }
 
@@ -316,15 +318,33 @@ export function stabilizeContextPercent(
 
 /**
  * Get context window usage percentage.
- * Prefers native percentage from Claude Code statusline stdin, falls back to manual calculation.
+ * Three-tier fallback:
+ *   1. Native `used_percentage` from Claude Code statusline stdin
+ *   2. Manual calculation from `current_usage` tokens / `context_window_size`
+ *   3. `total_input_tokens` / `context_window_size` for non-Anthropic providers
+ *      (e.g. GLM via proxy) that report zero in both `used_percentage` and
+ *      `current_usage`. This is a session-cumulative estimate — imperfect but
+ *      far better than showing 0%.
  */
 export function getContextPercent(stdin: StatuslineStdin): number {
   const nativePercent = getRoundedNativeContextPercent(stdin);
-  if (nativePercent !== null) {
+  if (nativePercent !== null && nativePercent > 0) {
     return nativePercent;
   }
 
-  return getManualContextPercent(stdin) ?? 0;
+  const manualPercent = getManualContextPercent(stdin);
+  if (manualPercent !== null && manualPercent > 0) {
+    return manualPercent;
+  }
+
+  // Fallback for non-Anthropic providers that don't populate usage fields.
+  const totalInput = stdin.context_window?.total_input_tokens;
+  const windowSize = stdin.context_window?.context_window_size;
+  if (totalInput && totalInput > 0 && windowSize && windowSize > 0) {
+    return Math.min(100, Math.round((totalInput / windowSize) * 100));
+  }
+
+  return 0;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #2873

The HUD context bar shows `ctx:0%` for non-Anthropic model providers (e.g., GLM via ZhipuAI's Anthropic-compatible endpoint) because these proxies report `used_percentage: 0` and `current_usage` as all zeros.

## Changes

**`src/hud/stdin.ts`** — two fixes:

1. **`getTotalTokens()`** — include `cache_read_input_tokens` in the total for accurate context size calculation with cached prompts

2. **`getContextPercent()`** — three-tier fallback chain:
   - Native `used_percentage` (existing, now guarded with `> 0`)
   - Manual `current_usage` calculation (existing, now guarded with `> 0`)
   - **NEW**: `total_input_tokens / context_window_size` as session-cumulative estimate

## Test plan

- [x] Verified fix locally with GLM-5.1 stdin cache data showing `used_percentage: 0`
- [x] HUD now shows ~15-20% instead of 0%
- [x] Simulated all-zero usage data — `total_input_tokens` fallback works correctly
- [x] When proxy reports real data (intermittent), native percentage is used correctly

## Trade-offs

`total_input_tokens` is session-cumulative, so it tends to overestimate current context usage. This is a conservative direction — better to warn early than silently show 0% while approaching the model's context limit.