### PR TITLE
fix(cancel): clear Ralph stop hook artifacts

### DIFF
--- a/dist/lib/__tests__/mode-state-io.test.js
+++ b/dist/lib/__tests__/mode-state-io.test.js
@@ -269,6 +269,23 @@ describe('mode-state-io', () => {
             expect(existsSync(sessionAPath)).toBe(false);
             expect(existsSync(sessionBPath)).toBe(false);
         });
+        it('should remove mode runtime artifacts during session-scoped clear', () => {
+            const stateDir = join(tempDir, '.omc', 'state');
+            const sessionDir = join(stateDir, 'sessions', 'session-runtime-cleanup');
+            mkdirSync(sessionDir, { recursive: true });
+            writeFileSync(join(sessionDir, 'ralph-state.json'), JSON.stringify({ active: true }));
+            writeFileSync(join(sessionDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 2 }));
+            writeFileSync(join(stateDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 2 }));
+            writeFileSync(join(stateDir, 'ralph-last-steer-at'), new Date().toISOString());
+            writeFileSync(join(stateDir, 'ralph-continue-steer.lock'), `${process.pid}`);
+            const result = clearModeStateFile('ralph', tempDir, 'session-runtime-cleanup');
+            expect(result).toBe(true);
+            expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
+            expect(existsSync(join(sessionDir, 'ralph-stop-breaker.json'))).toBe(false);
+            expect(existsSync(join(stateDir, 'ralph-stop-breaker.json'))).toBe(false);
+            expect(existsSync(join(stateDir, 'ralph-last-steer-at'))).toBe(false);
+            expect(existsSync(join(stateDir, 'ralph-continue-steer.lock'))).toBe(false);
+        });
         it('should return true when file does not exist (already absent)', () => {
             const result = clearModeStateFile('ralph', tempDir);
             expect(result).toBe(true);

--- a/dist/lib/mode-state-io.js
+++ b/dist/lib/mode-state-io.js
@@ -56,6 +56,25 @@ function getLegacyStateCandidates(mode, directory) {
         join(getOmcRoot(baseDir), `${normalizedName}.json`),
     ];
 }
+function getRuntimeArtifactCandidates(mode, directory, sessionId) {
+    const baseDir = resolveStateRoot(directory);
+    const stateRoot = join(getOmcRoot(baseDir), 'state');
+    const artifactNames = [
+        `${mode}-stop-breaker.json`,
+        `${mode}-last-steer-at`,
+        `${mode}-continue-steer.lock`,
+    ];
+    const candidateDirs = new Set([stateRoot]);
+    if (sessionId) {
+        candidateDirs.add(join(stateRoot, 'sessions', sessionId));
+    }
+    else {
+        for (const sid of listSessionIds(baseDir)) {
+            candidateDirs.add(join(stateRoot, 'sessions', sid));
+        }
+    }
+    return [...candidateDirs].flatMap((dir) => artifactNames.map((name) => join(dir, name)));
+}
 /**
  * Find session-scoped state files that belong to the requested session.
  *
@@ -178,6 +197,9 @@ export function clearModeStateFile(mode, directory, sessionId) {
     };
     if (sessionId) {
         unlinkIfPresent(resolveFile(mode, directory, sessionId));
+        for (const artifactPath of getRuntimeArtifactCandidates(mode, baseDir, sessionId)) {
+            unlinkIfPresent(artifactPath);
+        }
     }
     else {
         for (const legacyPath of getLegacyStateCandidates(mode, baseDir)) {
@@ -185,6 +207,9 @@ export function clearModeStateFile(mode, directory, sessionId) {
         }
         for (const sid of listSessionIds(baseDir)) {
             unlinkIfPresent(resolveSessionStatePath(mode, sid, baseDir));
+        }
+        for (const artifactPath of getRuntimeArtifactCandidates(mode, baseDir)) {
+            unlinkIfPresent(artifactPath);
         }
     }
     // Ghost-legacy cleanup: if sessionId provided, also check legacy path

--- a/dist/tools/__tests__/state-tools.test.js
+++ b/dist/tools/__tests__/state-tools.test.js
@@ -593,6 +593,28 @@ describe('state-tools', () => {
             expect(result.content[0].text).toContain('recovered session file');
             expect(existsSync(join(strandedDir, 'ralph-state.json'))).toBe(false);
         });
+        it('should clear ralph stop-hook runtime artifacts with session-scoped cancel cleanup', async () => {
+            const sessionId = 'ralph-stop-artifact-session';
+            const stateDir = join(TEST_DIR, '.omc', 'state');
+            const sessionDir = join(stateDir, 'sessions', sessionId);
+            mkdirSync(sessionDir, { recursive: true });
+            writeFileSync(join(sessionDir, 'ralph-state.json'), JSON.stringify({ active: true, session_id: sessionId }));
+            writeFileSync(join(sessionDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 3 }));
+            writeFileSync(join(stateDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 3 }));
+            writeFileSync(join(stateDir, 'ralph-last-steer-at'), new Date().toISOString());
+            writeFileSync(join(stateDir, 'ralph-continue-steer.lock'), `${process.pid}`);
+            const result = await stateClearTool.handler({
+                mode: 'ralph',
+                session_id: sessionId,
+                workingDirectory: TEST_DIR,
+            });
+            expect(result.content[0].text).toContain('runtime artifact');
+            expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
+            expect(existsSync(join(sessionDir, 'ralph-stop-breaker.json'))).toBe(false);
+            expect(existsSync(join(stateDir, 'ralph-stop-breaker.json'))).toBe(false);
+            expect(existsSync(join(stateDir, 'ralph-last-steer-at'))).toBe(false);
+            expect(existsSync(join(stateDir, 'ralph-continue-steer.lock'))).toBe(false);
+        });
         it('should clear the owning session when the current session resumed ralph from a different conversation', async () => {
             const currentSessionId = 'resume-session-b';
             const ownerSessionId = 'resume-session-a';
@@ -613,6 +635,23 @@ describe('state-tools', () => {
             expect(existsSync(join(ownerDir, 'ralph-state.json'))).toBe(false);
             expect(existsSync(join(TEST_DIR, '.omc', 'state', 'sessions', currentSessionId, 'cancel-signal-state.json'))).toBe(true);
             expect(existsSync(join(ownerDir, 'cancel-signal-state.json'))).toBe(true);
+        });
+        it('should clear ralph runtime artifacts during broad cancel cleanup', async () => {
+            const sessionId = 'ralph-broad-runtime-cleanup';
+            const stateDir = join(TEST_DIR, '.omc', 'state');
+            const sessionDir = join(stateDir, 'sessions', sessionId);
+            mkdirSync(sessionDir, { recursive: true });
+            writeFileSync(join(sessionDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 1 }));
+            writeFileSync(join(stateDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 1 }));
+            writeFileSync(join(stateDir, 'ralph-last-steer-at'), new Date().toISOString());
+            const result = await stateClearTool.handler({
+                mode: 'ralph',
+                workingDirectory: TEST_DIR,
+            });
+            expect(result.content[0].text).toContain('Locations cleared: 3');
+            expect(existsSync(join(sessionDir, 'ralph-stop-breaker.json'))).toBe(false);
+            expect(existsSync(join(stateDir, 'ralph-stop-breaker.json'))).toBe(false);
+            expect(existsSync(join(stateDir, 'ralph-last-steer-at'))).toBe(false);
         });
     });
     describe('session-scoped behavior', () => {

--- a/dist/tools/state-tools.js
+++ b/dist/tools/state-tools.js
@@ -168,6 +168,43 @@ function clearSessionOwnedStateCandidates(mode, root, sessionId) {
     }
     return { cleared, hadFailure, paths };
 }
+function getModeRuntimeArtifactNames(mode) {
+    return [
+        `${mode}-stop-breaker.json`,
+        `${mode}-last-steer-at`,
+        `${mode}-continue-steer.lock`,
+    ];
+}
+function clearModeRuntimeArtifacts(mode, root, sessionId) {
+    let cleared = 0;
+    let hadFailure = false;
+    const stateRoot = join(getOmcRoot(root), 'state');
+    const candidateDirs = new Set([stateRoot]);
+    if (sessionId) {
+        candidateDirs.add(join(stateRoot, 'sessions', sessionId));
+    }
+    else {
+        for (const sid of listSessionIds(root)) {
+            candidateDirs.add(join(stateRoot, 'sessions', sid));
+        }
+    }
+    for (const dir of candidateDirs) {
+        for (const artifactName of getModeRuntimeArtifactNames(mode)) {
+            const artifactPath = join(dir, artifactName);
+            if (!existsSync(artifactPath)) {
+                continue;
+            }
+            try {
+                unlinkSync(artifactPath);
+                cleared++;
+            }
+            catch {
+                hadFailure = true;
+            }
+        }
+    }
+    return { cleared, hadFailure };
+}
 function writeSessionCancelSignal(root, sessionId, mode) {
     const now = Date.now();
     const cancelSignalPath = resolveSessionStatePath('cancel-signal', sessionId, root);
@@ -452,6 +489,7 @@ export const stateClearTool = {
                 for (const teamStatePath of findSessionOwnedStateFiles('team', sessionId, root)) {
                     collectTeamNamesForCleanup(teamStatePath);
                 }
+                const runtimeCleanup = clearModeRuntimeArtifacts(mode, root, sessionId);
                 writeSessionCancelSignal(root, sessionId, mode);
                 if (MODE_CONFIGS[mode]) {
                     const success = clearModeState(mode, root, sessionId);
@@ -469,6 +507,9 @@ export const stateClearTool = {
                                 }
                             }
                             writeSessionCancelSignal(root, ownerSessionId, mode);
+                            const ownerRuntimeCleanup = clearModeRuntimeArtifacts(mode, root, ownerSessionId);
+                            runtimeCleanup.cleared += ownerRuntimeCleanup.cleared;
+                            runtimeCleanup.hadFailure ||= ownerRuntimeCleanup.hadFailure;
                             clearModeState(mode, root, ownerSessionId);
                             ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root, ownerSessionId);
                             ownerLegacyCleanup = clearLegacyStateCandidates(mode, root, ownerSessionId);
@@ -480,6 +521,9 @@ export const stateClearTool = {
                     }
                     if (sessionCleanup.cleared > 0) {
                         ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? '' : 's'}`);
+                    }
+                    if (runtimeCleanup.cleared > 0) {
+                        ghostNoteParts.push(`removed ${runtimeCleanup.cleared} runtime artifact${runtimeCleanup.cleared === 1 ? '' : 's'}`);
                     }
                     if (ownerSessionId) {
                         ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
@@ -502,7 +546,8 @@ export const stateClearTool = {
                         !legacyCleanup.hadFailure &&
                         !sessionCleanup.hadFailure &&
                         !ownerSessionCleanup.hadFailure &&
-                        !ownerLegacyCleanup.hadFailure) {
+                        !ownerLegacyCleanup.hadFailure &&
+                        !runtimeCleanup.hadFailure) {
                         return {
                             content: [{
                                     type: 'text',
@@ -534,6 +579,9 @@ export const stateClearTool = {
                             }
                         }
                         writeSessionCancelSignal(root, ownerSessionId, mode);
+                        const ownerRuntimeCleanup = clearModeRuntimeArtifacts(mode, root, ownerSessionId);
+                        runtimeCleanup.cleared += ownerRuntimeCleanup.cleared;
+                        runtimeCleanup.hadFailure ||= ownerRuntimeCleanup.hadFailure;
                         ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root, ownerSessionId);
                         ownerLegacyCleanup = clearLegacyStateCandidates(mode, root, ownerSessionId);
                     }
@@ -544,6 +592,9 @@ export const stateClearTool = {
                 }
                 if (sessionCleanup.cleared > 0) {
                     ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? '' : 's'}`);
+                }
+                if (runtimeCleanup.cleared > 0) {
+                    ghostNoteParts.push(`removed ${runtimeCleanup.cleared} runtime artifact${runtimeCleanup.cleared === 1 ? '' : 's'}`);
                 }
                 if (ownerSessionId) {
                     ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
@@ -565,7 +616,7 @@ export const stateClearTool = {
                 return {
                     content: [{
                             type: 'text',
-                            text: `${legacyCleanup.hadFailure || sessionCleanup.hadFailure || ownerSessionCleanup.hadFailure || ownerLegacyCleanup.hadFailure ? 'Warning: Some files could not be removed' : 'Successfully cleared state'} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
+                            text: `${legacyCleanup.hadFailure || sessionCleanup.hadFailure || ownerSessionCleanup.hadFailure || ownerLegacyCleanup.hadFailure || runtimeCleanup.hadFailure ? 'Warning: Some files could not be removed' : 'Successfully cleared state'} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
                         }]
                 };
             }
@@ -597,6 +648,7 @@ export const stateClearTool = {
                     catch { /* best-effort */ }
                 }
             }
