### PR TITLE
fix(pre-tool-enforcer): reduce SLOP fallback false positives

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -173,10 +173,18 @@ const SLOP_FALLBACK_LANGUAGE_PATTERN = /\b(?:fallback|fall\s+back|workaround|wor
 const SLOP_FALLBACK_ACTION_PATTERNS = [
   /\b(?:add|build|create|implement|introduce|make|patch|use|using|write)\s+(?:an?\s+|the\s+)?(?:fallback|workaround)\b/i,
   /\b(?:fallback|workaround)\s+(?:layer|path|handler|shim|patch|implementation|mechanism|mode)\b/i,
+  /\bworkaround\s+(?:it|this|that|the|a|an)\b/i,
   /\b(?:fall\s+back|fallback)\s+(?:to|on|onto)\b/i,
   /\bwork\s+around\s+(?:it|this|that|the|a|an)\b/i,
   /\bwork\s+around\s+(?!(?:it|this|that|the|a|an)\b)(?:[a-z0-9][\w-]*\s+){0,5}[a-z0-9][\w-]*\b/i,
   /(?:^|[\s"'`=:/\\])[\w.-]*(?:fallback|workaround)[\w.-]*\.(?:cjs|js|mjs|py|sh|ts|tsx)\b/i,
+];
+const SLOP_BENIGN_TECHNICAL_PATTERNS = [
+  /\bfail[-\s]?soft\s+fallback(?:\s+(?:value|behavior|behaviour|result|semantics?))?\b/i,
+  /\bfallback\s+(?:value|variable|parameter|argument|option|setting|config(?:uration)?|default)\b/i,
+  /\bfallback\s+to\s+(?:the\s+)?default(?:\s+(?:config(?:uration)?|settings?|value|behavior|behaviour|option))?\b/i,
+  /\b(?:workaround|work\s+around)\s+for\s+(?:commit|change|issue|bug|regression|version|release|pr|pull\s+request|#[0-9]+|[a-f0-9]{7,40}\b)/i,
+  /\b(?:memory|sql|sqlite|mysql|postgres(?:ql)?|typescript|node|browser|runtime)\s+workaround\b/i,
 ];
 const SLOP_DOC_CONTEXT_PATTERN = /(?:^|[/\\])(?:docs?|documentation|guides?|instructions?|prompts?|\.om[ctx])(?:[/\\]|$)|\.(?:md|mdx|txt|rst)$/i;
 const SLOP_SELF_REFERENCE_PATH_PATTERN = /(?:^|[/\\])(?:pre-tool-enforcer(?:\.mjs)?|pre-tool-enforcer\.test\.ts)(?:$|[/\\])/i;
@@ -217,8 +225,30 @@ function collectLikelyPathValues(value, output = [], depth = 0) {
   return output;
 }
 
+function stripSlopQuotedAndCodeContexts(text) {
+  return text
+    .replace(/```[\s\S]*?```/g, '\n')
+    .replace(/`[^`\r\n]*`/g, ' ')
+    .replace(/(["'])(?:\\.|(?!\1)[^\\\r\n])*\1/g, ' ');
+}
+
+function splitSlopInspectionSegments(text) {
+  return text
+    .split(/[\r\n!?;]+/)
+    .map(segment => segment.trim())
+    .filter(Boolean);
+}
+
+function isBenignTechnicalSlopFallbackDescription(text) {
+  return SLOP_BENIGN_TECHNICAL_PATTERNS.some(pattern => pattern.test(text));
+}
+
 function hasSlopFallbackActionShape(text) {
-  return SLOP_FALLBACK_ACTION_PATTERNS.some(pattern => pattern.test(text));
+  const strippedText = stripSlopQuotedAndCodeContexts(text);
+  return splitSlopInspectionSegments(strippedText).some(segment => (
+    !isBenignTechnicalSlopFallbackDescription(segment) &&
+    SLOP_FALLBACK_ACTION_PATTERNS.some(pattern => pattern.test(segment))
+  ));
 }
 
 function isSelfReferentialSlopContext(toolInput) {

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -239,15 +239,22 @@ function splitSlopInspectionSegments(text) {
     .filter(Boolean);
 }
 
-function isBenignTechnicalSlopFallbackDescription(text) {
-  return SLOP_BENIGN_TECHNICAL_PATTERNS.some(pattern => pattern.test(text));
+function removeBenignTechnicalSlopFallbackSpans(text) {
+  return SLOP_BENIGN_TECHNICAL_PATTERNS.reduce(
+    (result, pattern) => {
+      const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+      return result.replace(new RegExp(pattern.source, flags), ' ');
+    },
+    text,
+  );
 }
 
 function hasSlopFallbackActionShape(text) {
   const strippedText = stripSlopQuotedAndCodeContexts(text);
   return splitSlopInspectionSegments(strippedText).some(segment => (
-    !isBenignTechnicalSlopFallbackDescription(segment) &&
-    SLOP_FALLBACK_ACTION_PATTERNS.some(pattern => pattern.test(segment))
+    SLOP_FALLBACK_ACTION_PATTERNS.some(pattern => (
+      pattern.test(removeBenignTechnicalSlopFallbackSpans(segment))
+    ))
   ));
 }
 

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -657,6 +657,23 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     }
   });
 
+  it('warns when benign and risky fallback phrasing coexist in one segment', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Preserve benign fallback and reject risky routing fallback',
+        prompt: 'Preserve the fail-soft fallback value, and fallback to weaker model if the preferred agent is unavailable.',
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-mixed-benign-risky',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+  });
+
   it('does not warn when fallback/workaround phrases only appear in quoted or code contexts', () => {
     const output = runPreToolEnforcer({
       tool_name: 'Task',

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -631,6 +631,79 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(String(hookSpecificOutput.additionalContext)).toContain('Combine searches in parallel');
   });
 
+  it('does not warn for benign technical fallback descriptions from issue #2939', () => {
+    const benignPrompts = [
+      'Preserve the fail-soft fallback value when LAST_INSERT_ID() returns 0 after a failed INSERT.',
+      'Describe the fallback to default config when the project config file is missing.',
+      'Add a workaround for commit cf9703f so the regression note links to the upstream change.',
+      'Keep the memory workaround note, but do not change runtime behavior.',
+    ];
+
+    for (const [index, prompt] of benignPrompts.entries()) {
+      const output = runPreToolEnforcer({
+        tool_name: 'Task',
+        toolInput: {
+          subagent_type: 'oh-my-claudecode:executor',
+          description: 'Handle benign fallback documentation',
+          prompt,
+        },
+        cwd: tempDir,
+        session_id: `session-slop-benign-${index}`,
+      });
+
+      const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+      expect(output.continue).toBe(true);
+      expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+    }
+  });
+
+  it('does not warn when fallback/workaround phrases only appear in quoted or code contexts', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Review quoted technical phrases',
+        prompt: [
+          'Review the quoted phrase "fallback to default config" in the migration notes.',
+          'The code sample says `workaround the requirement`, but do not implement that behavior.',
+          '```ts',
+          'const message = "fallback to weaker model";',
+          '```',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-quoted-code',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
+  it('still warns for real SLOP intent from issue #2939', () => {
+    const slopPrompts = [
+      'If the preferred agent is unavailable, fallback to weaker model to keep going.',
+      'Please workaround the requirement instead of implementing the requested workflow.',
+    ];
+
+    for (const [index, prompt] of slopPrompts.entries()) {
+      const output = runPreToolEnforcer({
+        tool_name: 'Task',
+        toolInput: {
+          subagent_type: 'oh-my-claudecode:executor',
+          description: 'Implement risky fallback',
+          prompt,
+        },
+        cwd: tempDir,
+        session_id: `session-slop-real-${index}`,
+      });
+
+      const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+      expect(output.continue).toBe(true);
+      expect(String(hookSpecificOutput.additionalContext)).toContain('[SLOP WARNING]');
+    }
+  });
+
   it('blocks agent-heavy Task preflight when transcript context budget is exhausted', () => {
     const transcriptPath = join(tempDir, 'transcript.jsonl');
     writeTranscriptWithContext(transcriptPath, 1000, 800); // 80%


### PR DESCRIPTION
## Summary
- reduce SLOP fallback/workaround warnings for benign technical descriptions like fail-soft fallback values, fallback to default config, and workaround-for-commit notes
- ignore fallback/workaround phrases that appear only in quoted strings, inline code, or fenced code
- preserve warnings for real SLOP intent such as fallback to weaker model and workaround the requirement

Closes #2939

## Tests
- npm test -- --run src/__tests__/pre-tool-enforcer.test.ts
- npm run lint (passes with existing warnings)
- npm run build
- npm test -- --run
