### PR TITLE
Soft-fail autoresearch supervisor on stale candidate artifact + HEAD desync

### DIFF
--- a/src/autoresearch/__tests__/stale-artifact-freshness.test.ts
+++ b/src/autoresearch/__tests__/stale-artifact-freshness.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { isCandidateArtifactFresh } from '../runtime.js';
+
+describe('isCandidateArtifactFresh (B2 stale-artifact detection)', () => {
+  let dir: string;
+  let candidatePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'omc-fresh-'));
+    candidatePath = join(dir, 'candidate.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns true when no worker anchor is set (back-compat for callers without B2 wiring)', () => {
+    writeFileSync(candidatePath, '{}');
+    expect(isCandidateArtifactFresh(candidatePath, undefined)).toBe(true);
+    expect(isCandidateArtifactFresh(candidatePath, null)).toBe(true);
+  });
+
+  it('returns true when candidate.json mtime is at or after the worker start anchor', () => {
+    writeFileSync(candidatePath, '{}');
+    const anchor = '2026-04-30T22:00:00Z';
+    const future = new Date('2026-04-30T22:05:00Z').getTime() / 1000;
+    utimesSync(candidatePath, future, future);
+    expect(isCandidateArtifactFresh(candidatePath, anchor)).toBe(true);
+  });
+
+  it('returns false when candidate.json mtime predates the worker start anchor (stale-artifact case)', () => {
+    writeFileSync(candidatePath, '{}');
+    const past = new Date('2026-04-30T21:00:00Z').getTime() / 1000;
+    utimesSync(candidatePath, past, past);
+    const anchor = '2026-04-30T22:00:00Z';
+    expect(isCandidateArtifactFresh(candidatePath, anchor)).toBe(false);
+  });
+
+  it('returns false when the artifact path does not exist', () => {
+    expect(isCandidateArtifactFresh(join(dir, 'missing.json'), '2026-04-30T22:00:00Z')).toBe(false);
+  });
+
+  it('returns true when the anchor is unparseable (degrade permissively, do not falsely strand the run)', () => {
+    writeFileSync(candidatePath, '{}');
+    expect(isCandidateArtifactFresh(candidatePath, 'not-an-iso-string')).toBe(true);
+  });
+});

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { mkdir, readFile, symlink, writeFile } from 'fs/promises';
 import { dirname, join, resolve } from 'path';
 import {
@@ -100,7 +100,11 @@ export interface AutoresearchRunManifest {
   created_at: string;
   updated_at: string;
   completed_at: string | null;
+  current_worker_started_at?: string | null;
+  consecutive_noop_iterations?: number;
 }
+
+export const AUTORESEARCH_NOOP_CAP_DEFAULT = 3;
 
 interface AutoresearchActiveRunState {
   schema_version: 1;
@@ -1275,6 +1279,85 @@ function validateAutoresearchCandidate(
   };
 }
 
+export function isCandidateArtifactFresh(
+  candidatePath: string,
+  workerStartedAt: string | null | undefined,
+): boolean {
+  if (!workerStartedAt) return true;
+  const startedMs = new Date(workerStartedAt).getTime();
+  if (!Number.isFinite(startedMs)) return true;
+  try {
+    return statSync(candidatePath).mtimeMs >= startedMs;
+  } catch {
+    return false;
+  }
+}
+
+async function failIterationAsNoop(
+  manifest: AutoresearchRunManifest,
+  projectRoot: string,
+  reason: string,
+  candidate?: AutoresearchCandidateArtifact,
+): Promise<AutoresearchDecisionStatus> {
+  const nextNoopCount = (manifest.consecutive_noop_iterations ?? 0) + 1;
+  manifest.consecutive_noop_iterations = nextNoopCount;
+
+  if (nextNoopCount > AUTORESEARCH_NOOP_CAP_DEFAULT) {
+    return failAutoresearchIteration(
+      manifest,
+      projectRoot,
+      `consecutive supervisor-noop cap exceeded (${nextNoopCount} > ${AUTORESEARCH_NOOP_CAP_DEFAULT}); last reason: ${reason}`,
+      candidate,
+    );
+  }
+
+  try {
+    resetToLastKeptCommit(manifest);
+  } catch {
+    // Reset failure must not escalate — soft-fail's intent is to keep the loop alive.
+  }
+
+  const artifactLayout = getAutoresearchMissionArtifactLayout(projectRoot, manifest.mission_slug, manifest.run_id);
+  const headCommit = (() => {
+    try {
+      return readGitShortHead(manifest.worktree_path);
+    } catch {
+      return manifest.last_kept_commit;
+    }
+  })();
+
+  await appendAutoresearchResultsRow(manifest.results_file, {
+    iteration: manifest.iteration,
+    commit: headCommit,
+    status: 'noop',
+    description: candidate?.description || `supervisor noop: ${reason}`,
+  });
+  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+    iteration: manifest.iteration,
+    kind: 'iteration',
+    decision: 'noop',
+    decision_reason: reason,
+    candidate_status: candidate?.status ?? 'candidate',
+    base_commit: candidate?.base_commit ?? manifest.last_kept_commit,
+    candidate_commit: candidate?.candidate_commit ?? null,
+    kept_commit: manifest.last_kept_commit,
+    keep_policy: manifest.keep_policy,
+    evaluator: null,
+    created_at: nowIso(),
+    notes: [...(candidate?.notes ?? []), `supervisor_noop:${reason}`],
+    description: candidate?.description || `supervisor noop: ${reason}`,
+  });
+  await appendDecisionLog(artifactLayout.decisionLogFile, {
+    iteration: manifest.iteration,
+    decision: 'noop',
+    description: candidate?.description || `supervisor noop: ${reason}`,
+    reason,
+    notes: [...(candidate?.notes ?? []), `supervisor_noop:${reason}`],
+  });
+  await writeRunManifest(manifest);
+  return 'noop';
+}
+
 async function failAutoresearchIteration(
   manifest: AutoresearchRunManifest,
   projectRoot: string,
@@ -1340,8 +1423,25 @@ export async function processAutoresearchCandidate(
     );
   }
 
