### PR TITLE
Fix built-in Task tool spawn warnings

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -278,6 +278,14 @@ const MODE_STATE_FILES = [
   'omc-teams-state.json',
 ];
 const QUIET_LEVEL = getQuietLevel();
+const BUILT_IN_TASK_LIST_TOOL_NAMES = new Set([
+  'TaskCreate',
+  'TaskUpdate',
+  'TaskList',
+  'TaskGet',
+  'TaskOutput',
+  'TaskStop',
+]);
 
 function getQuietLevel() {
   const parsed = Number.parseInt(process.env.OMC_QUIET || '0', 10);
@@ -1003,7 +1011,7 @@ async function main() {
 
     const todoStatus = getTodoStatus(directory);
 
-    if (toolName === 'Task' || toolName === 'TaskCreate' || toolName === 'TaskUpdate') {
+    if (toolName === 'Task' || toolName === 'Agent') {
       const rawTranscriptPath = data.transcript_path || data.transcriptPath || '';
       const transcriptPath = resolveTranscriptPath(rawTranscriptPath, directory);
       const preflightBlock = evaluateAgentHeavyPreflight({
@@ -1018,7 +1026,12 @@ async function main() {
 
     const slopWarning = generateSlopWarning(data, toolName);
     let message;
-    if (toolName === 'Task' || toolName === 'TaskCreate' || toolName === 'TaskUpdate') {
+    if (BUILT_IN_TASK_LIST_TOOL_NAMES.has(toolName)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    if (toolName === 'Task' || toolName === 'Agent') {
       const toolInput = data.toolInput || data.tool_input || null;
       message = generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId);
     } else {

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -228,6 +228,51 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(String(hookSpecificOutput.additionalContext)).toContain('Spawning agent');
   });
 
+  it('suppresses built-in TaskCreate task-list operation chatter', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'TaskCreate',
+      toolInput: {
+        title: 'Inspect hook behavior',
+        status: 'pending',
+      },
+      cwd: tempDir,
+      session_id: 'session-taskcreate-builtin',
+    });
+
+    expect(output).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('suppresses built-in TaskUpdate task-list operation chatter', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'TaskUpdate',
+      toolInput: {
+        id: 'task-1',
+        status: 'in_progress',
+      },
+      cwd: tempDir,
+      session_id: 'session-taskupdate-builtin',
+    });
+
+    expect(output).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('preserves Agent spawn warnings for real subagent delegation', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Agent',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Fix type errors',
+        prompt: 'Fix all type errors in src/auth/',
+      },
+      cwd: tempDir,
+      session_id: 'session-agent-spawn',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('Spawning agent: oh-my-claudecode:executor');
+  });
+
   it('reads team state from legacy path when session_id is absent', () => {
     writeJson(join(tempDir, '.omc', 'state', 'team-state.json'), {
       active: true,


### PR DESCRIPTION
Fixes #2938

## Summary
- Suppress PreToolUse agent-spawn chatter for built-in Claude task-list tools: TaskCreate, TaskUpdate, TaskList, TaskGet, TaskOutput, TaskStop
- Keep real Task/Agent subagent delegation on the agent-spawn warning path
- Add targeted regression tests for TaskCreate/TaskUpdate suppression and Agent spawn warnings

## Tests
- npm test -- --run src/__tests__/pre-tool-enforcer.test.ts
- npm run lint (passes with existing warnings)
- npm run build