### PR TITLE
Fix stale terminal workflow skill-active slots

### DIFF
--- a/src/hooks/persistent-mode/__tests__/workflow-gating.test.ts
+++ b/src/hooks/persistent-mode/__tests__/workflow-gating.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
@@ -56,6 +56,36 @@ function writeRalphState(tempDir: string, sessionId: string): void {
       project_path: tempDir,
       linked_ultrawork: false,
     }, null, 2),
+  );
+}
+
+function writeModeState(
+  tempDir: string,
+  sessionId: string,
+  mode: 'autopilot' | 'ralph' | 'ralplan',
+  state: Record<string, unknown>,
+): void {
+  const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(join(stateDir, `${mode}-state.json`), JSON.stringify(state, null, 2));
+}
+
+function readSessionWorkflowLedger(tempDir: string, sessionId: string): {
+  active_skills: Record<string, { completed_at?: string | null }>;
+} {
+  return JSON.parse(
+    readFileSync(
+      join(tempDir, '.omc', 'state', 'sessions', sessionId, 'skill-active-state.json'),
+      'utf-8',
+    ),
+  );
+}
+
+function readRootWorkflowLedger(tempDir: string): {
+  active_skills: Record<string, { completed_at?: string | null }>;
+} {
+  return JSON.parse(
+    readFileSync(join(tempDir, '.omc', 'state', 'skill-active-state.json'), 'utf-8'),
   );
 }
 
