### PR TITLE
fix(skills): use plan skill id for consensus handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ These shortcuts run **inside a Claude Code / OMC session**, not as terminal CLI 
 
 - **ralph includes ultrawork**: when you activate ralph mode, it automatically includes ultrawork's parallel execution.
 - `swarm` compatibility alias has been removed; migrate existing prompts to `/team` syntax.
-- `plan this` / `plan the` keyword triggers were removed; use `ralplan` or explicit `/oh-my-claudecode:omc-plan`.
+- `plan this` / `plan the` keyword triggers were removed; use `ralplan` or explicit `/oh-my-claudecode:plan`.
 
 ## Utilities
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -544,14 +544,14 @@ Includes **34 canonical skills + 2 deprecated aliases** (`learner`, `psm`). Runt
 | `learner`                 | **Deprecated** compatibility alias for `skillify`                | `/oh-my-claudecode:learner`                 |
 | `mcp-setup`               | Configure MCP servers                                            | `/oh-my-claudecode:mcp-setup`               |
 | `omc-doctor`              | Diagnose and fix installation issues                             | `/oh-my-claudecode:omc-doctor`              |
-| `omc-plan`                | Planning workflow (`/plan` safe alias)                           | `/oh-my-claudecode:omc-plan`                |
+| `omc-plan`                | Planning workflow (`/plan` safe alias; bundled directory ID is `plan`) | `/oh-my-claudecode:plan`                    |
 | `omc-reference`           | Detailed OMC agent/tools/team/commit reference skill             | Auto-loaded reference only                  |
 | `omc-setup`               | One-time setup wizard                                            | `/oh-my-claudecode:omc-setup`               |
 | `omc-teams`               | Spawn `claude`/`codex`/`gemini` tmux workers for parallel execution | `/oh-my-claudecode:omc-teams`             |
 | `project-session-manager` | Manage isolated dev environments (git worktrees + tmux)          | `/oh-my-claudecode:project-session-manager` |
 | `psm` | **Deprecated** compatibility alias for `project-session-manager` | `/oh-my-claudecode:psm` |
 | `ralph`                   | Persistence loop until verified completion                       | `/oh-my-claudecode:ralph`                   |
-| `ralplan`                 | Consensus planning alias for `/omc-plan --consensus`             | `/oh-my-claudecode:ralplan`                 |
+| `ralplan`                 | Consensus planning alias for `/plan --consensus`                 | `/oh-my-claudecode:ralplan`                 |
 | `release`                 | Automated release workflow                                       | `/oh-my-claudecode:release`                 |
 | `self-improve`            | Autonomous evolutionary code improvement engine with tournament selection; artifacts are topic-scoped under `.omc/self-improve/topics/<topic-slug>/` by default, with flat `.omc/self-improve/` preserved for legacy single-track resumes | `/oh-my-claudecode:self-improve`    |
 | `setup`                   | Unified setup entrypoint for install, diagnostics, and MCP configuration | `/oh-my-claudecode:setup`              |
@@ -583,7 +583,7 @@ Each installed skill is exposed as `/oh-my-claudecode:<skill-name>`. The skills 
 | `/oh-my-claudecode:deepinit [path]`             | Index codebase with hierarchical AGENTS.md files                                           |
 | `/oh-my-claudecode:mcp-setup`                   | Configure MCP servers                                                                      |
 | `/oh-my-claudecode:omc-doctor`                  | Diagnose and fix installation issues                                                       |
-| `/oh-my-claudecode:omc-plan <description>`      | Start planning session (supports consensus structured deliberation)                        |
+| `/oh-my-claudecode:plan <description>`          | Start planning session (supports consensus structured deliberation)                        |
 | `/oh-my-claudecode:omc-setup`                   | One-time setup wizard                                                                      |
 | `/oh-my-claudecode:omc-teams <N>:<agent> <task>`       | Spawn `claude`/`codex`/`gemini` tmux workers for legacy parallel execution                |
 | `/oh-my-claudecode:project-session-manager <arguments>` | Manage isolated dev environments with git worktrees + tmux                         |
@@ -604,8 +604,8 @@ Each installed skill is exposed as `/oh-my-claudecode:<skill-name>`. The skills 
 Built-in skills and slash-loaded skills can now declare a lightweight pipeline/handoff contract in frontmatter:
 
 ```yaml
-pipeline: [deep-interview, omc-plan, autopilot]
-next-skill: omc-plan
+pipeline: [deep-interview, plan, autopilot]
+next-skill: plan
 next-skill-args: --consensus --direct
 handoff: .omc/specs/deep-interview-{slug}.md
 ```

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -544,14 +544,14 @@ Includes **34 canonical skills + 2 deprecated aliases** (`learner`, `psm`). Runt
 | `learner`                 | **Deprecated** compatibility alias for `skillify`                | `/oh-my-claudecode:learner`                 |
 | `mcp-setup`               | Configure MCP servers                                            | `/oh-my-claudecode:mcp-setup`               |
 | `omc-doctor`              | Diagnose and fix installation issues                             | `/oh-my-claudecode:omc-doctor`              |
