### PR TITLE
Fix hook background notification output isolation

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -7,6 +7,7 @@
  */
 
 import { existsSync, readFileSync, readdirSync, rmSync, mkdirSync, writeFileSync, symlinkSync, lstatSync, readlinkSync, unlinkSync, renameSync } from 'fs';
+import { spawn } from 'child_process';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
@@ -251,6 +252,38 @@ async function loadProjectMemoryModules() {
     };
   } catch {
     return null;
+  }
+}
+
+
+function dispatchSessionStartNotificationInBackground(pluginRoot, payload) {
+  if (!pluginRoot || process.env.OMC_NOTIFY === '0') return;
+
+  let serializedPayload;
+  try {
+    serializedPayload = JSON.stringify(payload);
+  } catch {
+    return;
+  }
+
+  const notificationsModuleUrl = pathToFileURL(join(pluginRoot, 'dist', 'notifications', 'index.js')).href;
+  const childSource = `import(${JSON.stringify(notificationsModuleUrl)})\n`
+    + `  .then(({ notify }) => notify('session-start', ${serializedPayload}))\n`
+    + `  .catch(() => {});`;
+
+  try {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', childSource], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: {
+        ...process.env,
+        OMC_HOOK_BACKGROUND_CHILD: '1',
+      },
+    });
+    child.unref();
+  } catch {
+    // Notification dispatch is best-effort and must never affect hook output.
   }
 }
 
@@ -979,17 +1012,17 @@ ${cleanContent}
       }
     } catch {}
 
