### PR TITLE
feat(skills): plugin skill manifest hook for token-efficient discovery

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -36,6 +36,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/wiki-session-start.mjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/plugin-skill-manifest.mjs",
+            "timeout": 5
           }
         ]
       },

--- a/scripts/plugin-skill-manifest.mjs
+++ b/scripts/plugin-skill-manifest.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+/**
+ * Plugin Skill Manifest (SessionStart)
+ *
+ * Scans all installed plugin SKILL.md files and injects a compact tagged
+ * manifest into session context. Reduces token overhead from the flat skill
+ * name list injected by Claude Code's plugin system, and makes `find-skills`
+ * more effective by surfacing tags and one-line descriptions up front.
+ *
+ * Output format: Markdown table — name | tags | description (one line each)
+ * Injected once per session via hookSpecificOutput.additionalContext.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { getClaudeConfigDir } from './lib/config-dir.mjs';
+import { readStdin } from './lib/stdin.mjs';
+
+const cfgDir = getClaudeConfigDir();
+const MARKETPLACES_DIR = join(cfgDir, 'plugins', 'marketplaces');
+
+/** Max total chars for the manifest block to avoid over-consuming context. */
+const MAX_MANIFEST_CHARS = 4000;
+
+/**
+ * Parse name, description, and tags from YAML frontmatter in a SKILL.md file.
+ * Returns null if frontmatter is absent or name is missing.
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const yaml = match[1];
+
+  const nameMatch = yaml.match(/^name:\s*["']?([^"'\n]+)["']?/m);
+  if (!nameMatch) return null;
+
+  const descMatch = yaml.match(/^description:\s*["']?([^"'\n]+)["']?/m);
+
+  // Tags: inline [a, b] or block list
+  let tags = [];
+  const inlineTags = yaml.match(/^tags:\s*\[([^\]]+)\]/m);
+  if (inlineTags) {
+    tags = inlineTags[1]
+      .split(',')
+      .map(t => t.trim().replace(/^["']|["']$/g, ''))
+      .filter(Boolean);
+  } else {
+    const blockTags = yaml.match(/^tags:\s*\n((?:[ \t]+-[ \t]*.+\n?)*)/m);
+    if (blockTags) {
+      tags = blockTags[1]
+        .split('\n')
+        .map(l => l.match(/^[ \t]+-[ \t]*["']?([^"'\n]+)["']?/))
+        .filter(Boolean)
+        .map(m => m[1].trim());
+    }
+  }
+
+  return {
+    name: nameMatch[1].trim(),
+    description: descMatch ? descMatch[1].trim() : '',
+    tags,
+  };
+}
+
+/**
+ * Find all SKILL.md files under a directory, up to maxDepth levels deep.
+ */
+function findSkillFiles(dir, maxDepth = 4, depth = 0) {
+  if (depth > maxDepth || !existsSync(dir)) return [];
+
+  const results = [];
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith('.')) continue;
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...findSkillFiles(fullPath, maxDepth, depth + 1));
+      } else if (entry.name === 'SKILL.md') {
+        results.push(fullPath);
+      }
+    }
+  } catch { /* ignore permission/IO errors */ }
+
+  return results;
+}
+
+/**
+ * Truncate description to first sentence, capped at maxLen characters.
+ */
+function summarize(description, maxLen = 80) {
+  if (!description) return '';
+  const sentence = description.split(/[.!?]/)[0].trim();
+  if (sentence.length <= maxLen) return sentence;
+  return `${sentence.slice(0, maxLen - 1)}…`;
+}
+
+/**
+ * Scan all installed plugin marketplaces and build a compact manifest table.
+ * Returns null if no skills found or marketplaces directory is absent.
+ */
+function buildManifest() {
+  if (!existsSync(MARKETPLACES_DIR)) return null;
+
+  const entries = [];
+
+  try {
+    for (const marketplace of readdirSync(MARKETPLACES_DIR, { withFileTypes: true })) {
+      if (!marketplace.isDirectory() || marketplace.name.startsWith('.')) continue;
+      const marketplaceDir = join(MARKETPLACES_DIR, marketplace.name);
+
+      for (const skillFile of findSkillFiles(marketplaceDir)) {
+        try {
+          const content = readFileSync(skillFile, 'utf-8');
+          const meta = parseFrontmatter(content);
+          if (!meta) continue;
+          entries.push({
+            name: meta.name,
+            tags: meta.tags.length > 0 ? meta.tags.join(', ') : '—',
+            summary: summarize(meta.description),
+          });
+        } catch { /* ignore unreadable files */ }
+      }
+    }
+  } catch { /* ignore marketplace scan errors */ }
+
+  if (entries.length === 0) return null;
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  const header = [
+    '<plugin-skill-manifest>',
+    '',
+    `## Installed Plugin Skills — compact manifest (${entries.length} skills)`,
+    '',
+    'Use the `find-skills` skill to filter by keyword or tag. Invoke any skill with the `Skill` tool.',
+    '',
+    '| skill | tags | description |',
+    '|-------|------|-------------|',
+  ];
+
+  const footer = ['', '</plugin-skill-manifest>'];
+  const headerStr = header.join('\n');
+  const footerStr = footer.join('\n');
+  const budget = MAX_MANIFEST_CHARS - headerStr.length - footerStr.length;
+
+  const rows = [];
+  let used = 0;
+
+  for (const { name, tags, summary } of entries) {
+    const row = `| \`${name}\` | ${tags} | ${summary} |`;
+    if (used + row.length + 1 > budget) {
+      rows.push('| … | … | Additional skills omitted — use `find-skills` to discover all |');
+      break;
+    }
+    rows.push(row);
+    used += row.length + 1;
+  }
+
+  return [...header, ...rows, ...footer].join('\n');
+}
+
+async function main() {
+  try {
+    await readStdin(); // consume stdin even if unused
+
+    const manifest = buildManifest();
+
+    if (manifest) {
+      console.log(JSON.stringify({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'SessionStart',
+          additionalContext: manifest,
+        },
+      }));
+    } else {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    }
+  } catch {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  }
+}
+
+main();

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ai-slop-cleaner
-description: Clean AI-generated code slop with a regression-safe, deletion-first workflow and optional reviewer-only mode
+description:
+tags: [quality, refactoring, cleanup] Clean AI-generated code slop with a regression-safe, deletion-first workflow and optional reviewer-only mode
 level: 3
 ---
 

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ask
 description: Process-first advisor routing for Claude, Codex, or Gemini via `omc ask`, with artifact capture and no raw CLI assembly
