### PR TITLE
Add UI design anti-slop signals

### DIFF
--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -93,6 +93,18 @@ In review mode:
    - **Needless abstraction** — pass-through wrappers, speculative indirection, single-use helper layers
    - **Boundary violations** — hidden coupling, misplaced responsibilities, wrong-layer imports or side effects
    - **Missing tests** — behavior not locked, weak regression coverage, edge-case gaps
+   - **UI/design defaults** — generic visual patterns that make an AI-built interface feel unreviewed
+
+### UI/Design Reviewer Checklist
+
+Use these as review prompts, not absolute bans. Keep intentional brand, accessibility, product-density, or design-system choices when they have a clear rationale.
+
+- **Korean readability:** flag body text set around 11-12px; Korean body copy generally needs at least 14px unless a validated dense-data exception applies.
+- **Shadow restraint:** question box shadows on every surface, logo, background, card, or icon; keep shadows only where they clarify elevation or interaction.
+- **Content hierarchy:** remove repetitive eyebrow/title/description/extra `<p>` stuffing when the title already carries the message; avoid generic emoji badges unless they are part of the product voice.
+- **Palette rationale:** challenge default AI blue/purple palettes, especially Tailwind-like `#3B82F6`, when no brand or system rationale exists.
+- **Layout rhythm:** avoid overly perfect 3- or 4-column uniform grids when the product context benefits from rhythm, emphasis, asymmetry, carousel/bento treatment, or varied card weights.
+- **Gradient restraint:** tone down extreme gradients unless the brand deliberately owns that visual language.
 
 4. **Run one smell-focused pass at a time**
    - **Pass 1: Dead code deletion**

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -677,6 +677,19 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('Reviewer pass');
     });
 
+    it('should expose UI/design AI-slop review signals', () => {
+      const skill = getBuiltinSkill('ai-slop-cleaner');
+      expect(skill).toBeDefined();
+      expect(skill?.template).toContain('UI/Design Reviewer Checklist');
+      expect(skill?.template).toContain('Korean body copy generally needs at least 14px');
+      expect(skill?.template).toContain('box shadows on every surface');
+      expect(skill?.template).toContain('eyebrow/title/description');
+      expect(skill?.template).toContain('#3B82F6');
+      expect(skill?.template).toContain('3- or 4-column uniform grids');
+      expect(skill?.template).toContain('extreme gradients');
+      expect(skill?.template).toContain('intentional brand');
+    });
+
     it('should require explicit tmux prerequisite checks for omc-teams', () => {
       const skill = getBuiltinSkill('omc-teams');
       expect(skill).toBeDefined();


### PR DESCRIPTION
## Summary
- Add a UI/Design Reviewer Checklist to the ai-slop-cleaner skill.
- Cover Korean body text sizing, shadow overuse, repetitive title/description stuffing, generic emoji badges, default AI blue/purple palettes such as #3B82F6, overly uniform grids, and extreme gradients.
- Frame these as reviewer prompts rather than absolute bans, with explicit brand/accessibility/product-density/design-system exceptions.
- Add a focused skill-text test so the checklist remains exposed.

## Verification
- npm ci
- npx vitest run src/__tests__/skills.test.ts -t "UI/design AI-slop"
  - Result: 1 passed, 47 skipped
- npm run lint -- --quiet
- git diff --check
- Architect verification: APPROVED for scope, wording, exceptions, checklist coverage, and test coverage.

## Owner confirmation gate
This changes skill guidance/contract behavior for ai-slop-cleaner. Please get owner confirmation before merging.