-| `omc-plan`                | Planning workflow (`/plan` safe alias)                           | `/oh-my-claudecode:omc-plan`                |
+| `omc-plan`                | Planning workflow (`/plan` safe alias; bundled directory ID is `plan`) | `/oh-my-claudecode:plan`                    |
 | `omc-reference`           | Detailed OMC agent/tools/team/commit reference skill             | Auto-loaded reference only                  |
 | `omc-setup`               | One-time setup wizard                                            | `/oh-my-claudecode:omc-setup`               |
 | `omc-teams`               | Spawn `claude`/`codex`/`gemini` tmux workers for parallel execution | `/oh-my-claudecode:omc-teams`             |
 | `project-session-manager` | Manage isolated dev environments (git worktrees + tmux)          | `/oh-my-claudecode:project-session-manager` |
 | `psm` | **Deprecated** compatibility alias for `project-session-manager` | `/oh-my-claudecode:psm` |
 | `ralph`                   | Persistence loop until verified completion                       | `/oh-my-claudecode:ralph`                   |
-| `ralplan`                 | Consensus planning alias for `/omc-plan --consensus`             | `/oh-my-claudecode:ralplan`                 |
+| `ralplan`                 | Consensus planning alias for `/plan --consensus`                 | `/oh-my-claudecode:ralplan`                 |
 | `release`                 | Automated release workflow                                       | `/oh-my-claudecode:release`                 |
 | `self-improve`            | Autonomous evolutionary code improvement engine with tournament selection; artifacts are topic-scoped under `.omc/self-improve/topics/<topic-slug>/` by default, with flat `.omc/self-improve/` preserved for legacy single-track resumes | `/oh-my-claudecode:self-improve`    |
 | `setup`                   | Unified setup entrypoint for install, diagnostics, and MCP configuration | `/oh-my-claudecode:setup`              |
@@ -583,7 +583,7 @@ Each installed skill is exposed as `/oh-my-claudecode:<skill-name>`. The skills 
 | `/oh-my-claudecode:deepinit [path]`             | Index codebase with hierarchical AGENTS.md files                                           |
 | `/oh-my-claudecode:mcp-setup`                   | Configure MCP servers                                                                      |
 | `/oh-my-claudecode:omc-doctor`                  | Diagnose and fix installation issues                                                       |
-| `/oh-my-claudecode:omc-plan <description>`      | Start planning session (supports consensus structured deliberation)                        |
+| `/oh-my-claudecode:plan <description>`          | Start planning session (supports consensus structured deliberation)                        |
 | `/oh-my-claudecode:omc-setup`                   | One-time setup wizard                                                                      |
 | `/oh-my-claudecode:omc-teams <N>:<agent> <task>`       | Spawn `claude`/`codex`/`gemini` tmux workers for legacy parallel execution                |
 | `/oh-my-claudecode:project-session-manager <arguments>` | Manage isolated dev environments with git worktrees + tmux                         |

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -170,6 +170,16 @@ const SLOP_RISK_TOOL_NAMES = new Set([
   'NotebookEdit',
 ]);
 const SLOP_FALLBACK_LANGUAGE_PATTERN = /\b(?:fallback|fall\s+back|workaround|work\s+around)\b/i;
