### PR TITLE
feat(deep-dive): add ownership scope to Lane 3 moves

### DIFF
--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -139,7 +139,7 @@ Use **Claude built-in team mode** to run 3 parallel tracer lanes:
    - Name the **critical unknown** for the lane
    - Recommend the best **discriminating probe**
    - For **Lane 3: Misplacement / SoT Violation** findings, classify every candidate MOVE destination with `ownership_scope` before ranking recommendations:
-     - `personal-config`: user-level dotfiles, `~/.claude/`, personal repositories, or user-only agent rules
+     - `personal-config`: user-level dotfiles, `[$CLAUDE_CONFIG_DIR|~/.claude]/`, personal repositories, or user-only agent rules
      - `shared-config`: company/org repositories, team-maintained config, or multi-tenant shared rules
      - `external`: third-party, vendor, or OSS upstream repositories outside the user's ownership
      - `project-scoped`: per-project storage owned by the current project boundary

--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -138,6 +138,12 @@ Use **Claude built-in team mode** to run 3 parallel tracer lanes:
    - Rank evidence strength (from controlled reproductions → speculation)
    - Name the **critical unknown** for the lane
    - Recommend the best **discriminating probe**
+   - For **Lane 3: Misplacement / SoT Violation** findings, classify every candidate MOVE destination with `ownership_scope` before ranking recommendations:
+     - `personal-config`: user-level dotfiles, `~/.claude/`, personal repositories, or user-only agent rules
+     - `shared-config`: company/org repositories, team-maintained config, or multi-tenant shared rules
+     - `external`: third-party, vendor, or OSS upstream repositories outside the user's ownership
+     - `project-scoped`: per-project storage owned by the current project boundary
+   - For Lane 3, compare source and destination `ownership_scope`; any cross-boundary MOVE (for example `personal-config` → `shared-config`) MUST be flagged with an explicit warning and MUST NOT be surfaced as the default recommendation. Prefer COMPRESS, KEEP, or a same-scope MOVE as the default when available.
 4. **Run a rebuttal round** between the leading hypothesis and the strongest alternative
 5. **Detect convergence**: if two "different" hypotheses reduce to the same mechanism, merge them explicitly
 6. **Leader synthesis**: produce the ranked output below
@@ -175,6 +181,15 @@ Save to `.omc/specs/deep-dive-trace-{slug}.md`:
 - **Lane 1 ({hypothesis_1})**: {critical_unknown_1}
 - **Lane 2 ({hypothesis_2})**: {critical_unknown_2}
 - **Lane 3 ({hypothesis_3})**: {critical_unknown_3}
+
+## Lane 3 Misplacement / SoT Ownership Scope
+For each MOVE candidate discovered by Lane 3, include:
+
+| Source | Candidate destination | ownership_scope | Boundary relationship | Default? | Warning |
+|--------|-----------------------|-----------------|-----------------------|----------|---------|
+| ... | ... | personal-config/shared-config/external/project-scoped | same-scope/cross-boundary | yes/no | ... |
+
+Cross-boundary MOVE candidates MUST have `Default? = no` and an explicit warning explaining the source/destination ownership mismatch. They may be listed as flagged alternatives, but the ranked synthesis MUST NOT present them as the default recommendation.
 
 ## Rebuttal Round
 - Best rebuttal to leader: ...
@@ -417,6 +432,7 @@ Why bad: Duplicates deep-interview's behavioral contract. These values should be
 - [ ] Phase 2 confirms hypotheses via AskUserQuestion (1 round)
 - [ ] Phase 3 runs trace with 3 parallel lanes (team mode, sequential fallback)
 - [ ] Phase 3 saves trace result to `.omc/specs/deep-dive-trace-{slug}.md` with per-lane critical unknowns
+- [ ] Lane 3 MOVE candidates include `ownership_scope` and cross-boundary MOVE candidates are warned/flagged, not default recommendations
 - [ ] Phase 4 starts with 3-point injection (initial_idea, codebase_context, question_queue from per-lane unknowns)
 - [ ] Phase 4 references deep-interview SKILL.md Phases 2-4 (not duplicated inline)
 - [ ] Phase 4 handles low-confidence trace gracefully

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -292,6 +292,11 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('initial question queue injection');
       // Verify per-lane critical unknowns (B3 fix)
       expect(skill?.template).toContain('Per-Lane Critical Unknowns');
+      // Verify Lane 3 ownership-boundary classification for MOVE recommendations
+      expect(skill?.template).toContain('Lane 3 Misplacement / SoT Ownership Scope');
+      expect(skill?.template).toContain('ownership_scope');
+      expect(skill?.template).toContain('personal-config/shared-config/external/project-scoped');
+      expect(skill?.template).toContain('Cross-boundary MOVE candidates MUST have `Default? = no`');
       // Verify pipeline handoff is fully wired (B1 fix)
       expect(skill?.template).toContain('Skill("oh-my-claudecode:autopilot")');
       expect(skill?.template).toContain('consensus plan as Phase 0+1 output');


### PR DESCRIPTION
## Summary\n- add Lane 3 ownership_scope classification for MOVE candidates\n- warn/flag cross-boundary MOVE candidates and prevent them from being default recommendations\n- add focused skill-template assertions for the ownership-scope contract\n\nCloses #2925\n\n## Verification\n- npx vitest run src/__tests__/skills.test.ts --reporter verbose\n- npm run lint (passes with existing warnings)\n- npx tsc --noEmit\n- git diff --check