### PR TITLE
fix(update): authenticate GitHub release fetches

### DIFF
--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -37,6 +37,7 @@ import {
   performUpdate,
   shouldBlockStandaloneUpdateInCurrentSession,
   syncPluginCache,
+  fetchLatestRelease,
 } from '../features/auto-update.js';
 
 const mockedExecSync = vi.mocked(execSync);
@@ -50,6 +51,8 @@ const mockedInstall = vi.mocked(install);
 const mockedIsProjectScopedPlugin = vi.mocked(isProjectScopedPlugin);
 const mockedCheckNodeVersion = vi.mocked(checkNodeVersion);
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+const originalGhToken = process.env.GH_TOKEN;
+const originalGithubToken = process.env.GITHUB_TOKEN;
 
 function mockPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', {
@@ -61,6 +64,8 @@ function mockPlatform(platform: NodeJS.Platform): void {
 describe('auto-update reconciliation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
     mockedCpSync.mockImplementation(() => undefined);
     mockedExistsSync.mockReturnValue(true);
     mockedIsProjectScopedPlugin.mockReturnValue(false);
@@ -95,9 +100,144 @@ describe('auto-update reconciliation', () => {
     vi.unstubAllGlobals();
     delete process.env.OMC_UPDATE_RECONCILE;
     delete process.env.CLAUDE_PLUGIN_ROOT;
+    if (originalGhToken === undefined) {
+      delete process.env.GH_TOKEN;
+    } else {
+      process.env.GH_TOKEN = originalGhToken;
+    }
+    if (originalGithubToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalGithubToken;
+    }
     if (originalPlatformDescriptor) {
       Object.defineProperty(process, 'platform', originalPlatformDescriptor);
     }
+  });
+
+  it('fetches latest release without Authorization when no GitHub token is configured', async () => {
+    const release = {
+      tag_name: 'v4.1.5',
+      name: '4.1.5',
+      published_at: '2026-02-09T00:00:00.000Z',
+      html_url: 'https://example.com/release',
+      body: 'notes',
+      prerelease: false,
+      draft: false,
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => release,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchLatestRelease()).resolves.toEqual(release);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/releases/latest'),
+      {
+        headers: {
+          'Accept': 'application/vnd.github.v3+json',
+          'User-Agent': 'oh-my-claudecode-updater',
+        },
+      },
+    );
+  });
+
+  it('uses GITHUB_TOKEN for latest release requests when GH_TOKEN is absent', async () => {
+    process.env.GITHUB_TOKEN = 'github-token-value';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        tag_name: 'v4.1.5',
+        name: '4.1.5',
+        published_at: '2026-02-09T00:00:00.000Z',
+        html_url: 'https://example.com/release',
+        body: 'notes',
+        prerelease: false,
+        draft: false,
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchLatestRelease();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/releases/latest'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer github-token-value',
+        }),
+      }),
+    );
+  });
+
+  it('prefers GH_TOKEN over GITHUB_TOKEN for latest release requests', async () => {
+    process.env.GH_TOKEN = 'gh-token-value';
+    process.env.GITHUB_TOKEN = 'github-token-value';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        tag_name: 'v4.1.5',
+        name: '4.1.5',
+        published_at: '2026-02-09T00:00:00.000Z',
+        html_url: 'https://example.com/release',
+        body: 'notes',
+        prerelease: false,
+        draft: false,
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchLatestRelease();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/releases/latest'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer gh-token-value',
+        }),
+      }),
+    );
+  });
+
+  it('adds a helpful rate-limit hint for unauthenticated 403 release responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      headers: new Headers({
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': '1893456000',
+      }),
+      text: async () => JSON.stringify({ message: 'API rate limit exceeded' }),
+    }));
+
+    await expect(fetchLatestRelease()).rejects.toThrow(
+      /GitHub API rate limit exceeded.*Set GH_TOKEN or GITHUB_TOKEN.*2030-01-01T00:00:00.000Z/,
+    );
+  });
+
+  it('does not leak a configured token in token-authenticated 403 errors', async () => {
+    process.env.GH_TOKEN = 'super-secret-token';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      headers: new Headers({
+        'x-ratelimit-remaining': '0',
+      }),
+      text: async () => JSON.stringify({ message: 'API rate limit exceeded' }),
+    }));
+
+    await expect(fetchLatestRelease()).rejects.toThrow(/configured GitHub token appears to be rate limited/);
+    await expect(fetchLatestRelease()).rejects.not.toThrow(/super-secret-token/);
   });
 
   it('reconciles runtime state without re-injecting settings hooks', () => {

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -495,15 +495,76 @@ export function updateLastCheckTime(): void {
   }
 }
 
+function getGitHubUpdateToken(): string | null {
+  const token = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim();
+  return token || null;
+}
+
+function getGitHubReleaseHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github.v3+json',
+    'User-Agent': 'oh-my-claudecode-updater'
+  };
+
+  const token = getGitHubUpdateToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+function getHeader(response: Response, name: string): string | null {
+  return response.headers?.get(name) ?? response.headers?.get(name.toLowerCase()) ?? null;
+}
+
+function formatRateLimitReset(resetHeader: string | null): string | null {
+  if (!resetHeader) {
+    return null;
+  }
+
+  const resetSeconds = Number.parseInt(resetHeader, 10);
+  if (!Number.isFinite(resetSeconds) || resetSeconds <= 0) {
+    return null;
+  }
+
+  return new Date(resetSeconds * 1000).toISOString();
+}
+
+async function formatGitHubReleaseFetchError(response: Response, usedToken: boolean): Promise<string> {
+  let body = '';
+  try {
+    body = await response.text();
+  } catch {
+    body = '';
+  }
+
+  const remaining = getHeader(response, 'x-ratelimit-remaining');
+  const resetAt = formatRateLimitReset(getHeader(response, 'x-ratelimit-reset'));
+  const bodyLooksRateLimited = /rate limit|api rate limit|secondary rate/i.test(body);
+  const isRateLimited =
+    response.status === 429 ||
+    (response.status === 403 && (remaining === '0' || bodyLooksRateLimited));
+
+  if (!isRateLimited) {
+    return `Failed to fetch release info: ${response.status} ${response.statusText}`;
+  }
+
+  const retrySuffix = resetAt ? ` Try again after ${resetAt}.` : '';
+  const authHint = usedToken
+    ? 'The configured GitHub token appears to be rate limited; verify the token or try again later.'
+    : 'Set GH_TOKEN or GITHUB_TOKEN to use authenticated GitHub API requests and increase rate limits.';
+
+  return `Failed to fetch release info: GitHub API rate limit exceeded (${response.status} ${response.statusText}). ${authHint}${retrySuffix}`;
+}
+
 /**
  * Fetch the latest release from GitHub
  */
 export async function fetchLatestRelease(): Promise<ReleaseInfo> {
+  const usedToken = getGitHubUpdateToken() !== null;
   const response = await fetch(`${GITHUB_API_URL}/releases/latest`, {
-    headers: {
-      'Accept': 'application/vnd.github.v3+json',
-      'User-Agent': 'oh-my-claudecode-updater'
-    }
+    headers: getGitHubReleaseHeaders()
   });
 
   if (response.status === 404) {
@@ -531,7 +592,7 @@ export async function fetchLatestRelease(): Promise<ReleaseInfo> {
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch release info: ${response.status} ${response.statusText}`);
+    throw new Error(await formatGitHubReleaseFetchError(response, usedToken));
   }
 
   return await response.json() as ReleaseInfo;


### PR DESCRIPTION
## Summary
- Use `GH_TOKEN`/`GITHUB_TOKEN` for `omc update` GitHub release API requests when available, with `GH_TOKEN` taking precedence.
- Preserve unauthenticated fallback when no token is configured.
- Improve 403/429 GitHub rate-limit errors without logging or exposing token values.
- Add targeted tests for no-token headers, token precedence, and rate-limit messaging.

Fixes #2936

## Tests
- `npm test -- --run src/__tests__/auto-update.test.ts` ✅
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (0 errors, existing warnings only)

Note: I started `npm test -- --run`, but the full local Vitest suite hung for over 5 minutes around a long-running Codex/version-related test path. Per maintainer instruction, I stopped waiting, checked for leftover Vitest processes, and proceeded with targeted verification.
