### PR TITLE
Fix managed helper launches to use current JS runtime

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -29290,8 +29290,11 @@ function listActiveSessions(teamName) {
     return [];
   }
 }
+function quoteBridgeShellArg(value) {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
 function spawnBridgeInSession(tmuxSession, bridgeScriptPath, configFilePath) {
-  const cmd = `node "${bridgeScriptPath}" --config "${configFilePath}"`;
+  const cmd = [process.execPath, bridgeScriptPath, "--config", configFilePath].map(quoteBridgeShellArg).join(" ");
   tmuxExec(["send-keys", "-t", tmuxSession, cmd, "Enter"], { stripTmux: true, stdio: "pipe", timeout: 5e3 });
 }
 async function createTeamSession(teamName, workerCount, cwd2, options = {}) {

--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -430,8 +430,11 @@ function listActiveSessions(teamName) {
     return [];
   }
 }
+function quoteBridgeShellArg(value) {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
 function spawnBridgeInSession(tmuxSession, bridgeScriptPath, configFilePath) {
-  const cmd = `node "${bridgeScriptPath}" --config "${configFilePath}"`;
+  const cmd = [process.execPath, bridgeScriptPath, "--config", configFilePath].map(quoteBridgeShellArg).join(" ");
   tmuxExec(["send-keys", "-t", tmuxSession, cmd, "Enter"], { stripTmux: true, stdio: "pipe", timeout: 5e3 });
 }
 async function createTeamSession(teamName, workerCount, cwd, options = {}) {

--- a/bridge/team-mcp.cjs
+++ b/bridge/team-mcp.cjs
@@ -19289,7 +19289,7 @@ async function handleStart(args) {
   const runtimeCliPath = (0, import_path9.join)(__ownDir, "runtime-cli.cjs");
   const job = { status: "running", startedAt: Date.now(), teamName: input.teamName, cwd: input.cwd };
   omcTeamJobs.set(jobId, job);
-  const child = (0, import_child_process3.spawn)("node", [runtimeCliPath], {
+  const child = (0, import_child_process3.spawn)(process.execPath, [runtimeCliPath], {
     env: { ...process.env, OMC_JOB_ID: jobId, OMC_JOBS_DIR },
     stdio: ["pipe", "pipe", "pipe"]
   });

--- a/bridge/team.js
+++ b/bridge/team.js
@@ -2020,8 +2020,11 @@ function listActiveSessions(teamName) {
     return [];
   }
 }
+function quoteBridgeShellArg(value) {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
 function spawnBridgeInSession(tmuxSession, bridgeScriptPath, configFilePath) {
-  const cmd = `node "${bridgeScriptPath}" --config "${configFilePath}"`;
+  const cmd = [process.execPath, bridgeScriptPath, "--config", configFilePath].map(quoteBridgeShellArg).join(" ");
   tmuxExec(["send-keys", "-t", tmuxSession, cmd, "Enter"], { stripTmux: true, stdio: "pipe", timeout: 5e3 });
 }
 async function createTeamSession(teamName, workerCount, cwd, options = {}) {
@@ -10435,7 +10438,7 @@ async function startTeamJob(input) {
     teamName: input.teamName,
     cwd: input.cwd
   };
-  const child = spawn("node", [runtimeCliPath], {
+  const child = spawn(process.execPath, [runtimeCliPath], {
     env: {
       ...process.env,
       OMC_JOB_ID: jobId,

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -121,7 +121,7 @@ describe('team cli', () => {
     expect(result.pid).toBe(4242);
 
     expect(mocks.spawn).toHaveBeenCalledWith(
-      'node',
+      process.execPath,
       ['/tmp/runtime-cli.cjs'],
       expect.objectContaining({
         detached: true,
@@ -136,6 +136,30 @@ describe('team cli', () => {
     const savedJob = JSON.parse(readFileSync(join(jobsDir, `${result.jobId}.json`), 'utf-8')) as { status: string; pid: number };
     expect(savedJob.status).toBe('running');
     expect(savedJob.pid).toBe(4242);
+  });
+
+  it('startTeamJob uses the current JS runtime instead of PATH node for runtime-cli', async () => {
+    const write = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    mocks.spawn.mockReturnValue({
+      pid: 5151,
+      stdin: { write, end },
+      unref,
+    });
+
+    const { startTeamJob } = await import('../team.js');
+
+    await startTeamJob({
+      teamName: 'runtime-team',
+      agentTypes: ['codex'],
+      tasks: [{ subject: 'one', description: 'desc' }],
+      cwd: '/tmp/project',
+    });
+
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+    expect(mocks.spawn.mock.calls[0][0]).toBe(process.execPath);
+    expect(mocks.spawn.mock.calls[0][0]).not.toBe('node');
   });
 
   it('teamCommand start --json outputs valid JSON envelope', async () => {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -396,7 +396,7 @@ export async function startTeamJob(input: TeamStartInput): Promise<TeamStartResu
     cwd: input.cwd,
   };
 
-  const child = spawn('node', [runtimeCliPath], {
+  const child = spawn(process.execPath, [runtimeCliPath], {
     env: {
       ...process.env,
       OMC_JOB_ID: jobId,

--- a/src/mcp/__tests__/team-cleanup.test.ts
+++ b/src/mcp/__tests__/team-cleanup.test.ts
@@ -194,6 +194,12 @@ describe('team start validation wiring', () => {
     expect(source).toContain('validateTeamName(input.teamName);');
   });
 
+  it('starts runtime-cli with process.execPath rather than bare PATH node', () => {
+    const source = readFileSync(join(__dirname, '..', 'team-server.ts'), 'utf-8');
+    expect(source).toContain('spawn(process.execPath, [runtimeCliPath]');
+    expect(source).not.toContain("spawn('node', [runtimeCliPath]");
+  });
+
   it('contains timeoutSeconds deprecation guard in omc_run_team_start', () => {
     const source = readFileSync(join(__dirname, '..', 'team-server.ts'), 'utf-8');
     expect(source).toContain("hasOwnProperty.call(args, 'timeoutSeconds')");

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -290,7 +290,7 @@ async function handleStart(args: unknown): Promise<{ content: Array<{ type: 'tex
   const job: OmcTeamJob = { status: 'running', startedAt: Date.now(), teamName: input.teamName, cwd: input.cwd };
   omcTeamJobs.set(jobId, job);
 
-  const child = spawn('node', [runtimeCliPath], {
+  const child = spawn(process.execPath, [runtimeCliPath], {
     env: { ...process.env, OMC_JOB_ID: jobId, OMC_JOBS_DIR },
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -8,6 +8,10 @@ vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../cli/tmux-utils.js')>();
   return {
     ...actual,
+    tmuxExec: vi.fn((args: string[]) => {
+      mockedCalls.tmuxArgs.push(args);
+      return '';
+    }),
     tmuxExecAsync: vi.fn(async (args: string[]) => {
       mockedCalls.tmuxArgs.push(args);
       return { stdout: '', stderr: '' };
@@ -15,7 +19,7 @@ vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
   };
 });
 
-import { spawnWorkerInPane } from '../tmux-session.js';
+import { spawnBridgeInSession, spawnWorkerInPane } from '../tmux-session.js';
 
 describe('spawnWorkerInPane', () => {
   beforeEach(() => {
@@ -44,6 +48,18 @@ describe('spawnWorkerInPane', () => {
     expect(launchLine).toContain("'--'");
     expect(launchLine).toContain("'gpt-5;touch /tmp/pwn'");
     expect(launchLine).not.toContain('exec codex --full-auto');
+  });
+
+  it('uses current JS runtime when launching bridge-entry helpers', () => {
+    spawnBridgeInSession('session:0', '/tmp/bridge-entry.js', '/tmp/bridge-config.json');
+
+    const sendKeys = mockedCalls.tmuxArgs.find((args) => args[0] === 'send-keys');
+    expect(sendKeys).toBeDefined();
+    const launchLine = sendKeys?.[3] ?? '';
+    expect(launchLine).toContain(process.execPath);
+    expect(launchLine).toContain('/tmp/bridge-entry.js');
+    expect(launchLine).toContain('--config');
+    expect(launchLine).not.toMatch(/^node\s/);
   });
 
   it('rejects invalid team names before command construction', async () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -441,14 +441,20 @@ export function listActiveSessions(teamName: string): string[] {
  *
  * Instead of passing JSON via tmux send-keys (brittle quoting), the caller
  * writes config to a temp file and passes --config flag:
- *   node dist/team/bridge-entry.js --config /tmp/omc-bridge-{worker}.json
+ *   <current-js-runtime> dist/team/bridge-entry.js --config /tmp/omc-bridge-{worker}.json
  */
+function quoteBridgeShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
 export function spawnBridgeInSession(
   tmuxSession: string,
   bridgeScriptPath: string,
   configFilePath: string
 ): void {
-  const cmd = `node "${bridgeScriptPath}" --config "${configFilePath}"`;
+  const cmd = [process.execPath, bridgeScriptPath, '--config', configFilePath]
+    .map(quoteBridgeShellArg)
+    .join(' ');
   tmuxExec(['send-keys', '-t', tmuxSession, cmd, 'Enter'], { stripTmux: true, stdio: 'pipe', timeout: 5000 });
 }
 


### PR DESCRIPTION
Fixes #2959

## Summary
- launch managed team runtime-cli helpers with `process.execPath` instead of bare PATH `node`
- construct tmux bridge-entry helper commands from the current JS runtime
- add focused regression coverage for CLI, MCP, and tmux helper launch surfaces

## Tests
- `npm test -- --run src/cli/__tests__/team.test.ts src/team/__tests__/tmux-session.spawn.test.ts src/mcp/__tests__/team-cleanup.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (passes with existing warnings)
- `npm run build:runtime-cli && npm run build:team-server && npm run build:cli`
