### PR TITLE
docs: explain prebuild-install warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ If you prefer the npm CLI/runtime path instead of the marketplace flow:
 npm i -g oh-my-claude-sisyphus@latest
 ```
 
+> **Known npm warning:** npm may print `deprecated prebuild-install@7.1.3` during the CLI install.
+> This currently comes from the upstream `better-sqlite3` native-addon dependency
+> (`better-sqlite3 -> prebuild-install`); `prebuild-install@7.1.3` is still the latest
+> published version, so there is no safe repo-side dependency bump or override to remove
+> the warning yet. The warning is tracked in [#2913](https://github.com/Yeachan-Heo/oh-my-claudecode/issues/2913)
+> and does not by itself mean the OMC CLI install failed.
+
 **Step 2: Setup**
 
 ```bash

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,6 +58,13 @@ If you want `omc setup`, `omc update`, `omc team`, `omc ask`, etc. on your shell
 npm i -g oh-my-claude-sisyphus@latest
 ```
 
+> **Known npm warning:** npm may print `deprecated prebuild-install@7.1.3` during this CLI install.
+> The warning currently comes from the upstream `better-sqlite3` native-addon dependency
+> (`better-sqlite3 -> prebuild-install`); `prebuild-install@7.1.3` is still the latest
+> published version, so there is no safe repo-side dependency bump or override to remove it
+> yet. The warning is tracked in [#2913](https://github.com/Yeachan-Heo/oh-my-claudecode/issues/2913)
+> and does not by itself mean the OMC CLI install failed.
+
 Both can be installed at the same time. The CLI auto-detects the plugin install and will not double-register skills under `~/.claude/skills/` (if you previously hit the duplicate-skill bug, run `omc update` once on 4.11.2+ — it self-heals leftover standalone skills that the plugin now provides via `prunePluginDuplicateSkills`).
 
 ### Step 3: Run initial setup


### PR DESCRIPTION
## Summary
- Documents the known npm install warning for `prebuild-install@7.1.3` in the README quick start and getting-started guide.
- Explains that the warning comes from upstream `better-sqlite3 -> prebuild-install` and that no safe repo-side dependency bump/override exists yet.
- Links the mitigation to #2913 so users can distinguish the warning from an install failure.

## Tests
- `npm run test:run -- src/__tests__/plugin-setup-deps.test.ts src/__tests__/auto-update.test.ts` (29 tests passed)
- `npm run build` (passed)
- `git diff --check README.md docs/GETTING-STARTED.md` (passed)