### PR TITLE
Fix Edit success classification in post-tool verifier

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -710,6 +710,7 @@ export function isClaudeCodeWriteSuccess(output) {
 
   const cleaned = stripClaudeTempCwdErrors(output);
   const successPatterns = [
+    /(^|\n)The file has been updated successfully\.?(\n|$)/i,
     /(^|\n)The file .+ has been updated successfully\.?(\n|$)/i,
     /(^|\n)File (?:created|written|updated) successfully(?:\s+at:\s*.+)?\.?(\n|$)/i,
     /(^|\n).*file state is current in your context\b.*(\n|$)/i,

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -530,6 +530,35 @@ describe('post-tool hook regression coverage (issue #2615)', () => {
     expect(out.hookSpecificOutput?.additionalContext).not.toContain('Edit operation failed');
   });
 
+  it('prefers exact Claude Code edit success output over embedded diagnostics', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Edit',
+      tool_response: [
+        'The file has been updated successfully.',
+        '',
+        'diagnostic fixture: Error: failed to write',
+        'No such file or directory',
+      ].join('\n'),
+      session_id: 'issue-2876-exact-edit-success',
+      cwd: process.cwd(),
+    });
+
+    expect(isClaudeCodeWriteSuccess('The file has been updated successfully.')).toBe(true);
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Code modified.');
+    expect(out.hookSpecificOutput?.additionalContext).not.toContain('Edit operation failed');
+  });
+
+  it('keeps exact edit failure text classified as an Edit failure', () => {
+    const out = runPostToolVerifier({
+      tool_name: 'Edit',
+      tool_response: 'Error: failed to edit file',
+      session_id: 'issue-2876-edit-failure',
+      cwd: process.cwd(),
+    });
+
+    expect(out.hookSpecificOutput?.additionalContext).toContain('Edit operation failed');
+  });
+
   it('prefers canonical write success output over serialized tool output with diagnostics', () => {
     const out = runPostToolVerifier({
       tool_name: 'Write',


### PR DESCRIPTION
## Summary
- Recognize Claude Code's exact pathless Edit success output: `The file has been updated successfully.`
- Keep real Edit failure strings classified as failures.
- Add regression coverage for the exact success string and failure behavior.

## Verification
- `npm test -- src/__tests__/post-tool-verifier.test.mjs` — 95 passed
- `npm run lint` — passed with existing warnings only (0 errors)
- `npm run build` — passed
- `git diff --check` — passed

Fixes #2876
