### PR TITLE
feat(pre-tool): warn on fallback slop language

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -157,6 +157,64 @@ function readAgentDefinitionModel(subagentType) {
   }
 }
 
+
+const SLOP_RISK_TOOL_NAMES = new Set([
+  'Task',
+  'TaskCreate',
+  'TaskUpdate',
+  'Agent',
+  'Bash',
+  'Edit',
+  'MultiEdit',
+  'Write',
+  'NotebookEdit',
+]);
+const SLOP_FALLBACK_LANGUAGE_PATTERN = /\b(?:fallback|fall\s+back|workaround|work\s+around)\b/i;
+
+function collectStringValues(value, output = [], depth = 0) {
+  if (depth > 5 || output.length > 100) return output;
+  if (typeof value === 'string') {
+    output.push(value);
+    return output;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStringValues(item, output, depth + 1);
+    return output;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      // Skip hook/runtime metadata so warnings are driven by user-authored tool intent.
+      if (/^(cwd|directory|session_?id|transcript_?path|hook_event_name)$/i.test(key)) continue;
+      collectStringValues(child, output, depth + 1);
+    }
+  }
+  return output;
+}
+
+function generateSlopWarning(data, toolName) {
+  if (!SLOP_RISK_TOOL_NAMES.has(toolName)) return '';
+  const toolInput = data.toolInput || data.tool_input || {};
+  const promptLikeFields = {
+    prompt: data.prompt,
+    userPrompt: data.userPrompt,
+    user_prompt: data.user_prompt,
+    message: data.message,
+  };
+  const inspectedText = collectStringValues(toolInput)
+    .concat(collectStringValues(promptLikeFields))
+    .join('\n');
+  if (!SLOP_FALLBACK_LANGUAGE_PATTERN.test(inspectedText)) return '';
+
+  return '[SLOP WARNING] Detected fallback/workaround language in this tool input. ' +
+    'Do not make potential slop: avoid ad-hoc fallback layers, workaround shims, or environment-specific patches unless explicitly justified. ' +
+    'For architecture concerns, consult the architect for a concrete design first. ' +
+    'If this seems environment-specific, ask the user to confirm constraints before proceeding.';
+}
+
+function combineHookMessages(...messages) {
+  return messages.filter(Boolean).join('\n\n');
+}
+
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 const MODE_STATE_FILES = [
   'autopilot-state.json',
@@ -907,6 +965,7 @@ async function main() {
       }
     }
 
+    const slopWarning = generateSlopWarning(data, toolName);
     let message;
     if (toolName === 'Task' || toolName === 'TaskCreate' || toolName === 'TaskUpdate') {
       const toolInput = data.toolInput || data.tool_input || null;
@@ -914,6 +973,7 @@ async function main() {
     } else {
       message = generateMessage(toolName, todoStatus, modeActive);
     }
+    message = combineHookMessages(slopWarning, message);
 
     if (!message) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -421,6 +421,66 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(output).toEqual({ continue: true, suppressOutput: true });
   });
 
+  it('warns without blocking when Task prompt uses fallback or workaround language', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Implement a fallback',
+        prompt: 'Add a workaround if the normal architecture is hard.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-warning',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    const context = String(hookSpecificOutput.additionalContext);
+    expect(output.continue).toBe(true);
+    expect(hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(context).toContain('[SLOP WARNING]');
+    expect(context).toContain('Do not make potential slop');
+    expect(context).toContain('consult the architect');
+    expect(context).toContain('ask the user to confirm constraints');
+    expect(context).toContain('Spawning agent');
+    expect(hookSpecificOutput).not.toHaveProperty('permissionDecision');
+  });
+
+  it('keeps slop warning visible even when routine reminders are quieted', () => {
+    const output = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Bash',
+        toolInput: {
+          command: 'node scripts/add-fallback-workaround.mjs',
+        },
+        cwd: tempDir,
+        session_id: 'session-slop-warning-quiet',
+      },
+      { OMC_QUIET: '2' },
+    );
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    const context = String(hookSpecificOutput.additionalContext);
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[SLOP WARNING]');
+    expect(context).not.toContain('Use parallel execution');
+  });
+
+  it('does not warn for read-only search tools that mention fallback as the query', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Grep',
+      toolInput: {
+        pattern: 'fallback|workaround',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-search',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+    expect(String(hookSpecificOutput.additionalContext)).toContain('Combine searches in parallel');
+  });
+
   it('blocks agent-heavy Task preflight when transcript context budget is exhausted', () => {
     const transcriptPath = join(tempDir, 'transcript.jsonl');
     writeTranscriptWithContext(transcriptPath, 1000, 800); // 80%


### PR DESCRIPTION
## Summary
- Add a narrow advisory PreToolUse slop warning for fallback/workaround language in risky tool inputs and prompts.
- Compose the warning with existing hook reminders without adding a new block/deny path.
- Add regression coverage for Task prompts, quiet-mode Bash warnings, and read-only Grep false-positive avoidance.

## Constraint
Keep the PreToolUse guard advisory and narrow; do not block normal tool use or read-only fallback searches.

## Tested
- npm test -- --run src/__tests__/pre-tool-enforcer.test.ts
- npm run lint (0 errors, existing warnings)
- npm run build

## Confidence
High

Co-authored-by: OmX <omx@oh-my-codex.dev>