### PR TITLE
Fix launch auth preservation in runtime config

### DIFF
--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -983,6 +983,37 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     expect(existsSync(join(runtimeDir, 'rules'))).toBe(true);
   });
 
+  it('preserves runtime .claude.json across runtime config dir rebuilds', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), '{"session":"keep-me"}');
+
+    const rebuiltRuntimeDir = prepareOmcLaunchConfigDir(configDir);
+
+    expect(rebuiltRuntimeDir).toBe(runtimeDir);
+    expect(readFileSync(join(rebuiltRuntimeDir, '.claude.json'), 'utf-8')).toBe('{"session":"keep-me"}');
+  });
+
+  it('removes non-mirrored runtime junk across runtime config dir rebuilds', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, 'junk.txt'), 'remove me');
+    mkdirSync(join(runtimeDir, 'junk-dir'), { recursive: true });
+    writeFileSync(join(runtimeDir, 'junk-dir', 'nested.txt'), 'remove me too');
+
+    const rebuiltRuntimeDir = prepareOmcLaunchConfigDir(configDir);
+
+    expect(rebuiltRuntimeDir).toBe(runtimeDir);
+    expect(existsSync(join(rebuiltRuntimeDir, 'junk.txt'))).toBe(false);
+    expect(existsSync(join(rebuiltRuntimeDir, 'junk-dir'))).toBe(false);
+  });
+
   it('leaves CLAUDE_CONFIG_DIR unchanged when no preserved companion exists', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(configDir, { recursive: true });

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -89,8 +89,16 @@ export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()):
   }
 
   const runtimeConfigDir = join(baseConfigDir, OMC_RUNTIME_DIRNAME);
+  const runtimeClaudeJsonPath = join(runtimeConfigDir, '.claude.json');
+  const preservedClaudeJson = existsSync(runtimeClaudeJsonPath)
+    ? readFileSync(runtimeClaudeJsonPath)
+    : null;
+
   rmSync(runtimeConfigDir, { recursive: true, force: true });
   mkdirSync(runtimeConfigDir, { recursive: true });
+  if (preservedClaudeJson) {
+    writeFileSync(runtimeClaudeJsonPath, preservedClaudeJson);
+  }
   copyFileSync(companionPath, join(runtimeConfigDir, 'CLAUDE.md'));
 
   for (const entry of [


### PR DESCRIPTION
## Summary
- Fixes #2906
- Preserve only runtime `.claude.json` across `.omc-launch` rebuilds so Claude Code auth/session state survives `omc launch` preserve mode.
- Keep the existing rebuild-and-remirror behavior so stale non-mirrored runtime files are still removed.
- Add regression coverage for both `.claude.json` preservation and runtime junk cleanup.

## Verification
- `npm ci` (installed lockfile dependencies; audit reports existing 3 moderate / 1 high vulnerabilities)
- `npm test -- --run src/cli/__tests__/launch.test.ts` → 125 tests passed
- `npx tsc --noEmit` → passed
- `npx eslint src/cli/launch.ts src/cli/__tests__/launch.test.ts --max-warnings=0` → passed
- `npm run build` → passed

— Codex/OMX
