### PR TITLE
Fix omc-setup jq config truncation guard

### DIFF
--- a/scripts/setup-progress.sh
+++ b/scripts/setup-progress.sh
@@ -88,6 +88,12 @@ cmd_resume() {
 cmd_complete() {
   local version="${1:-unknown}"
 
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required to update $CONFIG_FILE safely." >&2
+    echo "Install jq and rerun setup. Existing config was not modified." >&2
+    return 1
+  fi
+
   # Clear temporary state
   rm -f "$STATE_FILE"
 
@@ -113,8 +119,14 @@ cmd_complete() {
     existing=$(cat "$CONFIG_FILE")
   fi
 
-  echo "$existing" | jq --arg ts "$(date -Iseconds)" --arg ver "$version" \
-    '. + {setupCompleted: $ts, setupVersion: $ver}' > "$CONFIG_FILE"
+  local tmp_file
+  tmp_file=$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")
+  trap 'rm -f "$tmp_file"' RETURN
+
+  printf '%s\n' "$existing" | jq --arg ts "$(date -Iseconds)" --arg ver "$version" \
+    '. + {setupCompleted: $ts, setupVersion: $ver}' > "$tmp_file"
+  mv "$tmp_file" "$CONFIG_FILE"
+  trap - RETURN
 
   echo "Setup completed successfully!"
   echo "Note: Future updates will only refresh CLAUDE.md, not the full setup wizard."

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -83,6 +83,12 @@ Store the preference in `~/.claude/.omc-config.json`:
 CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to update $CONFIG_FILE safely."
+  echo "Install jq and rerun setup. Existing config was not modified."
+  exit 1
+fi
+
 if [ -f "$CONFIG_FILE" ]; then
   EXISTING=$(cat "$CONFIG_FILE")
 else
@@ -90,7 +96,15 @@ else
 fi
 
 # Set defaultExecutionMode (replace USER_CHOICE with "ultrawork" or "")
-echo "$EXISTING" | jq --arg mode "USER_CHOICE" '. + {defaultExecutionMode: $mode, configuredAt: (now | todate)}' > "$CONFIG_FILE"
+TEMP_FILE=$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")
+trap 'rm -f "$TEMP_FILE"' EXIT
+if printf '%s\n' "$EXISTING" | jq --arg mode "USER_CHOICE" '. + {defaultExecutionMode: $mode, configuredAt: (now | todate)}' > "$TEMP_FILE"; then
+  mv "$TEMP_FILE" "$CONFIG_FILE"
+else
+  echo "ERROR: Failed to update $CONFIG_FILE. Existing config was not modified."
+  exit 1
+fi
+trap - EXIT
 echo "Default execution mode set to: USER_CHOICE"
 ```
 
@@ -192,6 +206,12 @@ Store the preference:
 CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to update $CONFIG_FILE safely."
+  echo "Install jq and rerun setup. Existing config was not modified."
+  exit 1
+fi
+
 if [ -f "$CONFIG_FILE" ]; then
   EXISTING=$(cat "$CONFIG_FILE")
 else
@@ -199,7 +219,15 @@ else
 fi
 
 # USER_CHOICE is "builtin", "beads", or "beads-rust" based on user selection
-echo "$EXISTING" | jq --arg tool "USER_CHOICE" '. + {taskTool: $tool, taskToolConfig: {injectInstructions: true, useMcp: false}}' > "$CONFIG_FILE"
+TEMP_FILE=$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")
+trap 'rm -f "$TEMP_FILE"' EXIT
+if printf '%s\n' "$EXISTING" | jq --arg tool "USER_CHOICE" '. + {taskTool: $tool, taskToolConfig: {injectInstructions: true, useMcp: false}}' > "$TEMP_FILE"; then
+  mv "$TEMP_FILE" "$CONFIG_FILE"
+else
+  echo "ERROR: Failed to update $CONFIG_FILE. Existing config was not modified."
+  exit 1
+fi
+trap - EXIT
 echo "Task tool set to: USER_CHOICE"
 ```
 

--- a/skills/omc-setup/phases/03-integrations.md
+++ b/skills/omc-setup/phases/03-integrations.md
@@ -61,9 +61,22 @@ Use jq to safely merge without overwriting existing settings:
 ```bash
 SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to update $SETTINGS_FILE safely."
+  echo "Install jq and rerun setup. Existing settings were not modified."
+  exit 1
+fi
+
 if [ -f "$SETTINGS_FILE" ]; then
-  TEMP_FILE=$(mktemp)
-  jq '.env = (.env // {} | . + {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"})' "$SETTINGS_FILE" > "$TEMP_FILE" && mv "$TEMP_FILE" "$SETTINGS_FILE"
+  TEMP_FILE=$(mktemp "${SETTINGS_FILE}.tmp.XXXXXX")
+  trap 'rm -f "$TEMP_FILE"' EXIT
+  if jq '.env = (.env // {} | . + {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"})' "$SETTINGS_FILE" > "$TEMP_FILE"; then
+    mv "$TEMP_FILE" "$SETTINGS_FILE"
+  else
+    echo "ERROR: Failed to update $SETTINGS_FILE. Existing settings were not modified."
+    exit 1
+  fi
+  trap - EXIT
   echo "Added CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS to existing settings.json"
 else
   mkdir -p "$(dirname "$SETTINGS_FILE")"
@@ -96,9 +109,23 @@ If user chooses anything other than "Auto", add `teammateMode` to settings.json:
 ```bash
 SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to update $SETTINGS_FILE safely."
+  echo "Install jq and rerun setup. Existing settings were not modified."
+  exit 1
+fi
+
 # TEAMMATE_MODE is "in-process" or "tmux" based on user choice
 # Skip this if user chose "Auto" (that's the default)
-jq --arg mode "TEAMMATE_MODE" '. + {teammateMode: $mode}' "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp" && mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
+TEMP_FILE=$(mktemp "${SETTINGS_FILE}.tmp.XXXXXX")
+trap 'rm -f "$TEMP_FILE"' EXIT
+if jq --arg mode "TEAMMATE_MODE" '. + {teammateMode: $mode}' "$SETTINGS_FILE" > "$TEMP_FILE"; then
+  mv "$TEMP_FILE" "$SETTINGS_FILE"
+else
+  echo "ERROR: Failed to update $SETTINGS_FILE. Existing settings were not modified."
+  exit 1
+fi
+trap - EXIT
 echo "Teammate display mode set to: TEAMMATE_MODE"
 ```
 
@@ -126,6 +153,12 @@ Store the team configuration in `~/.claude/.omc-config.json`:
 CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to update $CONFIG_FILE safely."
+  echo "Install jq and rerun setup. Existing config was not modified."
+  exit 1
+fi
+
 if [ -f "$CONFIG_FILE" ]; then
   EXISTING=$(cat "$CONFIG_FILE")
 else
@@ -133,10 +166,18 @@ else
 fi
 
 # Replace MAX_AGENTS, AGENT_TYPE with user choices
-echo "$EXISTING" | jq \
+TEMP_FILE=$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")
+trap 'rm -f "$TEMP_FILE"' EXIT
+if printf '%s\n' "$EXISTING" | jq \
   --argjson maxAgents MAX_AGENTS \
   --arg agentType "AGENT_TYPE" \
-  '. + {team: {ops: {maxAgents: $maxAgents, defaultAgentType: $agentType, monitorIntervalMs: 30000, shutdownTimeoutMs: 15000}}}' > "$CONFIG_FILE"
+  '. + {team: {ops: {maxAgents: $maxAgents, defaultAgentType: $agentType, monitorIntervalMs: 30000, shutdownTimeoutMs: 15000}}}' > "$TEMP_FILE"; then
+  mv "$TEMP_FILE" "$CONFIG_FILE"
+else
+  echo "ERROR: Failed to update $CONFIG_FILE. Existing config was not modified."
+  exit 1
+fi
+trap - EXIT
 
 echo "Team configuration saved:"
 echo "  Max agents: MAX_AGENTS"

--- a/src/__tests__/setup-contracts-regression.test.ts
+++ b/src/__tests__/setup-contracts-regression.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, afterEach, beforeAll } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { readFileSync, readdirSync, existsSync } from 'fs';
 import { dirname, join, relative } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -194,6 +194,63 @@ describe('Contract 2: no unguarded $HOME/.claude in shell/script files', () => {
       expect.fail(
         `Found $HOME/.claude without CLAUDE_CONFIG_DIR guard:\n${details}\n\n` +
         `Replace with: \${CLAUDE_CONFIG_DIR:-$HOME/.claude}`
+      );
+    }
+  });
+});
+
+// ── Contract 2b: setup jq writes must not truncate user config ────────────────
+// Issue #2957 — `jq ... > "$CONFIG_FILE"` opens/truncates the config before
+// command-not-found can fail when jq is missing. Setup docs/scripts must fail
+// before destination redirection and write through temp files.
+
+describe('Contract 2b: setup jq writes are guarded against truncation', () => {
+  const SETUP_MUTATION_FILES = [
+    join(REPO_ROOT, 'skills', 'omc-setup', 'phases', '02-configure.md'),
+    join(REPO_ROOT, 'skills', 'omc-setup', 'phases', '03-integrations.md'),
+    join(REPO_ROOT, 'scripts', 'setup-progress.sh'),
+  ];
+
+  const directJqRedirectViolations: { file: string; command: string }[] = [];
+  const missingPreflightViolations: string[] = [];
+
+  for (const file of SETUP_MUTATION_FILES) {
+    const content = readFileSync(file, 'utf-8');
+    const rel = relPath(file);
+
+    if (content.includes('jq') && !/command -v jq/.test(content)) {
+      missingPreflightViolations.push(rel);
+    }
+
+    const logicalCommands = content.replace(/\\\r?\n/g, ' ');
+    const directRedirectPattern =
+      /(?:echo|printf|cat|jq)\b[^;\n]*\bjq\b[^;\n]*>\s*(?:"\$(?:\{)?(?:CONFIG_FILE|SETTINGS_FILE)(?:\})?"|\$\{(?:CONFIG_FILE|SETTINGS_FILE)\})/g;
+
+    for (const match of logicalCommands.matchAll(directRedirectPattern)) {
+      directJqRedirectViolations.push({
+        file: rel,
+        command: match[0].trim(),
+      });
+    }
+  }
+
+  it('preflights jq before setup files use it for JSON mutation', () => {
+    if (missingPreflightViolations.length > 0) {
+      expect.fail(
+        `Setup files use jq without a command -v jq preflight:\n` +
+          missingPreflightViolations.map(file => `  ${file}`).join('\n')
+      );
+    }
+  });
+
+  it('does not redirect jq output directly to live setup config/settings files', () => {
+    if (directJqRedirectViolations.length > 0) {
+      expect.fail(
+        `Found destructive jq redirects that can truncate live setup files:\n` +
+          directJqRedirectViolations
+            .map(v => `  ${v.file}: ${v.command}`)
+            .join('\n') +
+          `\n\nWrite jq output to a temp file and mv it into place only after jq succeeds.`
       );
     }
   });

--- a/src/__tests__/setup-progress-script.test.ts
+++ b/src/__tests__/setup-progress-script.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -51,5 +59,42 @@ describe('setup-progress.sh', () => {
 
     expect(config.setupVersion).toBe('v9.9.9');
     expect(config.setupCompleted).toBeTruthy();
+  });
+
+  it('fails without jq and preserves existing setup config', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-setup-progress-no-jq-'));
+    tempRoots.push(root);
+
+    const projectRoot = join(root, 'project');
+    const homeRoot = join(root, 'home');
+    const configDir = join(root, 'custom-claude');
+    const binDir = join(root, 'bin-no-jq');
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(homeRoot, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+
+    for (const command of ['dirname', 'pwd']) {
+      symlinkSync(`/usr/bin/${command}`, join(binDir, command));
+    }
+
+    const configPath = join(configDir, '.omc-config.json');
+    const originalConfig = '{\n  "existing": true\n}\n';
+    writeFileSync(configPath, originalConfig);
+
+    const result = spawnSync('/usr/bin/bash', [SCRIPT_PATH, 'complete', 'v9.9.9'], {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        HOME: homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+        PATH: binDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('jq is required');
+    expect(readFileSync(configPath, 'utf-8')).toBe(originalConfig);
   });
 });


### PR DESCRIPTION
## Summary
- Add jq preflight checks before setup writes mutate OMC config/settings JSON.
- Route jq mutations through temp files and move into place only after jq succeeds.
- Add regression coverage for missing jq preserving `.omc-config.json` and for destructive setup-doc jq redirects.

Fixes #2957

## Verification
- `npm test -- src/__tests__/setup-progress-script.test.ts src/__tests__/setup-contracts-regression.test.ts`
- `npm run lint` (passes; existing warnings outside this change remain)
- `npm run build`
