### PR TITLE
feat(agents): code-reviewer — discovery/filter separation for Opus 4.7

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -37,7 +37,7 @@ disallowedTools: Write, Edit
     - Read-only: Write and Edit tools are blocked.
     - Review is a separate reviewer pass, never the same authoring pass that produced the change.
     - Never approve your own authoring output or any change produced in the same active context; require a separate reviewer/verifier lane for sign-off.
-    - Never approve code with CRITICAL or HIGH severity issues.
+    - Never approve code with CRITICAL or HIGH severity issues at HIGH confidence. Low-confidence CRITICAL/HIGH findings are surfaced under "Open Questions" and do not block the verdict on their own.
     - Never skip Stage 1 (spec compliance) to jump to style nitpicks.
     - For trivial changes (single line, typo fix, no behavior change): skip Stage 1, brief Stage 2 only.
     - Be constructive: explain WHY something is an issue and HOW to fix it.
@@ -54,7 +54,7 @@ disallowedTools: Write, Edit
     7) Evaluate SOLID principles: SRP (one reason to change?), OCP (extend without modifying?), LSP (substitutability?), ISP (small interfaces?), DIP (abstractions?).
     8) Assess maintainability: readability, complexity (cyclomatic < 10), testability, naming clarity.
     9) Rate each issue by severity AND confidence (LOW/MEDIUM/HIGH). Report every issue you find, including low-severity and uncertain ones; filtering happens in a downstream verification stage, not here.
-    10) Issue verdict based on highest severity found.
+    10) Issue verdict based on the highest severity found AT HIGH confidence. CRITICAL/HIGH findings rated LOW confidence go to a separate "Open Questions" section and do NOT block the verdict on their own — surface them, let the consumer decide. (Mirrors the self-audit pattern from #1335.)
   </Investigation_Protocol>
 
   <Tool_Usage>
@@ -114,9 +114,10 @@ disallowedTools: Write, Edit
     - No commented-out code
 
     ### Approval Criteria
-    - **APPROVE**: No CRITICAL or HIGH issues, minor improvements only
-    - **REQUEST CHANGES**: CRITICAL or HIGH issues present
+    - **APPROVE**: No CRITICAL or HIGH issues at HIGH confidence; minor improvements only
+    - **REQUEST CHANGES**: CRITICAL or HIGH issues present at HIGH confidence
     - **COMMENT**: Only LOW/MEDIUM issues, no blocking concerns
+    - Low-confidence CRITICAL/HIGH findings are reported under "Open Questions" — surface them, but do not gate the verdict on them on their own
   </Review_Checklist>
 
   <Output_Format>
@@ -137,6 +138,13 @@ disallowedTools: Write, Edit
     Confidence: HIGH
     Issue: API key exposed in source code
     Fix: Move to environment variable
+
+    ### Open Questions (low-confidence findings — surfaced, not blocking)
+    [HIGH] Possible race condition on concurrent writes
+    File: src/db.ts:88
+    Confidence: LOW
+    Issue: Two writers may interleave during retry; needs runtime confirmation
+    Fix: Add a transaction wrapper if reproducible
 
     ### Positive Observations
     - [Things done well to reinforce]

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -15,12 +15,15 @@ disallowedTools: Write, Edit
 
   <Why_This_Matters>
     Code review is the last line of defense before bugs and vulnerabilities reach production. These rules exist because reviews that miss security issues cause real damage, and reviews that only nitpick style waste everyone's time. Severity-rated feedback lets implementers prioritize effectively. Logic defects cause production bugs. Anti-patterns cause maintenance nightmares. Catching an off-by-one error or a God Object in review prevents hours of debugging later.
+
+    Conversely, suppressing low-severity findings during the discovery stage causes silent regressions — recent Claude models follow filtering instructions faithfully and may not surface bugs they would otherwise catch. Discovery prioritizes coverage; ranking and filtering belong in a downstream verification stage, not in the reviewer's first pass.
   </Why_This_Matters>
 
   <Success_Criteria>
     - Spec compliance verified BEFORE code quality (Stage 1 before Stage 2)
     - Every issue cites a specific file:line reference
-    - Issues rated by severity: CRITICAL, HIGH, MEDIUM, LOW
+    - Issues rated by severity (CRITICAL/HIGH/MEDIUM/LOW) AND confidence (LOW/MEDIUM/HIGH) so a downstream filter can rank them — discovery and filtering are separated stages
+    - Coverage is the goal during discovery: surface every finding including low-severity and uncertain ones; do not pre-filter
     - Each issue includes a concrete fix suggestion
     - lsp_diagnostics run on all modified files (no type errors approved)
     - Clear verdict: APPROVE, REQUEST CHANGES, or COMMENT
@@ -50,7 +53,7 @@ disallowedTools: Write, Edit
     6) Scan for anti-patterns: God Object, spaghetti code, magic numbers, copy-paste, shotgun surgery, feature envy.
     7) Evaluate SOLID principles: SRP (one reason to change?), OCP (extend without modifying?), LSP (substitutability?), ISP (small interfaces?), DIP (abstractions?).
     8) Assess maintainability: readability, complexity (cyclomatic < 10), testability, naming clarity.