+            const runtimeCleanup = clearModeRuntimeArtifacts(mode, root);
             let clearedCount = 0;
             const errors = [];
             if (mode === 'team') {
@@ -618,6 +670,10 @@ export const stateClearTool = {
             clearedCount += extraLegacyCleanup.cleared;
             if (extraLegacyCleanup.hadFailure) {
                 errors.push('legacy path');
+            }
+            clearedCount += runtimeCleanup.cleared;
+            if (runtimeCleanup.hadFailure) {
+                errors.push('runtime artifacts');
             }
             // Clear all session-scoped state files
             const sessionIds = listSessionIds(root);

--- a/src/lib/__tests__/mode-state-io.test.ts
+++ b/src/lib/__tests__/mode-state-io.test.ts
@@ -370,6 +370,26 @@ describe('mode-state-io', () => {
       expect(existsSync(sessionBPath)).toBe(false);
     });
 
+    it('should remove mode runtime artifacts during session-scoped clear', () => {
+      const stateDir = join(tempDir, '.omc', 'state');
+      const sessionDir = join(stateDir, 'sessions', 'session-runtime-cleanup');
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(join(sessionDir, 'ralph-state.json'), JSON.stringify({ active: true }));
+      writeFileSync(join(sessionDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 2 }));
+      writeFileSync(join(stateDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 2 }));
+      writeFileSync(join(stateDir, 'ralph-last-steer-at'), new Date().toISOString());
+      writeFileSync(join(stateDir, 'ralph-continue-steer.lock'), `${process.pid}`);
+
+      const result = clearModeStateFile('ralph', tempDir, 'session-runtime-cleanup');
+
+      expect(result).toBe(true);
+      expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
+      expect(existsSync(join(sessionDir, 'ralph-stop-breaker.json'))).toBe(false);
+      expect(existsSync(join(stateDir, 'ralph-stop-breaker.json'))).toBe(false);
+      expect(existsSync(join(stateDir, 'ralph-last-steer-at'))).toBe(false);
+      expect(existsSync(join(stateDir, 'ralph-continue-steer.lock'))).toBe(false);
+    });
+
     it('should return true when file does not exist (already absent)', () => {
       const result = clearModeStateFile('ralph', tempDir);
       expect(result).toBe(true);

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -78,6 +78,27 @@ function getLegacyStateCandidates(mode: string, directory?: string): string[] {
   ];
 }
 
+function getRuntimeArtifactCandidates(mode: string, directory?: string, sessionId?: string): string[] {
+  const baseDir = resolveStateRoot(directory);
+  const stateRoot = join(getOmcRoot(baseDir), 'state');
+  const artifactNames = [
+    `${mode}-stop-breaker.json`,
+    `${mode}-last-steer-at`,
+    `${mode}-continue-steer.lock`,
+  ];
+  const candidateDirs = new Set<string>([stateRoot]);
+
+  if (sessionId) {
+    candidateDirs.add(join(stateRoot, 'sessions', sessionId));
+  } else {
+    for (const sid of listSessionIds(baseDir)) {
+      candidateDirs.add(join(stateRoot, 'sessions', sid));
+    }
+  }
+
+  return [...candidateDirs].flatMap((dir) => artifactNames.map((name) => join(dir, name)));
+}
+
 /**
  * Find session-scoped state files that belong to the requested session.
  *
@@ -221,6 +242,9 @@ export function clearModeStateFile(
 
   if (sessionId) {
     unlinkIfPresent(resolveFile(mode, directory, sessionId));
+    for (const artifactPath of getRuntimeArtifactCandidates(mode, baseDir, sessionId)) {
+      unlinkIfPresent(artifactPath);
+    }
   } else {
     for (const legacyPath of getLegacyStateCandidates(mode, baseDir)) {
       unlinkIfPresent(legacyPath);
@@ -228,6 +252,9 @@ export function clearModeStateFile(
 
     for (const sid of listSessionIds(baseDir)) {
       unlinkIfPresent(resolveSessionStatePath(mode, sid, baseDir));
+    }
+    for (const artifactPath of getRuntimeArtifactCandidates(mode, baseDir)) {
+      unlinkIfPresent(artifactPath);
     }
   }
 

--- a/src/tools/__tests__/state-tools.test.ts
+++ b/src/tools/__tests__/state-tools.test.ts
@@ -750,6 +750,34 @@ describe('state-tools', () => {
       expect(existsSync(join(strandedDir, 'ralph-state.json'))).toBe(false);
     });
 
+    it('should clear ralph stop-hook runtime artifacts with session-scoped cancel cleanup', async () => {
+      const sessionId = 'ralph-stop-artifact-session';
+      const stateDir = join(TEST_DIR, '.omc', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, 'ralph-state.json'),
+        JSON.stringify({ active: true, session_id: sessionId }),
+      );
+      writeFileSync(join(sessionDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 3 }));
+      writeFileSync(join(stateDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 3 }));
+      writeFileSync(join(stateDir, 'ralph-last-steer-at'), new Date().toISOString());
+      writeFileSync(join(stateDir, 'ralph-continue-steer.lock'), `${process.pid}`);
+
+      const result = await stateClearTool.handler({
+        mode: 'ralph',
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain('runtime artifact');
+      expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
+      expect(existsSync(join(sessionDir, 'ralph-stop-breaker.json'))).toBe(false);
+      expect(existsSync(join(stateDir, 'ralph-stop-breaker.json'))).toBe(false);
+      expect(existsSync(join(stateDir, 'ralph-last-steer-at'))).toBe(false);
+      expect(existsSync(join(stateDir, 'ralph-continue-steer.lock'))).toBe(false);
+    });
+
     it('should clear the owning session when the current session resumed ralph from a different conversation', async () => {
       const currentSessionId = 'resume-session-b';
       const ownerSessionId = 'resume-session-a';
@@ -775,6 +803,26 @@ describe('state-tools', () => {
       expect(existsSync(join(ownerDir, 'ralph-state.json'))).toBe(false);
       expect(existsSync(join(TEST_DIR, '.omc', 'state', 'sessions', currentSessionId, 'cancel-signal-state.json'))).toBe(true);
       expect(existsSync(join(ownerDir, 'cancel-signal-state.json'))).toBe(true);
+    });
+
+    it('should clear ralph runtime artifacts during broad cancel cleanup', async () => {
+      const sessionId = 'ralph-broad-runtime-cleanup';
+      const stateDir = join(TEST_DIR, '.omc', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(join(sessionDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 1 }));
+      writeFileSync(join(stateDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 1 }));
+      writeFileSync(join(stateDir, 'ralph-last-steer-at'), new Date().toISOString());
+
+      const result = await stateClearTool.handler({
+        mode: 'ralph',
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain('Locations cleared: 3');
+      expect(existsSync(join(sessionDir, 'ralph-stop-breaker.json'))).toBe(false);
+      expect(existsSync(join(stateDir, 'ralph-stop-breaker.json'))).toBe(false);
+      expect(existsSync(join(stateDir, 'ralph-last-steer-at'))).toBe(false);
     });
   });
 

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -213,6 +213,51 @@ function clearSessionOwnedStateCandidates(
   return { cleared, hadFailure, paths };
 }
 
+function getModeRuntimeArtifactNames(mode: StateToolMode): string[] {
+  return [
+    `${mode}-stop-breaker.json`,
+    `${mode}-last-steer-at`,
+    `${mode}-continue-steer.lock`,
+  ];
+}
+
+function clearModeRuntimeArtifacts(
+  mode: StateToolMode,
+  root: string,
+  sessionId?: string,
+): { cleared: number; hadFailure: boolean } {
+  let cleared = 0;
+  let hadFailure = false;
+  const stateRoot = join(getOmcRoot(root), 'state');
+  const candidateDirs = new Set<string>([stateRoot]);
+
+  if (sessionId) {
+    candidateDirs.add(join(stateRoot, 'sessions', sessionId));
+  } else {
+    for (const sid of listSessionIds(root)) {
+      candidateDirs.add(join(stateRoot, 'sessions', sid));
+    }
+  }
+
+  for (const dir of candidateDirs) {
+    for (const artifactName of getModeRuntimeArtifactNames(mode)) {
+      const artifactPath = join(dir, artifactName);
+      if (!existsSync(artifactPath)) {
+        continue;
+      }
+
+      try {
+        unlinkSync(artifactPath);
+        cleared++;
+      } catch {
+        hadFailure = true;
+      }
+    }
+  }
+
+  return { cleared, hadFailure };
+}
+
 function writeSessionCancelSignal(
   root: string,
   sessionId: string,
@@ -568,6 +613,7 @@ export const stateClearTool: ToolDefinition<{
         for (const teamStatePath of findSessionOwnedStateFiles('team', sessionId, root)) {
           collectTeamNamesForCleanup(teamStatePath);
         }
+        const runtimeCleanup = clearModeRuntimeArtifacts(mode, root, sessionId);
         writeSessionCancelSignal(root, sessionId, mode);
 
         if (MODE_CONFIGS[mode as ExecutionMode]) {
@@ -587,6 +633,9 @@ export const stateClearTool: ToolDefinition<{
                 }
               }
               writeSessionCancelSignal(root, ownerSessionId, mode);
+              const ownerRuntimeCleanup = clearModeRuntimeArtifacts(mode, root, ownerSessionId);
+              runtimeCleanup.cleared += ownerRuntimeCleanup.cleared;
+              runtimeCleanup.hadFailure ||= ownerRuntimeCleanup.hadFailure;
               clearModeState(mode as ExecutionMode, root, ownerSessionId);
               ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root, ownerSessionId);
               ownerLegacyCleanup = clearLegacyStateCandidates(mode, root, ownerSessionId);
@@ -599,6 +648,9 @@ export const stateClearTool: ToolDefinition<{
           }
           if (sessionCleanup.cleared > 0) {
             ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? '' : 's'}`);
+          }
+          if (runtimeCleanup.cleared > 0) {
+            ghostNoteParts.push(`removed ${runtimeCleanup.cleared} runtime artifact${runtimeCleanup.cleared === 1 ? '' : 's'}`);
           }
           if (ownerSessionId) {
             ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
@@ -619,7 +671,8 @@ export const stateClearTool: ToolDefinition<{
             !legacyCleanup.hadFailure &&
             !sessionCleanup.hadFailure &&
             !ownerSessionCleanup.hadFailure &&
-            !ownerLegacyCleanup.hadFailure
+            !ownerLegacyCleanup.hadFailure &&
+            !runtimeCleanup.hadFailure
           ) {
             return {
               content: [{
@@ -653,6 +706,9 @@ export const stateClearTool: ToolDefinition<{
               }
             }
             writeSessionCancelSignal(root, ownerSessionId, mode);
+            const ownerRuntimeCleanup = clearModeRuntimeArtifacts(mode, root, ownerSessionId);
+            runtimeCleanup.cleared += ownerRuntimeCleanup.cleared;
+            runtimeCleanup.hadFailure ||= ownerRuntimeCleanup.hadFailure;
             ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root, ownerSessionId);
             ownerLegacyCleanup = clearLegacyStateCandidates(mode, root, ownerSessionId);
           }
@@ -664,6 +720,9 @@ export const stateClearTool: ToolDefinition<{
         }
         if (sessionCleanup.cleared > 0) {
           ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? '' : 's'}`);
+        }
+        if (runtimeCleanup.cleared > 0) {
+          ghostNoteParts.push(`removed ${runtimeCleanup.cleared} runtime artifact${runtimeCleanup.cleared === 1 ? '' : 's'}`);
         }
         if (ownerSessionId) {
           ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
@@ -682,7 +741,7 @@ export const stateClearTool: ToolDefinition<{
         return {
           content: [{
             type: 'text' as const,
-            text: `${legacyCleanup.hadFailure || sessionCleanup.hadFailure || ownerSessionCleanup.hadFailure || ownerLegacyCleanup.hadFailure ? 'Warning: Some files could not be removed' : 'Successfully cleared state'} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
+            text: `${legacyCleanup.hadFailure || sessionCleanup.hadFailure || ownerSessionCleanup.hadFailure || ownerLegacyCleanup.hadFailure || runtimeCleanup.hadFailure ? 'Warning: Some files could not be removed' : 'Successfully cleared state'} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
           }]
         };
       }
@@ -711,6 +770,7 @@ export const stateClearTool: ToolDefinition<{
           } catch { /* best-effort */ }
         }
       }
+      const runtimeCleanup = clearModeRuntimeArtifacts(mode, root);
       let clearedCount = 0;
       const errors: string[] = [];
       if (mode === 'team') {
@@ -733,6 +793,10 @@ export const stateClearTool: ToolDefinition<{
       clearedCount += extraLegacyCleanup.cleared;
       if (extraLegacyCleanup.hadFailure) {
         errors.push('legacy path');
+      }
+      clearedCount += runtimeCleanup.cleared;
+      if (runtimeCleanup.hadFailure) {
+        errors.push('runtime artifacts');
       }
 
       // Clear all session-scoped state files


### PR DESCRIPTION
## Summary
- clear Ralph stop-hook runtime artifacts during `state_clear` / cancel cleanup
- cover session-scoped and broad cleanup of `ralph-stop-breaker.json`, `ralph-last-steer-at`, and `ralph-continue-steer.lock`
- keep generated output limited to direct dist counterparts for touched modules

## Verification
- `npm test -- --run src/tools/__tests__/state-tools.test.ts src/lib/__tests__/mode-state-io.test.ts` — 77 passed
- `npm run lint` — 0 errors, existing warnings only
- `npm run build` — passed

Fixes #2896

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
