### PR TITLE
fix(skills): gate default plugin skill budget

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,6 +15,20 @@
     "orchestration",
     "automation"
   ],
-  "skills": "./skills/",
-  "mcpServers": "./.mcp.json"
+  "skills": [
+    "./skills/ai-slop-cleaner/",
+    "./skills/autopilot/",
+    "./skills/cancel/",
+    "./skills/deep-interview/",
+    "./skills/omc-reference/",
+    "./skills/plan/",
+    "./skills/ralph/",
+    "./skills/ralplan/",
+    "./skills/setup/",
+    "./skills/team/",
+    "./skills/ultraqa/",
+    "./skills/ultrawork/"
+  ],
+  "mcpServers": "./.mcp.json",
+  "commands": "./commands/"
 }

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC ask
+
+This compatibility command keeps `/oh-my-claudecode:ask` available without loading the full `ask` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/ask/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/autoresearch.md
+++ b/commands/autoresearch.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC autoresearch
+
+This compatibility command keeps `/oh-my-claudecode:autoresearch` available without loading the full `autoresearch` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/autoresearch/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/ccg.md
+++ b/commands/ccg.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC ccg
+
+This compatibility command keeps `/oh-my-claudecode:ccg` available without loading the full `ccg` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/ccg/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/configure-notifications.md
+++ b/commands/configure-notifications.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC configure-notifications
+
+This compatibility command keeps `/oh-my-claudecode:configure-notifications` available without loading the full `configure-notifications` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/configure-notifications/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC debug
+
+This compatibility command keeps `/oh-my-claudecode:debug` available without loading the full `debug` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/debug/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/deep-dive.md
+++ b/commands/deep-dive.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC deep-dive
+
+This compatibility command keeps `/oh-my-claudecode:deep-dive` available without loading the full `deep-dive` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/deep-dive/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/deepinit.md
+++ b/commands/deepinit.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC deepinit
+
+This compatibility command keeps `/oh-my-claudecode:deepinit` available without loading the full `deepinit` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/deepinit/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/external-context.md
+++ b/commands/external-context.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC external-context
+
+This compatibility command keeps `/oh-my-claudecode:external-context` available without loading the full `external-context` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/external-context/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/hud.md
+++ b/commands/hud.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC hud
+
+This compatibility command keeps `/oh-my-claudecode:hud` available without loading the full `hud` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/hud/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/learner.md
+++ b/commands/learner.md
@@ -1,0 +1,13 @@
+---
+description: ""
+---
+
+# OMC learner
+
+`/oh-my-claudecode:learner` is a compatibility alias for `/oh-my-claudecode:skillify`.
+
+Read `skills/skillify/SKILL.md`, follow its full instructions, and pass through the user's arguments:
+
+```text
+$ARGUMENTS
+```

--- a/commands/mcp-setup.md
+++ b/commands/mcp-setup.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC mcp-setup
+
+This compatibility command keeps `/oh-my-claudecode:mcp-setup` available without loading the full `mcp-setup` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/mcp-setup/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/omc-doctor.md
+++ b/commands/omc-doctor.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC omc-doctor
+
+This compatibility command keeps `/oh-my-claudecode:omc-doctor` available without loading the full `omc-doctor` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/omc-doctor/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/omc-setup.md
+++ b/commands/omc-setup.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC omc-setup
+
+This compatibility command keeps `/oh-my-claudecode:omc-setup` available without loading the full `omc-setup` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/omc-setup/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/omc-teams.md
+++ b/commands/omc-teams.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC omc-teams
+
+This compatibility command keeps `/oh-my-claudecode:omc-teams` available without loading the full `omc-teams` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/omc-teams/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/project-session-manager.md
+++ b/commands/project-session-manager.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC project-session-manager
+
+This compatibility command keeps `/oh-my-claudecode:project-session-manager` available without loading the full `project-session-manager` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/project-session-manager/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/psm.md
+++ b/commands/psm.md
@@ -1,0 +1,13 @@
+---
+description: ""
+---
+
+# OMC psm
+
+`/oh-my-claudecode:psm` is a compatibility alias for `/oh-my-claudecode:project-session-manager`.
+
+Read `skills/project-session-manager/SKILL.md`, follow its full instructions, and pass through the user's arguments:
+
+```text
+$ARGUMENTS
+```

