### PR TITLE
Check Ralph Ruby dependency during setup

### DIFF
--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -27,6 +27,20 @@ const nodeBin = process.execPath || 'node';
 
 console.log('[OMC] Running post-install setup...');
 
+function checkRalphRubyDependency() {
+  try {
+    execFileSync('ruby', ['--version'], { stdio: 'ignore', timeout: 5000 });
+    console.log('[OMC] Ruby detected for Ralph workflows');
+  } catch {
+    console.log('[OMC] Warning: Ruby was not found on PATH. Ralph workflows require Ruby and may fail until it is installed.');
+    console.log('[OMC] Ubuntu/Debian: sudo apt update && sudo apt install ruby-full');
+    console.log('[OMC] macOS: brew install ruby');
+    console.log('[OMC] After installing Ruby, restart Claude Code and rerun /oh-my-claudecode:omc-setup if needed.');
+  }
+}
+
+checkRalphRubyDependency();
+
 // 1. Create HUD directory
 if (!existsSync(HUD_DIR)) {
   mkdirSync(HUD_DIR, { recursive: true });

--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -74,7 +74,25 @@ grep -o "CLAUDE-[^ )]*\.md" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" 2>/d
 - If `OMC:VERSION` marker is missing from deterministic CLAUDE source scan (base + referenced companion): WARN - cannot verify CLAUDE.md freshness
 - If `CLAUDE.md OMC version` != `Latest cached plugin version`: WARN - version drift detected (run `omc update` or `omc setup`)
 
-### Step 5: Check for Stale Plugin Cache
+### Step 5: Check Ralph Ruby Dependency
+
+Ralph workflows require Ruby. Check for Ruby explicitly so fresh installations get actionable guidance instead of a later opaque Ralph failure.
+
+```bash
+if command -v ruby >/dev/null 2>&1; then
+  echo "Ruby for Ralph: $(ruby --version 2>/dev/null | head -1)"
+else
+  echo "Ruby for Ralph: MISSING"
+  echo "Install Ruby before using Ralph. Ubuntu/Debian: sudo apt update && sudo apt install ruby-full"
+  echo "macOS: brew install ruby"
+fi
+```
+
+**Diagnosis**:
+- If Ruby is found: OK - Ralph dependency present
+- If Ruby is missing: WARN - Ralph workflows may fail until Ruby is installed
+
+### Step 6: Check for Stale Plugin Cache
 
 ```bash
 # Count versions in cache (cross-platform)
@@ -84,7 +102,7 @@ node -e "const p=require('path'),f=require('fs'),h=require('os').homedir(),d=pro
 **Diagnosis**:
 - If > 1 version: WARN - multiple cached versions (cleanup recommended)
 
-### Step 6: Check for Legacy Curl-Installed Content
+### Step 7: Check for Legacy Curl-Installed Content
 
 Check for legacy agents, commands, and skills installed via curl (before plugin system).
 **Important**: Only flag files whose names match actual plugin-provided names. Do NOT flag user's custom agents/commands/skills that are unrelated to OMC.
@@ -135,6 +153,7 @@ After running all checks, output a report:
 | Legacy Hooks (settings.json) | OK/CRITICAL | ... |
 | Legacy Scripts (~/.claude/hooks/) | OK/WARN | ... |
 | CLAUDE.md | OK/WARN/CRITICAL | ... |
+| Ralph Ruby Dependency | OK/WARN | ... |
 | Plugin Cache | OK/WARN | ... |
 | Legacy Agents (~/.claude/agents/) | OK/WARN | ... |
 | Legacy Commands (~/.claude/commands/) | OK/WARN | ... |

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -2,6 +2,21 @@
 
 **Skip condition**: If resuming and `lastCompletedStep >= 4`, skip this entire phase.
 
+## Step 2.0: Check Ralph Ruby Dependency
+
+Ralph workflows require Ruby. On fresh Ubuntu installations, missing Ruby can cause Ralph to fail later with an opaque Claude Code abort. Check for Ruby during setup and show a product-facing remediation hint without blocking the rest of setup:
+
+```bash
+if command -v ruby >/dev/null 2>&1; then
+  echo "Ruby detected for Ralph workflows: $(ruby --version 2>/dev/null | head -1)"
+else
+  echo "WARNING: Ruby was not found on PATH. Ralph workflows require Ruby."
+  echo "Install it, then restart Claude Code before using Ralph."
+  echo "Ubuntu/Debian: sudo apt update && sudo apt install ruby-full"
+  echo "macOS: brew install ruby"
+fi
+```
+
 ## Step 2.1: Setup HUD Statusline
 
 **Note**: If resuming and `lastCompletedStep >= 3`, skip to Step 2.2.

--- a/src/__tests__/plugin-setup-deps.test.ts
+++ b/src/__tests__/plugin-setup-deps.test.ts
@@ -74,3 +74,22 @@ describe('package.json prepare script removal', () => {
     expect(pkg.scripts.prepublishOnly).toContain('npm run build');
   });
 });
+
+
+describe('plugin-setup.mjs Ralph Ruby dependency guidance (issue #2969)', () => {
+  const scriptContent = existsSync(PLUGIN_SETUP_PATH)
+    ? readFileSync(PLUGIN_SETUP_PATH, 'utf-8')
+    : '';
+
+  it('checks for Ruby during plugin setup before Ralph workflows fail later', () => {
+    expect(scriptContent).toContain('checkRalphRubyDependency');
+    expect(scriptContent).toContain("execFileSync('ruby', ['--version']");
+    expect(scriptContent).toContain('Ruby was not found on PATH');
+  });
+
+  it('prints actionable install guidance for fresh Ubuntu users', () => {
+    expect(scriptContent).toContain('Ralph workflows require Ruby');
+    expect(scriptContent).toContain('sudo apt update && sudo apt install ruby-full');
+    expect(scriptContent).toContain('restart Claude Code');
+  });
+});

--- a/src/__tests__/setup-contracts-regression.test.ts
+++ b/src/__tests__/setup-contracts-regression.test.ts
@@ -557,3 +557,17 @@ describe('Contract 10: installer manages stale OMC-created agents and skills', (
     }
   });
 });
+
+
+describe('OMC setup Ralph Ruby dependency guidance (issue #2969)', () => {
+  it('checks Ruby during setup with product-facing Ralph remediation', () => {
+    const phasePath = join(REPO_ROOT, 'skills', 'omc-setup', 'phases', '02-configure.md');
+    const content = readFileSync(phasePath, 'utf-8');
+
+    expect(content).toContain('Step 2.0: Check Ralph Ruby Dependency');
+    expect(content).toContain('command -v ruby');
+    expect(content).toContain('Ralph workflows require Ruby');
+    expect(content).toContain('sudo apt update && sudo apt install ruby-full');
+    expect(content).toContain('restart Claude Code');
+  });
+});

--- a/src/skills/__tests__/omc-doctor-skill.test.ts
+++ b/src/skills/__tests__/omc-doctor-skill.test.ts
@@ -20,3 +20,17 @@ describe('omc-doctor skill (issue #2254)', () => {
     expect(content).toContain('If `CLAUDE.md OMC version` != `Latest cached plugin version`: WARN - version drift detected');
   });
 });
+
+
+describe('omc-doctor skill Ralph Ruby dependency check (issue #2969)', () => {
+  it('documents a narrow Ruby check with actionable Ralph guidance', () => {
+    const skillPath = join(process.cwd(), 'skills', 'omc-doctor', 'SKILL.md');
+    const content = readFileSync(skillPath, 'utf8');
+
+    expect(content).toContain('Check Ralph Ruby Dependency');
+    expect(content).toContain('Ruby for Ralph: MISSING');
+    expect(content).toContain('Ralph workflows require Ruby');
+    expect(content).toContain('sudo apt update && sudo apt install ruby-full');
+    expect(content).toContain('Ralph Ruby Dependency');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a narrow Ruby preflight in plugin post-install setup so missing Ruby is surfaced before Ralph fails opaquely.
- Adds `/omc-setup` Phase 2 guidance and `/omc-doctor` diagnostics for Ralph's Ruby requirement.
- Adds regression tests for the setup, plugin-setup, and doctor guidance.

Fixes #2969.

## Verification
- `npm test -- --run src/__tests__/plugin-setup-deps.test.ts src/skills/__tests__/omc-doctor-skill.test.ts src/__tests__/setup-contracts-regression.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (passes with existing warnings)

## Notes
- Scope is intentionally product-facing and Ralph-specific; this does not introduce a broad dependency manager.
- Not tested end-to-end on a fresh Ubuntu VM without Ruby.
