### PR TITLE
fix(keyword-detector): skip deep-interview routing on Ouroboros CLI invocations

### DIFF
--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -1885,6 +1885,49 @@ This article argues that fake popularity signals damage trust in open source.`;
         expect(match).toBeUndefined();
       });
 
+      // Ouroboros CLI invocation skip — the bare brand name `ouroboros`/`ooo`
+      // at the start of a prompt is a deterministic upstream CLI command,
+      // not a routing request for deep-interview. The skip predicate defers
+      // to the upstream CLI in those cases. Natural-language mentions where
+      // the brand appears mid-sentence are unaffected.
+      it('should NOT detect "ouroboros auto" as deep-interview (upstream CLI invocation)', () => {
+        const result = detectKeywordsWithType('ouroboros auto "Add /healthz endpoint"');
+        const match = result.find((r) => r.type === 'deep-interview');
+        expect(match).toBeUndefined();
+      });
+
+      it('should NOT detect "ooo auto" as deep-interview (upstream CLI shortcut)', () => {
+        const result = detectKeywordsWithType('ooo auto "Build a habit tracker"');
+        const match = result.find((r) => r.type === 'deep-interview');
+        expect(match).toBeUndefined();
+      });
+
+      it('should NOT detect "/ouroboros:auto" as deep-interview (upstream CLI slash form)', () => {
+        const result = detectKeywordsWithType('/ouroboros:auto "Refactor logger"');
+        const match = result.find((r) => r.type === 'deep-interview');
+        expect(match).toBeUndefined();
+      });
+
+      it('should NOT detect "ouroboros run" as deep-interview', () => {
+        const result = detectKeywordsWithType('ouroboros run');
+        const match = result.find((r) => r.type === 'deep-interview');
+        expect(match).toBeUndefined();
+      });
+
+      it('should still detect natural-language ouroboros mention as deep-interview', () => {
+        const result = detectKeywordsWithType(
+          'please use ouroboros to clarify my requirements'
+        );
+        const match = result.find((r) => r.type === 'deep-interview');
+        expect(match).toBeDefined();
+      });
+
+      it('should still detect "딥인터뷰" as deep-interview when CLI guard does not apply', () => {
+        const result = detectKeywordsWithType('딥인터뷰 좀 해줘');
+        const match = result.find((r) => r.type === 'deep-interview');
+        expect(match).toBeDefined();
+      });
+
       it('should detect "씨씨지" as ccg', () => {
         const result = detectKeywordsWithType('씨씨지');
         const match = result.find((r) => r.type === 'ccg');

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -63,6 +63,28 @@ const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
 };
 
 /**
+ * Matches the upstream Ouroboros CLI invocation form at the start of the
+ * prompt: `ouroboros <sub>`, `ooo <sub>`, or `/ouroboros:<sub>`. Used as a
+ * skip predicate for the deep-interview trigger so direct CLI calls are
+ * not rerouted into the OMC skill.
+ */
+const OUROBOROS_BRAND_AT_START = /^\s*\/?(?:ouroboros|ooo)\b/i;
+
+/**
+ * Optional per-keyword skip predicate. When the predicate returns true for
+ * a given prompt, the corresponding keyword regex match is suppressed even
+ * if it would otherwise fire. Used for narrow false-positive guards.
+ *
+ * `deep-interview` matches the bare brand name `ouroboros`, which fires on
+ * upstream CLI invocations like `ouroboros auto "X"`, `ooo auto`, and
+ * `/ouroboros:auto`. The predicate defers to the upstream CLI in those
+ * cases without changing what the trigger recognizes elsewhere.
+ */
+const KEYWORD_SKIP_PREDICATES: Partial<Record<KeywordType, (text: string) => boolean>> = {
+  'deep-interview': (text) => OUROBOROS_BRAND_AT_START.test(text),
+};
+
+/**
  * Priority order for keyword detection
  */
 const KEYWORD_PRIORITY: KeywordType[] = [
@@ -639,6 +661,10 @@ export function detectKeywordsWithType(
     }
 
     const pattern = KEYWORD_PATTERNS[type];
+    const skipPredicate = KEYWORD_SKIP_PREDICATES[type];
+    if (skipPredicate && skipPredicate(cleanedText)) {
+      continue;
+    }
     const match =
       type === 'ralplan'
         ? findActionableRalplanMatch(cleanedText, pattern)

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -950,8 +950,15 @@ async function main() {
     }
 
     // Deep interview keywords
+    // Skip when the prompt is an upstream Ouroboros CLI invocation —
+    // `ouroboros <sub>`, `ooo <sub>`, or `/ouroboros:<sub>`. The bare
+    // brand name as the first token is a deterministic command, not a
+    // routing request. Natural-language mentions ("please use ouroboros
+    // to clarify…") still match because the brand is mid-sentence.
     if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)/i)) {
-      matches.push({ name: 'deep-interview', args: '' });
+      if (!/^\s*\/?(?:ouroboros|ooo)\b/i.test(cleanPrompt)) {
+        matches.push({ name: 'deep-interview', args: '' });
+      }
     }
 
     // AI slop cleanup keywords


### PR DESCRIPTION
## Summary

- Skip `deep-interview` routing when the prompt starts with the Ouroboros brand name (CLI invocation form).
- Source-only diff: 2 files (TS + MJS kept in sync) + tests.
- No new config, no new env var, no enumeration of upstream subcommand surface.

Fixes #2954.

## Bug

The `deep-interview` regex matches the bare brand name `ouroboros`:

```ts
'deep-interview': /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)/i,
```

This is correct for natural language ("please use ouroboros to clarify…") but intercepts upstream CLI invocations:

- `ouroboros auto "..."`
- `ooo auto "..."`
- `/ouroboros:auto`

The shape of this defect mirrors the Korean false-positive class fixed in #2337 — a too-broad trigger that needs a narrow boundary guard, not a new trigger.

## Fix

Add an opt-in `KEYWORD_SKIP_PREDICATES` map keyed by `KeywordType`. For `deep-interview`, the predicate matches when the prompt starts with the brand (with optional leading `/` for slash form). When the predicate fires, the per-type loop skips that match check.

```diff
+ const OUROBOROS_BRAND_AT_START = /^\s*\/?(?:ouroboros|ooo)\b/i;
+
+ const KEYWORD_SKIP_PREDICATES: Partial<Record<KeywordType, (text: string) => boolean>> = {
+   'deep-interview': (text) => OUROBOROS_BRAND_AT_START.test(text),
+ };

  for (const type of KEYWORD_PRIORITY) {
    ...
    const pattern = KEYWORD_PATTERNS[type];
+   const skipPredicate = KEYWORD_SKIP_PREDICATES[type];
+   if (skipPredicate && skipPredicate(cleanedText)) {
+     continue;
+   }
    const match = ...
```

The MJS template gets the equivalent imperative guard at its existing deep-interview branch.

No enumeration of subcommands — Ouroboros can extend its CLI without requiring an OMC change.

## What does NOT change

- Natural-language mentions where the brand appears mid-sentence still route to `deep-interview`.
- `딥인터뷰` still routes to `deep-interview`.
- All other trigger inventory and routing untouched.
- No new module dependencies; the predicate is a 3-line entry next to `KEYWORD_PATTERNS`.

## Test plan

- [x] Both files in sync: `src/hooks/keyword-detector/index.ts` + `templates/hooks/keyword-detector.mjs`
- [x] `vitest run src/hooks/keyword-detector/__tests__/index.test.ts` — **347 tests passed** (was 341 before; added 6 new cases)
- [x] `ouroboros auto "..."` → no deep-interview match
- [x] `ooo auto "..."` → no deep-interview match
- [x] `/ouroboros:auto "..."` → no deep-interview match
- [x] `ouroboros run` → no deep-interview match
- [x] `please use ouroboros to clarify my requirements` → still routes
- [x] `딥인터뷰 좀 해줘` → still routes

## Out of scope

- Generic CLI invocation guard for other plugins (would help any tool whose CLI shares a name with an OMC trigger). Happy to follow up in a separate PR if you'd like; intentionally scoped this one to the immediate false positive.