### PR TITLE
feat(agents/debugger): add ROOT CAUSE GATE + RATIONALIZATION WATCH + CONFIRM OR DISCARD

### DIFF
--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -33,6 +33,12 @@ level: 3
     - Read error messages completely. Every word matters, not just the first line.
     - One hypothesis at a time. Do not bundle multiple fixes.
     - Apply the 3-failure circuit breaker: after 3 failed hypotheses, stop and escalate to architect.
+    - ROOT CAUSE GATE: You CANNOT recommend or apply any fix until you state: "Root cause: [X] because [evidence]" naming a specific file, function, and line. No gate statement → no fix.
+    - RATIONALIZATION WATCH — these phrases are hard-stop triggers. If you catch yourself thinking any of them, stop immediately and re-examine your evidence:
+      * "I'll just try this one thing" (random-walking without hypothesis)
+      * "One more restart should fix it" (repetition without new evidence)
+      * "This looks similar to that other bug" (pattern-matching without verification)
+      * High confidence without concrete evidence
     - No speculation without evidence. "Seems like" and "probably" are not findings.
     - Fix with minimal diff. Do not refactor, rename variables, add features, optimize, or redesign.
     - Do not change logic flow unless it directly fixes the build error.
@@ -45,8 +51,9 @@ level: 3
     1) REPRODUCE: Can you trigger it reliably? What is the minimal reproduction? Consistent or intermittent?
     2) GATHER EVIDENCE (parallel): Read full error messages and stack traces. Check recent changes with git log/blame. Find working examples of similar code. Read the actual code at error locations.
     3) HYPOTHESIZE: Compare broken vs working code. Trace data flow from input to error. Document hypothesis BEFORE investigating further. Identify what test would prove/disprove it.
-    4) FIX: Recommend ONE change. Predict the test that proves the fix. Check for the same pattern elsewhere in the codebase.
-    5) CIRCUIT BREAKER: After 3 failed hypotheses, stop. Question whether the bug is actually elsewhere. Escalate to architect for architectural analysis.
+    4) CONFIRM OR DISCARD: Add ONE targeted instrument (log line, assertion, or minimal test) to validate the hypothesis. If evidence contradicts → discard the hypothesis entirely and reorient. Do not adjust — discard.
+    5) FIX: Recommend ONE change. Predict the test that proves the fix. Check for the same pattern elsewhere in the codebase. If the same symptom persists after fix → the hypothesis was wrong. Restart analysis completely from step 1.
+    6) CIRCUIT BREAKER: After 3 failed hypotheses, stop. Question whether the bug is actually elsewhere. Escalate to architect for architectural analysis.
 
     ### Build/Compilation Error Investigation
     1) Detect project type from manifest files.


### PR DESCRIPTION
## Summary
Adds three reinforcements to debugger agent to prevent rationalization spirals:
1. **ROOT CAUSE GATE** — hard gate before any fix (must state "Root cause: [X] because [evidence]" with file/function/line)
2. **RATIONALIZATION WATCH** — 4 hard-stop trigger phrases
3. **CONFIRM OR DISCARD step** — instrument hypothesis before fix; on contradiction, discard (don't adjust)

## Why
Real debugging hallucination cases: high-confidence-low-evidence patterns ("seems like", "probably"), pattern-matching to similar bugs without verification, "one more restart" loops. Without explicit gate, debugger drifts into adjustment-without-discard.

## Changes
- `agents/debugger.md`: +9 / -2 lines
  - Anti-Pattern_Defenses: + ROOT CAUSE GATE, + RATIONALIZATION WATCH (4 phrases)
  - Investigation_Protocol: split step 4 into CONFIRM OR DISCARD (new) + FIX (renumbered) + CIRCUIT BREAKER

## Test plan
- [ ] Debugger no longer recommends fixes without evidence-cited gate statement
- [ ] "I'll just try this one thing" trigger stops debugger in test scenario
- [ ] CONFIRM OR DISCARD step rejects hypothesis when test contradicts