+  if (!isCandidateArtifactFresh(manifest.candidate_file, manifest.current_worker_started_at)) {
+    return failIterationAsNoop(
+      manifest,
+      projectRoot,
+      '[stale-artifact] candidate.json mtime predates worker start; treating as noop iter',
+      candidate,
+    );
+  }
+
   const validation = validateAutoresearchCandidate(manifest, candidate);
   if ('reason' in validation) {
+    if (validation.reason.includes('does not match worktree HEAD')) {
+      return failIterationAsNoop(
+        manifest,
+        projectRoot,
+        `[desync-soft] ${validation.reason}`,
+        candidate,
+      );
+    }
     return failAutoresearchIteration(manifest, projectRoot, validation.reason, candidate);
   }
   candidate = validation.candidate;
@@ -1464,6 +1564,7 @@ export async function processAutoresearchCandidate(
   if (decision.keep) {
     manifest.last_kept_commit = readGitFullHead(manifest.worktree_path);
     manifest.last_kept_score = typeof evaluation.score === 'number' ? evaluation.score : manifest.last_kept_score;
+    manifest.consecutive_noop_iterations = 0;
   } else {
     resetToLastKeptCommit(manifest);
   }


### PR DESCRIPTION
**Stacks on #2905** (bootstrap-pass acceptance). This PR closes the second half of a two-bug abort chain we observed in production: even with B1 fixed, a worker that exits without rewriting `candidate.json` (or whose worktree HEAD diverges from the artifact) still hard-aborts the entire run.

## Problem

`processAutoresearchCandidate` reads `candidate.json` from a fixed path and assumes the worker rewrites it before exit. If the worker:

1. **Exits without writing** — supervisor reads the previous iter's stale artifact. The stale `candidate_commit` doesn't match the new worktree HEAD, `validateAutoresearchCandidate` returns a "does not match worktree HEAD" reason, and `failAutoresearchIteration` finalizes the run with `status=failed`.
2. **Writes a candidate that desyncs from HEAD** — even with a fresh write, transient git state can produce a desync. Same hard-abort path.

Workers can crash mid-write, run out of context, or be killed externally. The supervisor should be resilient. Today it isn't.

## Fix

### B2 — stale candidate.json detection

- New exported helper \`isCandidateArtifactFresh(path, workerStartedAt)\` compares mtime against a worker-start anchor.
- New optional manifest field \`current_worker_started_at?: string | null\`. Skill callers write it before each \`processAutoresearchCandidate\` call and clear after worker exit. Existing callers without B2 wiring degrade permissively (no anchor → returns \`true\`).
- If the artifact predates the anchor, the iter is failed as a soft \"noop\" with reason \`[stale-artifact] candidate.json mtime predates worker start; treating as noop iter\` instead of finalizing the run.

### B3 — desync as recoverable error

- After \`validateAutoresearchCandidate\` returns a reason, only HEAD-mismatch reasons route through the new soft-fail path (\`[desync-soft] ${reason}\`).
- \`base_commit\` resolution failures and \`base_commit\` mismatches still hard-abort — those signal the worker built on the wrong base, which is unrecoverable.

### \`failIterationAsNoop\` semantics

- Resets worktree to \`last_kept_commit\` (recovers from any uncommitted/unwritten worker state).
- Appends \`results.tsv\` row (\`status=noop\`), ledger entry (\`decision=noop\`, \`decision_reason=<reason>\`), and decision-log entry.
- Increments \`manifest.consecutive_noop_iterations\`.
- If the counter exceeds \`AUTORESEARCH_NOOP_CAP_DEFAULT\` (3), promotes to a hard-fail via \`failAutoresearchIteration\` so a runaway worker can't loop forever.
- Successful \`keep\` resets the counter to 0.

## Tests

- \`src/autoresearch/__tests__/stale-artifact-freshness.test.ts\` — 5 unit tests covering \`isCandidateArtifactFresh\` edges:
  1. No worker anchor → permissive \`true\` (back-compat)
  2. mtime ≥ anchor → \`true\`
  3. mtime < anchor → \`false\` (the bug case)
  4. Path missing → \`false\`
  5. Unparseable anchor → \`true\` (degrade permissively, don't strand the run)
- All 46 existing \`src/autoresearch/\` tests still pass; \`tsc --noEmit\` clean.

## Backward compatibility

- Manifest fields are optional; older state files load without migration.
- \`isCandidateArtifactFresh\` is a no-op (returns \`true\`) when callers don't supply a worker anchor, so the old code path is preserved for any caller that hasn't adopted B2 yet.
- B3 only triggers on a specific validation-reason substring; other validation failures behave exactly as before.

## Dependency

Depends on #2905 conceptually — B1 must merge first or the bootstrap case still kills the run on iter-1. The diff on this PR will shrink to just the B2+B3 commit once #2905 lands. Happy to rebase or convert to draft if that ordering helps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)