### PR TITLE
Fix Claude worker startup notification readiness

### DIFF
--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -209,6 +209,8 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(requests).toHaveLength(1);
     expect(requests[0]?.to_worker).toBe('worker-1');
     expect(requests[0]?.status).toBe('notified');
+    expect(requests[0]?.transport_preference).toBe('transport_direct');
+    expect(requests[0]?.fallback_allowed).toBe(true);
     expect(requests[0]?.inbox_correlation_key).toBe('startup:worker-1:1');
     expect(requests[0]?.trigger_message).toContain('.omc/state/team/dispatch-team/workers/worker-1/inbox.md');
     expect(requests[0]?.trigger_message).toContain('execute now');
@@ -648,6 +650,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(requests).toHaveLength(1);
     expect(requests[0]?.status).toBe('failed');
     expect(requests[0]?.last_reason).toBe('worker_notify_failed');
+    expect(mocks.sendToWorker).toHaveBeenCalledTimes(1);
   });
 
   it('requires Claude startup evidence without resending the startup inbox', async () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -9,6 +9,7 @@ import {
   shouldAttemptAdaptiveRetry,
   getDefaultShell,
   buildWorkerStartCommand,
+  paneLooksReady,
 } from '../tmux-session.js';
 
 afterEach(() => {
@@ -300,6 +301,25 @@ describe('shouldAttemptAdaptiveRetry', () => {
       retriesAttempted: 0,
     })).toBe(false);
     delete process.env.OMC_TEAM_AUTO_INTERRUPT_RETRY;
+  });
+});
+
+describe('pane readiness startup banners', () => {
+  it('does not treat Claude bypass-permissions startup banner as ready', () => {
+    const capture = [
+      'Read .omc/state/team/example/workers/worker-1/inbox.md, execute now, report concrete progress.',
+      '─────────────────────────────────────────────',
+      '[OMC] Starting...',
+      '⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n');
+
+    expect(paneLooksReady(capture)).toBe(false);
+  });
+
+  it('still treats actual prompt lines as ready', () => {
+    expect(paneLooksReady('Welcome\n❯ ')).toBe(true);
+    expect(paneLooksReady('Welcome\n> ')).toBe(true);
+    expect(paneLooksReady('⏵⏵ bypass permissions on (shift+tab to cycle)\nReady\n❯ ')).toBe(true);
   });
 });
 

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -485,7 +485,10 @@ async function notifyStartupInbox(
   paneId: string,
   message: string,
 ): Promise<DispatchOutcome> {
-  const notified = await notifyPaneWithRetry(sessionName, paneId, message);
+  // Startup inbox triggers are only safe to type once after readiness. If the
+  // pane still rejects the send (for example Claude is showing a startup
+  // banner), repeated tmux send-keys calls append duplicate trigger text.
+  const notified = await notifyPaneWithRetry(sessionName, paneId, message, 1);
   return notified
     ? { ok: true, transport: 'tmux_send_keys', reason: 'worker_pane_notified' }
     : { ok: false, transport: 'tmux_send_keys', reason: 'worker_notify_failed' };
@@ -747,7 +750,7 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     triggerMessage: inboxTriggerMessage,
     cwd: opts.cwd,
     transportPreference: usePromptMode ? 'prompt_stdin' : 'transport_direct',
-    fallbackAllowed: false,
+    fallbackAllowed: DEFAULT_TEAM_TRANSPORT_POLICY.dispatch_mode === 'hook_preferred_with_fallback',
     inboxCorrelationKey: `startup:${opts.workerName}:${opts.taskId}`,
     notify: async (_target, triggerMessage) => {
       if (usePromptMode) {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -801,7 +801,8 @@ export async function spawnWorkerForTask(
     const notified = await notifyPaneWithRetry(
       runtime.sessionName,
       paneId,
-      generateTriggerMessage(runtime.teamName, workerNameValue)
+      generateTriggerMessage(runtime.teamName, workerNameValue),
+      1
     );
     if (!notified) {
       await killWorkerPane(runtime, workerNameValue, paneId);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -644,7 +644,23 @@ function paneHasTrustPrompt(captured: string): boolean {
   return hasQuestion && hasChoices;
 }
 
+function paneHasClaudeStartupBanner(captured: string): boolean {
+  const lines = captured
+    .split('\n')
+    .map((line) => line.replace(/\r/g, '').trim())
+    .filter((line) => line.length > 0)
+    .slice(-20);
+  const lastPromptIndex = lines.findLastIndex((line) => /^\s*[›>❯]\s*/u.test(line));
+  const lastStartupBannerIndex = lines.findLastIndex((line) =>
+    /bypass\s+permissions\s+on/i.test(line)
+    || /shift\+tab\s+to\s+cycle/i.test(line)
+    || /^⏵⏵\s+/.test(line),
+  );
+  return lastStartupBannerIndex >= 0 && lastStartupBannerIndex > lastPromptIndex;
+}
+
 function paneIsBootstrapping(captured: string): boolean {
+  if (paneHasClaudeStartupBanner(captured)) return true;
   const lines = captured
     .split('\n')
     .map((line) => line.replace(/\r/g, '').trim())
@@ -777,6 +793,9 @@ export async function sendToWorker(
 
     // Check for trust prompt and auto-dismiss before sending our text
     const initialCapture = await capturePaneAsync(paneId);
+    if (paneHasClaudeStartupBanner(initialCapture)) {
+      return false;
+    }
     const paneBusy = paneHasActiveTask(initialCapture);
 
     if (paneHasTrustPrompt(initialCapture)) {


### PR DESCRIPTION
## Summary
- Treat Claude Code startup/bypass-permissions banners as not-ready panes before tmux notify.
- Avoid duplicate startup trigger accumulation by sending the startup inbox trigger only once after readiness.
- Persist `fallback_allowed: true` for runtime-v2 startup inbox dispatch under the default `hook_preferred_with_fallback` policy.
- Add regressions for banner readiness, startup dispatch fallback policy, and notify failure not being treated as successful assignment.

Fixes #2947

## Verification
- `npm ci`
- `npx vitest run src/team/__tests__/tmux-session.test.ts src/team/__tests__/runtime-v2.dispatch.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run build`
- `git diff --check`

## Notes
- Generated `dist/` and `bridge/` outputs were intentionally not included to keep this PR source-scoped and avoid unrelated generated churn from the current checkout; build was run successfully from the source changes.
