### PR TITLE
fix(skills): discover namespaced agent skills

### DIFF
--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -247,6 +247,55 @@ Compatibility body`
     expect(result.replacementText).toContain('`templates/`');
   });
 
+  it('does not expose nested SKILL.md files under flat .agents skills as namespaced commands', async () => {
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'flat', 'examples'), { recursive: true });
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'flat', 'SKILL.md'),
+      `---
+name: flat
+description: Flat compatibility skill
+---
+
+Flat body`
+    );
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'flat', 'examples', 'SKILL.md'),
+      `---
+name: examples
+description: Nested examples instructions
+---
+
+Examples body`
+    );
+
+    const { findCommand, executeSlashCommand, listAvailableCommandsWithOptions } = await loadExecutor();
+
+    expect(findCommand('flat')?.metadata.description).toBe('Flat compatibility skill');
+    expect(findCommand('flat:examples')).toBeNull();
+    expect(listAvailableCommandsWithOptions({ includeAliases: true })
+      .some((command) => command.name.startsWith('flat:'))).toBe(false);
+
+    const nestedResult = executeSlashCommand({
+      command: 'flat:examples',
+      args: '',
+      raw: '/flat:examples',
+    });
+
+    expect(nestedResult.success).toBe(false);
+    expect(nestedResult.error).toContain('Command "/flat:examples" not found');
+
+    const result = executeSlashCommand({
+      command: 'flat',
+      args: '',
+      raw: '/flat',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('Flat body');
+    expect(result.replacementText).toContain('## Skill Resources');
+    expect(result.replacementText).toContain('`examples/`');
+  });
+
   it('discovers namespaced project-local compatibility skills from .agents/skills/<namespace>/<skill>/SKILL.md', async () => {
     mkdirSync(join(tempProjectDir, '.agents', 'skills', 'vendor', 'deploy', 'templates'), { recursive: true });
     writeFileSync(

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -18,6 +18,11 @@ async function loadExecutor() {
   return import('../hooks/auto-slash-command/executor.js');
 }
 
+async function loadDetector() {
+  vi.resetModules();
+  return import('../hooks/auto-slash-command/detector.js');
+}
+
 describe('auto slash aliases + skill guidance', () => {
   beforeEach(() => {
     tempConfigDir = join(tmpdir(), `omc-auto-slash-config-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -240,6 +245,113 @@ Compatibility body`
     expect(result.replacementText).toContain('## Skill Resources');
     expect(result.replacementText).toContain('.agents/skills/compat-skill');
     expect(result.replacementText).toContain('`templates/`');
+  });
+
+  it('discovers namespaced project-local compatibility skills from .agents/skills/<namespace>/<skill>/SKILL.md', async () => {
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'vendor', 'deploy', 'templates'), { recursive: true });
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'vendor', 'deploy', 'SKILL.md'),
+      `---
+description: Namespaced deploy skill
+aliases: [ship]
+---
+
+Deploy body`
+    );
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'vendor', 'deploy', 'templates', 'plan.txt'),
+      'plan'
+    );
+
+    const { parseSlashCommand } = await loadDetector();
+    const { findCommand, executeSlashCommand, listAvailableCommandsWithOptions } = await loadExecutor();
+
+    expect(parseSlashCommand('/vendor:deploy production')?.command).toBe('vendor:deploy');
+    expect(findCommand('vendor:deploy')?.scope).toBe('skill');
+    expect(findCommand('vendor:ship')?.metadata.aliasOf).toBe('vendor:deploy');
+    expect(listAvailableCommandsWithOptions({ includeAliases: true }).some((command) => command.name === 'vendor:deploy')).toBe(true);
+
+    const result = executeSlashCommand({
+      command: 'vendor:deploy',
+      args: 'production',
+      raw: '/vendor:deploy production',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('<command-name>/vendor:deploy</command-name>');
+    expect(result.replacementText).toContain('Namespaced deploy skill');
+    expect(result.replacementText).toContain('Deploy body');
+    expect(result.replacementText).toContain('.agents/skills/vendor/deploy');
+  });
+
+  it('keeps namespaced skill names scoped when frontmatter names collide with native slash commands', async () => {
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'vendor', 'review'), { recursive: true });
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'vendor', 'review', 'SKILL.md'),
+      `---
+name: review
+description: Scoped review skill
+aliases: [plan]
+---
+
+Review body`
+    );
+
+    const { findCommand } = await loadExecutor();
+
+    expect(findCommand('vendor:review')?.metadata.description).toBe('Scoped review skill');
+    expect(findCommand('vendor:plan')?.metadata.aliasOf).toBe('vendor:review');
+    expect(findCommand('vendor:omc-review')).toBeNull();
+    expect(findCommand('omc-review')).toBeNull();
+  });
+
+  it('ignores invalid deeper nested skills and de-duplicates colliding namespaced commands', async () => {
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'vendor', 'alpha'), { recursive: true });
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'vendor', 'beta'), { recursive: true });
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'vendor', 'alpha', 'nested'), { recursive: true });
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'vendor', 'alpha', 'SKILL.md'),
+      `---
+name: shared
+description: First shared skill
+---
+
+Alpha body`
+    );
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'vendor', 'beta', 'SKILL.md'),
+      `---
+name: shared
+description: Second shared skill
+---
+
+Beta body`
+    );
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'vendor', 'alpha', 'nested', 'SKILL.md'),
+      `---
+description: Too deep
+---
+
+Nested body`
+    );
+
+    const { findCommand, executeSlashCommand, listAvailableCommandsWithOptions } = await loadExecutor();
+
+    expect(findCommand('vendor:nested')).toBeNull();
+    expect(findCommand('vendor:shared')?.metadata.description).toBe('First shared skill');
+    expect(listAvailableCommandsWithOptions({ includeAliases: true })
+      .filter((command) => command.name === 'vendor:shared')).toHaveLength(1);
+
+    const result = executeSlashCommand({
+      command: 'vendor:shared',
+      args: '',
+      raw: '/vendor:shared',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('Alpha body');
+    expect(result.replacementText).not.toContain('Beta body');
   });
 
   it('renders deterministic autoresearch bridge guidance for deep-interview autoresearch mode', async () => {

--- a/src/hooks/auto-slash-command/constants.ts
+++ b/src/hooks/auto-slash-command/constants.ts
@@ -13,7 +13,7 @@ export const AUTO_SLASH_COMMAND_TAG_OPEN = '<auto-slash-command>';
 export const AUTO_SLASH_COMMAND_TAG_CLOSE = '</auto-slash-command>';
 
 /** Pattern to detect slash commands at start of message */
-export const SLASH_COMMAND_PATTERN = /^\/([a-zA-Z][\w-]*)\s*(.*)/;
+export const SLASH_COMMAND_PATTERN = /^\/([a-zA-Z][\w-]*(?::[a-zA-Z][\w-]*)?)\s*(.*)/;
 
 /**
  * Commands that should NOT be auto-expanded

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -18,7 +18,7 @@ import type {
 } from './types.js';
 import { resolveLiveData } from './live-data.js';
 import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
-import { formatOmcCliInvocation, rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
+import { rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from '../../features/builtin-skills/runtime-guidance.js';
@@ -60,6 +60,20 @@ function getFrontmatterString(
   if (!value) return undefined;
   const normalized = stripOptionalQuotes(value);
   return normalized.length > 0 ? normalized : undefined;
+}
+
+interface SkillFileCandidate {
+  namespace?: string;
+  skillName: string;
+  skillPath: string;
+}
+
+function toSkillCommandName(name: string, namespace?: string): string {
+  const normalized = name.trim();
+  const namespacedName = namespace && !normalized.includes(':')
+    ? `${namespace}:${normalized}`
+    : normalized;
+  return toSafeSkillName(namespacedName);
 }
 
 /**
@@ -116,30 +130,66 @@ function discoverCommandsFromDir(
   return commands;
 }
 
-function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
+function discoverSkillsFromDir(
+  skillsDir: string,
+  options?: { includeNamespaced?: boolean },
+): CommandInfo[] {
   if (!existsSync(skillsDir)) {
     return [];
   }
 
   const skillCommands: CommandInfo[] = [];
+  const includeNamespaced = options?.includeNamespaced ?? false;
 
   try {
-    const skillDirs = readdirSync(skillsDir, { withFileTypes: true });
+    const skillDirs = readdirSync(skillsDir, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+    const skillFiles: SkillFileCandidate[] = [];
+
     for (const dir of skillDirs) {
       if (!dir.isDirectory()) continue;
 
       const skillPath = join(skillsDir, dir.name, 'SKILL.md');
-      if (!existsSync(skillPath)) continue;
+      if (existsSync(skillPath)) {
+        skillFiles.push({
+          skillName: dir.name,
+          skillPath,
+        });
+      }
 
+      if (includeNamespaced) {
+        try {
+          const namespacedSkillDirs = readdirSync(join(skillsDir, dir.name), { withFileTypes: true })
+            .sort((a, b) => a.name.localeCompare(b.name));
+
+          for (const skillDir of namespacedSkillDirs) {
+            if (!skillDir.isDirectory()) continue;
+
+            const namespacedSkillPath = join(skillsDir, dir.name, skillDir.name, 'SKILL.md');
+            if (!existsSync(namespacedSkillPath)) continue;
+
+            skillFiles.push({
+              namespace: dir.name,
+              skillName: skillDir.name,
+              skillPath: namespacedSkillPath,
+            });
+          }
+        } catch {
+          continue;
+        }
+      }
+    }
+
+    for (const skillFile of skillFiles) {
       try {
-        const content = readFileSync(skillPath, 'utf-8');
+        const content = readFileSync(skillFile.skillPath, 'utf-8');
         const { metadata: fm, body } = parseFrontmatter(content);
 
-        const rawName = getFrontmatterString(fm, 'name') || dir.name;
-        const canonicalName = toSafeSkillName(rawName);
+        const rawName = getFrontmatterString(fm, 'name') || skillFile.skillName;
+        const canonicalName = toSkillCommandName(rawName, skillFile.namespace);
         const aliases = Array.from(new Set(
           parseFrontmatterAliases(fm.aliases)
-            .map((alias: string) => toSafeSkillName(alias))
+            .map((alias: string) => toSkillCommandName(alias, skillFile.namespace))
             .filter((alias: string) => alias.toLowerCase() !== canonicalName.toLowerCase())
         ));
         const commandNames = [canonicalName, ...aliases];
@@ -168,7 +218,7 @@ function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
 
           skillCommands.push({
             name: commandName,
-            path: skillPath,
+            path: skillFile.skillPath,
             metadata,
             content: body,
             scope: 'skill',
@@ -198,7 +248,7 @@ export function discoverAllCommands(): CommandInfo[] {
   const userCommands = discoverCommandsFromDir(userCommandsDir, 'user');
   const projectCommands = discoverCommandsFromDir(projectCommandsDir, 'project');
   const projectOmcSkills = discoverSkillsFromDir(projectOmcSkillsDir);
-  const projectAgentSkills = discoverSkillsFromDir(projectAgentSkillsDir);
+  const projectAgentSkills = discoverSkillsFromDir(projectAgentSkillsDir, { includeNamespaced: true });
   const userSkills = discoverSkillsFromDir(userSkillsDir);
   const builtinSkills = discoverSkillsFromDir(getSkillsDir());
 

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -150,14 +150,17 @@ function discoverSkillsFromDir(
       if (!dir.isDirectory()) continue;
 
       const skillPath = join(skillsDir, dir.name, 'SKILL.md');
-      if (existsSync(skillPath)) {
+      const hasFlatSkill = existsSync(skillPath);
+      if (hasFlatSkill) {
         skillFiles.push({
           skillName: dir.name,
           skillPath,
         });
       }
 
-      if (includeNamespaced) {
+      // A top-level directory that contains SKILL.md is a flat skill. Its
+      // child directories are resources for that skill, not namespace members.
+      if (includeNamespaced && !hasFlatSkill) {
         try {
           const namespacedSkillDirs = readdirSync(join(skillsDir, dir.name), { withFileTypes: true })
             .sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- Support `.agents/skills/<namespace>/<skillName>/SKILL.md` discovery for project compatibility skills.
- Register namespaced skills and aliases as `namespace:skillName` slash commands while preserving existing flat `.agents/skills/<skill>/SKILL.md` behavior.
- Add regression coverage for flat + namespaced discovery, scoped native-name collisions, duplicate namespaced command de-duping, and invalid deeper nesting.

## Verification
- `npm test -- --run src/__tests__/auto-slash-aliases.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/hooks/auto-slash-command/executor.ts src/hooks/auto-slash-command/constants.ts src/__tests__/auto-slash-aliases.test.ts`
- `npm run build`

Fixes #2900

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
