### PR TITLE
Fix Ralph stop-hook during pending async work

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -272,6 +272,7 @@ async function sendStopNotification(modeName, stateData, sessionId, directory) {
  * from causing the stop hook to malfunction in new sessions.
  */
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
 
 // Stop breaker constants for first-class mode enforcement
 const TEAM_PIPELINE_STOP_BLOCKER_MAX = 20;
@@ -331,6 +332,71 @@ function isStaleState(state) {
 
   const age = Date.now() - mostRecent;
   return age > STALE_STATE_THRESHOLD_MS;
+}
+
+
+function sanitizeSessionId(sessionId) {
+  if (!sessionId || typeof sessionId !== "string") return "";
+  return /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId) ? sessionId : "";
+}
+
+function parseTimestamp(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isFreshTimestamp(value, ttlMs = PENDING_ASYNC_STATE_STALE_MS) {
+  const parsed = parseTimestamp(value);
+  return parsed !== null && Date.now() - parsed <= ttlMs;
+}
+
+function hasPendingBackgroundTask(stateDir, sessionId) {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const hudPath = safeSessionId
+    ? join(stateDir, "sessions", safeSessionId, "hud-state.json")
+    : join(stateDir, "hud-state.json");
+  const hudState = readJsonFile(hudPath);
+  return Boolean(hudState?.backgroundTasks?.some((task) => {
+    if (task?.status !== "running") return false;
+    return isFreshTimestamp(task.startedAt ?? task.startTime);
+  }));
+}
+
+function readPendingWakeupStates(stateDir, sessionId) {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const dirs = safeSessionId ? [join(stateDir, "sessions", safeSessionId), stateDir] : [stateDir];
+  const fileNames = ["scheduled-wakeup-state.json", "schedule-wakeup-state.json", "wakeup-state.json"];
+  const states = [];
+  for (const dir of dirs) {
+    for (const fileName of fileNames) {
+      const state = readJsonFile(join(dir, fileName));
+      if (state && typeof state === "object") states.push(state);
+    }
+  }
+  return states;
+}
+
+function hasPendingScheduledWakeup(stateDir, sessionId) {
+  const now = Date.now();
+  return readPendingWakeupStates(stateDir, sessionId).some((state) => {
+    const status = typeof state.status === "string" ? state.status.toLowerCase() : "";
+    if (["completed", "complete", "cancelled", "canceled", "failed", "expired"].includes(status)) {
+      return false;
+    }
+    const dueAt = parseTimestamp(
+      state.due_at ?? state.wakeup_at ?? state.scheduled_for ?? state.deadline_at ?? state.expires_at,
+    );
+    if (dueAt !== null) return dueAt > now;
+    if (state.active === true || state.pending === true) {
+      return isFreshTimestamp(state.created_at ?? state.updated_at ?? state.started_at);
+    }
+    return false;
+  });
+}
+
+function hasPendingOwnedAsyncWork(stateDir, sessionId) {
+  return hasPendingBackgroundTask(stateDir, sessionId) || hasPendingScheduledWakeup(stateDir, sessionId);
 }
 
 function normalizeTeamPhase(state) {
@@ -913,6 +979,11 @@ async function main() {
     }
 
     if (isScheduledWakeupStop(data)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    if (hasPendingOwnedAsyncWork(stateDir, sessionId)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -182,6 +182,7 @@ Do NOT skip this step. Do NOT move on without fixing the error.
  * from causing the stop hook to malfunction in new sessions.
  */
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
 const CANCEL_SIGNAL_TTL_MS = 30_000;
 const TEAM_TERMINAL_PHASES = new Set([
   "completed",
@@ -227,6 +228,66 @@ function isStaleState(state) {
 
   const age = Date.now() - mostRecent;
   return age > STALE_STATE_THRESHOLD_MS;
+}
+
+
+function parseTimestamp(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isFreshTimestamp(value, ttlMs = PENDING_ASYNC_STATE_STALE_MS) {
+  const parsed = parseTimestamp(value);
+  return parsed !== null && Date.now() - parsed <= ttlMs;
+}
+
+function hasPendingBackgroundTask(stateDir, sessionId) {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const hudPath = safeSessionId
+    ? join(stateDir, "sessions", safeSessionId, "hud-state.json")
+    : join(stateDir, "hud-state.json");
+  const hudState = readJsonFile(hudPath);
+  return Boolean(hudState?.backgroundTasks?.some((task) => {
+    if (task?.status !== "running") return false;
+    return isFreshTimestamp(task.startedAt ?? task.startTime);
+  }));
+}
+
+function readPendingWakeupStates(stateDir, sessionId) {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const dirs = safeSessionId ? [join(stateDir, "sessions", safeSessionId), stateDir] : [stateDir];
+  const fileNames = ["scheduled-wakeup-state.json", "schedule-wakeup-state.json", "wakeup-state.json"];
+  const states = [];
+  for (const dir of dirs) {
+    for (const fileName of fileNames) {
+      const state = readJsonFile(join(dir, fileName));
+      if (state && typeof state === "object") states.push(state);
+    }
+  }
+  return states;
+}
+
+function hasPendingScheduledWakeup(stateDir, sessionId) {
+  const now = Date.now();
+  return readPendingWakeupStates(stateDir, sessionId).some((state) => {
+    const status = typeof state.status === "string" ? state.status.toLowerCase() : "";
+    if (["completed", "complete", "cancelled", "canceled", "failed", "expired"].includes(status)) {
+      return false;
+    }
+    const dueAt = parseTimestamp(
+      state.due_at ?? state.wakeup_at ?? state.scheduled_for ?? state.deadline_at ?? state.expires_at,
+    );
+    if (dueAt !== null) return dueAt > now;
+    if (state.active === true || state.pending === true) {
+      return isFreshTimestamp(state.created_at ?? state.updated_at ?? state.started_at);
+    }
+    return false;
+  });
+}
+
+function hasPendingOwnedAsyncWork(stateDir, sessionId) {
+  return hasPendingBackgroundTask(stateDir, sessionId) || hasPendingScheduledWakeup(stateDir, sessionId);
 }
 
 function normalizeTeamPhase(state) {
@@ -747,6 +808,11 @@ async function main() {
     }
 
     if (isScheduledWakeupStop(data)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    if (hasPendingOwnedAsyncWork(stateDir, sessionId)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -153,6 +153,7 @@ const TEAM_STAGE_ALIASES: Record<string, string> = {
 };
 
 const BACKGROUND_AGENT_ID_PATTERN = /agentId:\s*([a-zA-Z0-9_-]+)/;
+const BACKGROUND_BASH_ID_PATTERN = /(?:background (?:bash )?(?:command|process|task).*?(?:id|ID)|bash_id|task_id)[:=]\s*([a-zA-Z0-9_-]+)/i;
 const TASK_OUTPUT_ID_PATTERN = /<task_id>([^<]+)<\/task_id>/i;
 const TASK_OUTPUT_STATUS_PATTERN = /<status>([^<]+)<\/status>/i;
 const SAFE_SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
@@ -442,6 +443,26 @@ function extractAsyncAgentId(toolOutput: unknown): string | undefined {
   return toolOutput.match(BACKGROUND_AGENT_ID_PATTERN)?.[1];
 }
 
+function extractBackgroundBashId(toolOutput: unknown): string | undefined {
+  if (typeof toolOutput !== "string") {
+    return undefined;
+  }
+  return toolOutput.match(BACKGROUND_BASH_ID_PATTERN)?.[1];
+}
+
+function bashLaunchIsBackgroundPending(toolOutput: unknown): boolean {
+  if (typeof toolOutput !== "string") {
+    return false;
+  }
+
+  const normalized = toolOutput.toLowerCase();
+  return normalized.includes("running in the background")
+    || normalized.includes("started in the background")
+    || normalized.includes("background command")
+    || normalized.includes("background process")
+    || Boolean(extractBackgroundBashId(toolOutput));
+}
+
 function parseTaskOutputLifecycle(toolOutput: unknown): { taskId: string; status: string } | null {
   if (typeof toolOutput !== "string") {
     return null;
@@ -467,6 +488,72 @@ function taskLaunchDidFail(toolOutput: unknown): boolean {
 
   const normalized = toolOutput.toLowerCase();
   return normalized.includes("error") || normalized.includes("failed");
+}
+
+function getSessionStateDir(directory: string, sessionId?: string): string {
+  const stateDir = join(getOmcRoot(directory), "state");
+  if (sessionId && SAFE_SESSION_ID_PATTERN.test(sessionId)) {
+    return join(stateDir, "sessions", sessionId);
+  }
+  return stateDir;
+}
+
+function getScheduledWakeupStatePath(directory: string, sessionId?: string): string {
+  return join(getSessionStateDir(directory, sessionId), "scheduled-wakeup-state.json");
+}
+
+function parseWakeupDueAt(toolInput: unknown): string | undefined {
+  if (!toolInput || typeof toolInput !== "object") {
+    return undefined;
+  }
+
+  const input = toolInput as Record<string, unknown>;
+  const absolute = input.due_at ?? input.wakeup_at ?? input.scheduled_for ?? input.deadline_at ?? input.at;
+  if (typeof absolute === "string") {
+    const parsed = new Date(absolute).getTime();
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+
+  const delaySeconds = input.seconds ?? input.delay_seconds ?? input.delaySeconds;
+  if (typeof delaySeconds === "number" && Number.isFinite(delaySeconds)) {
+    return new Date(Date.now() + Math.max(0, delaySeconds) * 1000).toISOString();
+  }
+
+  const delayMs = input.milliseconds ?? input.delay_ms ?? input.delayMs;
+  if (typeof delayMs === "number" && Number.isFinite(delayMs)) {
+    return new Date(Date.now() + Math.max(0, delayMs)).toISOString();
+  }
+
+  const delayMinutes = input.minutes ?? input.delay_minutes ?? input.delayMinutes;
+  if (typeof delayMinutes === "number" && Number.isFinite(delayMinutes)) {
+    return new Date(Date.now() + Math.max(0, delayMinutes) * 60_000).toISOString();
+  }
+
+  return undefined;
+}
+
+function recordScheduledWakeup(directory: string, sessionId: string | undefined, toolInput: unknown): void {
+  try {
+    const statePath = getScheduledWakeupStatePath(directory, sessionId);
+    mkdirSync(dirname(statePath), { recursive: true });
+    writeFileSync(
+      statePath,
+      JSON.stringify(
+        {
+          active: true,
+          pending: true,
+          status: "pending",
+          session_id: sessionId,
+          created_at: new Date().toISOString(),
+          due_at: parseWakeupDueAt(toolInput),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch {
+    // Wakeup state is best-effort; never fail the hook.
+  }
 }
 
 function getModeStatePaths(directory: string, modeName: string, sessionId?: string): string[] {
@@ -2512,6 +2599,35 @@ function processPreToolUse(input: HookInput): HookOutput {
     }
   }
 
+  // Track background Bash invocations too. Ralph's Stop hook uses this
+  // session-owned pending-work signal to avoid reinforcing while Claude Code is
+  // expected to notify when the background command finishes.
+  if (input.toolName === "Bash") {
+    const toolInput = (modifiedToolInput ?? input.toolInput) as
+      | {
+          command?: string;
+          run_in_background?: boolean;
+        }
+      | undefined;
+
+    if (toolInput?.run_in_background === true && toolInput.command) {
+      const taskId =
+        getHookToolUseId(input)
+        ?? `bash-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      addBackgroundTask(
+        taskId,
+        toolInput.command,
+        "bash",
+        directory,
+        input.sessionId,
+      );
+    }
+  }
+
+  if ((input.toolName || "").toLowerCase() === "schedulewakeup") {
+    recordScheduledWakeup(directory, input.sessionId, input.toolInput);
+  }
+
   // Track file ownership for Edit/Write tools
   if (input.toolName === "Edit" || input.toolName === "Write") {
     const toolInput = input.toolInput as { file_path?: string } | undefined;
@@ -2711,6 +2827,47 @@ async function processPostToolUse(input: HookInput): Promise<HookOutput> {
           agentType,
           input.sessionId,
         );
+      }
+    }
+  }
+
+  if (input.toolName === "Bash") {
+    const toolInput = input.toolInput as
+      | {
+          command?: string;
+          run_in_background?: boolean;
+        }
+      | undefined;
+    if (toolInput?.run_in_background === true) {
+      const toolUseId = getHookToolUseId(input);
+      const backgroundBashId = extractBackgroundBashId(input.toolOutput);
+      const command = toolInput.command;
+
+      if (backgroundBashId) {
+        if (toolUseId) {
+          remapBackgroundTaskId(toolUseId, backgroundBashId, directory, input.sessionId);
+        } else if (command) {
+          remapMostRecentMatchingBackgroundTaskId(
+            command,
+            backgroundBashId,
+            directory,
+            "bash",
+            input.sessionId,
+          );
+        }
+      } else if (!bashLaunchIsBackgroundPending(input.toolOutput)) {
+        const failed = taskLaunchDidFail(input.toolOutput);
+        if (toolUseId) {
+          completeBackgroundTask(toolUseId, directory, failed, input.sessionId);
+        } else if (command) {
+          completeMostRecentMatchingBackgroundTask(
+            command,
+            directory,
+            failed,
+            "bash",
+            input.sessionId,
+          );
+        }
       }
     }
   }

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -93,6 +93,7 @@ export interface PersistentModeResult {
 const MAX_TODO_CONTINUATION_ATTEMPTS = 5;
 const CANCEL_SIGNAL_TTL_MS = 30_000;
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
 
 /** Track todo-continuation attempts per session to prevent infinite loops */
 const todoContinuationAttempts = new Map<string, number>();
@@ -172,6 +173,105 @@ function isStaleState(state: unknown): boolean {
   }
 
   return Date.now() - mostRecent > STALE_STATE_THRESHOLD_MS;
+}
+
+function parseTimestamp(value: unknown): number | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return null;
+  }
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isFreshTimestamp(value: unknown, ttlMs = PENDING_ASYNC_STATE_STALE_MS): boolean {
+  const parsed = parseTimestamp(value);
+  return parsed !== null && Date.now() - parsed <= ttlMs;
+}
+
+function hasPendingBackgroundTask(directory: string, sessionId?: string): boolean {
+  try {
+    const stateRoot = join(getOmcRoot(directory), 'state');
+    const hudPath = sessionId
+      ? join(stateRoot, 'sessions', sessionId, 'hud-state.json')
+      : join(stateRoot, 'hud-state.json');
+    if (!existsSync(hudPath)) return false;
+    const hudState = JSON.parse(readFileSync(hudPath, 'utf-8')) as {
+      backgroundTasks?: Array<{
+        status?: string;
+        startedAt?: string;
+        startTime?: string;
+      }>;
+    };
+    return Boolean(hudState?.backgroundTasks?.some((task) => {
+      if (task.status !== 'running') return false;
+      return isFreshTimestamp(task.startedAt ?? task.startTime);
+    }));
+  } catch {
+    return false;
+  }
+}
+
+function readPendingWakeupState(directory: string, sessionId?: string): Array<Record<string, unknown>> {
+  const stateRoot = join(getOmcRoot(directory), 'state');
+  const dirs = sessionId
+    ? [join(stateRoot, 'sessions', sessionId), stateRoot]
+    : [stateRoot];
+  const fileNames = [
+    'scheduled-wakeup-state.json',
+    'schedule-wakeup-state.json',
+    'wakeup-state.json',
+  ];
+  const states: Array<Record<string, unknown>> = [];
+
+  for (const dir of dirs) {
+    for (const fileName of fileNames) {
+      const filePath = join(dir, fileName);
+      try {
+        if (!existsSync(filePath)) continue;
+        const parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
+        if (parsed && typeof parsed === 'object') {
+          states.push(parsed as Record<string, unknown>);
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return states;
+}
+
+function hasPendingScheduledWakeup(directory: string, sessionId?: string): boolean {
+  const now = Date.now();
+  return readPendingWakeupState(directory, sessionId).some((state) => {
+    const status = typeof state.status === 'string' ? state.status.toLowerCase() : '';
+    if (['completed', 'complete', 'cancelled', 'canceled', 'failed', 'expired'].includes(status)) {
+      return false;
+    }
+
+    const dueAt = parseTimestamp(
+      state.due_at ?? state.wakeup_at ?? state.scheduled_for ?? state.deadline_at ?? state.expires_at,
+    );
+    if (dueAt !== null) {
+      return dueAt > now;
+    }
+
+    if (state.active === true || state.pending === true) {
+      return isFreshTimestamp(state.created_at ?? state.updated_at ?? state.started_at);
+    }
+
+    return false;
+  });
+}
+
+/**
+ * Pending owned async work (background Bash/Task or an armed wakeup) means the
+ * agent is legitimately waiting for an external notification/resume. In that
+ * window persistent modes should not inject a "stalled" reinforcement.
+ */
+export function hasPendingOwnedAsyncWork(directory: string, sessionId?: string): boolean {
+  return hasPendingBackgroundTask(directory, sessionId)
+    || hasPendingScheduledWakeup(directory, sessionId);
 }
 
 /**
@@ -1810,6 +1910,17 @@ export async function checkPersistentModes(
   // inject `/cancel` guidance from stale state and cause the scheduled turn to
   // cancel itself before the real work runs.
   if (isScheduledWakeupStop(stopContext)) {
+    return {
+      shouldBlock: false,
+      message: '',
+      mode: 'none'
+    };
+  }
+
+  // If this session owns pending async work, quiescence is intentional: Claude
+  // Code will notify on background completion or resume via ScheduleWakeup.
+  // Do not convert that waiting window into a Ralph/persistent-mode stall loop.
+  if (hasPendingOwnedAsyncWork(workingDir, sessionId)) {
     return {
       shouldBlock: false,
       message: '',

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -60,6 +60,60 @@ function writePendingTodo(tempDir: string, content: string): void {
   );
 }
 
+function writeActiveRalphState(tempDir: string, sessionId: string): void {
+  const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, "ralph-state.json"),
+    JSON.stringify({
+      active: true,
+      iteration: 1,
+      max_iterations: 50,
+      session_id: sessionId,
+      started_at: new Date().toISOString(),
+      last_checked_at: new Date().toISOString(),
+      prompt: "Test ralph task",
+    }),
+  );
+}
+
+function writeRunningBackgroundTask(tempDir: string, sessionId: string): void {
+  const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, "hud-state.json"),
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      sessionId,
+      backgroundTasks: [
+        {
+          id: "bash-bg-1",
+          description: "npm run long-backtest",
+          agentType: "bash",
+          startedAt: new Date().toISOString(),
+          status: "running",
+        },
+      ],
+    }),
+  );
+}
+
+function writePendingScheduledWakeup(tempDir: string, sessionId: string): void {
+  const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, "scheduled-wakeup-state.json"),
+    JSON.stringify({
+      active: true,
+      pending: true,
+      status: "pending",
+      session_id: sessionId,
+      created_at: new Date().toISOString(),
+      due_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    }),
+  );
+}
+
 function writeLegacyModeState(
   tempDir: string,
   fileName: string,
@@ -681,20 +735,7 @@ describe("Stop Hook Blocking Contract", () => {
 
     it("blocks stop for active ralph loop", async () => {
       const sessionId = "test-ralph-block";
-      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
-      mkdirSync(sessionDir, { recursive: true });
-      writeFileSync(
-        join(sessionDir, "ralph-state.json"),
-        JSON.stringify({
-          active: true,
-          iteration: 1,
-          max_iterations: 50,
-          session_id: sessionId,
-          started_at: new Date().toISOString(),
-          last_checked_at: new Date().toISOString(),
-          prompt: "Test ralph task",
-        })
-      );
+      writeActiveRalphState(tempDir, sessionId);
 
       const result = await checkPersistentModes(sessionId, tempDir);
       expect(result.shouldBlock).toBe(true);
@@ -703,6 +744,26 @@ describe("Stop Hook Blocking Contract", () => {
       const output = createHookOutput(result);
       expect(output.continue).toBe(false);
       expect(output.message).toContain("RALPH");
+    });
+
+    it("does not reinforce active ralph while an owned background Bash task is pending", async () => {
+      const sessionId = "test-ralph-bg-bash-pending";
+      writeActiveRalphState(tempDir, sessionId);
+      writeRunningBackgroundTask(tempDir, sessionId);
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe("none");
+    });
+
+    it("does not reinforce active ralph while a scheduled wakeup is pending", async () => {
+      const sessionId = "test-ralph-wakeup-pending";
+      writeActiveRalphState(tempDir, sessionId);
+      writePendingScheduledWakeup(tempDir, sessionId);
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+      expect(result.mode).toBe("none");
     });
 
     it("keeps blocking active ralph loop when stop reason is interrupt", async () => {
@@ -835,23 +896,32 @@ describe("Stop Hook Blocking Contract", () => {
 
     it("returns decision: block when ralph is active", () => {
       const sessionId = "ralph-mjs-test";
-      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
-      mkdirSync(sessionDir, { recursive: true });
-      writeFileSync(
-        join(sessionDir, "ralph-state.json"),
-        JSON.stringify({
-          active: true,
-          iteration: 1,
-          max_iterations: 50,
-          session_id: sessionId,
-          started_at: new Date().toISOString(),
-          last_checked_at: new Date().toISOString(),
-          prompt: "Test task",
-        })
-      );
+      writeActiveRalphState(tempDir, sessionId);
 
       const output = runScript({ directory: tempDir, sessionId });
       expect(output.decision).toBe("block");
+    });
+
+    it("returns continue: true for active ralph with pending background Bash task", () => {
+      const sessionId = "ralph-mjs-bg-bash-pending";
+      writeActiveRalphState(tempDir, sessionId);
+      writeRunningBackgroundTask(tempDir, sessionId);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+      expect(String(output.reason || "")).not.toContain("[RALPH LOOP");
+    });
+
+    it("returns continue: true for active ralph with pending scheduled wakeup", () => {
+      const sessionId = "ralph-mjs-wakeup-pending";
+      writeActiveRalphState(tempDir, sessionId);
+      writePendingScheduledWakeup(tempDir, sessionId);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+      expect(String(output.reason || "")).not.toContain("[RALPH LOOP");
     });
 
     it("returns continue: true for tombstoned stale ralph state", () => {
@@ -1410,6 +1480,28 @@ describe("Stop Hook Blocking Contract", () => {
         stop_reason: "oauth_expired",
       });
       expect(output.continue).toBe(true);
+    });
+
+    it("returns continue: true for active ralph with pending background Bash task", () => {
+      const sessionId = "ralph-cjs-bg-bash-pending";
+      writeActiveRalphState(tempDir, sessionId);
+      writeRunningBackgroundTask(tempDir, sessionId);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+      expect(String(output.reason || "")).not.toContain("[RALPH LOOP");
+    });
+
+    it("returns continue: true for active ralph with pending scheduled wakeup", () => {
+      const sessionId = "ralph-cjs-wakeup-pending";
+      writeActiveRalphState(tempDir, sessionId);
+      writePendingScheduledWakeup(tempDir, sessionId);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+      expect(String(output.reason || "")).not.toContain("[RALPH LOOP");
     });
 
     it("returns continue: true for ScheduleWakeup-triggered stop", () => {

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -137,6 +137,7 @@ Do NOT skip this step. Do NOT move on without fixing the error.
  * from causing the stop hook to malfunction in new sessions.
  */
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
 const TEAM_TERMINAL_PHASES = new Set([
   "completed",
   "complete",
@@ -181,6 +182,66 @@ function isStaleState(state) {
 
   const age = Date.now() - mostRecent;
   return age > STALE_STATE_THRESHOLD_MS;
+}
+
+
+function parseTimestamp(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isFreshTimestamp(value, ttlMs = PENDING_ASYNC_STATE_STALE_MS) {
+  const parsed = parseTimestamp(value);
+  return parsed !== null && Date.now() - parsed <= ttlMs;
+}
+
+function hasPendingBackgroundTask(stateDir, sessionId) {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const hudPath = safeSessionId
+    ? join(stateDir, "sessions", safeSessionId, "hud-state.json")
+    : join(stateDir, "hud-state.json");
+  const hudState = readJsonFile(hudPath);
+  return Boolean(hudState?.backgroundTasks?.some((task) => {
+    if (task?.status !== "running") return false;
+    return isFreshTimestamp(task.startedAt ?? task.startTime);
+  }));
+}
+
+function readPendingWakeupStates(stateDir, sessionId) {
+  const safeSessionId = sanitizeSessionId(sessionId);
+  const dirs = safeSessionId ? [join(stateDir, "sessions", safeSessionId), stateDir] : [stateDir];
+  const fileNames = ["scheduled-wakeup-state.json", "schedule-wakeup-state.json", "wakeup-state.json"];
+  const states = [];
+  for (const dir of dirs) {
+    for (const fileName of fileNames) {
+      const state = readJsonFile(join(dir, fileName));
+      if (state && typeof state === "object") states.push(state);
+    }
+  }
+  return states;
+}
+
+function hasPendingScheduledWakeup(stateDir, sessionId) {
+  const now = Date.now();
+  return readPendingWakeupStates(stateDir, sessionId).some((state) => {
+    const status = typeof state.status === "string" ? state.status.toLowerCase() : "";
+    if (["completed", "complete", "cancelled", "canceled", "failed", "expired"].includes(status)) {
+      return false;
+    }
+    const dueAt = parseTimestamp(
+      state.due_at ?? state.wakeup_at ?? state.scheduled_for ?? state.deadline_at ?? state.expires_at,
+    );
+    if (dueAt !== null) return dueAt > now;
+    if (state.active === true || state.pending === true) {
+      return isFreshTimestamp(state.created_at ?? state.updated_at ?? state.started_at);
+    }
+    return false;
+  });
+}
+
+function hasPendingOwnedAsyncWork(stateDir, sessionId) {
+  return hasPendingBackgroundTask(stateDir, sessionId) || hasPendingScheduledWakeup(stateDir, sessionId);
 }
 
 function normalizeTeamPhase(state) {
@@ -700,6 +761,11 @@ async function main() {
     }
 
     if (isScheduledWakeupStop(data)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    if (hasPendingOwnedAsyncWork(stateDir, sessionId)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }


### PR DESCRIPTION
Fixes #2933.

## Summary
- Suppress persistent-mode/Ralph stop reinforcement while the session owns pending async work (running HUD background task or pending scheduled wakeup).
- Track `Bash(run_in_background=true)` in HUD background task state so long-running shell work participates in the pending-work signal.
- Record ScheduleWakeup state with a due time so stop-hook quiescence is treated as awaiting notification until the wakeup expires.
- Added targeted MJS/CJS/TypeScript stop-hook tests for pending background Bash and scheduled wakeup behavior while preserving cancel/stale cases.

## Tests
- `npm test -- --run src/hooks/persistent-mode/stop-hook-blocking.test.ts src/hooks/persistent-mode/__tests__/rate-limit-stop.test.ts src/hooks/__tests__/background-process-guard.test.ts` — 124 passed
- `npm run build` — passed
- `npm run lint` — passed with existing warnings only (0 errors)
- `git diff --check` — passed
- `npm test -- --run` — 9,088 passed, 7 skipped
