### PR TITLE
Fix autoresearch supervisor discarding the first passing candidate

### DIFF
--- a/src/autoresearch/__tests__/decide-outcome.test.ts
+++ b/src/autoresearch/__tests__/decide-outcome.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  AutoresearchCandidateArtifact,
+  AutoresearchEvaluationRecord,
+  AutoresearchRunManifest,
+} from '../runtime.js';
+import { decideAutoresearchOutcome } from '../runtime.js';
+
+type ManifestSlice = Pick<AutoresearchRunManifest, 'keep_policy' | 'last_kept_score'>;
+
+function makeCandidate(
+  overrides: Partial<AutoresearchCandidateArtifact> = {},
+): AutoresearchCandidateArtifact {
+  return {
+    status: 'candidate',
+    candidate_commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    base_commit: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    description: 'fixture candidate',
+    notes: [],
+    created_at: '2026-04-30T22:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeEvaluation(
+  overrides: Partial<AutoresearchEvaluationRecord> = {},
+): AutoresearchEvaluationRecord {
+  return {
+    command: 'node scripts/eval.js',
+    ran_at: '2026-04-30T22:01:00Z',
+    status: 'pass',
+    pass: true,
+    score: 0.42,
+    ...overrides,
+  };
+}
+
+describe('decideAutoresearchOutcome (score_improvement bootstrap)', () => {
+  it('keeps the first numeric-scored pass when last_kept_score is null', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: null };
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), makeEvaluation({ score: 0.398459 }));
+    expect(decision.decision).toBe('keep');
+    expect(decision.keep).toBe(true);
+    expect(decision.decisionReason).toMatch(/bootstrap/i);
+    expect(decision.evaluator?.score).toBe(0.398459);
+  });
+
+  it('still discards an ambiguous pass that has no numeric score', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: null };
+    const evaluation = makeEvaluation();
+    delete evaluation.score;
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), evaluation);
+    expect(decision.decision).toBe('ambiguous');
+    expect(decision.keep).toBe(false);
+    expect(decision.decisionReason).toMatch(/numeric score/i);
+  });
+
+  it('keeps a higher-scoring pass once a comparable baseline is set', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: 0.36 };
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), makeEvaluation({ score: 0.40 }));
+    expect(decision.decision).toBe('keep');
+    expect(decision.keep).toBe(true);
+    expect(decision.decisionReason).toMatch(/score improved/i);
+  });
+
+  it('discards a pass that does not improve the kept score', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: 0.50 };
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), makeEvaluation({ score: 0.40 }));
+    expect(decision.decision).toBe('discard');
+    expect(decision.keep).toBe(false);
+  });
+
+  it('discards an evaluator failure regardless of bootstrap state', () => {
+    const manifest: ManifestSlice = { keep_policy: 'score_improvement', last_kept_score: null };
+    const decision = decideAutoresearchOutcome(
+      manifest,
+      makeCandidate(),
+      makeEvaluation({ status: 'fail', pass: false, score: 0.10 }),
+    );
+    expect(decision.decision).toBe('discard');
+    expect(decision.keep).toBe(false);
+  });
+
+  it('still accepts pass_only policy without touching the bootstrap branch', () => {
+    const manifest: ManifestSlice = { keep_policy: 'pass_only', last_kept_score: null };
+    const decision = decideAutoresearchOutcome(manifest, makeCandidate(), makeEvaluation());
+    expect(decision.decision).toBe('keep');
+    expect(decision.keep).toBe(true);
+    expect(decision.decisionReason).toMatch(/pass_only/i);
+  });
+});

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -722,12 +722,26 @@ export function decideAutoresearchOutcome(
     };
   }
   if (!comparableScore(manifest.last_kept_score, evaluation.score)) {
+    // Bootstrap case: there is no prior comparable score to improve over (first
+    // pass in the run, or the first pass after a fail-only stretch left
+    // last_kept_score=null). The candidate's pass IS the new comparison anchor.
+    // Discarding it would lose the only validated signal the loop has produced
+    // and pin score_improvement to null forever.
+    if (typeof evaluation.score === 'number') {
+      return {
+        decision: 'keep',
+        decisionReason: '[bootstrap] first comparable score in score_improvement run',
+        keep: true,
+        evaluator: evaluation,
+        notes: ['candidate kept because no prior comparable score existed; this becomes the new baseline'],
+      };
+    }
     return {
       decision: 'ambiguous',
-      decisionReason: 'evaluator pass without comparable score',
+      decisionReason: 'evaluator pass without numeric score',
       keep: false,
       evaluator: evaluation,
-      notes: ['candidate discarded because score_improvement policy requires comparable numeric scores'],
+      notes: ['candidate discarded because score_improvement policy requires a numeric score'],
     };
   }
   if ((evaluation.score as number) > (manifest.last_kept_score as number)) {


### PR DESCRIPTION
Resubmission of #2884 against \`dev\` per maintainer's bot rule. Same focused fix and tests, rebased onto current \`dev\` HEAD.

## Problem

\`decideAutoresearchOutcome\` (\`src/autoresearch/runtime.ts:724\`) discards the first numeric-scored passing candidate when \`keep_policy: 'score_improvement'\` and \`last_kept_score\` is \`null\` (initial state, or after a fail-only stretch). Because \`comparableScore(null, anyNumber)\` returns \`false\`, every bootstrap pass falls through the \"evaluator pass without numeric score\" ambiguous-discard branch — even though the score is numeric. The supervisor loop then never sets a baseline, so \`last_kept_score\` stays \`null\` forever and no candidate is ever kept.

Empirically: this caused our v6.1 autoresearch run to abort at iter-3 after iter-2 had produced a statistically-significant pass (z=+1.87 vs noise floor) that the supervisor silently discarded.

## Fix

Bootstrap the comparison anchor: when \`last_kept_score\` is non-comparable AND the candidate's score IS a number, keep the candidate as the new baseline. Existing ambiguous-discard semantics preserved for genuinely non-numeric scores.

## Tests

Added \`src/autoresearch/__tests__/decide-outcome.test.ts\` (6 unit tests):
1. Keeps first numeric-scored pass when \`last_kept_score\` is null (the bug)
2. Still discards an ambiguous pass that has no numeric score
3. Keeps a higher-scoring pass once a baseline is set (regression guard)
4. Discards a pass that does not improve the kept score
5. Discards an evaluator failure regardless of bootstrap state
6. \`pass_only\` policy unaffected

\`npx vitest run\` and \`tsc --noEmit\` both green.

## Out of scope (follow-up PR)

Two related supervisor bugs identified during the same investigation are deferred:
- **B2 stale-artifact:** supervisor occasionally reuses a prior iteration's \`candidate.json\` when worker exits before regenerating; needs a freshness/iteration-id check.
- **B3 desync soft-fail:** when the worker's worktree HEAD diverges from manifest's \`candidate_commit\`, supervisor hard-aborts; soft-fail with notes preserves the run.

Will stack on this branch once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)