### PR TITLE
fix(pre-tool-enforcer): reduce SLOP fallback false positives

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -170,6 +170,16 @@ const SLOP_RISK_TOOL_NAMES = new Set([
   'NotebookEdit',
 ]);
 const SLOP_FALLBACK_LANGUAGE_PATTERN = /\b(?:fallback|fall\s+back|workaround|work\s+around)\b/i;
+const SLOP_FALLBACK_ACTION_PATTERNS = [
+  /\b(?:add|build|create|implement|introduce|make|patch|use|using|write)\s+(?:an?\s+|the\s+)?(?:fallback|workaround)\b/i,
+  /\b(?:fallback|workaround)\s+(?:layer|path|handler|shim|patch|implementation|mechanism|mode)\b/i,
+  /\bfall\s+back\s+to\b/i,
+  /\bwork\s+around\s+(?:it|this|that|the|a|an)\b/i,
+  /(?:^|[\s"'`=:/\\])[\w.-]*(?:fallback|workaround)[\w.-]*\.(?:cjs|js|mjs|py|sh|ts|tsx)\b/i,
+];
+const SLOP_DOC_CONTEXT_PATTERN = /(?:^|[/\\])(?:docs?|documentation|guides?|instructions?|prompts?|\.om[ctx])(?:[/\\]|$)|\.(?:md|mdx|txt|rst)$/i;
+const SLOP_SELF_REFERENCE_PATH_PATTERN = /(?:^|[/\\])(?:pre-tool-enforcer(?:\.mjs)?|pre-tool-enforcer\.test\.ts)(?:$|[/\\])/i;
+const SLOP_DOCUMENTATION_PHRASE_PATTERN = /\b(?:document|documents|documenting|describe|describes|describing|explain|explains|explaining|mention|mentions|quote|quotes|instruction|instructions|rule|rules|detector|warning)\b/i;
 
 function collectStringValues(value, output = [], depth = 0) {
   if (depth > 5 || output.length > 100) return output;
@@ -191,8 +201,50 @@ function collectStringValues(value, output = [], depth = 0) {
   return output;
 }
 
+function collectLikelyPathValues(value, output = [], depth = 0) {
+  if (depth > 5 || output.length > 100 || !value || typeof value !== 'object') return output;
+  if (Array.isArray(value)) {
+    for (const item of value) collectLikelyPathValues(item, output, depth + 1);
+    return output;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (typeof child === 'string' && /(?:^|_)(?:file_?path|path|filename|target|command)$/i.test(key)) {
+      output.push(child);
+      continue;
+    }
+    collectLikelyPathValues(child, output, depth + 1);
+  }
+  return output;
+}
+
+function hasSlopFallbackActionShape(text) {
+  return SLOP_FALLBACK_ACTION_PATTERNS.some(pattern => pattern.test(text));
+}
+
+function isSelfReferentialSlopContext(toolInput) {
+  return collectLikelyPathValues(toolInput).some(value => SLOP_SELF_REFERENCE_PATH_PATTERN.test(value));
+}
+
+function isDocumentationSlopContext(toolInput, inspectedText) {
+  const pathLikeValues = collectLikelyPathValues(toolInput);
+  return pathLikeValues.some(value => SLOP_DOC_CONTEXT_PATTERN.test(value))
+    || (/^#{1,6}\s+\S/m.test(inspectedText) && SLOP_DOCUMENTATION_PHRASE_PATTERN.test(inspectedText));
+}
+
+function shouldWarnForSlopFallbackLanguage(data, toolName, inspectedText) {
+  if (!SLOP_RISK_TOOL_NAMES.has(toolName)) return false;
+  if (!SLOP_FALLBACK_LANGUAGE_PATTERN.test(inspectedText)) return false;
+
+  const toolInput = data.toolInput || data.tool_input || {};
+  if (isSelfReferentialSlopContext(toolInput)) return false;
+  if (isDocumentationSlopContext(toolInput, inspectedText) && !hasSlopFallbackActionShape(inspectedText)) {
+    return false;
+  }
+
+  return hasSlopFallbackActionShape(inspectedText);
+}
+
 function generateSlopWarning(data, toolName) {
-  if (!SLOP_RISK_TOOL_NAMES.has(toolName)) return '';
   const toolInput = data.toolInput || data.tool_input || {};
   const promptLikeFields = {
     prompt: data.prompt,
@@ -203,7 +255,7 @@ function generateSlopWarning(data, toolName) {
   const inspectedText = collectStringValues(toolInput)
     .concat(collectStringValues(promptLikeFields))
     .join('\n');
-  if (!SLOP_FALLBACK_LANGUAGE_PATTERN.test(inspectedText)) return '';
+  if (!shouldWarnForSlopFallbackLanguage(data, toolName, inspectedText)) return '';
 
   return '[SLOP WARNING] Detected fallback/workaround language in this tool input. ' +
     'Do not make potential slop: avoid ad-hoc fallback layers, workaround shims, or environment-specific patches unless explicitly justified. ' +

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -173,14 +173,13 @@ const SLOP_FALLBACK_LANGUAGE_PATTERN = /\b(?:fallback|fall\s+back|workaround|wor
 const SLOP_FALLBACK_ACTION_PATTERNS = [
   /\b(?:add|build|create|implement|introduce|make|patch|use|using|write)\s+(?:an?\s+|the\s+)?(?:fallback|workaround)\b/i,
   /\b(?:fallback|workaround)\s+(?:layer|path|handler|shim|patch|implementation|mechanism|mode)\b/i,
-  /\bfall\s+back\s+to\b/i,
+  /\b(?:fall\s+back|fallback)\s+(?:to|on|onto)\b/i,
   /\bwork\s+around\s+(?:it|this|that|the|a|an)\b/i,
   /\bwork\s+around\s+(?!(?:it|this|that|the|a|an)\b)(?:[a-z0-9][\w-]*\s+){0,5}[a-z0-9][\w-]*\b/i,
   /(?:^|[\s"'`=:/\\])[\w.-]*(?:fallback|workaround)[\w.-]*\.(?:cjs|js|mjs|py|sh|ts|tsx)\b/i,
 ];
 const SLOP_DOC_CONTEXT_PATTERN = /(?:^|[/\\])(?:docs?|documentation|guides?|instructions?|prompts?|\.om[ctx])(?:[/\\]|$)|\.(?:md|mdx|txt|rst)$/i;
 const SLOP_SELF_REFERENCE_PATH_PATTERN = /(?:^|[/\\])(?:pre-tool-enforcer(?:\.mjs)?|pre-tool-enforcer\.test\.ts)(?:$|[/\\])/i;
-const SLOP_DOCUMENTATION_PHRASE_PATTERN = /\b(?:document|documents|documenting|describe|describes|describing|explain|explains|explaining|mention|mentions|quote|quotes|instruction|instructions|rule|rules|detector|warning)\b/i;
 
 function collectStringValues(value, output = [], depth = 0) {
   if (depth > 5 || output.length > 100) return output;
@@ -226,10 +225,9 @@ function isSelfReferentialSlopContext(toolInput) {
   return collectLikelyPathValues(toolInput).some(value => SLOP_SELF_REFERENCE_PATH_PATTERN.test(value));
 }
 
-function isDocumentationSlopContext(toolInput, inspectedText) {
+function isDocumentationSlopContext(toolInput) {
   const pathLikeValues = collectLikelyPathValues(toolInput);
-  return pathLikeValues.some(value => SLOP_DOC_CONTEXT_PATTERN.test(value))
-    || (/^#{1,6}\s+\S/m.test(inspectedText) && SLOP_DOCUMENTATION_PHRASE_PATTERN.test(inspectedText));
+  return pathLikeValues.some(value => SLOP_DOC_CONTEXT_PATTERN.test(value));
 }
 
 function shouldWarnForSlopFallbackLanguage(data, toolName, inspectedText) {
@@ -238,7 +236,7 @@ function shouldWarnForSlopFallbackLanguage(data, toolName, inspectedText) {
 
   const toolInput = data.toolInput || data.tool_input || {};
   if (isSelfReferentialSlopContext(toolInput)) return false;
-  if (isDocumentationSlopContext(toolInput, inspectedText)) {
+  if (isDocumentationSlopContext(toolInput)) {
     return false;
   }
 

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -175,6 +175,7 @@ const SLOP_FALLBACK_ACTION_PATTERNS = [
   /\b(?:fallback|workaround)\s+(?:layer|path|handler|shim|patch|implementation|mechanism|mode)\b/i,
   /\bfall\s+back\s+to\b/i,
   /\bwork\s+around\s+(?:it|this|that|the|a|an)\b/i,
+  /\bwork\s+around\s+(?!(?:it|this|that|the|a|an)\b)(?:[a-z0-9][\w-]*\s+){0,5}[a-z0-9][\w-]*\b/i,
   /(?:^|[\s"'`=:/\\])[\w.-]*(?:fallback|workaround)[\w.-]*\.(?:cjs|js|mjs|py|sh|ts|tsx)\b/i,
 ];
 const SLOP_DOC_CONTEXT_PATTERN = /(?:^|[/\\])(?:docs?|documentation|guides?|instructions?|prompts?|\.om[ctx])(?:[/\\]|$)|\.(?:md|mdx|txt|rst)$/i;
@@ -237,7 +238,7 @@ function shouldWarnForSlopFallbackLanguage(data, toolName, inspectedText) {
 
   const toolInput = data.toolInput || data.tool_input || {};
   if (isSelfReferentialSlopContext(toolInput)) return false;
-  if (isDocumentationSlopContext(toolInput, inspectedText) && !hasSlopFallbackActionShape(inspectedText)) {
+  if (isDocumentationSlopContext(toolInput, inspectedText)) {
     return false;
   }
 

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -465,6 +465,64 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(context).not.toContain('Use parallel execution');
   });
 
+  it('does not warn for documentation edits that describe workaround terms as nouns', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Write',
+      toolInput: {
+        file_path: join(tempDir, 'docs', 'troubleshooting.md'),
+        content: [
+          '# Troubleshooting',
+          '',
+          'Document workaround for a specific bug in the troubleshooting guide.',
+          'This section explains when the workaround term appears in instructions.',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-doc-text',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
+  it('does not warn for self-referential pre-tool enforcer edits that document the rule', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Edit',
+      toolInput: {
+        file_path: 'scripts/pre-tool-enforcer.mjs',
+        old_string: 'const SLOP_FALLBACK_LANGUAGE_PATTERN = /fallback|workaround/i;',
+        new_string: [
+          '// The fallback/workaround detector should avoid warning on rule documentation.',
+          'const SLOP_FALLBACK_LANGUAGE_PATTERN = /fallback|workaround/i;',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-self-reference',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
+  it('still warns for action-shaped fallback narration outside documentation contexts', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Implement fallback routing',
+        prompt: 'Please implement a fallback layer for the flaky API.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-action-shaped',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
   it('does not warn for read-only search tools that mention fallback as the query', () => {
     const output = runPreToolEnforcer({
       tool_name: 'Grep',

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -523,6 +523,43 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
   });
 
+  it('warns for natural work-around phrasing with direct noun objects', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Skip architecture for flaky API failures',
+        prompt: 'Please work around flaky API failures by skipping the normal architecture.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-work-around-noun-object',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
+  it('does not warn for documentation edits that quote action-shaped work-around wording', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Write',
+      toolInput: {
+        file_path: join(tempDir, 'docs', 'architecture-notes.md'),
+        content: [
+          '# Architecture notes',
+          '',
+          'Explain why the phrase "Please work around flaky API failures" should be reviewed carefully.',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-doc-action-shaped',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
   it('does not warn for read-only search tools that mention fallback as the query', () => {
     const output = runPreToolEnforcer({
       tool_name: 'Grep',

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -540,6 +540,61 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
   });
 
+  it('warns for fall back on cached responses phrasing', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Add API fallback',
+        prompt: 'If the API fails, fall back on cached responses.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-fall-back-on',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
+  it('warns for single-word fallback to cached responses phrasing', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Add API fallback',
+        prompt: 'If the API fails, fallback to cached responses.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-fallback-to',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
+  it('does not treat markdown headings alone as documentation context for Task prompts', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Implement fallback routing',
+        prompt: [
+          '## Implementation',
+          '',
+          'Please implement a fallback layer and explain why.',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-markdown-task',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
   it('does not warn for documentation edits that quote action-shaped work-around wording', () => {
     const output = runPreToolEnforcer({
       tool_name: 'Write',


### PR DESCRIPTION
## Summary
- narrow SLOP fallback/workaround warnings to action-shaped fallback narration
- suppress target-path self-referential pre-tool-enforcer edits
- add regression coverage for doc/instruction noun false positives while preserving real warning cases

Closes #2927

## Tests
- npm test -- --run src/__tests__/pre-tool-enforcer.test.ts