--- a/commands/release.md
+++ b/commands/release.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC release
+
+This compatibility command keeps `/oh-my-claudecode:release` available without loading the full `release` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/release/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/remember.md
+++ b/commands/remember.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC remember
+
+This compatibility command keeps `/oh-my-claudecode:remember` available without loading the full `remember` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/remember/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/sciomc.md
+++ b/commands/sciomc.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC sciomc
+
+This compatibility command keeps `/oh-my-claudecode:sciomc` available without loading the full `sciomc` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/sciomc/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/self-improve.md
+++ b/commands/self-improve.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC self-improve
+
+This compatibility command keeps `/oh-my-claudecode:self-improve` available without loading the full `self-improve` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/self-improve/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/skill.md
+++ b/commands/skill.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC skill
+
+This compatibility command keeps `/oh-my-claudecode:skill` available without loading the full `skill` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/skill/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/skillify.md
+++ b/commands/skillify.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC skillify
+
+This compatibility command keeps `/oh-my-claudecode:skillify` available without loading the full `skillify` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/skillify/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/trace.md
+++ b/commands/trace.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC trace
+
+This compatibility command keeps `/oh-my-claudecode:trace` available without loading the full `trace` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/trace/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC verify
+
+This compatibility command keeps `/oh-my-claudecode:verify` available without loading the full `verify` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/verify/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/visual-verdict.md
+++ b/commands/visual-verdict.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC visual-verdict
+
+This compatibility command keeps `/oh-my-claudecode:visual-verdict` available without loading the full `visual-verdict` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/visual-verdict/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/wiki.md
+++ b/commands/wiki.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC wiki
+
+This compatibility command keeps `/oh-my-claudecode:wiki` available without loading the full `wiki` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/wiki/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/commands/writer-memory.md
+++ b/commands/writer-memory.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC writer-memory
+
+This compatibility command keeps `/oh-my-claudecode:writer-memory` available without loading the full `writer-memory` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/writer-memory/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -167,10 +167,25 @@ describe('Installer Constants', () => {
     });
   });
 