-    // Send session-start notification (non-blocking, fire-and-forget)
+    // Send session-start notification from an isolated detached process.
+    // Notification transports/custom integrations must never write into this
+    // foreground hook's stdout JSON protocol or stderr CI checks.
     try {
       const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
       if (pluginRoot) {
-        const { notify } = await import(pathToFileURL(join(pluginRoot, 'dist', 'notifications', 'index.js')).href);
-        // Fire and forget - don't await, don't block session start
-        notify('session-start', {
+        dispatchSessionStartNotificationInBackground(pluginRoot, {
           sessionId,
           projectPath: directory,
           timestamp: new Date().toISOString(),
-        }).catch(() => {}); // swallow errors silently
+        });
 
         // Start reply listener daemon if notification reply config is available
         try {

--- a/src/__tests__/session-start-background-output.test.ts
+++ b/src/__tests__/session-start-background-output.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync, spawnSync } from "child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const SCRIPT_PATH = join(process.cwd(), "scripts", "session-start.mjs");
+
+describe("session-start background output isolation", () => {
+  it("keeps foreground hook stdout/stderr clean when notification module writes", () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "omc-session-start-bg-"));
+    const projectDir = join(sandbox, "project");
+    const pluginRoot = join(sandbox, "plugin");
+    const notificationsDir = join(pluginRoot, "dist", "notifications");
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(notificationsDir, { recursive: true });
+    writeFileSync(join(pluginRoot, "package.json"), JSON.stringify({ type: "module" }));
+    writeFileSync(
+      join(notificationsDir, "index.js"),
+      `export async function notify() { console.log("BACKGROUND_STDOUT_LEAK"); console.error("BACKGROUND_STDERR_LEAK"); }\n`,
+    );
+    writeFileSync(
+      join(notificationsDir, "reply-listener.js"),
+      `export async function buildDaemonConfig() { return null; }\nexport function startReplyListener() {}\n`,
+    );
+
+    try {
+      execFileSync("git", ["init"], { cwd: projectDir, stdio: "ignore" });
+      const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+        cwd: projectDir,
+        input: JSON.stringify({ cwd: projectDir, session_id: "sess-bg-output" }),
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          CLAUDE_PLUGIN_ROOT: pluginRoot,
+          CLAUDE_CONFIG_DIR: join(sandbox, "claude"),
+          OMC_NOTIFY: "1",
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(() => JSON.parse(result.stdout)).not.toThrow();
+      expect(JSON.parse(result.stdout).continue).toBe(true);
+      expect(result.stdout).not.toContain("BACKGROUND_STDOUT_LEAK");
+      expect(result.stderr).not.toContain("BACKGROUND_STDERR_LEAK");
+      expect(result.stderr).toBe("");
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hooks/__tests__/background-notifications.test.ts
+++ b/src/hooks/__tests__/background-notifications.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const spawnMock = vi.fn();
+const unrefMock = vi.fn();
+
+vi.mock("child_process", () => ({
+  spawn: spawnMock,
+}));
+
+describe("dispatchNotificationInBackground", () => {
+  beforeEach(() => {
+    spawnMock.mockReturnValue({ unref: unrefMock });
+    delete process.env.OMC_NOTIFY;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("spawns detached notification work with ignored stdio", async () => {
+    const { dispatchNotificationInBackground } = await import("../background-notifications.js");
+
+    dispatchNotificationInBackground("session-start", {
+      sessionId: "sess-1",
+      projectPath: "/tmp/project",
+    });
+
+    expect(spawnMock).toHaveBeenCalledOnce();
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      ["--input-type=module", "-e", expect.stringContaining("notify(\"session-start\"")],
+      expect.objectContaining({
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+        env: expect.objectContaining({ OMC_HOOK_BACKGROUND_CHILD: "1" }),
+      }),
+    );
+    expect(unrefMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not spawn when notifications are explicitly disabled", async () => {
+    vi.stubEnv("OMC_NOTIFY", "0");
+    const { dispatchNotificationInBackground } = await import("../background-notifications.js");
+
+    dispatchNotificationInBackground("session-idle", { sessionId: "sess-1" });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/background-notifications.ts
+++ b/src/hooks/background-notifications.ts
@@ -1,0 +1,57 @@
+import { spawn } from "child_process";
+import type { NotificationEvent, NotificationPayload } from "../notifications/types.js";
+
+export type BackgroundNotificationData = Partial<NotificationPayload> & {
+  sessionId: string;
+  profileName?: string;
+};
+
+/**
+ * Dispatch hook-triggered notifications from an isolated detached Node process.
+ *
+ * Hook foreground processes have a strict stdout JSON protocol, and some CI
+ * checks fail on unexpected stderr. Running notification work in-process means
+ * late console output from notification formatters, transport failures, custom
+ * integrations, or transitive modules can pollute the foreground hook streams.
+ * The detached child uses stdio: "ignore" so all notification stdout/stderr is
+ * isolated while the foreground hook can return its protocol payload promptly.
+ */
+export function dispatchNotificationInBackground(
+  event: NotificationEvent,
+  data: BackgroundNotificationData,
+): void {
+  if (process.env.OMC_NOTIFY === "0") return;
+
+  let serializedEvent: string;
+  let serializedData: string;
+  try {
+    serializedEvent = JSON.stringify(event);
+    serializedData = JSON.stringify(data);
+  } catch {
+    return;
+  }
+
+  const notificationsModuleUrl = new URL(
+    "../notifications/index.js",
+    import.meta.url,
+  ).href;
+
+  const childSource = `import(${JSON.stringify(notificationsModuleUrl)})\n` +
+    `  .then(({ notify }) => notify(${serializedEvent}, ${serializedData}))\n` +
+    `  .catch(() => {});`;
+
+  try {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", childSource], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+      env: {
+        ...process.env,
+        OMC_HOOK_BACKGROUND_CHILD: "1",
+      },
+    });
+    child.unref();
+  } catch {
+    // Best-effort only: notification dispatch must never break hook handling.
+  }
+}

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -30,6 +30,7 @@ import { readModeState, writeModeState } from "../lib/mode-state-io.js";
 import { SESSION_END_MODE_STATE_FILES } from "../lib/mode-names.js";
 import { formatOmcCliInvocation } from "../utils/omc-cli-rendering.js";
 import { createSwallowedErrorLogger } from "../lib/swallowed-error.js";
+import { dispatchNotificationInBackground } from "./background-notifications.js";
 import { readCanonicalTeamStateCandidate } from "./team-canonical-state.js";
 
 // Hot-path imports: needed on every/most hook invocations (keyword-detector, pre/post-tool-use)
@@ -1824,18 +1825,11 @@ async function processPersistentMode(input: HookInput): Promise<HookOutput> {
         }
         if (shouldSendIdleNotification(stateDir, sessionId, idleRepoState)) {
           recordIdleNotificationSent(stateDir, sessionId, idleRepoState);
-          const logSessionIdleNotifyFailure = createSwallowedErrorLogger(
-            'hooks.bridge session-idle notification failed',
-          );
-          import("../notifications/index.js")
-            .then(({ notify }) =>
-              notify("session-idle", {
-                sessionId,
-                projectPath: directory,
-                profileName: process.env.OMC_NOTIFY_PROFILE,
-              }).catch(logSessionIdleNotifyFailure),
-            )
-            .catch(logSessionIdleNotifyFailure);
+          dispatchNotificationInBackground("session-idle", {
+            sessionId,
+            projectPath: directory,
+            profileName: process.env.OMC_NOTIFY_PROFILE,
+          });
         }
       }
 
@@ -1922,18 +1916,11 @@ async function processSessionStart(input: HookInput): Promise<HookOutput> {
 
   // Send session-start notification (non-blocking, swallows errors)
   if (sessionId) {
-    const logSessionStartNotifyFailure = createSwallowedErrorLogger(
-      'hooks.bridge session-start notification failed',
-    );
-    import("../notifications/index.js")
-      .then(({ notify }) =>
-        notify("session-start", {
-          sessionId,
-          projectPath: directory,
-          profileName: process.env.OMC_NOTIFY_PROFILE,
-        }).catch(logSessionStartNotifyFailure),
-      )
-      .catch(logSessionStartNotifyFailure);
+    dispatchNotificationInBackground("session-start", {
+      sessionId,
+      projectPath: directory,
+      profileName: process.env.OMC_NOTIFY_PROFILE,
+    });
     // Wake OpenClaw gateway for session-start (non-blocking)
     _openclaw.wake("session-start", { sessionId, projectPath: directory });
   }
@@ -2200,20 +2187,12 @@ export function dispatchAskUserQuestionNotification(
       .filter(Boolean)
       .join("; ") || "User input requested";
 
-  const logAskUserQuestionNotifyFailure = createSwallowedErrorLogger(
-    'hooks.bridge ask-user-question notification failed',
-  );
-
-  import("../notifications/index.js")
-    .then(({ notify }) =>
-      notify("ask-user-question", {
-        sessionId,
-        projectPath: directory,
-        question: questionText,
-        profileName: process.env.OMC_NOTIFY_PROFILE,
-      }).catch(logAskUserQuestionNotifyFailure),
-    )
-    .catch(logAskUserQuestionNotifyFailure);
+  dispatchNotificationInBackground("ask-user-question", {
+    sessionId,
+    projectPath: directory,
+    question: questionText,
+    profileName: process.env.OMC_NOTIFY_PROFILE,
+  });
 }
 
 /** @internal Object wrapper so tests can spy on the dispatch call. */
@@ -2505,20 +2484,13 @@ function processPreToolUse(input: HookInput): HookOutput {
     const agentName = agentType?.includes(":")
       ? agentType.split(":").pop()
       : agentType;
-    const logAgentCallNotifyFailure = createSwallowedErrorLogger(
-      'hooks.bridge agent-call notification failed',
-    );
-    import("../notifications/index.js")
-      .then(({ notify }) =>
-        notify("agent-call", {
-          sessionId: input.sessionId!,
-          projectPath: directory,
-          agentName,
-          agentType,
-          profileName: process.env.OMC_NOTIFY_PROFILE,
-        }).catch(logAgentCallNotifyFailure),
-      )
-      .catch(logAgentCallNotifyFailure);
+    dispatchNotificationInBackground("agent-call", {
+      sessionId: input.sessionId!,
+      projectPath: directory,
+      agentName,
+      agentType,
+      profileName: process.env.OMC_NOTIFY_PROFILE,
+    });
   }
 
   // Warn about pkill -f self-termination risk (issue #210)


### PR DESCRIPTION
## Summary
- audited OMC hook notification/background paths against OmX PR #2155 foreground-output isolation behavior
- moved hook-triggered notification dispatch to detached Node helpers with `stdio: "ignore"` / `unref()` for bridge notifications and `scripts/session-start.mjs`
- added regressions proving noisy background notification stdout/stderr does not contaminate foreground hook protocol output

Fixes #2962.

## Verification
- `npm run test:run -- src/hooks/__tests__/background-notifications.test.ts src/__tests__/session-start-background-output.test.ts`
- `npx tsc --noEmit`
- `npm run test:run -- src/hooks/__tests__/askuserquestion-lifecycle.test.ts src/hooks/__tests__/bridge-openclaw.test.ts src/__tests__/hooks.test.ts src/hooks/__tests__/background-notifications.test.ts src/__tests__/session-start-background-output.test.ts`
- `npm run build`