+const SLOP_FALLBACK_ACTION_PATTERNS = [
+  /\b(?:add|build|create|implement|introduce|make|patch|use|using|write)\s+(?:an?\s+|the\s+)?(?:fallback|workaround)\b/i,
+  /\b(?:fallback|workaround)\s+(?:layer|path|handler|shim|patch|implementation|mechanism|mode)\b/i,
+  /\b(?:fall\s+back|fallback)\s+(?:to|on|onto)\b/i,
+  /\bwork\s+around\s+(?:it|this|that|the|a|an)\b/i,
+  /\bwork\s+around\s+(?!(?:it|this|that|the|a|an)\b)(?:[a-z0-9][\w-]*\s+){0,5}[a-z0-9][\w-]*\b/i,
+  /(?:^|[\s"'`=:/\\])[\w.-]*(?:fallback|workaround)[\w.-]*\.(?:cjs|js|mjs|py|sh|ts|tsx)\b/i,
+];
+const SLOP_DOC_CONTEXT_PATTERN = /(?:^|[/\\])(?:docs?|documentation|guides?|instructions?|prompts?|\.om[ctx])(?:[/\\]|$)|\.(?:md|mdx|txt|rst)$/i;
+const SLOP_SELF_REFERENCE_PATH_PATTERN = /(?:^|[/\\])(?:pre-tool-enforcer(?:\.mjs)?|pre-tool-enforcer\.test\.ts)(?:$|[/\\])/i;
 
 function collectStringValues(value, output = [], depth = 0) {
   if (depth > 5 || output.length > 100) return output;
@@ -191,8 +201,49 @@ function collectStringValues(value, output = [], depth = 0) {
   return output;
 }
 
+function collectLikelyPathValues(value, output = [], depth = 0) {
+  if (depth > 5 || output.length > 100 || !value || typeof value !== 'object') return output;
+  if (Array.isArray(value)) {
+    for (const item of value) collectLikelyPathValues(item, output, depth + 1);
+    return output;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (typeof child === 'string' && /(?:^|_)(?:file_?path|path|filename|target|command)$/i.test(key)) {
+      output.push(child);
+      continue;
+    }
+    collectLikelyPathValues(child, output, depth + 1);
+  }
+  return output;
+}
+
+function hasSlopFallbackActionShape(text) {
+  return SLOP_FALLBACK_ACTION_PATTERNS.some(pattern => pattern.test(text));
+}
+
+function isSelfReferentialSlopContext(toolInput) {
+  return collectLikelyPathValues(toolInput).some(value => SLOP_SELF_REFERENCE_PATH_PATTERN.test(value));
+}
+
+function isDocumentationSlopContext(toolInput) {
+  const pathLikeValues = collectLikelyPathValues(toolInput);
+  return pathLikeValues.some(value => SLOP_DOC_CONTEXT_PATTERN.test(value));
+}
+
+function shouldWarnForSlopFallbackLanguage(data, toolName, inspectedText) {
+  if (!SLOP_RISK_TOOL_NAMES.has(toolName)) return false;
+  if (!SLOP_FALLBACK_LANGUAGE_PATTERN.test(inspectedText)) return false;
+
+  const toolInput = data.toolInput || data.tool_input || {};
+  if (isSelfReferentialSlopContext(toolInput)) return false;
+  if (isDocumentationSlopContext(toolInput)) {
+    return false;
+  }
+
+  return hasSlopFallbackActionShape(inspectedText);
+}
+
 function generateSlopWarning(data, toolName) {
-  if (!SLOP_RISK_TOOL_NAMES.has(toolName)) return '';
   const toolInput = data.toolInput || data.tool_input || {};
   const promptLikeFields = {
     prompt: data.prompt,
@@ -203,7 +254,7 @@ function generateSlopWarning(data, toolName) {
   const inspectedText = collectStringValues(toolInput)
     .concat(collectStringValues(promptLikeFields))
     .join('\n');
-  if (!SLOP_FALLBACK_LANGUAGE_PATTERN.test(inspectedText)) return '';
+  if (!shouldWarnForSlopFallbackLanguage(data, toolName, inspectedText)) return '';
 
   return '[SLOP WARNING] Detected fallback/workaround language in this tool input. ' +
     'Do not make potential slop: avoid ad-hoc fallback layers, workaround shims, or environment-specific patches unless explicitly justified. ' +

--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -7,8 +7,8 @@ triggers:
   - "deep-dive"
   - "trace and interview"
   - "investigate deeply"
-pipeline: [deep-dive, omc-plan, autopilot]
-next-skill: omc-plan
+pipeline: [deep-dive, plan, autopilot]
+next-skill: plan
 next-skill-args: --consensus --direct
 handoff: .omc/specs/deep-dive-{slug}.md
 ---
@@ -322,7 +322,7 @@ If the guidance gate does not apply, or the pre-flight passes, present execution
 
 1. **Ralplan → Autopilot (Recommended)**
    - Description: "3-stage pipeline: consensus-refine this spec with Planner/Architect/Critic, then execute with full autopilot. Maximum quality."
-   - Action: Invoke `Skill("oh-my-claudecode:omc-plan")` with `--consensus --direct` flags and the spec file path (`spec_path` from state) as context. The `--direct` flag skips the omc-plan skill's interview phase (the deep-dive interview already gathered requirements), while `--consensus` triggers the Planner/Architect/Critic loop. When consensus completes and produces a plan in `.omc/plans/`, invoke `Skill("oh-my-claudecode:autopilot")` with the consensus plan as Phase 0+1 output — autopilot skips both Expansion and Planning, starting directly at Phase 2 (Execution).
+   - Action: Invoke `Skill("oh-my-claudecode:plan")` with `--consensus --direct` flags and the spec file path (`spec_path` from state) as context. The `--direct` flag skips the omc-plan skill's interview phase (the deep-dive interview already gathered requirements), while `--consensus` triggers the Planner/Architect/Critic loop. When consensus completes and produces a plan in `.omc/plans/`, invoke `Skill("oh-my-claudecode:autopilot")` with the consensus plan as Phase 0+1 output — autopilot skips both Expansion and Planning, starting directly at Phase 2 (Execution).
    - Pipeline: `deep-dive spec → omc-plan --consensus --direct → autopilot execution`
 
 2. **Execute with autopilot (skip ralplan)**

--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -7,8 +7,8 @@ triggers:
   - "deep-dive"
   - "trace and interview"
   - "investigate deeply"
-pipeline: [deep-dive, omc-plan, autopilot]
-next-skill: omc-plan
+pipeline: [deep-dive, plan, autopilot]
+next-skill: plan
 next-skill-args: --consensus --direct
 handoff: .omc/specs/deep-dive-{slug}.md
 ---
@@ -278,7 +278,7 @@ Present execution options via `AskUserQuestion`:
 
 1. **Ralplan → Autopilot (Recommended)**
    - Description: "3-stage pipeline: consensus-refine this spec with Planner/Architect/Critic, then execute with full autopilot. Maximum quality."
-   - Action: Invoke `Skill("oh-my-claudecode:omc-plan")` with `--consensus --direct` flags and the spec file path (`spec_path` from state) as context. The `--direct` flag skips the omc-plan skill's interview phase (the deep-dive interview already gathered requirements), while `--consensus` triggers the Planner/Architect/Critic loop. When consensus completes and produces a plan in `.omc/plans/`, invoke `Skill("oh-my-claudecode:autopilot")` with the consensus plan as Phase 0+1 output — autopilot skips both Expansion and Planning, starting directly at Phase 2 (Execution).
+   - Action: Invoke `Skill("oh-my-claudecode:plan")` with `--consensus --direct` flags and the spec file path (`spec_path` from state) as context. The `--direct` flag skips the omc-plan skill's interview phase (the deep-dive interview already gathered requirements), while `--consensus` triggers the Planner/Architect/Critic loop. When consensus completes and produces a plan in `.omc/plans/`, invoke `Skill("oh-my-claudecode:autopilot")` with the consensus plan as Phase 0+1 output — autopilot skips both Expansion and Planning, starting directly at Phase 2 (Execution).
    - Pipeline: `deep-dive spec → omc-plan --consensus --direct → autopilot execution`
 
 2. **Execute with autopilot (skip ralplan)**

--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -138,6 +138,12 @@ Use **Claude built-in team mode** to run 3 parallel tracer lanes:
    - Rank evidence strength (from controlled reproductions → speculation)
    - Name the **critical unknown** for the lane
    - Recommend the best **discriminating probe**
+   - For **Lane 3: Misplacement / SoT Violation** findings, classify every candidate MOVE destination with `ownership_scope` before ranking recommendations:
+     - `personal-config`: user-level dotfiles, `[$CLAUDE_CONFIG_DIR|~/.claude]/`, personal repositories, or user-only agent rules
+     - `shared-config`: company/org repositories, team-maintained config, or multi-tenant shared rules
+     - `external`: third-party, vendor, or OSS upstream repositories outside the user's ownership
+     - `project-scoped`: per-project storage owned by the current project boundary
+   - For Lane 3, compare source and destination `ownership_scope`; any cross-boundary MOVE (for example `personal-config` → `shared-config`) MUST be flagged with an explicit warning and MUST NOT be surfaced as the default recommendation. Prefer COMPRESS, KEEP, or a same-scope MOVE as the default when available.
 4. **Run a rebuttal round** between the leading hypothesis and the strongest alternative
 5. **Detect convergence**: if two "different" hypotheses reduce to the same mechanism, merge them explicitly
 6. **Leader synthesis**: produce the ranked output below
@@ -175,6 +181,15 @@ Save to `.omc/specs/deep-dive-trace-{slug}.md`:
 - **Lane 1 ({hypothesis_1})**: {critical_unknown_1}
 - **Lane 2 ({hypothesis_2})**: {critical_unknown_2}
 - **Lane 3 ({hypothesis_3})**: {critical_unknown_3}
+
+## Lane 3 Misplacement / SoT Ownership Scope
+For each MOVE candidate discovered by Lane 3, include:
+
+| Source | Candidate destination | ownership_scope | Boundary relationship | Default? | Warning |
+|--------|-----------------------|-----------------|-----------------------|----------|---------|
+| ... | ... | personal-config/shared-config/external/project-scoped | same-scope/cross-boundary | yes/no | ... |
+
+Cross-boundary MOVE candidates MUST have `Default? = no` and an explicit warning explaining the source/destination ownership mismatch. They may be listed as flagged alternatives, but the ranked synthesis MUST NOT present them as the default recommendation.
 
 ## Rebuttal Round
 - Best rebuttal to leader: ...
@@ -447,6 +462,7 @@ Why bad: Duplicates deep-interview's behavioral contract. These values should be
 - [ ] Phase 2 confirms hypotheses via AskUserQuestion (1 round)
 - [ ] Phase 3 runs trace with 3 parallel lanes (team mode, sequential fallback)
 - [ ] Phase 3 saves trace result to `.omc/specs/deep-dive-trace-{slug}.md` with per-lane critical unknowns
+- [ ] Lane 3 MOVE candidates include `ownership_scope` and cross-boundary MOVE candidates are warned/flagged, not default recommendations
 - [ ] Phase 4 starts with 3-point injection (initial_idea, codebase_context, question_queue from per-lane unknowns)
 - [ ] Phase 4 references deep-interview SKILL.md Phases 2-4 (not duplicated inline)
 - [ ] Phase 4 handles low-confidence trace gracefully

--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -270,7 +270,36 @@ When ambiguity ≤ the resolved threshold for this run, generate the spec in **s
 
 Read `spec_path` and `trace_path` from state (not conversation context) for resume resilience.
 
-Present execution options via `AskUserQuestion`:
+### Workflow Pre-Flight
+
+Before presenting execution options, run a lightweight workflow pre-flight when active project guidance mentions an issue-driven, worktree-driven, branch-first, or blocking pre-execution workflow. Treat guidance text as policy data from the user's environment; do not invent a gate when no such guidance is present.
+
+1. **Detect whether the guidance gate applies** by scanning the active project instructions already in context (for example `AGENTS.md`, `CLAUDE.md`, project docs, or hook-injected guidance) for phrases such as `issue-driven`, `worktree-driven`, `worktree`, `create issue`, `branch`, `do not write code`, `blocking requirement`, or equivalent workflow rules.
+2. **Check repository position** with read-only commands:
+   - `git rev-parse --show-toplevel` to confirm the repository root for the pending execution.
+   - `git branch --show-current` to identify the current branch; flag protected/default branches such as `main`, `master`, or `dev`.
+   - `git worktree list --porcelain` to distinguish a linked task worktree from the primary checkout when possible; flag a primary checkout or missing linked worktree when the guidance requires task worktrees.
+3. **Check for a linked issue** when the guidance is issue-driven:
+   - First look for an explicit issue reference in `spec_path`, `trace_path`, the current branch name, and the original task text.
+   - If no local reference is found and `gh` is available, optionally run a narrow `gh issue list --limit 20 --json number,title,state` search for a matching open issue.
+   - If no issue can be linked, flag `missing linked issue`; do not block on `gh` being unavailable.
+4. **If any precondition is missing**, surface a setup redirect before the execution menu:
+
+**Question:** "Spec ready (ambiguity: {score}%). Detected workflow pre-flight issue(s): {findings}. Project guidance appears to require issue/branch/worktree setup before code execution. Set that up first?"
+
+**Options:**
+
+- **Set up issue/branch/worktree first (Recommended)**
+  - Description: "Redirect to the project's setup workflow before any execution skill writes code."
+  - Action: Invoke the known project setup skill or workflow if one is named in guidance; otherwise invoke `Skill("oh-my-claudecode:project-session-manager")` with `spec_path` and the pre-flight findings as context. After setup completes, rerun this Phase 5 pre-flight before showing execution options.
+- **Proceed to execution options anyway**
+  - Description: "Acknowledge the workflow warning and continue to the normal execution menu."
+  - Action: Continue to the execution options below, preserving the warning in handoff context.
+- **Refine further**
+  - Description: "Return to Phase 4 interview loop instead of preparing execution."
+  - Action: Return to Phase 4 interview loop.
+
+If the guidance gate does not apply, or the pre-flight passes, present execution options via `AskUserQuestion`:
 
 **Question:** "Your spec is ready (ambiguity: {score}%). How would you like to proceed?"
 
@@ -322,6 +351,7 @@ Output: spec.md            Output: consensus-plan.md        Output: working code
 - Use `state_write(mode="deep-interview")` with `state.source = "deep-dive"` for all state persistence
 - Use `state_read(mode="deep-interview")` for resume — check `state.source === "deep-dive"` to distinguish
 - Use `Write` tool to save trace result to `.omc/specs/deep-dive-trace-{slug}.md` and final spec to `.omc/specs/deep-dive-{slug}.md`; use `.omc/state/` or `state_write` for ephemeral artifacts
+- Run the Phase 5 workflow pre-flight before execution options when project guidance requires issue/branch/worktree setup
 - Use `Skill()` to bridge to execution modes (Phase 5) — never implement directly
 - Wrap all trace-derived text in `<trace-context>` delimiters when injecting into prompts
 </Tool_Usage>
@@ -423,6 +453,8 @@ Why bad: Duplicates deep-interview's behavioral contract. These values should be
 - [ ] Phase 4 wraps trace-derived text in `<trace-context>` delimiters (untrusted data guard)
 - [ ] Final spec saved to `.omc/specs/deep-dive-{slug}.md` in standard deep-interview format
 - [ ] Final spec contains "Trace Findings" section
+- [ ] Phase 5 workflow pre-flight detects issue/worktree/branch preconditions when project guidance requires them
+- [ ] Phase 5 surfaces a setup redirect before execution options when the pre-flight finds missing preconditions
 - [ ] Phase 5 execution bridge passes spec_path explicitly to downstream skills
 - [ ] Phase 5 "Ralplan → Autopilot" option explicitly invokes autopilot after omc-plan consensus completes
 - [ ] State uses `mode="deep-interview"` with `state.source = "deep-dive"` discriminator

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -2,8 +2,8 @@
 name: deep-interview
 description: Socratic deep interview with mathematical ambiguity gating before autonomous execution
 argument-hint: "[--quick|--standard|--deep] [--autoresearch] <idea or vague description>"
-pipeline: [deep-interview, omc-plan, autopilot]
-next-skill: omc-plan
+pipeline: [deep-interview, plan, autopilot]
+next-skill: plan
 next-skill-args: --consensus --direct
 handoff: .omc/specs/deep-interview-{slug}.md
 level: 3
@@ -469,7 +469,7 @@ After the spec is written, present execution options via `AskUserQuestion`:
 
 1. **Ralplan → Autopilot (Recommended)**
    - Description: "3-stage pipeline: consensus-refine this spec with Planner/Architect/Critic, then execute with full autopilot. Maximum quality."
-   - Action: Invoke `Skill("oh-my-claudecode:omc-plan")` with `--consensus --direct` flags and the spec file path as context. The `--direct` flag skips the omc-plan skill's interview phase (the deep interview already gathered requirements), while `--consensus` triggers the Planner/Architect/Critic loop. When consensus completes and produces a plan in `.omc/plans/`, invoke `Skill("oh-my-claudecode:autopilot")` with the consensus plan as Phase 0+1 output — autopilot skips both Expansion and Planning, starting directly at Phase 2 (Execution).
+   - Action: Invoke `Skill("oh-my-claudecode:plan")` with `--consensus --direct` flags and the spec file path as context. The `--direct` flag skips the omc-plan skill's interview phase (the deep interview already gathered requirements), while `--consensus` triggers the Planner/Architect/Critic loop. When consensus completes and produces a plan in `.omc/plans/`, invoke `Skill("oh-my-claudecode:autopilot")` with the consensus plan as Phase 0+1 output — autopilot skips both Expansion and Planning, starting directly at Phase 2 (Execution).
    - Pipeline: `deep-interview spec → omc-plan --consensus --direct → autopilot execution`
 
 2. **Execute with autopilot (skip ralplan)**

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -2,7 +2,7 @@
 name: omc-plan
 description: Strategic planning with optional interview workflow
 argument-hint: "[--direct|--consensus|--review] [--interactive] [--deliberate] <task description>"
-pipeline: [deep-interview, omc-plan, autopilot]
+pipeline: [deep-interview, plan, autopilot]
 next-skill: autopilot
 handoff: .omc/plans/ralplan-*.md
 level: 4

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -7,7 +7,7 @@ level: 4
 
 # Ralplan (Consensus Planning Alias)
 
-Ralplan is a shorthand alias for `/oh-my-claudecode:omc-plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work).
+Ralplan is a shorthand alias for `/oh-my-claudecode:plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work).
 
 ## Usage
 
@@ -33,7 +33,7 @@ Ralplan is a shorthand alias for `/oh-my-claudecode:omc-plan --consensus`. It tr
 This skill invokes the Plan skill in consensus mode:
 
 ```
-/oh-my-claudecode:omc-plan --consensus <arguments>
+/oh-my-claudecode:plan --consensus <arguments>
 ```
 
 The consensus workflow:

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -185,8 +185,8 @@ Advanced: ambiguity ≤ 20%
       `---
 name: deep-interview
 description: Deep interview
-pipeline: [deep-interview, omc-plan, autopilot]
-next-skill: omc-plan
+pipeline: [deep-interview, plan, autopilot]
+next-skill: plan
 next-skill-args: --consensus --direct
 handoff: .omc/specs/deep-interview-{slug}.md
 ---
@@ -203,9 +203,9 @@ Deep interview body`
 
     expect(result.success).toBe(true);
     expect(result.replacementText).toContain('## Skill Pipeline');
-    expect(result.replacementText).toContain('Pipeline: `deep-interview → omc-plan → autopilot`');
+    expect(result.replacementText).toContain('Pipeline: `deep-interview → plan → autopilot`');
     expect(result.replacementText).toContain('Next skill arguments: `--consensus --direct`');
-    expect(result.replacementText).toContain('Skill("oh-my-claudecode:omc-plan")');
+    expect(result.replacementText).toContain('Skill("oh-my-claudecode:plan")');
     expect(result.replacementText).toContain('`.omc/specs/deep-interview-{slug}.md`');
   });
 
@@ -249,8 +249,8 @@ Compatibility body`
       `---
 name: deep-interview
 description: Deep interview
-pipeline: [deep-interview, omc-plan, autopilot]
-next-skill: omc-plan
+pipeline: [deep-interview, plan, autopilot]
+next-skill: plan
 next-skill-args: --consensus --direct
 handoff: .omc/specs/deep-interview-{slug}.md
 ---

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -465,6 +465,156 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(context).not.toContain('Use parallel execution');
   });
 
+  it('does not warn for documentation edits that describe workaround terms as nouns', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Write',
+      toolInput: {
+        file_path: join(tempDir, 'docs', 'troubleshooting.md'),
+        content: [
+          '# Troubleshooting',
+          '',
+          'Document workaround for a specific bug in the troubleshooting guide.',
+          'This section explains when the workaround term appears in instructions.',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-doc-text',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
+  it('does not warn for self-referential pre-tool enforcer edits that document the rule', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Edit',
+      toolInput: {
+        file_path: 'scripts/pre-tool-enforcer.mjs',
+        old_string: 'const SLOP_FALLBACK_LANGUAGE_PATTERN = /fallback|workaround/i;',
+        new_string: [
+          '// The fallback/workaround detector should avoid warning on rule documentation.',
+          'const SLOP_FALLBACK_LANGUAGE_PATTERN = /fallback|workaround/i;',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-self-reference',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
+  it('still warns for action-shaped fallback narration outside documentation contexts', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Implement fallback routing',
+        prompt: 'Please implement a fallback layer for the flaky API.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-action-shaped',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
+  it('warns for natural work-around phrasing with direct noun objects', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Skip architecture for flaky API failures',
+        prompt: 'Please work around flaky API failures by skipping the normal architecture.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-work-around-noun-object',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
+  it('warns for fall back on cached responses phrasing', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Add API fallback',
+        prompt: 'If the API fails, fall back on cached responses.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-fall-back-on',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
+  it('warns for single-word fallback to cached responses phrasing', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Add API fallback',
+        prompt: 'If the API fails, fallback to cached responses.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-fallback-to',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
+  it('does not treat markdown headings alone as documentation context for Task prompts', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Implement fallback routing',
+        prompt: [
+          '## Implementation',
+          '',
+          'Please implement a fallback layer and explain why.',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-markdown-task',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
+  it('does not warn for documentation edits that quote action-shaped work-around wording', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Write',
+      toolInput: {
+        file_path: join(tempDir, 'docs', 'architecture-notes.md'),
+        content: [
+          '# Architecture notes',
+          '',
+          'Explain why the phrase "Please work around flaky API failures" should be reviewed carefully.',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-doc-action-shaped',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
   it('does not warn for read-only search tools that mention fallback as the query', () => {
     const output = runPreToolEnforcer({
       tool_name: 'Grep',

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -280,8 +280,8 @@ describe('Builtin Skills', () => {
       expect(skill).toBeDefined();
       expect(skill?.name).toBe('deep-dive');
       expect(skill?.pipeline).toEqual({
-        steps: ['deep-dive', 'omc-plan', 'autopilot'],
-        nextSkill: 'omc-plan',
+        steps: ['deep-dive', 'plan', 'autopilot'],
+        nextSkill: 'plan',
         nextSkillArgs: '--consensus --direct',
         handoff: '.omc/specs/deep-dive-{slug}.md',
       });
@@ -311,14 +311,14 @@ describe('Builtin Skills', () => {
     it('should expose pipeline metadata for deep-interview handoff into omc-plan', () => {
       const skill = getBuiltinSkill('deep-interview');
       expect(skill?.pipeline).toEqual({
-        steps: ['deep-interview', 'omc-plan', 'autopilot'],
-        nextSkill: 'omc-plan',
+        steps: ['deep-interview', 'plan', 'autopilot'],
+        nextSkill: 'plan',
         nextSkillArgs: '--consensus --direct',
         handoff: '.omc/specs/deep-interview-{slug}.md',
       });
       expect(skill?.template).toContain('## Skill Pipeline');
-      expect(skill?.template).toContain('Pipeline: `deep-interview → omc-plan → autopilot`');
-      expect(skill?.template).toContain('Skill("oh-my-claudecode:omc-plan")');
+      expect(skill?.template).toContain('Pipeline: `deep-interview → plan → autopilot`');
+      expect(skill?.template).toContain('Skill("oh-my-claudecode:plan")');
       expect(skill?.template).toContain('`--consensus --direct`');
       expect(skill?.template).toContain('`.omc/specs/deep-interview-{slug}.md`');
       expect(skill?.template).toContain('Why now: {one_sentence_targeting_rationale}');
@@ -629,7 +629,7 @@ describe('Builtin Skills', () => {
     it('should expose pipeline metadata for omc-plan handoff into autopilot', () => {
       const skill = getBuiltinSkill('omc-plan');
       expect(skill?.pipeline).toEqual({
-        steps: ['deep-interview', 'omc-plan', 'autopilot'],
+        steps: ['deep-interview', 'plan', 'autopilot'],
         nextSkill: 'autopilot',
         handoff: '.omc/plans/ralplan-*.md',
       });

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -280,8 +280,8 @@ describe('Builtin Skills', () => {
       expect(skill).toBeDefined();
       expect(skill?.name).toBe('deep-dive');
       expect(skill?.pipeline).toEqual({
-        steps: ['deep-dive', 'omc-plan', 'autopilot'],
-        nextSkill: 'omc-plan',
+        steps: ['deep-dive', 'plan', 'autopilot'],
+        nextSkill: 'plan',
         nextSkillArgs: '--consensus --direct',
         handoff: '.omc/specs/deep-dive-{slug}.md',
       });
@@ -322,14 +322,14 @@ describe('Builtin Skills', () => {
     it('should expose pipeline metadata for deep-interview handoff into omc-plan', () => {
       const skill = getBuiltinSkill('deep-interview');
       expect(skill?.pipeline).toEqual({
-        steps: ['deep-interview', 'omc-plan', 'autopilot'],
-        nextSkill: 'omc-plan',
+        steps: ['deep-interview', 'plan', 'autopilot'],
+        nextSkill: 'plan',
         nextSkillArgs: '--consensus --direct',
         handoff: '.omc/specs/deep-interview-{slug}.md',
       });
       expect(skill?.template).toContain('## Skill Pipeline');
-      expect(skill?.template).toContain('Pipeline: `deep-interview → omc-plan → autopilot`');
-      expect(skill?.template).toContain('Skill("oh-my-claudecode:omc-plan")');
+      expect(skill?.template).toContain('Pipeline: `deep-interview → plan → autopilot`');
+      expect(skill?.template).toContain('Skill("oh-my-claudecode:plan")');
       expect(skill?.template).toContain('`--consensus --direct`');
       expect(skill?.template).toContain('`.omc/specs/deep-interview-{slug}.md`');
       expect(skill?.template).toContain('Why now: {one_sentence_targeting_rationale}');
@@ -640,8 +640,9 @@ describe('Builtin Skills', () => {
     it('should expose pipeline metadata for omc-plan handoff into autopilot', () => {
       const skill = getBuiltinSkill('omc-plan');
       expect(skill?.pipeline).toEqual({
-        steps: ['deep-interview', 'omc-plan', 'autopilot'],
+        steps: ['deep-interview', 'plan', 'autopilot'],
         nextSkill: 'autopilot',
+        nextSkillArgs: undefined,
         handoff: '.omc/plans/ralplan-*.md',
       });
       expect(skill?.template).toContain('## Skill Pipeline');

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -295,6 +295,12 @@ describe('Builtin Skills', () => {
       // Verify pipeline handoff is fully wired (B1 fix)
       expect(skill?.template).toContain('Skill("oh-my-claudecode:autopilot")');
       expect(skill?.template).toContain('consensus plan as Phase 0+1 output');
+      // Verify Phase 5 workflow pre-flight guards issue/worktree-driven project guidance (#2926)
+      expect(skill?.template).toContain('Workflow Pre-Flight');
+      expect(skill?.template).toContain('issue-driven, worktree-driven, branch-first');
+      expect(skill?.template).toContain('git worktree list --porcelain');
+      expect(skill?.template).toContain('Set up issue/branch/worktree first (Recommended)');
+      expect(skill?.template).toContain('before showing execution options');
       // Verify untrusted data guard (NB1 fix)
       expect(skill?.template).toContain('trace-context');
       expect(skill?.template).toContain('untrusted data');

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -292,6 +292,11 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('initial question queue injection');
       // Verify per-lane critical unknowns (B3 fix)
       expect(skill?.template).toContain('Per-Lane Critical Unknowns');
+      // Verify Lane 3 ownership-boundary classification for MOVE recommendations
+      expect(skill?.template).toContain('Lane 3 Misplacement / SoT Ownership Scope');
+      expect(skill?.template).toContain('ownership_scope');
+      expect(skill?.template).toContain('personal-config/shared-config/external/project-scoped');
+      expect(skill?.template).toContain('Cross-boundary MOVE candidates MUST have `Default? = no`');
       // Verify pipeline handoff is fully wired (B1 fix)
       expect(skill?.template).toContain('Skill("oh-my-claudecode:autopilot")');
       expect(skill?.template).toContain('consensus plan as Phase 0+1 output');

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -863,7 +863,7 @@ $ ultrawork search the codebase`,
       }
     });
 
-    it('activates ralplan state when Skill tool invokes omc-plan in consensus mode', async () => {
+    it('activates ralplan state when Skill tool invokes plan in consensus mode', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-plan-consensus-skill-'));
       try {
         execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
@@ -873,7 +873,7 @@ $ ultrawork search the codebase`,
           sessionId,
           toolName: 'Skill',
           toolInput: {
-            skill: 'oh-my-claudecode:omc-plan',
+            skill: 'oh-my-claudecode:plan',
             args: '--consensus issue #1926',
           },
           directory: tempDir,


### PR DESCRIPTION
## Summary
- Replace broken `oh-my-claudecode:omc-plan` invocation references with the registered `oh-my-claudecode:plan` skill ID.
- Update deep-interview/deep-dive pipeline metadata and ralplan/docs references to point at `plan` without renaming the `skills/plan/` directory.
- Refresh tests that assert the rendered handoff invocation and consensus routing behavior.

Fixes #2931

## Verification
- `git diff --check`
- `npm test -- --run src/__tests__/skills.test.ts src/__tests__/auto-slash-aliases.test.ts src/hooks/__tests__/bridge-routing.test.ts` (targeted vitest)

-- 
gaebal-gajae