-  describe('Commands directory removed (#582)', () => {
-    it('should NOT have a commands/ directory in the package root', () => {
-      const commandsDir = join(getPackageDir(), 'commands');
-      expect(existsSync(commandsDir)).toBe(false);
+  describe('Claude Code plugin command wrappers', () => {
+    it('should ship package-root commands/*.md wrappers through plugin.json', () => {
+      const packageDir = getPackageDir();
+      const commandsDir = join(packageDir, 'commands');
+      const pluginJson = JSON.parse(
+        readFileSync(join(packageDir, '.claude-plugin', 'plugin.json'), 'utf-8')
+      ) as { commands?: unknown };
+
+      expect(pluginJson.commands).toBe('./commands/');
+      expect(existsSync(commandsDir)).toBe(true);
+
+      const files = readdirSync(commandsDir).filter(f => f.endsWith('.md'));
+      expect(files.length).toBeGreaterThan(0);
+
+      for (const file of files) {
+        const content = readFileSync(join(commandsDir, file), 'utf-8');
+        expect(content, `${file} should dispatch to a bundled skill`).toContain('SKILL.md');
+        expect(content, `${file} should pass through user arguments`).toContain('$ARGUMENTS');
+      }
     });
   });
 
@@ -179,14 +194,7 @@ describe('Installer Constants', () => {
       const packageDir = getPackageDir();
       const commandsDir = join(packageDir, 'commands');
 
-      // commands/ directory should not exist at all
-      if (!existsSync(commandsDir)) {
-        // This is the expected state - no commands directory
-        expect(true).toBe(true);
-        return;
-      }
-
-      // If commands/ somehow gets re-added, ensure no self-referential stubs
+      // commands/ now intentionally contains Claude Code plugin wrappers.
       const files = readdirSync(commandsDir).filter(f => f.endsWith('.md'));
       const selfReferentialStubs: string[] = [];
 

--- a/src/__tests__/plugin-skill-budget.test.ts
+++ b/src/__tests__/plugin-skill-budget.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, '..', '..');
+const PLUGIN_JSON = join(REPO_ROOT, '.claude-plugin', 'plugin.json');
+const SKILLS_DIR = join(REPO_ROOT, 'skills');
+const COMMANDS_DIR = join(REPO_ROOT, 'commands');
+
+function readPluginJson(): { skills?: unknown; commands?: unknown } {
+  return JSON.parse(readFileSync(PLUGIN_JSON, 'utf-8')) as { skills?: unknown; commands?: unknown };
+}
+
+function bundledSkillDirs(): string[] {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(SKILLS_DIR, entry.name, 'SKILL.md')))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function pluginSkillDirs(): string[] {
+  const { skills } = readPluginJson();
+  expect(Array.isArray(skills)).toBe(true);
+  return (skills as string[])
+    .map((skillPath) => skillPath.replace(/^\.\/skills\//, '').replace(/\/$/, ''))
+    .sort();
+}
+
+describe('plugin skill context budget gate (issue #2943)', () => {
+  it('loads only tier-0/core workflow skills by default through plugin.json', () => {
+    const defaultSkillDirs = pluginSkillDirs();
+    const allSkillDirs = bundledSkillDirs();
+
+    expect(allSkillDirs.length).toBeGreaterThan(30);
+    expect(defaultSkillDirs).toEqual([
+      'ai-slop-cleaner',
+      'autopilot',
+      'cancel',
+      'deep-interview',
+      'omc-reference',
+      'plan',
+      'ralph',
+      'ralplan',
+      'setup',
+      'team',
+      'ultraqa',
+      'ultrawork',
+    ]);
+
+    // Keep OMC well below Claude Code's skill-description context budget and
+    // leave most slots for user/project skills.
+    expect(defaultSkillDirs.length).toBeLessThanOrEqual(12);
+    expect(defaultSkillDirs.length).toBeLessThan(allSkillDirs.length / 2);
+  });
+
+  it('keeps non-default bundled skills reachable as explicit plugin commands', () => {
+    const defaultSkillDirs = new Set(pluginSkillDirs());
+    const nonDefaultSkillDirs = bundledSkillDirs().filter((name) => !defaultSkillDirs.has(name));
+
+    expect(readPluginJson().commands).toBe('./commands/');
+
+    for (const skillDir of nonDefaultSkillDirs) {
+      const skillContent = readFileSync(join(SKILLS_DIR, skillDir, 'SKILL.md'), 'utf-8');
+      const frontmatterName = skillContent.match(/^name:\s*(.+)$/m)?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? skillDir;
+      const commandPath = join(COMMANDS_DIR, `${frontmatterName}.md`);
+      expect(existsSync(commandPath), `${frontmatterName} command wrapper exists`).toBe(true);
+      const commandContent = readFileSync(commandPath, 'utf-8');
+      const expectedSkillPath = skillDir === 'learner' ? 'skills/skillify/SKILL.md' : `skills/${skillDir}/SKILL.md`;
+      expect(commandContent).toContain(expectedSkillPath);
+      expect(commandContent).toContain('$ARGUMENTS');
+    }
+  });
+
+  it('preserves deprecated slash aliases as command wrappers', () => {
+    expect(readFileSync(join(COMMANDS_DIR, 'learner.md'), 'utf-8')).toContain('skills/skillify/SKILL.md');
+    expect(readFileSync(join(COMMANDS_DIR, 'psm.md'), 'utf-8')).toContain('skills/project-session-manager/SKILL.md');
+  });
+});


### PR DESCRIPTION
## Summary
- Gate the Claude Code plugin manifest to 12 tier-0/core OMC skills instead of scanning the full bundled `skills/` directory by default.
- Add lightweight slash-command compatibility wrappers for non-default bundled workflows so explicit `/oh-my-claudecode:<name>` entrypoints can still load the full on-disk `SKILL.md` on demand.
- Add regression coverage proving default skill-description load stays below the budget target and compatibility wrappers exist, including deprecated aliases.

## Why
Fixes #2943 by substantially reducing OMC's default skill-description footprint while preserving the full bundled skill library and core keyword workflows.

## Tested
- `claude plugin validate .claude-plugin/plugin.json`
- `claude plugin validate .`
- `npm test -- --run src/__tests__/plugin-skill-budget.test.ts src/__tests__/skills-frontmatter-regression.test.ts src/__tests__/tier0-contracts.test.ts src/__tests__/consolidation-contracts.test.ts`
- `npm run build`
- `npm run lint` (0 errors, existing warnings)

Co-authored-by: OmX <omx@oh-my-codex.dev>
