### PR TITLE
fix(launch): preserve Windows plugin root paths

### DIFF
--- a/src/cli/__tests__/plugin-dir-capture.test.ts
+++ b/src/cli/__tests__/plugin-dir-capture.test.ts
@@ -25,6 +25,16 @@ describe('parsePluginDirArg', () => {
     expect(out).toBe(resolve('/foo/bar'));
   });
 
+  it('preserves Windows drive-letter absolute paths on non-Windows hosts', () => {
+    const out = parsePluginDirArg(['--plugin-dir', 'C:\\Users\\me\\omc']);
+    expect(out).toBe('C:\\Users\\me\\omc');
+  });
+
+  it('preserves Windows UNC absolute paths on non-Windows hosts', () => {
+    const out = parsePluginDirArg(['--plugin-dir=\\\\server\\share\\omc']);
+    expect(out).toBe('\\\\server\\share\\omc');
+  });
+
   it('returns null when --plugin-dir is absent', () => {
     expect(parsePluginDirArg(['--madmax', '--notify', 'false'])).toBeNull();
   });

--- a/src/lib/plugin-dir.ts
+++ b/src/lib/plugin-dir.ts
@@ -5,15 +5,19 @@
  * and `src/cli/index.ts` (Commander option value passed as a string).
  */
 
-import { resolve } from 'path';
+import { posix, resolve, win32 } from 'path';
 
 /**
  * Resolve a raw `--plugin-dir` value (relative or absolute string) to an
  * absolute path.  Throws with a clear message if the value is empty.
  */
+function isCrossPlatformAbsolutePath(rawPath: string): boolean {
+  return posix.isAbsolute(rawPath) || win32.isAbsolute(rawPath);
+}
+
 export function resolvePluginDirArg(rawPath: string): string {
   if (!rawPath || rawPath.trim().length === 0) {
     throw new Error('--plugin-dir requires a non-empty path argument');
   }
-  return resolve(rawPath);
+  return isCrossPlatformAbsolutePath(rawPath) ? rawPath : resolve(rawPath);
 }


### PR DESCRIPTION
## Summary\n- audit OMC launch/tmux path handling against OmX PRs #2157 and #2178\n- preserve cross-platform absolute --plugin-dir / OMC_PLUGIN_ROOT values, including Windows drive-letter and UNC paths, instead of resolving them relative to POSIX cwd\n- add focused launch regression coverage for Windows absolute plugin-root paths\n\nFixes #2961\n\n## Tests\n- npm test -- --run src/cli/__tests__/plugin-dir-capture.test.ts src/cli/__tests__/tmux-utils.test.ts src/cli/__tests__/launch.test.ts\n- npm run build\n- npm run lint -- src/lib/plugin-dir.ts src/cli/__tests__/plugin-dir-capture.test.ts (passes with existing repo warnings)