### PR TITLE
feat(planning): timestamp canonical handoff artifacts

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -296,6 +296,34 @@ describe('team cli', () => {
     logSpy.mockRestore();
   });
 
+  it('legacy team alias fails closed for incomplete approved short follow-up hints', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-approved-incomplete-'));
+    const plansDir = join(cwd, '.omc', 'plans');
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, 'prd-feature.md'),
+      [
+        '# PRD',
+        '',
+        '## Acceptance criteria',
+        '- done',
+        '',
+        '## Requirement coverage map',
+        '- req -> impl',
+        '',
+        'omc team 4:codex "execute draft plan"',
+        '',
+      ].join('\n'),
+    );
+
+    const { teamCommand } = await import('../team.js');
+    await expect(teamCommand(['3:claude', 'team', '--cwd', cwd, '--json']))
+      .rejects.toThrow('approved_execution_hint_incomplete:team');
+    expect(mocks.spawn).not.toHaveBeenCalled();
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
   it('legacy team alias fails closed for ambiguous approved short follow-up hints', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-approved-ambiguous-'));
     const plansDir = join(cwd, '.omc', 'plans');

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -236,6 +236,108 @@ describe('team cli', () => {
     logSpy.mockRestore();
   });
 
+  it('legacy team alias reuses an approved short follow-up launch hint', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-approved-followup-'));
+    const plansDir = join(cwd, '.omc', 'plans');
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, 'prd-feature.md'),
+      [
+        '# PRD',
+        '',
+        '## Acceptance criteria',
+        '- done',
+        '',
+        '## Requirement coverage map',
+        '- req -> impl',
+        '',
+        'omc team 4:codex "execute approved plan"',
+        '',
+      ].join('\n'),
+    );
+    writeFileSync(
+      join(plansDir, 'test-spec-feature.md'),
+      [
+        '# Test Spec',
+        '',
+        '## Unit coverage',
+        '- unit',
+        '',
+        '## Verification mapping',
+        '- verify',
+        '',
+      ].join('\n'),
+    );
+
+    mocks.spawn.mockReturnValue({
+      pid: 8889,
+      stdin: { write, end },
+      unref,
+    });
+
+    const { teamCommand } = await import('../team.js');
+    await teamCommand(['3:claude', 'team', '--cwd', cwd, '--json']);
+
+    const stdinPayload = JSON.parse(write.mock.calls[0][0] as string) as {
+      agentTypes: string[];
+      tasks: Array<{ description: string }>;
+      workerCount?: number;
+    };
+    expect(stdinPayload.workerCount).toBe(4);
+    expect(stdinPayload.agentTypes).toEqual(['codex', 'codex', 'codex', 'codex']);
+    expect(stdinPayload.tasks).toHaveLength(4);
+    expect(stdinPayload.tasks.every((task) => task.description === 'execute approved plan')).toBe(true);
+
+    rmSync(cwd, { recursive: true, force: true });
+    logSpy.mockRestore();
+  });
+
+  it('legacy team alias fails closed for ambiguous approved short follow-up hints', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-team-cli-approved-ambiguous-'));
+    const plansDir = join(cwd, '.omc', 'plans');
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, 'prd-feature.md'),
+      [
+        '# PRD',
+        '',
+        '## Acceptance criteria',
+        '- done',
+        '',
+        '## Requirement coverage map',
+        '- req -> impl',
+        '',
+        'omc team 2:claude "execute alpha"',
+        'omc team 4:codex "execute beta"',
+        '',
+      ].join('\n'),
+    );
+    writeFileSync(
+      join(plansDir, 'test-spec-feature.md'),
+      [
+        '# Test Spec',
+        '',
+        '## Unit coverage',
+        '- unit',
+        '',
+        '## Verification mapping',
+        '- verify',
+        '',
+      ].join('\n'),
+    );
+
+    const { teamCommand } = await import('../team.js');
+    await expect(teamCommand(['3:claude', 'team', '--cwd', cwd, '--json']))
+      .rejects.toThrow('approved_execution_hint_ambiguous:team');
+    expect(mocks.spawn).not.toHaveBeenCalled();
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
   it('teamCommand start without --json outputs non-JSON', async () => {
     const write = vi.fn();
     const end = vi.fn();

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1271,9 +1271,14 @@ function parseLegacyStartAlias(args: string[]): TeamLegacyStartArgs | null {
 
   const shortFollowup = ['team', '/team', 'team please', 'run team', 'start team'].includes(task.toLowerCase());
   if (shortFollowup) {
-    const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team');
+    const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
+      requirePlanningComplete: true,
+    });
     if (approvedHintOutcome.status === 'ambiguous') {
       throw new Error('approved_execution_hint_ambiguous:team');
+    }
+    if (approvedHintOutcome.status === 'incomplete') {
+      throw new Error('approved_execution_hint_incomplete:team');
     }
     if (approvedHintOutcome.status === 'resolved') {
       task = approvedHintOutcome.hint.task;

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -12,6 +12,7 @@ import { monitorTeam, resumeTeam, shutdownTeam } from '../team/runtime.js';
 import { readTeamConfig } from '../team/monitor.js';
 import { isProcessAlive } from '../platform/index.js';
 import { getGlobalOmcStatePath } from '../utils/paths.js';
+import { readApprovedExecutionLaunchHintOutcome } from '../planning/artifacts.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
 const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor']);
@@ -1223,10 +1224,10 @@ function parseLegacyStartAlias(args: string[]): TeamLegacyStartArgs | null {
   const match = spec.match(/^(\d+):([a-zA-Z0-9_-]+)(?::([a-zA-Z0-9_-]+))?$/);
   if (!match) return null;
 
-  const workerCount = toInt(match[1], 'worker-count');
+  let workerCount = toInt(match[1], 'worker-count');
   if (workerCount < 1) throw new Error('worker-count must be >= 1');
 
-  const agentType = normalizeAgentType(match[2]);
+  let agentType = normalizeAgentType(match[2]);
   const role = match[3] || undefined;
   index += 1;
 
@@ -1265,8 +1266,33 @@ function parseLegacyStartAlias(args: string[]): TeamLegacyStartArgs | null {
     taskParts.push(token);
   }
 
-  const task = taskParts.join(' ').trim();
+  let task = taskParts.join(' ').trim();
   if (!task) throw new Error('Legacy start alias requires a task string');
+
+  const shortFollowup = ['team', '/team', 'team please', 'run team', 'start team'].includes(task.toLowerCase());
+  if (shortFollowup) {
+    const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team');
+    if (approvedHintOutcome.status === 'ambiguous') {
+      throw new Error('approved_execution_hint_ambiguous:team');
+    }
+    if (approvedHintOutcome.status === 'resolved') {
+      task = approvedHintOutcome.hint.task;
+      workerCount = approvedHintOutcome.hint.workerCount ?? workerCount;
+      agentType = approvedHintOutcome.hint.agentType
+        ? normalizeAgentType(approvedHintOutcome.hint.agentType)
+        : agentType;
+      ralph = approvedHintOutcome.hint.linkedRalph === true ? true : ralph;
+    }
+  } else {
+    const command = `omc team ${ralph ? 'ralph ' : ''}${spec} ${JSON.stringify(task)}`;
+    const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
+      task,
+      command,
+    });
+    if (approvedHintOutcome.status === 'ambiguous') {
+      throw new Error('approved_execution_hint_ambiguous:team');
+    }
+  }
 
   return {
     workerCount,

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -7,6 +7,10 @@ import {
   isPlanningComplete,
   readApprovedExecutionLaunchHint,
 } from "../artifacts.js";
+import {
+  planningArtifactTimestamp,
+  selectMatchingTestSpecsForPrd,
+} from "../artifact-names.js";
 
 describe("planning/artifacts", () => {
   let testDir: string;
@@ -122,6 +126,34 @@ describe("planning/artifacts", () => {
       expect(result.prdPaths).toHaveLength(2);
       expect(result.prdPaths[0]).toContain(join(".omx", "plans", "prd-zzz.md"));
       expect(result.prdPaths[1]).toContain(join(".omc", "plans", "prd-aaa.md"));
+    });
+
+    it("orders timestamped artifacts after legacy names by timestamp", () => {
+      writeFileSync(join(plansDir, "prd-alpha.md"), "# PRD A");
+      writeFileSync(join(plansDir, "prd-20260502T090000Z-alpha.md"), "# PRD B");
+      writeFileSync(join(plansDir, "prd-20260502T091500Z-alpha.md"), "# PRD C");
+
+      const result = readPlanningArtifacts(testDir);
+
+      expect(result.prdPaths[0]).toContain("prd-20260502T091500Z-alpha.md");
+      expect(result.prdPaths[1]).toContain("prd-20260502T090000Z-alpha.md");
+      expect(result.prdPaths[2]).toContain("prd-alpha.md");
+    });
+  });
+
+  describe("artifact names", () => {
+    it("formats canonical artifact timestamps without milliseconds", () => {
+      expect(planningArtifactTimestamp(new Date("2026-05-02T08:09:10.456Z"))).toBe(
+        "20260502T080910Z",
+      );
+    });
+
+    it("selects exact timestamped test specs for timestamped PRDs", () => {
+      const prdPath = join(plansDir, "prd-20260502T080910Z-alpha.md");
+      const matching = join(plansDir, "test-spec-20260502T080910Z-alpha.md");
+      const stale = join(plansDir, "test-spec-alpha.md");
+
+      expect(selectMatchingTestSpecsForPrd(prdPath, [stale, matching])).toEqual([matching]);
     });
   });
 
@@ -258,6 +290,20 @@ describe("planning/artifacts", () => {
 
     it("returns true when both latest artifacts contain required sections", () => {
       writeValidArtifacts();
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(true);
+    });
+
+    it("requires timestamped PRDs to use matching timestamped test specs", () => {
+      writeValidArtifacts(
+        "prd-20260502T080910Z-alpha.md",
+        "test-spec-alpha.md",
+      );
+      expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(false);
+
+      writeValidArtifacts(
+        "prd-20260502T080910Z-alpha.md",
+        "test-spec-20260502T080910Z-alpha.md",
+      );
       expect(isPlanningComplete(readPlanningArtifacts(testDir))).toBe(true);
     });
 
@@ -401,6 +447,84 @@ describe("planning/artifacts", () => {
       expect(result!.task).toBe("implement the feature");
       expect(result!.workerCount).toBeUndefined();
       expect(result!.agentType).toBeUndefined();
+    });
+
+    it("resolves exact team launch hints by command when tasks repeat", () => {
+      const firstCommand = 'omc team 2:claude "ship it"';
+      const secondCommand = 'omc team 4:codex "ship it"';
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          `Run: ${firstCommand}`,
+          `Run: ${secondCommand}`,
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+
+      expect(readApprovedExecutionLaunchHint(testDir, "team", { task: "ship it" })).toBeNull();
+      const result = readApprovedExecutionLaunchHint(testDir, "team", {
+        task: "ship it",
+        command: secondCommand,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.workerCount).toBe(4);
+      expect(result!.agentType).toBe("codex");
+      expect(result!.command).toBe(secondCommand);
+    });
+
+    it("does not treat ralph-prefixed mode names as ralph launch hints", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          'omc ralph-verify "do the work"',
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(plansDir, "test-spec-feature.md"),
+        [
+          "# Test Spec",
+          "",
+          "## Unit coverage",
+          "- unit",
+          "",
+          "## Verification mapping",
+          "- verify",
+          "",
+        ].join("\n"),
+      );
+
+      expect(readApprovedExecutionLaunchHint(testDir, "ralph")).toBeNull();
     });
 
     it("extracts OMX team launch hints from PRDs written under .omx/plans", () => {

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -6,6 +6,7 @@ import {
   readPlanningArtifacts,
   isPlanningComplete,
   readApprovedExecutionLaunchHint,
+  readApprovedExecutionLaunchHintOutcome,
 } from "../artifacts.js";
 import {
   planningArtifactTimestamp,
@@ -424,6 +425,46 @@ describe("planning/artifacts", () => {
       expect(result!.agentType).toBe("claude");
       expect(result!.linkedRalph).toBe(false);
       expect(result!.sourcePath).toContain("prd-feature.md");
+    });
+
+    it("marks launch hints incomplete when planning-complete validation is required", () => {
+      writeFileSync(
+        join(plansDir, "prd-feature.md"),
+        [
+          "# PRD",
+          "",
+          "## Acceptance criteria",
+          "- done",
+          "",
+          "## Requirement coverage map",
+          "- req -> impl",
+          "",
+          'omc team 3:claude "implement auth"',
+          "",
+        ].join("\n"),
+      );
+
+      expect(readApprovedExecutionLaunchHint(testDir, "team")!.task).toBe(
+        "implement auth",
+      );
+      expect(
+        readApprovedExecutionLaunchHintOutcome(testDir, "team", {
+          requirePlanningComplete: true,
+        }),
+      ).toEqual({ status: "incomplete" });
+    });
+
+    it("resolves launch hints when required planning artifacts are complete", () => {
+      writeValidArtifacts();
+
+      const outcome = readApprovedExecutionLaunchHintOutcome(testDir, "team", {
+        requirePlanningComplete: true,
+      });
+
+      expect(outcome.status).toBe("resolved");
+      expect(outcome.status === "resolved" ? outcome.hint.task : null).toBe(
+        "implement auth",
+      );
     });
 
     it("extracts team launch hint without worker spec", () => {

--- a/src/planning/artifact-names.ts
+++ b/src/planning/artifact-names.ts
@@ -1,0 +1,148 @@
+import { basename } from "path";
+
+const PLANNING_ARTIFACT_TIMESTAMP_PATTERN = /^\d{8}T\d{6}Z$/;
+
+export type PlanningArtifactKind =
+  | "prd"
+  | "test-spec"
+  | "deep-interview"
+  | "deep-interview-autoresearch";
+
+export interface PlanningArtifactNameInfo {
+  kind: PlanningArtifactKind;
+  slug: string;
+  timestamp?: string;
+}
+
+export function planningArtifactTimestamp(date: Date = new Date()): string {
+  return date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+function legacyTestSpecSlug(fileNameOrPath: string): string | null {
+  const match = basename(fileNameOrPath).match(/^test-?spec-(?<slug>.+)\.md$/i);
+  return match?.groups?.slug ?? null;
+}
+
+function requiredTimestampedTestSpecFileName(
+  prdArtifact: PlanningArtifactNameInfo,
+): string | null {
+  return prdArtifact.kind === "prd" && prdArtifact.timestamp
+    ? `test-spec-${prdArtifact.timestamp}-${prdArtifact.slug}.md`
+    : null;
+}
+
+function splitTimestampPrefix(rawSlug: string): { slug: string; timestamp?: string } {
+  const separatorIndex = rawSlug.indexOf("-");
+  if (separatorIndex === -1) {
+    return { slug: rawSlug };
+  }
+
+  const prefix = rawSlug.slice(0, separatorIndex);
+  if (!PLANNING_ARTIFACT_TIMESTAMP_PATTERN.test(prefix)) {
+    return { slug: rawSlug };
+  }
+
+  return {
+    timestamp: prefix,
+    slug: rawSlug.slice(separatorIndex + 1),
+  };
+}
+
+export function parsePlanningArtifactFileName(
+  fileNameOrPath: string,
+): PlanningArtifactNameInfo | null {
+  const fileName = basename(fileNameOrPath);
+
+  const autoresearchDeepInterviewMatch = fileName.match(
+    /^deep-interview-autoresearch-(?<slug>.+)\.md$/i,
+  );
+  if (autoresearchDeepInterviewMatch?.groups?.slug) {
+    const parsedSlug = splitTimestampPrefix(autoresearchDeepInterviewMatch.groups.slug);
+    if (!parsedSlug.slug) return null;
+    return {
+      kind: "deep-interview-autoresearch",
+      ...parsedSlug,
+    };
+  }
+
+  const deepInterviewMatch = fileName.match(/^deep-interview-(?<slug>.+)\.md$/i);
+  if (deepInterviewMatch?.groups?.slug) {
+    const parsedSlug = splitTimestampPrefix(deepInterviewMatch.groups.slug);
+    if (!parsedSlug.slug) return null;
+    return {
+      kind: "deep-interview",
+      ...parsedSlug,
+    };
+  }
+
+  const prdMatch = fileName.match(/^prd-(?<slug>.+)\.md$/i);
+  if (prdMatch?.groups?.slug) {
+    const parsedSlug = splitTimestampPrefix(prdMatch.groups.slug);
+    if (!parsedSlug.slug) return null;
+    return {
+      kind: "prd",
+      ...parsedSlug,
+    };
+  }
+
+  const testSpecMatch = fileName.match(/^test-?spec-(?<slug>.+)\.md$/i);
+  if (testSpecMatch?.groups?.slug) {
+    const parsedSlug = splitTimestampPrefix(testSpecMatch.groups.slug);
+    if (!parsedSlug.slug) return null;
+    return {
+      kind: "test-spec",
+      ...parsedSlug,
+    };
+  }
+
+  return null;
+}
+
+export function planningArtifactSlug(
+  fileNameOrPath: string,
+  kind: PlanningArtifactKind,
+): string | null {
+  const parsed = parsePlanningArtifactFileName(fileNameOrPath);
+  return parsed?.kind === kind ? parsed.slug : null;
+}
+
+export function comparePlanningArtifactPaths(left: string, right: string): number {
+  const leftParsed = parsePlanningArtifactFileName(left);
+  const rightParsed = parsePlanningArtifactFileName(right);
+
+  if (leftParsed?.timestamp && rightParsed?.timestamp && leftParsed.timestamp !== rightParsed.timestamp) {
+    return leftParsed.timestamp.localeCompare(rightParsed.timestamp);
+  }
+  if (leftParsed?.timestamp && !rightParsed?.timestamp) {
+    return 1;
+  }
+  if (!leftParsed?.timestamp && rightParsed?.timestamp) {
+    return -1;
+  }
+
+  return left.localeCompare(right);
+}
+
+export function selectMatchingTestSpecsForPrd(
+  prdPath: string | null,
+  testSpecPaths: readonly string[],
+): string[] {
+  if (!prdPath) {
+    return [];
+  }
+
+  const prdArtifact = parsePlanningArtifactFileName(prdPath);
+  if (prdArtifact?.kind !== "prd") {
+    return [];
+  }
+
+  const requiredTimestampedFileName = requiredTimestampedTestSpecFileName(prdArtifact);
+  return (requiredTimestampedFileName
+    ? testSpecPaths.filter((path) => basename(path) === requiredTimestampedFileName)
+    : testSpecPaths.filter((path) => legacyTestSpecSlug(path) === prdArtifact.slug))
+    .sort(comparePlanningArtifactPaths);
+}
+
+export function selectLatestPlanningArtifactPath(paths: readonly string[]): string | null {
+  return [...paths].sort(comparePlanningArtifactPaths).at(-1) ?? null;
+}

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -8,7 +8,12 @@
  */
 
 import { readdirSync, readFileSync, existsSync } from "fs";
-import { basename, join } from "path";
+import { join } from "path";
+import {
+  comparePlanningArtifactPaths,
+  selectLatestPlanningArtifactPath,
+  selectMatchingTestSpecsForPrd,
+} from "./artifact-names.js";
 
 export interface PlanningArtifacts {
   prdPaths: string[];
@@ -24,6 +29,17 @@ export interface ApprovedExecutionLaunchHint {
   linkedRalph?: boolean;
   sourcePath: string;
 }
+
+interface ApprovedExecutionLaunchHintReadOptions {
+  prdPath?: string;
+  task?: string;
+  command?: string;
+}
+
+export type ApprovedExecutionLaunchHintOutcome =
+  | { status: "absent" }
+  | { status: "ambiguous" }
+  | { status: "resolved"; hint: ApprovedExecutionLaunchHint };
 
 function readFileSafe(path: string): string | null {
   try {
@@ -63,14 +79,7 @@ function getPlansDirCandidates(cwd: string): string[] {
 }
 
 function sortArtifactPathsDescending(paths: string[]): string[] {
-  return [...paths].sort((a, b) => {
-    const fileCompare = basename(b).localeCompare(basename(a));
-    if (fileCompare !== 0) {
-      return fileCompare;
-    }
-
-    return b.localeCompare(a);
-  });
+  return [...paths].sort((a, b) => comparePlanningArtifactPaths(b, a));
 }
 
 /**
@@ -113,12 +122,18 @@ export function readPlanningArtifacts(cwd: string): PlanningArtifacts {
  * the required non-empty quality-gate sections.
  */
 export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
-  if (artifacts.prdPaths.length === 0 || artifacts.testSpecPaths.length === 0) {
+  const latestPrdPath = selectLatestPlanningArtifactPath(artifacts.prdPaths);
+  const matchingTestSpecPaths = selectMatchingTestSpecsForPrd(
+    latestPrdPath,
+    artifacts.testSpecPaths,
+  );
+
+  if (!latestPrdPath || matchingTestSpecPaths.length === 0) {
     return false;
   }
 
-  const latestPrd = readFileSafe(artifacts.prdPaths[0]);
-  const latestTestSpec = readFileSafe(artifacts.testSpecPaths[0]);
+  const latestPrd = readFileSafe(latestPrdPath);
+  const latestTestSpec = readFileSafe(matchingTestSpecPaths[0]);
   if (!latestPrd || !latestTestSpec) {
     return false;
   }
@@ -135,18 +150,80 @@ export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
   );
 }
 
-/**
- * Regex patterns for extracting omc/omx team/ralph launch commands from PRD markdown.
- *
- * Matches lines like:
- *   omc team 3:claude "implement the feature"
- *   omx team ".omx/plans/ralplan-feature.md"
- *   omc team 2:codex "fix the bug" --linked-ralph
- *   omx ralph ".omx/plans/ralplan-feature.md"
- */
-const TEAM_LAUNCH_RE =
-  /\bom[cx]\s+team\s+(?:(\d+):(\w+)\s+)?"([^"]+)"((?:\s+--[\w-]+)*)/;
-const RALPH_LAUNCH_RE = /\bom[cx]\s+ralph\s+"([^"]+)"((?:\s+--[\w-]+)*)/;
+type LaunchHintSelection =
+  | { status: "no-match" }
+  | { status: "ambiguous" }
+  | {
+      status: "unique";
+      command: string;
+      task: string;
+      workerCount?: number;
+      agentType?: string;
+      linkedRalph: boolean;
+    };
+
+function decodeQuotedValue(raw: string): string | null {
+  const normalized = raw.trim();
+  if (!normalized) return null;
+  try {
+    return JSON.parse(normalized) as string;
+  } catch {
+    if (
+      (normalized.startsWith('"') && normalized.endsWith('"')) ||
+      (normalized.startsWith("'") && normalized.endsWith("'"))
+    ) {
+      return normalized.slice(1, -1);
+    }
+    return null;
+  }
+}
+
+function launchHintPattern(mode: "team" | "ralph"): RegExp {
+  return mode === "team"
+    ? /(?<command>(?:om[cx]\s+team|\$team)(?:\s+ralph)?(?:\s+(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?)?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')(?<flags>(?:\s+--[\w-]+)*))/gi
+    : /(?<command>(?:om[cx]\s+ralph|\$ralph)\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')(?<flags>(?:\s+--[\w-]+)*))/gi;
+}
+
+function collectLaunchHintMatches(
+  content: string,
+  mode: "team" | "ralph",
+): RegExpMatchArray[] {
+  return [...content.matchAll(launchHintPattern(mode))];
+}
+
+function selectLaunchHintMatch(
+  matches: RegExpMatchArray[],
+  normalizedTask?: string,
+  normalizedCommand?: string,
+): LaunchHintSelection {
+  const decodedMatches = matches.flatMap((match) => {
+    const command = match[0]?.trim();
+    const task = match.groups?.task ? decodeQuotedValue(match.groups.task) : null;
+    if (!command || task == null) return [];
+    const flags = match.groups?.flags ?? "";
+    const workerCount = match.groups?.count
+      ? Number.parseInt(match.groups.count, 10)
+      : undefined;
+
+    return [{
+      command,
+      task,
+      ...(workerCount == null ? {} : { workerCount }),
+      agentType: match.groups?.role || undefined,
+      linkedRalph: /\sralph(?:\s|$)/.test(command) || parseFlags(flags).linkedRalph,
+    }];
+  });
+
+  const matchesToConsider = normalizedCommand
+    ? decodedMatches.filter((match) => match.command === normalizedCommand)
+    : normalizedTask
+      ? decodedMatches.filter((match) => match.task.trim() === normalizedTask)
+      : decodedMatches;
+
+  if (matchesToConsider.length === 0) return { status: "no-match" };
+  if (matchesToConsider.length > 1) return { status: "ambiguous" };
+  return { status: "unique", ...matchesToConsider[0]! };
+}
 
 function parseFlags(flagStr: string): { linkedRalph: boolean } {
   return {
@@ -161,43 +238,67 @@ function parseFlags(flagStr: string): { linkedRalph: boolean } {
 export function readApprovedExecutionLaunchHint(
   cwd: string,
   mode: "team" | "ralph",
+  options: ApprovedExecutionLaunchHintReadOptions = {},
 ): ApprovedExecutionLaunchHint | null {
-  const artifacts = readPlanningArtifacts(cwd);
-  if (artifacts.prdPaths.length === 0) return null;
+  const outcome = readApprovedExecutionLaunchHintOutcome(cwd, mode, options);
+  return outcome.status === "resolved" ? outcome.hint : null;
+}
 
-  const prdPath = artifacts.prdPaths[0];
+export function readApprovedExecutionLaunchHintOutcome(
+  cwd: string,
+  mode: "team" | "ralph",
+  options: ApprovedExecutionLaunchHintReadOptions = {},
+): ApprovedExecutionLaunchHintOutcome {
+  const artifacts = readPlanningArtifacts(cwd);
+  if (artifacts.prdPaths.length === 0) return { status: "absent" };
+
+  const prdPath = options.prdPath
+    ? artifacts.prdPaths.includes(options.prdPath)
+      ? options.prdPath
+      : null
+    : selectLatestPlanningArtifactPath(artifacts.prdPaths);
+  const matchingTestSpecs = selectMatchingTestSpecsForPrd(
+    prdPath,
+    artifacts.testSpecPaths,
+  );
+  if (!prdPath) return { status: "absent" };
+  if (artifacts.testSpecPaths.length > 0 && matchingTestSpecs.length === 0) {
+    return { status: "absent" };
+  }
   const content = readFileSafe(prdPath);
-  if (!content) return null;
+  if (!content) return { status: "absent" };
+
+  const selected = selectLaunchHintMatch(
+    collectLaunchHintMatches(content, mode),
+    options.task?.trim(),
+    options.command?.trim(),
+  );
+  if (selected.status === "ambiguous") return { status: "ambiguous" };
+  if (selected.status !== "unique") return { status: "absent" };
 
   if (mode === "team") {
-    const match = TEAM_LAUNCH_RE.exec(content);
-    if (!match) return null;
-
-    const [fullMatch, workerCountStr, agentType, task, flagStr] = match;
-    const { linkedRalph } = parseFlags(flagStr ?? "");
-
     return {
-      mode: "team",
-      command: fullMatch.trim(),
-      task,
-      workerCount: workerCountStr ? parseInt(workerCountStr, 10) : undefined,
-      agentType: agentType || undefined,
-      linkedRalph,
-      sourcePath: prdPath,
+      status: "resolved",
+      hint: {
+        mode: "team",
+        command: selected.command,
+        task: selected.task,
+        workerCount: selected.workerCount,
+        agentType: selected.agentType,
+        linkedRalph: selected.linkedRalph,
+        sourcePath: prdPath,
+      },
     };
   }
 
-  const match = RALPH_LAUNCH_RE.exec(content);
-  if (!match) return null;
-
-  const [fullMatch, task, flagStr] = match;
-  const { linkedRalph } = parseFlags(flagStr ?? "");
-
   return {
-    mode: "ralph",
-    command: fullMatch.trim(),
-    task,
-    linkedRalph,
-    sourcePath: prdPath,
+    status: "resolved",
+    hint: {
+      mode: "ralph",
+      command: selected.command,
+      task: selected.task,
+      linkedRalph: selected.linkedRalph,
+      sourcePath: prdPath,
+    },
   };
 }

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -34,11 +34,13 @@ interface ApprovedExecutionLaunchHintReadOptions {
   prdPath?: string;
   task?: string;
   command?: string;
+  requirePlanningComplete?: boolean;
 }
 
 export type ApprovedExecutionLaunchHintOutcome =
   | { status: "absent" }
   | { status: "ambiguous" }
+  | { status: "incomplete" }
   | { status: "resolved"; hint: ApprovedExecutionLaunchHint };
 
 function readFileSafe(path: string): string | null {
@@ -80,6 +82,32 @@ function getPlansDirCandidates(cwd: string): string[] {
 
 function sortArtifactPathsDescending(paths: string[]): string[] {
   return [...paths].sort((a, b) => comparePlanningArtifactPaths(b, a));
+}
+
+function hasCompletePlanningPair(
+  prdPath: string,
+  matchingTestSpecPaths: string[],
+): boolean {
+  if (matchingTestSpecPaths.length === 0) {
+    return false;
+  }
+
+  const prd = readFileSafe(prdPath);
+  const testSpec = readFileSafe(matchingTestSpecPaths[0]);
+  if (!prd || !testSpec) {
+    return false;
+  }
+
+  return (
+    hasRequiredSections(prd, [
+      "Acceptance criteria",
+      "Requirement coverage map",
+    ]) &&
+    hasRequiredSections(testSpec, [
+      "Unit coverage",
+      "Verification mapping",
+    ])
+  );
 }
 
 /**
@@ -132,22 +160,7 @@ export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
     return false;
   }
 
-  const latestPrd = readFileSafe(latestPrdPath);
-  const latestTestSpec = readFileSafe(matchingTestSpecPaths[0]);
-  if (!latestPrd || !latestTestSpec) {
-    return false;
-  }
-
-  return (
-    hasRequiredSections(latestPrd, [
-      "Acceptance criteria",
-      "Requirement coverage map",
-    ]) &&
-    hasRequiredSections(latestTestSpec, [
-      "Unit coverage",
-      "Verification mapping",
-    ])
-  );
+  return hasCompletePlanningPair(latestPrdPath, matchingTestSpecPaths);
 }
 
 type LaunchHintSelection =
@@ -275,6 +288,12 @@ export function readApprovedExecutionLaunchHintOutcome(
   );
   if (selected.status === "ambiguous") return { status: "ambiguous" };
   if (selected.status !== "unique") return { status: "absent" };
+  if (
+    options.requirePlanningComplete &&
+    !hasCompletePlanningPair(prdPath, matchingTestSpecs)
+  ) {
+    return { status: "incomplete" };
+  }
 
   if (mode === "team") {
     return {

--- a/src/team/__tests__/api-interop.compatibility.test.ts
+++ b/src/team/__tests__/api-interop.compatibility.test.ts
@@ -98,4 +98,159 @@ describe('team api compatibility (task + mailbox legacy formats)', () => {
     expect(canonical.messages[0]?.message_id).toBe('msg-1');
     expect(typeof canonical.messages[0]?.notified_at).toBe('string');
   });
+
+  it('rejects broad delegated task completion without spawn evidence or skip reason', async () => {
+    const taskPath = join(cwd, '.omc', 'state', 'team', teamName, 'tasks', 'task-1.json');
+    await writeFile(taskPath, JSON.stringify({
+      id: '1',
+      subject: 'Investigate flaky runtime behavior',
+      description: 'Search runtime and debug flaky assignment behavior',
+      status: 'pending',
+      owner: 'worker-1',
+      created_at: new Date().toISOString(),
+      version: 1,
+      delegation: {
+        mode: 'auto',
+        required_parallel_probe: true,
+        skip_allowed_reason_required: true,
+      },
+    }, null, 2));
+
+    const claimResult = await executeTeamApiOperation('claim-task', {
+      team_name: teamName,
+      task_id: '1',
+      worker: 'worker-1',
+    }, cwd);
+    expect(claimResult.ok).toBe(true);
+    if (!claimResult.ok) return;
+    const claimData = claimResult.data as { ok?: boolean; claimToken?: string };
+    expect(claimData.ok).toBe(true);
+
+    const missing = await executeTeamApiOperation('transition-task-status', {
+      team_name: teamName,
+      task_id: '1',
+      from: 'in_progress',
+      to: 'completed',
+      claim_token: claimData.claimToken,
+      result: 'Verification:\nPASS - focused regression',
+    }, cwd);
+
+    expect(missing.ok).toBe(true);
+    if (!missing.ok) return;
+    const missingData = missing.data as { ok?: boolean; error?: string };
+    expect(missingData.ok).toBe(false);
+    expect(missingData.error).toBe('missing_delegation_compliance_evidence');
+
+    const reread = await executeTeamApiOperation('read-task', {
+      team_name: teamName,
+      task_id: '1',
+    }, cwd);
+    expect(reread.ok).toBe(true);
+    if (!reread.ok) return;
+    const rereadData = reread.data as { task?: { status?: string } };
+    expect(rereadData.task?.status).toBe('in_progress');
+  });
+
+  it('records delegation compliance when broad delegated completion includes spawn evidence', async () => {
+    const taskPath = join(cwd, '.omc', 'state', 'team', teamName, 'tasks', 'task-1.json');
+    await writeFile(taskPath, JSON.stringify({
+      id: '1',
+      subject: 'Investigate flaky runtime behavior',
+      description: 'Search runtime and debug flaky assignment behavior',
+      status: 'pending',
+      owner: 'worker-1',
+      created_at: new Date().toISOString(),
+      version: 1,
+      delegation: {
+        mode: 'auto',
+        required_parallel_probe: true,
+        skip_allowed_reason_required: true,
+      },
+    }, null, 2));
+
+    const claimResult = await executeTeamApiOperation('claim-task', {
+      team_name: teamName,
+      task_id: '1',
+      worker: 'worker-1',
+    }, cwd);
+    expect(claimResult.ok).toBe(true);
+    if (!claimResult.ok) return;
+    const claimData = claimResult.data as { ok?: boolean; claimToken?: string };
+    expect(claimData.ok).toBe(true);
+
+    const completed = await executeTeamApiOperation('transition-task-status', {
+      team_name: teamName,
+      task_id: '1',
+      from: 'in_progress',
+      to: 'completed',
+      claim_token: claimData.claimToken,
+      result: [
+        'Verification:',
+        'PASS - focused regression',
+        'Subagent spawn evidence: spawned 2 native subagents for runtime map and test probe',
+      ].join('\n'),
+    }, cwd);
+
+    expect(completed.ok).toBe(true);
+    if (!completed.ok) return;
+    const completedData = completed.data as {
+      ok?: boolean;
+      task?: {
+        result?: string;
+        delegation_compliance?: { status?: string; source?: string; detail?: string };
+      };
+    };
+    expect(completedData.ok).toBe(true);
+    expect(completedData.task?.result).toContain('Subagent spawn evidence:');
+    expect(completedData.task?.delegation_compliance?.status).toBe('spawned');
+    expect(completedData.task?.delegation_compliance?.source).toBe('terminal_result');
+    expect(completedData.task?.delegation_compliance?.detail).toContain('spawned 2 native subagents');
+  });
+
+  it('accepts documented skip reason when broad delegated task allows skipping', async () => {
+    const taskPath = join(cwd, '.omc', 'state', 'team', teamName, 'tasks', 'task-1.json');
+    await writeFile(taskPath, JSON.stringify({
+      id: '1',
+      subject: 'Review focused regression',
+      description: 'Audit one already-isolated failing test',
+      status: 'pending',
+      owner: 'worker-1',
+      created_at: new Date().toISOString(),
+      version: 1,
+      delegation: {
+        mode: 'auto',
+        required_parallel_probe: true,
+        skip_allowed_reason_required: true,
+      },
+    }, null, 2));
+
+    const claimResult = await executeTeamApiOperation('claim-task', {
+      team_name: teamName,
+      task_id: '1',
+      worker: 'worker-1',
+    }, cwd);
+    expect(claimResult.ok).toBe(true);
+    if (!claimResult.ok) return;
+    const claimData = claimResult.data as { ok?: boolean; claimToken?: string };
+    expect(claimData.ok).toBe(true);
+
+    const completed = await executeTeamApiOperation('transition-task-status', {
+      team_name: teamName,
+      task_id: '1',
+      from: 'in_progress',
+      to: 'completed',
+      claim_token: claimData.claimToken,
+      result: [
+        'Verification:',
+        'PASS - focused regression',
+        'Subagent skip reason: task scope collapsed to one isolated assertion; spawning would duplicate serial verification',
+      ].join('\n'),
+    }, cwd);
+
+    expect(completed.ok).toBe(true);
+    if (!completed.ok) return;
+    const completedData = completed.data as { ok?: boolean; task?: { delegation_compliance?: { status?: string } } };
+    expect(completedData.ok).toBe(true);
+    expect(completedData.task?.delegation_compliance?.status).toBe('skipped');
+  });
 });

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -164,6 +164,10 @@ describe('worker-bootstrap', () => {
       expect(overlay).toContain('team api transition-task-status');
       expect(overlay).toContain('team api release-task-claim --input');
       expect(overlay).toContain('claim_token');
+      expect(overlay).toContain('Delegation compliance evidence');
+      expect(overlay).toContain('Subagent spawn evidence:');
+      expect(overlay).toContain('Subagent skip reason:');
+      expect(overlay).toContain('missing_delegation_compliance_evidence');
       expect(overlay).not.toContain('Read your task file at');
     });
 

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -742,6 +742,8 @@ export async function executeTeamApiOperation(
         const from = String(args.from || '').trim();
         const to = String(args.to || '').trim();
         const claimToken = String(args.claim_token || '').trim();
+        const transitionResult = args.result;
+        const transitionError = args.error;
         if (!teamName || !taskId || !from || !to || !claimToken) {
           return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name, task_id, from, to, claim_token are required' } };
         }
@@ -749,7 +751,24 @@ export async function executeTeamApiOperation(
         if (!allowed.has(from) || !allowed.has(to)) {
           return { ok: false, operation, error: { code: 'invalid_input', message: 'from and to must be valid task statuses' } };
         }
-        const result = await teamTransitionTaskStatus(teamName, taskId, from as TeamTaskStatus, to as TeamTaskStatus, claimToken, cwd);
+        if (transitionResult !== undefined && typeof transitionResult !== 'string') {
+          return { ok: false, operation, error: { code: 'invalid_input', message: 'result must be a string when provided' } };
+        }
+        if (transitionError !== undefined && typeof transitionError !== 'string') {
+          return { ok: false, operation, error: { code: 'invalid_input', message: 'error must be a string when provided' } };
+        }
+        const result = await teamTransitionTaskStatus(
+          teamName,
+          taskId,
+          from as TeamTaskStatus,
+          to as TeamTaskStatus,
+          claimToken,
+          cwd,
+          {
+            result: typeof transitionResult === 'string' ? transitionResult : undefined,
+            error: typeof transitionError === 'string' ? transitionError : undefined,
+          },
+        );
         return { ok: true, operation, data: result as unknown as Record<string, unknown> };
       }
       case 'release-task-claim': {

--- a/src/team/state/tasks.ts
+++ b/src/team/state/tasks.ts
@@ -5,6 +5,7 @@ import { readFile, readdir } from 'fs/promises';
 import type { TeamTaskStatus } from '../contracts.js';
 import type {
   TeamTask,
+  TeamTaskDelegationComplianceEvidence,
   TeamTaskV2,
   TaskReadiness,
   ClaimTaskResult,
@@ -101,6 +102,38 @@ export async function claimTask(
   return lock.value;
 }
 
+function extractDelegationComplianceEvidence(
+  task: TeamTaskV2,
+  terminalData: { result?: string; error?: string } | undefined,
+): TeamTaskDelegationComplianceEvidence | null {
+  const plan = task.delegation;
+  if (!plan || plan.mode === 'none') return null;
+  if (plan.mode === 'optional' && plan.required_parallel_probe !== true) return null;
+
+  const result = typeof terminalData?.result === 'string' ? terminalData.result : '';
+  const spawnMatch = result.match(/^\s*Subagent spawn evidence:\s*(.+)$/im);
+  if (spawnMatch?.[1]?.trim()) {
+    const detail = spawnMatch[1].trim();
+    if (!/^none\b|^0\b/i.test(detail)) {
+      return { status: 'spawned', source: 'terminal_result', detail, recorded_at: new Date().toISOString() };
+    }
+  }
+
+  if (plan.skip_allowed_reason_required === true) {
+    const skipMatch = result.match(/^\s*Subagent skip reason:\s*(.+)$/im);
+    if (skipMatch?.[1]?.trim()) {
+      return { status: 'skipped', source: 'terminal_result', detail: skipMatch[1].trim(), recorded_at: new Date().toISOString() };
+    }
+  }
+
+  return null;
+}
+
+function requiresDelegationComplianceEvidence(task: TeamTaskV2): boolean {
+  const plan = task.delegation;
+  return !!plan && (plan.mode === 'auto' || plan.mode === 'required' || plan.required_parallel_probe === true);
+}
+
 interface TransitionDeps extends ClaimTaskDeps {
   canTransitionTaskStatus: (from: TeamTaskStatus, to: TeamTaskStatus) => boolean;
   appendTeamEvent: (
@@ -123,6 +156,7 @@ export async function transitionTaskStatus(
   from: TeamTaskStatus,
   to: TeamTaskStatus,
   claimToken: string,
+  terminalData: { result?: string; error?: string } | undefined,
   deps: TransitionDeps,
 ): Promise<TransitionTaskResult> {
   if (!deps.canTransitionTaskStatus(from, to)) return { ok: false, error: 'invalid_transition' };
@@ -141,10 +175,22 @@ export async function transitionTaskStatus(
     }
     if (new Date(v.claim.leased_until) <= new Date()) return { ok: false as const, error: 'lease_expired' as const };
 
+    const normalizedResult = typeof terminalData?.result === 'string' ? terminalData.result : undefined;
+    const normalizedError = typeof terminalData?.error === 'string' ? terminalData.error : undefined;
+    const delegationCompliance = to === 'completed'
+      ? extractDelegationComplianceEvidence(v, terminalData)
+      : null;
+    if (to === 'completed' && requiresDelegationComplianceEvidence(v) && !delegationCompliance) {
+      return { ok: false as const, error: 'missing_delegation_compliance_evidence' as const };
+    }
+
     const updated: TeamTaskV2 = {
       ...v,
       status: to,
       completed_at: to === 'completed' ? new Date().toISOString() : v.completed_at,
+      result: to === 'completed' ? normalizedResult : undefined,
+      error: to === 'failed' ? normalizedError : undefined,
+      delegation_compliance: to === 'completed' ? delegationCompliance ?? v.delegation_compliance : v.delegation_compliance,
       claim: undefined,
       version: v.version + 1,
     };

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -442,8 +442,9 @@ export async function teamTransitionTaskStatus(
   to: TeamTaskStatus,
   claimToken: string,
   cwd: string,
+  terminalData?: { result?: string; error?: string },
 ): Promise<TransitionTaskResult> {
-  return transitionTaskStatusImpl(taskId, from, to, claimToken, {
+  return transitionTaskStatusImpl(taskId, from, to, claimToken, terminalData, {
     teamName,
     cwd,
     readTask: teamReadTask,

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -162,6 +162,28 @@ export interface TeamTaskV2 extends TeamTask {
   version: number;
 }
 
+export type TeamTaskDelegationMode = 'none' | 'optional' | 'auto' | 'required';
+export type TeamTaskChildModelPolicy = 'standard' | 'fast' | 'inherit' | 'frontier';
+
+export interface TeamTaskDelegationComplianceEvidence {
+  status: 'spawned' | 'skipped';
+  source: 'terminal_result';
+  detail: string;
+  recorded_at: string;
+}
+
+export interface TeamTaskDelegationPlan {
+  mode: TeamTaskDelegationMode;
+  max_parallel_subtasks?: number;
+  required_parallel_probe?: boolean;
+  spawn_before_serial_search_threshold?: number;
+  child_model_policy?: TeamTaskChildModelPolicy;
+  child_model?: string;
+  subtask_candidates?: string[];
+  child_report_format?: 'bullets' | 'json';
+  skip_allowed_reason_required?: boolean;
+}
+
 /** Claim metadata attached to a task */
 export interface TeamTaskClaim {
   owner: string;
@@ -186,6 +208,8 @@ export interface TeamTask {
   claim?: TeamTaskClaim;
   created_at: string;
   completed_at?: string;
+  delegation?: TeamTaskDelegationPlan;
+  delegation_compliance?: TeamTaskDelegationComplianceEvidence;
 }
 
 /** Team leader identity */
@@ -412,7 +436,7 @@ export type ClaimTaskResult =
 /** Result of transitioning a task status */
 export type TransitionTaskResult =
   | { ok: true; task: TeamTaskV2 }
-  | { ok: false; error: 'claim_conflict' | 'invalid_transition' | 'task_not_found' | 'already_terminal' | 'lease_expired' };
+  | { ok: false; error: 'claim_conflict' | 'invalid_transition' | 'task_not_found' | 'already_terminal' | 'lease_expired' | 'missing_delegation_compliance_evidence' };
 
 /** Result of releasing a task claim */
 export type ReleaseTaskClaimResult =

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -191,6 +191,10 @@ Use the CLI API for all task lifecycle operations. Do NOT directly edit task fil
 - Complete task: \`${completeTaskCommand}\`
 - Fail task: \`${failTaskCommand}\`
 - Release claim (rollback): \`${releaseClaimCommand}\`
+- Delegation compliance evidence (required for broad delegated tasks):
+  - Include exactly one completion \`result\` line: \`Subagent spawn evidence: <count, child task names/thread ids, and integrated findings>\`
+  - Or include: \`Subagent skip reason: <why serial execution was safer/sufficient>\`
+  - Completion is rejected with \`missing_delegation_compliance_evidence\` when required evidence is absent.
 
 ## Canonical Team State Root
 - Resolve the team state root in this order: \`OMC_TEAM_STATE_ROOT\` env -> worker identity \`team_state_root\` -> config/manifest \`team_state_root\` -> ${params.cwd}/.omc/state/team/${teamName}.


### PR DESCRIPTION
## Summary
- Backports Theme 1 from oh-my-codex: timestamp-aware planning artifact naming and exact launch-hint disambiguation.
- Adds `src/planning/artifact-names.ts` and wires timestamped PRD/test-spec pairing into planning completion and launch hint selection.
- Updates `omc team` legacy follow-up behavior to reuse approved short team launch hints and fail closed on ambiguous hints.

## Backport Evidence
- Gap confirmed in claudecode: `src/planning/artifacts.ts` selected latest artifacts by first sorted path and used first-match launch regexes.
- `src/cli/team.ts` exists; `src/cli/ralph.ts` does not, so the ralph CLI half from codex was intentionally skipped per plan.

## Verification
- `npm test -- src/planning` passed: 34 tests.
- `src/cli/__tests__/team.test.ts` passed in isolated temp cwd with team env unset: 26 tests.
- `npm run build` passed.
- `npm run lint` passed with existing warnings only.

## Known Test Harness Limitations
- Full `npm test -- src/cli` in the live team pane is blocked by existing environment/harness issues: active team one-team-per-leader guard, and macOS `/private/var` vs `/var` path expectations in self-improve tests.

Backport-of: aca69fe7 d65df196 (oh-my-codex#2047 #2045)
Constraint: Long-diverged fork; manual port, not cherry-pick
Constraint: Atomic single-commit port to preserve bisect signal
Rejected: Cherry-pick from oh-my-codex | identifier renames + missing src/cli/ralph.ts
Confidence: high
Scope-risk: narrow