### PR TITLE
Fix wiki PreCompact hook output schema

### DIFF
--- a/scripts/wiki-pre-compact.mjs
+++ b/scripts/wiki-pre-compact.mjs
@@ -10,10 +10,7 @@ async function main() {
     if (result.additionalContext) {
       console.log(JSON.stringify({
         continue: true,
-        hookSpecificOutput: {
-          hookEventName: 'PreCompact',
-          additionalContext: result.additionalContext,
-        },
+        systemMessage: result.additionalContext,
       }));
     } else {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/src/__tests__/wiki-hook-output-format.test.ts
+++ b/src/__tests__/wiki-hook-output-format.test.ts
@@ -53,6 +53,7 @@ describe('wiki hook wrapper output', () => {
       continue?: boolean;
       suppressOutput?: boolean;
       additionalContext?: string;
+      systemMessage?: string;
       hookSpecificOutput?: {
         hookEventName?: string;
         additionalContext?: string;
@@ -71,14 +72,13 @@ describe('wiki hook wrapper output', () => {
     });
   });
 
-  it('wraps PreCompact wiki context under hookSpecificOutput', () => {
+  it('emits PreCompact wiki context as top-level systemMessage', () => {
     const output = runHook(PRE_COMPACT_SCRIPT);
 
     expect(output.continue).toBe(true);
-    expect(output.additionalContext).toBeUndefined();
-    expect(output.hookSpecificOutput).toEqual({
-      hookEventName: 'PreCompact',
-      additionalContext: '[Wiki: 1 pages | categories: reference | last updated: 2026-04-13T00:00:00.000Z]',
-    });
+    expect(output.hookSpecificOutput).toBeUndefined();
+    expect(output.systemMessage).toBe(
+      '[Wiki: 1 pages | categories: reference | last updated: 2026-04-13T00:00:00.000Z]',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Emit wiki PreCompact context via top-level `systemMessage` instead of `hookSpecificOutput`
- Update focused wiki hook output test to assert the PreCompact schema

## Validation
- `npm run test:run -- src/__tests__/wiki-hook-output-format.test.ts`
- `npx tsc --noEmit`

Closes #2923