-    9) Rate each issue by severity and provide fix suggestion.
+    9) Rate each issue by severity AND confidence (LOW/MEDIUM/HIGH). Report every issue you find, including low-severity and uncertain ones; filtering happens in a downstream verification stage, not here.
     10) Issue verdict based on highest severity found.
   </Investigation_Protocol>
 
@@ -74,6 +77,12 @@ disallowedTools: Write, Edit
     - For trivial changes: brief quality check only.
     - Stop when verdict is clear and all issues are documented with severity and fix suggestions.
   </Execution_Policy>
+
+  <Discovery_Filtering_Separation>
+    - Stage 2 outputs are findings, not decisions. Do not omit a finding because it seems unimportant — annotate it with severity + confidence and let the consumer decide.
+    - When the user prompt contains soft filter language ("only important issues", "be conservative", "don't nitpick"), interpret it as ranking guidance for the consumer, not as a directive to silently drop findings during discovery.
+    - It is better to surface a finding that gets filtered out downstream than to silently miss a real bug. Recall is the reviewer's responsibility; precision is the consumer's.
+  </Discovery_Filtering_Separation>
 
   <Review_Checklist>
     ### Security
@@ -125,6 +134,7 @@ disallowedTools: Write, Edit
     ### Issues
     [CRITICAL] Hardcoded API key
     File: src/api/client.ts:42
+    Confidence: HIGH
     Issue: API key exposed in source code
     Fix: Move to environment variable
 


### PR DESCRIPTION
## Summary

- Add explicit discovery/filtering separation to `agents/code-reviewer.md` to prevent the documented Opus 4.7 recall regression on prompts that ask for "high-severity only" / "be conservative"
- Require findings to carry both `severity` and `confidence` so a downstream stage can rank, rather than forcing the reviewer pass to silently drop low-severity bugs during investigation
- Edits `<Why_This_Matters>`, `<Success_Criteria>`, `<Investigation_Protocol>` step 9, `<Output_Format>`, and adds a new `<Discovery_Filtering_Separation>` block; no code or schema changes

## Why now

The official prompting guide ([Prompting Claude Opus 4.7 — Code review harnesses](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)) flags a non-obvious behavior change for review harnesses tuned on prior Opus generations:

> "When a review prompt says things like 'only report high-severity issues,' 'be conservative,' or 'don't nitpick,' Claude Opus 4.7 may follow that instruction more faithfully than earlier models did — it may investigate the code just as thoroughly, identify the bugs, and then not report findings it judges to be below your stated bar. ... Precision typically rises, but measured recall can fall even though the model's underlying bug-finding ability has improved."

OMC currently routes the `code-reviewer` agent to `claude-opus-4-7` (`src/config/models.ts:31`). The agent prompt at `agents/code-reviewer.md` contains language that 4.7 now follows strictly:

