### PR TITLE
Fix autoresearch supervisor discarding the first passing candidate

### DIFF
--- a/src/autoresearch/__tests__/decide-outcome.test.ts
+++ b/src/autoresearch/__tests__/decide-outcome.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  AutoresearchCandidateArtifact,
+  AutoresearchEvaluationRecord,
+  AutoresearchRunManifest,
+} from '../runtime.js';
+import { decideAutoresearchOutcome } from '../runtime.js';
+
+type ManifestSlice = Pick<AutoresearchRunManifest, 'keep_policy' | 'last_kept_score'>;
+
+function makeCandidate(
+  overrides: Partial<AutoresearchCandidateArtifact> = {},
+): AutoresearchCandidateArtifact {
+  return {
+    status: 'candidate',
+    candidate_commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    base_commit: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    description: 'fixture candidate',
+    notes: [],
+    created_at: '2026-04-30T22:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeEvaluation(
+  overrides: Partial<AutoresearchEvaluationRecord> = {},
+): AutoresearchEvaluationRecord {
+  return {
+    command: 'node scripts/eval.js',
+    ran_at: '2026-04-30T22:01:00Z',
+    status: 'pass',
+    pass: true,
+    score: 0.42,
+    ...overrides,
+  };
+}
+
+describe('decideAutoresearchOutcome (score_improvement bootstrap)', () => {
+  it('keeps the first numeric-scored pass when last_kept_score is null', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: null };
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), makeEvaluation({ score: 0.398459 }));
+    expect(decision.decision).toBe('keep');
+    expect(decision.keep).toBe(true);
+    expect(decision.decisionReason).toMatch(/bootstrap/i);
+    expect(decision.evaluator?.score).toBe(0.398459);
+  });
+
+  it('still discards an ambiguous pass that has no numeric score', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: null };
+    const evaluation = makeEvaluation();
+    delete evaluation.score;
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), evaluation);
+    expect(decision.decision).toBe('ambiguous');
+    expect(decision.keep).toBe(false);
+    expect(decision.decisionReason).toMatch(/numeric score/i);
+  });
+
+  it('keeps a higher-scoring pass once a comparable baseline is set', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: 0.36 };
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), makeEvaluation({ score: 0.40 }));
+    expect(decision.decision).toBe('keep');
+    expect(decision.keep).toBe(true);
+    expect(decision.decisionReason).toMatch(/score improved/i);
+  });
+
+  it('discards a pass that does not improve the kept score', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: 0.50 };
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), makeEvaluation({ score: 0.40 }));
+    expect(decision.decision).toBe('discard');
+    expect(decision.keep).toBe(false);
+  });
+
+  it('discards an evaluator failure regardless of bootstrap state', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: null };
+    const decision = decideAutoresearchOutcome(
+      manifest,
+      makeCandidate(),
+      makeEvaluation({ status: 'fail', pass: false, score: 0.10 }),
+    );
+    expect(decision.decision).toBe('discard');
+    expect(decision.keep).toBe(false);
+  });
+
+  it('still accepts pass_only policy without touching the bootstrap branch', () => {
+    const manifest: ManifestSlice = { keep_policy: 'pass_only', last_kept_score: null };
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), makeEvaluation());
+    expect(decision.decision).toBe('keep');
+    expect(decision.keep).toBe(true);
+    expect(decision.decisionReason).toMatch(/pass_only/i);
+  });
+});

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -722,12 +722,26 @@ export function decideAutoresearchOutcome(
     };
   }
   if (!comparableScore(manifest.last_kept_score, evaluation.score)) {
+    // Bootstrap case: there is no prior comparable score to improve over (first
+    // pass in the run, or the first pass after a fail-only stretch left
+    // last_kept_score=null). The candidate's pass IS the new comparison anchor.
+    // Discarding it would lose the only validated signal the loop has produced
+    // and pin score_improvement to null forever.
+    if (typeof evaluation.score === 'number') {
+      return {
+        decision: 'keep',
+        decisionReason: '[bootstrap] first comparable score in score_improvement run',
+        keep: true,
+        evaluator: evaluation,
+        notes: ['candidate kept because no prior comparable score existed; this becomes the new baseline'],
+      };
+    }
     return {
       decision: 'ambiguous',
-      decisionReason: 'evaluator pass without comparable score',
+      decisionReason: 'evaluator pass without numeric score',
       keep: false,
       evaluator: evaluation,
-      notes: ['candidate discarded because score_improvement policy requires comparable numeric scores'],
+      notes: ['candidate discarded because score_improvement policy requires a numeric score'],
     };
   }
   if ((evaluation.score as number) > (manifest.last_kept_score as number)) {


### PR DESCRIPTION
## Summary

In `decideAutoresearchOutcome`, when `keep_policy === 'score_improvement'` and `manifest.last_kept_score === null` (always true for the first pass in a run, or any pass after a fail-only stretch), the supervisor returned `decision: 'ambiguous'` with `keep: false`. Downstream in `processAutoresearchCandidate` this triggered `resetToLastKeptCommit` — `git reset --hard` on the worktree — throwing away the only validated signal the loop had produced and pinning the score-comparison anchor to `null` forever, so the loop could never ratchet.

A pass with no prior comparable score IS the bootstrap. This PR keeps the candidate so it becomes the new comparison anchor.

The narrow ambiguous case (pass with **no numeric score**) is preserved — that case still has nothing to anchor on and remains a discard.

## What changes

`src/autoresearch/runtime.ts:724` — replace the unconditional `ambiguous → keep=false` branch with:
- `evaluation.score` is numeric → `decision: 'keep'`, `decisionReason: '[bootstrap] first comparable score in score_improvement run'`. The candidate becomes the new `last_kept_commit` / `last_kept_score`.
- `evaluation.score` is non-numeric → unchanged, `decision: 'ambiguous'`, `keep: false`.

The `[bootstrap]` prefix on `decision_reason` makes the first-kept event easy to spot in `results.tsv` and the ledger.

## Tests

New file: `src/autoresearch/__tests__/decide-outcome.test.ts` — 6 unit tests covering:

1. Bootstrap-keep: numeric pass with `last_kept_score=null` → `keep`.
2. Bootstrap-ambiguous: pass with no `score` field → still `ambiguous`.
3. Score-improved: pass scoring above prior baseline → `keep`.
4. Score-not-improved: pass scoring at/below prior baseline → `discard`.
5. Evaluator-fail: `pass=false` regardless of bootstrap state → `discard`.
6. `pass_only` policy short-circuits before reaching the bootstrap branch.

Full run:
```
src/autoresearch/__tests__/decide-outcome.test.ts (6 tests) passed
src/autoresearch/__tests__/runtime.test.ts (7 tests) passed
src/autoresearch/__tests__/runtime-parity-extra.test.ts (10 tests) passed
... 41 autoresearch tests total, all passing
tsc --noEmit clean
```

The pre-existing `runtime.test.ts` integration test (\"keeps improved candidates and resets discarded candidates back to the last kept commit\") still passes — it sets up `last_kept_score` via the baseline phase and so doesn't touch the bootstrap branch.

## Real-world evidence

This bug fires on a real autoresearch run, not a synthetic mission. Run `missions-geo-citations-citation-service-v6-20260430t212108z`, 2026-04-30:

| iter | pass  | score    | z vs noise band | what happened |
|------|-------|----------|-----------------|---------------|
| 0    | -     | 0.310959 | -               | baseline (worktree) |
| 1    | false | 0.360183 | -0.25           | discard (correct) |
| 2    | **true**  | **0.398459** | **+1.87**           | **Bug fired:** `ambiguous → keep=false`, worktree reset, validated signal lost |
| 3    | err   | -        | -               | (separate stale-`candidate.json` issue — see follow-up note below) |

Pre-launch baseline-sample: median=0.364756, stdev=0.018049, n=5. The standard deviation (0.018) was well above any noise floor, so iter-2's z=+1.87 is real signal — and the supervisor threw it away.

## Out of scope (planned follow-ups)

The same run also surfaced a second supervisor bug: when a worker commits to the worktree but exits without rewriting `candidate.json`, `validateAutoresearchCandidate` reads the stale artifact, fails the `candidate_commit !== HEAD` check, and `failAutoresearchIteration` aborts the entire run via `finalizeRun(status: 'failed')`.

Two fixes are deferred to a follow-up PR (kept out of this one to keep the diff focused and reviewable):

1. Freshness check on `candidate.json` (mtime ≥ worker_started_at) → treat stale as `noop`, not fatal.
2. Defensive soft-fail for the `candidate_commit !== HEAD` desync path → `failIterationAsNoop` instead of `failAutoresearchIteration`. Cap consecutive noops (suggest 3) so a chronically broken worker eventually halts the run.

I'd like to land this PR first since it's narrow and unblocks the bootstrap path; happy to open the follow-up immediately after.

## Backward compatibility

- Existing tests pass unchanged.
- Pre-existing runs that already have a non-null `last_kept_score` are unaffected (they take the comparable-score branch as before).
- The only behavior delta is on bootstrap (`last_kept_score === null` AND `evaluation.score` numeric AND `pass=true`), which previously discarded the candidate. The new behavior matches what `pass_only` already does in equivalent state, just under `score_improvement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)