@@ -248,6 +278,85 @@ describe('workflow-gating: tombstoned slot suppresses stale mode files (spec j)'
       // Ralph-state.json is active + slot is live → should block
       expect(result.shouldBlock).toBe(true);
       expect(result.mode).toBe('ralph');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('workflow-gating: terminal mode state tombstones stale workflow slots (issue #2960)', () => {
+  it('tombstones a live autopilot slot when autopilot state is terminal', async () => {
+    const sessionId = 'terminal-autopilot-2960';
+    const tempDir = makeTempProject();
+
+    try {
+      writeWorkflowLedger(tempDir, sessionId, { autopilot: {} });
+      writeModeState(tempDir, sessionId, 'autopilot', {
+        active: false,
+        phase: 'complete',
+        completed_at: new Date().toISOString(),
+        session_id: sessionId,
+      });
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+
+      const sessionLedger = readSessionWorkflowLedger(tempDir, sessionId);
+      const rootLedger = readRootWorkflowLedger(tempDir);
+      expect(sessionLedger.active_skills.autopilot?.completed_at).toEqual(expect.any(String));
+      expect(rootLedger.active_skills.autopilot?.completed_at).toEqual(expect.any(String));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('tombstones a live ralplan slot when ralplan state is terminal', async () => {
+    const sessionId = 'terminal-ralplan-2960';
+    const tempDir = makeTempProject();
+
+    try {
+      writeWorkflowLedger(tempDir, sessionId, { ralplan: {} });
+      writeModeState(tempDir, sessionId, 'ralplan', {
+        active: false,
+        current_phase: 'complete',
+        completed_at: new Date().toISOString(),
+        session_id: sessionId,
+      });
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+
+      const sessionLedger = readSessionWorkflowLedger(tempDir, sessionId);
+      const rootLedger = readRootWorkflowLedger(tempDir);
+      expect(sessionLedger.active_skills.ralplan?.completed_at).toEqual(expect.any(String));
+      expect(rootLedger.active_skills.ralplan?.completed_at).toEqual(expect.any(String));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('tombstones a live ralph slot when ralph state is inactive', async () => {
+    const sessionId = 'terminal-ralph-2960';
+    const tempDir = makeTempProject();
+
+    try {
+      writeWorkflowLedger(tempDir, sessionId, { ralph: {} });
+      writeModeState(tempDir, sessionId, 'ralph', {
+        active: false,
+        iteration: 3,
+        max_iterations: 10,
+        started_at: new Date().toISOString(),
+        last_checked_at: new Date().toISOString(),
+        session_id: sessionId,
+      });
+
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(false);
+
+      const sessionLedger = readSessionWorkflowLedger(tempDir, sessionId);
+      const rootLedger = readRootWorkflowLedger(tempDir);
+      expect(sessionLedger.active_skills.ralph?.completed_at).toEqual(expect.any(String));
+      expect(rootLedger.active_skills.ralph?.completed_at).toEqual(expect.any(String));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -94,6 +94,17 @@ const MAX_TODO_CONTINUATION_ATTEMPTS = 5;
 const CANCEL_SIGNAL_TTL_MS = 30_000;
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
 const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
+const TERMINAL_WORKFLOW_SLOT_MODES = new Set(['autopilot', 'ralph', 'ralplan']);
+const TERMINAL_WORKFLOW_PHASES = new Set([
+  'complete',
+  'completed',
+  'failed',
+  'cancelled',
+  'canceled',
+  'cancel',
+  'done',
+  'stopped',
+]);
 
 /** Track todo-continuation attempts per session to prevent infinite loops */
 const todoContinuationAttempts = new Map<string, number>();
@@ -262,6 +273,60 @@ function hasPendingScheduledWakeup(directory: string, sessionId?: string): boole
 
     return false;
   });
+}
+
+function normalizeWorkflowTerminalPhase(state: Record<string, unknown>): string | null {
+  const raw = state.current_phase ?? state.phase ?? state.status;
+  return typeof raw === 'string' && raw.trim().length > 0
+    ? raw.trim().toLowerCase()
+    : null;
+}
+
+function isTerminalWorkflowModeState(state: Record<string, unknown> | null): boolean {
+  if (!state) return false;
+  if (state.active === false) return true;
+  if (typeof state.completed_at === 'string' && state.completed_at.length > 0) return true;
+  const phase = normalizeWorkflowTerminalPhase(state);
+  return Boolean(phase && TERMINAL_WORKFLOW_PHASES.has(phase));
+}
+
+async function reconcileTerminalWorkflowSlots(
+  workingDir: string,
+  sessionId?: string,
+): Promise<void> {
+  try {
+    const {
+      readSkillActiveStateNormalized,
+      pruneExpiredWorkflowSkillTombstones,
+      markWorkflowSkillCompleted,
+      writeSkillActiveStateCopies,
+    } = await import('../skill-state/index.js');
+
+    const original = readSkillActiveStateNormalized(workingDir, sessionId);
+    let current = pruneExpiredWorkflowSkillTombstones(original);
+    let changed = current !== original;
+
+    for (const [slotName, slot] of Object.entries(current.active_skills)) {
+      if (slot.completed_at || !TERMINAL_WORKFLOW_SLOT_MODES.has(slotName)) {
+        continue;
+      }
+
+      const modeState = readModeState<Record<string, unknown>>(slotName, workingDir, sessionId);
+      if (!isTerminalWorkflowModeState(modeState)) {
+        continue;
+      }
+
+      current = markWorkflowSkillCompleted(current, slotName);
+      changed = true;
+    }
+
+    if (changed) {
+      writeSkillActiveStateCopies(workingDir, current, sessionId);
+    }
+  } catch {
+    // Best-effort reconciliation only. Stop enforcement falls back to the
+    // direct mode-state checks below if the ledger cannot be updated.
+  }
 }
 
 /**
@@ -1821,21 +1886,12 @@ export async function checkPersistentModes(
     return { shouldBlock: false, message: '', mode: 'none' };
   }
 
-  // Best-effort: prune expired tombstones so stale completion markers do not
-  // linger past their TTL and mask a fresh invocation. Never let a prune
-  // failure interfere with stop enforcement.
-  try {
-    const { readSkillActiveStateNormalized, pruneExpiredWorkflowSkillTombstones, writeSkillActiveStateCopies } =
-      await import('../skill-state/index.js');
-    const current = readSkillActiveStateNormalized(workingDir, sessionId);
-    const pruned = pruneExpiredWorkflowSkillTombstones(current);
-    if (pruned !== current) {
-      writeSkillActiveStateCopies(workingDir, pruned, sessionId);
-    }
-  } catch {
-    // Skill-state module unavailable or ledger unreadable — continue with
-    // legacy priority enforcement.
-  }
+  // Best-effort: keep the workflow-slot ledger aligned with terminal mode
+  // state before using it for stop-gating authority. This both prunes old
+  // tombstones and tombstones live slots whose autopilot/Ralph/ralplan mode
+  // state already reached a terminal/inactive state through a path other than
+  // the Skill PostToolUse completion hook.
+  await reconcileTerminalWorkflowSlots(workingDir, sessionId);
 
   // CRITICAL: Never block context-limit/critical-context stops.
   // Blocking these causes a deadlock where Claude Code cannot compact or exit.


### PR DESCRIPTION
## Summary
- reconcile workflow skill-active slots before stop gating so terminal/inactive autopilot, ralplan, and Ralph mode state tombstones stale live slots
- preserve existing tombstone TTL pruning while keeping root/session skill-active copies synchronized
- add regression coverage for terminal autopilot/ralplan/Ralph slots across root and session ledgers

Fixes #2960

## Verification
- npx vitest run src/hooks/persistent-mode/__tests__/workflow-gating.test.ts src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts src/hooks/skill-state/__tests__/skill-state.test.ts --reporter=dot
- npx tsc -p tsconfig.json --noEmit
- npm run build

Note: build-generated dist/bridge output was reverted to keep this PR source-only and avoid unrelated generated churn.