### PR TITLE
feat(hud): add Context ETA display (~15m until full)

### DIFF
--- a/src/__tests__/hud/context-eta.test.ts
+++ b/src/__tests__/hud/context-eta.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it } from 'vitest';
+
+import { updateContextEta } from '../../hud/eta.js';
+import type { ContextEtaSample } from '../../hud/eta.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a sample array with linearly spaced timestamps and percents. */
+function makeSamples(
+  count: number,
+  startPercent: number,
+  endPercent: number,
+  startMs: number,
+  intervalMs: number,
+): ContextEtaSample[] {
+  const samples: ContextEtaSample[] = [];
+  for (let i = 0; i < count; i++) {
+    const t = i / Math.max(count - 1, 1);
+    samples.push({
+      timestampMs: startMs + i * intervalMs,
+      percent: Math.round(startPercent + t * (endPercent - startPercent)),
+    });
+  }
+  return samples;
+}
+
+const BASE_MS = 1_700_000_000_000; // arbitrary fixed epoch for determinism
+
+// ---------------------------------------------------------------------------
+// describe: cold start
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — cold start', () => {
+  it('returns etaMinutes null when previousSamples is empty', () => {
+    const result = updateContextEta(50, [], BASE_MS);
+    expect(result.etaMinutes).toBe(null);
+  });
+
+  it('stores one sample when previousSamples is empty', () => {
+    const result = updateContextEta(50, [], BASE_MS);
+    expect(result.samples).toHaveLength(1);
+  });
+
+  it('stores the current timestampMs in the first sample', () => {
+    const result = updateContextEta(50, [], BASE_MS);
+    expect(result.samples[0].timestampMs).toBe(BASE_MS);
+  });
+
+  it('stores clamped percent in the first sample (normal value)', () => {
+    const result = updateContextEta(67, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(67);
+  });
+
+  it('clamps negative percent to 0', () => {
+    const result = updateContextEta(-5, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(0);
+  });
+
+  it('clamps percent > 100 to 100', () => {
+    const result = updateContextEta(105, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(100);
+  });
+
+  it('rounds percent to nearest integer', () => {
+    const result = updateContextEta(67.7, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(68);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: two-sample boundary (need >= 2 to compute slope)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — two-sample boundary', () => {
+  it('returns null with exactly one previous sample (total 2)', () => {
+    // spec: need >= 2 *previous* samples to compute (i.e. >= 3 total)?
+    // spec says "< 2 returns null" — verify the boundary at exactly 2 total samples
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 40 }];
+    const nowMs = BASE_MS + 5_000; // 5 sec later
+    const result = updateContextEta(45, prev, nowMs);
+    // With 2 total data points we have a slope — implementation decides.
+    // Spec rule 3: "two-point slope (samples.length 2-5)".
+    // 2 samples total: slope = (45-40)/(5/60) = 60 %/min → ETA = ceil((100-45)/60) = 1 min
+    // The stub returns null, so this test must FAIL on the stub.
+    expect(result.etaMinutes).not.toBe(null);
+  });
+
+  it('accumulates sample when one previous sample exists', () => {
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 40 }];
+    const nowMs = BASE_MS + 5_000;
+    const result = updateContextEta(45, prev, nowMs);
+    expect(result.samples).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: two-point slope (samples 2-5 accumulated)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — two-point slope mode', () => {
+  it('computes ETA using first-to-last linear slope with 3 samples', () => {
+    // 3 previous samples spanning 10 sec, 10% growth → slope = 60 %/min
+    const prev: ContextEtaSample[] = [
+      { timestampMs: BASE_MS, percent: 30 },
+      { timestampMs: BASE_MS + 5_000, percent: 35 },
+      { timestampMs: BASE_MS + 10_000, percent: 40 },
+    ];
+    const nowMs = BASE_MS + 15_000;
+    const currentPercent = 45;
+    // slope first→last: (40-30)/((10_000)/60_000) = 10/0.1667 = 60 %/min
+    // with 4 total samples after append: still uses two-point (first/last)
+    // ETA = ceil((100-45)/60) = ceil(0.9167) = 1 min
+    const result = updateContextEta(currentPercent, prev, nowMs);
+    expect(result.etaMinutes).toBe(1);
+  });
+
+  it('returns etaMinutes > 0 for normal growth with 4 accumulated samples', () => {
+    const prev = makeSamples(4, 20, 40, BASE_MS, 10_000); // 40% over 30 sec → 80 %/min
+    const nowMs = BASE_MS + 4 * 10_000;
+    const result = updateContextEta(45, prev, nowMs);
+    expect(result.etaMinutes).toBeGreaterThan(0);
+  });
+
+  it('adds new sample to rolling window in two-point mode', () => {
+    const prev = makeSamples(3, 20, 35, BASE_MS, 5_000);
+    const nowMs = BASE_MS + 3 * 5_000;
+    const result = updateContextEta(40, prev, nowMs);
+    expect(result.samples).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: linear regression (>= 6 samples)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — linear regression mode', () => {
+  it('returns non-null ETA with 6 previous samples of steady growth', () => {
+    // 6 samples, 5 %/sample over 5 sec each → ~60 %/min
+    const prev = makeSamples(6, 20, 45, BASE_MS, 5_000);
+    const nowMs = BASE_MS + 6 * 5_000;
+    const result = updateContextEta(50, prev, nowMs);
+    expect(result.etaMinutes).not.toBe(null);
+  });
+
+  it('ETA via regression is within ±2 min of expected for clean linear data', () => {
+    // 10 samples, strict 1 %/5 sec = 12 %/min
+    const prev = makeSamples(10, 30, 39, BASE_MS, 5_000);
+    const nowMs = BASE_MS + 10 * 5_000;
+    const currentPercent = 40;
+    // slope ≈ 12 %/min → ETA = ceil((100-40)/12) = ceil(5) = 5
+    const result = updateContextEta(currentPercent, prev, nowMs);
+    expect(result.etaMinutes).toBeGreaterThanOrEqual(4);
+    expect(result.etaMinutes).toBeLessThanOrEqual(7);
+  });
+
+  it('keeps samples in regression mode (appends new sample)', () => {
+    const prev = makeSamples(6, 20, 45, BASE_MS, 5_000);
+    const nowMs = BASE_MS + 6 * 5_000;
+    const result = updateContextEta(50, prev, nowMs);
+    expect(result.samples).toHaveLength(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: edge cases — clock skew / suspend (rule 5)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — clock skew / suspend (rule 5)', () => {
+  it('drops history and returns null when gap is 0 seconds', () => {
+    const prev: ContextEtaSample[] = [
+      { timestampMs: BASE_MS, percent: 40 },
+    ];
+    // same timestamp → gapSec = 0
+    const result = updateContextEta(45, prev, BASE_MS);
+    expect(result.etaMinutes).toBe(null);
+  });
+
+  it('stores new sample as fresh first when gap is 0', () => {
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 40 }];
+    const result = updateContextEta(45, prev, BASE_MS);
+    expect(result.samples).toHaveLength(1);
+  });
+
+  it('drops history and returns null when gap > 90 seconds (suspend)', () => {
+    const prev: ContextEtaSample[] = [
+      { timestampMs: BASE_MS, percent: 40 },
+    ];
+    const nowMs = BASE_MS + 95_000; // 95 sec gap
+    const result = updateContextEta(45, prev, nowMs);
+    expect(result.etaMinutes).toBe(null);
+  });
+
+  it('resets to single sample after suspend gap', () => {
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 40 }];
+    const nowMs = BASE_MS + 95_000;
+    const result = updateContextEta(45, prev, nowMs);
+    expect(result.samples).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: /compact reset (rule 6)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — /compact reset (rule 6)', () => {
+  it('drops history when deltaPct <= -10 (large drop)', () => {
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 60 }];
+    const nowMs = BASE_MS + 5_000;
+    // 60 → 45: deltaPct = -15 → compact
+    const result = updateContextEta(45, prev, nowMs);
+    expect(result.etaMinutes).toBe(null);
+  });
+
+  it('stores single fresh sample after compact reset', () => {
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 60 }];
+    const nowMs = BASE_MS + 5_000;
+    const result = updateContextEta(45, prev, nowMs);
+    expect(result.samples).toHaveLength(1);
+  });
+
+  it('drops history when current < last * 0.5', () => {
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 80 }];
+    const nowMs = BASE_MS + 10_000;
+    // 80 → 30: 30 < 80*0.5=40 → compact
+    const result = updateContextEta(30, prev, nowMs);
+    expect(result.etaMinutes).toBe(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: single huge paste outlier (rule 7)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — paste outlier (rule 7)', () => {
+  it('returns null when deltaPct >= 15 and gapSec <= 30', () => {
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 30 }];
+    const nowMs = BASE_MS + 10_000; // 10 sec gap
+    // 30 → 50: deltaPct = 20 → paste outlier
+    const result = updateContextEta(50, prev, nowMs);
+    expect(result.etaMinutes).toBe(null);
+  });
+
+  it('stores new sample as fresh baseline after paste outlier', () => {
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 30 }];
+    const nowMs = BASE_MS + 10_000;
+    const result = updateContextEta(50, prev, nowMs);
+    expect(result.samples).toHaveLength(1);
+  });
+
+  it('does NOT treat large delta as outlier when gap > 30 sec', () => {
+    // deltaPct=20 but gap=60s → NOT a paste outlier; treat as normal growth
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 30 }];
+    const nowMs = BASE_MS + 60_000;
+    const result = updateContextEta(50, prev, nowMs);
+    // Should NOT drop history (samples len 2 or compute ETA, not reset to 1)
+    // etaMinutes may be null for other reasons (slope, cap) but samples should be 2
+    expect(result.samples).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: idle / asymptote (rule 8)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — idle / asymptote (rule 8)', () => {
+  it('returns null when computed slope < 0.25 %/min', () => {
+    // Very slow growth: 2% over 30 min (6 samples × 5 min intervals)
+    const prev = makeSamples(6, 50, 52, BASE_MS, 300_000); // 5-min intervals
+    const nowMs = BASE_MS + 6 * 300_000;
+    // slope ≈ 2%/30min ≈ 0.067 %/min < 0.25 → null
+    const result = updateContextEta(53, prev, nowMs);
+    expect(result.etaMinutes).toBe(null);
+  });
+
+  it('keeps samples intact when suppressing due to idle slope', () => {
+    const prev = makeSamples(6, 50, 52, BASE_MS, 300_000);
+    const nowMs = BASE_MS + 6 * 300_000;
+    const result = updateContextEta(53, prev, nowMs);
+    // samples should NOT be cleared — just suppressed display
+    expect(result.samples.length).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: ETA cap (rule 9)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — ETA cap (rule 9)', () => {
+  it('returns null when computed ETA > 240 minutes', () => {
+    // Very slow growth: 2 samples 30 sec apart with 0.1% growth → huge ETA
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 10 }];
+    const nowMs = BASE_MS + 30_000; // 30 sec
+    // 10 → 10.1 (round to 10): near-zero slope → either idle or ETA > 240
+    const result = updateContextEta(10, prev, nowMs); // no growth at all
+    expect(result.etaMinutes).toBe(null);
+  });
+
+  it('returns null when computed ETA <= 0', () => {
+    // percent already at 100 — ETA should be 0 or negative → null
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 95 }];
+    const nowMs = BASE_MS + 5_000;
+    const result = updateContextEta(100, prev, nowMs);
+    expect(result.etaMinutes).toBe(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: window cap (rule 10)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — window cap (rule 10)', () => {
+  it('caps sample window at 36 entries', () => {
+    // Provide 36 previous samples; new one should push oldest off
+    const prev = makeSamples(36, 10, 81, BASE_MS, 5_000);
+    const nowMs = BASE_MS + 36 * 5_000;
+    const result = updateContextEta(82, prev, nowMs);
+    expect(result.samples).toHaveLength(36);
+  });
+
+  it('never exceeds 36 samples even with many prior samples', () => {
+    const prev = makeSamples(40, 5, 84, BASE_MS, 5_000);
+    const nowMs = BASE_MS + 40 * 5_000;
+    const result = updateContextEta(85, prev, nowMs);
+    expect(result.samples.length).toBeLessThanOrEqual(36);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: percent clamping (rule 11)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — percent clamping (rule 11)', () => {
+  it('rounds fractional percent before storing', () => {
+    const result = updateContextEta(67.7, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(68);
+  });
+
+  it('clamps -5 to 0', () => {
+    const result = updateContextEta(-5, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(0);
+  });
+
+  it('clamps 105 to 100', () => {
+    const result = updateContextEta(105, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(100);
+  });
+
+  it('stores 0 when input is exactly 0', () => {
+    const result = updateContextEta(0, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(0);
+  });
+
+  it('stores 100 when input is exactly 100', () => {
+    const result = updateContextEta(100, [], BASE_MS);
+    expect(result.samples[0].percent).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: ETA rounding (rule 12)
+// ---------------------------------------------------------------------------
+
+describe('updateContextEta — ETA rounding (rule 12)', () => {
+  it('uses Math.ceil so 89 sec remaining rounds up to 2 min not 1', () => {
+    // slope = 60 %/min; currentPercent = 99; remaining = 1%; 1/60 min = 1 sec → ceil = 1
+    // Use a cleaner case: slope = 1 %/min, remaining = 1.5% → ceil(1.5) = 2
+    // 2 samples: 10sec apart, +1% growth → slope = 6 %/min
+    // At 98%: remaining = 2%, ETA = ceil(2/6 * 60 sec in min) = ceil(0.333 min) = 1
+    // Let's use: slope = 30 %/min (2% in 4 sec = 2/(4/60) = 30 %/min)
+    // At 95%: remaining = 5%; ETA = ceil(5/30) = ceil(0.1667) = 1
+    // Verify ceil not floor: floor would give 0 (not displayed), ceil gives 1
+
+    // Two-sample slope: 0% → 2% in 4 sec = 30 %/min
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 0 }];
+    const nowMs = BASE_MS + 4_000;
+    const result = updateContextEta(2, prev, nowMs);
+    // slope = 2%/(4/60 min) = 30 %/min; remaining = 98%; ETA = ceil(98/30) = ceil(3.267) = 4
+    expect(result.etaMinutes).toBe(4);
+  });
+
+  it('ceil ensures fractional minutes round up not down', () => {
+    // slope = 10 %/min exactly; at 65%; remaining = 35%; ETA = ceil(3.5) = 4
+    // Two samples: 60 sec apart, 10% growth
+    const prev: ContextEtaSample[] = [{ timestampMs: BASE_MS, percent: 55 }];
+    const nowMs = BASE_MS + 60_000; // 60 sec
+    const result = updateContextEta(65, prev, nowMs);
+    // slope = 10/(60/60) = 10 %/min; remaining = 35; ETA = ceil(3.5) = 4
+    expect(result.etaMinutes).toBe(4);
+  });
+});

--- a/src/hud/elements/context.ts
+++ b/src/hud/elements/context.ts
@@ -121,32 +121,54 @@ export function getStableContextDisplayPercent(
 }
 
 /**
+ * Format an ETA suffix string. Uses `~Nm` under an hour and `~Nh` at and
+ * above an hour. Returns empty when ETA is null/zero/invalid.
+ *
+ * The leading space is intentional: callers append this directly after the
+ * existing ANSI RESET so the dim styling does not inherit warning/critical
+ * color from the percent block.
+ */
+function formatEtaSuffix(etaMinutes: number | null | undefined): string {
+  if (etaMinutes === null || etaMinutes === undefined) return '';
+  if (!Number.isFinite(etaMinutes) || etaMinutes <= 0) return '';
+  const body = etaMinutes < 60
+    ? `~${etaMinutes}m`
+    : `~${Math.floor(etaMinutes / 60)}h`;
+  return ` ${DIM}${body}${RESET}`;
+}
+
+/**
  * Render context window percentage.
  *
- * Format: ctx:67%
+ * Format: ctx:67%       (no ETA)
+ *         ctx:67% ~15m  (with ETA, dim-styled, after RESET)
  */
 export function renderContext(
   percent: number,
   thresholds: HudThresholds,
   displayScope?: string | null,
+  etaMinutes?: number | null,
   labels: Pick<HudLabels, 'context'> = DEFAULT_HUD_LABELS,
 ): string | null {
   const safePercent = getStableContextDisplayPercent(percent, thresholds, displayScope);
   const { color, suffix } = getContextDisplayStyle(safePercent, thresholds);
+  const eta = formatEtaSuffix(etaMinutes);
 
-  return `${labels.context}:${color}${safePercent}%${suffix}${RESET}`;
+  return `${labels.context}:${color}${safePercent}%${suffix}${RESET}${eta}`;
 }
 
 /**
  * Render context window with visual bar.
  *
- * Format: ctx:[████░░░░░░]67%
+ * Format: ctx:[████░░░░░░]67%       (no ETA)
+ *         ctx:[████░░░░░░]67% ~15m  (with ETA, dim-styled, after RESET)
  */
 export function renderContextWithBar(
   percent: number,
   thresholds: HudThresholds,
   barWidth: number = 10,
   displayScope?: string | null,
+  etaMinutes?: number | null,
   labels: Pick<HudLabels, 'context'> = DEFAULT_HUD_LABELS,
 ): string | null {
   const safePercent = getStableContextDisplayPercent(percent, thresholds, displayScope);
@@ -155,5 +177,6 @@ export function renderContextWithBar(
 
   const { color, suffix } = getContextDisplayStyle(safePercent, thresholds);
   const bar = `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
-  return `${labels.context}:[${bar}]${color}${safePercent}%${suffix}${RESET}`;
+  const eta = formatEtaSuffix(etaMinutes);
+  return `${labels.context}:[${bar}]${color}${safePercent}%${suffix}${RESET}${eta}`;
 }

--- a/src/hud/eta.ts
+++ b/src/hud/eta.ts
@@ -2,7 +2,22 @@
  * OMC HUD - Context ETA
  *
  * Predicts time-to-context-full based on rolling percent samples.
- * Stub only — implementation lands in the next PR.
+ *
+ * Algorithm:
+ *   1. Clamp + round input percent into [0, 100].
+ *   2. Cold start: store one sample, return null ETA.
+ *   3. Reject pathological gaps (clock skew/suspend/zero), /compact resets,
+ *      and huge paste outliers — drop history, store fresh single sample.
+ *   4. Append sample, cap rolling window at 36.
+ *   5. Slope:
+ *        - n < 6: two-point first→last slope
+ *        - n >= 6: least-squares linear regression over the window
+ *   6. Suppress when slope < 0.25 %/min (idle), ETA <= 0, ETA > 240, or
+ *      non-finite.
+ *   7. ETA = ceil((100 - percent) / slope) minutes.
+ *
+ * Inspired by codachi (https://github.com/vincent-k2026/codachi, MIT,
+ * vincent-k2026); algorithm independently derived per codex consult.
  */
 
 export type ContextEtaSample = {
@@ -15,14 +30,159 @@ export type ContextEtaResult = {
   samples: ContextEtaSample[]; // updated rolling window, max 36
 };
 
+const MAX_SAMPLES = 36;
+const MIN_GAP_SEC = 0; // strictly > 0 required
+// Suspend / clock-skew baseline threshold. With only one prior sample (no
+// cadence signal yet), gaps above this trigger a fresh start because we can't
+// distinguish "user idle for 95s" from "machine suspended for 95s". With
+// multiple prior samples we extend tolerance based on the established cadence
+// (see effectiveMaxGapSec below).
+const MAX_GAP_SEC_BASE = 90;
+// Multiplier applied to the typical historical inter-sample gap when
+// computing the effective max-gap. 2.5x balances "let normal idle polling
+// through" vs "still catch suspend events that exceed normal cadence".
+const HISTORICAL_GAP_MULTIPLIER = 2.5;
+const COMPACT_DELTA_THRESHOLD = -10; // deltaPct <= -10 → /compact
+const COMPACT_RATIO_THRESHOLD = 0.5; // current < last * 0.5 → /compact
+const PASTE_DELTA_THRESHOLD = 15; // deltaPct >= 15 within ...
+const PASTE_GAP_SEC_THRESHOLD = 30; // ... 30s gap → paste outlier
+const REGRESSION_MIN_SAMPLES = 6; // < 6 uses two-point slope
+const IDLE_SLOPE_MIN = 0.25; // %/min below this → suppress
+const ETA_CAP_MINUTES = 240; // > 240 minutes → suppress
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+function freshStart(percent: number, nowMs: number): ContextEtaResult {
+  return {
+    etaMinutes: null,
+    samples: [{ timestampMs: nowMs, percent }],
+  };
+}
+
 /**
- * Stub implementation — returns sentinel values so TDD red tests fail
- * on assertions. Replace with real algorithm in the implementation PR.
+ * Compute the suspend-vs-idle threshold for the next-sample gap.
+ *
+ * With only one prior sample we have no cadence information, so we must use
+ * the conservative MAX_GAP_SEC_BASE (anything beyond that is more likely
+ * "machine suspended" than "user paused for 90s"). With multiple prior
+ * samples we use the average historical inter-sample gap × multiplier so
+ * naturally slow polling (e.g. 5-min intervals on an idle session) stays
+ * within bounds.
  */
+function effectiveMaxGap(previousSamples: ContextEtaSample[]): number {
+  if (previousSamples.length < 2) return MAX_GAP_SEC_BASE;
+  const first = previousSamples[0];
+  const last = previousSamples[previousSamples.length - 1];
+  const totalSec = (last.timestampMs - first.timestampMs) / 1000;
+  if (totalSec <= 0) return MAX_GAP_SEC_BASE;
+  const avgGapSec = totalSec / (previousSamples.length - 1);
+  return Math.max(MAX_GAP_SEC_BASE, avgGapSec * HISTORICAL_GAP_MULTIPLIER);
+}
+
+/**
+ * Two-point slope from first to last sample, in %/min.
+ * Returns null when the timespan is non-positive.
+ */
+function twoPointSlope(samples: ContextEtaSample[]): number | null {
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  const minutes = (last.timestampMs - first.timestampMs) / 60_000;
+  if (minutes <= 0) return null;
+  return (last.percent - first.percent) / minutes;
+}
+
+/**
+ * Least-squares linear regression slope over samples, in %/min.
+ * x = timestampMs (converted to minutes from first sample), y = percent.
+ * Returns null when degenerate (zero variance in x).
+ */
+function regressionSlope(samples: ContextEtaSample[]): number | null {
+  const n = samples.length;
+  const t0 = samples[0].timestampMs;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (const s of samples) {
+    const x = (s.timestampMs - t0) / 60_000; // minutes from first sample
+    const y = s.percent;
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const denom = n * sumXX - sumX * sumX;
+  if (denom <= 0) return null;
+  return (n * sumXY - sumX * sumY) / denom;
+}
+
 export function updateContextEta(
-  _currentPercent: number,
-  _previousSamples: ContextEtaSample[],
-  _nowMs: number,
+  currentPercent: number,
+  previousSamples: ContextEtaSample[],
+  nowMs: number,
 ): ContextEtaResult {
-  return { etaMinutes: null, samples: [] };
+  const percent = clampPercent(currentPercent);
+
+  // Rule 1: cold start
+  if (previousSamples.length === 0) {
+    return freshStart(percent, nowMs);
+  }
+
+  const last = previousSamples[previousSamples.length - 1];
+  const gapSec = (nowMs - last.timestampMs) / 1000;
+  const deltaPct = percent - last.percent;
+
+  // Rule 2: clock skew, suspend, zero/negative gap.
+  // Effective max-gap widens when we already have an established sampling
+  // cadence: low-activity sessions polling every several minutes shouldn't
+  // be treated as a suspend just because a single inter-sample gap exceeds
+  // the cold-start 90s threshold.
+  const effectiveMaxGapSec = effectiveMaxGap(previousSamples);
+  if (gapSec <= MIN_GAP_SEC || gapSec > effectiveMaxGapSec) {
+    return freshStart(percent, nowMs);
+  }
+
+  // Rule 3: /compact reset (large drop or sudden halving)
+  if (
+    deltaPct <= COMPACT_DELTA_THRESHOLD ||
+    percent < last.percent * COMPACT_RATIO_THRESHOLD
+  ) {
+    return freshStart(percent, nowMs);
+  }
+
+  // Rule 4: huge paste outlier (large jump within short window)
+  if (deltaPct >= PASTE_DELTA_THRESHOLD && gapSec <= PASTE_GAP_SEC_THRESHOLD) {
+    return freshStart(percent, nowMs);
+  }
+
+  // Append new sample, cap window
+  const appended = [...previousSamples, { timestampMs: nowMs, percent }];
+  const samples =
+    appended.length > MAX_SAMPLES
+      ? appended.slice(appended.length - MAX_SAMPLES)
+      : appended;
+
+  // Need >= 2 samples to compute slope
+  if (samples.length < 2) {
+    return { etaMinutes: null, samples };
+  }
+
+  const slope =
+    samples.length < REGRESSION_MIN_SAMPLES
+      ? twoPointSlope(samples)
+      : regressionSlope(samples);
+
+  if (slope === null || !isFinite(slope) || slope < IDLE_SLOPE_MIN) {
+    return { etaMinutes: null, samples };
+  }
+
+  const etaMinutes = Math.ceil((100 - percent) / slope);
+
+  if (!isFinite(etaMinutes) || etaMinutes <= 0 || etaMinutes > ETA_CAP_MINUTES) {
+    return { etaMinutes: null, samples };
+  }
+
+  return { etaMinutes, samples };
 }

--- a/src/hud/eta.ts
+++ b/src/hud/eta.ts
@@ -1,0 +1,28 @@
+/**
+ * OMC HUD - Context ETA
+ *
+ * Predicts time-to-context-full based on rolling percent samples.
+ * Stub only — implementation lands in the next PR.
+ */
+
+export type ContextEtaSample = {
+  timestampMs: number;
+  percent: number; // 0-100
+};
+
+export type ContextEtaResult = {
+  etaMinutes: number | null; // null = don't display
+  samples: ContextEtaSample[]; // updated rolling window, max 36
+};
+
+/**
+ * Stub implementation — returns sentinel values so TDD red tests fail
+ * on assertions. Replace with real algorithm in the implementation PR.
+ */
+export function updateContextEta(
+  _currentPercent: number,
+  _previousSamples: ContextEtaSample[],
+  _nowMs: number,
+): ContextEtaResult {
+  return { etaMinutes: null, samples: [] };
+}

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -16,6 +16,7 @@ import {
 import { renderTodosWithCurrent } from "./elements/todos.js";
 import { renderSkills, renderLastSkill } from "./elements/skills.js";
 import { renderContext, renderContextWithBar } from "./elements/context.js";
+import { readStdinCache } from "./stdin.js";
 import { renderBackground } from "./elements/background.js";
 import { renderPrd } from "./elements/prd.js";
 import {
@@ -422,18 +423,28 @@ export async function render(
   }
 
   if (enabledElements.contextBar) {
+    // Resolve ETA: prefer the explicitly-passed render-context value, then
+    // fall back to whatever `writeStdinCache` stamped onto the cache during
+    // the current render cycle (single best-effort read; render must stay
+    // pure of cache-write side effects).
+    const etaMinutes =
+      context.contextEtaMinutes
+      ?? readStdinCache()?.contextEtaMinutes
+      ?? null;
     const ctx = enabledElements.useBars
       ? renderContextWithBar(
           context.contextPercent,
           config.thresholds,
           10,
           context.contextDisplayScope,
+          etaMinutes,
           hudLabels,
         )
       : renderContext(
           context.contextPercent,
           config.thresholds,
           context.contextDisplayScope,
+          etaMinutes,
           hudLabels,
         );
     if (ctx) rendered.set("contextBar", ctx);

--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -13,6 +13,7 @@ import {
   listSessionIds,
   resolveOmcPath,
 } from '../lib/worktree-paths.js';
+import { updateContextEta, type ContextEtaSample } from './eta.js';
 import type { RateLimits, StatuslineStdin } from './types.js';
 
 const TRANSIENT_CONTEXT_PERCENT_TOLERANCE = 3;
@@ -73,10 +74,27 @@ function getStdinCachePath(): string {
 
 /**
  * Persist the last successful stdin read to disk.
- * Used by --watch mode to recover data when stdin is a TTY.
+ *
+ * Used by --watch mode to recover data when stdin is a TTY. As a side
+ * effect this also evolves the rolling Context-ETA window: it reads the
+ * previous cache, computes the new ETA via `updateContextEta`, stamps
+ * `contextEtaSamples` and `contextEtaMinutes` onto `stdin` so they survive
+ * to disk *and* are observable to the in-process render via a follow-up
+ * `readStdinCache` call.
  */
 export function writeStdinCache(stdin: StatuslineStdin): void {
   try {
+    // Pre-write side effect: roll the ETA sample window forward.
+    // Done here (before writeFileSync) so the persisted JSON contains the
+    // fresh window for the next render cycle.
+    try {
+      const previous = readStdinCache();
+      const currentPercent = getContextPercent(stdin);
+      applyContextEta(stdin, previous, currentPercent, Date.now());
+    } catch {
+      // ETA is best-effort; never block the cache write on it.
+    }
+
     const cachePath = getStdinCachePath();
     const cacheDir = dirname(cachePath);
     if (!existsSync(cacheDir)) {
@@ -305,6 +323,32 @@ function isSameContextStream(current: StatuslineStdin, previous: StatuslineStdin
   return current.cwd === previous.cwd
     && current.transcript_path === previous.transcript_path
     && current.context_window?.context_window_size === previous.context_window?.context_window_size;
+}
+
+/**
+ * Compute the Context-ETA for the current render and update the rolling
+ * sample history in-place on `stdin`, so the next call to `writeStdinCache`
+ * persists the new window. Returns the predicted minutes (or null when
+ * suppressed).
+ *
+ * Stream identity is gated by `isSameContextStream`: when the previous cache
+ * came from a different cwd / transcript / context-window-size, history is
+ * dropped so samples never bleed across sessions.
+ */
+export function applyContextEta(
+  stdin: StatuslineStdin,
+  previousStdin: StatuslineStdin | null | undefined,
+  currentPercent: number,
+  nowMs: number,
+): number | null {
+  const previousSamples: ContextEtaSample[] =
+    previousStdin && isSameContextStream(stdin, previousStdin)
+      ? (previousStdin.contextEtaSamples ?? [])
+      : [];
+  const result = updateContextEta(currentPercent, previousSamples, nowMs);
+  stdin.contextEtaSamples = result.samples;
+  stdin.contextEtaMinutes = result.etaMinutes;
+  return result.etaMinutes;
 }
 
 /**

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -7,6 +7,7 @@
 import type { AutopilotStateForHud } from './elements/autopilot.js';
 import type { ApiKeySource } from './elements/api-key-source.js';
 import type { SessionSummaryState } from './elements/session-summary.js';
+import type { ContextEtaSample } from './eta.js';
 import type { MissionBoardConfig, MissionBoardState } from './mission-board.js';
 import { DEFAULT_MISSION_BOARD_CONFIG } from './mission-board.js';
 
@@ -79,6 +80,23 @@ export interface StatuslineStdin {
       resets_at?: number | string;
     };
   };
+
+  /**
+   * Rolling Context-ETA samples persisted in the stdin cache between HUD
+   * renders. Not part of Claude Code's actual stdin payload — the field is
+   * appended by `writeStdinCache` so the next render can extend the slope
+   * regression. Cleared on stream identity change (cwd / transcript_path /
+   * context_window_size) by the writer to prevent cross-session collision.
+   */
+  contextEtaSamples?: ContextEtaSample[];
+
+  /**
+   * Most recently computed Context-ETA in minutes. Persisted alongside
+   * `contextEtaSamples` so an in-process `readStdinCache` after
+   * `writeStdinCache` can surface the freshly-computed ETA to the renderer
+   * without re-running the algorithm.
+   */
+  contextEtaMinutes?: number | null;
 }
 
 // ============================================================================
@@ -316,6 +334,13 @@ export interface HudRenderContext {
 
   /** Stable display scope for context smoothing (e.g. session/worktree key) */
   contextDisplayScope?: string | null;
+
+  /**
+   * Predicted minutes until context window fills, computed from a rolling
+   * sample window. null when there isn't enough history, slope is too flat,
+   * or the prediction exceeds the display cap.
+   */
+  contextEtaMinutes?: number | null;
 
   /** Model display name */
   modelName: string;


### PR DESCRIPTION
## Summary

Adds **Context ETA** to the HUD: predicts and displays time remaining until the context window fills up — `ctx:67% ~15m` (or `~3h` for hour-scale).

> 💡 Inspired by [codachi](https://github.com/vincent-k2026/codachi) (MIT, vincent-k2026). Algorithm independently derived from spec, not a code port.

## Format

- `ctx:67% ~15m` — under 60 min
- `ctx:67% ~3h` — 60+ min
- `ctx:67%` — no ETA when: cold start, idle (slope < 0.25 %/min), large outliers, or ETA > 240 min

ETA suffix is dimmed and appended **post-RESET** so it never inherits warning/critical colors.

## Algorithm

Sliding-window slope over rolling 36-sample window (~3 min @ 5s polling):

- 2–5 samples: two-point slope
- 6+ samples: least-squares linear regression
- Outlier guards: `/compact` reset (delta ≤ -10 or > 50% drop), suspend (gap > 90s baseline; widens to 2.5× cadence after history establishes), single paste (delta ≥ 15 within 30s)
- Idle suppression (slope < 0.25 %/min)
- ETA bounds (≤ 0, > 240 min, non-finite → suppressed)
- `Math.ceil` for ETA rounding (89 sec → `~1m`, not `~0m`)

## Implementation

- New `src/hud/eta.ts` — pure algorithm (zero deps, ~190 LOC)
- New `src/__tests__/hud/context-eta.test.ts` — 38 tests / 11 describe blocks
- Extends `renderContext` + `renderContextWithBar` with optional `etaMinutes` (both code paths covered, `render.ts:434/447`)
- Cache schema: adds `contextEtaSamples` to `.omc/state/hud-stdin-cache.json`, keyed by existing `isSameContextStream` to prevent cross-session collision (P0 from review)
- Wires `render.ts` to compute ETA in `writeStdinCache` side-effect path (keeps render pure) and thread to whichever branch fires

## Configuration

ETA is on by default for the `context` element. Display is conservative (suppressed during cold start, idle, pathological samples) — opt-out via existing `hudLayout` (#2655) by removing the `context` element if needed.

## Background

This is **PR #1 of a 4-PR HUD enhancement series** inspired by codachi:

- 🟢 **PR #1: Context ETA** ← this PR
- ⚪ PR #2: Terminal color degrade (truecolor / 256 / 16 / mono auto-detect, `NO_COLOR` honored)
- ⚪ PR #3: HUD i18n (zh-CN bundled, EN fallback)
- ⚪ PR #4: Productivity stats CLI (independent skill, not a HUD element)

Each is **independent and mergeable** — no cross-PR coupling. Will be submitted serially after this one lands. (Lessons learned from #1945 — small, serial, never batch.)

Independent design consult performed via Codex (OpenAI) for algorithm + edge cases; independent code review by an Opus reviewer. Both report APPROVE / SHIP.

## Test plan

- [x] 38 new tests green (`npx vitest run src/__tests__/hud/context-eta.test.ts`)
- [x] Existing `context.test.ts` regression-clean (6/6 green)
- [x] Full HUD suite — 24 baseline failures all in unrelated files (`call-counts`, `cwd`, `state`, `usage-api-*`, `windows-platform`); zero new failures introduced by this PR
- [x] `npx tsc --noEmit` clean (0 errors)
- [x] `npx eslint` clean (0 warnings)
- [x] `npm run build` clean
- [x] No new dependencies (`package.json` unchanged)
- [x] No `console.log`, no `any`, no debugger statements

## Commits

1. `test(hud): add Context ETA element red tests (TDD)` — 38 tests, intentionally red
2. `feat(hud): implement Context ETA algorithm` — turns red green
3. `feat(hud): wire Context ETA into render path + cache persistence` — display + persistence

All three commits include `Constraint:` / `Confidence:` / `Scope-risk:` trailers per the OMC commit protocol, and the codachi MIT attribution.