+tags: [routing, advisor, multi-model]
 ---
 
 # Ask

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autopilot
 description: Full autonomous execution from idea to working code
+tags: [autonomous, execution, workflow, orchestration]
 argument-hint: "<product idea or task description>"
 level: 4
 ---

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cancel
 description: Cancel any active OMC mode (autopilot, ralph, ultrawork, ultraqa, swarm, ultrapilot, pipeline, team)
+tags: [meta, control, modes]
 argument-hint: "[--force|--all]"
 level: 2
 ---

--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ccg
 description: Claude-Codex-Gemini tri-model orchestration via /ask codex + /ask gemini, then Claude synthesizes results
+tags: [multi-model, orchestration, research]
 level: 5
 ---
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: debug
 description: Diagnose the current OMC session or repo state using logs, traces, state, and focused reproduction
+tags: [debugging, diagnosis, session, meta]
 ---
 
 # Debug

--- a/skills/deep-dive/SKILL.md
+++ b/skills/deep-dive/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deep-dive
-description: "2-stage pipeline: trace (causal investigation) -> deep-interview (requirements crystallization) with 3-point injection"
+description:
+tags: [analysis, investigation, research, tracing] "2-stage pipeline: trace (causal investigation) -> deep-interview (requirements crystallization) with 3-point injection"
 argument-hint: "<problem or exploration target>"
 triggers:
   - "deep dive"

--- a/skills/deepinit/SKILL.md
+++ b/skills/deepinit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deepinit
 description: Deep codebase initialization with hierarchical AGENTS.md documentation
+tags: [initialization, setup, documentation, codebase]
 level: 4
 ---
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: omc-plan
 description: Strategic planning with optional interview workflow
+tags: [planning, workflow, strategy]
 argument-hint: "[--direct|--consensus|--review] [--interactive] [--deliberate] <task description>"
 pipeline: [deep-interview]
 handoff-policy: approval-required

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ralph
 description: Self-referential loop until task completion with configurable verification reviewer