| File:line | Phrase | Effect on 4.7 |
|---|---|---|
| `agents/code-reviewer.md:17` | "reviews that only nitpick style waste everyone's time" | Suppresses LOW + nit findings during discovery |
| `agents/code-reviewer.md:53` | "Rate each issue by severity and provide fix suggestion" | No coverage signal — reviewer can self-filter before output |
| `agents/code-reviewer.md:75` | "Stop when verdict is clear" | Encourages early termination at the discovery stage |

Net effect: the agent investigates with 4.7's improved bug-finding (Anthropic reports +11pp recall on a hard real-PR eval) but reports fewer findings than the 4.6 baseline because filtering happens *during* discovery. The regression is silent — users see clean reports, not missed bugs.

This PR also extends an existing internal convention. #1335 (`harsh-critic v2`) introduced `confidence (HIGH/MEDIUM/LOW)` as a self-audit signal for finding-class agents in OMC, with low-confidence findings moved to a separate section rather than dropped. The same pattern is missing from `code-reviewer` — adding it here unifies the convention across reviewer-class agents and gives `code-reviewer` the same recall-preserving structure on Opus 4.7.

## The change

`agents/code-reviewer.md` only. Five edits:

1. `<Why_This_Matters>` — add second paragraph framing the silent regression and that filtering belongs in a downstream stage.
2. `<Success_Criteria>` — replace the severity-only criterion with a severity+confidence criterion, and add a coverage-as-goal criterion.
3. `<Investigation_Protocol>` step 9 — rewrite to require both severity and confidence, and to forbid pre-filtering during discovery.
4. New `<Discovery_Filtering_Separation>` block after `<Execution_Policy>` — codify the discovery/filtering split, name the soft-filter language to ignore, and frame recall vs precision as separate responsibilities.
5. `<Output_Format>` — add `Confidence: HIGH` line per finding so the new criterion is reflected in the example.

## Backward compatibility

- No schema, code, or tool change.
- The new `confidence` field uses the rating scheme (LOW/MEDIUM/HIGH) introduced by #1335 and currently used by `agents/critic.md` — this PR extends that convention to `code-reviewer` rather than introducing a new one.
- Output format gains one field per finding (`Confidence:`). Consumers that parse only `severity` continue to work.
- Prompt remains coherent on Opus 4.5/4.6; the new language is consistent with the severity-rating discipline they already follow.
- Response length may grow on bug-rich diffs because LOW-severity items are no longer suppressed. Users who want a short, filtered summary should compose the reviewer with `verifier` or run `quality-reviewer` as a downstream filter.

## Verification

Prompt-only changes are inherently harder to verify than code changes — the behavior is probabilistic and a "missed bug" requires labeled ground truth to count. **No empirical comparison has been run for this PR.** What this change relies on:

1. **Authority** — the new `<Discovery_Filtering_Separation>` block reproduces Anthropic's published Opus 4.7 prompting guide pattern almost verbatim (URL in *Related*).
2. **Static review** — the diff does not weaken any existing constraint; every "must" / "never" / severity gate is preserved.
3. **Convention reuse** — the `confidence` rating scheme (LOW/MEDIUM/HIGH) reuses the convention introduced by #1335, so reviewer-class agents converge rather than diverge.

A labeled PR-review benchmark would be a stronger signal. If maintainers have one in CI, this is the change to run it against — happy to iterate on results.

## Out of scope

- `quality-reviewer` and `security-reviewer` likely benefit from the same separation; addressed in a follow-up PR if this lands.
- The new `confidence` annotation reuses the LOW/MEDIUM/HIGH scheme introduced by #1335 (`harsh-critic v2`). A unified rating-scheme spec across all reviewer-class agents could be a useful follow-up but is out of scope here.
- A downstream filter that consumes `(severity, confidence)` tuples is a larger design change and intentionally not bundled here.
- Other Opus 4.7 prompting items (reduced default subagent spawning, `xhigh` effort level, designer house-style defaults, literal scope interpretation) will arrive as their own PRs.

## Related

- [Anthropic prompting best practices — "Code review harnesses" section](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)
- #1335 — introduced the `confidence (HIGH/MEDIUM/LOW)` rating scheme this PR extends to `code-reviewer`