### PR TITLE
fix: mirror themes in omc launch profile

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -89409,6 +89409,7 @@ function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
     "projects",
     "rules",
     "skills",
+    "themes",
     OMC_CONFIG_FILE_REL,
     ".omc-version.json",
     ".omc-silent-update.json",

--- a/dist/cli/launch.js
+++ b/dist/cli/launch.js
@@ -82,6 +82,7 @@ export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) 
         'projects',
         'rules',
         'skills',
+        'themes',
         OMC_CONFIG_FILE_REL,
         '.omc-version.json',
         '.omc-silent-update.json',

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -972,17 +972,21 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     expect(runtimeSettings.mcpServers?.exa).toBeDefined();
   });
 
-  it('mirrors keybindings.json and rules/ into the runtime config dir', () => {
+  it('mirrors keybindings.json, rules/, and themes/ into the runtime config dir', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(join(configDir, 'rules'), { recursive: true });
+    mkdirSync(join(configDir, 'themes'), { recursive: true });
     writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
     writeFileSync(join(configDir, 'keybindings.json'), '{"bindings":[]}');
     writeFileSync(join(configDir, 'rules', 'my-rule.md'), '# Rule');
+    writeFileSync(join(configDir, 'themes', 'custom-theme.json'), '{"name":"custom"}');
 
     const runtimeDir = prepareOmcLaunchConfigDir(configDir);
     expect(runtimeDir).not.toBe(configDir);
     expect(existsSync(join(runtimeDir, 'keybindings.json'))).toBe(true);
     expect(existsSync(join(runtimeDir, 'rules'))).toBe(true);
+    expect(existsSync(join(runtimeDir, 'themes'))).toBe(true);
+    expect(readFileSync(join(runtimeDir, 'themes', 'custom-theme.json'), 'utf-8')).toBe('{"name":"custom"}');
   });
 
   it('preserves runtime .claude.json across runtime config dir rebuilds', () => {

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -111,6 +111,7 @@ export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()):
     'projects',
     'rules',
     'skills',
+    'themes',
     OMC_CONFIG_FILE_REL,
     '.omc-version.json',
     '.omc-silent-update.json',


### PR DESCRIPTION
## Summary
- mirror `themes/` into the `.omc-launch` runtime config profile
- extend launch runtime mirror coverage to assert a custom theme file is available under `.omc-launch/themes/`

Fixes #2952.

## Verification
- `npm test -- --run src/cli/__tests__/launch.test.ts` → 142 passed
- `npx tsc --noEmit` → passed
- `npm run lint -- src/cli/launch.ts src/cli/__tests__/launch.test.ts` → 0 errors; existing unrelated repository warnings remain
- Architect verification: APPROVED

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