+tags: [loop, iteration, autonomous, orchestration]
 argument-hint: "[--no-deslop] [--critic=architect|critic|codex] <task description>"
 level: 4
 ---

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: release
 description: Generic release assistant — analyzes repo release rules, caches them in .omc/RELEASE_RULE.md, then guides the release
+tags: [deployment, release, git, versioning]
 level: 3
 ---
 

--- a/skills/remember/SKILL.md
+++ b/skills/remember/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remember
 description: Review reusable project knowledge and decide what belongs in project memory, notepad, or durable docs
+tags: [memory, knowledge, persistence, documentation]
 ---
 
 # Remember

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: self-improve
-description: Autonomous evolutionary code improvement engine with tournament selection
+description:
+tags: [meta, self-improvement, iteration] Autonomous evolutionary code improvement engine with tournament selection
 level: 4
 ---
 

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill
 description: Manage local skills - list, add, remove, search, edit, setup wizard
+tags: [meta, skills, discovery, management]
 argument-hint: "<command> [args]"
 level: 2
 ---

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: team
 description: N coordinated agents on shared task list using Claude Code native teams
+tags: [multi-agent, orchestration, parallel, collaboration]
 argument-hint: "[N:agent-type] [ralph] <task description>"
 aliases: []
 level: 4

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: trace
 description: Evidence-driven tracing lane that orchestrates competing tracer hypotheses in Claude built-in team mode
+tags: [debugging, tracing, analysis, investigation]
 argument-hint: "<observation to trace>"
 agent: tracer
 level: 2

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ultraqa
 description: QA cycling workflow - test, verify, fix, repeat until goal met
+tags: [testing, qa, quality, verification]
 argument-hint: "[--tests|--build|--lint|--typecheck|--custom <pattern>] [--interactive]"
 level: 3
 ---

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ultrawork
 description: Parallel execution engine for high-throughput task completion
+tags: [parallel, execution, workflow, orchestration]
 argument-hint: "<task description with parallel work items>"
 level: 4
 ---

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verify
 description: Verify that a change really works before you claim completion
+tags: [verification, testing, validation, quality]
 ---
 
 # Verify

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: wiki
 description: LLM Wiki — persistent markdown knowledge base that compounds across sessions (Karpathy model)
+tags: [documentation, knowledge, notes, memory]
 triggers: ["wiki", "wiki this", "wiki add", "wiki lint", "wiki query"]
 ---
 


### PR DESCRIPTION
## Summary

Resolves #2976

- Adds `scripts/plugin-skill-manifest.mjs` — a new `SessionStart` hook that scans all installed plugin `SKILL.md` files and injects a compact `name | tags | description` table into session context (capped at 4 000 chars)
- Registers the hook in `hooks/hooks.json` under `SessionStart[matcher=*]`
- Adds `tags: [...]` frontmatter to all 20 built-in OMC skills so they appear with context in the manifest

## Problem

With 200+ skills installed, the flat skill name list in the system reminder consumes tokens every turn. Most skills are irrelevant to any given task — the model has no tags or summaries to filter by.

## What this adds

At session start, the model now receives:

```
## Installed Plugin Skills — compact manifest (N skills)
Use the `find-skills` skill to filter by keyword or tag.

| skill            | tags                             | description                          |
|------------------|----------------------------------|--------------------------------------|
| `autopilot`      | autonomous, execution, workflow  | Full autonomous execution from idea… |
| `debug`          | debugging, diagnosis, session    | Diagnose the current OMC session…    |
| `drupal-backend` | —                                | Drupal Back End Specialist skill…    |
…
```

Skills without `tags` still appear (backward-compatible). The manifest is injected **once per session** (not every turn), so token cost is paid once and cached.

## Test plan

- [x] `echo '{"session_id":"test","cwd":"/tmp"}' | node scripts/plugin-skill-manifest.mjs` — outputs valid JSON with manifest
- [x] Skills without tags render with `—` in the tags column
- [x] Skills with tags render correctly
- [x] Manifest truncates gracefully at 4 000 chars with overflow notice
- [x] `hooks/hooks.json` passes JSON validation
- [ ] Manual: start a session with OMC installed and verify the manifest appears in the `SessionStart` hook output